### PR TITLE
[MDB Ignore] Remaps KC13 + Mapper Terminals

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -804,6 +804,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
+"da" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/hallway_primary)
 "db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1186,6 +1189,7 @@
 "eO" = (
 /obj/machinery/computer/security/wooden_tv,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
 "eP" = (
@@ -1196,6 +1200,8 @@
 "eS" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
 "eT" = (
@@ -1250,6 +1256,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
 "fg" = (
@@ -1482,6 +1489,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
 "gv" = (
@@ -1517,6 +1525,7 @@
 "gC" = (
 /obj/structure/table/wood,
 /obj/item/camera,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
 "gE" = (
@@ -1652,6 +1661,7 @@
 /obj/machinery/power/apc/auto_name/directional/east{
 	start_charge = 0
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
 "hr" = (
@@ -2766,6 +2776,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
+"mE" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/security/detective)
 "mF" = (
 /obj/machinery/gibber,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3294,6 +3307,9 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
+"po" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/security)
 "pq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3312,6 +3328,9 @@
 /obj/machinery/photocopier,
 /turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
+"pB" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/research)
 "pD" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -3478,6 +3497,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
+"qT" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/security/detective)
 "qW" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -3488,6 +3510,9 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/hallway_primary)
+"ra" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/bridge)
 "re" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -3507,6 +3532,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
+"rm" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/medical)
 "rs" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3615,6 +3643,9 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/engineering)
+"st" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/service/janitor)
 "sv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -3760,6 +3791,7 @@
 /area/ruin/space/derelict/hallway_primary)
 "tm" = (
 /obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
 "tn" = (
@@ -3875,6 +3907,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"tU" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/maintenance/starboard)
 "tZ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -4130,6 +4165,9 @@
 	icon_state = "panelscorched"
 	},
 /area/template_noop)
+"vL" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/security)
 "vN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -4210,6 +4248,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"wQ" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/starboard)
 "wS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -4364,6 +4405,9 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
+"xV" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/research/xenobiology)
 "xW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -4676,7 +4720,7 @@
 	pixel_x = 8;
 	pixel_y = -1
 	},
-/turf/closed/wall,
+/turf/closed/wall/rust,
 /area/ruin/space/derelict/maintenance/starboard/central)
 "zY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -4881,7 +4925,7 @@
 	pixel_x = 4;
 	pixel_y = -3
 	},
-/turf/closed/wall,
+/turf/closed/wall/rust,
 /area/ruin/space/derelict/maintenance/starboard/central)
 "Bf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -5237,14 +5281,17 @@
 	icon_state = "platingdmg2"
 	},
 /area/template_noop)
+"Du" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/research)
 "Dz" = (
 /obj/item/stack/cable_coil,
 /obj/structure/closet/crate,
 /obj/item/circuitboard/machine/protolathe/offstation,
 /obj/item/circuitboard/machine/circuit_imprinter/offstation,
-/obj/item/circuitboard/computer/research,
 /obj/item/circuitboard/machine/destructive_analyzer,
 /obj/item/storage/part_replacer/cargo,
+/obj/item/circuitboard/computer/rdconsole,
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
@@ -5714,6 +5761,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -5943,6 +5991,9 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"Js" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/cargo)
 "Jt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6477,6 +6528,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
 "Nw" = (
@@ -6815,6 +6867,9 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"PO" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "PP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6967,6 +7022,9 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
+"QR" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/crew)
 "QU" = (
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port)
@@ -8253,6 +8311,9 @@
 "Zg" = (
 /turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
+"Zi" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/port/lesser)
 "Zj" = (
 /turf/closed/wall,
 /area/template_noop)
@@ -9524,15 +9585,15 @@ Zx
 Fk
 jd
 dA
-Zx
+kM
 Fk
 jd
 Zx
 GU
+st
 GU
 GU
-GU
-GU
+st
 Bs
 Vv
 QL
@@ -9612,7 +9673,7 @@ Zx
 Zx
 NM
 np
-Zx
+kM
 se
 yI
 Bg
@@ -9697,7 +9758,7 @@ Zx
 lZ
 Fk
 nq
-Zx
+kM
 ht
 yK
 BB
@@ -9774,15 +9835,15 @@ ZB
 ZB
 Mb
 Mb
-Mb
+QR
+kM
 Zx
 Zx
-Zx
-Zx
+kM
 mb
 mL
 jd
-Zx
+kM
 Oo
 yT
 BR
@@ -10019,15 +10080,15 @@ ZB
 YO
 FM
 SH
-YO
+Zi
 cA
 cY
 yq
 ZU
 OJ
-Tl
+Js
 ZB
-Mb
+QR
 Mb
 pF
 Mb
@@ -10110,9 +10171,9 @@ nM
 nM
 vU
 eE
-Tl
+Js
 fk
-Mb
+QR
 HW
 Gb
 wS
@@ -10121,7 +10182,7 @@ kq
 Zx
 Fk
 Zx
-Zx
+kM
 on
 sD
 Zx
@@ -10197,7 +10258,7 @@ IB
 eF
 Tl
 ZB
-Mb
+QR
 QP
 xE
 Tz
@@ -10262,13 +10323,13 @@ aa
 aa
 aa
 NO
-NO
-NO
-NO
-NO
+ra
+ra
+ra
+ra
 NO
 ZB
-YO
+Zi
 YK
 YO
 bp
@@ -10288,9 +10349,9 @@ xE
 iH
 qa
 kr
-Zx
+kM
 Fk
-Zx
+kM
 Oa
 Zx
 Zx
@@ -10346,7 +10407,7 @@ aa
 (24,1,1) = {"
 aa
 NO
-NO
+ra
 tH
 au
 bX
@@ -10358,8 +10419,8 @@ aX
 YO
 FM
 kZ
-YO
-YO
+Zi
+Zi
 Yv
 Yv
 dz
@@ -10382,7 +10443,7 @@ Ga
 Fk
 Zx
 Zx
-Zx
+kM
 hG
 YW
 ji
@@ -10437,7 +10498,7 @@ aV
 TK
 ON
 cK
-YO
+Zi
 uj
 bB
 FM
@@ -10467,7 +10528,7 @@ Zx
 jd
 jB
 Gz
-Zx
+kM
 hG
 YW
 hG
@@ -10525,7 +10586,7 @@ aO
 YO
 by
 FM
-YO
+Zi
 FM
 SH
 YO
@@ -10552,7 +10613,7 @@ Zx
 zc
 Zx
 Hi
-Zx
+kM
 Pi
 WU
 RZ
@@ -10607,10 +10668,10 @@ aV
 uf
 aV
 oi
+Zi
 YO
-YO
-YO
-YO
+Zi
+Zi
 YO
 bC
 YO
@@ -10631,12 +10692,12 @@ iu
 Zx
 mc
 Zx
+kM
 Zx
+kM
 Zx
-Zx
-Zx
-Zx
-Zx
+kM
+kM
 Zx
 ic
 ZD
@@ -10949,7 +11010,7 @@ aV
 qh
 hU
 hU
-hU
+wQ
 hU
 hU
 bD
@@ -10958,8 +11019,8 @@ cp
 cQ
 nR
 ER
-ER
-ER
+vL
+vL
 ER
 fr
 na
@@ -10976,7 +11037,7 @@ Yl
 Yl
 Yl
 Yl
-Yl
+PO
 zX
 Yq
 iz
@@ -11046,9 +11107,9 @@ Ot
 er
 ib
 ER
+vL
 ER
-ER
-ER
+vL
 kD
 fv
 eB
@@ -11117,13 +11178,13 @@ ON
 aC
 aV
 cK
-hU
+wQ
 aT
 cd
 cd
 cd
 lj
-Qb
+tU
 iA
 cS
 nT
@@ -11196,7 +11257,7 @@ aa
 (34,1,1) = {"
 aa
 NO
-NO
+ra
 lB
 aV
 aF
@@ -11208,7 +11269,7 @@ ba
 hU
 hU
 lj
-Qb
+tU
 mn
 cQ
 fl
@@ -11222,7 +11283,7 @@ ER
 eB
 fz
 kD
-Yl
+PO
 sN
 YD
 tz
@@ -11285,15 +11346,15 @@ NO
 NO
 bf
 NO
-NO
-NO
+ra
+ra
 ZB
 hU
 Xq
-hU
+wQ
 hJ
 lr
-Qb
+tU
 Mj
 cU
 dk
@@ -11558,7 +11619,7 @@ QA
 QA
 QA
 hh
-ER
+vL
 BG
 fY
 Ua
@@ -11643,7 +11704,7 @@ UV
 UV
 fI
 hi
-ER
+vL
 Ua
 mY
 Ua
@@ -11728,7 +11789,7 @@ PQ
 Ot
 IJ
 Ot
-ER
+vL
 XF
 mY
 kD
@@ -11805,7 +11866,7 @@ PQ
 bI
 ck
 ct
-PQ
+po
 Bv
 lD
 LD
@@ -11813,7 +11874,7 @@ PQ
 WT
 vj
 LD
-ER
+vL
 Ua
 Ui
 Wm
@@ -11890,7 +11951,7 @@ aa
 ZB
 aa
 Iy
-PQ
+po
 nV
 dR
 et
@@ -11977,17 +12038,17 @@ aa
 ZB
 PQ
 PQ
-PQ
+po
 eu
 eu
-eu
-eu
-eu
+qT
+qT
+qT
 eu
 BG
 Ui
 kD
-Yl
+PO
 sN
 Yh
 sN
@@ -12242,7 +12303,7 @@ Ol
 iv
 mY
 Ua
-uu
+da
 ZB
 ZB
 ZB
@@ -12251,7 +12312,7 @@ Yl
 Yl
 zh
 Yl
-Yl
+PO
 LT
 du
 YW
@@ -12318,7 +12379,7 @@ aa
 aa
 ZB
 aa
-fQ
+mE
 fQ
 fQ
 fQ
@@ -12327,7 +12388,7 @@ fQ
 kD
 mY
 Ua
-uu
+da
 aa
 ZB
 aa
@@ -12336,7 +12397,7 @@ oy
 Xy
 BX
 Ji
-mJ
+rm
 LT
 hG
 YW
@@ -12412,7 +12473,7 @@ Ua
 kD
 Ui
 BG
-uu
+da
 aa
 ZB
 aa
@@ -12582,7 +12643,7 @@ Sr
 gk
 iI
 gk
-uu
+da
 aa
 ZB
 aa
@@ -12653,18 +12714,18 @@ bJ
 Zm
 Zm
 Zm
+xV
+xV
+xV
 Zm
 Zm
-Zm
-Zm
-Zm
-PD
-PD
+Du
+Du
 dx
 As
 As
 PD
-PD
+Du
 iJ
 PD
 PD
@@ -12819,11 +12880,11 @@ aa
 aa
 aa
 aa
-Zm
+xV
 Xs
 Zu
 hd
-Zm
+xV
 ms
 hd
 hd
@@ -12904,7 +12965,7 @@ aa
 aa
 aa
 aa
-Zm
+xV
 Xs
 hd
 hd
@@ -12922,7 +12983,7 @@ WC
 Gh
 KY
 ju
-WC
+pB
 aa
 ZB
 ZB
@@ -12989,7 +13050,7 @@ aa
 aa
 aa
 aa
-Zm
+xV
 NJ
 bv
 Yf
@@ -13007,7 +13068,7 @@ WC
 WC
 Gv
 WC
-WC
+pB
 aa
 ZB
 aa
@@ -13414,7 +13475,7 @@ aa
 aa
 aa
 aa
-Zm
+xV
 Yf
 bx
 NJ
@@ -13517,7 +13578,7 @@ WC
 fd
 GT
 gT
-WC
+pB
 ZB
 ZB
 ZB
@@ -13588,7 +13649,7 @@ aa
 aa
 ZB
 vI
-Zm
+xV
 uW
 Ty
 gV
@@ -13602,7 +13663,7 @@ WC
 Kv
 xW
 YV
-WC
+pB
 aa
 aa
 ZB
@@ -13673,15 +13734,15 @@ aa
 ZB
 ZB
 ZB
-Zm
+xV
 TV
 cW
 dv
 Zm
 Zm
-WC
-WC
-WC
+pB
+pB
+pB
 WC
 WC
 Kv

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -3691,6 +3691,7 @@
 "pS" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "pV" = (
@@ -4307,6 +4308,7 @@
 /area/ruin/space/derelict/engineering)
 "uc" = (
 /obj/effect/spawner/random/engineering/tank,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "ud" = (
@@ -4548,10 +4550,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "vX" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "12"
+/obj/effect/spawner/random/structure/girder,
+/obj/structure/window/spawner,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "vZ" = (
 /turf/open/floor/plating,
@@ -4595,6 +4598,11 @@
 	},
 /turf/open/floor/carpet/blue/airless,
 /area/ruin/space/derelict/arrival)
+"wt" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "wv" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden"
@@ -4824,6 +4832,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"yj" = (
+/obj/item/electronics/airlock,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "yk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6319,6 +6333,7 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "Is" = (
@@ -7733,6 +7748,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"Qr" = (
+/obj/structure/door_assembly/door_assembly_mhatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "Qt" = (
 /obj/effect/turf_decal/siding/thinplating/end,
 /turf/open/floor/iron/dark,
@@ -8803,8 +8823,8 @@
 	},
 /area/ruin/space/derelict/engineering/gravity_generator)
 "WS" = (
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/effect/spawner/random/maintenance/two,
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "WT" = (
@@ -10328,11 +10348,11 @@ xU
 xU
 mk
 uc
-jm
+WS
 jm
 mk
-tb
-tH
+wt
+ow
 MX
 aa
 HJ
@@ -10431,12 +10451,12 @@ BT
 xU
 nM
 mk
-OT
-OT
+Fz
+Fz
 OT
 mk
 OT
-tH
+ow
 qI
 aa
 hk
@@ -10536,11 +10556,11 @@ Hi
 kK
 mk
 tH
+ow
+ow
+Qe
 tH
-tH
-vX
-tH
-tH
+ow
 mk
 aa
 HJ
@@ -10639,12 +10659,12 @@ mt
 xU
 kK
 mk
-tH
-OT
+ow
+Fz
 OT
 mk
-tH
-OT
+ow
+Fz
 mk
 Nh
 Nh
@@ -10744,10 +10764,10 @@ mk
 mk
 mk
 tH
-WS
+lq
 mk
 mk
-tH
+Fz
 QV
 mk
 RC
@@ -10846,13 +10866,13 @@ pV
 Ke
 Ke
 pV
-mk
-tH
-WS
+vX
+ow
+lq
 mk
 EX
-tH
-OT
+ow
+yj
 mk
 yu
 tX
@@ -10956,7 +10976,7 @@ mk
 mk
 av
 tH
-OT
+Fz
 mk
 rk
 pD
@@ -11060,7 +11080,7 @@ nN
 mk
 mk
 tH
-OT
+Qr
 mk
 Tl
 OJ
@@ -11162,8 +11182,8 @@ uf
 np
 nO
 mk
-tH
-tH
+ow
+ow
 mk
 mk
 mk
@@ -11266,7 +11286,7 @@ uf
 uf
 nQ
 mk
-tH
+ow
 pS
 mk
 RA
@@ -11370,7 +11390,7 @@ oh
 QQ
 Ba
 mk
-tH
+ow
 mk
 mk
 HO
@@ -11474,7 +11494,7 @@ cK
 TK
 TK
 mk
-tH
+ow
 mk
 Ew
 HO
@@ -11578,7 +11598,7 @@ pu
 vC
 DE
 mk
-tH
+ow
 mk
 YK
 mk

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -3,3019 +3,3328 @@
 /turf/template_noop,
 /area/template_noop)
 "ac" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
+/obj/structure/reflector/single/anchored{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
 "ad" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/solars/derelict_starboard)
+/turf/closed/mineral/random/stationside/asteroid,
+/area/template_noop)
 "af" = (
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg2"
-	},
-/area/solars/derelict_starboard)
+/turf/closed/wall,
+/area/ruin/space/derelict/bridge)
 "ag" = (
-/obj/structure/cable,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/solars/derelict_starboard)
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/obj/item/wrench,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
 "ai" = (
-/turf/template_noop,
-/area/ruin/space/derelict/singularity_engine)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
 "al" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/ruin/space/derelict/medical/chapel)
-"ap" = (
-/obj/machinery/power/solar{
-	id = "derelictsolar";
-	name = "Derelict Solar Array"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/solars/derelict_starboard)
-"aq" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/template_noop,
-/area/solars/derelict_starboard)
-"as" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/solar_control)
-"at" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/solar_control)
-"au" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "External Engineering"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/solar_control)
-"ax" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/bridge/ai_upload)
-"ay" = (
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"az" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"aA" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"aB" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"aC" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"aF" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/solar_control)
-"aK" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"aL" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Air Bridge Access"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"aM" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Air Bridge Access"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/solar_control)
-"aO" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"aP" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"aQ" = (
-/obj/machinery/door/window,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"aR" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"aS" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/solar_control)
-"aT" = (
-/obj/machinery/power/apc/unlocked{
-	dir = 8;
-	environ = 0;
-	equipment = 0;
-	lighting = 0;
-	name = "Starboard Solar APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"aV" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "External Engineering"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/solar_control)
-"aW" = (
-/obj/machinery/door/airlock/highsecurity,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"aX" = (
-/obj/structure/frame/computer,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"aY" = (
-/turf/closed/wall/r_wall,
-/area/ruin/unpowered/no_grav)
-"aZ" = (
-/obj/machinery/computer/monitor/secret{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"ba" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"bc" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/solar_control)
-"bd" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating/airless,
-/area/template_noop)
-"be" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bf" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/fluff/oldturret,
-/obj/structure/fluff/oldturret,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bg" = (
-/obj/structure/fluff/oldturret,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bh" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Starboard Solar Access";
-	req_access_txt = "10"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"bi" = (
-/obj/structure/grille,
-/turf/template_noop,
-/area/ruin/unpowered/no_grav)
-"bj" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bl" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bn" = (
-/obj/machinery/computer/atmos_alert,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bo" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bp" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bq" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"br" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"bs" = (
-/turf/open/floor/iron{
-	icon_state = "damaged1"
-	},
-/area/ruin/space/derelict/solar_control)
-"bt" = (
-/obj/machinery/door/window,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bu" = (
-/turf/open/floor/iron{
-	icon_state = "damaged5"
-	},
-/area/ruin/space/derelict/solar_control)
-"bv" = (
-/obj/item/stock_parts/matter_bin,
-/turf/open/floor/iron{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/solar_control)
-"bw" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/smes,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bx" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/microwave,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"by" = (
-/obj/structure/rack,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bz" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bB" = (
-/turf/open/floor/iron{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/solar_control)
-"bC" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/solar_control)
-"bD" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/cryo_tube,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bE" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/bridge/ai_upload)
-"bF" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/bridge/ai_upload)
-"bG" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bI" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bJ" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bK" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/bridge/ai_upload)
-"bL" = (
-/turf/template_noop,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bM" = (
-/obj/item/stack/sheet/glass,
-/turf/template_noop,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bO" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bP" = (
-/obj/structure/fluff/oldturret,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bQ" = (
+/obj/structure/table/reinforced,
 /obj/item/aicard,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"am" = (
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/pipe_dispenser,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"ap" = (
+/obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
+"aq" = (
+/obj/machinery/computer/communications,
+/obj/effect/turf_decal/tile/blue/half,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
+"as" = (
+/obj/machinery/modular_computer/console/preset/id,
+/turf/open/floor/iron/white/side,
+/area/ruin/space/derelict/bridge)
+"at" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/iron/white/side,
+/area/ruin/space/derelict/bridge)
+"au" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/timer,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"aw" = (
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
 	},
-/area/ruin/space/derelict/bridge/ai_upload)
-"bR" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bS" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"bT" = (
-/obj/structure/rack,
-/obj/item/circuitboard/computer/solar_control,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bU" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/autolathe,
-/obj/item/circuitboard/machine/protolathe/offstation{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bV" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/circuit_imprinter/offstation,
-/obj/item/ai_module/core/full/drone{
-	pixel_x = -4;
-	pixel_y = -2
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bW" = (
-/turf/closed/indestructible/riveted{
-	color = "#FF8888"
-	},
-/area/ruin/space/derelict/bridge/ai_upload)
-"bX" = (
-/obj/structure/rack,
-/obj/item/circuitboard/computer/turbine_computer,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bY" = (
-/obj/structure/frame/computer{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/item/circuitboard/computer/rdconsole,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"bZ" = (
-/obj/structure/frame/computer{
-	dir = 8
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"ca" = (
-/obj/machinery/door/airlock/external/ruin,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"cd" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"ce" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/bridge/ai_upload)
-"ch" = (
-/turf/closed/wall,
-/area/ruin/unpowered/no_grav)
-"ci" = (
-/turf/closed/wall/r_wall,
-/area/template_noop)
-"cl" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/gravity_generator)
-"cm" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"cn" = (
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
-/turf/template_noop,
-/area/template_noop)
-"co" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/gravity_generator)
-"cp" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/ruin/space/derelict/gravity_generator)
-"cq" = (
-/obj/item/stock_parts/manipulator,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/gravity_generator)
-"cr" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/ruin/space/derelict/bridge/access)
-"cs" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/bridge/access)
-"ct" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cu" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/gravity_generator)
-"cv" = (
-/obj/item/stack/ore/slag,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/gravity_generator)
-"cw" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/ruin/space/derelict/gravity_generator)
-"cx" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cA" = (
-/obj/structure/rack,
-/obj/item/clothing/head/helmet/swat,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cC" = (
-/obj/structure/rack,
-/obj/item/electronics/apc,
-/obj/item/electronics/airalarm,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cD" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/smes,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cE" = (
-/obj/structure/rack,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/manipulator,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cF" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cG" = (
-/obj/item/screwdriver,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/ruin/space/derelict/gravity_generator)
-"cH" = (
-/obj/machinery/gravity_generator/main/station{
-	on = 0
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/gravity_generator)
-"cI" = (
-/obj/item/stack/ore/slag,
-/turf/template_noop,
-/area/template_noop)
-"cO" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/gravity_generator)
-"cP" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/gravity_generator)
-"cQ" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cR" = (
-/obj/structure/rack,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"ax" = (
+/obj/machinery/vending/tool,
 /turf/open/floor/plating,
-/area/ruin/space/derelict/bridge/access)
-"cS" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/rack,
-/obj/item/stack/cable_coil/cut,
-/obj/item/stack/cable_coil/cut,
-/obj/item/storage/box/lights/mixed,
+/area/ruin/space/derelict/maintenance/port/central)
+"az" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/secure/safe/caps_spare/directional/east,
+/obj/item/multitool,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cT" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/area/ruin/space/derelict/bridge)
+"aA" = (
+/obj/structure/displaycase/noalert,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"aB" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"aC" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/bridge)
+"aD" = (
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/storage/pill_bottle/mannitol,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"aF" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/ruin/space/derelict/bridge)
+"aL" = (
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/ruin/space/derelict/bridge/access)
-"cU" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/area/ruin/space/derelict/bridge)
+"aM" = (
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/ruin/space/derelict/bridge)
+"aO" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"aP" = (
+/obj/structure/displaycase_chassis,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"aQ" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"aR" = (
+/obj/machinery/computer/security,
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
+"aS" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"aT" = (
+/obj/structure/fireaxecabinet/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"aV" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"aW" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/bridge)
+"aX" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/bridge)
+"aZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/bridge/access)
-"cV" = (
-/obj/machinery/door/airlock/command{
-	name = "E.V.A.";
-	req_access_txt = "18"
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cW" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Secure Storage";
-	req_access_txt = "10"
+/area/ruin/space/derelict/bridge)
+"ba" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cX" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
+/area/ruin/space/derelict/bridge)
+"bb" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"bc" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/secure/briefcase,
+/obj/item/assembly/flash/handheld,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"cY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/area/ruin/space/derelict/bridge)
+"bd" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/gravity_generator)
-"cZ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"be" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"bh" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/gravity_generator)
-"da" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access_txt = "10"
-	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/gravity_generator)
-"db" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/gravity_generator)
-"dc" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/gravity_generator)
-"dd" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/bridge/access)
-"df" = (
-/obj/item/wallframe/apc,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/gravity_generator)
-"dg" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/gravity_generator)
-"di" = (
-/obj/structure/frame/machine,
-/obj/item/stack/sheet/glass,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/gravity_generator)
-"dj" = (
-/turf/open/floor/iron/solarpanel/airless,
-/area/template_noop)
-"dk" = (
-/obj/item/stack/cable_coil/cut,
-/turf/template_noop,
-/area/template_noop)
-"dl" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"dm" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/bridge/access)
-"dp" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"dq" = (
-/obj/item/reagent_containers/food/drinks/bottle/beer,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"dr" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/singularity_engine)
-"ds" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/table,
-/obj/item/paper/fluff/ruins/thederelict/equipment,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/gravity_generator)
-"du" = (
-/obj/machinery/light/small/directional/east,
-/obj/item/stock_parts/matter_bin{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/matter_bin{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/stock_parts/matter_bin,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/gravity_generator)
-"dv" = (
-/obj/item/stock_parts/matter_bin,
-/turf/template_noop,
-/area/template_noop)
-"dw" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"dx" = (
-/obj/machinery/door/window,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"dy" = (
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"dz" = (
-/turf/closed/wall,
 /area/ruin/space/derelict/bridge)
-"dA" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/singularity_engine)
-"dB" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/singularity_engine)
-"dC" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access_txt = "10"
+"bi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"bk" = (
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"bl" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"bn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"bp" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"bq" = (
+/obj/machinery/keycard_auth/directional/south,
+/obj/machinery/airalarm/directional/west,
+/obj/item/documents/nanotrasen,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"br" = (
+/obj/machinery/keycard_auth/directional/south,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"bs" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"bt" = (
+/obj/structure/window/spawner/east,
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"bu" = (
+/obj/effect/turf_decal/tile/blue/half,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
+"bv" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
+"bw" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "31"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"bx" = (
+/obj/structure/window/spawner/west,
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"by" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"bz" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard)
+"bB" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"bC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/bridge)
+"bD" = (
+/obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/gravity_generator)
-"dD" = (
-/obj/structure/sign/warning/securearea{
-	name = "ENGINEERING ACCESS"
+/turf/open/floor/iron/edge{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/gravity_generator)
-"dF" = (
-/obj/structure/window/reinforced{
+/area/ruin/space/derelict/hallway_primary)
+"bI" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/plaque/static_plaque/golden/commission/mini,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/bridge)
+"bJ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"bM" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"dG" = (
-/obj/structure/frame/computer,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"dJ" = (
-/obj/machinery/computer/security,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"dK" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
+/area/ruin/space/derelict/research/xenobiology)
+"bN" = (
+/obj/machinery/telecomms/message_server/preset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"bP" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock";
+	req_access_txt = "48"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"bR" = (
+/obj/machinery/door/window/westleft{
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"bS" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"bT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"bU" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"bV" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway_primary)
+"bX" = (
+/obj/structure/table/wood,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"ca" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
-"dL" = (
-/obj/structure/table,
+"cb" = (
+/obj/machinery/blackbox_recorder,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"cd" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall,
+/area/ruin/space/derelict/research/xenobiology)
+"cg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"ch" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"ci" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"cj" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"cl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"cm" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/cargo)
+"cp" = (
+/obj/structure/chair,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"cr" = (
+/obj/machinery/mecha_part_fabricator,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"cs" = (
+/obj/machinery/rnd/server,
+/turf/open/floor/circuit/telecomms/server,
+/area/ruin/space/derelict/research)
+"ct" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"dM" = (
+/area/ruin/space/derelict/security)
+"cu" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"cv" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"cw" = (
 /obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
 	},
+/obj/item/pen,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"dN" = (
-/obj/item/grenade/empgrenade,
-/obj/structure/table,
-/obj/structure/window/reinforced{
+/area/ruin/space/derelict/security)
+"cx" = (
+/obj/machinery/mecha_part_fabricator,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"cy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"dO" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"cz" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
-/area/ruin/space/derelict/singularity_engine)
-"dP" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"dR" = (
-/obj/machinery/light/small/directional/north,
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"dV" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/gravity_generator)
-"dW" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"dX" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"dZ" = (
-/obj/item/reagent_containers/food/drinks/bottle/beer,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"ea" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"eb" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/bridge)
-"ec" = (
-/obj/structure/table,
-/obj/item/paper/crumpled,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"ed" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"ee" = (
-/obj/structure/window/reinforced,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"ef" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"eh" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"ei" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"ej" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/gravity_generator)
-"ek" = (
-/obj/structure/closet/radiation,
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = 32
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/gravity_generator)
-"el" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/gravity_generator)
-"em" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"en" = (
-/obj/machinery/power/emitter{
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"cA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"eo" = (
-/obj/machinery/field/generator,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"eq" = (
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"et" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"eu" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"ev" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"ew" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"ex" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/turf/open/floor/iron/dark/telecomms,
+/area/ruin/space/derelict/research)
+"cB" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"ey" = (
-/obj/structure/noticeboard,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/singularity_engine)
-"ez" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"eB" = (
-/obj/machinery/door/window/eastleft{
-	name = "Heads of Staff";
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"cC" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"cD" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"cE" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
 	req_access_txt = "19"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"eC" = (
+/area/ruin/space/derelict/bridge)
+"cG" = (
 /obj/structure/table,
-/obj/item/paicard,
+/obj/machinery/recharger,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"eD" = (
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"eE" = (
+/area/ruin/space/derelict/security)
+"cH" = (
 /obj/structure/table,
-/obj/item/stock_parts/cell,
-/obj/structure/window/reinforced{
+/obj/item/storage/lockbox/loyalty,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"cI" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"cK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"cQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"cR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/bridge)
-"eF" = (
-/obj/item/storage/toolbox/syndicate,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+"cS" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/area/ruin/space/derelict/singularity_engine)
-"eG" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"eJ" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"eK" = (
-/obj/structure/cable,
+/area/ruin/space/derelict/research/xenobiology)
+"cU" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"cV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"cW" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/cargo)
+"cY" = (
+/obj/structure/closet/crate,
+/obj/item/stack/ore/silver,
+/obj/item/stack/ore/iron,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"eL" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/ruin/space/derelict/singularity_engine)
-"eN" = (
-/obj/item/paper/fluff/ruins/thederelict/nukie_objectives,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+/area/ruin/space/derelict/cargo)
+"cZ" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/departures)
+"db" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock";
+	req_access_txt = "48"
 	},
-/area/ruin/space/derelict/singularity_engine)
-"eO" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/space/derelict/bridge/access)
-"eP" = (
-/obj/structure/table,
+/area/ruin/space/derelict/cargo)
+"dc" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/hallway_primary)
+"dd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
+"de" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/engineering)
+"dg" = (
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"dk" = (
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"eS" = (
-/obj/structure/chair,
+/area/ruin/space/derelict/hallway_primary)
+"dm" = (
+/turf/open/floor/iron/white/side{
+	dir = 10
+	},
+/area/ruin/space/derelict/research)
+"dq" = (
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"eT" = (
-/obj/structure/table,
-/obj/item/screwdriver,
+/area/ruin/space/derelict/security)
+"dt" = (
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"eU" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/beer,
-/obj/structure/window/reinforced{
+/area/ruin/space/derelict/service)
+"dv" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"eV" = (
-/obj/item/stack/rods,
-/turf/template_noop,
-/area/template_noop)
-"eW" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/area/ruin/space/derelict/research)
+"dx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"dy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"dz" = (
+/obj/machinery/photocopier,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"dB" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"dE" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"dI" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"dJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/research/explosive_compressor,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"dL" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"dM" = (
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research/xenobiology)
+"dN" = (
+/obj/machinery/door/window/westleft{
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research/xenobiology)
+"dP" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"eX" = (
-/obj/item/shard,
-/obj/structure/grille/broken,
-/obj/effect/decal/remains/human{
-	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	name = "Syndicate agent remains"
-	},
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"eY" = (
-/obj/item/clothing/suit/space/eva,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"eZ" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fa" = (
-/obj/item/shard,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"fb" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fc" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fd" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fe" = (
 /obj/structure/table,
-/obj/item/rack_parts,
+/obj/item/areaeditor/blueprints,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"ff" = (
-/obj/structure/window/fulltile,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"fh" = (
-/obj/structure/table,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"fj" = (
-/obj/structure/window/reinforced{
+/area/ruin/space/derelict/EVA)
+"dR" = (
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"dS" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
+	pixel_y = 24
 	},
-/area/ruin/space/derelict/singularity_engine)
-"fk" = (
-/obj/item/clothing/head/helmet/space/eva,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fl" = (
-/obj/item/shard{
-	icon_state = "small"
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
+	name = "Burn Chamber Interior Airlock"
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fm" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fn" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research)
+"dU" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fo" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/bridge)
-"fp" = (
-/obj/machinery/door/window{
-	name = "Captain's Quarters";
-	req_access_txt = "20"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/bridge)
-"fq" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fr" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"fs" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"dV" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"ft" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"dZ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"ec" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"ed" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"ef" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"eg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/arrival)
+"eh" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/derelict/departures)
+"en" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"eo" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"eq" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/rack,
+/obj/item/storage/box/teargas{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"et" = (
+/obj/structure/closet/secure_closet/contraband/armory,
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"eu" = (
+/obj/structure/rack,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/security)
+"ex" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fu" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research/xenobiology)
+"ey" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/area/ruin/space/derelict/singularity_engine)
-"fw" = (
-/obj/effect/mob_spawn/ghost_role/drone/derelict,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
-"fx" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
-"fy" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research/xenobiology)
+"ez" = (
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/ruin/space/derelict/departures)
+"eA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"eB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/engine/vacuum,
+/area/ruin/space/derelict/research)
+"eC" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance";
+	req_access_txt = "48"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"eD" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"eE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"eF" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Armory";
+	req_access_txt = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"eG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"eJ" = (
+/obj/machinery/igniter/incinerator_ordmix,
+/turf/open/floor/engine/vacuum,
+/area/ruin/space/derelict/research)
+"eN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"eO" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/ordnance_mixing_input{
+	dir = 8
+	},
+/turf/open/floor/engine/vacuum,
+/area/ruin/space/derelict/research)
+"eP" = (
+/turf/open/floor/engine/vacuum,
+/area/ruin/space/derelict/research)
+"eS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"eT" = (
+/obj/structure/rack,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/security)
+"eU" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"eV" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"eX" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Dock";
+	req_access_txt = "48"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"eY" = (
 /obj/structure/table,
-/obj/item/assembly/flash/handheld,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
-"fz" = (
-/obj/structure/table,
-/obj/machinery/light/small/directional/north,
-/obj/item/electronics/airlock,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
-"fA" = (
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/obj/item/stack/sheet/rglass{
+	amount = 50
+	},
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"eZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"fa" = (
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"fb" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"fc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"fd" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"fe" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"ff" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"fg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"fh" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"fi" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
 	pixel_y = -7
 	},
-/obj/item/stock_parts/matter_bin,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
-"fB" = (
+/obj/item/stack/cable_coil,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"fk" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"fl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/table,
-/obj/item/stock_parts/cell{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
 	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
-"fC" = (
-/turf/template_noop,
-/area/ruin/space/derelict/bridge/access)
-"fD" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"fE" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fF" = (
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
 	pixel_y = -1
 	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
-"fG" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
 	},
-/area/ruin/space/derelict/singularity_engine)
-"fI" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"fm" = (
+/obj/structure/rack,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"fn" = (
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"fp" = (
+/obj/machinery/flasher/directional/north{
+	id = "brigentry"
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/security)
+"fq" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"fr" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"fs" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/security)
+"fw" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"fD" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"fE" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"fF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"fG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/area/ruin/space/derelict/singularity_engine)
-"fJ" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"fK" = (
-/obj/machinery/door/window,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
+/area/ruin/space/derelict/hallway_primary)
+"fI" = (
+/obj/structure/rack,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/security)
+"fK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
 "fN" = (
-/obj/item/shard{
-	icon_state = "medium"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
 "fO" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"fP" = (
-/obj/structure/grille,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/singularity_engine)
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/hallway_primary)
 "fQ" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"fR" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Tech Storage";
-	req_access_txt = "23"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
+/obj/structure/chair,
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/hallway_primary)
 "fS" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/bridge/access)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
 "fT" = (
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
-"fU" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"fV" = (
-/obj/item/screwdriver,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fW" = (
-/obj/item/stack/rods,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"fX" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"fZ" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/hallway/primary)
-"ga" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"gb" = (
-/obj/structure/cable,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"gc" = (
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"gd" = (
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/bridge/access)
-"gg" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
-"gh" = (
-/obj/item/stack/ore/slag,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"gi" = (
-/obj/item/shard,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"gj" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"gk" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/hallway/primary)
-"gl" = (
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"gm" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"gn" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"go" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"gp" = (
-/obj/structure/window/fulltile,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"gq" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/bridge/access)
-"gr" = (
-/turf/open/floor/iron/airless,
-/area/ruin/unpowered/no_grav)
-"gs" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"gt" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"gw" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"gz" = (
-/turf/open/floor/iron/airless{
-	icon_state = "floorscorched2"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"gA" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"gC" = (
-/turf/open/floor/iron/airless{
-	icon_state = "floorscorched2"
-	},
-/area/ruin/unpowered/no_grav)
-"gD" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/unpowered/no_grav)
-"gE" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"gF" = (
-/obj/machinery/door/window,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"gH" = (
-/turf/open/floor/iron/airless{
-	icon_state = "floorscorched1"
-	},
-/area/ruin/unpowered/no_grav)
-"gI" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"gJ" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"gK" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"gL" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"gM" = (
-/obj/item/crowbar,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"gN" = (
-/obj/structure/grille,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"gO" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"gP" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/unpowered/no_grav)
-"gR" = (
-/obj/item/shard{
-	icon_state = "small"
-	},
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"gS" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"gT" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"gV" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/arrival)
-"gW" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/arrival)
-"gX" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/medical/chapel)
-"gY" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/singularity_engine)
-"gZ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"hb" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"hc" = (
-/obj/structure/lattice,
-/obj/structure/window/fulltile,
-/turf/template_noop,
-/area/ruin/unpowered/no_grav)
-"hd" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"he" = (
-/obj/structure/chair,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"hf" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"hg" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"hh" = (
-/obj/structure/chair{
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"ga" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"gb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/drinks/britcup,
+/obj/effect/turf_decal/siding/thinplating/light{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
+"gc" = (
+/obj/machinery/computer/med_data,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"gg" = (
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"gh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"gj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"gk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"gl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"gm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/folder/white,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
+"gn" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"go" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"gp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/flat_white,
+/area/ruin/space/derelict/medical)
+"gr" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"gy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"gz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/paper_bin{
+	pixel_y = 4
 	},
 /obj/item/pen,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"hi" = (
-/obj/structure/chair{
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
+"gC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"hj" = (
-/obj/structure/closet/crate/coffin,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/medical/chapel)
-"hk" = (
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/medical/chapel)
-"hl" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/medical/chapel)
-"hm" = (
-/obj/item/shard,
-/turf/template_noop,
-/area/template_noop)
-"hn" = (
-/obj/structure/grille,
-/turf/template_noop,
-/area/ruin/space/derelict/singularity_engine)
-"ho" = (
-/obj/item/shard,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+/area/ruin/space/derelict/cargo)
+"gD" = (
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_one_access_txt = "73"
 	},
-/area/ruin/space/derelict/singularity_engine)
-"hp" = (
-/turf/open/floor/iron/airless{
-	icon_state = "floorscorched2"
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"gE" = (
+/obj/machinery/monkey_recycler,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"gG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/area/ruin/space/derelict/arrival)
-"hq" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/arrival)
-"hr" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"gH" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
 	},
-/area/ruin/space/derelict/arrival)
-"ht" = (
-/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"gJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/crew)
+"gK" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/iron/dark,
-/area/ruin/space/derelict/medical/chapel)
-"hu" = (
-/obj/machinery/door/airlock/medical{
-	name = "Morgue";
-	req_access_txt = "6"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/medical/chapel)
-"hv" = (
+/area/ruin/space/derelict/service)
+"gL" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
 /area/ruin/space/derelict/medical)
-"hw" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating/airless,
+"gM" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"hx" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+"gN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"gO" = (
+/obj/machinery/door/airlock/medical{
+	name = "Cryogenic";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"gR" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"gS" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/medical)
-"hy" = (
-/obj/item/shard,
-/obj/structure/grille/broken,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/medical)
-"hz" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/medical)
-"hA" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/medical)
-"hB" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "External Engineering"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"hD" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"hE" = (
-/obj/machinery/door/window{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"hF" = (
+/area/ruin/space/derelict/service)
+"gT" = (
 /obj/structure/table,
-/obj/machinery/computer/pod/old{
-	id = "derelict_gun";
-	name = "ProComp IIe";
-	pixel_y = 7
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"gV" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/iron/chapel,
-/area/ruin/space/derelict/medical/chapel)
-"hG" = (
-/obj/machinery/door/morgue{
-	name = "coffin storage";
-	req_access_txt = "22"
+/area/ruin/space/derelict/departures)
+"gW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/medical/chapel)
-"hH" = (
-/obj/structure/bodycontainer/morgue,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/medical/chapel)
-"hI" = (
-/turf/open/floor/iron/white/airless,
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"gZ" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/service)
+"hb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/medical)
-"hJ" = (
-/obj/item/bot_assembly/medbot,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"hL" = (
-/obj/structure/frame/computer,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
+"hc" = (
+/obj/machinery/vending/wallmed/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
+/turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"hM" = (
-/obj/machinery/light/directional/north,
-/obj/item/shard{
-	icon_state = "small"
+"hd" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"he" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/space/derelict/departures)
+"hf" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"hg" = (
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"hh" = (
+/obj/machinery/photocopier,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"hi" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"hj" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/medical)
-"hN" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/area/ruin/space/derelict/singularity_engine)
-"hP" = (
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
-"hQ" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/grille,
-/turf/template_noop,
-/area/template_noop)
-"hS" = (
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical/chapel)
-"hT" = (
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/ruin/space/derelict/medical/chapel)
-"hU" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/ruin/space/derelict/medical/chapel)
-"hV" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"hW" = (
-/obj/item/stack/medical/bruise_pack,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"hX" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/medical)
-"hY" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/medical)
-"hZ" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/medical)
-"ia" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/template_noop)
-"ib" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating/airless,
-/area/template_noop)
-"ic" = (
+"hk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
+"hl" = (
 /obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/cell_charger,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"hm" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/stamp{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/stamp/denied{
+	pixel_x = 9
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"id" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"if" = (
-/obj/structure/chair{
-	dir = 4
+/area/ruin/space/derelict/cargo)
+"ho" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/turf/open/floor/iron/chapel,
-/area/ruin/space/derelict/medical/chapel)
-"ii" = (
-/turf/open/floor/iron/chapel{
+/obj/structure/chair,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"hq" = (
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
 	},
-/area/ruin/space/derelict/medical/chapel)
-"ij" = (
-/turf/open/floor/iron/chapel,
-/area/ruin/space/derelict/medical/chapel)
-"ik" = (
-/obj/structure/chair,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
 	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"hr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/security)
+"ht" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"hw" = (
+/obj/machinery/vending/cart,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"hx" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/security)
+"hA" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"hC" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"hD" = (
+/turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"im" = (
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"in" = (
-/obj/effect/mob_spawn/ghost_role/drone/derelict,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"ip" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+"hE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/area/ruin/space/derelict/hallway/primary)
-"iq" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/template_noop)
-"ir" = (
-/obj/structure/chair{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"is" = (
-/obj/structure/chair{
-	dir = 1
+/area/ruin/space/derelict/security)
+"hF" = (
+/obj/structure/chair/office,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
+/area/ruin/space/derelict/security)
+"hG" = (
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 1
+	},
+/obj/machinery/computer/department_orders/security{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/security)
+"hI" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"hJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"hL" = (
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"hN" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"hO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"hP" = (
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"hQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"hS" = (
+/obj/structure/table,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"hT" = (
+/obj/item/construction/rcd,
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/ruin/space/derelict/departures)
+"hU" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"hV" = (
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/autolathe,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"hX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"hZ" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ia" = (
+/obj/structure/table,
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/blood_filter,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"ib" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ic" = (
+/obj/structure/frame/computer,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"id" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"ie" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft{
+	req_access_txt = "69"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
+"if" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/security)
+"im" = (
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"in" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"ip" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/security)
+"iq" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/defibrillator/loaded,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"ir" = (
+/obj/effect/turf_decal/siding/thinplating/end,
+/obj/machinery/modular_computer/console/preset/cargochat/security{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/security)
+"is" = (
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "it" = (
-/obj/structure/window/reinforced,
-/turf/template_noop,
-/area/template_noop)
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "iu" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/plasma/five,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"iv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/security)
+"iw" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"ix" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"iz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"iA" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"iB" = (
+/obj/structure/sign/warning/docking,
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/departures)
+"iD" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/cargo)
+"iE" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"iF" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/hallway_primary)
+"iG" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"iH" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	name = "Cargo Desk";
+	req_access_txt = "31"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"iI" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"iJ" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
+"iK" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"iL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"iN" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"iO" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"iP" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"iQ" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"iR" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"iT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"iV" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"iW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"iX" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"iY" = (
+/obj/machinery/processor/slime,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"ja" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/computer/camera_advanced/xenobio{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"jd" = (
+/obj/machinery/smartfridge/extract/preloaded,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"jf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"jg" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"jj" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	req_one_access_txt = "31;48"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"jk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"jm" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"jo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"jp" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
 /turf/template_noop,
 /area/template_noop)
-"iw" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical/chapel)
-"ix" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/ruin/space/derelict/medical/chapel)
-"iA" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"iB" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/item/reagent_containers/glass/beaker,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"iC" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"iD" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"iE" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/white/airless,
-/area/ruin/unpowered/no_grav)
-"iG" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"iH" = (
-/obj/machinery/door/poddoor{
-	id = "derelict_gun";
-	name = "Derelict Mass Driver"
-	},
-/turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
-"iI" = (
-/turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
-"iJ" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical/chapel)
-"iK" = (
-/obj/machinery/mass_driver{
-	dir = 8;
-	id = "derelict_gun"
-	},
-/obj/machinery/door/window{
-	dir = 4;
-	req_access_txt = "25"
-	},
-/obj/structure/closet/crate/coffin,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical/chapel)
-"iL" = (
-/obj/item/shard{
-	icon_state = "small"
-	},
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"iM" = (
-/obj/item/stack/medical/bruise_pack,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/medical)
-"iN" = (
-/obj/item/stack/medical/ointment,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/medical)
-"iO" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/medical)
-"iP" = (
-/obj/structure/closet/l3closet,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"iQ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"iR" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/template_noop,
-/area/template_noop)
-"iT" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/grille,
-/turf/template_noop,
-/area/template_noop)
-"iV" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical/chapel)
-"iW" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/ruin/space/derelict/medical/chapel)
-"iX" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical/chapel)
-"iY" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"iZ" = (
-/obj/item/cigbutt,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"ja" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Med-Sci";
-	req_access_txt = "9"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/medical)
-"jb" = (
-/obj/structure/table,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"jd" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"jf" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"jg" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"ji" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"jj" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/medical)
-"jk" = (
-/obj/item/reagent_containers/glass/beaker,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/medical)
-"jm" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"jn" = (
-/obj/item/shard,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"jo" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"jp" = (
-/turf/open/floor/iron/white/airless,
-/area/ruin/unpowered/no_grav)
 "jr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 8;
+	output_dir = 4
 	},
-/area/ruin/space/derelict/hallway/primary)
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
 "js" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/geiger_counter,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
 "jt" = (
-/obj/item/pen,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
+/area/ruin/space/derelict/hallway_primary)
 "ju" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/chapel{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical/chapel)
-"jv" = (
-/obj/machinery/door/window{
-	dir = 8
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/medical/chapel)
-"jw" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/medical/chapel)
-"jx" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/medical/chapel)
-"jy" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/medical/chapel)
-"jz" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"jA" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/bed,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"jB" = (
-/obj/item/stack/medical/ointment,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"jC" = (
-/obj/structure/bed,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"jD" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/medical)
-"jE" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medical"
-	},
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"jF" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"jG" = (
-/obj/structure/window/fulltile,
-/turf/template_noop,
-/area/ruin/unpowered/no_grav)
-"jH" = (
 /obj/machinery/light/directional/west,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"jI" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"jJ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"jK" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"jL" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/medical/chapel)
-"jM" = (
-/obj/machinery/door/window,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/medical/chapel)
-"jN" = (
-/obj/machinery/door/window/southleft,
-/obj/structure/cable,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"jO" = (
-/obj/machinery/door/window/southright,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"jQ" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Research";
-	req_access_txt = "7"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"jR" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"jS" = (
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"jT" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/template_noop,
-/area/ruin/unpowered/no_grav)
-"jU" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Arrivals Docking Bay 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"jV" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/unpowered/no_grav)
-"jX" = (
-/obj/structure/cable,
-/turf/open/floor/iron/airless{
-	icon_state = "floorscorched1"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"jY" = (
-/turf/open/floor/iron/airless{
-	icon_state = "floorscorched1"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"jZ" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"ka" = (
-/obj/structure/frame/computer,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kb" = (
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/unpowered/no_grav)
-"kd" = (
-/obj/structure/window/fulltile,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"kf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/unpowered/no_grav)
-"kg" = (
-/obj/structure/window/fulltile,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"kh" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Research";
-	req_access_txt = "7"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/arrival)
-"ki" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"kj" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"kl" = (
-/obj/machinery/door/airlock/command{
-	name = "Teleporter Room"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/medical/chapel)
-"km" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless{
-	icon_state = "floorscorched1"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"ko" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kp" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kq" = (
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kr" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"ks" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"kw" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kx" = (
-/obj/machinery/door/airlock/vault/derelict,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"kB" = (
-/obj/structure/window/fulltile,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/arrival)
-"kC" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"kD" = (
-/obj/machinery/door/window,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kF" = (
-/obj/effect/spawner/random/maintenance,
-/turf/template_noop,
-/area/ruin/space/derelict/hallway/primary/port)
-"kI" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"kJ" = (
-/obj/structure/girder,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kK" = (
-/obj/structure/girder,
-/turf/open/floor/iron/airless,
-/area/ruin/unpowered/no_grav)
-"kL" = (
-/obj/structure/window/fulltile,
-/turf/template_noop,
-/area/template_noop)
-"kM" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"kN" = (
-/obj/structure/bed,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kO" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kP" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kQ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kR" = (
-/obj/machinery/door/airlock/security{
-	name = "Security";
-	req_access_txt = "1"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kS" = (
-/obj/machinery/door/window,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"kT" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"kU" = (
-/obj/item/cigbutt,
-/turf/template_noop,
-/area/template_noop)
-"kV" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"kX" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kY" = (
-/obj/machinery/vending/sovietsoda,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"kZ" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"la" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"lc" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"ld" = (
-/obj/structure/lattice,
-/obj/item/stack/cable_coil/cut,
-/turf/template_noop,
-/area/template_noop)
-"le" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"lf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"lh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Atmospherics Access";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"li" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"lj" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"ll" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"ln" = (
-/obj/item/stock_parts/manipulator{
-	pixel_x = -15;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/manipulator,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"lp" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"lq" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker{
-	list_reagents = list(/datum/reagent/toxin/acid = 50)
-	},
-/obj/item/paper/crumpled/bloody/ruins/thederelict/unfinished,
-/obj/item/pen,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"lr" = (
-/obj/structure/table,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"ls" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/atmospherics)
-"lt" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"lu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"lv" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/atmospherics)
-"lw" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine/air{
-	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
-	},
-/area/ruin/space/derelict/atmospherics)
-"lx" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/atmospherics)
-"ly" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/atmospherics)
-"lz" = (
-/turf/template_noop,
-/area/ruin/space/derelict/hallway/primary/port)
-"lA" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/ruin/space/derelict/hallway/primary/port)
-"lB" = (
-/obj/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"lC" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"lD" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"lE" = (
-/obj/structure/bed,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"lF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"lG" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"lH" = (
-/obj/item/ammo_casing/a357,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"lI" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"lJ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"lK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"lL" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"lN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber,
-/turf/open/floor/engine/air{
-	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
-	},
-/area/ruin/space/derelict/atmospherics)
-"lO" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
-	name = "engine outlet injector"
-	},
-/turf/open/floor/engine/air{
-	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
-	},
-/area/ruin/space/derelict/atmospherics)
-"lP" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Atmospherics Access";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"lQ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"lT" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/atmospherics)
-"lU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"lV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+/area/ruin/space/derelict/security)
+"jv" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/port/central)
+"jB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"lX" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"lY" = (
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"lZ" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Escape Airlock"
+/area/ruin/space/derelict/maintenance/port)
+"jC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"ma" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"mb" = (
-/obj/structure/lattice,
-/obj/item/stack/cable_coil/cut,
-/turf/template_noop,
-/area/ruin/space/derelict/hallway/primary/port)
-"mc" = (
-/obj/machinery/door/window{
+/area/template_noop)
+"jD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"md" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/hallway/secondary)
-"me" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mf" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/hallway/secondary)
-"mg" = (
-/obj/structure/window/reinforced{
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"jE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"mh" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"mi" = (
-/obj/item/ammo_casing/a357{
-	pixel_x = -5
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"jF" = (
+/obj/machinery/flasher/directional/south{
+	id = "Cell 2"
 	},
-/obj/item/ammo_casing/a357{
-	pixel_x = 5;
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"jG" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"jH" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/research)
+"jI" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/high{
 	pixel_y = 6
 	},
-/obj/item/ammo_casing/a357,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"mj" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"mk" = (
-/turf/open/floor/iron/airless{
-	icon_state = "floorscorched1"
+/obj/item/hand_tele,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"jJ" = (
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"jK" = (
+/obj/structure/closet/secure_closet/cytology,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"jL" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
 	},
-/area/ruin/space/derelict/atmospherics)
-"ml" = (
-/obj/structure/window/fulltile,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mm" = (
-/obj/structure/grille,
-/obj/item/shard,
-/obj/item/shard{
-	icon_state = "medium"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "engimaintport"
 	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"jM" = (
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Lab";
+	req_access_txt = "55"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"jO" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"jP" = (
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"jQ" = (
+/turf/open/floor/iron/dark/telecomms,
+/area/ruin/space/derelict/research)
+"jR" = (
+/obj/machinery/rnd/server/master,
+/turf/open/floor/circuit/telecomms/server,
+/area/ruin/space/derelict/research)
+"jS" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "31"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"jT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"jU" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	req_one_access_txt = "31;48"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"jV" = (
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"mn" = (
+/area/template_noop)
+"jY" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"jZ" = (
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"ka" = (
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"kb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"kc" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"kd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ke" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"kf" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_one_access_txt = "31;48"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"kg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"kh" = (
+/obj/machinery/rnd/production/techfab/department/security,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"ki" = (
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	name = "Cell 1";
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"kj" = (
+/obj/machinery/computer/security/wooden_tv,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"km" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"kn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"ko" = (
+/obj/item/storage/secure/safe/directional/north,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/security/detective)
+"kp" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"kq" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/security/detective)
+"kr" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/destructive_scanner,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ks" = (
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"kt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"kv" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/item/tank/internals/emergency_oxygen/empty,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"kw" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"kA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"kB" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/research)
+"kC" = (
+/obj/structure/sign/warning/biohazard{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"kD" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"kE" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"mo" = (
-/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/service)
+"kF" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white/side{
+	dir = 10
+	},
+/area/ruin/space/derelict/research)
+"kI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/airless,
-/area/ruin/space/derelict/atmospherics)
-"mp" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
+/area/ruin/space/derelict/departures)
+"kJ" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"kK" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"kL" = (
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/timer,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"kM" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
 	},
-/area/ruin/space/derelict/atmospherics)
-"mq" = (
-/turf/open/floor/iron{
-	icon_state = "damaged2";
-	initial_gas_mix = "TEMP=2.7"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"kO" = (
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"kP" = (
+/obj/machinery/modular_computer/console/preset/cargochat/engineering,
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 8
 	},
-/area/ruin/space/derelict/atmospherics)
-"mr" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"kQ" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"kR" = (
+/obj/structure/chair/office{
+	dir = 4
 	},
-/area/ruin/space/derelict/atmospherics)
-"ms" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
 	},
-/area/ruin/space/derelict/atmospherics)
-"mt" = (
-/obj/structure/window/fulltile,
-/turf/template_noop,
-/area/ruin/space/derelict/atmospherics)
-"mu" = (
-/obj/item/stack/rods,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mv" = (
-/obj/item/shard{
-	icon_state = "small"
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/security/detective)
+"kS" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = -3;
+	pixel_y = 7
 	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 3
+	},
+/obj/item/lighter,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/security/detective)
+"kT" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"kU" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "7"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research)
+"kV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"kX" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"kZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"la" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"lc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white/side{
+	dir = 10
+	},
+/area/ruin/space/derelict/research)
+"ld" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"lf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"lh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"li" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research)
+"lj" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/research)
+"ll" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"lr" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"lu" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/security/detective)
+"lv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"lw" = (
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"lx" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/rack,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"ly" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"lz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/template_noop)
-"mw" = (
-/obj/structure/frame/computer,
-/obj/structure/window/reinforced{
+"lA" = (
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"lB" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"lC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"lD" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/atmospherics)
-"mx" = (
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/atmospherics)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"lE" = (
+/obj/structure/closet/secure_closet/detective,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"lF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"lJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"lK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"lM" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"lN" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"lO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"lP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"lQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/security/detective)
+"lU" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"lV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"lW" = (
+/obj/structure/table,
+/obj/item/storage/box/masks{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"lX" = (
+/obj/structure/table/wood,
+/obj/item/camera/detective,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/security/detective)
+"lY" = (
+/obj/machinery/lapvend,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"lZ" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"mb" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/research)
+"mc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/rnd/destructive_analyzer,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"md" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"me" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"mf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/rnd/production/protolathe/department/science,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"mg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"mh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"mi" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"mk" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/port/central)
+"ml" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"mm" = (
+/turf/open/floor/iron/white/side{
+	dir = 9
+	},
+/area/ruin/space/derelict/research)
+"mn" = (
+/obj/machinery/suit_storage_unit/rd,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"mo" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/starboard)
+"mp" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"mq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"mr" = (
+/obj/machinery/computer/rdservercontrol{
+	dir = 8
+	},
+/obj/machinery/door/window/westleft{
+	req_access_txt = "30"
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"ms" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"mt" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"mu" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"mv" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"mw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
 "my" = (
-/obj/machinery/light/directional/north,
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
+/obj/machinery/computer/prisoner/management{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "mz" = (
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"mA" = (
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"mB" = (
+/obj/machinery/vending/security,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"mC" = (
+/obj/structure/filingcabinet/security,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"mD" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"mF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"mG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"mH" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"mI" = (
+/obj/machinery/flasher/directional/south{
+	id = "Cell 1"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"mJ" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/medical)
+"mK" = (
+/obj/machinery/chem_heater/withbuffer,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"mL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"mN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"mP" = (
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"mT" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"mU" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"mV" = (
+/obj/machinery/vending/wardrobe/det_wardrobe,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"mY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"nc" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"nd" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
 /obj/structure/lattice,
 /turf/template_noop,
-/area/ruin/space/derelict/atmospherics)
-"mA" = (
-/obj/item/stack/cable_coil/cut,
-/turf/template_noop,
-/area/ruin/space/derelict/hallway/primary/port)
-"mB" = (
-/obj/structure/door_assembly/door_assembly_mai{
-	name = "airlock assembly"
+/area/template_noop)
+"ne" = (
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"nf" = (
+/obj/machinery/vending/modularpc,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ng" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mC" = (
-/obj/item/wirecutters,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mD" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/research)
+"nh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/computer/rdconsole{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mF" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"mG" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/atmospherics)
-"mI" = (
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mJ" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"mL" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"mM" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/atmospherics)
-"mN" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged1"
-	},
-/area/ruin/space/derelict/atmospherics)
-"mP" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"mT" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/atmospherics)
-"mU" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mV" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mW" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aux Storage";
-	req_access_txt = "23"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"mZ" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"na" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"nc" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"ne" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict9"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"nf" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict10"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"ng" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict11"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"nh" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict12"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
 "ni" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict13"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
 "nj" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict14"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/obj/machinery/drone_dispenser/derelict,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
 "nk" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict15"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "nl" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict16"
-	},
-/obj/structure/cable,
+/obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/area/ruin/space/derelict/departures)
+"nn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
 "no" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict1"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/obj/structure/table/wood,
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
 "np" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict2"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/obj/effect/spawner/random/structure/closet_private,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
 "nq" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict3"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/obj/machinery/vending/clothing,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
 "nr" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict4"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
 "ns" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict5"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/obj/structure/table/wood,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
 "nt" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict6"
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
 	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "nu" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict7"
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
 	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "nv" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict8"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"ny" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"nz" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"nA" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"nB" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/se_solar)
-"nC" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Aft Solar Access";
-	req_access_txt = "10"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
-"nD" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Escape Airlock"
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"nF" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
-"nG" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"nH" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office";
+	req_access_txt = "4"
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"nw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"ny" = (
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/service)
+"nz" = (
+/obj/structure/reflector/box/anchored{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"nI" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/se_solar)
-"nJ" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/se_solar)
-"nL" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"nM" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/se_solar)
-"nN" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"nO" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
-"nQ" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"nA" = (
+/obj/machinery/door/airlock/research{
+	name = "Production";
+	req_access_txt = "47"
 	},
-/area/ruin/space/derelict/se_solar)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nD" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nE" = (
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"nF" = (
+/obj/machinery/mass_driver/ordnance{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research)
+"nG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research)
+"nH" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research)
+"nI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/item/light/tube/broken,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"nJ" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"nK" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
+"nL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"nM" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"nN" = (
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/dorms_double{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
+"nO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
+"nQ" = (
+/obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
 "nR" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
 "nS" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/washing_machine,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
 "nT" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -3028,742 +3337,5643 @@
 /turf/template_noop,
 /area/template_noop)
 "nU" = (
-/obj/machinery/power/terminal{
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"nV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"nX" = (
+/obj/effect/turf_decal/tile/red/half{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/mob_spawn/ghost_role/drone/derelict,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
-"nV" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/se_solar)
-"nX" = (
-/obj/item/storage/toolbox/syndicate,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/hallway_primary)
 "nY" = (
-/obj/machinery/power/solar_control{
-	dir = 1;
-	id = "derelictsolar";
-	name = "Primary Solar Control"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "nZ" = (
-/obj/machinery/power/apc/unlocked{
-	dir = 8;
-	environ = 0;
-	equipment = 0;
-	lighting = 0;
-	name = "Worn-out APC";
-	pixel_x = -25
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "oa" = (
-/obj/item/paper/fluff/ruins/thederelict/syndie_mission,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/area/ruin/space/derelict/se_solar)
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "ob" = (
-/obj/machinery/light/small/directional/east,
-/obj/item/clothing/head/helmet/space/eva,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "oc" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side,
+/area/ruin/space/derelict/research)
+"od" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
 "oe" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
 "of" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right"
+/obj/machinery/door/window/northleft{
+	req_access_txt = "8"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
+	pixel_x = -24
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
 "og" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right"
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research)
 "oh" = (
-/obj/item/clothing/suit/space/eva,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
 "oi" = (
-/obj/effect/decal/remains/human{
-	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	name = "Syndicate agent remains"
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitory"
 	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"oj" = (
+/obj/machinery/photocopier,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
 "ok" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "ol" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/template_noop,
-/area/solars/derelict_aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "on" = (
-/obj/machinery/power/solar{
-	id = "derelictsolar";
-	name = "Derelict Solar Array"
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/solars/derelict_aft)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
 "op" = (
-/obj/machinery/power/solar{
-	id = "derelictsolar";
-	name = "Derelict Solar Array"
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/area/solars/derelict_aft)
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/research)
 "oq" = (
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg2"
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
 	},
-/area/solars/derelict_aft)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/ruin/space/derelict/research)
+"ot" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ox" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/item/shovel/spade,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
 "oy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"oz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"oC" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8;
+	filter_type = list(/datum/gas/nitrogen)
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"oD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"oE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"oF" = (
+/obj/structure/table/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"oK" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 10
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
+"oL" = (
+/obj/machinery/gravity_generator/main/station,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"oO" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"oR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"oS" = (
+/obj/structure/reflector/single/anchored{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"oV" = (
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/table,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"oX" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"pc" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"pe" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/service)
+"pk" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"pu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"pv" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"pA" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/arrival)
+"pB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"pD" = (
+/obj/structure/chair/stool/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"pF" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/ruin/space/derelict/arrival)
+"pH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"pJ" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/security)
+"pM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/binary/pressure_valve/on{
+	dir = 4;
+	name = "Output Release"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"pZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"qa" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"qb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"qh" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"qi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"qk" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/ce,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"ql" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"qm" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "25"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"qo" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"qp" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"qv" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"qx" = (
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/departures)
+"qy" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"qz" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"qN" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"qO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"qP" = (
+/obj/machinery/vending/medical,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"qW" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"ra" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"rb" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"re" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"rf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"rg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"rh" = (
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"ri" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"rj" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"rk" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"rl" = (
+/obj/item/crowbar/large,
+/obj/structure/rack,
+/obj/item/flashlight,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"rp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "External Gas to Loop"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"rs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"rt" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"ry" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"rA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"rB" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
+"rC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/doppler_array/research/science{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/ordnance{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"rK" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"rL" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"rN" = (
+/obj/effect/turf_decal/tile/green/half{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/medical)
+"rO" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"rP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"rQ" = (
+/obj/machinery/stasis,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"rU" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"rV" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"rY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict11"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"sa" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"sb" = (
+/obj/machinery/telecomms/broadcaster/preset_left/birdstation,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"sc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"sd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"se" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard)
+"sj" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/hallway_primary)
+"sk" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"sl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"sp" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"st" = (
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"sv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/textured_large,
+/area/ruin/space/derelict/hallway_primary)
+"sD" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/collectable/tophat,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/service)
+"sE" = (
+/obj/machinery/telecomms/processor/preset_one/birdstation,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"sG" = (
+/obj/machinery/vending/wallmed/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"sH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"sJ" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"sM" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/kitchen/fork,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"sN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/flat_white,
+/area/ruin/space/derelict/medical)
+"sO" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/item/chair,
+/turf/open/floor/iron/white/corner/airless{
+	dir = 8
+	},
+/area/ruin/space/derelict/departures)
+"sQ" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"sT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"sX" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard)
+"tb" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"tc" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Gas to Mix"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"tl" = (
+/obj/machinery/telecomms/hub/preset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"tm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"tp" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock";
+	space_dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"tr" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/template_noop,
+/area/template_noop)
+"tu" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/moth_epi{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"tx" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"tz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"tA" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Pharmacy";
+	req_access_txt = "69"
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"tC" = (
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"tF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/medical)
+"tH" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"tI" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Custodial Maintenance";
+	req_access_txt = "26"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"tK" = (
+/obj/structure/closet/toolcloset,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"tM" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"tP" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"tQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"tS" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"tV" = (
+/obj/structure/sign/barsign,
+/turf/closed/wall,
+/area/ruin/space/derelict/service)
+"tX" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"tZ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Gas to Chamber"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"uc" = (
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"ud" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"uf" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/crew)
+"uj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
+"uk" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/seed_extractor,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/service)
+"ul" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"uq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"uu" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/item/multitool,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"ux" = (
+/obj/machinery/vending/dinnerware,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"uy" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior{
+	name = "Burn Chamber Exterior Airlock"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research)
+"uz" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ruin/space/derelict/research)
+"uA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor/flat_white,
+/area/ruin/space/derelict/medical)
+"uB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
+"uH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"uK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"uO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"uP" = (
+/obj/structure/table,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"uW" = (
+/obj/structure/table,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/side{
+	dir = 5
+	},
+/area/ruin/space/derelict/medical)
+"uY" = (
+/obj/machinery/rnd/production/techfab/department/medical,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"vc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"vd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"vf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"vh" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"vj" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/hallway_primary)
+"vk" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"vl" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"vn" = (
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"vo" = (
+/obj/structure/table/wood,
+/obj/item/storage/dice,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
+"vr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"vB" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"vC" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"vD" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/item/shovel/spade,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
+"vG" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitory"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"vP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research)
+"vV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"vZ" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"wa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/ruin/space/derelict/arrival)
+"wb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"wi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"wj" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"wr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"ws" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/ruin/space/derelict/arrival)
+"wv" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"wx" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"wz" = (
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"wF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"wK" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"wN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"wO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Engine Coolant Bypass"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"wS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"wT" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"wY" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"wZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict14"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"xa" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"xb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"xc" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"xf" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"xi" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"xj" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"xm" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/service)
+"xo" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/security/detective)
+"xp" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"xx" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard)
+"xy" = (
+/obj/structure/closet/secure_closet/medical1,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"xz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/moth_delam{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"xB" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"xI" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"xK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/medical)
+"xP" = (
+/obj/structure/disposalpipe/trunk,
+/obj/structure/lattice/catwalk,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"xQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/arrival)
+"xT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"xU" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"xX" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"yb" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"yd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"yk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict13"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"yn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Bar";
+	req_access_txt = "25"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"yq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict16"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"yr" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"ys" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/heater/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"yt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"yu" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"yv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"yw" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"yx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"yy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"yC" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"yD" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_edge,
+/area/ruin/space/derelict/hallway_primary)
+"yE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"yI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"yK" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white/corner/airless{
+	dir = 8
+	},
+/area/ruin/space/derelict/departures)
+"yL" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/item/lighter/greyscale{
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/arrival)
+"yN" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"yO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Cooling Loop to Gas"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"yR" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"yT" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"yW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"yZ" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"za" = (
+/obj/machinery/airlock_sensor/incinerator_ordmix{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research)
+"zc" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Foyer";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"zg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/ruin/space/derelict/research)
+"zh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"zo" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"zp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 9
+	},
+/area/ruin/space/derelict/research)
+"zv" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"zx" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"zz" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"zB" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"zG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"zJ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"zK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"zL" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
+"zO" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"zS" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/medical)
+"zZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/EVA)
+"Ab" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Ad" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/template_noop,
+/area/ruin/space/derelict/maintenance/port)
+"Ai" = (
+/obj/machinery/pdapainter,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"Aj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"Ak" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = list(25)
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Al" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Ao" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Ap" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Ar" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"As" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"Au" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/camera,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/arrival)
+"Av" = (
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
-/area/solars/derelict_aft)
-"oz" = (
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/solars/derelict_aft)
-"oD" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/solars/derelict_aft)
-"oE" = (
-/obj/structure/frame/computer{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"pZ" = (
-/obj/machinery/air_sensor/atmos/air_tank,
-/turf/open/floor/engine/air{
-	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
-	},
-/area/ruin/space/derelict/atmospherics)
-"rC" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/mineral/titanium{
-	amount = 15
-	},
-/obj/item/stack/sheet/mineral/wood/fifty,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"rK" = (
-/turf/template_noop,
-/area/ruin/space/derelict/medical)
-"sd" = (
-/obj/structure/chair/stool/directional/south,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"tc" = (
-/obj/item/wallframe/airalarm,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"tS" = (
-/turf/template_noop,
-/area/ruin/unpowered/no_grav)
-"ux" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/singularity_engine)
-"uz" = (
-/obj/structure/rack,
-/obj/machinery/light/small/directional/north,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"vf" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/template_noop)
-"vo" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/mineral/gold{
-	amount = 15
-	},
-/obj/item/stack/sheet/mineral/silver{
-	amount = 15
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"vC" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/template_noop,
-/area/template_noop)
-"vG" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/chapel{
-	dir = 1
-	},
-/area/ruin/space/derelict/medical/chapel)
-"wr" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"wK" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/ruin/space/derelict/se_solar)
-"xa" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"xi" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/template_noop,
-/area/ruin/unpowered/no_grav)
-"xr" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"xI" = (
-/obj/structure/table,
-/obj/machinery/light/small/directional/east,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"yd" = (
-/obj/effect/spawner/random/structure/crate_abandoned,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/access)
-"yE" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"yH" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"yP" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary)
-"zg" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"zp" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged5"
-	},
-/area/ruin/space/derelict/singularity_engine)
-"zB" = (
-/obj/structure/table,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"zJ" = (
-/obj/structure/closet/wardrobe/orange,
-/obj/effect/spawner/random/maintenance/two,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"Av" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"AA" = (
-/obj/structure/rack,
-/obj/item/melee/baton,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"Ba" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"Bf" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
-	},
-/area/template_noop)
-"Bs" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance/eight,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"Bx" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
-	},
-/area/template_noop)
-"BO" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/solarpanel/airless,
-/area/template_noop)
-"CZ" = (
-/obj/item/clothing/suit/space/eva,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/bridge/ai_upload)
-"DE" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Escape Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"DX" = (
-/obj/machinery/light/directional/south,
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"El" = (
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
-"Ev" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/template_noop)
-"ES" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"FU" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
+/area/ruin/space/derelict/departures)
+"Aw" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Ax" = (
+/obj/structure/window/reinforced/plasma{
 	dir = 4
 	},
-/obj/effect/spawner/random/maintenance,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"AA" = (
+/obj/structure/closet/crate/bin,
+/obj/item/wallframe/light_fixture,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/derelict/departures)
+"AB" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"Gu" = (
-/obj/structure/grille,
+/area/ruin/space/derelict/service/janitor)
+"AG" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"AH" = (
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"AJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"AK" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
 /turf/template_noop,
 /area/template_noop)
-"Gz" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance,
+"AN" = (
+/obj/structure/girder,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"AO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/EVA)
+"AP" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"AS" = (
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"AV" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"GM" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/ruin/unpowered/no_grav)
-"GP" = (
-/obj/structure/cable,
+/area/ruin/space/derelict/EVA)
+"AW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"Hl" = (
-/obj/structure/closet/wardrobe/mixed,
-/obj/effect/spawner/random/maintenance/two,
+/area/ruin/space/derelict/departures)
+"AZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"Ba" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"Bc" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Bd" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"Bf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Bg" = (
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"Hx" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"HF" = (
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/secondary)
-"Ih" = (
-/turf/open/floor/iron/airless{
-	icon_state = "damaged3"
+"Bh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
 	},
-/area/ruin/space/derelict/hallway/primary/port)
-"Ik" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/beanie/rasta,
-/obj/item/clothing/head/beanie/black,
-/obj/item/clothing/head/beanie/christmas,
-/obj/item/clothing/head/beanie/darkblue,
-/obj/item/clothing/head/beanie/red,
-/obj/item/clothing/head/beanie/waldo,
-/obj/item/clothing/head/bearpelt,
-/obj/item/clothing/head/beret,
-/obj/item/clothing/head/bomb_hood,
-/obj/item/clothing/head/bunnyhead,
-/obj/item/clothing/head/cardborg,
-/obj/item/clothing/head/cone,
-/obj/item/clothing/head/festive,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/sec,
-/obj/item/clothing/head/jester,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/head/papersack,
-/obj/item/clothing/head/rabbitears,
-/obj/item/clothing/head/snowman,
-/obj/item/clothing/head/sombrero,
-/obj/item/clothing/head/wig,
-/obj/item/clothing/head/wizard/fake,
-/obj/item/clothing/head/wizard/santa,
-/obj/item/clothing/head/xenos,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"IA" = (
-/turf/open/floor/iron/airless{
-	icon_state = "floorscorched2"
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/arrival)
+"Bi" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Bm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/area/template_noop)
-"Jl" = (
-/obj/effect/spawner/random/maintenance,
-/turf/template_noop,
-/area/template_noop)
-"Kf" = (
-/obj/item/paper/fluff/ruins/thederelict/vaultraider,
-/obj/effect/decal/remains/human{
-	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	name = "Syndicate agent remains"
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Bs" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Bt" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Bv" = (
+/obj/structure/mirror/directional/north,
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/area/ruin/space/derelict/bridge/ai_upload)
-"KN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/hallway_primary)
+"Bx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"By" = (
 /turf/closed/wall,
-/area/ruin/space/derelict/hallway/primary/port)
-"KP" = (
-/obj/item/language_manual/dronespeak_manual,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"KS" = (
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
-"KT" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"Le" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Arrivals Docking Bay 1"
+/area/ruin/space/derelict/service)
+"BB" = (
+/obj/machinery/airalarm/engine{
+	dir = 8;
+	pixel_x = -23
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Filter"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"BE" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"BK" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plating,
+/area/template_noop)
+"BM" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes{
+	pixel_y = 8
+	},
+/obj/structure/sign/poster/official/moth_meth{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"BP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Cooling Loop Bypass"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"BR" = (
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 4
+	},
+/obj/machinery/computer/department_orders/medical,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"BS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"Lr" = (
-/obj/machinery/computer/vaultcontroller{
+"BT" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"BU" = (
+/obj/effect/turf_decal/siding/thinplating/end,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"BV" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/turf/open/floor/iron/white/smooth_edge,
+/area/ruin/space/derelict/hallway_primary)
+"Ch" = (
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/ruin/space/derelict/arrival)
+"Cn" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Co" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict6"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Cq" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 8
 	},
-/obj/structure/cable,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Cr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Cv" = (
+/obj/machinery/air_sensor/atmos/air_tank,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/ruin/space/derelict/engineering)
+"Cy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/barricade/sandbags,
 /turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
+/area/ruin/space/derelict/departures)
+"Cz" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"CC" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"CG" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"CN" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"CT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"CY" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/service)
+"Db" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"Dc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Dj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"Dl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/light/directional/east,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Dm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/departures)
+"Dn" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"Dp" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Ds" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research/xenobiology)
+"Dt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
+"Du" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"Dx" = (
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"DB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"DC" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"DE" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/coin,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen,
+/obj/item/razor{
+	pixel_y = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"DF" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/vending/drugs,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"DH" = (
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"DM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"DN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"DR" = (
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"DX" = (
+/obj/machinery/bookbinder,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"Ef" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output,
+/turf/open/floor/engine/air,
+/area/ruin/space/derelict/engineering)
+"El" = (
+/obj/machinery/photocopier,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"En" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Ep" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Eq" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine/air,
+/area/ruin/space/derelict/engineering)
+"Es" = (
+/obj/structure/reflector/double/anchored{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Ev" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"Ey" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"EB" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"ED" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"EF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"EH" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict8"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"EN" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/security)
+"EP" = (
+/obj/machinery/telecomms/server/presets/common/birdstation,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"ER" = (
+/obj/machinery/vending/boozeomat,
+/obj/structure/sign/picture_frame/portrait/bar{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/service)
+"EU" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"EZ" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"Fd" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"Ff" = (
+/obj/effect/turf_decal/loading_area/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/arrival)
+"Fi" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Fm" = (
+/obj/machinery/power/supermatter_crystal/shard/engine,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Fp" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/service)
+"Fr" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"Ft" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"Fw" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict5"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"FI" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/bot_white/left,
+/obj/structure/window/spawner/east,
+/turf/open/floor/iron/white/smooth_large,
+/area/ruin/space/derelict/medical)
+"FL" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/research/xenobiology)
+"FM" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/service)
+"FO" = (
+/obj/structure/chair/stool/directional/north,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"FS" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"FU" = (
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab";
+	req_access_txt = "8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"FY" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"FZ" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Gb" = (
+/obj/structure/table,
+/obj/item/paper_bin/carbon{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/stamp/hop,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"Gc" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	base_state = "rightsecure";
+	icon_state = "rightsecure";
+	name = "Head of Personnel's Desk";
+	req_access_txt = "57"
+	},
+/obj/machinery/door/window/northleft{
+	name = "Reception Window"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
+"Gd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Ge" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Gf" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Gh" = (
+/obj/structure/table/reinforced/rglass,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Gl" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"Gm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Gr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"Gs" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Gu" = (
+/obj/machinery/computer/department_orders/science{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Gv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Gz" = (
+/obj/machinery/modular_computer/console/preset/cargochat/science{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"GA" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"GC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"GD" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"GI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"GK" = (
+/obj/machinery/chem_mass_spec,
+/obj/structure/sign/poster/official/periodic_table{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"GM" = (
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
+"GN" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"GR" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"GT" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access_txt = "26"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"GU" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"GY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"GZ" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Hd" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"He" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "External Gas to Loop"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Hi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"Hj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Hl" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Ho" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Hr" = (
+/obj/machinery/rnd/production/techfab/department/service,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Ht" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/template_noop,
+/area/template_noop)
+"Hu" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/iron/white/smooth_large,
+/area/ruin/space/derelict/medical)
+"Hv" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Hw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Hx" = (
+/obj/structure/sign/warning/docking,
+/turf/closed/wall,
+/area/ruin/space/derelict/departures)
+"HA" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/item/hatchet,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
+"HB" = (
+/obj/machinery/griddle,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"HF" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "toxins"
+	},
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/large,
+/area/ruin/space/derelict/research)
+"HJ" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/arrival)
+"HN" = (
+/obj/machinery/modular_computer/console/preset/cargochat/medical,
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"HP" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/blue,
+/area/ruin/space/derelict/arrival)
+"HS" = (
+/obj/machinery/suit_storage_unit/cmo,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"HT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"HU" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"HW" = (
+/obj/structure/table,
+/obj/item/stack/package_wrap{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/hand_labeler,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"HZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Id" = (
+/obj/machinery/power/emitter/welded{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Ie" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Ih" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/door/window/eastright{
+	req_access_txt = "71"
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "toxins"
+	},
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/large,
+/area/ruin/space/derelict/research)
+"Ii" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Ik" = (
+/obj/structure/tank_dispenser,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Is" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator Chamber";
+	req_one_access_txt = "19; 61"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"It" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"Iu" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Ix" = (
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/science,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes,
+/obj/structure/reagent_dispensers/wall/virusfood/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Iy" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"IA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"IB" = (
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/table,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"IE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"IF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"II" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"IJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/hallway_primary)
+"IP" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"IR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"IX" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "EVA Storage";
+	req_access_txt = "18"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Jb" = (
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Jd" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/item/cultivator,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
+"Je" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"Jh" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = null;
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Ji" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"Jl" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/igniter{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -6
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Jv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 9
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"JA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"JC" = (
+/obj/machinery/airalarm/mixingchamber{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"JD" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"JF" = (
+/obj/machinery/gibber,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"JG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Gas to Cooling Loop"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"JJ" = (
+/obj/machinery/telecomms/bus/preset_one/birdstation,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"JS" = (
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"JV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"JY" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"Kb" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"Kh" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Ki" = (
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/stack/cable_coil,
+/obj/item/screwdriver{
+	pixel_x = 2;
+	pixel_y = 11
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Kl" = (
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/departures)
+"Km" = (
+/obj/effect/turf_decal/tile/yellow/anticorner,
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
+/area/ruin/space/derelict/hallway_primary)
+"Kp" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Kq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Kr" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Ku" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Kw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Kx" = (
+/obj/structure/table,
+/obj/item/defibrillator/loaded{
+	pixel_y = 3
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"KA" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/departures)
+"KE" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"KF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"KG" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"KJ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"KN" = (
+/obj/item/assembly/signaler{
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"KP" = (
+/obj/structure/table/reinforced,
+/obj/item/assembly/timer{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/assembly/timer{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/assembly/timer{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/assembly/timer{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/item/book/manual/wiki/ordnance,
+/obj/item/storage/firstaid/toxin,
+/obj/item/assembly/prox_sensor{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/raw_anomaly_core/random{
+	pixel_y = 11
+	},
+/obj/item/raw_anomaly_core/random{
+	pixel_y = -2
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"KQ" = (
+/obj/structure/chair/comfy/lime,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
+"KR" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Canteen"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"KS" = (
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/analyzer,
+/obj/item/pipe_dispenser,
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"KT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"KU" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"KW" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"KX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"KY" = (
+/obj/machinery/chem_master,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Le" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Lp" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Lr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
+"Ls" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
 "Lv" = (
 /turf/closed/wall,
 /area/template_noop)
-"LX" = (
-/obj/machinery/power/smes/engineering{
-	charge = 0
+"Lw" = (
+/obj/machinery/announcement_system,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"Mi" = (
-/obj/machinery/pipedispenser,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"ME" = (
-/obj/structure/window/reinforced,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Lx" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/area/ruin/space/derelict/singularity_engine)
-"MQ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/se_solar)
-"MS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"Ni" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"Nx" = (
-/obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"LA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/chapel{
-	dir = 1
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict12"
 	},
-/area/ruin/space/derelict/medical/chapel)
-"NK" = (
-/obj/structure/closet/wardrobe,
-/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"Ob" = (
-/obj/item/clothing/head/helmet/space/eva,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"Oj" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/bridge/access)
-"Oo" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/power_compressor,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"OD" = (
-/obj/structure/closet/wardrobe/genetics_white,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"OT" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/hallway/primary/port)
-"Pi" = (
-/obj/structure/window/reinforced{
-	dir = 8
+"LC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"Pm" = (
-/obj/structure/closet,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/medical)
-"PR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/atmospherics)
-"Qb" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"LD" = (
 /obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/gun/syringe,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/chapel{
-	dir = 8
-	},
-/area/ruin/space/derelict/medical/chapel)
-"Qt" = (
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"LE" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/atmospherics)
-"Qv" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"LF" = (
 /obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/tile/yellow,
+/obj/item/hand_labeler,
+/obj/item/stack/package_wrap,
+/turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"QA" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
+"LL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/area/ruin/space/derelict/hallway/primary/port)
-"QW" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/sign/poster/official/wtf_is_co2{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
-"Rd" = (
-/obj/item/stack/cable_coil,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged4"
+/area/ruin/space/derelict/engineering)
+"LN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 1
 	},
-/area/ruin/space/derelict/singularity_engine)
-"Rr" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/chapel{
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"LO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict10"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"LT" = (
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
 	},
-/area/ruin/space/derelict/medical/chapel)
-"Rw" = (
-/obj/structure/plaque/static_plaque/golden/commission/ks13,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"LV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix Bypass"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"LW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"LX" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/components/binary/thermomachine/heater/on{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"LY" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"LZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/carpet/blue,
+/area/ruin/space/derelict/arrival)
+"Mb" = (
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"Md" = (
+/obj/structure/table,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Mg" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Mi" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Mj" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Mq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Mr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Mt" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard)
+"Mw" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"Mx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"My" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"MA" = (
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"MB" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"MC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ME" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"ML" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
+	dir = 8;
+	filter_type = list(/datum/gas/nitrogen,/datum/gas/oxygen)
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"MM" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/arrival)
+"MQ" = (
+/obj/structure/closet/bombcloset,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"MU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"MV" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/template_noop,
+/area/template_noop)
+"MX" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"MY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Nc" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"Ne" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Nf" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"Ng" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Nh" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/service/janitor)
+"Ni" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"Nk" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/template_noop,
+/area/template_noop)
+"Nm" = (
+/obj/item/wrench,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/structure/rack,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"No" = (
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"Ns" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/service)
+"Nt" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"Nv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Nw" = (
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Nx" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
+"Nz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/recharge_station,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"NC" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/corner,
+/area/ruin/space/derelict/hallway_primary)
+"NE" = (
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"NF" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"NJ" = (
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"NK" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/obj/machinery/navbeacon/wayfinding/dockesc,
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"NO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"NP" = (
+/obj/structure/fireaxecabinet/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"NQ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Gas"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"NS" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/crowbar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"NT" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"NW" = (
+/obj/machinery/stasis{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Oa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"Ob" = (
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"Of" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	name = "Bar";
+	req_access_txt = "25"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Oj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Ol" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/service)
+"Om" = (
+/obj/effect/decal/remains/robot,
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary)
+/area/ruin/space/derelict/departures)
+"Oo" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"Or" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Ot" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/hallway_primary)
+"Ou" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Oy" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Oz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"OB" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/cargo)
+"OD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"OG" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/template_noop,
+/area/template_noop)
+"OJ" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"OM" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/analyzer,
+/obj/item/pipe_dispenser,
+/obj/item/flashlight,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"ON" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"OQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"OS" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
+"OT" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"OU" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/kitchen/fork,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"OY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"OZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Pb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"Pd" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict3"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Pf" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"Pi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/item/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"Pj" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Pk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Pm" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"Pq" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Pt" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes{
+	pixel_y = 8
+	},
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Pv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"Py" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Pz" = (
+/turf/open/floor/engine/air,
+/area/ruin/space/derelict/engineering)
+"PA" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/musician/piano,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"PB" = (
+/obj/structure/closet/l3closet/janitor,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"PC" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/maintenance/port)
+"PD" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/item/hatchet,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
+"PE" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"PH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"PI" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"PK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"PP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"PQ" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"PV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"PY" = (
+/obj/machinery/power/emitter/welded{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Qa" = (
+/obj/structure/table,
+/obj/item/construction/plumbing,
+/obj/item/paper{
+	info = "NOTICE - Due to the Air tank's extreme susceptibility to sabotage, Engineering has been supplied one chemistry plumberer to help curate more air in case of emergencies - Just remember to use smoke machines!"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Qb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Qd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Ql" = (
+/obj/structure/table,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Qt" = (
+/obj/effect/turf_decal/siding/thinplating/end,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Qu" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to Distro"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Qv" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Qz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 5
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"QA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"QB" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"QC" = (
+/obj/machinery/modular_computer/console/preset/cargochat/service{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"QD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"QG" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/ruin/space/derelict/service)
+"QI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"QK" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"QO" = (
+/obj/structure/closet/secure_closet/hop,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"QP" = (
+/obj/structure/table,
+/obj/item/folder/blue,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"QQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"QU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"QW" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ruin/space/derelict/research)
+"QY" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"QZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Rb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Rg" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"Ri" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"Rk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Rl" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"Rr" = (
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"Rs" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Ru" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"Rw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"RB" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "head of personnel's office maintenance";
+	req_access_txt = "57"
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port)
+"RC" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
 "RF" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access_txt = "10"
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "toxins"
+	},
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/large,
+/area/ruin/space/derelict/research)
+"RH" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/item/cultivator,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
+"RI" = (
+/obj/machinery/light/directional/east,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/service)
+"RN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"RP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"RQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"RR" = (
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"RT" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"RX" = (
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"RY" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Sd" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Se" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Sj" = (
+/obj/machinery/computer/department_orders/engineering,
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Sl" = (
+/obj/structure/table,
+/obj/item/storage/box/masks{
+	pixel_y = 4
+	},
+/obj/item/crowbar,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Sm" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "toxins"
+	},
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/iron/large,
+/area/ruin/space/derelict/research)
+"Sp" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/maintenance/starboard)
+"Sq" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Sr" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Ss" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"St" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"Su" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/door/window/eastright{
+	req_access_txt = "71"
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "toxins"
+	},
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/iron/large,
+/area/ruin/space/derelict/research)
+"SA" = (
+/obj/machinery/computer/atmos_control/tank/air_tank,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"SF" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"SI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"SJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"SK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"SL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"SR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"SS" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
+/area/ruin/space/derelict/arrival)
+"SU" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Virology";
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"SV" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"SX" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict1"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"SY" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/ruin/space/derelict/engineering)
+"Tg" = (
+/obj/structure/table,
+/obj/item/gun/syringe,
+/obj/item/reagent_containers/dropper{
+	pixel_y = -6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Ti" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/hallway_primary)
+"Tl" = (
+/obj/structure/table,
+/obj/item/storage/box/mousetraps,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"Tm" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"Tn" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"To" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Tp" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/service)
+"Tq" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"Tr" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Ts" = (
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "toxins"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Tt" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Tx" = (
+/obj/structure/closet/secure_closet/bar{
+	req_access_txt = "25"
+	},
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Ty" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"Tz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"TA" = (
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"TB" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"TC" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "EVA Storage";
+	req_access_txt = "18"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/gravity_generator)
-"Sm" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"Su" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/airless,
-/area/ruin/unpowered/no_grav)
-"SR" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered/no_grav)
-"Tm" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"TJ" = (
-/obj/machinery/light/directional/west,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/medical)
-"Ua" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"Ud" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/solar_control)
-"Uz" = (
-/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/EVA)
+"TE" = (
+/obj/machinery/door/airlock/command{
+	name = "Head of Personnel";
+	req_access_txt = "57"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/arrival)
+"TI" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/template_noop,
 /area/template_noop)
+"TJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"TK" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"TP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"TQ" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"TS" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall,
+/area/ruin/space/derelict/medical)
+"TV" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/surgical,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"TW" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Ua" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Ub" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"Uc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Ud" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Ug" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/port)
+"Ul" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Un" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"Uo" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Ux" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"Uz" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/hallway_primary)
+"UD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "UG" = (
-/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"UH" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"UJ" = (
+/obj/machinery/oven,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"UM" = (
+/obj/structure/chair/comfy/lime{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
+"UN" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"UQ" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"US" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/EVA)
+"UT" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"UU" = (
+/obj/structure/closet/crate,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"UV" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/service)
+"UX" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"UY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Va" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"Vb" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Ve" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Vf" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/turf/template_noop,
+/area/ruin/space/derelict/maintenance/port)
+"Vg" = (
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Vl" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Vn" = (
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"Vq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"Vr" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research)
+"Vt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"Vu" = (
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Vv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Vx" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Bar";
+	req_access_txt = "25"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Vz" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/template_noop,
+/area/template_noop)
+"VA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"VC" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict2"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"VG" = (
+/obj/machinery/ntnet_relay,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"VH" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"VI" = (
+/obj/machinery/door/airlock/medical{
+	name = "Surgery";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"VM" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"VN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"VQ" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"VS" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"VT" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"VV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"VZ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner/airless{
+	dir = 8
+	},
+/area/ruin/space/derelict/departures)
+"Wb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
+"Wf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research)
+"Wl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Wm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"Wn" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"Wp" = (
+/obj/machinery/computer/pandemic,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Wr" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Ww" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/bridge/ai_upload)
-"Vg" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/power_turbine,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Wz" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"WA" = (
+/obj/effect/turf_decal/tile/green/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"WC" = (
+/obj/structure/table,
+/obj/item/storage/box/beakers{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"WF" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"WG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/ai_upload)
-"Vt" = (
-/obj/structure/cable,
-/turf/closed/indestructible/riveted{
-	color = "#FF8888"
+/area/ruin/space/derelict/engineering)
+"WH" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/area/ruin/space/derelict/bridge/ai_upload)
-"Vz" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway/primary/port)
-"VV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/atmospherics)
+/turf/template_noop,
+/area/template_noop)
+"WJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"WL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"WS" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"WU" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/service)
+"Xc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Emitter Room";
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Xh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Xi" = (
+/obj/machinery/telecomms/receiver/preset_left/birdstation,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Xl" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Xm" = (
+/obj/structure/table/reinforced,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 5
+	},
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
 "Xq" = (
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/iron/airless{
-	icon_state = "damaged2"
-	},
-/area/ruin/space/derelict/singularity_engine)
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"Xs" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
 "Xu" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Xv" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
+/turf/open/floor/engine/air,
+/area/ruin/space/derelict/engineering)
+"Xw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"Xz" = (
+/obj/structure/chair/office,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"XF" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/service)
+"XL" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"XN" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"XR" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"XS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"XT" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"XY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/barricade/wooden,
 /turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
+/area/ruin/space/derelict/departures)
+"Ya" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Yd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Yf" = (
+/obj/structure/table/optable,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Yg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/security/detective)
+"Yh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Yk" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Yl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Ys" = (
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Yv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict9"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"YA" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"YC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"YD" = (
+/obj/machinery/processor,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"YE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"YF" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"YJ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/cmo,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"YO" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
 "YQ" = (
-/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research/xenobiology)
+"YR" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"YV" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"YW" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"YX" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"YZ" = (
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
+"Zg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/plating/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
-"Zu" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 15
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 15
-	},
+/area/template_noop)
+"Zj" = (
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/airless,
-/area/ruin/space/derelict/bridge/ai_upload)
+/area/ruin/space/derelict/departures)
+"Zk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Zm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"Zt" = (
+/obj/machinery/computer/department_orders/service{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Zu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"Zw" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"Zx" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Zz" = (
+/obj/structure/chair/comfy/lime,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
 "ZB" = (
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
+"ZD" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway_primary)
+"ZF" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"ZH" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/biogenerator,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/service)
+"ZI" = (
+/obj/structure/sign/departments/medbay/alt{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"ZK" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/departures)
 "ZM" = (
-/obj/machinery/drone_dispenser/derelict,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/rack,
+/obj/item/mod/core/standard,
+/obj/item/mod/core/standard,
+/obj/item/mod/core/standard,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge/access)
+/area/ruin/space/derelict/research)
+"ZO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"ZR" = (
+/obj/effect/turf_decal/tile/green,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"ZU" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict4"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"ZW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"ZX" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	name = "Pharmacy Desk";
+	req_access_txt = "69"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
 
 (1,1,1) = {"
 aa
@@ -3793,46 +9003,37 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+cZ
+zB
+iz
+NK
+iz
+ZB
+ZB
+ZB
+iz
+zB
+iz
+zB
+KA
 ZB
 aa
 aa
 aa
-ZB
-iH
-ZB
 aa
 aa
-ZB
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -3906,48 +9107,39 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+KA
+Kb
+iz
+CN
+iz
 aa
 ZB
+aa
+iz
+Kb
+iz
+CN
+cZ
 ZB
 ZB
 aa
-Gu
-hQ
-hQ
-iu
-iI
-iT
-hQ
-hQ
-Gu
-ZB
-ZB
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -4019,49 +9211,40 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+cZ
+zJ
+iB
+zJ
+KA
+nJ
+iz
+iz
+cZ
+tp
+Hx
+zJ
+cZ
 ZB
-ZB
-gX
-gX
-gX
-gX
-vG
-Qb
-al
-iJ
-Nx
-Qb
-vG
-jL
-aY
-aY
-ZB
-ZB
+HJ
+hk
+HJ
+hk
+hk
+hk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -4132,48 +9315,39 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-gX
+eh
+Av
+ZK
+kI
+sO
+VZ
+yK
+VZ
+It
+kI
+kI
+kI
+KA
+HJ
+HJ
+Rs
+Rs
+rB
+zL
 hj
-gX
-hF
-hS
-if
-iw
-iJ
-iV
-ij
-hS
-jL
-gP
-gH
-ay
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Lv
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -4245,6 +9419,26 @@ aa
 aa
 aa
 aa
+gV
+ZK
+ez
+gV
+iG
+iG
+iG
+iG
+iG
+vn
+zh
+iG
+iz
+SS
+HJ
+Bg
+Rs
+hk
+hk
+hk
 aa
 aa
 aa
@@ -4252,40 +9446,11 @@ aa
 aa
 aa
 aa
+Lv
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-gX
-hj
-gX
-gX
-hT
-Rr
-ix
-iJ
-iW
-ii
-hT
-jL
-ay
-Jl
 aa
 aa
 aa
@@ -4358,24 +9523,26 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+he
+hT
+gV
+iG
+iG
+Om
+iG
+iG
+Rl
+iG
+Cz
+cZ
+KA
+Gm
+TW
+Rs
+Rs
+Se
+xp
+hk
 aa
 aa
 aa
@@ -4384,20 +9551,9 @@ aa
 aa
 aa
 ZB
-ZB
-gX
-hj
-hj
-gX
-hS
-ij
-iw
-iK
-iV
-ij
-ju
-jL
-ZB
+aa
+aa
+aa
 aa
 aa
 aa
@@ -4463,6 +9619,34 @@ aa
 aa
 aa
 aa
+ef
+bw
+ef
+bw
+ef
+aa
+aa
+aa
+he
+AA
+ZK
+eh
+nl
+iG
+iG
+iG
+Rr
+ul
+Cy
+qx
+Rs
+Xh
+Rs
+Rs
+Rs
+Rs
+XR
+hk
 aa
 aa
 aa
@@ -4470,46 +9654,9 @@ aa
 aa
 aa
 aa
+jV
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-gX
-hj
-ht
-gX
-hU
-ii
-hT
-ii
-hT
-ii
-hT
-jL
 aa
 aa
 aa
@@ -4576,53 +9723,44 @@ aa
 aa
 aa
 aa
+ef
+by
+ef
+by
+ef
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-gX
+Av
+Kl
+AZ
+AW
+nI
+AW
+Pi
+AW
+XY
+SI
+xT
+Dm
+SJ
+Yv
+SX
+Rs
+Rs
+Rs
+Vl
 hk
-hk
-gX
-hS
-ij
-hS
-ij
-iX
-ij
-hS
-jL
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+jV
+aa
+aa
 aa
 aa
 aa
@@ -4678,64 +9816,55 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-gX
+ZB
+Lv
+iD
+iD
+iD
+iD
+iD
+iD
+iD
+iD
+iD
+ef
+jS
+ef
+jS
+ef
+iD
+iD
+iD
+KA
+Zj
+iG
+iG
+iG
+iG
+vl
+iG
+iG
+iG
+ul
+qx
+Rs
+LO
+VC
+Rs
+Rs
+IF
+rU
 hk
-hk
-gX
-hT
-ii
-hT
-ii
-hU
-ii
-hT
-jL
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ZB
+aa
+aa
 aa
 aa
 aa
@@ -4783,52 +9912,53 @@ aa
 aa
 "}
 (10,1,1) = {"
+ad
+ad
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ZB
+jV
+jV
+iD
+cm
+cW
+cW
+cW
+iD
+xU
+xU
+Ux
+jg
+OB
+OB
+OB
+ms
+xU
+xU
+mk
+mk
+mk
+jv
+jv
+mk
+ON
+mk
+mk
+jv
+qx
+qx
+KA
+Rs
+rY
+Pd
+Rs
+rb
+hk
+hk
+hk
 aa
 aa
 aa
@@ -4837,19 +9967,9 @@ aa
 aa
 aa
 ZB
-gX
-hk
-hk
-hG
-hS
-ij
-hS
-ij
-hS
-ij
-hS
-jL
-ZB
+aa
+aa
+aa
 aa
 aa
 aa
@@ -4896,75 +10016,66 @@ aa
 aa
 "}
 (11,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-gX
-hk
-gX
-gX
-gX
-gX
-gX
-gX
-gX
-gX
-jv
-jL
+ad
+ad
 ZB
 ZB
-ay
+ZB
+ZB
+ZB
+ZB
+jV
+jV
+ef
+Xw
+Xw
+Xw
+Xw
+iD
+hd
+xU
+xU
+xU
+KX
+xU
+xU
+xU
+xU
+xU
+mk
+uc
+jm
+jm
+mk
+tb
+tH
+MX
+tH
+mk
+KQ
+yL
+oK
+Rs
+LA
+ZU
+Rs
+Rs
+rB
+zL
+hj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Lv
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -5016,68 +10127,59 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ZB
-ZB
-gX
+jV
+jV
+ef
+xU
+xU
+ZO
+xU
+eX
+xU
+xU
+xU
+xU
+QD
+BT
+xU
+BT
+xU
+nM
+mk
+tH
+tH
+tH
+tH
+tH
+tH
+tH
+tH
+mk
+Zz
+Au
+YZ
+Rs
+yk
+Fw
+Rs
+Rs
 hk
-gX
-hH
-hH
-hH
-hH
-hH
-hH
-gX
-jw
-jL
-Jl
-ay
+hk
+hk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Ug
+Ug
+Ug
 ZB
+aa
+aa
 aa
 aa
 aa
@@ -5130,68 +10232,57 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jV
+jV
+iD
+zo
+cY
+dZ
+Oz
+fc
+Oz
+Oz
+Oz
+Oz
+jT
+kJ
+VV
+kJ
+Hi
+kK
+mk
+tH
+tH
+tH
+tH
+tH
+tH
+tH
+tH
+mk
+nK
+UM
+YZ
+Rs
+wZ
+Co
+Rs
+Rs
+HJ
+HJ
 ZB
 aa
-gX
-hl
-hu
-hk
-hk
-hk
-hk
-hk
-hk
-gX
-jw
+aa
+aa
+aa
+aa
+aa
+aa
+Ug
+vZ
 jL
 jV
-gP
-ay
-aY
+ZB
 aa
 aa
 aa
@@ -5204,13 +10295,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Fd
+TI
+Fd
+KJ
+Db
+KJ
+Db
+KJ
+Rg
 aa
 aa
 aa
@@ -5242,88 +10335,79 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ZB
-aa
-gX
-hj
-gX
-hl
-hH
-hH
-hH
-hH
-hk
-gX
-jw
-jL
-jL
-kl
-jL
-jL
-aa
-aa
-aa
-aa
+jV
+jV
+ef
+xU
+xU
+QD
+xU
+eX
+xU
+xU
+xU
+xU
+gC
+kK
+xU
+mt
+xU
+kK
+mk
+tH
+tH
+tH
+tH
+tH
+tH
+mk
+mk
+mk
+Nh
+Nh
+Nh
+rA
+yq
+EH
+Rs
+Rs
+Rs
+HJ
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ZB
+ZB
+ZB
+ZB
+ZB
+ZB
+ZB
+Ug
+jL
+PC
+GU
+Bs
+Bs
+Bs
+Bs
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+ZB
+FS
+AK
+FS
+MV
+Db
+OG
+Db
+OG
+rO
 aa
 aa
 aa
@@ -5356,87 +10440,78 @@ aa
 aa
 aa
 aa
+jV
+jV
+ef
+xU
+xU
+QD
+xU
+iD
+hf
+xU
+xU
+xU
+gC
+mk
+mk
+mk
+mk
+mk
+mk
+tH
+WS
+mk
+mk
+tH
+tH
+mk
+RC
+PB
+Bd
+RR
+Nh
+YA
+MU
+YA
+Ff
+pA
+TE
+pA
+pA
+PC
+Ug
+Ug
+Ug
+Ug
+Ug
+Ug
+Ug
+vZ
+zz
+tx
+xj
+Ve
+wz
+Uo
+SY
+de
+qk
+tx
+Pq
+tx
+Vu
+GU
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-gX
-gX
-gX
-hk
-hk
-hk
-hk
-hk
-hk
-gX
-jx
-gX
-fZ
-go
-fZ
-fZ
-fZ
-aa
-aa
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FS
+Gl
+FS
+Pf
+Db
+KJ
+Db
+KJ
+Rg
 aa
 aa
 aa
@@ -5469,87 +10544,78 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ZB
-ZB
-ZB
-gX
-hk
-hH
-hH
-hH
-hH
+jV
+iD
+cC
+xU
+QD
+xU
+iD
+hf
+xU
+xU
+xU
+gC
+mk
+tH
+tH
+tH
+tH
+tH
+tH
+WS
+mk
+OT
+tH
+tH
+mk
+yu
+tX
+Mw
+qv
+Nh
+PE
+vV
+Rs
+MM
+pA
+tC
+tC
+QO
+PC
+vZ
+vZ
+vZ
+vZ
+pv
 ht
-gX
-jw
-gX
-yH
-gL
-mJ
-gn
-gL
-ZB
-ZB
+Ug
+vZ
+PC
+tx
+tx
+tx
+tx
+tx
+NT
+de
+AH
+Ap
+Hv
+Dc
+BE
+Bs
 aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FS
+AK
+FS
+MV
+Db
+OG
+Db
+OG
+rO
 aa
 aa
 aa
@@ -5583,86 +10649,77 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-gX
+jV
+iD
+ef
+iD
+ec
+xU
+iD
+VH
+xU
+xU
+xU
+gC
+mk
+tH
+mk
+mk
+mk
+mk
+mk
+mk
+mk
+OT
+tH
+tH
+mk
+rk
+pD
+wN
+WJ
+GT
+SJ
+eg
+Rs
+MM
 hk
-hk
-hk
-hk
-hk
-hk
-gX
-jy
-jM
-jX
-gL
-gn
-gL
-gm
-gn
-ZB
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+tC
+zK
+tC
+RB
+vZ
+vZ
+vZ
+vZ
+vZ
+Oo
+Ug
+vZ
+PC
+jY
+km
+tx
+tx
+tx
+qi
+de
+oX
+uK
+Hj
+rf
+zO
+GU
+GU
+FS
+AK
+FS
+WH
+Db
+OG
+Db
+OG
+Rg
 aa
 aa
 aa
@@ -5696,86 +10753,77 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-gX
-gX
-gX
-hu
-gX
-hu
-gX
-gX
-gX
-gX
+jV
+bP
+cD
+db
+xU
+xU
+iD
+hg
+xU
+SV
+xU
+gC
+mk
+tH
+mk
+no
+nN
+uf
+vo
+nN
+mk
+mk
+tH
+tH
+mk
+Tl
+OJ
+AB
+rL
+Nh
+Rs
+xQ
+Rs
+MM
+hk
+Ch
+ws
+tC
+PC
+kv
+vZ
+vZ
+vZ
+vZ
+vZ
+Ug
+vZ
+PC
 jY
 km
-gl
-fZ
-fZ
-fZ
-fZ
-gL
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+tx
+tx
+tx
+qi
+tx
+tx
+qi
+tx
+uH
+tx
+Yk
+GU
+FS
+Gl
+FS
+nd
+Db
+KJ
+Db
+KJ
+rO
 aa
 aa
 aa
@@ -5809,86 +10857,77 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-hv
-hI
-TJ
-hI
-iA
-hI
-hI
-hV
-iA
-fZ
-go
-go
-jX
-fZ
-kN
+jV
+iD
+iD
+Dn
+Dn
+eC
+Dn
+iD
+iD
+iD
+jj
+jU
+mk
+tH
+mk
+np
+nO
+uf
+np
+nO
+mk
+tH
+tH
+tH
+mk
+mk
+mk
+tI
+mk
+mk
+xX
+BS
+SJ
+Bh
+Gc
+HP
+LZ
+LY
+PC
+Ug
+Ug
+Ug
+Ug
+vZ
+vZ
+Ug
+xB
+PC
+jY
+km
+GD
+OY
+OY
 wr
-fZ
-gL
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+HT
+AS
+KW
+BU
+IR
+de
+de
+GU
+FS
+AK
+FS
+WH
+Db
+OG
+Db
+OG
+Rg
 aa
 aa
 aa
@@ -5924,84 +10963,75 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-hw
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-fZ
-go
-go
-gc
-fZ
-jZ
-go
-fZ
-gL
-gL
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Dn
+EZ
+EZ
+Dn
+hh
+hV
+Ux
+xU
+gC
+mk
+tH
+mk
+uf
+nQ
+uf
+uf
+nQ
+mk
+tH
+tH
+tH
+tH
+YO
+mk
+tH
+tH
+mk
+Rs
+xQ
+Rs
+pA
+pA
+pF
+wa
+tC
+hw
+PC
+vZ
+vZ
+vZ
+vZ
+vZ
+vZ
+vZ
+PC
+kw
+kw
+kw
+kw
+kw
+qi
+uH
+tx
+tx
+qi
+tx
+hC
+Vb
+tM
+FS
+Pf
+rO
+nd
+Db
+KJ
+Db
+KJ
+rO
 aa
 aa
 aa
@@ -6036,83 +11066,74 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jV
 ZB
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-hw
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-fZ
+Dn
+EZ
+EZ
+Dn
+hi
+xU
+xU
+jo
+kb
+mk
+tH
+mk
+nq
+nR
+oh
+QQ
+Ba
+mk
+tH
+tH
+tH
+tH
+YO
+mk
+tH
+tH
+ON
+Rs
+xQ
+Rs
+pA
+HW
+Gb
+wS
+tC
+Ai
+PC
+KE
+vZ
+vZ
+vZ
+vZ
+vZ
+vZ
+PC
 jZ
-go
-gc
-go
-go
+Ru
+jZ
+FY
+LE
 kX
-fZ
-ln
-gL
-gL
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uH
+tx
+Bs
+VS
+Bs
+GU
+GU
+GU
+DC
+GU
+Bs
+DC
+Bs
+Bs
+GU
 aa
 aa
 aa
@@ -6148,91 +11169,82 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-hw
-hJ
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-fZ
-go
-go
-gc
-fZ
-fZ
-fZ
-fZ
-ka
-jY
-gL
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-aa
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
+Dn
+bS
+Dn
+Dn
+EZ
+eD
+Dn
+hl
+pH
+lv
+lv
+yy
+mk
+tH
+mk
+nr
+TK
+cK
+TK
+TK
+mk
+tH
+tH
+tH
+tH
+mk
+mk
+tH
+tH
+mk
+Rs
+vV
+Rs
+pA
+QP
+Tq
+Tz
+oj
+PC
+PC
+vZ
+vZ
+Ug
+Ug
+Ug
+Ug
+vZ
+PC
+bk
+Pv
+bk
+rh
+LE
+cz
+uH
+Bs
+Bs
+wi
+Pk
+Pk
+Pk
+Pk
+JG
+QI
+hL
+yO
+Pk
+RN
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 aa
 aa
 aa
@@ -6254,98 +11266,89 @@ aa
 (23,1,1) = {"
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+af
+af
+af
+af
+af
+af
 ZB
-ZB
-dr
-dr
-dr
-ZB
-ZB
-aa
-aa
-aa
-aa
-hv
-hI
-hI
-hI
-hI
-hI
-hI
-jf
-jz
-fZ
-yH
-go
-gc
-fZ
-kN
-wr
-fZ
-jY
+Dn
+EZ
+Dn
+Fr
+EZ
+EZ
+Dn
+hm
+ic
+Ft
+BT
+gC
+mk
+tH
+mk
+ns
+TK
+pu
+vC
+DE
+mk
+tH
+tH
+tH
+tH
+tH
+tH
+tH
+tH
+mk
+wb
+Zx
+wb
+pA
+St
+tC
+tC
+qa
+PC
+pv
+YC
+No
+Oa
+Ad
+Vf
+Ug
+vZ
+PC
+Wn
+rV
+oL
+WL
+Is
+GI
+lf
+GU
 lF
-gL
-gL
-ZB
-aa
-aa
-aa
-aa
-ZB
-aa
-aa
-aa
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
+GN
+hL
+hL
+hL
+hL
+uq
+hL
+hL
+ZW
+hL
+XT
+Uc
+GU
+fi
+Nw
+UX
+Nw
+Nm
+GU
 aa
 aa
 aa
@@ -6366,99 +11369,90 @@ aa
 "}
 (24,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-aa
-aa
-ZB
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-ZB
-aa
-aa
-aa
-hx
+af
+af
+aA
+aQ
+aV
+bq
+af
+Dn
+Dn
+bU
+Dn
+EZ
+EZ
+Dn
+Dn
+ef
+ef
+iH
+jr
+kf
+mk
+tH
+mk
+bX
+qO
+NO
+TK
+DX
+mk
+tH
+tH
+tH
+tH
+tH
+tH
+tH
+ax
+mk
+Ua
+gj
+dB
+PC
+PC
+PC
+PC
+PC
+PC
 Pm
-hW
-hI
-iB
-iL
-iY
-jg
-jA
-fZ
-go
-go
-gc
-fZ
-jZ
-go
-fZ
-yP
-go
-jY
-gL
-ZB
-ZB
-ZB
-ZB
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-ZB
-aa
-ZB
-aa
-aa
-aa
+TP
+vZ
+Ug
+Ug
+Ug
+Ug
+vZ
+PC
+bk
+Je
+bk
+rh
+LE
+la
+uH
+Bs
+lJ
+hL
+Iu
+AJ
+AJ
+Dl
+Yd
+AJ
+BP
+QU
+Ul
+Qz
+sa
+Bs
+Nw
+Nw
+Nw
+Nw
+Nw
+GU
 aa
 aa
 aa
@@ -6479,99 +11473,90 @@ aa
 "}
 (25,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-ZB
-ZB
-aa
-aa
-aa
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-aa
-ZB
-ZB
-ZB
-dr
-dr
-xa
-em
-ez
-dr
-dr
-ZB
-ZB
-aa
-aa
-hy
-hL
+aL
+ag
+aB
+bl
+aZ
+bl
+bs
+Dn
+EZ
+EZ
+EZ
+EZ
+EZ
+Dn
+dk
+dk
+dk
+iI
+jt
+gj
+mk
+tH
+ON
+TK
+TK
+cK
+TK
+El
+mk
+tH
+tH
+tH
+tH
+tH
+tH
+tH
+My
+mk
+Ua
+Cr
+Ua
+qN
+vZ
+vZ
+vZ
+vZ
+vZ
+vZ
 hX
-hX
-iC
-hI
-hI
+jf
+jf
+jf
+jf
 jf
 jB
-fZ
-go
-go
-gc
+PC
+nE
+DN
+nE
 kD
-go
-wr
-fZ
-jY
-lG
-go
-gL
-gL
-fZ
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-ch
-ZB
-ZB
-ZB
-aa
-aa
-aa
+LE
+la
+uH
+Bs
+lJ
+hL
+ke
+LC
+UH
+GU
+Zk
+Zk
+Zk
+GU
+lJ
+IE
+sa
+Xc
+Vb
+Vb
+Vb
+Vb
+ZF
+GU
 aa
 aa
 aa
@@ -6592,99 +11577,90 @@ aa
 "}
 (26,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-ZB
-aa
-aa
-ZB
-ZB
-ZB
-dr
-dr
-ez
-dO
-dX
-ez
-ez
-dr
-dr
-ZB
-aa
-hm
-hz
-hz
-hY
-ik
-hX
-iM
-iZ
-ji
-jC
-fZ
-fZ
-fZ
+aL
+al
+bl
+bl
+ba
+bl
+bt
+Dn
+EZ
+EZ
+EZ
+EZ
+EZ
+Dn
+ff
+iJ
+iJ
+iJ
+Ua
+gj
+mk
+mk
+mk
+uf
+nS
+cK
+TK
+Ev
+mk
+tH
+tH
+tH
+tH
+tH
+tH
+tH
+tb
+mk
+fD
+DB
+fG
+Ug
+Mb
+Ug
+Ug
+Ug
+Ug
+vZ
+vZ
+vZ
+vZ
+vZ
+vZ
+vZ
+TP
+PC
 kw
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
+kw
+kw
+kw
+kw
+qi
+uH
+GU
+OM
+hL
+dE
 mh
-fZ
-aa
-aa
-aa
-aa
-ZB
-aa
-aa
-aa
+UH
+GU
+hL
+hL
+hL
+GU
+vc
+oC
+sa
 md
-mZ
-mZ
-ZB
-ZB
-ZB
-aa
+Vb
+Vb
+PY
+PY
+Vb
+GU
 aa
 aa
 aa
@@ -6705,99 +11681,90 @@ aa
 "}
 (27,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ax
-aK
+aL
 aR
 aW
-aR
-ax
-aa
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-fG
-fE
-fU
-fU
-gs
-dr
-dr
-dr
-aa
-aa
-hA
-hz
-hz
-Qv
-hY
-hX
-hI
-jf
-hI
-fZ
+bl
+ba
+bl
+bu
+Dn
+Dn
+Dn
+Dn
+Dn
+yT
+Dn
+Ua
+hq
+id
+iK
+Ua
+gj
+bV
 ka
 kp
-gc
-go
-kO
-kY
-go
-go
+uf
+gJ
+oi
+vG
+gJ
+mk
+ON
+mk
+mk
+mk
+mk
+mk
+mk
+mk
+mk
+Ua
+gj
+Ua
+Ug
+Ug
+Ug
+NC
+TB
+Ug
+Ug
+Ug
+Ug
+Ug
+Ug
+Ug
+Ug
+zv
+Ug
+ka
 kp
-go
-go
+ZD
+GU
+kO
+qi
+xz
+GU
+Xm
+hL
+cy
 mi
-fZ
-gL
-aa
-gL
-gL
-ZB
-gL
-aa
-aa
-me
+GU
+JA
+Ax
+Cq
+UQ
+GU
+LW
+nL
+sa
+GU
 mU
-mZ
-ZB
-ay
-ZB
-aa
+Nw
+Nw
+Nw
+Nw
+GU
 aa
 aa
 aa
@@ -6818,99 +11785,90 @@ aa
 "}
 (28,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ax
-ax
 aL
-ax
-ax
-aR
-ax
+ap
+aC
+aS
+bc
 bl
-bl
-bl
-bl
-bl
-bl
-bl
-bl
-bl
-bl
-ZB
-ZB
-ZB
-ZB
-ZB
-aa
-aa
-aa
-ZB
-ZB
-ZB
-ZB
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-Xq
-fd
-ft
-ft
-ew
-dr
-dr
-dr
-gY
-dW
-hv
-hM
+bu
+bB
+aX
+bu
+cE
+dc
+Ua
+Ua
+Ua
+eZ
+Ua
+Ua
+Ua
+gj
+Ua
+Ua
+Ua
+nt
+Ua
+gj
+Ua
+Ua
+ix
+Ua
+Ua
+Ua
+Ua
+yR
+Ua
+Ua
+Ua
+Ua
+Ua
+gj
+Ua
+nt
+Ua
+Ua
+Ua
+Ua
+Ua
+Ua
 hZ
-hz
-hz
+Ua
+Ua
 iN
-hX
-ji
-hv
-fZ
-go
-go
-gc
-go
-kO
+Ua
+iN
 kZ
-le
-lp
-lH
-go
-go
-go
-fZ
-gL
-gL
-mJ
-gL
-fZ
-gL
-ZB
-gL
-md
-mU
-mZ
-ny
+LT
+eZ
+Ua
+st
+GU
+Oy
+qi
+uH
+lr
+lJ
+hL
+LN
+vd
+BB
+Jv
+GC
+GC
+GC
+VM
+yv
+dU
+tQ
+Bs
+Es
+Nw
+Nw
 ac
-ZB
-ZB
+Nw
+GU
 aa
 aa
 aa
@@ -6931,99 +11889,90 @@ aa
 "}
 (29,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-ZB
-ax
+aL
+aq
 aX
 be
-ax
+bd
 vf
-vf
-vf
-vf
-vf
-vf
-Uz
+bv
+bC
+bI
+bv
+cR
 Uz
 Bf
-aa
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-ZB
-ZB
-dr
-dr
-ee
-ev
-dW
-ez
-dO
-ez
-ez
-ez
-ez
-ez
-dP
-ez
-dO
-ez
-dO
-dX
-dW
-dW
-hB
-eL
-hz
-hz
-hz
-hY
-hX
-hX
+Bf
+Bf
 jD
-jN
-gc
-gc
-gc
-gc
-kO
-kZ
+Bf
+Bf
+Bf
+kg
+Bf
+ll
+Bf
+nu
+Bf
+ok
+Bf
+Bf
+Bf
+Bf
+Bf
+ll
+Bf
+VT
+Bf
+MC
+MC
+Bf
+Bf
+sv
+Bf
+nu
+Bf
+Bf
+ll
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+jD
+Bf
+ot
+Bf
+iF
+zc
+Kw
+yW
 lf
-lq
-lI
-lr
-sd
-go
-fZ
-hD
-gm
-gL
-gL
-gL
-gL
-gL
-gL
-md
-mU
-mU
+Bs
+lJ
+hL
+wO
+WF
+hL
+WF
+hL
+Fm
+hL
+Bs
+En
+NF
+QK
+Bs
 nz
-ac
-aa
-aa
+Nw
+nz
+AN
+Nw
+GU
 aa
 aa
 aa
@@ -7044,99 +11993,90 @@ aa
 "}
 (30,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ax
-ax
-aW
-ax
+aL
+as
+aF
+be
+bh
 bl
-bl
-bl
-bl
-bl
-bl
-bl
-bl
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ci
-ZB
-dr
-dr
-ef
-ev
-ez
-dP
-dX
-dO
-ez
-ez
-ez
-dP
-dP
-dX
-dP
-ez
-gI
-dP
-gY
-hn
-eL
-eL
-hz
-hz
-hz
-hz
-hY
-hY
+bu
+bB
+aX
+ca
+cE
+bD
+Ua
+Ua
+fh
+gj
+fh
+Ua
+Ua
+Ua
+iE
+Rw
+Ua
+nt
+Ua
+gj
+Ua
+Ua
+Ua
+Ua
+Ua
+Rw
+Ua
+yR
+iE
+tS
+Ua
+Ua
+Ua
+gj
+Ua
+nt
+Ua
+Ua
+Rw
+Ua
+Ua
+Ua
+Ua
+iE
+Ua
+jO
+Ua
+jO
 jE
 jO
-go
-go
-go
-gc
+Ua
+Ua
+Km
+GU
 kP
-go
-sd
+qi
+uH
 lr
-lr
-lr
-sd
-go
-fZ
-gn
-gL
-gn
-go
-fZ
-gn
-gL
-gL
-md
-na
-mU
-nz
-ac
-aa
-aa
+lJ
+hL
+rP
+RP
+tZ
+Wm
+VA
+VA
+VA
+xf
+SK
+Ao
+Uc
+Bs
+Nw
+Nw
+Nw
+oS
+Nw
+GU
 aa
 aa
 aa
@@ -7157,99 +12097,90 @@ aa
 "}
 (31,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ax
-aR
-aR
-aR
-aR
-aR
-aR
-aR
-aR
-bg
-ax
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ci
-BO
-dr
-dr
-dO
-ME
-ev
-ez
-dX
-dO
-eW
-fq
-fq
-fI
-ez
-dP
-eZ
-gt
-fq
-gJ
-gR
-eL
-eL
-hn
-eL
-eL
-rK
-rK
-hz
-hz
-jj
-hv
-fZ
-go
-go
-go
-gc
-kD
-go
-go
-El
-go
-go
-go
-go
-kD
-go
-go
-gL
-go
-fZ
-gm
+aL
+at
+aM
+bl
+bi
+bl
+bu
+mo
+mo
+mo
+mo
+mo
+sX
+Sp
+fk
+hr
+fk
+pJ
+pJ
+pJ
+pJ
+lA
+mu
+bV
+Ua
+gj
+Ua
+hU
+hU
+ed
+hU
+hU
+hU
+hU
+hU
+hU
+hU
+hU
+Ua
+gj
+Ua
+By
+By
+Ns
+Ns
+Ns
+Ns
+By
+By
+By
+By
+By
+AP
+AP
+Tt
+AP
+lA
+mu
+ZD
+GU
+Sj
+qi
+uH
+GU
+CG
+hL
+GR
+GU
+xf
+Ri
+ra
+kc
+YF
+GU
+LW
 nL
-gm
-md
+sa
+GU
 mU
-mU
-nz
-ac
-aa
-aa
+Nw
+Nw
+Nw
+Nw
+GU
 aa
 nT
 aa
@@ -7270,99 +12201,90 @@ aa
 "}
 (32,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ax
-bf
-ax
-ax
-ax
-ax
-ax
-ax
-bo
-ax
-ax
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-dr
-dr
-dP
-eh
-ev
-ez
-dO
-eW
-fj
-fr
-fj
-fJ
-dW
-dX
-gh
+aL
+au
+bl
+bl
+bi
+bl
+bx
+mo
+se
+se
+se
+se
+se
+Sp
+fp
+hx
+if
+iv
+ju
+kh
+pJ
+pJ
+pJ
+pJ
+Ua
 gj
-dW
-dW
-dW
-eL
-eL
-eL
-eL
-eL
-eL
+Ua
+hU
+Xq
+Xq
+Xq
+Xq
+Xq
+Xq
+Xq
+Xq
+Xq
+hU
+ib
+gh
+Ua
+tV
+yb
+hN
+Xl
+Xl
+hN
+PA
+By
+UU
 rK
 iO
-hz
+AP
 jk
-hv
-fZ
-go
+eA
+ud
+GU
+GU
+GU
+GU
+GU
+qi
+LL
+GU
 js
-go
-gc
-kQ
-go
-go
-go
-js
-go
-go
-go
-fZ
-lG
-go
-go
-gm
-fZ
-go
-gn
-go
-mW
-mU
-mU
-md
-ac
-aa
-aa
+hL
+rP
+rp
+RT
+GU
+hL
+hL
+hL
+GU
+Kq
+rj
+sa
+Bs
+Vb
+Vb
+Id
+Vb
+Vb
+GU
 aa
 aa
 aa
@@ -7383,99 +12305,90 @@ aa
 "}
 (33,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ax
-bg
-aR
-aR
-aR
-aR
-aR
-aR
-aR
-ax
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-dr
-dA
-zp
-eh
-ew
-eF
-eN
-eX
-fk
-dP
-dP
-dW
-dW
-dW
-dW
-dW
-dW
-dO
-dW
-gJ
-dW
-ez
-dr
-dr
-eL
-eL
-hv
-ja
-hv
-hv
-fZ
-fZ
-fZ
-fZ
-kw
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-gO
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-md
-mU
-mU
-nz
-ac
-aa
-aa
+aL
+az
+aO
+bl
+bn
+bl
+bs
+mo
+bz
+se
+se
+se
+se
+Sp
+sQ
+hA
+sQ
+iv
+Zw
+Zw
+kL
+cG
+mv
+pJ
+Ua
+gj
+Ua
+hU
+Xq
+ci
+ci
+ci
+ci
+ci
+ci
+iA
+Xq
+hU
+nU
+Cr
+Ua
+By
+Al
+CC
+hN
+hN
+yr
+EU
+By
+JY
+TA
+Nc
+AP
+OD
+ud
+ud
+EP
+bN
+Lw
+cb
+Bs
+la
+uH
+Bs
+lJ
+hL
+rP
+He
+RT
+GU
+rs
+rs
+rs
+GU
+Ii
+CT
+sa
+Xc
+Vb
+Vb
+Vb
+Vb
+ZF
+GU
 aa
 aa
 aa
@@ -7496,99 +12409,90 @@ aa
 "}
 (34,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ax
-ax
-aR
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-cl
-cl
-cl
-cl
-dr
-dr
-dR
-dO
-dW
+af
+af
+aP
+aT
+bp
+br
+af
+mo
+mo
+xx
+mo
+se
+se
+Sp
+fq
+hr
+fq
+pJ
+Zw
+Zw
+Zw
+lB
+my
+pJ
+Ua
+gj
+Ua
+hU
+Xq
+ci
 dP
-dO
+NS
 eY
 fl
-dW
-dW
-eZ
-dW
-dW
-dW
-dW
-dO
-dX
-dO
-fb
+ci
+Xq
+hI
+hU
+Ua
+gj
+Ua
+By
 ho
-ez
-dr
-dr
-dr
-eL
-hv
-hz
+OU
+YW
+hN
+KU
+hN
+By
+tz
+aw
+JF
+AP
 OD
-hv
-fZ
-go
-kp
-go
-gc
-kp
-go
-fZ
-ls
+ud
+sb
+tx
+tx
+Ap
+tx
+Bs
+la
+uH
+Bs
 lJ
-lT
-lt
-mj
-mo
+hL
+MB
+mL
+mL
 mw
 mF
 mL
-lt
-ls
-lt
-lx
-aa
-md
-mU
-mU
-nz
-ac
-aa
-aa
+LV
+Py
+To
+wF
+PK
+Bs
+Nw
+Nw
+Nw
+Nw
+Nw
+GU
 aa
 aa
 aa
@@ -7610,98 +12514,89 @@ aa
 (35,1,1) = {"
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ax
-ax
-aR
-aR
-aR
-aR
-aR
-aR
-aR
-bg
-ax
-aa
-aa
-aa
-aa
-aa
-cn
+af
+af
+af
+af
+af
+af
+ZB
+mo
+se
+mo
+se
+se
+Sp
+fs
+hE
+ip
+Zw
+Zw
 cu
 cu
-cw
-cO
-cY
-df
-ds
+Zw
+mz
+pJ
+Ua
+gj
 dB
-dW
-ei
-ex
-dO
-dX
-eZ
-dW
-dW
-dW
-ai
-ai
-ai
-ai
-ai
-dW
-dW
+hU
+Xq
+ci
+AV
+yZ
+Qb
+Mj
+ci
+ci
+ci
+ci
+vk
+yw
+yR
+By
+hN
 gS
-ft
-ez
-dO
-ez
-dr
-dr
-dr
-hv
-ja
-hv
-hv
-fZ
-go
-go
-go
-gc
-go
-go
-fZ
-lt
+hN
+hN
+UT
+GZ
+By
+Of
+By
+By
+AP
+OD
+ud
+JJ
+tx
+kA
+Aj
+Kw
+xc
+Va
+WG
+GU
 lK
 lU
-ls
-lt
-lt
-mx
-ls
-mM
-ls
+hL
+hL
+hL
+hL
+NQ
+hL
+hL
 tc
-mP
-lx
-aa
-md
+hL
+sJ
+pM
+GU
 nc
-mU
-nz
-ac
-aa
-aa
+Nw
+cj
+Nw
+rl
+GU
 aa
 aa
 aa
@@ -7730,91 +12625,82 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-bo
-ax
-ax
-aa
-aa
-ZB
-aa
-ZB
-co
-cv
+mo
+Mt
+Sp
+Sp
+Sp
+Sp
+fr
+hF
+Zw
+Zw
+cp
+AG
 cG
-cO
-cO
-cZ
-dg
-cO
-cl
-da
-da
-dr
+Zw
+mA
+pJ
+Ua
+gj
+Ua
+hU
+Xq
+ci
 eG
-dO
-dW
-dW
-dW
-dW
+yZ
+Mg
+Ne
+AO
+Nz
 ai
-ai
-ai
-ai
-ai
-dW
-dW
-dO
-ez
-dO
-dP
+zZ
+XS
+gj
+Ua
+KR
 hN
-dr
+hN
+hN
+ho
+sM
+YW
+By
 im
-dr
-hv
-iD
-gP
-jp
-fZ
-go
-Rw
-go
-gc
-gc
+dg
+Tx
+AP
+OD
+ud
+sE
+tx
+Mq
+tx
+tx
+Bs
 la
-fZ
-lu
-lt
+uH
+Bs
+Bs
 lV
-lt
-lt
-lt
-lt
-lt
-ls
-lt
-ls
-ma
-ls
-lx
-md
-mI
-mU
-nz
-ac
-aa
-aa
+Rk
+Ya
+Rk
+Rk
+uO
+Rk
+Rk
+uO
+Rk
+tQ
+EF
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 aa
 aa
 aa
@@ -7843,89 +12729,80 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-ax
-bg
-aR
-aR
-aR
-aR
-aR
-aR
-aR
-ax
-ax
-aa
-Uz
 ZB
-aa
+jV
+EN
+dq
+dq
+dq
+Zw
+hG
+ir
 cl
 cp
 cw
 cH
-cO
-cO
-RF
-dg
-dg
-dC
-ej
-ej
-dr
-ez
-dW
+Zw
+mB
+pJ
+Ua
+gj
+Ua
+hU
+Xq
+ci
+pk
+hO
 fa
-dW
-dW
-dW
-ai
-ai
-ai
-ai
-ai
-dW
-dW
-dP
-ez
-dO
-dP
-dX
-dW
+QA
+TC
+QA
+QA
+IX
+Mr
+ok
+Bf
+kE
+qh
+JD
+PV
+PV
+Lp
+qh
+yn
 in
-dr
+kt
 iP
-ay
-ay
-jp
-fZ
-go
-go
-go
-gc
-go
-go
-fZ
-lt
-lL
-lL
-ma
-lt
-lt
-lt
-lt
-lt
-lt
-lt
-lt
-mG
+AP
+vB
+ud
+Xi
+tx
+tl
+VG
+jY
+Ww
+re
+uH
+tx
+Bs
+dI
+Bs
+GU
+GU
+GU
+ql
+Nw
+Nw
+ql
+Nw
+am
 mT
-md
-ne
-no
-nz
-ac
+sp
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -7957,88 +12834,79 @@ aa
 aa
 aa
 aa
-aa
-aa
-ax
-ax
-aR
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-aa
-vf
-Lv
-aa
-cl
-co
-cu
-cu
-cP
-cO
-db
-dg
-cO
-cl
-dV
-ek
-ey
-dW
-dW
-dW
-dW
-dW
-dW
-ai
-ai
-ai
-ai
-ai
-dW
-dP
-dX
-ez
-fW
-dP
-dO
-dr
+ZB
+EN
+Zw
+Zw
+Zw
+Zw
+hJ
+is
+sH
+Zw
+Zw
+Zw
+Zw
+mC
+pJ
+Ua
+gj
+Ua
+hU
+Xq
+ci
+eG
+sd
+Qv
+yC
+AO
+oO
+bT
+zZ
+XS
+gj
+Ua
+KR
+hN
+Ge
+hN
+hN
+hN
+RY
+By
 ux
-dr
+dg
 iQ
-ay
-ay
-gP
-fZ
-go
-go
-go
-gc
-go
-go
-gk
-lv
-lv
-lv
-lt
-ls
-lt
-lt
-lt
-ls
+AP
+OD
+ud
+ud
+ud
+ud
+GU
+GU
+GU
+PH
+Ku
+OY
+yt
+IR
+tx
+tx
+Bs
+Nw
+Hw
+mN
 mN
 mG
-lt
-lt
-mG
-md
-nf
-np
-md
-ch
+Nw
+Pj
+GU
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -8071,87 +12939,78 @@ aa
 aa
 aa
 aa
-aa
-ax
-ax
-aR
-aR
-aR
-aR
-aR
-aR
-aR
-bg
-ax
-aa
-vf
-Lv
-aa
-cl
-cq
-cu
+EN
+dz
+eq
+eE
+fE
+hP
 cI
-co
-cu
-dc
-di
-du
-dD
-cl
-el
-dr
-ez
-ez
-dW
-dW
-dW
-dW
-ai
-ai
-ai
-ai
-ai
-dW
-dO
-eh
+iL
+cI
+ki
+cI
+lC
+mD
+pJ
+Ua
+gj
+Ua
+hU
+Xq
+ci
+eG
+JV
+yZ
+Mj
+US
+US
+US
+US
+SL
+gj
+Ua
+By
+ry
 gZ
-ez
-dO
-ez
-dr
-dr
-dr
-GM
-ay
-ay
-gD
-fZ
-fZ
-fZ
-go
-gc
-go
-go
-gk
+gZ
+gZ
+gZ
+gZ
+By
+UJ
+dg
+HB
+AP
+JS
+AP
+Zt
+QC
+ud
+Pz
+Pz
+GU
+UN
+sc
 lw
 lN
 Qt
-PR
-MS
+tx
+tx
 mp
-ls
-ls
-lt
-ls
-mN
-lt
-ls
-mG
-md
-ng
-nq
-nz
-ac
+Nw
+Tr
+Bc
+vh
+vh
+TQ
+tK
+GU
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -8184,87 +13043,78 @@ aa
 aa
 aa
 aa
-aa
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-bp
-aR
-ax
-ax
-vf
-Lv
-aa
-cl
-cl
-ZB
-aa
-aa
-ZB
-cl
-cl
-dr
-dr
-dW
-em
-dW
-ez
-dO
+EN
+EN
+EN
+eF
+EN
+EN
+iv
+iR
+iv
+EN
+iv
+lD
+iv
+pJ
+nU
+gj
+Ua
+hU
+Xq
+ci
+uu
+PQ
 fb
 fm
-dW
-dW
-dW
-dW
-dW
-dW
-dW
-dW
-dW
-ei
-ev
-ez
-ez
-dr
-dr
-dr
-GM
-tS
-tS
-jm
-jF
-fZ
-fZ
-fZ
-go
-gc
-go
-go
-gk
+US
+sj
+IJ
+Ot
+Bf
+ol
+fG
+By
+By
+XF
+Tp
+sD
+xm
+pe
+By
+HU
+dg
+Ak
+AP
+OD
+AP
+Xz
+qW
+ud
+Pz
+Xv
+Gr
+ML
+cB
 pZ
 lO
-ES
-VV
-mk
+qb
+qb
+qb
 mq
-mp
-lt
-lt
-lt
+mq
+mq
+Un
+xb
 Mi
 Bs
-lt
-lt
-md
-nh
-nr
-nz
-ac
+Bs
+GU
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -8298,86 +13148,77 @@ aa
 aa
 aa
 aa
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-bp
-ax
-ax
-ax
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-dr
-dr
-dO
-dO
-ez
-dO
-dO
-fc
-fm
-dW
-dW
-dW
-dW
-dW
-dW
-dW
-dW
-dW
-eh
-ev
-dO
-ez
-dr
-dr
-GM
-GM
-GM
-GM
-jn
-ay
-gD
-fZ
-fZ
-jZ
-gc
-go
-go
-gk
+EN
+et
+eN
+UD
+EN
+ct
+eN
+jF
+EN
+ct
+eN
+mI
+pJ
+Ua
+gj
+Ua
+hU
+Xq
+ci
+ci
+ci
+ci
+ci
+ci
+Bv
+vj
+bV
+Ua
+gj
+Ua
+By
+ER
+ny
+ny
+ny
+ny
+FM
+By
+rt
+Qd
+YD
+AP
+OD
+AP
+RQ
+Sq
+ud
+Eq
+Cv
+Bs
+SA
+Vb
 ly
-ly
-ly
-lx
-lx
-mr
-lt
-lt
-lt
-lt
-ms
-lt
-lt
-lt
-md
-ni
-ns
-nz
-ac
+Ab
+sT
+tx
+tx
+GU
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -8411,86 +13252,77 @@ aa
 aa
 aa
 aa
-ax
-ax
-ax
-ax
-aR
-by
-bw
-by
-aR
-aR
-bT
-ax
-Uz
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-dr
-dr
-dX
-dO
-dX
-dP
-dO
+EN
+Pb
+eS
+Pb
+EN
+it
+iT
+jG
+EN
+kM
+iT
+jG
+pJ
+Ua
+gj
+Ua
+hU
+Xq
+Xq
+Xq
+Iy
 fd
 fn
-fs
-fE
-fE
-fN
-fV
-dW
-dW
-dW
+hU
+hU
+hU
+hU
+Ua
+gj
+Ua
+By
 gK
-gS
-ew
-dP
-dO
-dr
-dr
-GM
-tS
-tS
-GM
-ay
+ny
+Fp
+RI
+ny
+ny
+Vx
+nn
+yx
+yx
+qm
+Gd
 gD
-jp
-fZ
-fZ
-go
-gc
-go
-go
+Yl
+Bm
+ud
+Pz
+Ef
+Dj
+Qu
 lh
-lt
+ri
 lP
-ls
-lP
-lP
-mr
-lt
-mr
-mr
-mG
-mN
-mp
-lx
-lx
-md
-nj
-nt
-nz
-ac
+tx
+tx
+tx
+GU
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -8524,86 +13356,77 @@ aa
 aa
 aa
 aa
-ax
-ax
-ax
-bg
-aR
-aR
-aR
-aR
-be
-ax
-ax
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ci
-dj
-dr
-dr
-dO
-dO
+EN
+eu
+eT
+fI
+EN
+EN
+EN
+xo
+xo
+xo
+xo
+xo
+xo
+Ua
+gj
+Ua
+hU
 Xq
-Rd
-dO
-ez
-fd
-ft
-ft
-ew
-dW
-dW
-gi
-gw
-gE
-gE
-gT
-dO
-dX
-dP
-dr
-dr
-GM
-tS
-xi
-GM
-ay
-ay
-jp
-fZ
-go
-gc
-gc
-go
-go
-fZ
+Xq
+Xq
+Xq
+Xq
+Xq
+Xq
+Xq
+Xq
+ed
+Ua
+gj
+Ua
+By
+By
+By
+By
+By
+QG
+Ol
+By
+AP
+AP
+AP
+AP
+zG
+AP
+Hr
+Dx
+ud
+Pz
+Pz
+GU
+Qa
+ys
 lx
-lx
-lx
-lx
-lx
-ms
-mt
-mG
-mG
-mp
-mp
-mt
-lx
-lz
-md
-nk
-nu
-nz
-ac
+qi
+YX
+tx
+NP
+GU
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -8637,86 +13460,77 @@ aa
 aa
 aa
 aa
-ax
-ax
-ax
-ax
-bn
-aR
-bx
-bD
-aR
-ax
-bU
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+EN
+EN
+EN
+EN
+EN
 ZB
-ci
 ZB
-dr
-dr
+lu
+kj
+kQ
+lE
+mV
+Yg
+nV
+gj
+Ua
+hU
 en
-ez
-ez
-dX
-dP
-dO
-ez
-dW
-dW
-ez
-ez
-dW
-ez
-dP
-dX
-dP
-dO
-ez
-dr
-dr
-GM
-tS
-iD
-tS
-GM
-ay
-ay
-jp
-fZ
-go
-gc
-go
-gk
-gk
-gk
-ly
-ly
-ly
-ly
-ly
-mt
-mz
-mt
-lx
-lx
-mt
-lA
-lA
-lz
-md
-nl
-nv
-md
-eu
+Xq
+Xq
+Xq
+Xq
+Xq
+Xq
+Xq
+hU
+hU
+nU
+tm
+Bf
+Bf
+wv
+Ey
+gy
+Fi
+DM
+Kr
+Kr
+Bt
+Dp
+Dp
+Yh
+cg
+ud
+ud
+ud
+ud
+GU
+GU
+GU
+oR
+PI
+GU
+tP
+GU
+Bs
+GU
+GU
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -8750,86 +13564,77 @@ aa
 aa
 aa
 aa
-ax
-ax
-ax
-bg
-aR
-aR
-aR
-aR
-bt
-aW
-be
-ax
 aa
-aa
-aa
-aa
-aa
-aa
+ZB
 aa
 aa
 aa
 ZB
-ZB
-ZB
-dr
-dr
+aa
+lu
+ko
+kR
+lQ
+mY
+nv
+nX
+ol
+fG
+hU
 eo
-dW
-ez
-dO
-dX
-dP
-fu
-ez
-ez
+Xq
+Xq
+ci
+Xq
+Xq
+Xq
+hI
+hU
 fO
-fW
-ez
-ez
-dP
-ez
-dP
-ez
-ez
-dr
-dr
-tS
-tS
-iD
-tS
-tS
-jo
-gP
-gD
-fZ
-go
-gc
-go
-gk
+Ua
+gj
+Ua
+Ua
+Ns
+Kr
+Jd
+GM
+RH
+GM
+CY
+AP
+AP
+AP
+VQ
+AP
+AP
+jp
+Nk
+Nk
+Nk
+Nk
+Nk
 Vz
 Tm
 lz
-lz
-lz
-lz
-OT
-lz
-lA
-lA
-lz
-Ih
-Ih
-lz
-lA
-lz
-md
-mI
-mU
-nz
-eu
+sl
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -8862,104 +13667,95 @@ aa
 aa
 aa
 aa
+aa
+aa
 ZB
-ax
-ax
-ax
-ax
-bo
-Oo
-Vg
-bX
-bg
-ax
-bV
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
 ZB
-ZB
-ZB
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-dO
-fP
-fX
-dO
-fb
-dr
-dr
-dr
-dr
-dr
-dr
+aa
+lu
+kq
+kS
+lX
+ne
+Yg
+nY
+gj
+Ua
+ci
+ci
+ci
+ci
+ci
+hU
+hU
+QY
+hU
+hU
+fQ
+Ua
+gj
+Ua
+Ua
+Ol
+Kr
+ox
 GM
-ay
-ay
-iE
-ay
-jb
+vD
+GM
+uk
+By
+ZB
+Lv
+jC
+Lv
 jp
-jp
-jb
-fZ
-go
-gc
-go
-gk
-Vz
-Tm
-lz
-lA
-lA
-lA
-OT
-lA
-lA
-lA
-lz
-lz
-kF
-lz
-lA
-lz
-md
-mI
-mU
-nz
-eu
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Ht
+ZB
 aa
 ZB
+aa
 ZB
+XN
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 "}
@@ -8975,106 +13771,97 @@ aa
 aa
 aa
 aa
+aa
+aa
 ZB
-Uz
-ax
-bj
-ax
-bp
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
 ZB
-ZB
-ZB
-ZB
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-ez
-fQ
-fQ
+aa
+lu
+lu
+lu
+lu
+lu
+lu
+Ua
 gj
-fJ
-dr
-dr
-dr
-dr
-dr
-dr
-GM
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-go
-gc
-go
-gk
+Ua
+fe
+HF
+RF
 Sm
-Tm
-lA
-lA
-lz
-lA
-OT
-lz
-Ih
-lA
-lA
-lA
-lA
-lA
-KN
-lz
-md
-mI
-mU
-nz
-ac
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fe
+Sl
+hD
+hD
+Cn
+mJ
+fQ
+Ua
+gj
+Ua
+Ua
+Ol
+Kr
+HA
+GM
+PD
+GM
+ZH
+By
+ZB
+Lv
+BK
+Lv
+Ji
+ZB
 aa
 aa
 ZB
 aa
+aa
 ZB
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (48,1,1) = {"
 aa
@@ -9088,106 +13875,97 @@ aa
 aa
 aa
 aa
-ZB
-Uz
-ax
-bj
-ax
-aW
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 ZB
 aa
 aa
 aa
-aa
-aa
-aa
 ZB
-ZB
-dr
-dr
-dW
-dO
-dO
-dX
-ez
-dr
-dr
-tS
-tS
-tS
-tS
-gL
+aa
+Lr
+kr
+cv
+lY
+nf
+Ua
+Ua
+gj
+Ua
+fe
+HF
+Sm
+Sm
+fe
+uP
+hD
+hD
+Bx
 mJ
-gm
-gn
-fZ
-go
-go
-go
-go
-go
-go
-gc
-go
-gk
-Vz
-Tm
-Av
-lA
-lz
-lA
-OT
-lA
-OT
-QA
-lA
-OT
-Tm
-KN
-KN
-KN
-md
-mI
-mU
-nz
-ac
+Ti
+ib
+kd
+Ua
+Ua
+Ns
+dt
+Ou
+WU
+zx
+Kr
+UV
+By
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-nB
-vf
-vf
-vf
-vf
-vf
-vf
 ZB
-vf
-vf
-vf
-vf
+Zg
+Nk
+Ht
+aa
+aa
+aa
+tr
+tr
+tr
+tr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (49,1,1) = {"
 aa
@@ -9202,94 +13980,49 @@ aa
 aa
 aa
 aa
-Uz
-ax
-bj
-ax
-aR
-bt
-bz
-bz
-bI
-bP
-bj
-bj
-ax
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ZB
 aa
 aa
 aa
 ZB
-ZB
-dr
-dr
-ez
+aa
+Lr
+Ua
+Ua
+Ua
+Ua
+Ua
+Ua
+gj
+Ua
+fe
+HF
+Sm
+Sm
+fe
+HN
+hD
+hD
+Wr
+mJ
+mJ
 xI
-ez
-dr
-dr
-GM
-tS
-gL
-gL
-gl
-gl
-gm
-gm
-gb
-ip
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-go
-gk
-Vz
-Vz
-Tm
-lA
-lz
-mb
-lz
-lz
-mA
-lA
-lz
-OT
-Tm
-lz
-lA
-lz
-md
-mI
-mU
-nz
-ac
-aa
-aa
+gj
+Jb
+bV
+By
+By
+Ns
+By
+Ns
+By
+By
+By
 aa
 aa
 ZB
 ZB
-ZB
-nB
 aa
 aa
 aa
@@ -9297,10 +14030,46 @@ aa
 aa
 aa
 aa
-ZB
 aa
 aa
-vf
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (50,1,1) = {"
 aa
@@ -9314,106 +14083,97 @@ aa
 aa
 aa
 aa
-ZB
-Uz
-ax
-bj
-ax
-ax
-ax
-bj
-bj
-bz
-bj
-bj
-bj
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 ZB
-dr
-dr
-dr
-dr
+ZB
+ZB
+aa
+ZB
+ZB
+ZB
+Lr
+ks
+kT
+lZ
+Ua
+iE
+kT
+on
+kT
+fe
+Ih
+Su
+Su
+fe
+BR
+hD
+hD
+Nv
+Hu
+mJ
+ZI
 gk
-gk
-gk
-GM
-gl
-gl
-gL
-gm
-gm
-gn
-ip
-gn
-gn
-go
-go
-go
-gc
-go
-go
-gc
-gc
-kR
-lc
-li
-Vz
-Tm
-Tm
-Tm
-lz
-lz
-lz
-lA
-lz
-lz
-lz
-lz
-lA
-lz
-md
-mI
-mU
-md
-aY
-nB
-nI
+Nf
+bV
 ZB
+aa
+aa
+aa
+aa
 ZB
-ld
-nV
-nV
-nB
 aa
 aa
-on
-ol
-on
 aa
-on
-ol
-on
 aa
-vf
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (51,1,1) = {"
 aa
@@ -9426,107 +14186,98 @@ aa
 aa
 aa
 aa
-aa
-ZB
-Uz
-ax
-bj
-bj
-bj
-bj
-bj
-bj
-bz
-bj
-bj
-bj
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-Oj
-Oj
-aa
-ZB
-dr
-dr
-gk
-gl
-gl
-gl
+FL
+FL
+FL
+FL
+FL
+FL
+FL
+FL
+FL
+fe
+fe
+kU
+vP
+vP
+fe
+fe
+op
+fe
+fe
+yE
+yE
+yE
+fe
+fe
+hD
+hD
+Nv
+FI
 mJ
-gm
-gm
-gn
-gn
-gn
-gn
-go
-fZ
-go
-go
-js
-gc
-go
-go
-gk
-gk
-gk
-Vz
-lj
-lB
-lQ
-lj
-Tm
-KT
-lz
-lz
-lA
-lz
-lz
-lz
-lz
-lA
-lz
-md
-mI
-mU
-nz
-ac
+tu
+dx
+As
+bV
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
 aa
-nV
+aa
+aa
+aa
 ZB
-nV
-nV
-wK
-nR
 aa
 aa
 aa
-on
-ol
-on
 aa
-on
-ol
-on
 aa
-vf
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (52,1,1) = {"
 aa
@@ -9539,21 +14290,50 @@ aa
 aa
 aa
 aa
+FL
+bJ
+dL
+mP
+FL
+bJ
+dL
+mP
+FL
+jH
+kB
+kB
+mb
+ng
+OS
+nZ
+dy
+wK
+OS
+Ys
+Ys
+Ys
+Ts
+fe
+Ls
+hD
+Nv
+hD
+Hd
+Ob
+dx
+Ob
+BV
+hb
+ED
+mK
+Ho
+GK
+hb
+aa
+aa
+aa
 aa
 ZB
-Uz
-ax
-bj
-bj
-bj
-bj
-ax
-ax
-bJ
-ax
-ax
-ax
-ax
 aa
 aa
 aa
@@ -9572,74 +14352,36 @@ aa
 aa
 aa
 aa
-cs
-cs
-cs
-cs
-cs
-fZ
-fZ
-gl
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-go
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-fZ
-gc
-fZ
-fZ
-gk
-kI
-kS
-Vz
-Vz
-lC
-Vz
-Vz
-Vz
-OT
-lA
-lA
-lA
-lA
-lA
-lA
-lA
-lA
-Tm
-md
-mI
-mU
-nz
-ac
-aa
-nV
-nV
-nV
-wK
-og
-nR
-nB
 aa
 aa
-on
-ol
-on
 aa
-on
-ol
-on
 aa
-vf
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (53,1,1) = {"
 aa
@@ -9652,107 +14394,98 @@ aa
 aa
 aa
 aa
-aa
-aa
-ci
-ax
-bj
-bj
-bj
-bj
-ax
-bz
-bz
-bO
-bz
-bP
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-dk
-aa
-aa
-aa
-aa
-aa
-aa
-cs
+FL
+Vt
+mP
+mP
+FL
+Vt
+mP
+mP
+FL
+jI
+Ys
+Ys
+Ys
+Ys
+OS
+oa
+Wl
+xa
+OS
+Ik
+Ys
+gG
+wx
+fe
+Xs
 yd
 fF
-fx
-cs
+OQ
+pc
 ga
 gl
 ga
-fZ
-gn
-gn
-go
-fZ
-go
-go
-go
-fZ
-go
-gL
-go
-go
-go
-gc
-go
-go
-gk
-gk
-kT
-OT
-OT
-lD
-lD
-lX
-mc
-OT
-Tm
-Tm
-lz
-lz
-lA
-lz
-lz
-Tm
-Vz
-md
-mI
-mU
-nz
-ac
+yD
+ie
+Ng
+Ep
+Ie
+qo
+hb
 aa
-nB
-nB
-nB
-nB
-oe
-nB
-nB
+aa
+aa
+aa
 ZB
 aa
 aa
-ol
 aa
 aa
 aa
-ol
 aa
 aa
-vf
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (54,1,1) = {"
 aa
@@ -9765,107 +14498,98 @@ aa
 aa
 aa
 aa
-aa
-ZB
-Uz
-ax
-bj
-bj
-bj
-bj
-ax
-bE
-bE
-bQ
-bY
-bO
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-dk
-cs
+FL
+Vt
+mP
+mP
+FL
+Vt
+mP
+mP
+FL
+jJ
+Ys
+Ys
+mc
+nh
+OS
+ob
+yI
+xi
+OS
+Jl
+Ys
+mg
+Wz
+fe
+mJ
 fw
-fx
-fx
-fR
+qp
+mJ
+mJ
 gb
 gm
 gz
-fZ
+mJ
 gL
-gL
-go
-fZ
-gz
-gn
-gn
-fZ
-gz
-go
-go
-jr
-go
-gc
-gn
-ko
-go
-gk
-gk
-OT
-Sm
-Vz
-Vz
-Vz
-Vz
-OT
-Vz
-KT
-Tm
-lz
-lA
-lz
-lz
-Tm
-Vz
-md
-mI
-mU
-nz
-ac
+Gh
+KY
+hD
+Ki
+hb
+ZB
 aa
-nJ
-nO
-nU
-nY
-of
-MQ
-ok
-ol
-ol
-ol
-ol
-ol
-oz
-ol
-ol
-ol
-oD
-vf
+aa
+aa
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (55,1,1) = {"
 aa
@@ -9878,107 +14602,98 @@ aa
 aa
 aa
 aa
-aa
-aa
-Uz
-ax
-bj
-bj
-bj
-bj
-ax
-bz
-bL
+FL
+YQ
 bR
-bK
+Ds
 cd
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-dk
-aa
-Jl
-dk
-aa
-aa
-aa
-aa
-aa
-cs
-fx
-fx
-fx
-cs
-gb
-gn
-gn
-gF
-gL
-gn
-go
-go
-gn
-gL
-gn
-fZ
-gn
-gL
-go
-go
-go
-gb
-go
-gn
-go
-kJ
-fZ
+YQ
+bR
+Ds
+FL
+jK
+Ys
+Ys
+me
+sk
+OS
+OS
+oq
+OS
+OS
 KN
-Vz
-Vz
-lE
-lE
-Vz
-OT
-Vz
-Tm
-Tm
-Tm
-OT
-lz
-Tm
-Vz
-Vz
-md
-mI
-mU
-md
-nB
-nB
-nJ
-nB
-nV
-nB
-og
-nB
-nB
+Ys
+mg
+Aw
+fe
+NJ
+hD
+hD
+rQ
+fS
+Du
+gn
+RX
+mJ
+BM
+hD
+Gv
+hD
+xy
+hb
+ZB
 ZB
 aa
 aa
-ol
-aa
-aa
-aa
-ol
-aa
-aa
 ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (56,1,1) = {"
 aa
@@ -9991,107 +14706,98 @@ aa
 aa
 aa
 aa
-aa
-ZB
-Uz
-ax
-bj
-bj
-bj
-bj
-ax
-bz
+FL
 bM
-bL
-bF
-bO
-ax
-ci
-ci
-ci
-ci
-aa
-aa
-aa
-aa
-aa
-dk
+dM
+ex
+FL
+bM
+dM
+ex
+FL
+FL
+Ys
+Ys
+mf
+ni
+OS
+gR
 dv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-cs
-fy
-fx
-fx
+gR
+OS
+KP
+Ys
+mg
+wT
+fe
+Tg
+hD
+hD
+NW
 fS
 gc
 go
-go
-fZ
-fZ
-gn
-gn
-fZ
-gz
-gz
-gL
-gz
-gz
-gz
-go
-js
-gL
-gc
-go
-gn
-go
-gn
-fZ
-KN
-zJ
-lE
-lE
-lE
-Vz
-OT
-Vz
-lj
-Vz
-Vz
-OT
-Tm
-Vz
-Vz
-Vz
-md
-mI
-mI
-mI
-nC
-nF
-nC
-MQ
-MQ
-nZ
-nR
-nR
-nB
+od
+mJ
+LF
+FO
+mH
+EB
+Lx
+mJ
+mJ
+hb
+mJ
+mJ
+ZB
 aa
 aa
-on
-ol
-on
 aa
-on
-ol
-on
 aa
-vf
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (57,1,1) = {"
 aa
@@ -10104,107 +14810,98 @@ aa
 aa
 aa
 aa
-aa
-aa
-Uz
-ax
-bj
-bj
-bj
-bj
-ax
-bF
-Kf
-CZ
-bZ
-bE
-ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Ds
+Vn
+Vn
+Vn
+eU
+Vn
+Vn
+Vn
+iV
+FL
+kC
+Ys
+mg
+Ys
+OS
 Oj
-dk
-Oj
-aa
-aa
-aa
-aa
-aa
-ZB
-cs
-fz
-fx
-fx
-fS
-gc
-go
-gA
-fZ
-go
-go
-hb
-fZ
-fZ
-gz
-gk
-gk
-gk
-gk
-gk
-gk
-go
-gc
-gL
-go
-go
-fZ
-fZ
-ch
-ch
-ch
-ch
-ch
-md
-mf
-mf
-mB
-mf
-mf
-mf
-md
-md
-md
-md
-md
-mI
-mU
-mZ
-nB
-nB
-nB
-nQ
-nR
-nR
-oh
-nR
-nB
-aa
-aa
-op
-ol
 oy
+yE
+OS
+KS
+Ys
+HZ
+IP
+fe
+DF
+hD
+hD
+qz
+mJ
+hb
+Jh
+hb
+mJ
+gL
+ZX
+hb
+tA
+mJ
+mJ
+NE
+IB
+oV
+mJ
+mJ
 aa
-on
-ol
-on
 aa
-vf
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (58,1,1) = {"
 aa
@@ -10217,107 +14914,98 @@ aa
 aa
 aa
 aa
-aa
-ZB
-Uz
-ax
-bj
-bj
-bj
-bj
-ax
-bG
-Ob
-xr
-GP
-YQ
-ce
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-Oj
-Oj
-Oj
-aa
-aa
-aa
-aa
-ZB
-ZB
-cs
-fA
-fx
-fx
-fS
-gc
-go
-go
-fZ
-gM
-go
-go
-fZ
-gz
-hD
-gk
-Bx
-IA
-IA
-iq
-gk
-go
-gc
-go
-kq
-go
-kK
-aa
-gD
-ay
-ZB
-ZB
-ZB
-me
+Ds
+Vn
+Vn
+Vn
+eV
+fN
+hQ
+hQ
+iW
+jM
+MY
+kV
 ml
-mu
-mC
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mU
-mZ
-mZ
-nG
-nM
-KS
-nX
-oa
-oi
-nV
-nB
+MY
+nA
+oc
+Vv
+zg
+FU
+KT
+SR
+Rb
+bb
+Vq
+GA
+hD
+hD
+hD
+hD
+hD
+OZ
+hD
+Kh
+gM
+zS
+zS
+zS
+KG
+Dt
+Mx
+Bx
+hD
+Kx
+hb
 aa
 aa
-oq
-dk
 aa
-dk
-on
-ol
-on
 aa
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (59,1,1) = {"
 aa
@@ -10330,96 +15018,50 @@ aa
 aa
 aa
 aa
-aa
-ZB
-Uz
-ax
-bj
-bj
-bj
-bj
-ax
-bO
-bE
-bO
-bO
-bO
-ce
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-Oj
-Oj
-Oj
-aa
-aa
-aa
-ZB
-ZB
-ZB
-cs
-fB
-fx
-fx
-fS
-gc
+FL
+cS
+dN
+ey
+FL
+gr
+Vn
+Vn
+iX
+FL
+kF
+lc
+mm
+mm
+OS
+dm
+Wl
+mm
+OS
+Le
+TJ
+UY
+IP
+GY
+QB
+hD
+hD
+hD
+QZ
+sN
 gp
-gp
-fZ
+sN
+OQ
 gN
-go
-fZ
-fZ
-gz
-gz
-gk
+sN
+uA
+sN
+OQ
+Sr
+PP
 IA
-iq
+hD
 ia
-IA
-gk
-gk
-jQ
-gk
-gk
-gk
-ch
-aa
-aa
-ZB
-ch
-aa
-ZB
-mf
-mf
-mf
-mD
-mD
-mD
-mD
-mD
-mD
-mf
-mU
-mU
-mZ
-mU
-mU
-mU
-nG
-nM
-nS
-nR
-ob
-nR
-nR
-nB
+hb
 aa
 aa
 aa
@@ -10427,89 +15069,103 @@ aa
 aa
 aa
 aa
-ZB
 aa
 aa
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (60,1,1) = {"
 aa
 aa
 aa
-ZB
-ZB
 aa
 aa
-ZB
-ZB
 aa
 aa
-ZB
-ci
-ax
-bj
-bj
-bj
-bj
-ax
-bK
-Lr
-xr
+aa
+aa
+aa
+FL
+Ds
+dR
 YQ
-LX
+FL
 UG
-ce
-ce
-ce
+Vn
+iu
+iY
+FL
 cr
-cr
-cr
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-gd
-cs
-cs
-fZ
-fZ
-fZ
-fZ
-fZ
+ld
+KF
+KF
+OS
+kF
+Wl
+mm
+OS
+LX
+Ud
+Ys
+wY
+GY
+HS
+Gf
 hD
-gL
-gk
-Bx
-IA
-aa
-aa
-Uz
-fZ
-gc
-fZ
-fD
-fD
-ZB
-aa
-aa
-aa
-ZB
-aa
-aa
-aY
+FZ
+Zm
+hD
+lM
+hD
+hD
+Zm
+ZR
+WA
+qy
+hD
+Dt
+Mx
+rg
+hD
+YJ
+hb
 aa
 aa
 aa
@@ -10518,113 +15174,102 @@ aa
 aa
 aa
 aa
-md
-mV
-mU
-mU
-mU
-mU
-mU
-mf
-mf
-mf
-mf
-mf
-mf
-mf
-mf
-vf
-vf
-vf
-vf
-ZB
-vf
-vf
-ZB
-ZB
-vf
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}
 (61,1,1) = {"
 aa
 aa
 aa
-ZB
-vf
-vf
-vf
-vf
-ZB
 aa
 aa
 aa
-Uz
-ax
-bj
-bj
-bj
-bj
-ax
-ax
-ax
-kx
-ce
-ax
-ax
-bj
-bj
-bj
-cs
+aa
+aa
+aa
+aa
+FL
+mP
+mP
+Vt
+FL
+gE
+Vn
+iw
+ja
+FL
 ZM
-cF
-cx
-cT
-cx
-dl
-dw
-cx
-dl
-dw
-cx
-cx
-cx
-cs
-cs
-cs
-cs
-cs
-fx
-fT
-gq
-fx
-fZ
+Ss
+Ss
+Ss
+OS
+dm
+Wl
+mm
+OS
+ME
+Vg
+Ys
+MA
+GY
+mJ
+mJ
+mJ
+mJ
+VI
+mJ
+mJ
+mJ
+fS
 gO
-fZ
-fZ
-fZ
-gz
-gL
-gk
+mJ
+SU
+hb
+mJ
+mJ
+LD
 iq
-IA
-aa
-aa
-ZB
-jG
-jR
-jG
-ZB
-ZB
-aa
-aa
-eV
-ZB
-ZB
-aa
-aa
-aY
-ay
-ch
+uY
+mJ
+mJ
 aa
 aa
 aa
@@ -10632,110 +15277,102 @@ aa
 aa
 aa
 aa
-md
-mU
-mU
-mU
-mU
-mZ
-nH
-nN
-nN
-nN
-oc
-nN
-nN
-nN
-ZB
 aa
 aa
 aa
 aa
 aa
 aa
-ZB
-ZB
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 "}
 (62,1,1) = {"
-ZB
-ZB
-aa
-aa
-ZB
-aa
-aa
-vf
 aa
 aa
 aa
-ZB
-Uz
-ax
-bj
-bj
-bj
-bj
-bW
-bW
-bW
-kx
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+FL
+mP
+mP
 Vt
-bW
-bW
-bj
-bj
-bj
-cs
+FL
+gH
+Vn
+Vn
+jd
+FL
 cx
-cF
-cx
-cT
-cx
-cx
-dx
-cx
-cx
-dx
-dd
-cx
-cx
-cs
-cx
-cx
-cx
-cs
-fx
-fT
-fx
-fx
-fZ
-gL
-aa
-ZB
-ch
-ay
-ch
-ZB
-aa
-aa
-aa
-aa
-ZB
-jG
-jS
-ch
-aa
-aa
-aa
-aa
-aa
-ZB
-dk
-aa
-ZB
-ZB
+gR
+Ss
+nj
+OS
+dm
+Wl
+mm
+OS
+MQ
+Xu
+Ys
+JC
+GY
+uW
+Ty
+Ho
+hD
+tF
+Or
+mJ
+aD
+yd
+xK
+mJ
+rN
+YV
+qP
+mJ
+mJ
+hb
+mJ
+mJ
 aa
 aa
 aa
@@ -10746,20 +15383,35 @@ aa
 aa
 aa
 aa
-mY
-mD
-mD
-nA
-nD
-mf
-mf
-mf
-mf
-mf
-mf
-mf
-mf
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -10772,80 +15424,55 @@ aa
 aa
 "}
 (63,1,1) = {"
-ZB
-aa
-af
-aq
-ap
-ZB
-ZB
-vf
 aa
 aa
 aa
-ZB
-Uz
-ax
-bj
-bj
-bj
-bj
-bW
-Xu
-bz
-bz
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+FL
+mP
+dV
 Ni
-Xu
-bW
-bj
-bj
-bj
-cs
-AA
-cF
-cx
-cT
-cx
+FL
+gT
+hS
+gT
+FL
+FL
+OS
+OS
+OS
+OS
+OS
 dm
 dy
-cF
-dm
-dy
-cF
-cF
-cF
-cF
-cF
-cF
-cF
+zp
+OS
+OS
+Zu
+dS
+nw
+Ub
+TV
+hD
+yd
 fK
 fT
-fT
-fx
-fx
-cs
-cs
-ZB
+WC
+mJ
+Tn
+kn
+Nv
+mJ
 hc
-gC
-gC
-ch
-ZB
-ZB
-ZB
-ZB
-ZB
-Uz
-ch
-jR
-kb
-jG
-aa
-aa
-aa
-aa
-ZB
-ZB
+hD
+DR
+mJ
 ZB
 ZB
 aa
@@ -10862,17 +15489,33 @@ aa
 aa
 aa
 aa
-it
-HF
-nH
-nN
-nN
-nN
-nN
-nN
-oc
-oc
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -10885,80 +15528,55 @@ aa
 aa
 "}
 (64,1,1) = {"
-vf
-aa
-ag
-aq
-ap
-aa
-aa
-vf
 aa
 aa
 aa
-ZB
-Uz
-ax
-bj
-bj
-bj
-bj
-bW
-my
-bz
-Ik
-bz
-DX
-bW
-bj
-bj
-bj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+FL
+FL
+FL
+FL
+FL
+Ds
+Ds
+Ds
+FL
 cs
 uz
-cF
-cx
+li
+mn
 cU
-cx
-cF
-dw
-cx
-cx
-dw
-cx
-cF
-cx
-cs
-cs
-cs
-cs
-cs
-fx
-fx
-fx
-fx
-cs
-cs
-ZB
+Ys
+Ys
+oz
+fg
+Gu
+Nx
+za
+Vr
+Wf
+II
+Ql
+hD
+Yf
+XL
+Nv
+Pt
+mJ
+Sd
+YE
+DH
+mJ
 ch
-ay
-gC
-hc
-ZB
-aa
-aa
-aa
-aa
-ZB
-jG
-jG
-ay
-jG
-aa
-aa
-aa
-aa
-aa
-ZB
+hD
+jP
+mJ
 ZB
 aa
 aa
@@ -10975,18 +15593,34 @@ aa
 aa
 aa
 aa
-it
-ml
-mf
-mf
-mf
-mf
-mf
-mf
-mf
-mf
-ZB
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -10998,81 +15632,55 @@ aa
 aa
 "}
 (65,1,1) = {"
-vf
-aa
-ap
-aq
-ap
 aa
 aa
-vf
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ZB
 ZB
-ZB
-ZB
-Uz
-ax
-bj
-bj
-bj
-bj
-bW
-Zu
-bz
-rC
-KP
-vo
-bW
-bj
-bj
-bj
-cs
+OS
+jQ
 cA
-cF
-cF
+lj
 cV
-cF
-cF
-dw
-cx
-cx
-dw
-cx
-dm
-cx
-cx
-cs
-fC
-fC
-cs
-fx
+cV
+nB
+Ys
+Wl
+Ys
+Gz
+OS
+uB
+uy
+Wb
+fe
+Ar
+hD
+hD
+pB
+VN
 gg
-fx
-fx
-cs
-aa
-ay
-ch
-ay
-gC
-hc
-aa
-aa
-aa
-aa
-aa
-Uz
-aa
-jG
-kb
-jG
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
+TS
+wj
+vr
+sG
+mJ
+oF
+Gs
+yN
+mJ
 aa
 aa
 aa
@@ -11088,18 +15696,35 @@ aa
 aa
 aa
 aa
-it
-ml
-vC
-ZB
-ZB
 aa
-ZB
 aa
-ZB
-ZB
 aa
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -11111,80 +15736,55 @@ aa
 aa
 "}
 (66,1,1) = {"
-vf
-aa
-aa
-aq
 aa
 aa
 aa
-vf
-Uz
-Uz
-Uz
-Uz
-Uz
-ax
-bj
-bj
-bj
-bj
-bW
-bW
-bW
-bW
-bW
-bW
-bW
-bj
-bj
-bj
-cs
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ZB
+OS
+jR
 QW
-cx
+li
 cQ
-cs
-cs
-cX
-cs
-dF
-dF
-eq
+nk
+nC
+Ys
+Wl
+Ys
+Hl
+OS
 eB
 eJ
 eO
-dF
-cs
-fC
-fC
-cs
-cs
-cs
-cs
-cs
-cs
-ZB
-aa
-ch
-gC
-ay
-hc
-aa
-aa
-dk
-aa
-aa
-ZB
-aa
-jG
-kd
-ay
-aa
-aa
-kU
-aa
-aa
-ZB
+fe
+lW
+Md
+hD
+Nt
+hD
+YR
+mJ
+Kp
+pB
+SF
+mJ
+Wp
+Bi
+Ix
+mJ
 aa
 aa
 aa
@@ -11202,8 +15802,6 @@ aa
 aa
 aa
 aa
-mZ
-vC
 aa
 aa
 aa
@@ -11211,8 +15809,26 @@ aa
 aa
 aa
 aa
-ZB
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -11224,81 +15840,55 @@ aa
 aa
 "}
 (67,1,1) = {"
-vf
-aa
-ap
-aq
-ap
 aa
 aa
-as
-as
-aF
-aM
-aS
-aS
-aS
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-cs
-cs
-cs
-cs
-cs
-cs
-dp
-cs
-dG
-dZ
-ea
-ea
-eK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+OS
+OS
+OS
+OS
+mr
+OS
+nD
+Ys
+oD
+Ys
+OS
+OS
+eP
+eP
 eP
 fe
-fo
-aY
-ZB
-ZB
-dk
-ZB
-aa
-aa
-aa
-ZB
-aa
-hc
-gC
-gC
-hc
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ch
-Ba
-fD
-aa
-aa
-aa
-aa
-ZB
-ZB
-ZB
+fS
+fS
+mJ
+mJ
+fS
+fS
+mJ
+mJ
+fS
+fS
+mJ
+uj
+hb
+mJ
+mJ
 aa
 aa
 aa
@@ -11315,9 +15905,26 @@ aa
 aa
 aa
 aa
-ZB
-vC
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -11337,79 +15944,52 @@ aa
 aa
 "}
 (68,1,1) = {"
-vf
-aa
-ap
-aq
-ap
 aa
 aa
-at
-az
-az
-az
-aT
-aZ
-as
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-bj
-cs
-cC
-cx
-cR
-cT
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ZB
+OS
+OS
+OS
 dd
-cF
-cs
-dG
-ea
-ea
-ea
-eK
-Hx
-eP
-fo
+oe
+oE
+KF
+OS
 ZB
 aa
 aa
 aa
-ZB
 aa
 aa
 aa
-ay
-ay
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+xP
 gW
-hp
-hq
-gV
-ia
-aa
-aa
-aa
-aa
-ZB
-aa
-ch
-kf
-ch
-aa
-aa
-aa
-ZB
-ZB
 aa
 aa
 aa
@@ -11426,10 +16006,28 @@ aa
 aa
 aa
 aa
-mv
 aa
 aa
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -11452,78 +16050,33 @@ aa
 (69,1,1) = {"
 aa
 aa
-ap
-aq
-ap
-aa
-aa
-at
-Pi
-aA
-aO
-az
-ba
-as
-bj
-bj
-as
-as
-as
-as
-as
-as
-as
-as
-as
-as
-as
-as
-cs
-cD
-cx
-cx
-cW
-cx
-cF
-cs
-Ua
-eb
-eb
-ea
-eK
-ea
-ff
-fp
-ay
 aa
 aa
 aa
 aa
 aa
 aa
-ay
-ay
-gr
-gW
-hp
-hp
-gV
-Ev
 aa
 aa
 aa
 aa
-Uz
-ZB
-jT
-kg
 aa
 aa
 aa
-ZB
-ld
+aa
+aa
+aa
+aa
+aa
+aa
 ZB
 ZB
+OS
+nF
+of
+Ss
+Ss
+vP
 aa
 aa
 aa
@@ -11540,9 +16093,45 @@ aa
 aa
 aa
 aa
-iR
 aa
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -11563,84 +16152,35 @@ aa
 aa
 "}
 (70,1,1) = {"
-ad
-aq
-aq
-aq
-aq
-aq
-aq
-au
-aB
-az
-aP
-az
-aB
-as
-as
-as
-as
-Gz
-Ud
-zg
-az
-az
-az
-zg
-az
-az
-zg
-as
-cs
-cE
-cx
-cS
-cT
-cx
-cF
-cs
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ZB
+OS
+nG
+og
+rC
 dJ
-ea
-ea
-ea
-eK
-eK
-zB
-fo
-ay
-aa
-aa
-aa
-aa
-aa
-aa
-ay
-gC
-gr
-gW
-hq
-hr
-gV
-ia
-ia
-aa
-aa
-aa
-ZB
-aa
-ch
-kb
-jG
-aa
-aa
-aa
-ld
-aa
-aa
-ZB
-aa
-aa
-eV
+OS
 aa
 aa
 aa
@@ -11655,7 +16195,47 @@ aa
 aa
 aa
 aa
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -11678,77 +16258,6 @@ aa
 (71,1,1) = {"
 aa
 aa
-ap
-aq
-ap
-aa
-aa
-at
-aC
-az
-aP
-az
-aB
-as
-Gz
-as
-bq
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
-az
-cs
-cs
-cs
-cs
-cs
-cx
-cF
-cs
-dK
-ea
-ea
-eC
-eb
-eS
-fh
-fo
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ch
-ch
-ch
-gW
-hq
-hr
-gV
-Uz
-ZB
-iq
-aa
-aa
-ZB
-aa
-ch
-jR
-jG
-aa
-aa
-ZB
-ZB
-ZB
 aa
 aa
 aa
@@ -11767,8 +16276,70 @@ aa
 aa
 aa
 aa
-ZB
-ZB
+aa
+aa
+aa
+OS
+nH
+OS
+vP
+vP
+OS
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -11789,78 +16360,11 @@ aa
 aa
 "}
 (72,1,1) = {"
-ZB
-aa
-ap
-aq
-ap
-aa
-aa
-at
-aB
-aB
-aQ
-aB
-aB
-bh
-aB
-aQ
-br
-bu
-bB
-br
-aB
-aB
-aB
-aB
-aB
-aB
-az
-cm
-cs
-cx
-cs
-cx
-cs
-cx
-cF
-cs
-dL
-ea
-ea
-ea
-ea
-ea
-oE
-fo
-aY
-ZB
-ZB
 aa
 aa
 aa
 aa
-ay
-ay
-ay
-gW
-hr
-hq
-gV
-ib
-iq
-ZB
-Bx
-gV
-Uz
 aa
-ch
-kb
-jG
-aa
-aa
-ZB
-ZB
 aa
 aa
 aa
@@ -11880,6 +16384,64 @@ aa
 aa
 aa
 ZB
+jV
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -11902,81 +16464,15 @@ aa
 aa
 "}
 (73,1,1) = {"
-ZB
-aa
-ap
-aq
-ap
-aa
-aa
-as
-as
-as
-as
-az
-az
-as
-az
-as
-bs
-bv
-bC
-bs
-az
-bS
-az
-az
-az
-aB
-aB
-aB
-ct
-cF
-ct
-cF
-cX
-cF
-dq
-cs
-Ua
-ea
-eb
-ea
-ea
-eS
-oE
-dz
-fD
-ZB
 aa
 aa
 aa
 aa
-ay
-ay
-aY
-gV
-gW
-gW
-hE
-gV
-gV
-gV
-gV
-gV
-gV
-Uz
-ZB
-hc
-kb
-jG
 aa
-kL
-gW
-gW
-kL
-kL
-kL
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -11992,7 +16488,64 @@ aa
 aa
 aa
 ZB
+aa
 ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12015,85 +16568,20 @@ aa
 aa
 "}
 (74,1,1) = {"
-vf
-aa
-aa
-aq
-aa
-aa
-aa
-vf
-vf
-vf
-as
-aV
-bc
-as
-as
-as
-as
-as
-as
-as
-as
-as
-az
-as
-as
-as
-as
-as
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-cs
-dM
-ec
-ea
-eD
-ea
-eT
-Hx
-dz
-ay
 aa
 aa
 aa
 aa
-ay
-ay
-gD
-gr
-gV
-hd
-yE
-hf
-hf
-hd
-ir
-hf
-gW
-gV
-gV
-gV
-gV
-kh
-gV
-kB
-kM
-hP
-kM
-ll
-ll
-ll
-lY
-mg
-mm
-mv
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12104,6 +16592,62 @@ aa
 aa
 aa
 ZB
+aa
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12128,84 +16672,20 @@ aa
 aa
 "}
 (75,1,1) = {"
-vf
-aa
-ap
-aq
-ap
-aa
-aa
-vf
-ZB
-vf
-vf
-aa
-bd
-Gu
-Gu
-aa
-aa
-aa
-aa
-Gu
-Gu
-as
-az
-as
-bi
-bi
-ch
-ZB
 aa
 aa
 aa
 aa
 aa
-ZB
-ac
-dz
-dN
-ed
-et
-eE
-et
-eU
-FU
-dz
-ch
 aa
 aa
 aa
 aa
-ay
-ay
-SR
-gC
-gV
-he
-hd
-hf
-hf
-hd
-ir
-hf
-hf
-hf
-hf
-jH
-gW
-ki
-gW
-gW
-gW
-kV
-hf
-hf
-kM
-hf
-lZ
-hP
-DE
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12216,6 +16696,61 @@ aa
 aa
 aa
 ZB
+aa
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12241,16 +16776,30 @@ aa
 aa
 "}
 (76,1,1) = {"
-vf
-aa
-ap
-aq
-ap
 aa
 aa
-vf
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ZB
 aa
 ZB
 aa
@@ -12262,63 +16811,6 @@ aa
 aa
 aa
 aa
-as
-ca
-as
-aa
-aa
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ch
-aa
-ac
-eu
-ac
-ac
-ay
-eu
-ac
-ac
-ZB
-aa
-ay
-ay
-ay
-ay
-gH
-gD
-gV
-hf
-yE
-hf
-hP
-hf
-hf
-hf
-hf
-hf
-hf
-hf
-hf
-kj
-hf
-hf
-hf
-hf
-hf
-hf
-hf
-hf
-lY
-jF
-mn
 aa
 aa
 aa
@@ -12327,7 +16819,41 @@ aa
 aa
 aa
 aa
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12354,14 +16880,6 @@ aa
 aa
 "}
 (77,1,1) = {"
-vf
-aa
-ap
-aq
-ap
-ZB
-ZB
-vf
 aa
 aa
 aa
@@ -12374,11 +16892,7 @@ aa
 aa
 aa
 aa
-ZB
 aa
-aa
-ZB
-ZB
 aa
 aa
 aa
@@ -12390,48 +16904,9 @@ aa
 aa
 aa
 ZB
-ZB
-aa
-aa
-aa
-aa
-eV
 aa
 ZB
 aa
-ZB
-aa
-ay
-ay
-gr
-gC
-gr
-gP
-gV
-hg
-hf
-hf
-hf
-hd
-ir
-hf
-gW
-gW
-hf
-hf
-hf
-ki
-kr
-gW
-gW
-hf
-hP
-hf
-hf
-hf
-jJ
-ay
-ch
 aa
 aa
 aa
@@ -12441,7 +16916,49 @@ aa
 aa
 aa
 aa
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12467,27 +16984,6 @@ aa
 aa
 "}
 (78,1,1) = {"
-vf
-aa
-aa
-aa
-ZB
-aa
-aa
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -12513,48 +17009,60 @@ aa
 aa
 ZB
 aa
-aa
-aY
-aY
-aY
-aY
-aY
-aY
-gV
-hf
-hf
-hf
-hf
-ic
-is
-iG
-gW
-jd
-hf
-hf
-hf
-hP
-hf
-hf
-gW
-jt
-hf
-hf
-hf
-hf
-jJ
-ay
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12580,14 +17088,31 @@ aa
 aa
 "}
 (79,1,1) = {"
-vf
-vf
-vf
-vf
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ZB
-vf
-vf
-vf
+aa
 ZB
 aa
 aa
@@ -12627,36 +17152,6 @@ aa
 aa
 aa
 aa
-ch
-ch
-ch
-ch
-ch
-ch
-gW
-hh
-hi
-hf
-hf
-hf
-hf
-hd
-gW
-jd
-hf
-hf
-hf
-hf
-hf
-hf
-gW
-kV
-hf
-hP
-hf
-hf
-jJ
-ay
 aa
 aa
 aa
@@ -12664,10 +17159,14 @@ aa
 aa
 aa
 aa
-ay
-ac
-ac
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12693,14 +17192,36 @@ aa
 aa
 "}
 (80,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ZB
+aa
 ZB
 aa
 aa
 aa
 aa
-ZB
-ZB
-ZB
 aa
 aa
 aa
@@ -12740,47 +17261,16 @@ aa
 aa
 aa
 aa
-ay
-ay
-ay
-gD
-gr
-Su
-gW
-hi
-hf
-hf
-hf
-id
-hf
-yE
-gW
-jd
-jt
-jI
-hf
-hf
-ks
-kC
-gW
-hf
-hf
-hf
-hf
-hf
-jJ
-ay
-ch
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
 aa
-ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12829,70 +17319,61 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ch
-fD
-ch
-ch
-fD
-ch
-gW
-gW
-gW
-gW
-gW
-gW
-gW
-gW
-gW
-gW
-gW
-gW
-jU
-gW
-gW
-gW
-gW
-gV
-hf
-NK
-hf
-Hl
-jJ
-aa
-aa
-ay
-aa
-ay
-aa
-ay
-aa
-ay
+ZB
 aa
 ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -12944,67 +17425,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ay
-ay
-ay
-ay
-ay
-ay
-ay
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-jJ
-hP
-jJ
-aa
-aa
-gV
-gV
-gV
-gV
-gV
-gV
-gV
-aY
-aY
-aY
-aY
-aY
-aY
-aY
-aY
-aY
-aY
 ZB
 aa
 aa
@@ -13030,8 +17450,6 @@ aa
 aa
 aa
 aa
-"}
-(83,1,1) = {"
 aa
 aa
 aa
@@ -13061,65 +17479,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-ZB
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-jK
-Le
-jK
-aa
-aa
-aa
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-aa
-ZB
 aa
 aa
 aa

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -2,99 +2,44 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ac" = (
-/obj/structure/reflector/single/anchored{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
 "ad" = (
-/turf/closed/mineral/random/stationside/asteroid,
-/area/template_noop)
-"af" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/bridge)
-"ag" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/emergency,
 /obj/item/wrench,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"ai" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"al" = (
+"af" = (
 /obj/structure/table/reinforced,
 /obj/item/aicard,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"am" = (
-/obj/structure/table,
-/obj/item/analyzer,
-/obj/item/pipe_dispenser,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"ap" = (
+"ag" = (
 /obj/effect/turf_decal/tile/red/half,
 /obj/structure/frame/computer,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
-"aq" = (
+"al" = (
 /obj/effect/turf_decal/tile/blue/half,
-/obj/structure/frame/computer,
+/obj/machinery/computer/terminal/derelict/bridge,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
-"as" = (
-/obj/structure/frame/computer,
-/turf/open/floor/iron/white/side,
-/area/ruin/space/derelict/bridge)
-"at" = (
+"ap" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/iron/white/side,
 /area/ruin/space/derelict/bridge)
-"au" = (
+"aq" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/timer,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"av" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"aw" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/service)
-"ax" = (
-/obj/item/stack/sheet/iron/fifty,
-/turf/template_noop,
-/area/template_noop)
-"az" = (
-/obj/structure/table/reinforced,
-/obj/item/multitool,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"aA" = (
-/obj/structure/displaycase/noalert,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"aB" = (
+"as" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"aC" = (
+"at" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
 	},
@@ -105,63 +50,11 @@
 	dir = 1
 	},
 /area/ruin/space/derelict/bridge)
-"aD" = (
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/storage/pill_bottle/mannitol,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"aF" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/ruin/space/derelict/bridge)
-"aL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/bridge)
-"aM" = (
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/ruin/space/derelict/bridge)
-"aO" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"aP" = (
-/obj/structure/displaycase_chassis,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"aQ" = (
+"au" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"aR" = (
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/edge,
-/area/ruin/space/derelict/bridge)
-"aS" = (
+"ax" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -170,156 +63,71 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"aT" = (
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"aV" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"aW" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/bridge)
-"aX" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/bridge)
-"aZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"ba" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"bb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"bc" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/secure/briefcase,
-/obj/item/assembly/flash/handheld,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"bd" = (
-/obj/structure/chair/comfy/black,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"be" = (
+"az" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"bh" = (
+"aA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"bi" = (
+"aB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"bk" = (
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering/gravity_generator)
-"bl" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"bn" = (
+"aC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"bp" = (
+"aD" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"aF" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"bq" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/table/reinforced,
+"aG" = (
+/obj/structure/rack,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"aK" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = list(25)
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"aL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"br" = (
+"aM" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"bs" = (
-/obj/structure/closet/emcloset,
+"aN" = (
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"bt" = (
+/area/ruin/space/derelict/engineering)
+"aO" = (
 /obj/structure/window/spawner/east,
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"bu" = (
-/obj/effect/turf_decal/tile/blue/half,
-/turf/open/floor/iron/edge,
-/area/ruin/space/derelict/bridge)
-"bv" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/edge,
-/area/ruin/space/derelict/bridge)
-"bw" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "31"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
-"bx" = (
+"aP" = (
 /obj/structure/window/spawner/west,
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"by" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
-"bz" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard)
-"bB" = (
+"aQ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -329,21 +137,13 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"bC" = (
+"aR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/bridge)
-"bD" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/hallway_primary)
-"bI" = (
+"aS" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
@@ -354,32 +154,11 @@
 	dir = 1
 	},
 /area/ruin/space/derelict/bridge)
-"bJ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/disposaloutlet,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research/xenobiology)
-"bM" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research/xenobiology)
-"bN" = (
-/obj/machinery/telecomms/message_server/preset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"bP" = (
+"aT" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard)
+"aV" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock";
 	req_access_txt = "48"
@@ -387,16 +166,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/cargo)
-"bR" = (
-/obj/machinery/door/window/westleft{
-	req_access_txt = "55"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research/xenobiology)
-"bS" = (
+"aW" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
 	},
@@ -405,13 +175,7 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port/lesser)
-"bT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"bU" = (
+"aX" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
 	},
@@ -420,143 +184,49 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port/lesser)
-"bV" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/hallway_primary)
-"bX" = (
-/obj/structure/table/wood,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"ca" = (
+"aZ" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
-"cb" = (
-/obj/machinery/blackbox_recorder,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"ba" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
 	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"cd" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall,
-/area/ruin/space/derelict/research/xenobiology)
-"cg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"ch" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/area/ruin/space/derelict/maintenance/starboard)
+"bc" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
 	},
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"ci" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"cj" = (
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"cl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"cm" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard)
+"bd" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/cargo)
-"cp" = (
-/obj/structure/chair,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"cr" = (
-/obj/machinery/mecha_part_fabricator,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"cs" = (
-/obj/machinery/rnd/server,
-/turf/open/floor/circuit/telecomms/server,
-/area/ruin/space/derelict/research)
-"ct" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"cu" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"cw" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"cx" = (
-/obj/machinery/mecha_part_fabricator,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"cy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/directional/south,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"cz" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+"be" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"bf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/engineering)
-"cA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/ruin/space/derelict/research)
-"cB" = (
-/obj/effect/turf_decal/stripes/corner{
+/turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"cC" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"cD" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
-"cE" = (
+/area/ruin/space/derelict/medical)
+"bh" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -567,81 +237,27 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"cG" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"cH" = (
-/obj/structure/table,
-/obj/item/storage/lockbox/loyalty,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"cI" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/security)
-"cK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"cQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"cR" = (
+"bi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/bridge)
-"cS" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research/xenobiology)
-"cU" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/recharge_station,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"cV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"cW" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/cargo)
-"cY" = (
+"bl" = (
 /obj/structure/closet/crate,
 /obj/item/stack/ore/silver,
 /obj/item/stack/ore/iron,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"cZ" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/departures)
-"db" = (
+"bm" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict2"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"bn" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock";
 	req_access_txt = "48"
@@ -651,7 +267,11 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/cargo)
-"dc" = (
+"bp" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"bq" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
@@ -660,126 +280,52 @@
 	dir = 1
 	},
 /area/ruin/space/derelict/hallway_primary)
-"dd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/ruin/space/derelict/research)
-"de" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/engineering)
-"dg" = (
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"dk" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"dm" = (
-/turf/open/floor/iron/white/side{
-	dir = 10
-	},
-/area/ruin/space/derelict/research)
-"dq" = (
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"dt" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"dv" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"dx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
-"dy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+"br" = (
+/obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"dz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/hallway_primary)
+"bs" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/hallway_primary)
+"bt" = (
 /obj/machinery/photocopier,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"dB" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"dE" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"dI" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_one_access_txt = "10;24"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"dJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/research/explosive_compressor,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"dL" = (
+"bu" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
-"dM" = (
-/obj/machinery/door/window/eastleft{
-	req_access_txt = "55"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research/xenobiology)
-"dN" = (
+"bv" = (
 /obj/machinery/door/window/westleft{
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"bw" = (
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research/xenobiology)
-"dP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"dR" = (
+"bx" = (
 /obj/machinery/door/window/eastleft{
 	req_access_txt = "55"
 	},
@@ -788,30 +334,13 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
-"dS" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
-	pixel_y = 24
-	},
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
-	name = "Burn Chamber Interior Airlock"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research)
-"dU" = (
-/obj/effect/turf_decal/stripes/line{
+"by" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"dV" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research/xenobiology)
-"dZ" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"bz" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -822,82 +351,50 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"ec" = (
+"bB" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"ed" = (
+"bC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"ef" = (
-/obj/effect/spawner/structure/window/reinforced,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"bD" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
-"eg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/area/ruin/space/derelict/maintenance/starboard)
+"bF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/arrival)
-"eh" = (
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg2"
-	},
-/area/ruin/space/derelict/departures)
-"en" = (
-/obj/machinery/vending/assist,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"eo" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"eq" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/rack,
-/obj/item/storage/box/teargas{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"er" = (
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/crowbar,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"et" = (
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
+"bI" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/spawner/random/maintenance/three,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"eu" = (
+"bJ" = (
 /obj/structure/rack,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/security)
-"ex" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
+"bL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research/xenobiology)
-"ey" = (
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/derelict/arrival)
+"bM" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -908,27 +405,12 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research/xenobiology)
-"ez" = (
-/turf/open/floor/plating/airless{
-	icon_state = "panelscorched"
-	},
-/area/ruin/space/derelict/departures)
-"eA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"eB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
-/area/ruin/space/derelict/research)
-"eC" = (
+"bO" = (
+/obj/effect/turf_decal/bot,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"bP" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance";
 	req_access_txt = "48"
@@ -936,11 +418,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port/lesser)
-"eD" = (
+"bR" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port/lesser)
-"eE" = (
+"bS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -952,7 +434,7 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"eF" = (
+"bT" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Armory";
 	req_access_txt = "3"
@@ -965,135 +447,86 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"eG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/suit_storage_unit/open,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"eJ" = (
-/obj/machinery/igniter/incinerator_ordmix,
-/turf/open/floor/engine/vacuum,
-/area/ruin/space/derelict/research)
-"eN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"eO" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/ordnance_mixing_input{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
-/area/ruin/space/derelict/research)
-"eP" = (
-/turf/open/floor/engine/vacuum,
-/area/ruin/space/derelict/research)
-"eR" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"eS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"eT" = (
+"bU" = (
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/security)
-"eU" = (
+"bV" = (
+/obj/machinery/computer/security,
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
+"bX" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"bZ" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"ca" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall,
+/area/ruin/space/derelict/research/xenobiology)
+"cb" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"eV" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research/xenobiology)
-"eX" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Dock";
-	req_access_txt = "48"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"eZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"fa" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"fb" = (
-/obj/structure/frame/machine,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"fc" = (
+"cd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/cargo)
-"fd" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"fe" = (
-/turf/closed/wall/r_wall,
+"cf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/ruin/space/derelict/engineering)
+"ch" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"ff" = (
+"cj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"ck" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"cl" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"cm" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"fg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"fh" = (
-/obj/effect/turf_decal/tile/red/half{
+"co" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/hallway_primary)
-"fi" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil,
 /turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"fk" = (
+/area/ruin/space/derelict/engineering/gravity_generator)
+"cp" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
 	name = "Brig";
@@ -1104,28 +537,16 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"fl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+"cq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"fm" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"fn" = (
-/obj/effect/spawner/random/engineering/tank,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"fp" = (
-/obj/machinery/flasher/directional/north{
-	id = "brigentry"
-	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"cr" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
@@ -1133,39 +554,7 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/security)
-"fq" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"fr" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"fs" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/security)
-"fw" = (
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"fD" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"fE" = (
+"cs" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -1173,373 +562,49 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"fF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"fG" = (
+"ct" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"fI" = (
+/area/ruin/space/derelict/security)
+"cw" = (
 /obj/structure/rack,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/security)
-"fK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"fN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research/xenobiology)
-"fO" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/hallway_primary)
-"fQ" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/hallway_primary)
-"fS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
-"fT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"ga" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
-"gb" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
-"gc" = (
-/obj/machinery/computer/med_data,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
-"gg" = (
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"gh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"gj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"gk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/ruin/space/derelict/hallway_primary)
-"gl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
-"gm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/folder/white,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
-"gn" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/hallway_primary)
-"go" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
-"gp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/flat_white,
-/area/ruin/space/derelict/medical)
-"gr" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research/xenobiology)
-"gy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"gz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/obj/item/pen,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
-"gC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"gD" = (
-/obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_one_access_txt = "73"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"gE" = (
+"cx" = (
 /obj/machinery/monkey_recycler,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"gG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"gH" = (
+"cz" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research/xenobiology)
-"gJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/crew)
-"gK" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/service)
-"gL" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
-/area/ruin/space/derelict/medical)
-"gM" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"gN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"gO" = (
-/obj/machinery/door/airlock/medical{
-	name = "Cryogenic";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"gR" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"gS" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"gT" = (
-/obj/structure/table,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research/xenobiology)
-"gV" = (
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/space/derelict/departures)
-"gW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
-"gZ" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/service)
-"hb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
-"hc" = (
-/obj/machinery/vending/wallmed/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"hd" = (
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"he" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/ruin/space/derelict/departures)
-"hf" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"hg" = (
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"hh" = (
+/obj/item/folder/blue,
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
+"cA" = (
 /obj/machinery/photocopier,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"hi" = (
+"cB" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"cC" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"hj" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"hk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"hl" = (
+"cD" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"hm" = (
+"cE" = (
 /obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -1555,15 +620,12 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"ho" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/chair,
+"cG" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"hq" = (
+/area/ruin/space/derelict/bridge)
+"cH" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
 	},
@@ -1574,7 +636,41 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/hallway_primary)
-"hr" = (
+"cI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"cJ" = (
+/obj/structure/table/reinforced/rglass,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"cK" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"cL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"cM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"cP" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"cQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -1584,12 +680,7 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/security)
-"ht" = (
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"hx" = (
+"cR" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
@@ -1603,7 +694,7 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/security)
-"hA" = (
+"cS" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
@@ -1617,18 +708,16 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/security)
-"hC" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_one_access_txt = "10;24"
+"cT" = (
+/obj/structure/table,
+/obj/item/paper_bin/carbon{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"hD" = (
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"hE" = (
+/obj/item/pen,
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
+"cU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -1637,127 +726,30 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"hG" = (
-/obj/effect/turf_decal/siding/thinplating/end{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/suit_storage_unit/open,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/security)
-"hI" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"hJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"hL" = (
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"hN" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"hO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"hP" = (
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/security)
-"hQ" = (
+"cV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"hS" = (
+"cW" = (
 /obj/structure/table,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"hT" = (
-/obj/item/construction/rcd,
-/turf/open/floor/plating/airless{
-	icon_state = "panelscorched"
-	},
-/area/ruin/space/derelict/departures)
-"hU" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"hV" = (
+"cY" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"hX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"hZ" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"ia" = (
-/obj/structure/table,
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/blood_filter,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"ib" = (
+"db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"ic" = (
-/obj/structure/frame/computer,
+/area/ruin/space/derelict/cargo)
+"dc" = (
+/obj/machinery/computer/terminal/derelict/cargo,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"id" = (
+"dd" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
 	},
@@ -1768,48 +760,25 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/hallway_primary)
-"ie" = (
+"de" = (
+/obj/machinery/door/airlock/command{
+	name = "Head of Personnel";
+	req_access_txt = "57"
+	},
 /obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft{
-	req_access_txt = "69"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
-"if" = (
-/obj/effect/turf_decal/tile/red/half{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/security)
-"im" = (
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"in" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/area/ruin/space/derelict/arrival)
+"dj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/wood,
+/turf/open/floor/iron,
 /area/ruin/space/derelict/service)
-"io" = (
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"ip" = (
+"dk" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
@@ -1820,67 +789,58 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/security)
-"iq" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/defibrillator/loaded,
-/obj/item/clothing/gloves/color/latex/nitrile,
+"dl" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"dm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"dp" = (
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"ir" = (
-/obj/effect/turf_decal/siding/thinplating/end,
-/obj/machinery/suit_storage_unit/open,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/security)
-"is" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"iu" = (
+"dq" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"iv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/security)
-"iw" = (
+"dt" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"ix" = (
-/obj/machinery/light/directional/west,
+"dv" = (
+/obj/structure/table,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"dw" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"dx" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "7"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research)
+"dy" = (
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"iz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/departures)
-"iA" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"iB" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/departures)
-"iD" = (
-/turf/closed/wall,
 /area/ruin/space/derelict/cargo)
-"iE" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"iF" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/edge,
-/area/ruin/space/derelict/hallway_primary)
-"iG" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"iH" = (
+"dz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -1889,15 +849,18 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/cargo)
-"iI" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"iJ" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
-"iK" = (
+"dI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"dJ" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
@@ -1906,89 +869,89 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/hallway_primary)
-"iL" = (
+"dL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"dM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"dN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"iN" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/hallway_primary)
-"iO" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/service)
-"iP" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"iQ" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"iT" = (
+"dR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"iV" = (
-/obj/structure/closet/crate/bin,
+"dS" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"dU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research/xenobiology)
-"iW" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"dV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"iX" = (
+"dZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"iY" = (
-/obj/machinery/processor/slime,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research/xenobiology)
-"ja" = (
+"ea" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/template_noop,
+/area/template_noop)
+"ec" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"jd" = (
+"ee" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"ef" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"jf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"jg" = (
+"eh" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"jj" = (
+"en" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
 	req_one_access_txt = "31;48"
@@ -1996,31 +959,7 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"jk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"jm" = (
-/obj/machinery/space_heater,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"jo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"jp" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/template_noop,
-/area/template_noop)
-"jr" = (
+"eo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/mineral/ore_redemption{
@@ -2029,110 +968,36 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/cargo)
-"js" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/effect/turf_decal/stripes/line{
+"ep" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/item/geiger_counter,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/engine,
+/turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"jt" = (
+"eq" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"ju" = (
+"er" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"jv" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/maintenance/port/central)
-"jB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"jC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/template_noop)
-"jD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"jE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"jF" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"jG" = (
+"et" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"jH" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/research)
-"jI" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/high{
-	pixel_y = 6
-	},
-/obj/item/hand_tele,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"jJ" = (
+"eu" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/security/detective)
+"ex" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"jK" = (
-/obj/structure/closet/secure_closet/cytology,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"jL" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "dereengimaintport"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"jM" = (
+"ey" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
 	req_access_txt = "55"
@@ -2141,76 +1006,28 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"jO" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/hallway_primary)
-"jP" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"jQ" = (
-/turf/open/floor/iron/dark/telecomms,
+"ez" = (
+/obj/machinery/rnd/server,
+/turf/open/floor/circuit/telecomms/server,
 /area/ruin/space/derelict/research)
-"jR" = (
+"eB" = (
 /obj/machinery/rnd/server/master,
 /turf/open/floor/circuit/telecomms/server,
 /area/ruin/space/derelict/research)
-"jS" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "31"
+"eC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"jT" = (
+"eD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"jU" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay";
-	req_one_access_txt = "31;48"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"jV" = (
-/turf/open/floor/plating/airless,
-/area/template_noop)
-"jY" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"jZ" = (
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/ruin/space/derelict/engineering/gravity_generator)
-"ka" = (
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"kb" = (
+"eE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2218,31 +1035,20 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"kc" = (
-/obj/structure/window/reinforced/plasma{
-	dir = 8
-	},
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"kd" = (
+"eF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"ke" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/area/ruin/space/derelict/cargo)
+"eI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"kf" = (
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"eJ" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
 	req_one_access_txt = "31;48"
@@ -2256,7 +1062,26 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"kg" = (
+"eK" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"eM" = (
+/obj/structure/lattice,
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"eN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -2265,148 +1090,72 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"kh" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"ki" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/arrival)
-"kj" = (
+"eO" = (
 /obj/machinery/computer/security/wooden_tv,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
-"km" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/engineering)
-"kn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"ko" = (
+"eP" = (
 /obj/item/storage/secure/safe/directional/north,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
-"kp" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"kq" = (
+"eS" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
-"kr" = (
+"eT" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"ks" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"kt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"kv" = (
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/item/tank/internals/emergency_oxygen/empty,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"kw" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering/gravity_generator)
-"kA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/engineering)
-"kB" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/research)
-"kC" = (
-/obj/structure/sign/warning/biohazard{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"kD" = (
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/ruin/space/derelict/engineering/gravity_generator)
-"kE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/service)
-"kF" = (
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white/side{
-	dir = 10
-	},
-/area/ruin/space/derelict/research)
-"kI" = (
+"eU" = (
+/obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"kJ" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/structure/crate,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"kK" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/structure/crate,
+/area/ruin/space/derelict/research)
+"eV" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/rack,
+/obj/item/mod/core/standard,
+/obj/item/mod/core/standard,
+/obj/item/mod/core/standard,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"kL" = (
+/area/ruin/space/derelict/research)
+"eX" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/timer,
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"kM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+"eZ" = (
+/obj/item/shard,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"kO" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
+"fb" = (
+/obj/structure/table,
+/obj/machinery/recharger,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"kP" = (
-/obj/machinery/modular_computer/console/preset/cargochat/engineering,
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 8
+/area/ruin/space/derelict/security)
+"fc" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"fd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"kQ" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/security/detective)
-"kR" = (
+/area/ruin/space/derelict/security)
+"ff" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
@@ -2415,7 +1164,7 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
-"kS" = (
+"fg" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
 	pixel_x = -3;
@@ -2430,7 +1179,151 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
-"kT" = (
+"fh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research)
+"fi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"fj" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
+"fk" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/derelict/maintenance/port/central)
+"fl" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"fp" = (
+/obj/structure/window/fulltile,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/central)
+"fq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"fr" = (
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"fs" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"fv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"fz" = (
+/obj/structure/disposalpipe/trunk,
+/obj/structure/lattice/catwalk,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"fE" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"fI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"fM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"fN" = (
+/obj/structure/closet/secure_closet/detective,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"fQ" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/security/detective)
+"fS" = (
+/obj/structure/closet/secure_closet/cytology,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"fZ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
+"gd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"gf" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"gg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/ruin/space/derelict/research)
+"gk" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
@@ -2438,44 +1331,7 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/hallway_primary)
-"kU" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	req_access_txt = "7"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/research)
-"kV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"kX" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/machinery/power/port_gen/pacman,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/engineering)
-"kZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"la" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/engineering)
-"lc" = (
+"gp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -2483,231 +1339,36 @@
 	dir = 10
 	},
 /area/ruin/space/derelict/research)
-"ld" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"lf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"lh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"li" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/research)
-"lj" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/research)
-"ll" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"lq" = (
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"lr" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_one_access_txt = "10;24"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"lu" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/security/detective)
-"lv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"lw" = (
-/obj/effect/turf_decal/siding/thinplating/end{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"lx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/east,
-/obj/structure/rack,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"ly" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"lz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
-"lA" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"lB" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"lC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"lD" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor/westleft,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/security)
-"lE" = (
-/obj/structure/closet/secure_closet/detective,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/security/detective)
-"lF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"lJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"lK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"lM" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"lN" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"lO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"lP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"lQ" = (
+"gr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
-"lU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+"gv" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"lV" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
+"gz" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/rnd/destructive_analyzer,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"lW" = (
-/obj/structure/table,
-/obj/item/storage/box/masks{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"lX" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"gC" = (
 /obj/structure/table/wood,
 /obj/item/camera/detective,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
-"lY" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"lZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"mb" = (
+"gE" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/large{
 	pixel_x = -3;
@@ -2727,415 +1388,13 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/research)
-"mc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"md" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"me" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"mf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/rnd/production/protolathe/department/science,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"mg" = (
+"gH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"mh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"mi" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"mk" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/maintenance/port/central)
-"ml" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"mm" = (
-/turf/open/floor/iron/white/side{
-	dir = 9
-	},
-/area/ruin/space/derelict/research)
-"mn" = (
-/obj/machinery/suit_storage_unit/rd,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"mo" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/maintenance/starboard)
-"mp" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_one_access_txt = "10;24"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"mq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"mr" = (
-/obj/machinery/computer/rdservercontrol{
-	dir = 8
-	},
-/obj/machinery/door/window/westleft{
-	req_access_txt = "30"
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"ms" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"mt" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/structure/crate,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"mu" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"mv" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"mw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"my" = (
-/obj/machinery/computer/prisoner/management{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"mz" = (
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"mA" = (
-/obj/machinery/computer/security{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"mB" = (
-/obj/machinery/vending/security,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"mC" = (
-/obj/structure/filingcabinet/security,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"mD" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/security)
-"mF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"mG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"mH" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
-"mI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/arrival)
-"mJ" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/medical)
-"mK" = (
-/obj/machinery/chem_heater/withbuffer,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"mL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"mN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"mP" = (
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research/xenobiology)
-"mR" = (
-/obj/effect/decal/cleanable/crayon{
-	color = "#DE3A3A";
-	icon_state = "a";
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/crayon{
-	color = "#DE3A3A";
-	icon_state = "i"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"mT" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"mU" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"mV" = (
-/obj/machinery/vending/wardrobe/det_wardrobe,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/security/detective)
-"mY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/security/detective)
-"nc" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"nd" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
-"ne" = (
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/security/detective)
-"nf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/arrival)
-"ng" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/research)
-"nh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/computer/rdconsole{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"ni" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"nj" = (
-/obj/machinery/drone_dispenser/derelict,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"nk" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"nl" = (
-/obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"nn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"no" = (
-/obj/structure/table/wood,
-/obj/item/toy/beach_ball/holoball,
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/crew)
-"np" = (
-/obj/effect/spawner/random/structure/closet_private,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/crew)
-"nq" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"nr" = (
-/obj/machinery/vending/autodrobe/all_access,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"ns" = (
-/obj/structure/table/wood,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"nt" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"nu" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"nv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office";
-	req_access_txt = "4"
-	},
-/obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/security/detective)
-"nw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
-"ny" = (
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/service)
-"nz" = (
-/obj/structure/reflector/box/anchored{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"nA" = (
+"gM" = (
 /obj/machinery/door/airlock/research{
 	name = "Production";
 	req_access_txt = "47"
@@ -3144,197 +1403,291 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"nB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"nC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+"gR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"nD" = (
+"gS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"gT" = (
+/obj/machinery/computer/rdservercontrol{
+	dir = 8
+	},
+/obj/machinery/door/window/westleft{
+	req_access_txt = "30"
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"gV" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"gW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"hb" = (
+/obj/structure/sign/warning/biohazard{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"hd" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"he" = (
+/obj/structure/table,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"hf" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/computer/terminal/derelict/security{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"hg" = (
+/obj/item/stack/sheet/iron/five,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"hh" = (
+/obj/structure/filingcabinet/security,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"hi" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"hj" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/derelict/departures)
+"hl" = (
+/obj/machinery/vending/wardrobe/det_wardrobe,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"hm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"hq" = (
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"hr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/computer/rdconsole{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"ht" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"hw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
+"hx" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"hz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"hA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"hE" = (
+/obj/machinery/drone_dispenser/derelict,
+/obj/effect/mob_spawn/ghost_role/drone/derelict,
+/obj/effect/mob_spawn/ghost_role/drone/derelict,
+/obj/effect/mob_spawn/ghost_role/drone/derelict,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"hG" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"hJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"hK" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"hN" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/security)
+"hP" = (
+/obj/structure/table/wood,
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
+"hQ" = (
+/obj/structure/table/wood,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"hR" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"hS" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"hT" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"nE" = (
-/turf/open/floor/iron/dark/side{
-	dir = 8
+"hU" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/starboard)
+"hV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 10
 	},
-/area/ruin/space/derelict/engineering/gravity_generator)
-"nF" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
+"hW" = (
+/turf/open/floor/engine/airless,
+/area/ruin/space/derelict/engineering)
+"hY" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/service)
+"hZ" = (
 /obj/machinery/mass_driver/ordnance{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/research)
-"nG" = (
+"ib" = (
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"ic" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/research)
-"nH" = (
+"id" = (
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/research)
-"nI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/item/light/tube/broken,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"nJ" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/departures)
-"nK" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 4
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/arrival)
-"nL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"nM" = (
+"if" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"nN" = (
-/obj/structure/bed{
+"ik" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/item/bedsheet/dorms_double{
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"in" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/crew)
-"nO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/crew)
-"nQ" = (
-/obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"io" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
+"ip" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
-"nR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"nS" = (
+"ir" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/washing_machine,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
-"nT" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 22;
-	id = "whiteship_z4";
-	name = "KSS13: Derelict";
-	width = 35
-	},
-/turf/template_noop,
-/area/template_noop)
-"nU" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"nV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"nX" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/hallway_primary)
-"nY" = (
+"iu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/crew)
+"iv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"nZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+"iw" = (
+/turf/open/floor/iron/white/side{
+	dir = 10
 	},
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"oa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"ob" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"oc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side,
-/area/ruin/space/derelict/research)
-"od" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
-"oe" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall,
-/area/ruin/space/derelict/research)
-"of" = (
+"iz" = (
 /obj/machinery/door/window/northleft{
 	req_access_txt = "8"
 	},
@@ -3346,47 +1699,54 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
-"og" = (
+"iA" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"iB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/research)
-"oh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+"iC" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"iD" = (
+/obj/effect/spawner/random/structure/girder,
+/obj/structure/window/spawner,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"oi" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Dormitory"
-	},
+/area/ruin/space/derelict/maintenance/port/central)
+"iE" = (
+/obj/structure/frame/computer,
+/turf/open/floor/iron/white/side,
+/area/ruin/space/derelict/bridge)
+"iF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/textured_large,
+/area/ruin/space/derelict/hallway_primary)
+"iH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
-"oj" = (
-/obj/machinery/photocopier,
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"ok" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"ol" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"on" = (
+"iI" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
@@ -3400,7 +1760,7 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/hallway_primary)
-"op" = (
+"iJ" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
 	req_access_txt = "47"
@@ -3419,50 +1779,7 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/research)
-"oq" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access";
-	req_access_txt = "47"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/ruin/space/derelict/research)
-"ot" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"ow" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/ruin/space/derelict/maintenance/port/central)
-"ox" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half{
-	dir = 1
-	},
-/obj/item/shovel/spade,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/service)
-"oy" = (
+"iK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -3474,452 +1791,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"oz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+"iL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"oC" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8;
-	filter_type = list(/datum/gas/nitrogen)
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"oD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"oE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"oF" = (
-/obj/structure/table/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"oK" = (
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/arrival)
-"oL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/gravity_generator/main/station{
-	on = 0
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering/gravity_generator)
-"oM" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"oO" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/recharge_station,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"oR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"oS" = (
-/obj/structure/reflector/single/anchored{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"oU" = (
-/obj/structure/window/fulltile,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/ruin/space/derelict/maintenance/port/central)
-"oV" = (
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"oX" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"pc" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"pe" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/service)
-"pg" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port)
-"pk" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/suit_storage_unit/open,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"po" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/maintenance/port/central)
-"pu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"pv" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"pA" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/arrival)
-"pB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"pD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/screwdriver,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"pF" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/frame/computer{
-	dir = 8
-	},
-/turf/open/floor/carpet/blue/airless,
-/area/ruin/space/derelict/arrival)
-"pH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"pJ" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/security)
-"pM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/binary/pressure_valve/on{
-	dir = 4;
-	name = "Output Release"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"pS" = (
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"pV" = (
-/turf/template_noop,
-/area/ruin/space/derelict/maintenance/port/central)
-"pZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"qa" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"qb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"qh" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"qi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"qk" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"ql" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"qm" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "25"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"qo" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 7
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"qp" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"qv" = (
-/obj/machinery/light/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"qx" = (
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/departures)
-"qy" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"qz" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"qI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port/central)
-"qN" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port)
-"qO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"qP" = (
-/obj/machinery/vending/medical,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"qW" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/decal/remains/human,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"ra" = (
-/obj/structure/window/reinforced/plasma{
-	dir = 8
-	},
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"rb" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"re" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/engineering)
-"rf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"rg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"rh" = (
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/ruin/space/derelict/engineering/gravity_generator)
-"ri" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"rj" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"rk" = (
-/obj/structure/table,
-/obj/item/toy/plush/lizard_plushie,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"rl" = (
-/obj/item/crowbar/large,
-/obj/structure/rack,
-/obj/item/flashlight,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"rm" = (
-/obj/structure/lattice,
-/obj/structure/frame/computer{
-	dir = 4
-	},
-/turf/template_noop,
-/area/template_noop)
-"rp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "External Gas to Loop"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"rs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"rt" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"ry" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"rA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"rB" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"rC" = (
+"iN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -3932,702 +1809,93 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
-"rK" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/service)
-"rL" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"rN" = (
-/obj/effect/turf_decal/tile/green/half{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+"iP" = (
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/medical)
-"rO" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
-"rP" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"rQ" = (
-/obj/machinery/stasis,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"rU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"rV" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering/gravity_generator)
-"rY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict11"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"sa" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"sb" = (
-/obj/machinery/telecomms/broadcaster/preset_left/birdstation,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"sc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"sd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
-"se" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard)
-"sj" = (
-/obj/structure/toilet{
-	pixel_y = 12
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/hallway_primary)
-"sk" = (
-/obj/machinery/light/directional/south,
+"iQ" = (
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"sl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
-"sp" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
-"st" = (
-/obj/effect/turf_decal/tile/yellow/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
-/area/ruin/space/derelict/hallway_primary)
-"sv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/textured_large,
-/area/ruin/space/derelict/hallway_primary)
-"sD" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/collectable/tophat,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/service)
-"sE" = (
-/obj/machinery/telecomms/processor/preset_one/birdstation,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"sG" = (
-/obj/machinery/vending/wallmed/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"sH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"sJ" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"sM" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/kitchen/fork,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"sN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/flat_white,
-/area/ruin/space/derelict/medical)
-"sO" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/item/chair,
-/turf/open/floor/iron/white/corner/airless{
-	dir = 8
-	},
-/area/ruin/space/derelict/departures)
-"sQ" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/security)
-"sT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"sX" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard)
-"tb" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"tc" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Gas to Mix"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"td" = (
+/area/ruin/space/derelict/EVA)
+"iT" = (
 /turf/closed/wall/rust,
-/area/ruin/space/derelict/maintenance/port)
-"tl" = (
-/obj/machinery/telecomms/hub/preset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"tm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"tp" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock";
-	space_dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
-"tr" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/template_noop,
-/area/template_noop)
-"tu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/moth_epi{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
-"tx" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"tz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/service)
-"tA" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Pharmacy";
-	req_access_txt = "69"
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"tF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/medical)
-"tH" = (
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/ruin/space/derelict/maintenance/port/central)
-"tI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Custodial Maintenance";
-	req_access_txt = "26"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"tK" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"tM" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_one_access_txt = "10;24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"tP" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"tQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"tS" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"tV" = (
-/obj/structure/sign/barsign,
+"iV" = (
 /turf/closed/wall,
-/area/ruin/space/derelict/service)
-"tX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/chair/stool,
-/obj/effect/decal/cleanable/blood/gibs/limb{
-	dir = 4
+/area/ruin/space/derelict/departures)
+"iW" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"tZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Gas to Chamber"
+/area/ruin/space/derelict/departures)
+"iX" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/space/derelict/departures)
+"iY" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"uc" = (
+/area/ruin/space/derelict/departures)
+"ja" = (
 /obj/effect/spawner/random/engineering/tank,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
-"ud" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"uf" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/crew)
-"uj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
-"uk" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/machinery/seed_extractor,
-/turf/open/floor/iron/edge,
-/area/ruin/space/derelict/service)
-"ul" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"uq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"uu" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"ux" = (
-/obj/machinery/vending/dinnerware,
+"jb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"uy" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior{
-	name = "Burn Chamber Exterior Airlock"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research)
-"uz" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ruin/space/derelict/research)
-"uA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor/flat_white,
-/area/ruin/space/derelict/medical)
-"uB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/ruin/space/derelict/research)
-"uH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"uK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"uO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"uP" = (
-/obj/structure/table,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/neck/stethoscope,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"uW" = (
-/obj/structure/table,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/side{
+"jc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
-/area/ruin/space/derelict/medical)
-"uY" = (
-/obj/machinery/rnd/production/techfab/department/medical,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"vc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"vd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"vf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
-"vh" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"vj" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/freezer,
+"jd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"jh" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"ji" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
-"vk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"vl" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"vn" = (
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"vo" = (
+"jj" = (
 /obj/structure/table/wood,
 /obj/item/storage/dice,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/crew)
-"vr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"vB" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+"jl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"vC" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"vD" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half{
-	dir = 1
-	},
-/obj/item/shovel/spade,
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/service)
-"vG" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Dormitory"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"vP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/research)
-"vU" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/thinplating_new,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"vV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
-"vW" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"vX" = (
-/obj/effect/spawner/random/structure/girder,
-/obj/structure/window/spawner,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/space/derelict/maintenance/port/central)
-"vZ" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"wa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue/airless,
-/area/ruin/space/derelict/arrival)
-"wb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"wi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"wj" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"wr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"ws" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue/airless,
-/area/ruin/space/derelict/arrival)
-"wt" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"wv" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
+"jo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"wx" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"wz" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
+/area/ruin/space/derelict/crew)
+"jr" = (
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"wF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"wK" = (
+/area/ruin/space/derelict/hallway_primary)
+"jt" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4637,435 +1905,42 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"wN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"wO" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Engine Coolant Bypass"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"wS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"wT" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/window/reinforced/spawner/east,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"wY" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"wZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict14"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"xa" = (
-/obj/structure/closet/firecloset/full,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"xb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"xc" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Telecommunications";
-	req_access_txt = "61"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"xf" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"xi" = (
+"ju" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"xj" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"xm" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/service)
-"xo" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/security/detective)
-"xp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"xx" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard)
-"xy" = (
-/obj/structure/closet/secure_closet/medical1,
+"jz" = (
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"xz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+"jB" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
 	},
-/obj/structure/sign/poster/official/moth_delam{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"xB" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"xI" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"xK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/medical)
-"xP" = (
-/obj/structure/disposalpipe/trunk,
-/obj/structure/lattice/catwalk,
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/turf/template_noop,
-/area/template_noop)
-"xQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/arrival)
-"xT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"xU" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"xX" = (
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"yb" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"yd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"yj" = (
-/obj/item/electronics/airlock,
-/obj/item/stack/cable_coil/cut,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
-"yk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict13"
-	},
-/obj/machinery/vending/coffee{
-	layer = ABOVE_MOB_LAYER;
-	plane = GAME_PLANE_UPPER;
-	tilted = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"yn" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/door/airlock{
-	name = "Bar";
-	req_access_txt = "25"
-	},
-/obj/machinery/door/firedoor,
+"jD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"yq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict16"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"yr" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"ys" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/heater/on{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"yt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"yu" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"yv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"yw" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"jE" = (
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"yx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"yy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"yC" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"yD" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_edge,
-/area/ruin/space/derelict/hallway_primary)
-"yE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"yI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"yK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white/corner/airless{
-	dir = 8
-	},
-/area/ruin/space/derelict/departures)
-"yL" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/entertainment/cigarette_pack,
-/obj/item/lighter/greyscale{
-	pixel_x = 5
-	},
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/arrival)
-"yN" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/infections{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"yO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Cooling Loop to Gas"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"yR" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"yT" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port/lesser)
-"yW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"yZ" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"za" = (
-/obj/machinery/airlock_sensor/incinerator_ordmix{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research)
-"zc" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Foyer";
-	req_one_access_txt = "32;19"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"zg" = (
+"jG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
 /area/ruin/space/derelict/research)
-"zh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"zi" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/maintenance/port/central)
-"zo" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"zp" = (
+"jH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -5073,254 +1948,135 @@
 	dir = 9
 	},
 /area/ruin/space/derelict/research)
-"zq" = (
-/obj/item/stack/tile/iron,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"zv" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"zx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"zz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Maintenance";
-	req_one_access_txt = "10;24"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"zB" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/departures)
-"zG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"zJ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/departures)
-"zK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"zL" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"zO" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"zS" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/medical)
-"zZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/EVA)
-"Ab" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Ad" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/template_noop,
-/area/ruin/space/derelict/maintenance/port)
-"Aj" = (
+"jI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/engineering)
-"Ak" = (
-/obj/structure/closet/secure_closet/freezer/fridge{
-	req_access = list(25)
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"Al" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"Ao" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Ap" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Ar" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/latex,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"As" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
-"Au" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/item/camera,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/arrival)
-"Av" = (
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/space/derelict/departures)
-"Aw" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"Ax" = (
-/obj/structure/window/reinforced/plasma{
+"jJ" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+/obj/machinery/research/explosive_compressor,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"jK" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"jM" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"jP" = (
+/obj/machinery/computer/department_orders/science{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"AA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"jQ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"jR" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/departures)
+"jS" = (
+/obj/item/construction/rcd,
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/ruin/space/derelict/departures)
+"jT" = (
 /obj/structure/closet/crate/bin,
 /obj/item/wallframe/light_fixture,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/ruin/space/derelict/departures)
-"AB" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/spawner/random/trash/mopbucket,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"AG" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"AH" = (
-/obj/structure/reagent_dispensers/fueltank/large,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"AJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"AK" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/template_noop,
-/area/template_noop)
-"AN" = (
-/obj/structure/girder,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"AO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/EVA)
-"AP" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"AS" = (
-/obj/effect/turf_decal/siding/thinplating/end{
-	dir = 1
+"jU" = (
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/departures)
+"jV" = (
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"jY" = (
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access_txt = "26"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"AV" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"jZ" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"ka" = (
+/obj/effect/turf_decal/tile/red/half{
 	dir = 1
 	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/bridge)
+"kb" = (
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"kd" = (
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"AW" = (
+/area/ruin/space/derelict/hallway_primary)
+"kj" = (
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"kk" = (
+/obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"AZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"Ba" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_edge,
+/area/ruin/space/derelict/hallway_primary)
+"km" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"ko" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"kq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
@@ -5329,337 +2085,7 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
-"Bc" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Bd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"Bf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"Bg" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Bh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/arrival)
-"Bi" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Bm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/frame/computer{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"Bs" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"Bt" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"Bv" = (
-/obj/structure/mirror/directional/north,
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/hallway_primary)
-"Bx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"By" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/service)
-"BB" = (
-/obj/machinery/airalarm/engine{
-	dir = 8;
-	pixel_x = -23
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Filter"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"BE" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"BK" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/template_noop)
-"BM" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes{
-	pixel_y = 8
-	},
-/obj/structure/sign/poster/official/moth_meth{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"BP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Cooling Loop Bypass"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"BR" = (
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 4
-	},
-/obj/machinery/computer/department_orders/medical,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"BS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"BT" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"BU" = (
-/obj/effect/turf_decal/siding/thinplating/end,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"BV" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/turf/open/floor/iron/white/smooth_edge,
-/area/ruin/space/derelict/hallway_primary)
-"Ch" = (
-/obj/structure/frame/computer{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue/airless,
-/area/ruin/space/derelict/arrival)
-"Cn" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Co" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict6"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Cq" = (
-/obj/structure/window/reinforced/plasma{
-	dir = 4
-	},
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Cr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"Cv" = (
-/obj/machinery/air_sensor/atmos/air_tank,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine/air,
-/area/ruin/space/derelict/engineering)
-"Cy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"Cz" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"CC" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"CG" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/geiger_counter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"CN" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/departures)
-"CT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"CY" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/iron/edge,
-/area/ruin/space/derelict/service)
-"Db" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
-"Dc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Dh" = (
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/space/derelict/maintenance/port/central)
-"Dj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"Dl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/machinery/light/directional/east,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Dm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/departures)
-"Dn" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/maintenance/port/lesser)
-"Dp" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"Ds" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/research/xenobiology)
-"Dt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
-"Du" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/hallway_primary)
-"Dx" = (
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"DB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"DC" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"DE" = (
+"kr" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/coin,
 /obj/item/paper_bin{
@@ -5672,550 +2098,83 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
-"DF" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/vending/drugs,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"DH" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"DM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"DN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/ruin/space/derelict/engineering/gravity_generator)
-"DR" = (
-/obj/structure/closet/l3closet/virology,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"DX" = (
+"ks" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
-"Ef" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output,
-/turf/open/floor/engine/air,
-/area/ruin/space/derelict/engineering)
-"El" = (
-/obj/machinery/photocopier,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"En" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Ep" = (
+"kt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Eq" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/engine/air,
-/area/ruin/space/derelict/engineering)
-"Es" = (
-/obj/structure/reflector/double/anchored{
 	dir = 6
 	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Ev" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"kA" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"kB" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/bookmanagement,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
-"Ew" = (
-/turf/open/floor/wood,
-/area/ruin/space/derelict/maintenance/port/central)
-"Ey" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"EB" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
-"EC" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"ED" = (
-/obj/machinery/chem_dispenser,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"EF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"EH" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict8"
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"EN" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/security)
-"EP" = (
-/obj/machinery/telecomms/server/presets/common/birdstation,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"ER" = (
-/obj/machinery/vending/boozeomat,
-/obj/structure/sign/picture_frame/portrait/bar{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/service)
-"EU" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"EX" = (
-/obj/effect/spawner/random/structure/chair_maintenance,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"EZ" = (
+"kC" = (
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port/lesser)
-"Fd" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
-"Fe" = (
-/obj/effect/spawner/random/engineering/tank,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/maintenance/port/central)
-"Ff" = (
-/obj/effect/turf_decal/loading_area/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 9
-	},
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/arrival)
-"Fi" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"Fm" = (
-/obj/machinery/power/supermatter_crystal/shard/engine,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Fp" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/service)
-"Fq" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port/central)
-"Fr" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port/lesser)
-"Ft" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"Fw" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict5"
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Fz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"FI" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/bot_white/left,
-/obj/structure/window/spawner/east,
-/turf/open/floor/iron/white/smooth_large,
-/area/ruin/space/derelict/medical)
-"FL" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/research/xenobiology)
-"FM" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/service)
-"FO" = (
-/obj/structure/chair/stool/directional/north,
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
-"FS" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
-"FU" = (
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Lab";
-	req_access_txt = "8"
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"FY" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark/corner{
-	dir = 4
-	},
-/area/ruin/space/derelict/engineering/gravity_generator)
-"FZ" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Gb" = (
-/obj/structure/table,
-/obj/item/paper_bin/carbon{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"Gc" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	base_state = "rightsecure";
-	icon_state = "rightsecure";
-	name = "Head of Personnel's Desk";
-	req_access_txt = "57"
-	},
-/obj/machinery/door/window/northleft{
-	name = "Reception Window"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"Gd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"Ge" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"Gf" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Gh" = (
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Gl" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
-"Gm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Gr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"Gs" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Gu" = (
-/obj/machinery/computer/department_orders/science{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Gv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Gz" = (
-/obj/machinery/modular_computer/console/preset/cargochat/science{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"GA" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"GC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"GD" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"GI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/engineering)
-"GK" = (
-/obj/machinery/chem_mass_spec,
-/obj/structure/sign/poster/official/periodic_table{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"GM" = (
-/obj/effect/turf_decal/tile/green/half{
-	dir = 1
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/service)
-"GN" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"GR" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"GT" = (
-/obj/machinery/door/airlock{
-	name = "Custodial Closet";
-	req_access_txt = "26"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"GU" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"GY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
-"GZ" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"Hd" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"He" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "External Gas to Loop"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Hi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"Hj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Hl" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Ho" = (
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Hr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Ht" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/template_noop,
-/area/template_noop)
-"Hu" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/bot_white/right,
-/turf/open/floor/iron/white/smooth_large,
-/area/ruin/space/derelict/medical)
-"Hv" = (
-/obj/structure/tank_dispenser,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Hw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Hx" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall,
 /area/ruin/space/derelict/departures)
-"HA" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half{
-	dir = 1
+"kD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"kF" = (
+/obj/structure/sign/warning/docking,
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/departures)
+"kI" = (
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
 	},
-/obj/item/hatchet,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/service)
-"HB" = (
-/obj/machinery/griddle,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"HF" = (
+/area/ruin/space/derelict/departures)
+"kJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"kK" = (
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"kL" = (
+/obj/structure/table/reinforced,
+/obj/item/multitool,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"kM" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/port/central)
+"kQ" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"kR" = (
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"kS" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"kT" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"kU" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"kV" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/conveyor{
@@ -6226,50 +2185,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/large,
 /area/ruin/space/derelict/research)
-"HJ" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/arrival)
-"HN" = (
-/obj/machinery/modular_computer/console/preset/cargochat/medical,
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"HO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/maintenance/port/central)
-"HP" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/blue/airless,
-/area/ruin/space/derelict/arrival)
-"HS" = (
-/obj/machinery/suit_storage_unit/cmo,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"HT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"HU" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"HW" = (
+"kX" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap{
 	pixel_x = -1;
@@ -6278,28 +2194,7 @@
 /obj/item/hand_labeler,
 /turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
-"HZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Id" = (
-/obj/machinery/power/emitter/welded{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"Ie" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Ih" = (
+"kZ" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/door/window/eastright{
@@ -6313,198 +2208,11 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/large,
 /area/ruin/space/derelict/research)
-"Ii" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Ik" = (
+"lc" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"Il" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"Is" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator Chamber";
-	req_one_access_txt = "19; 61"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering/gravity_generator)
-"It" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"Iu" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Ix" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/science,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes,
-/obj/structure/reagent_dispensers/wall/virusfood/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Iy" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"IA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"IB" = (
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"IE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"IF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"II" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
-"IJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/hallway_primary)
-"IP" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"IR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"IX" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "EVA Storage";
-	req_access_txt = "18"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"IZ" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/maintenance/port)
-"Jb" = (
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"Jd" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half{
-	dir = 1
-	},
-/obj/item/cultivator,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/service)
-"Je" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering/gravity_generator)
-"Jh" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Ji" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/template_noop,
-/area/template_noop)
-"Jj" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"Jl" = (
+"ld" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/igniter{
 	pixel_x = -8;
@@ -6525,221 +2233,13 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"Jv" = (
+"lg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 9
 	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"JA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"JC" = (
-/obj/machinery/airalarm/mixingchamber{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"JD" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"JF" = (
-/obj/machinery/gibber,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/service)
-"JG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Gas to Cooling Loop"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"JJ" = (
-/obj/machinery/telecomms/bus/preset_one/birdstation,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"JO" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"JP" = (
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/space/derelict/maintenance/port/central)
-"JS" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"JV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"JY" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/service)
-"Kb" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/departures)
-"Ke" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/ruin/space/derelict/maintenance/port/central)
-"Kh" = (
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"Ki" = (
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/stack/cable_coil,
-/obj/item/screwdriver{
-	pixel_x = 2;
-	pixel_y = 11
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Kl" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/departures)
-"Km" = (
-/obj/effect/turf_decal/tile/yellow/anticorner,
-/turf/open/floor/iron/corner{
-	dir = 1
-	},
-/area/ruin/space/derelict/hallway_primary)
-"Kp" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Kq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Kr" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"Ku" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"Kw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Kx" = (
-/obj/structure/table,
-/obj/item/defibrillator/loaded{
-	pixel_y = 3
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"KA" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/departures)
-"KE" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"KF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"KG" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"KJ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
-"KN" = (
+"li" = (
 /obj/item/assembly/signaler{
 	pixel_y = 8
 	},
@@ -6758,7 +2258,7 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"KP" = (
+"lj" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/timer{
 	pixel_x = 6;
@@ -6802,21 +2302,34 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"KQ" = (
-/obj/structure/chair/comfy/lime,
-/obj/effect/turf_decal/siding/thinplating_new{
+"lk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"ll" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/bridge)
+"lr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/arrival)
-"KR" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Canteen"
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"lt" = (
+/obj/machinery/vending/dinnerware,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/ruin/space/derelict/service)
-"KS" = (
+"lu" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/item/screwdriver{
@@ -6840,501 +2353,100 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"KT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"KU" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"KW" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"KX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"KY" = (
-/obj/machinery/chem_master,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Le" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Lp" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"Lr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
-"Ls" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Lv" = (
-/turf/closed/wall,
-/area/template_noop)
-"Lw" = (
-/obj/machinery/announcement_system,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Lx" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"LA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict12"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"LC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"LD" = (
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/gun/syringe,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"LE" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering/gravity_generator)
-"LF" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/yellow,
-/obj/item/hand_labeler,
-/obj/item/stack/package_wrap,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"LL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/wtf_is_co2{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"LN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"LO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict10"
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"LR" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/arrival)
-"LT" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/hallway_primary)
-"LV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix Bypass"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"LW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"LX" = (
+"lv" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/binary/thermomachine/heater/on{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"LY" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"LZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/carpet/blue/airless,
-/area/ruin/space/derelict/arrival)
-"Mb" = (
-/obj/effect/spawner/random/engineering/tank,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port)
-"Md" = (
-/obj/structure/table,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Mg" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"Mi" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"Mj" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"Mq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+"lw" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Mr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"Mt" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard)
-"Mw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/wrench,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"Mx" = (
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"lz" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green/half{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"My" = (
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"MA" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/turf/open/floor/iron/edge{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"MB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/area/ruin/space/derelict/service)
+"lA" = (
+/turf/open/floor/iron/white/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"MC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"ME" = (
+/area/ruin/space/derelict/bridge)
+"lB" = (
+/obj/structure/displaycase_chassis,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"lC" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"ML" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 8;
-	filter_type = list(/datum/gas/nitrogen,/datum/gas/oxygen)
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"MM" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/arrival)
-"MN" = (
-/obj/effect/mob_spawn/corpse/human/skeleton,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"MQ" = (
+"lD" = (
 /obj/structure/closet/bombcloset,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"MU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"MV" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/template_noop,
-/area/template_noop)
-"MX" = (
-/obj/machinery/airalarm/directional/west,
-/turf/closed/wall,
-/area/ruin/space/derelict/maintenance/port/central)
-"MY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Nc" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/service)
-"Ne" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"Nf" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/ruin/space/derelict/hallway_primary)
-"Ng" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Nh" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/service/janitor)
-"Ni" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research/xenobiology)
-"Nk" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/template_noop,
-/area/template_noop)
-"Nm" = (
-/obj/item/wrench,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/rack,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"No" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/layer2,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"Ns" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/service)
-"Nt" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12
-	},
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
-"Nv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Nw" = (
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Nx" = (
+"lE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/closed/wall,
 /area/ruin/space/derelict/research)
-"Nz" = (
+"lF" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
+"lI" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"lK" = (
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "b";
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "a"
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "r";
+	pixel_x = 10
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"lM" = (
+/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/recharge_station,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"NC" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron/corner,
-/area/ruin/space/derelict/hallway_primary)
-"NE" = (
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
+/area/ruin/space/derelict/research)
+"lP" = (
 /obj/structure/table,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"NF" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"NJ" = (
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"NK" = (
+/obj/machinery/light/broken/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"lQ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -7348,741 +2460,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
-"NO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"NP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"NQ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Gas"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"NS" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"NT" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"NW" = (
-/obj/machinery/stasis{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Oa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"Ob" = (
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
-"Of" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/door/airlock{
-	name = "Bar";
-	req_access_txt = "25"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"Oj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Ol" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/service)
-"Om" = (
-/obj/effect/decal/remains/robot,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"Oo" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"Or" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Ot" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/hallway_primary)
-"Ou" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"Ov" = (
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/ruin/space/derelict/maintenance/port)
-"Oy" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Oz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"OB" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/cargo)
-"OD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"OG" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/template_noop,
-/area/template_noop)
-"OJ" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"OM" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/analyzer,
-/obj/item/pipe_dispenser,
-/obj/item/flashlight,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"ON" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/turf_decal/siding/thinplating_new,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"OQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"OS" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/research)
-"OT" = (
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"OU" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/item/kitchen/fork,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"OY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"OZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Pb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"Pd" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict3"
-	},
-/obj/item/toy/crayon/red,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Pf" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
-"Pi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/item/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"Pj" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Pk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Pm" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"Pq" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Pt" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes{
-	pixel_y = 8
-	},
-/obj/machinery/vending/wallmed/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Pv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering/gravity_generator)
-"Py" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Pz" = (
-/turf/open/floor/engine/air,
-/area/ruin/space/derelict/engineering)
-"PA" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/musician/piano,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"PB" = (
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"PC" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/maintenance/port)
-"PD" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half{
-	dir = 1
-	},
-/obj/item/hatchet,
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/service)
-"PE" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"PH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"PI" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"PK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"PP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"PQ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"PV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"PY" = (
-/obj/machinery/power/emitter/welded{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"Qa" = (
-/obj/structure/table,
-/obj/item/construction/plumbing,
-/obj/item/paper{
-	info = "NOTICE - Due to the Air tank's extreme susceptibility to sabotage, Engineering has been supplied one chemistry plumberer to help curate more air in case of emergencies - Just remember to use smoke machines!"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"Qb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"Qd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"Qe" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "12"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"Ql" = (
-/obj/structure/table,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Qr" = (
-/obj/structure/door_assembly/door_assembly_mhatch,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"Qt" = (
-/obj/effect/turf_decal/siding/thinplating/end,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Qu" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air to Distro"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"Qv" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"Qz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 5
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"QA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"QB" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"QC" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"QD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"QG" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall,
-/area/ruin/space/derelict/service)
-"QI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"QK" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"QO" = (
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"QP" = (
-/obj/structure/table,
-/obj/item/folder/blue,
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"QQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"QU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"QV" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port/central)
-"QW" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ruin/space/derelict/research)
-"QY" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"QZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Rb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Rg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
-"Rh" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
-"Ri" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"Rk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Rl" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"Rr" = (
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"Rs" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Ru" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/ruin/space/derelict/engineering/gravity_generator)
-"Rw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"RA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 12;
-	pixel_y = 9
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/maintenance/port/central)
-"RB" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "head of personnel's office maintenance";
-	req_access_txt = "57"
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/maintenance/port)
-"RC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet,
-/obj/effect/spawner/random/exotic/tool,
-/obj/item/mop/advanced,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"RF" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "toxins"
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/large,
-/area/ruin/space/derelict/research)
-"RH" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green/half{
-	dir = 1
-	},
-/obj/item/cultivator,
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/service)
-"RI" = (
-/obj/machinery/light/directional/east,
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/service)
-"RN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"RP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"RQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"RR" = (
-/obj/effect/decal/cleanable/blood/gibs/core,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service/janitor)
-"RT" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"RX" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/hallway_primary)
-"RY" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"Sd" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Se" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Sj" = (
-/obj/machinery/computer/department_orders/engineering,
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Sl" = (
-/obj/structure/table,
-/obj/item/storage/box/masks{
-	pixel_y = 4
-	},
-/obj/item/crowbar,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Sm" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "toxins"
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/turf/open/floor/iron/large,
-/area/ruin/space/derelict/research)
-"Sp" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/maintenance/starboard)
-"Sq" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"Sr" = (
+"lS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -8092,14 +2470,76 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"Ss" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
-"St" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"Su" = (
+"lT" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine/air,
+/area/ruin/space/derelict/engineering)
+"lU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"lV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/kitchen/fork,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"lW" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"lX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"lY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"lZ" = (
+/obj/effect/spawner/random/structure/chair_maintenance,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"mb" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"mc" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"me" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"mf" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/door/window/eastright{
@@ -8113,74 +2553,2686 @@
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/large,
 /area/ruin/space/derelict/research)
-"SA" = (
-/obj/machinery/computer/atmos_control/tank/air_tank,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+"ml" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"mm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"mn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"mo" = (
+/obj/machinery/airlock_sensor/incinerator_ordmix{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research)
+"mp" = (
+/obj/machinery/oven,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"mq" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"mr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
+"ms" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"SE" = (
-/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/engine/vacuum,
+/area/ruin/space/derelict/research)
+"mt" = (
+/turf/open/floor/engine/vacuum,
+/area/ruin/space/derelict/research)
+"mw" = (
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"mA" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/item/chair,
+/turf/open/floor/iron/white/corner/airless{
+	dir = 8
+	},
+/area/ruin/space/derelict/departures)
+"mB" = (
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"mC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/item/light/tube/broken,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"mD" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"mF" = (
+/obj/machinery/gibber,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"mH" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"mJ" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/medical)
+"mK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"mP" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"mT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"mV" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port/central)
-"SF" = (
+"mW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"mX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"mY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nb" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"SI" = (
+"nc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"ne" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
+	pixel_y = 24
+	},
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
+	name = "Burn Chamber Interior Airlock"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research)
+"ng" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research)
+"nh" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior{
+	name = "Burn Chamber Exterior Airlock"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research)
+"ni" = (
+/obj/machinery/igniter/incinerator_ordmix,
+/turf/open/floor/engine/vacuum,
+/area/ruin/space/derelict/research)
+"nj" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"nk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner/airless{
+	dir = 8
+	},
+/area/ruin/space/derelict/departures)
+"nl" = (
+/obj/effect/decal/remains/robot,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"nm" = (
+/obj/machinery/vending/wallmed/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"no" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"np" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"nq" = (
+/obj/item/electronics/airlock,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"nr" = (
+/obj/structure/door_assembly/door_assembly_mhatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"nt" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/secure/briefcase,
+/obj/item/assembly/flash/handheld,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"nu" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"nv" = (
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
+"nw" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"nz" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Foyer";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"nA" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"nB" = (
+/obj/effect/spawner/random/engineering/tank,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/maintenance/port/central)
+"nC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"nD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"nF" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"nG" = (
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "toxins"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nH" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nI" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nJ" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nM" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nQ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nR" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nT" = (
+/obj/machinery/airalarm/mixingchamber{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"nV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"nX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research)
+"nY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
+"nZ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/ordnance_mixing_input{
+	dir = 8
+	},
+/turf/open/floor/engine/vacuum,
+/area/ruin/space/derelict/research)
+"oa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white/corner/airless{
+	dir = 8
+	},
+/area/ruin/space/derelict/departures)
+"ob" = (
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"oc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/item/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"od" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/rnd/production/protolathe/department/science,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"oe" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"of" = (
+/obj/machinery/airalarm/directional/west,
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/port/central)
+"og" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"oh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 12;
+	pixel_y = 9
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
+"oi" = (
+/obj/effect/turf_decal/tile/blue/half,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
+"ok" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
+"on" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
+"oo" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"op" = (
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/maintenance/port/central)
+"oq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"or" = (
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ot" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"oy" = (
+/obj/structure/table,
+/obj/item/storage/box/masks{
+	pixel_y = 4
+	},
+/obj/item/crowbar,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"oz" = (
+/obj/structure/table,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"oC" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"oD" = (
+/obj/machinery/modular_computer/console/preset/cargochat/medical,
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"oE" = (
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 4
+	},
+/obj/machinery/computer/department_orders/medical,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"oG" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/derelict/engineering)
+"oH" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"oL" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"oN" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"oP" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"oQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"oR" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"oS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"oV" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"oW" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"oX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
+"pc" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = 6
+	},
+/obj/item/hand_tele,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"pg" = (
+/obj/machinery/photocopier,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"ph" = (
+/obj/machinery/rnd/production/techfab/department/medical,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"pj" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"pq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"pt" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/template_noop,
+/area/template_noop)
+"py" = (
+/obj/effect/turf_decal/tile/green/half{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/medical)
+"pz" = (
+/obj/machinery/photocopier,
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
+"pD" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"pF" = (
+/obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"pG" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/engineering)
+"pH" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"pL" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/template_noop,
+/area/template_noop)
+"pM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"pN" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"pO" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"pQ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"pT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor/flat_white,
+/area/ruin/space/derelict/medical)
+"pV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"qa" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"qb" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"qi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
+"ql" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"qm" = (
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"qr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/derelict/arrival)
+"qz" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"qC" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/item/tank/internals/emergency_oxygen/empty,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"qE" = (
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/item/shovel/spade,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
+"qJ" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/hallway_primary)
+"qL" = (
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"qN" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"qO" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"qR" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"qW" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/hallway_primary)
+"qZ" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/defibrillator/loaded,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"re" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"rh" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"ri" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"rs" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"rv" = (
+/obj/structure/table,
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/blood_filter,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"rz" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway_primary)
+"rC" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"rF" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/structure/window/fulltile,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"rL" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"rM" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"rP" = (
+/obj/structure/musician/piano,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"rS" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"sa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"sb" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"sc" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"se" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet,
+/obj/effect/spawner/random/exotic/tool,
+/obj/item/mop/advanced,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"sf" = (
+/obj/machinery/vending/wallmed/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"sk" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"sl" = (
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
+"sn" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"sp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"sr" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/ruin/space/derelict/engineering)
+"sv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
+"sC" = (
+/obj/machinery/computer/atmos_control/tank/air_tank,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"sD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
+"sE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"sG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"sH" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"sJ" = (
+/obj/effect/decal/cleanable/robot_debris/down,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"sO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"sQ" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"sR" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"sV" = (
+/obj/structure/table,
+/obj/item/construction/plumbing,
+/obj/item/paper{
+	info = "NOTICE - Due to the Air tank's extreme susceptibility to sabotage, Engineering has been supplied one chemistry plumberer to help curate more air in case of emergencies - Just remember to use smoke machines!"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"sX" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"sY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/engineering)
+"ta" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/template_noop,
+/area/template_noop)
+"tb" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"tl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"tm" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"tn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"tp" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"tq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"tr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ts" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"tv" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict1"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"tz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"tA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"tC" = (
+/obj/effect/spawner/random/structure/furniture_parts,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"tH" = (
+/obj/structure/displaycase/noalert,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"tJ" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"tK" = (
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"tM" = (
+/obj/effect/spawner/random/structure/girder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"tO" = (
+/obj/structure/closet/secure_closet/medical1,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"tP" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"tQ" = (
+/obj/effect/decal/cleanable/robot_debris/up,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"tT" = (
+/obj/structure/table/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"tZ" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ud" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"ue" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"uf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"uj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"uo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"up" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"uq" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/template_noop,
+/area/ruin/space/derelict/maintenance/port)
+"ur" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"us" = (
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"uv" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"uw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/wtf_is_co2{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"uy" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"uz" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"uB" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"uE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"uH" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/derelict/arrival)
+"uO" = (
+/obj/structure/closet/secure_closet/bar{
+	req_access_txt = "25"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"uP" = (
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"uV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"uW" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"uY" = (
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"vb" = (
+/obj/machinery/computer/pandemic,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"vd" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"vf" = (
+/obj/structure/table,
+/obj/item/gun/syringe,
+/obj/item/reagent_containers/dropper{
+	pixel_y = -6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"vh" = (
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"vi" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"vj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"vm" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"vn" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/vending/drugs,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"vo" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"vs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"vt" = (
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/template_noop,
+/area/template_noop)
+"vw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"vx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"vB" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "EVA Storage";
+	req_access_txt = "18"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"vC" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"vE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"vH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Bar";
+	req_access_txt = "25"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"vN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
+"vP" = (
+/obj/machinery/suit_storage_unit/cmo,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"vU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"vX" = (
+/obj/structure/table,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/side{
+	dir = 5
+	},
+/area/ruin/space/derelict/medical)
+"vY" = (
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/table,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"wc" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/north,
+/obj/structure/frame/machine,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"wg" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/template_noop,
+/area/template_noop)
+"wj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"wk" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"wq" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"wr" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	base_state = "rightsecure";
+	icon_state = "rightsecure";
+	name = "Head of Personnel's Desk";
+	req_access_txt = "57"
+	},
+/obj/machinery/door/window/northleft{
+	name = "Reception Window"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
+"wz" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"wF" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"wG" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"wK" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/surgical,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"wM" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"wP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"wS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"wT" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research/xenobiology)
+"wZ" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"xa" = (
+/obj/structure/table,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"xh" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"xi" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"xj" = (
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"xn" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/service)
+"xo" = (
+/obj/structure/table,
+/obj/item/storage/box/masks{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"xp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
+"xr" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"xu" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"xv" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict3"
+	},
+/obj/item/toy/crayon/red,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"xw" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"xx" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"xB" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Custodial Maintenance";
+	req_access_txt = "26"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"xC" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"xG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"xI" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"xJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"xP" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
+"xT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/barricade/wooden,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"xX" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	req_one_access_txt = "31;48"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"yc" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"ye" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Bar";
+	req_access_txt = "25"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"yk" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"yl" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"ym" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/service)
+"yq" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"yv" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"yw" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"yx" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"yy" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/arrival)
+"yA" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"yH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"yI" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"yK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/chair/stool,
+/obj/effect/decal/cleanable/blood/gibs/limb{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"yN" = (
+/obj/machinery/modular_computer/console/preset/cargochat/science{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"yP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"yQ" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall,
+/area/ruin/space/derelict/medical)
+"yR" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"yT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/screwdriver,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"yW" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"zc" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"zd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/ruin/space/derelict/engineering)
+"zg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/EVA)
+"zh" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"zn" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"zo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"zp" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"zq" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"zs" = (
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_one_access_txt = "73"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"zw" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"zz" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"zA" = (
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "n";
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "g";
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "e";
+	pixel_x = 11;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"zB" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"zE" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"zJ" = (
+/obj/structure/table,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"zM" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
+"zN" = (
+/obj/effect/turf_decal/siding/thinplating/end,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"zP" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
+"zQ" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"zS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side,
+/area/ruin/space/derelict/research)
+"zW" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"zX" = (
+/obj/machinery/chem_master,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"zY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
+"Ag" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Aj" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Ak" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Ao" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock";
+	space_dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/departures)
+"Ar" = (
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"As" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research)
+"At" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"Av" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"AA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
-"SJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+"AG" = (
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/departures)
+"AJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
+"AK" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"AL" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall,
+/area/ruin/space/derelict/medical)
+"AN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"SK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
 /area/ruin/space/derelict/engineering)
-"SL" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"SR" = (
+"AS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"SS" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron/white/corner{
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/derelict/arrival)
+"AW" = (
+/obj/structure/chair/comfy/lime,
+/obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
+/turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/arrival)
-"SU" = (
+"AY" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/engineering)
+"AZ" = (
+/obj/structure/chair/comfy/lime,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
+"Ba" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
+"Bb" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Bf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Bg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"Bl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Bo" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
+"Bp" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Bs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Bv" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"Bw" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Bx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"By" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"BB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wrench,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"BI" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"BR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"BT" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/spawner/random/trash/mopbucket,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"BU" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/maintenance/port)
+"BV" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/research)
+"Ca" = (
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"Cb" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Cd" = (
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"Ce" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/engineering)
+"Ch" = (
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/dorms_double{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
+"Ci" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "25"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Cj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Cm" = (
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Cn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/recharge_station,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Co" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"Cu" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Cv" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Cy" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/hallway_primary)
+"Cz" = (
+/obj/structure/mirror/directional/north,
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/hallway_primary)
+"CB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"CC" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"CE" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/template_noop,
+/area/template_noop)
+"CG" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/service)
+"CH" = (
+/obj/item/stack/sheet/animalhide/monkey,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"CK" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"CL" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = null;
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"CN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"CO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"CQ" = (
+/obj/item/storage/backpack/satchel/flat/empty,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
+"CT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"CU" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Dh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Dn" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Do" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
+/turf/open/floor/engine/air,
+/area/ruin/space/derelict/engineering)
+"Dq" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"Dr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"Ds" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Dt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"DC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"DI" = (
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/cmo,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"DN" = (
+/obj/structure/table/optable,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"DT" = (
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"DU" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"DV" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"DW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
+"Ea" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/arrival)
+"Ec" = (
+/obj/item/stack/cable_coil,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Ef" = (
+/obj/structure/sign/warning/docking,
+/turf/closed/wall,
+/area/ruin/space/derelict/departures)
+"Em" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"En" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"Ex" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"Ey" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"EA" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"ED" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"EE" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"EF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"EG" = (
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
+"EL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"EN" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"EQ" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"ER" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/security)
+"EX" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"EZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"Fa" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Fg" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"Fi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
+"Fm" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/item/lighter/greyscale{
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/arrival)
+"Fr" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/camera,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/arrival)
+"Ft" = (
+/obj/structure/chair/comfy/lime{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
+"Fv" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Fy" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Virology";
 	req_access_txt = "39"
@@ -8193,653 +5245,547 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"SV" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"SX" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict1"
+"FD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"FF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"FG" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"SY" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/tile/yellow/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
-/area/ruin/space/derelict/engineering)
-"Tg" = (
-/obj/structure/table,
-/obj/item/gun/syringe,
-/obj/item/reagent_containers/dropper{
-	pixel_y = -6
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Ti" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/hallway_primary)
-"Tl" = (
-/obj/structure/table,
+"FL" = (
+/obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
-"Tm" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/template_noop,
-/area/template_noop)
-"Tn" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"To" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Tp" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/service)
-"Tq" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"Tr" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Ts" = (
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "toxins"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Tt" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"Tx" = (
-/obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
-	},
-/obj/item/gun/ballistic/shotgun/doublebarrel,
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"Ty" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
-"Tz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/wood/airless,
-/area/ruin/space/derelict/arrival)
-"TA" = (
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/service)
-"TB" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
-/area/ruin/space/derelict/hallway_primary)
-"TC" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "EVA Storage";
-	req_access_txt = "18"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"TE" = (
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel";
-	req_access_txt = "57"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/arrival)
-"TI" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
-"TJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"TK" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/crew)
-"TP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"TQ" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"TS" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall,
-/area/ruin/space/derelict/medical)
-"TV" = (
-/obj/structure/table,
-/obj/item/clothing/suit/apron/surgical,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"TW" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Ua" = (
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"Ub" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
-"Uc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Ud" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Ug" = (
-/turf/closed/wall,
-/area/ruin/space/derelict/maintenance/port)
-"Ul" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Un" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"Uo" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Ux" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"Uz" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/ruin/space/derelict/hallway_primary)
-"UD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"UG" = (
-/obj/machinery/portable_atmospherics/canister/bz,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research/xenobiology)
-"UH" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"UJ" = (
-/obj/machinery/oven,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"UM" = (
-/obj/structure/chair/comfy/lime{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/arrival)
-"UN" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"UQ" = (
-/obj/structure/window/reinforced/plasma{
-	dir = 4
-	},
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"US" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/EVA)
-"UT" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"UU" = (
-/obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/freezer,
-/area/ruin/space/derelict/service)
-"UV" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/iron/edge,
-/area/ruin/space/derelict/service)
-"UX" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"UY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Va" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/engineering)
-"Vb" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"Ve" = (
-/obj/machinery/vending/engivend,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Vf" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 1
-	},
-/turf/template_noop,
-/area/ruin/space/derelict/maintenance/port)
-"Vg" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Vj" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Vl" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Vn" = (
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research/xenobiology)
-"Vq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
-"Vr" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research)
-"Vt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research/xenobiology)
-"Vu" = (
-/obj/machinery/computer/station_alert{
-	dir = 1
-	},
+"FO" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Vv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"Vx" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/door/airlock{
-	name = "Bar";
-	req_access_txt = "25"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"Vz" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/template_noop,
-/area/template_noop)
-"VA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/engine,
+"FR" = (
+/turf/open/floor/engine/air,
 /area/ruin/space/derelict/engineering)
-"VC" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict2"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"VG" = (
-/obj/machinery/ntnet_relay,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"VH" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"VI" = (
-/obj/machinery/door/airlock/medical{
-	name = "Surgery";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"VM" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"VN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"VQ" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"VS" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_one_access_txt = "10;24"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"VT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"VV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"VZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron/white/corner/airless{
-	dir = 8
-	},
-/area/ruin/space/derelict/departures)
-"Wb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/ruin/space/derelict/research)
-"Wf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research)
-"Wl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Wm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/engineering)
-"Wn" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering/gravity_generator)
-"Wp" = (
-/obj/machinery/computer/pandemic,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Wr" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Ww" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"Wz" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"WA" = (
-/obj/effect/turf_decal/tile/green/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
-"WC" = (
-/obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -6
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"WF" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_one_access_txt = "10;24"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"WG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"WH" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/template_noop,
-/area/template_noop)
-"WJ" = (
+"FU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
-"WL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/side{
-	dir = 1
+"FZ" = (
+/obj/machinery/processor/slime,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"Gb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
 	},
-/area/ruin/space/derelict/engineering/gravity_generator)
-"WS" = (
-/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"Ge" = (
+/obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"Gh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Gm" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
-"WT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/blood/tracks{
+"Go" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Gq" = (
+/obj/machinery/airalarm/directional/east,
+/obj/item/hatchet,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Gu" = (
+/obj/effect/spawner/random/structure/girder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
+"Gv" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/footprints{
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/ruin/space/derelict/research)
+"Gx" = (
+/obj/machinery/processor,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Gz" = (
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"GA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"GC" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"GD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"WU" = (
+"GI" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
+"GO" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"GS" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"GU" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/service/janitor)
+"GV" = (
+/obj/machinery/vending/medical,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"GW" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"GX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"Hd" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/research)
+"Hh" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Hi" = (
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"Hj" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "head of personnel's office maintenance";
+	req_access_txt = "57"
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port)
+"Hl" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/iron/white/smooth_large,
+/area/ruin/space/derelict/medical)
+"Ht" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Hu" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/bot_white/left,
+/obj/structure/window/spawner/east,
+/turf/open/floor/iron/white/smooth_large,
+/area/ruin/space/derelict/medical)
+"Hw" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Hx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Hy" = (
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"HB" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"HF" = (
+/obj/machinery/stasis,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"HG" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	name = "Pharmacy Desk";
+	req_access_txt = "69"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
+"HI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	name = "Bar";
+	req_access_txt = "25"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"HJ" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"HM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"HN" = (
+/obj/machinery/stasis{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"HP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
+"HR" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/medical)
+"HS" = (
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"HT" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/derelict/arrival)
+"HU" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"HW" = (
+/obj/machinery/vending/clothing,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"Ia" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Ie" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Ih" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Il" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/cargo)
+"Iq" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
+	dir = 8;
+	filter_type = list(/datum/gas/nitrogen,/datum/gas/oxygen)
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Is" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/arrival)
+"It" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Iu" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"Ix" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Iy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"IA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"IB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"IG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"IH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/engineering)
+"IJ" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/westleft,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"IN" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"IQ" = (
+/obj/effect/turf_decal/tile/green,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"IT" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/template_noop,
+/area/template_noop)
+"IV" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/template_noop,
+/area/template_noop)
+"IX" = (
+/obj/structure/chair,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"Jb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Jd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Je" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Jg" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"Ji" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Jj" = (
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Jk" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"Jp" = (
+/obj/machinery/chem_heater/withbuffer,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Jq" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Jt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"Ju" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/service)
+"Jv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Jx" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"JD" = (
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 12
@@ -8847,74 +5793,199 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
-/turf/open/floor/iron/edge{
+/turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/ruin/space/derelict/service)
-"Xc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Emitter Room";
-	req_one_access_txt = "10;24"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Xh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Xi" = (
-/obj/machinery/telecomms/receiver/preset_left/birdstation,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/engineering)
-"Xl" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"Xm" = (
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = 5
-	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Xq" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
-"Xs" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"Xu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Xv" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
-/turf/open/floor/engine/air,
-/area/ruin/space/derelict/engineering)
-"Xw" = (
+"JF" = (
+/obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"Xy" = (
+/area/ruin/space/derelict/EVA)
+"JI" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/biogenerator,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/service)
+"JK" = (
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/table,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"JP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/departures)
+"JR" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"JU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"JV" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/rack,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"JZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
+"Ka" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/arrival)
+"Kb" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
+"Kc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"Ke" = (
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/arrival)
+"Kg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/item/cultivator,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Kh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Kl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/EVA)
+"Kp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Kr" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/hallway_primary)
+"Ku" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"Kw" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Kx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"KF" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "EVA Storage";
+	req_access_txt = "18"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"KG" = (
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab";
+	req_access_txt = "8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"KJ" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"KR" = (
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"KW" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
+"KY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Lf" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict4"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Lg" = (
 /obj/effect/decal/cleanable/crayon{
 	color = "#DE3A3A";
 	icon_state = "b";
@@ -8934,227 +6005,276 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"Xz" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+"Lj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"XF" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/space/derelict/service)
-"XL" = (
-/obj/machinery/computer/operating,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Lm" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/turf/open/floor/iron/white/smooth_edge,
+/area/ruin/space/derelict/hallway_primary)
+"Lo" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow,
+/obj/item/hand_labeler,
+/obj/item/stack/package_wrap,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"XN" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
+"Lq" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes{
+	pixel_y = 8
+	},
+/obj/structure/sign/poster/official/moth_meth{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Lr" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/hallway_primary)
+"Ls" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"Lw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Ly" = (
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/kitchen/fork,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"Lz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"LC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
+"LD" = (
+/obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
-"XR" = (
-/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"LG" = (
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "c"
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"XS" = (
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"LH" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/turf/template_noop,
+/area/ruin/space/derelict/maintenance/port)
+"LK" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/light/broken/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"LT" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/hallway_primary)
+"LV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"LY" = (
+/obj/effect/spawner/random/structure/closet_private,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
+"Mb" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/crew)
+"Md" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/hallway_primary)
+"Mf" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"Mj" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/security)
+"Mm" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft{
+	req_access_txt = "69"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
+"Mn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Mq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"XT" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+"Mr" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"XY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/barricade/wooden,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"Ya" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/item/pen,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"Mt" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
 	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Yd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"Yf" = (
-/obj/structure/table/optable,
-/obj/item/defibrillator/loaded,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"Yg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/security/detective)
-"Yh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"Yk" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"Yl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"Ys" = (
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Yv" = (
+"Mx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict9"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"My" = (
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"YA" = (
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 8
+/area/ruin/space/derelict/hallway_primary)
+"MC" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"YC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port)
-"YD" = (
-/obj/machinery/processor,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/service)
-"YE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"YF" = (
-/obj/structure/window/reinforced/plasma{
-	dir = 8
-	},
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"YJ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/hypospray/cmo,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"YK" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "12"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/maintenance/port/central)
-"YO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ruin/space/derelict/maintenance/port/central)
-"YQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/research/xenobiology)
-"YR" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"YV" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"YW" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/service)
-"YX" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
-"YY" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
+"MI" = (
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/crowbar,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"YZ" = (
-/obj/effect/turf_decal/siding/thinplating_new,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/arrival)
-"Zg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+"MV" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access"
 	},
-/turf/open/floor/plating/airless,
-/area/template_noop)
-"Zj" = (
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/departures)
-"Zk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "dereengimaintport"
 	},
 /turf/open/floor/plating,
-/area/ruin/space/derelict/engineering)
-"Zm" = (
+/area/ruin/space/derelict/maintenance/port)
+"MX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"MY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Ne" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"Nf" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Ng" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Nh" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Dock";
+	req_access_txt = "48"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"Ni" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -9165,28 +6285,62 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/medical)
-"Zo" = (
-/obj/item/storage/backpack/satchel/flat/empty,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
-"Zt" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
-"Zu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+"Nj" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Nl" = (
+/obj/structure/chair/stool/directional/north,
+/obj/effect/turf_decal/tile/yellow/half{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
-"Zw" = (
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"Nn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/moth_delam{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"Zx" = (
+/area/ruin/space/derelict/engineering)
+"Ns" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office";
+	req_access_txt = "4"
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/derelict/security/detective)
+"Nw" = (
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Ny" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"NB" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
+	name = "Canteen"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"NC" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitory"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -9195,30 +6349,491 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/arrival)
-"Zz" = (
-/obj/structure/chair/comfy/lime,
+/area/ruin/space/derelict/crew)
+"ND" = (
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/derelict/arrival)
-"ZB" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
-"ZD" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"NE" = (
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"NF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"ZF" = (
-/obj/machinery/light/directional/south,
+"NJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
+/area/ruin/space/derelict/research/xenobiology)
+"NK" = (
+/obj/machinery/door/airlock/medical{
+	name = "Surgery";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"NO" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/bridge)
+"NR" = (
+/obj/structure/table,
+/obj/item/defibrillator/loaded{
+	pixel_y = 3
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"NU" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator Chamber";
+	req_one_access_txt = "19; 61"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"Oa" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
+"Ob" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/research)
+"Of" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Oi" = (
+/obj/machinery/chem_mass_spec,
+/obj/structure/sign/poster/official/periodic_table{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Oj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/medical)
+"Ok" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output,
+/turf/open/floor/engine/air,
 /area/ruin/space/derelict/engineering)
-"ZH" = (
+"Ol" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/security/detective)
+"Om" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"On" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Oo" = (
+/obj/structure/table,
+/obj/item/toy/plush/lizard_plushie,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service/janitor)
+"Or" = (
+/obj/machinery/mecha_part_fabricator,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
+"Ot" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/security)
+"Oy" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Oz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"OA" = (
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"OB" = (
+/turf/closed/mineral/random/stationside/asteroid,
+/area/template_noop)
+"OE" = (
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/science,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes,
+/obj/structure/reagent_dispensers/wall/virusfood/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"OG" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"OJ" = (
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"OK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"ON" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"OU" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"OW" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"OY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"OZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Pb" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Pd" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/cargo)
+"Pe" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Pg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"Pi" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Po" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#DE3A3A";
+	icon_state = "a";
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/crayon{
+	color = "#DE3A3A";
+	icon_state = "i"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Pt" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ruin/space/derelict/research)
+"Pu" = (
 /obj/effect/turf_decal/tile/yellow/half,
-/obj/machinery/biogenerator,
+/obj/machinery/seed_extractor,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/service)
-"ZI" = (
+"Pv" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Py" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"PB" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"PC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"PD" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"PH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"PI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"PK" = (
+/obj/effect/decal/cleanable/robot_debris/limb,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"PN" = (
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"PP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"PQ" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/security)
+"PW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"PX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"PY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Qb" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/maintenance/starboard)
+"Qe" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"Qk" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to Distro"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Qn" = (
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"Qo" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Qt" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"Qu" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"Qx" = (
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/storage/pill_bottle/mannitol,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"QA" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"QB" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"QD" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"QE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/gravity_generator/main/station{
+	on = 0
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"QF" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/derelict/engineering)
+"QH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/engineering)
+"QK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"QL" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict8"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"QO" = (
+/turf/template_noop,
+/area/ruin/space/derelict/maintenance/port/central)
+"QP" = (
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"QQ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"QU" = (
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
+"QV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"QW" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"QY" = (
 /obj/structure/sign/departments/medbay/alt{
 	pixel_y = 32
 	},
@@ -9229,55 +6844,1574 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/hallway_primary)
-"ZK" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/departures)
-"ZM" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/rack,
-/obj/item/mod/core/standard,
-/obj/item/mod/core/standard,
-/obj/item/mod/core/standard,
+"Rg" = (
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Rk" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"Rl" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/moth_epi{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"Ro" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"Rr" = (
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"Rs" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "31"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"Ru" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Rw" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/ruin/space/derelict/bridge)
+"RE" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"RF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"RI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/drinks/britcup,
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
+"RJ" = (
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/derelict/arrival)
+"RM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"RN" = (
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"RP" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"RQ" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/hallway_primary)
+"RS" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"RT" = (
+/obj/structure/closet/crate,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"RU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"RW" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	id = "whiteship_z4";
+	name = "KSS13: Derelict";
+	width = 35
+	},
+/turf/template_noop,
+/area/template_noop)
+"RX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
-"ZO" = (
+"Sd" = (
+/obj/machinery/suit_storage_unit/rd,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Se" = (
+/obj/machinery/computer/med_data,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"Sl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
+"Sm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/flat_white,
+/area/ruin/space/derelict/medical)
+"Sn" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Sp" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Sq" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway_primary)
+"Sr" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"Ss" = (
+/obj/structure/table,
+/obj/item/storage/box/beakers{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"St" = (
+/obj/structure/table/wood,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"Su" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes{
+	pixel_y = 8
+	},
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Sx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Sy" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"Sz" = (
+/obj/effect/turf_decal/tile/yellow/anticorner,
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
+/area/ruin/space/derelict/hallway_primary)
+"SA" = (
+/obj/machinery/vending/boozeomat,
+/obj/structure/sign/picture_frame/portrait/bar{
+	pixel_x = -32
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"SC" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"SE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"SF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"SG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"SI" = (
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"SL" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"SO" = (
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"SS" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"SV" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/arrival)
+"SX" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"SY" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/arrival)
+"Te" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"Tg" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research/xenobiology)
+"Ti" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
+"Tj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"Tl" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/cargo)
+"Tm" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
+"To" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/frame/machine,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Tq" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"Tr" = (
+/obj/machinery/griddle,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Tx" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Ty" = (
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"Tz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"TB" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitory"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"TC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"TF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"TH" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"TI" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
+/area/ruin/space/derelict/arrival)
+"TJ" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research/xenobiology)
+"TK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
+"TO" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"TP" = (
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/central)
+"TQ" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"TS" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/research)
+"TU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/flat_white,
+/area/ruin/space/derelict/medical)
+"TV" = (
+/obj/structure/table,
+/obj/item/slime_extract/grey,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"TW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"TX" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"TZ" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/service)
+"Ua" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Uc" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"Ue" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/service)
+"Ug" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Ul" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/maintenance/port)
+"Un" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Uo" = (
+/obj/effect/turf_decal/loading_area/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/arrival)
+"Up" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"Uu" = (
+/obj/effect/turf_decal/siding/thinplating/end,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
+"Ux" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Uz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict9"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"UB" = (
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/stack/cable_coil,
+/obj/item/screwdriver{
+	pixel_x = 2;
+	pixel_y = 11
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"UD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict10"
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"UE" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"UG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict11"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"UJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"UM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"ZR" = (
-/obj/effect/turf_decal/tile/green,
-/obj/structure/sign/warning/nosmoking{
+"UN" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"UO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "i"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"UP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"UQ" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/port)
+"US" = (
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
 	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
+"UV" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "toxins"
+	},
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/iron/large,
+/area/ruin/space/derelict/research)
+"UW" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"UX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"UY" = (
+/obj/machinery/door/window/westleft{
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research/xenobiology)
+"Va" = (
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"Vb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/derelict/service)
+"Vc" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Ve" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Vl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Vm" = (
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"ZU" = (
+"Vn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "derelict4"
+	icon_state = "derelict13"
+	},
+/obj/machinery/vending/coffee{
+	layer = ABOVE_MOB_LAYER;
+	plane = GAME_PLANE_UPPER;
+	tilted = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Vq" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
+"Vt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict14"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Vv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict16"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Vz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/service)
+"VA" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"VB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"VC" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "31"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"VF" = (
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/gun/syringe,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"VG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"VH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"VL" = (
+/obj/machinery/air_sensor/atmos/air_tank,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/ruin/space/derelict/engineering)
+"VM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"VN" = (
+/turf/open/floor/iron/dark/telecomms,
+/area/ruin/space/derelict/research)
+"VS" = (
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
+"VT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/arrival)
+"VV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/arrival)
+"VW" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict5"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"ZW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+"VZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/arrival)
+"Wb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/arrival)
+"Wi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Wl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Wm" = (
+/obj/structure/window/fulltile,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Wo" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Wr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Wt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Ww" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/service)
+"Wy" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"WA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"WC" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
+"WD" = (
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"WF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/window/fulltile,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"WG" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"WI" = (
+/obj/item/stack/tile/iron,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"WK" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"WL" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"WR" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"WS" = (
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"WT" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/space/derelict/maintenance/port/central)
+"WU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"WW" = (
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"Xc" = (
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"Xf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/service)
+"Xi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
+"Xm" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"Xp" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/derelict/engineering)
+"Xq" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard)
+"Xs" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/space/derelict/engineering)
-"ZX" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	dir = 8;
-	name = "Pharmacy Desk";
+/area/ruin/space/derelict/research/xenobiology)
+"Xv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Xw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Xz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/derelict/hallway_primary)
+"XD" = (
+/obj/structure/sign/barsign,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/derelict/service)
+"XF" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"XG" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Pharmacy";
 	req_access_txt = "69"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"XK" = (
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"XN" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/service)
+"XR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"XS" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
+"XT" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
+"XU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/derelict/engineering)
+"XV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"XY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
+"XZ" = (
+/obj/effect/turf_decal/tile/green/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/medical)
+"Ya" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/derelict/service)
+"Yd" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/port)
+"Yf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/research/xenobiology)
+"Yg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"Yh" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"Yk" = (
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"Yl" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"Yn" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port)
+"Yq" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Yr" = (
+/obj/machinery/door/airlock/medical{
+	name = "Cryogenic";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Yt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/pen,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
+"Yv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/cargo)
+"Yw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Yx" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Yy" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/decal/remains/human,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"YA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"YB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"YC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/central)
+"YD" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"YE" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"YF" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"YJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/research)
+"YK" = (
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"YM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"YN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"YO" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/port/lesser)
+"YQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"YR" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ruin/space/derelict/research)
+"YT" = (
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
+"YV" = (
+/turf/open/floor/iron/white/side{
+	dir = 9
+	},
+/area/ruin/space/derelict/research)
+"YW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"YX" = (
+/obj/machinery/smartfridge,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/service)
+"YY" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/derelict/maintenance/port/central)
+"Za" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Zb" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict6"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"Zd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/rack,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Zg" = (
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
+"Zj" = (
+/turf/closed/wall,
+/area/template_noop)
+"Zk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
+"Zl" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
+"Zm" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/research/xenobiology)
+"Zo" = (
+/obj/item/stack/sheet/iron/fifty,
+/turf/template_noop,
+/area/template_noop)
+"Zr" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"Zt" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/EVA)
+"Zu" = (
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
+"Zv" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/heater/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"Zw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/bridge)
+"Zx" = (
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/port/central)
+"ZB" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"ZD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ZE" = (
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "r"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"ZF" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
+"ZG" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/corner,
+/area/ruin/space/derelict/hallway_primary)
+"ZH" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "toxins"
+	},
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/large,
+/area/ruin/space/derelict/research)
+"ZI" = (
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"ZK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/folder/white,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
+"ZM" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/hallway_primary)
+"ZN" = (
+/obj/item/bikehorn,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/derelict/service)
+"ZO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/hallway_primary)
+"ZR" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white/side{
+	dir = 10
+	},
+/area/ruin/space/derelict/research)
+"ZU" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"ZW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
+"ZX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
+"ZZ" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
 
 (1,1,1) = {"
 aa
@@ -9307,39 +8441,20 @@ aa
 aa
 aa
 aa
-cZ
-zB
-iz
-NK
-iz
+iT
+jK
+kC
+lQ
+kC
 ZB
 ZB
 ZB
-iz
-zB
-iz
-zB
-KA
+kC
+jK
+kC
+jK
+iV
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -9411,40 +8526,21 @@ aa
 aa
 aa
 aa
-KA
-Kb
-iz
-CN
-iz
+iV
+jM
+kC
+lW
+kC
 aa
 ZB
 aa
-iz
-Kb
-iz
-CN
-cZ
+kC
+jM
+kC
+lW
+iT
 ZB
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -9515,45 +8611,26 @@ aa
 aa
 aa
 aa
-cZ
-zJ
-iB
-zJ
-KA
-nJ
-iz
-iz
-cZ
-tp
-Hx
-zJ
-cZ
+iT
+jQ
+kF
+jQ
+iV
+nj
+kC
+kC
+iT
+Ao
+Ef
+jQ
+iT
 ZB
-ki
-hk
-ki
-hk
-hk
-hk
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+SV
+qi
+SV
+qi
+qi
+qi
 aa
 aa
 aa
@@ -9619,26 +8696,26 @@ aa
 aa
 aa
 aa
-eh
-Av
-ZK
-kI
-sO
-VZ
-yK
-VZ
-It
-kI
-kI
-kI
-KA
-ki
-ki
-is
-Rs
-rB
-zL
 hj
+iY
+jR
+lX
+mA
+nk
+oa
+nk
+xx
+lX
+lX
+lX
+iV
+SV
+SV
+Ru
+Pv
+gv
+zM
+fj
 aa
 aa
 aa
@@ -9646,26 +8723,7 @@ aa
 aa
 aa
 aa
-Lv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Zj
 aa
 aa
 aa
@@ -9723,26 +8781,26 @@ aa
 aa
 aa
 aa
-gV
-ZK
-ez
-gV
-iG
-iG
-aT
-iG
-iG
-vn
-zh
-iG
-iz
-SS
-HJ
-Bg
-is
-hk
-hk
-hk
+iW
+jR
+kI
+iW
+kK
+kK
+ob
+kK
+kK
+Ar
+En
+kK
+kC
+TI
+yy
+oN
+Ru
+qi
+qi
+qi
 aa
 aa
 aa
@@ -9750,26 +8808,7 @@ aa
 aa
 aa
 aa
-Lv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Zj
 aa
 aa
 aa
@@ -9827,26 +8866,26 @@ aa
 aa
 aa
 aa
-he
-hT
-gV
-iG
-iG
-Om
-aT
-fb
-Rl
-iG
-Cz
-cZ
-KA
-Gm
+iX
+jS
+iW
+kK
+kK
+nl
+ob
+rC
+xI
+kK
+EN
+iT
+iV
 TW
-er
-zq
-Se
-xp
-hk
+Cb
+MI
+WI
+Wi
+CB
+qi
 aa
 aa
 aa
@@ -9855,25 +8894,6 @@ aa
 aa
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -9923,42 +8943,34 @@ aa
 aa
 aa
 aa
-ef
-bw
-ef
-bw
-ef
-ax
-aa
-aa
-he
-AA
-ZK
-eh
-nl
-iG
-aT
-iG
-Rr
-ul
-Cy
-qx
+Yv
 Rs
-Xh
-QC
-MN
+Yv
+Rs
+Yv
 Zo
-is
-XR
-hk
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+iX
+jT
+jR
+hj
+mB
+kK
+ob
+kK
 jV
+Av
+EZ
+AG
+Pv
+Ux
+FG
+Bp
+CQ
+Ru
+OW
+qi
 aa
 aa
 aa
@@ -9966,18 +8978,7 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+WS
 aa
 aa
 aa
@@ -10027,34 +9028,34 @@ aa
 aa
 aa
 aa
-ef
-by
-ef
-by
-ef
-aa
-aa
-aa
-Av
-Kl
-AZ
-AW
-nI
-AW
-Pi
-AW
-XY
-SI
-xT
-Dm
-SJ
 Yv
 SX
-mR
-is
-is
-Vl
-hk
+Yv
+SX
+Yv
+aa
+aa
+aa
+iY
+jU
+kJ
+lY
+mC
+lY
+oc
+lY
+xT
+AA
+Fi
+JP
+km
+Uz
+tv
+Po
+Ru
+Ru
+Fa
+qi
 aa
 aa
 aa
@@ -10062,26 +9063,7 @@ aa
 aa
 aa
 aa
-jV
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+WS
 aa
 aa
 aa
@@ -10121,44 +9103,44 @@ aa
 aa
 aa
 ZB
-Lv
-iD
-iD
-iD
-iD
-iD
-iD
-iD
-iD
-iD
-ef
-jS
-ef
-jS
-ef
-iD
-iD
-iD
-KA
 Zj
-iG
-iG
-iG
-iG
-vl
-iG
-iG
-iG
-ul
-qx
-is
-LO
+Tl
+Tl
+Tl
+Tl
+Tl
+Tl
+Tl
+Tl
+Tl
+Yv
 VC
-Xy
-is
-IF
-rU
-hk
+Yv
+VC
+Yv
+Tl
+Tl
+Tl
+iV
+kb
+kK
+kK
+kK
+kK
+oe
+kK
+kK
+kK
+Av
+AG
+Ru
+UD
+bm
+Lg
+Ru
+uV
+vs
+qi
 aa
 aa
 aa
@@ -10167,25 +9149,6 @@ aa
 aa
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -10216,53 +9179,53 @@ aa
 aa
 "}
 (10,1,1) = {"
-ad
-ad
+OB
+OB
 aa
 aa
 aa
 aa
 aa
 ZB
-jV
-jV
-iD
-cm
-cW
-cW
-cW
-iD
-xU
-xU
-Ux
-jg
-OB
-OB
-OB
-ms
-xU
-xU
-mk
-mk
-mk
-jv
-jv
-mk
+WS
+WS
+Tl
+bd
 Il
-mk
-KA
-cZ
-qx
-qx
-KA
-Rs
-rY
+Il
+Il
+Tl
+ZU
+ZU
+tb
+eh
 Pd
-is
-rb
-hk
-hk
-hk
+Pd
+Pd
+gV
+ZU
+ZU
+Zx
+Zx
+Zx
+kM
+kM
+Zx
+no
+Zx
+iV
+iT
+AG
+AG
+iV
+Pv
+UG
+xv
+Ru
+wM
+qi
+qi
+qi
 aa
 aa
 aa
@@ -10271,25 +9234,6 @@ aa
 aa
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -10320,53 +9264,53 @@ aa
 aa
 "}
 (11,1,1) = {"
-ad
-ad
+OB
+OB
 ZB
 ZB
 ZB
 ZB
 ZB
 ZB
-jV
-jV
-ef
-Xw
-Xw
-Xw
-Xw
-iD
-hd
-xU
-xU
-xU
-KX
-xU
-xU
-xU
-xU
-xU
-mk
-uc
 WS
-jm
-mk
-wt
-ow
+WS
+Yv
 MX
-aa
+MX
+MX
+MX
+Tl
 HJ
-KQ
-yL
-oK
-is
-LA
 ZU
-is
-Rs
-rB
-zL
-hj
+ZU
+ZU
+eC
+ZU
+ZU
+ZU
+ZU
+ZU
+Zx
+ja
+kj
+kQ
+Zx
+mD
+YC
+of
+aa
+yy
+AW
+Fm
+Kb
+Ru
+Vl
+Lf
+Ru
+Pv
+gv
+zM
+fj
 aa
 aa
 aa
@@ -10374,26 +9318,7 @@ aa
 aa
 aa
 aa
-Lv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Zj
 aa
 aa
 aa
@@ -10432,45 +9357,45 @@ aa
 aa
 aa
 ZB
-jV
-jV
-ef
-xU
-xU
-ZO
-xU
-eX
-xU
-xU
-xU
-xU
-QD
-BT
-xU
-BT
-xU
-nM
-mk
-Fz
-Fz
-OT
-mk
-OT
-ow
-qI
-aa
-hk
-Zz
-Au
-YZ
-is
+WS
+WS
+Yv
+ZU
+ZU
+by
+ZU
+Nh
+ZU
+ZU
+ZU
+ZU
+QV
 yk
-Fw
-is
-Rs
-hk
-hk
-hk
+ZU
+yk
+ZU
+if
+Zx
+jd
+jd
+kR
+Zx
+kR
+YC
+og
+aa
+qi
+AZ
+Fr
+Ke
+Ru
+Vn
+VW
+Ru
+Pv
+qi
+qi
+qi
 aa
 aa
 aa
@@ -10478,29 +9403,10 @@ aa
 aa
 aa
 aa
-td
-td
-Ug
+Yd
+Yd
+UQ
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -10536,44 +9442,44 @@ aa
 aa
 aa
 aa
-jV
-jV
-iD
-zo
-cY
-dZ
-Oz
-fc
-Oz
-Oz
-Oz
-Oz
-jT
-kJ
-VV
-kJ
-Hi
-kK
-mk
-tH
-ow
-ow
+WS
+WS
+Tl
 Qe
-tH
-ow
-mk
-aa
-HJ
-nK
+bl
+bz
 UM
-YZ
-is
+cd
+UM
+UM
+UM
+UM
+eD
 wZ
 Co
-is
-is
-HJ
-HJ
+wZ
+hJ
+yq
+Zx
+TP
+YC
+YC
+jB
+TP
+YC
+Zx
+aa
+yy
+Ba
+Ft
+Ke
+Ru
+Vt
+Zb
+Ru
+Ru
+yy
+yy
 ZB
 aa
 aa
@@ -10582,10 +9488,10 @@ aa
 aa
 aa
 aa
-td
-vZ
-jL
-jV
+Yd
+KJ
+MV
+WS
 ZB
 aa
 aa
@@ -10599,34 +9505,15 @@ aa
 aa
 aa
 aa
-Fd
-TI
-Fd
-KJ
-Db
-KJ
-Db
-KJ
-Rg
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+RE
+dw
+RE
+zw
+Te
+zw
+Te
+zw
+Dq
 aa
 aa
 aa
@@ -10640,97 +9527,78 @@ aa
 aa
 aa
 ZB
-jV
-jV
-ef
-xU
-xU
-QD
-xU
-eX
-xU
-xU
-xU
-xU
-gC
-kK
-xU
-mt
-xU
-kK
-mk
-ow
-Fz
-OT
-mk
-ow
-Fz
-mk
+WS
+WS
+Yv
+ZU
+ZU
+QV
+ZU
 Nh
-Nh
-Nh
-Nh
-Nh
-rA
+ZU
+ZU
+ZU
+ZU
+YA
 yq
-EH
-Rs
-is
-is
-ki
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-Ug
-jL
-PC
+ZU
+hd
+ZU
+yq
+Zx
+YC
+jd
+kR
+Zx
+YC
+jd
+Zx
+GU
+GU
+GU
+GU
 GU
 Bs
-Bs
-Bs
-Bs
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
+Vv
+QL
+Pv
+Ru
+Ru
+SV
 ZB
-FS
-AK
-FS
+ZB
+ZB
+ZB
+ZB
+ZB
+ZB
+ZB
+UQ
 MV
-Db
+Ul
 OG
-Db
+ZF
+ZF
+ZF
+ZF
 OG
-rO
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OG
+OG
+OG
+OG
+OG
+OG
+OG
+ZB
+rM
+GO
+rM
+IT
+Te
+CE
+Te
+CE
+xr
 aa
 aa
 aa
@@ -10744,97 +9612,78 @@ aa
 aa
 aa
 aa
-jV
-jV
-ef
-xU
-xU
-QD
-xU
-iD
-hf
-xU
-xU
-xU
-gC
-mk
-mk
-mk
-mk
-mk
-mk
-tH
-lq
-mk
-mk
-Fz
+WS
+WS
+Yv
+ZU
+ZU
 QV
-mk
-RC
+ZU
+Tl
 PB
-Bd
-RR
-Nh
+ZU
+ZU
+ZU
 YA
-MU
-vW
-Ff
-pA
-TE
-LR
-LR
-PC
-Ug
-td
-td
-td
-Ug
-td
-Ug
-vZ
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+TP
+ko
+Zx
+Zx
+jd
+np
+Zx
+se
+yI
+Bg
 zz
-tx
+GU
 xj
 Ve
 wz
 Uo
 SY
 de
-qk
-tx
-Pq
-tx
-Vu
-GU
-aa
-FS
-Gl
-FS
-Pf
-Db
-KJ
-Db
-KJ
+Is
+Is
+Ul
+UQ
+Yd
+Yd
+Yd
+UQ
+Yd
+UQ
+QU
+fM
+wF
+aG
+RS
 Rg
+oW
+sr
+AY
+pN
+wF
+CU
+wF
+PN
+OG
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+rM
+DV
+rM
+zn
+Te
+zw
+Te
+zw
+Dq
 aa
 aa
 aa
@@ -10849,96 +9698,77 @@ aa
 aa
 aa
 ZB
-jV
-iD
-cC
-xU
-QD
-xU
-iD
-hf
-xU
-xU
-xU
-gC
-mk
-pV
-Ke
-Ke
-pV
-vX
-ow
-lq
-mk
+WS
+Tl
 EX
-ow
-yj
-mk
-yu
-tX
-Mw
-qv
-Nh
-PE
-vV
-JO
-MM
-pA
+ZU
+QV
+ZU
+Tl
+PB
+ZU
+ZU
+ZU
+YA
+Zx
 QO
+WT
+WT
 QO
-QO
-PC
-vZ
-vZ
-vZ
-vZ
-pv
+iD
+YC
+ko
+Zx
+lZ
+YC
+nq
+Zx
 ht
-td
-vZ
-PC
-tx
-tx
-tx
-tx
-tx
-NT
-de
-AH
-Ap
-Hv
-Dc
-BE
-Bs
-aa
-FS
+yK
+BB
+FL
+GU
+OU
+VH
+yA
+Ka
+SY
+VS
+VS
+VS
+Ul
+Yk
+DC
+Yk
+DC
+Fg
 AK
-FS
-MV
-Db
-OG
-Db
-OG
-rO
+Yd
+ZW
+Ul
+wF
+wF
+wF
+wF
+wF
+dl
+AY
+aN
+gd
+Ia
+SG
+bO
+ZF
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+rM
+GO
+rM
+IT
+Te
+CE
+Te
+CE
+xr
 aa
 aa
 aa
@@ -10953,96 +9783,77 @@ aa
 aa
 aa
 aa
-jV
-iD
-ef
-iD
-ec
-xU
-iD
-VH
-xU
-xU
-xU
-gC
-mk
-Ke
-mk
-mk
-mk
-mk
-mk
-mk
-mk
-av
-tH
-Fz
-mk
-rk
+WS
+Tl
+Yv
+Tl
+bB
+ZU
+Tl
 pD
-wN
-WJ
-GT
-SJ
-eg
-Vj
-MM
-hk
-QO
-zK
-QO
-RB
-vZ
-vZ
-vZ
-vZ
-vZ
+ZU
+ZU
+ZU
+YA
+Zx
+WT
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+mb
+TP
+jd
+Zx
 Oo
-Ug
-vZ
-PC
+yT
+BR
+FU
 jY
 km
-tx
-tx
-tx
+VT
+tJ
+Ka
 qi
-de
+VS
 oX
-uK
+VS
 Hj
-rf
-zO
-GU
-GU
-FS
-AK
-FS
-WH
-Db
+ZW
+ZW
+ZW
+ZW
+ZW
+ND
+UQ
+ZW
+Ul
+GW
+hR
+wF
+wF
+wF
+PY
+AY
+Sn
+wP
+cM
+Lz
+up
 OG
-Db
 OG
-Rg
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+rM
+GO
+rM
+ta
+Te
+CE
+Te
+CE
+Dq
 aa
 aa
 aa
@@ -11057,98 +9868,79 @@ aa
 aa
 aa
 aa
-jV
-bP
-cD
-db
-xU
-xU
-iD
-hg
-xU
-SV
-xU
-gC
-mk
-JP
-mk
-no
-nN
-uf
-vo
-nN
-mk
-mk
-tH
-Qr
-mk
+WS
+aV
+be
+bn
+ZU
+ZU
 Tl
 OJ
-AB
+ZU
 rL
-Nh
-Rs
-mI
+ZU
+YA
+Zx
 YY
-MM
-hk
+Zx
+hP
 Ch
-ws
-QO
-PC
-kv
-vZ
-vZ
-vZ
-vZ
-vZ
-td
-vZ
-PC
-jY
-km
-tx
-tx
-tx
-qi
-tx
-tx
-qi
-tx
-uH
-tx
-Yk
+Mb
+jj
+Ch
+Zx
+Zx
+TP
+nr
+Zx
+sk
+yW
+BT
+Ge
 GU
-FS
-Gl
-FS
-nd
-Db
-KJ
-Db
-KJ
-rO
+Pv
+VV
+oo
+Ka
+qi
+RJ
+qr
+VS
+Ul
+qC
+DC
+Yk
+Yk
+ZW
+DC
+Yd
+ZW
+Ul
+GW
+hR
+wF
+wF
+wF
+PY
+wF
+wF
+PY
+wF
+oS
+wF
+yc
+OG
+rM
+DV
+rM
+Zr
+Te
+zw
+ZB
+wg
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ZB
 aa
 "}
 (19,1,1) = {"
@@ -11161,99 +9953,80 @@ aa
 aa
 aa
 aa
-jV
-iD
-iD
-Dn
-Dn
-eC
-Dn
-iD
-iD
-iD
-jj
-jU
-mk
-Ke
-mk
-np
-nO
-uf
-np
-nO
-mk
-ow
-ow
-mk
-mk
-mk
-mk
-tI
-mk
-mk
+WS
+Tl
+Tl
+YO
+YO
+bP
+YO
+Tl
+Tl
+Tl
+en
 xX
-BS
+Zx
 WT
-Bh
-Gc
-HP
-LZ
+Zx
 LY
-IZ
-Ug
-td
-td
-td
-vZ
-vZ
-Ug
+HP
+Mb
+LY
+HP
+Zx
+YC
+YC
+Zx
+Zx
+Zx
+Zx
 xB
-PC
-jY
-km
+Zx
+Zx
+Pb
 GD
 OY
-OY
+Ea
 wr
 HT
 AS
 KW
 BU
-IR
-de
-de
-GU
-FS
-AK
-FS
-WH
-Db
+UQ
+Yd
+Yd
+Yd
+ZW
+Yn
+UQ
+Bo
+Ul
+GW
+hR
+Qo
+vx
+vx
+Wt
+JU
+Cm
+qR
+zN
+PW
+AY
+AY
 OG
-Db
-OG
-Rg
+rM
+GO
+rM
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ZB
+ZB
+ZB
 "}
 (20,1,1) = {"
 aa
@@ -11268,94 +10041,75 @@ aa
 aa
 aa
 ZB
-Dn
-EZ
-EZ
-Dn
-hh
-hV
-Ux
-xU
-gC
-mk
-Ke
-mk
-uf
-nQ
-uf
-uf
-nQ
-mk
-ow
-pS
-mk
-RA
 YO
-mk
-ow
+YK
+YK
+YO
+cA
+cY
 tb
-mk
-is
-nf
-YY
-LR
-pA
+ZU
+YA
+Zx
+WT
+Zx
+Mb
 pF
-wa
-QO
-QO
-PC
-vZ
-vZ
-vZ
-vZ
-vZ
-vZ
-vZ
-PC
-kw
-kw
-kw
-kw
-kw
-qi
+Mb
+Mb
+pF
+Zx
+YC
+mP
+Zx
+oh
+sv
+Zx
+YC
+Gm
+Zx
+Ru
+VZ
+oo
+Is
+SY
 uH
-tx
-tx
-qi
-tx
-hC
-Vb
+bL
+VS
+VS
+Ul
+Yk
+DC
 tM
-FS
-Pf
-rO
-nd
-Db
-KJ
-Db
-KJ
-rO
+ZW
+ZW
+QU
+ZW
+Ul
+oC
+oC
+oC
+oC
+oC
+PY
+oS
+wF
+wF
+PY
+wF
+Vc
+sR
+TH
+rM
+ZB
+ZB
+ZB
+aa
+CE
+CE
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ZB
 aa
 aa
 "}
@@ -11370,87 +10124,68 @@ aa
 aa
 aa
 aa
-jV
+WS
 ZB
-Dn
-EZ
-EZ
-Dn
-hi
-xU
-xU
-jo
-kb
-mk
-Dh
-mk
-nq
-nR
-oh
-QQ
-Ba
-mk
-ow
-mk
-mk
-HO
-po
-mk
-ow
-ow
+YO
+YK
+YK
+YO
+cC
+ZU
+ZU
 vU
-is
-xQ
-is
-pA
+eE
+Zx
+fk
+Zx
 HW
 Gb
 wS
-QO
-QO
-IZ
-KE
-vZ
-vZ
-vZ
-vZ
-vZ
-vZ
-PC
+jo
+kq
+Zx
+YC
+Zx
+Zx
+on
+sD
+Zx
+YC
+YC
 jZ
 Ru
-jZ
-FY
-LE
+Wb
+Ru
+SY
 kX
-uH
-tx
-Bs
+cT
+jl
 VS
-Bs
-GU
-GU
-GU
+VS
+BU
+EA
 DC
-GU
-Bs
 DC
-Bs
-Bs
-GU
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+DC
+Yk
+DC
+ZW
+Ul
+OA
+cL
+OA
+vm
+Ex
+Jx
+oS
+wF
+ZF
+oH
+ZF
+OG
+OG
+OG
+JR
 aa
 aa
 aa
@@ -11473,87 +10208,68 @@ aa
 aa
 aa
 aa
-Dn
-bS
-Dn
-Dn
-EZ
-eD
-Dn
-hl
-pH
-lv
-lv
-yy
-mk
-Ke
-mk
-nr
-TK
-cK
-TK
-TK
-mk
-ow
-mk
-Ew
-HO
-mk
-mk
-ow
+YO
+aW
+YO
+YO
+YK
+bR
+YO
+cD
+db
 SE
-mk
-Rs
-Hr
-EC
-pA
+SE
+eF
+Zx
+WT
+Zx
 QP
 Tq
 Tz
-oj
-PC
-PC
-vZ
-vZ
-td
-Ug
-Ug
-td
-vZ
-PC
-bk
+Tq
+Tq
+Zx
+YC
+Zx
+nv
+on
+Zx
+Zx
+YC
+Gu
+Zx
 Pv
-bk
+Wl
 rh
-LE
+SY
 cz
-uH
-Bs
-Bs
-wi
-Pk
-Pk
-Pk
-Pk
-JG
-QI
-hL
-yO
-Pk
+zP
+hw
+pz
+Ul
+Ul
+DC
+DC
+Yd
+UQ
+UQ
+Yd
+ZW
+Ul
 RN
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
+co
+RN
+YT
+Ex
+xh
+oS
+ZF
+ZF
+cf
+QF
+ZB
 aa
-aa
-aa
-aa
-aa
+ZB
 aa
 aa
 aa
@@ -11570,94 +10286,75 @@ aa
 (23,1,1) = {"
 aa
 aa
-af
-af
-af
-af
-af
-af
+NO
+NO
+NO
+NO
+NO
+NO
 ZB
-Dn
-EZ
-Dn
-Fr
-EZ
-EZ
-Dn
-hm
-ic
-Ft
-BT
-gC
-mk
-oU
-mk
-ns
-TK
-pu
-vC
-DE
-mk
-ow
-mk
+YO
 YK
-mk
-mk
-ow
-tH
-lq
-mk
-wb
+YO
+bp
+YK
+YK
+YO
+cE
+dc
+dy
+yk
+YA
 Zx
-wb
-LR
+fp
+Zx
 St
-QO
-QO
+Tq
+iH
 qa
-PC
-pv
+kr
+Zx
 YC
-No
+Zx
 Oa
-Ad
-Vf
-Ug
-vZ
-PC
-Wn
-rV
+Zx
+Zx
+YC
+TP
+ko
+Zx
+WL
 oL
 WL
 Is
 GI
-lf
-GU
+VS
+VS
 lF
-GN
-hL
-hL
-hL
-hL
+Ul
+Sy
+zY
+EG
+Em
 uq
-hL
-hL
+LH
+UQ
 ZW
-hL
+Ul
 XT
 Uc
-GU
+QE
 fi
-Nw
+NU
 UX
-Nw
-Nm
-GU
+AN
+OG
+pG
+XU
 aa
+ZB
 aa
-aa
-aa
-aa
+ZB
 aa
 aa
 aa
@@ -11673,95 +10370,76 @@ aa
 "}
 (24,1,1) = {"
 aa
-af
-af
-aA
-aQ
-aV
-bq
-af
-Dn
-Dn
-bU
-Dn
-EZ
-EZ
-Dn
-Dn
-ef
-ef
-iH
-jr
-kf
-mk
+NO
+NO
 tH
-mk
+au
 bX
 qO
 NO
-TK
-DX
-mk
-tH
-ow
-ow
-ow
-Qe
-ow
-mk
-mk
-mk
-Ua
-gj
-dB
-IZ
-IZ
-IZ
-PC
-IZ
-IZ
-Pm
+YO
+YO
+aX
+YO
+YK
+YK
+YO
+YO
+Yv
+Yv
+dz
+eo
+eJ
+Zx
 TP
-vZ
-Ug
-td
-td
-td
-vZ
+Zx
+hQ
+ip
 PC
-bk
-Je
-bk
-rh
-LE
-la
-uH
-Bs
-lJ
-hL
+Tq
+ks
+Zx
+TP
+YC
+YC
+YC
+jB
+YC
+Zx
+Zx
+Zx
+Ua
+YW
+or
+BU
+BU
+BU
+Ul
+BU
+BU
 Iu
 AJ
-AJ
-Dl
+Yk
+UQ
 Yd
-AJ
-BP
+Yd
+Yd
 QU
 Ul
-Qz
+RN
 sa
-Bs
-Nw
-Nw
-Nw
-Nw
-Nw
-GU
+RN
+YT
+Ex
+YM
+oS
+ZF
 aa
-aa
-aa
-aa
-aa
+ZB
+ZB
+ZB
+ZB
+ZB
 aa
 aa
 aa
@@ -11777,95 +10455,76 @@ aa
 "}
 (25,1,1) = {"
 aa
-aL
-ag
-aB
-bl
-aZ
-bl
-bs
-Dn
-EZ
-EZ
-EZ
-EZ
-EZ
-Dn
-dk
-dk
-dk
-iI
-jt
-gj
-mk
-tH
+Zw
+ad
+as
 ON
 TK
-TK
+ON
 cK
-TK
-El
-mk
-ow
-mk
-Rh
-Rh
-mk
-Fz
-Qe
+YO
+YK
+YK
+YK
+YK
+YK
+YO
+cl
+cl
+cl
 My
-mk
-Ua
-Cr
-Ua
+eq
+YW
+Zx
+TP
 qN
-Ov
-Ov
-Ov
-Ov
+Tq
+Tq
+Tz
+Tq
 pg
-vZ
-hX
-jf
-jf
-jf
-jf
-jf
+Zx
+YC
+Zx
+nA
+nA
+Zx
+jd
 jB
-PC
-nE
-DN
-nE
+Gz
+Zx
+Ua
+Wr
 kD
-LE
-la
-uH
-Bs
-lJ
-hL
-ke
+ee
+QU
+ZW
+ZW
+QU
+ZZ
+ZW
 LC
-UH
-GU
 Zk
 Zk
 Zk
-GU
-lJ
-IE
-sa
+Zk
+Zk
+vN
+Ul
 Xc
-Vb
-Vb
-Vb
-Vb
+yH
+Xc
+ts
+Ex
+YM
+oS
 ZF
-GU
+ZB
+ZB
 aa
 aa
 aa
-aa
-aa
+ZB
 aa
 aa
 aa
@@ -11881,95 +10540,76 @@ aa
 "}
 (26,1,1) = {"
 aa
-aL
-al
-bl
-bl
-ba
-bl
-bt
-Dn
-EZ
-EZ
-EZ
-EZ
-EZ
-Dn
-ff
-iJ
-iJ
-iJ
-Ua
-gj
-mk
-mk
-mk
+Zw
+af
+ON
+ON
 uf
-nS
-cK
-TK
-Ev
-mk
-ow
-Fq
-Fe
-zi
-mk
+ON
+aO
+YO
+YK
+YK
+YK
+YK
+YK
+YO
+cm
 io
-mk
-eR
-mk
-fD
-DB
-fG
-td
+io
+io
+Ua
+YW
+Zx
+Zx
+Zx
 Mb
-Ug
-td
-Ug
-td
-vZ
-vZ
-vZ
-vZ
-vZ
-vZ
-vZ
-TP
-PC
-kw
-kw
-kw
-kw
-kw
-qi
-uH
-GU
-OM
-hL
-dE
-mh
-UH
-GU
-hL
-hL
-hL
-GU
-vc
+ir
+Tz
+Tq
+kB
+Zx
+YC
+mV
+nB
+op
+Zx
+zc
+Zx
+Hi
+Zx
+Pi
+WU
+Xv
+Yd
+Ca
+UQ
+Yd
+UQ
+Yd
+Yk
+DC
+DC
+tC
+Qn
+UQ
+DC
+bF
+Ul
 oC
-sa
-md
-Vb
-Vb
+oC
+oC
+oC
+oC
 PY
-PY
-Vb
-GU
+oS
+OG
+aa
+ZB
 aa
 aa
 aa
-aa
-aa
+ZB
 aa
 aa
 aa
@@ -11985,95 +10625,76 @@ aa
 "}
 (27,1,1) = {"
 aa
-aL
-aR
-aW
-bl
-ba
-bl
-bu
-Dn
-Dn
-Dn
-Dn
-Dn
-yT
-Dn
-Ua
-hq
-id
-iK
-Ua
-gj
+Zw
 bV
 ka
-kp
+ON
 uf
-gJ
+ON
 oi
-vG
-gJ
-mk
-oM
-mk
-mk
-mk
-mk
-mk
-mk
-mk
-mk
-jF
-NP
+YO
+YO
+YO
+YO
+YO
+bC
+YO
+Ua
+cH
+dd
+dJ
+Ua
+YW
+Sq
 Jj
 Ug
-Ug
-td
+Mb
+iu
 NC
 TB
-td
-Ug
-td
-Ug
-Ug
-td
-td
-Ug
-zv
-Ug
-ka
-kp
+iu
+Zx
+mc
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+QD
 ZD
-GU
-kO
-qi
-xz
-GU
-Xm
-hL
-cy
-mi
-GU
-JA
-Ax
-Cq
+zE
 UQ
-GU
-LW
-nL
-sa
-GU
-mU
-Nw
-Nw
-Nw
-Nw
-GU
+UQ
+Yd
+ZG
+Xm
+Yd
+UQ
+Yd
+UQ
+UQ
+Yd
+Yd
+UQ
+Zl
+UQ
+Jj
+Ug
+rz
+OG
+wF
+PY
+Nn
+OG
+pG
+pG
 aa
 aa
-aa
-aa
-aa
+ZB
+ZB
 aa
 aa
 aa
@@ -12089,94 +10710,75 @@ aa
 "}
 (28,1,1) = {"
 aa
-aL
-ap
-aC
-aS
-bc
-bl
-bu
-bB
-aX
-bu
-cE
-dc
-Ua
-Ua
-Ua
-eZ
-Ua
-Ua
-Ua
-gj
-Ua
-Ua
-Ua
+Zw
+ag
+at
+ax
 nt
-Ua
-gj
-Ua
-Ua
-ix
-Ua
-Ua
-Ua
-Ua
-yR
+ON
+oi
+aQ
+ll
+oi
+bh
+bq
 Ua
 Ua
 Ua
-Ua
-Ua
-gj
-Ua
-nt
+dU
 Ua
 Ua
 Ua
+YW
 Ua
 Ua
 Ua
-hZ
-Ua
-Ua
-iN
-Ua
-iN
-kZ
-LT
-eZ
-Ua
-st
-GU
 Oy
-qi
-uH
-lr
-lJ
-hL
-LN
+Ua
+YW
+Ua
+Ua
+kS
+Ua
+Ua
+Ua
+Ua
+Kw
+Ua
+Ua
+Ua
+Ua
+Ua
+YW
+Ua
+Oy
+Ua
+Ua
+Ua
+Ua
+Ua
+Wm
 vd
-BB
-Jv
+Ua
+Ua
 GC
-GC
-GC
+Ua
+rF
 VM
 yv
 dU
-tQ
-Bs
-Es
-Nw
-Nw
-ac
-Nw
-GU
-aa
-aa
-aa
-aa
+Ua
+XK
+OG
+wF
+PY
+oS
+BI
+hW
+hW
+oG
+ZB
+ZB
 aa
 aa
 aa
@@ -12193,91 +10795,72 @@ aa
 "}
 (29,1,1) = {"
 aa
+Zw
+al
+ll
+az
+nu
 aL
-aq
-aX
-be
-bd
-vf
-bv
-bC
-bI
-bv
-cR
-Uz
-Bf
-Bf
-Bf
-jD
-Bf
-Bf
-Bf
-kg
-Bf
-ll
-Bf
-nu
-Bf
 ok
+aR
+aS
+ok
+bi
+br
+Bf
+Bf
+Bf
+cI
+Bf
+Bf
+Bf
+eN
+Bf
+fq
+Bf
+hS
+Bf
+VG
 Bf
 Bf
 Bf
 Bf
 Bf
-ll
+fq
 Bf
-VT
-Bf
-MC
-MC
-Bf
-Bf
-sv
-Bf
-nu
-Bf
-Bf
-ll
-Bf
-Bf
-Bf
-Bf
-Bf
-Bf
-Bf
-Bf
+sH
 Bf
 jD
+jD
 Bf
-ot
 Bf
 iF
-zc
-Kw
-yW
-lf
-Bs
-lJ
-hL
-wO
+Bf
+hS
+Bf
 WF
-hL
+fq
+Bf
+Bf
 WF
-hL
-Fm
-hL
-Bs
-En
+Bf
+Bf
+WF
+Bf
+Bf
+WF
+cI
+Bf
 NF
-QK
-Bs
+Bf
+qJ
 nz
-Nw
-nz
+Yw
+Sx
 AN
-Nw
-GU
-aa
+ZF
+hW
+pG
 aa
 aa
 aa
@@ -12297,91 +10880,72 @@ aa
 "}
 (30,1,1) = {"
 aa
-aL
-as
-aF
-be
-bh
-bl
-bu
-bB
-aX
-ca
-cE
-bD
-Ua
-Ua
-fh
-gj
-fh
-Ua
-Ua
-Ua
+Zw
 iE
 Rw
+az
+aA
+ON
+oi
+aQ
+ll
+aZ
+bh
+bs
 Ua
-nt
-Ua
-gj
-Ua
-Ua
-Ua
-Ua
-Ua
-Rw
 Ua
 yR
-iE
-tS
+YW
+yR
 Ua
 Ua
 Ua
-gj
-Ua
-nt
-Ua
-Ua
-Rw
-Ua
-Ua
-Ua
-Ua
-iE
-Ua
-jO
-Ua
-jO
-jE
-jO
-Ua
-Ua
-Km
-GU
-kP
-qi
-uH
+tZ
 lr
-lJ
-hL
-rP
-RP
+Ua
+Oy
+Ua
+YW
+Ua
+Ua
+Ua
+Ua
+Ua
+lr
+Ua
+Kw
+tZ
+jE
+Ua
+Ua
+Ua
+YW
+Ua
+Oy
+Ua
+Ua
+lr
+Ua
+Ua
+Ua
+Ua
 tZ
 Wm
 VA
+Ua
 VA
+tq
 VA
-xf
-SK
-Ao
-Uc
-Bs
-Nw
-Nw
-Nw
+Ua
+Ua
+Sz
+OG
+wF
+PY
 oS
-Nw
-GU
-aa
+BI
+hW
+Xp
 aa
 aa
 aa
@@ -12401,99 +10965,80 @@ aa
 "}
 (31,1,1) = {"
 aa
-aL
-at
-aM
-bl
-bi
-bl
-bu
-mo
-mo
-mo
-mo
-mo
-sX
-Sp
-fk
-hr
-fk
-pJ
-pJ
-pJ
-pJ
+Zw
+ap
 lA
-mu
-bV
+ON
+aB
+ON
+oi
+hU
+hU
+hU
+hU
+hU
+bD
+Qb
+cp
+cQ
+cp
+ER
+ER
+ER
+ER
+fr
+By
+Sq
 Ua
-gj
+YW
 Ua
-hU
-hU
-ed
-hU
-hU
-hU
-hU
-hU
-hU
-hU
-hU
+Yl
+Yl
+me
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
+Yl
 Ua
-gj
+YW
 Ua
-By
-By
-Ns
-Ns
-Ns
-Ns
-By
-By
-By
-By
-By
-AP
-AP
-Tt
-AP
-lA
-mu
-ZD
-GU
-Sj
-qi
-uH
-GU
+Ya
+Ya
 CG
-hL
-GR
-GU
-xf
-Ri
-ra
-kc
+CG
+CG
+CG
+Ya
+Ya
+Ya
+Ya
+Ya
+Un
 YF
-GU
-LW
-nL
-sa
-GU
-mU
-Nw
-Nw
-Nw
-Nw
-GU
-aa
-nT
-aa
+eK
+YF
+fr
+By
+rz
+OG
+wF
+PY
+oS
+OG
+pG
+ZB
 aa
 aa
 aa
 aa
 aa
 aa
+aa
+RW
 aa
 aa
 aa
@@ -12505,93 +11050,74 @@ aa
 "}
 (32,1,1) = {"
 aa
-aL
-au
-bl
-bl
-bi
-bl
-bx
-mo
-se
-se
-se
-se
-se
-Sp
-fp
-hx
-if
-iv
-ju
-kh
-pJ
-pJ
-pJ
-pJ
-Ua
-gj
-Ua
+Zw
+aq
+ON
+ON
+aB
+ON
+aP
 hU
 Xq
 Xq
 Xq
 Xq
 Xq
-Xq
-Xq
-Xq
-Xq
-hU
+Qb
+cr
+cR
+cr
+Ot
+er
 ib
-gh
+ER
+ER
+ER
+ER
 Ua
-tV
-yb
-hN
-Xl
-Xl
-hN
-PA
-By
-UU
-rK
-iO
-AP
-jk
-eA
-ud
-GU
-GU
-GU
-GU
-GU
-qi
-LL
-GU
-js
-hL
+YW
+Ua
+Yl
+Yh
+Yh
+Yh
+Yh
+Yh
+Yh
+Yh
+Yh
+Yh
+Yl
+QK
+Xw
+Ua
+XD
+wk
+Vb
+bZ
+Vb
+PH
 rP
-rp
+Ya
 RT
-GU
-hL
-hL
-hL
-GU
-Kq
-rj
-sa
-Bs
-Vb
-Vb
-Id
-Vb
-Vb
-GU
+ue
+vi
+Un
+EL
+Pe
+Py
+OG
+OG
+OG
+OG
+OG
+PY
+uw
+OG
 aa
-aa
-aa
+ZB
+ZB
+ZB
 aa
 aa
 aa
@@ -12609,94 +11135,75 @@ aa
 "}
 (33,1,1) = {"
 aa
-aL
-az
-aO
-bl
-bn
-bl
-bs
-mo
-bz
-se
-se
-se
-se
-Sp
-sQ
-hA
-sQ
-iv
-Zw
 Zw
 kL
 cG
-mv
-pJ
-Ua
-gj
-Ua
+ON
+aC
+ON
+cK
 hU
+aT
 Xq
-ci
-ci
-ci
-ci
-ci
-ci
+Xq
+Xq
+Xq
+Qb
 iA
-Xq
-hU
-nU
-Cr
+cS
+iA
+Ot
+QA
+QA
+eX
+fb
+he
+ER
 Ua
-By
-Al
-CC
-hN
-hN
-yr
-EU
-By
-JY
-TA
-Nc
-AP
-OD
+YW
+Ua
+Yl
+Yh
+YD
+YD
+YD
+YD
+YD
+YD
 ud
-ud
-EP
-bN
+Yh
+Yl
+XF
 Lw
-cb
-Bs
-la
-uH
-Bs
-lJ
-hL
-rP
-He
-RT
-GU
+Ua
+Ya
+Cd
+Mf
+Va
+PH
+uo
+LK
+Ya
+Ue
+CH
 rs
-rs
-rs
-GU
-Ii
+Un
+LV
+Py
+Py
 CT
-sa
-Xc
-Vb
-Vb
-Vb
-Vb
+CT
+CT
+pq
 ZF
-GU
+YM
+oS
+ZF
+ZB
+ZB
 aa
-aa
-aa
-aa
+ZB
+ZB
 aa
 aa
 aa
@@ -12713,94 +11220,75 @@ aa
 "}
 (34,1,1) = {"
 aa
-af
-af
-aP
-bl
-bp
-br
-af
-mo
-mo
-xx
-mo
-se
-se
-Sp
-fq
-hr
-fq
-pJ
-Zw
-Zw
-Zw
+NO
+NO
 lB
-my
-pJ
-Ua
-gj
-Ua
+ON
+aF
+aM
+NO
+hU
+hU
+ba
 hU
 Xq
-ci
-dP
-NS
-NS
+Xq
+Qb
 fl
-ci
-Xq
-hI
-hU
+cQ
+fl
+ER
+QA
+QA
+eZ
+fs
+hf
+ER
 Ua
-gj
-Ua
-By
-ho
-OU
 YW
-hN
-KU
-hN
-By
+Ua
+Yl
+Yh
+YD
 tz
-aw
 JF
-AP
-OD
-ud
+JF
+sO
+YD
+Yh
 sb
-tx
-tx
-Ap
-tx
-Bs
-la
-uH
-Bs
-lJ
-hL
-MB
-mL
-mL
+Yl
+Ua
+YW
+Ua
+Ya
+wG
+Ly
+lI
+Va
+FF
+Vb
+Ya
+Jt
 mw
 mF
-mL
+Un
 LV
 Py
 To
 wF
 PK
-Bs
-Nw
-Nw
-Nw
-Nw
-Nw
-GU
+gd
+wF
+ZF
+YM
+oS
+ZF
+aa
+ZB
 aa
 aa
-aa
-aa
+ZB
 aa
 aa
 aa
@@ -12818,93 +11306,74 @@ aa
 (35,1,1) = {"
 aa
 aa
-af
-af
-af
-af
-af
-af
+NO
+NO
+NO
+NO
+NO
+NO
 ZB
-mo
-se
-mo
-se
-se
-Sp
-fs
-hE
-ip
-Zw
-Zw
-cu
-cu
-Zw
-mz
-pJ
-Ua
-gj
-dB
 hU
 Xq
-ci
-AV
-yZ
+hU
+Xq
+Xq
 Qb
 Mj
-ci
-ci
-ci
-ci
-vk
+cU
+dk
+QA
+QA
 yw
-yR
-By
+yw
+QA
+hg
 hN
-gS
-hN
-hN
-UT
-GZ
-By
+Ua
+YW
+jr
+Yl
+Yh
+YD
 Of
-By
-By
-AP
-OD
-ud
-JJ
-tx
+HB
+oq
+sQ
+YD
+YD
+YD
+YD
 kA
 Aj
 Kw
-xc
+Ya
 Va
 WG
-GU
+LG
 lK
 lU
-hL
-hL
-hL
-hL
-NQ
-hL
-hL
-tc
-hL
+Wy
+Ya
+HI
+Ya
+Ya
+Un
+LV
+Py
+wc
 sJ
 pM
-GU
+Dr
 nc
-Nw
+EE
 cj
-Nw
-rl
-GU
+xJ
+OG
+oG
+sY
 aa
 aa
-aa
-aa
+ZB
 aa
 aa
 aa
@@ -12929,86 +11398,67 @@ aa
 aa
 aa
 aa
-mo
-Mt
-Sp
-Sp
-Sp
-Sp
-fr
-hJ
-Zw
-Zw
-cp
-AG
-cG
-Zw
-mA
-pJ
-Ua
-gj
-Ua
 hU
-Xq
-ci
-eG
-yZ
-Mg
+bc
+Qb
+Qb
+Qb
+Qb
 Ne
-AO
-Nz
-ai
-zZ
+TC
+QA
+QA
+IX
 XS
-gj
-Ua
+fb
+fE
 KR
-hN
-hN
-hN
-ho
-sM
+ER
+Ua
 YW
-By
-im
-dg
+Ua
+Yl
+Yh
+YD
+UJ
+HB
 Tx
-AP
-OD
-ud
+sX
+zg
+Cn
 sE
-tx
+Kl
 Mq
-tx
-tx
-Bs
-la
-uH
-Bs
-Bs
+YW
+Ua
+NB
+ZN
+jh
+ZE
+EQ
 lV
 Rk
 Ya
-Rk
-Rk
+WD
+Nw
 uO
-Rk
-Rk
-uO
-Rk
+Un
+LV
+Py
+To
 tQ
 EF
-GU
-GU
-GU
-GU
-GU
-GU
-GU
+Ec
+wF
+ZF
+YM
+oS
+ZF
+ZF
+zd
+QF
 aa
-aa
-aa
-aa
+ZB
 aa
 aa
 aa
@@ -13034,85 +11484,66 @@ aa
 aa
 aa
 ZB
-jV
-EN
-dq
-dq
-dq
-Zw
-hG
-ir
-cl
-cp
-cw
-cH
-Zw
-mB
-pJ
-Ua
-gj
-Ua
-hU
-Xq
-ci
-pk
-hO
-fa
+WS
+PQ
+QA
+QA
+QA
 QA
 TC
 QA
-QA
+dL
 IX
 Mr
-ok
-Bf
-kE
-qh
-JD
-PV
-PV
-Lp
-qh
-yn
+fc
+QA
+QA
+ER
+Ua
+YW
+Ua
+Yl
+Yh
+YD
 in
 kt
 iP
-AP
-vB
-ud
 Xi
-tx
+vB
+Xi
+Xi
+KF
 tl
 VG
-jY
+Bf
 Ww
 re
-uH
-tx
-Bs
+mW
+UO
+Ny
 dI
-Bs
-GU
-GU
-GU
+GX
+ye
+Mn
+eI
 ql
-Nw
-Nw
-ql
-Nw
-am
+Un
+UE
+Py
+To
+wF
 mT
 sp
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+GW
+DU
+xC
+oS
+wF
+ZF
+Ce
+ZF
+OG
+OG
 aa
 aa
 aa
@@ -13139,85 +11570,66 @@ aa
 aa
 aa
 ZB
-EN
-Zw
-Zw
-Zw
-Zw
-hJ
-Zw
-sH
-Zw
-Zw
-Zw
-Zw
-mC
-pJ
+PQ
+QA
+QA
+QA
+QA
+TC
+QA
+dM
+QA
+QA
+QA
+QA
+hh
+ER
 Ua
-gj
+YW
 Ua
-hU
-Xq
-ci
-eG
-sd
-Qv
-yC
-AO
-oO
-bT
-zZ
-XS
-gj
-Ua
-KR
-hN
-Ge
-hN
-hN
-hN
-RY
-By
-ux
-dg
+Yl
+Yh
+YD
+UJ
+nC
 iQ
-AP
-OD
-ud
-ud
-ud
-ud
-GU
-GU
-GU
+tp
+zg
+Cv
+Ak
+Kl
+Mq
+YW
+Ua
+NB
 PH
 Ku
-OY
-yt
-IR
-tx
-tx
-Bs
+zA
+Vb
+PH
+Up
+Ya
+lt
 Nw
 Hw
-mN
-mN
-mG
-Nw
-Pj
-GU
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Un
+LV
+Py
+Py
+Py
+Py
+OG
+OG
+OG
+RU
+VB
+vx
+RM
+PW
+wF
+wF
+ZF
+hW
 aa
 aa
 aa
@@ -13243,86 +11655,67 @@ aa
 aa
 aa
 aa
-EN
-dz
-eq
-eE
-fE
-hP
-cI
-iL
-cI
-cI
-cI
-lC
-mD
-pJ
-Ua
-gj
-Ua
-hU
-Xq
-ci
-eG
+PQ
+bt
 JV
-yZ
-Mj
-US
-US
-US
+bS
+cs
 US
 SL
-gj
+dN
+SL
+SL
+SL
+fI
+hi
+ER
 Ua
-By
-ry
-gZ
-gZ
-gZ
-gZ
-gZ
-By
+YW
+Ua
+Yl
+Yh
+YD
 UJ
-dg
+nD
 HB
-AP
-JS
-AP
+sQ
 Zt
-Dx
-ud
-Pz
-Pz
-GU
+Zt
+Zt
+Zt
+QQ
+YW
+Ua
+Ya
 UN
 sc
 lw
-lN
 Qt
-tx
-tx
+Qt
+lw
+Ya
 mp
 Nw
 Tr
-Bc
+Un
 vh
-vh
+YF
 TQ
 tK
-GU
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Py
+FR
+FR
+OG
+sn
+IG
+SO
+gf
+Uu
+wF
+wF
+oP
+hW
+hW
 aa
 aa
 aa
@@ -13347,87 +11740,68 @@ aa
 aa
 aa
 aa
-EN
-EN
-EN
-eF
-EN
-EN
-iv
-lD
-iv
-EN
-iv
-lD
-iv
-pJ
-nU
-gj
-Ua
-hU
-Xq
-ci
-uu
+PQ
+PQ
 PQ
 bT
-fm
-US
-sj
+PQ
+PQ
+Ot
 IJ
 Ot
-Bf
-ol
-fG
-By
-By
+PQ
+Ot
+IJ
+Ot
+ER
 XF
-Tp
-sD
-xm
-pe
-By
+YW
+Ua
+Yl
+Yh
+YD
 HU
-dg
+nF
 Ak
-AP
-OD
-AP
+uy
+Zt
+Cy
 Xz
 qW
-ud
-Pz
+Bf
+Jd
 Xv
-Gr
-ML
+Ya
+Ya
 cB
-pZ
-lO
 qb
 qb
 qb
+iC
+Ya
 mq
-mq
-mq
+Nw
+aK
 Un
-xb
-Mi
-Bs
-Bs
-GU
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+LV
+YF
+xw
+Yy
+Py
+FR
+Do
+HM
+Iq
+pQ
+oQ
+YB
+Cj
+Cj
+Cj
+Pg
+IH
+ZB
+ZB
 aa
 aa
 aa
@@ -13452,84 +11826,65 @@ aa
 aa
 aa
 aa
-EN
-et
-eN
-UD
-EN
+PQ
+bI
+vj
 ct
-eN
-UD
-EN
-ct
-eN
-UD
-pJ
-Ua
-gj
-Ua
-hU
-Xq
-ci
-ci
-ci
-ci
-ci
-ci
+PQ
 Bv
 vj
-bV
-Ua
-gj
-Ua
-By
+ct
+PQ
+Bv
+vj
+ct
 ER
-ny
-ny
-ny
-ny
-FM
-By
-rt
-Qd
+Ua
+YW
+Ua
+Yl
+Yh
 YD
-AP
-OD
-AP
+YD
+YD
+YD
+YD
+YD
+Cz
 RQ
 Sq
-ud
-Eq
-Cv
-Bs
+Ua
+YW
+Ua
+Ya
 SA
 Vb
-ly
-Ab
-sT
-tx
-tx
-GU
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Vb
+Va
+Vb
+Ro
+Ya
+SC
+Xf
+Gx
+Un
+LV
+YF
+tn
+WK
+Py
+lT
+VL
+ZF
+sC
+sR
+IN
+Lj
+ep
+wF
+wF
+OG
+ZB
 aa
 aa
 aa
@@ -13556,83 +11911,64 @@ aa
 aa
 aa
 aa
-EN
-Pb
-eS
-Pb
-EN
-kM
-iT
-jG
-EN
-kM
-iT
-jG
-pJ
-Ua
-gj
-Ua
-hU
-Xq
-Xq
-Xq
+PQ
 Iy
 fd
-fn
-hU
-hU
-hU
-hU
+Iy
+PQ
+dm
+dR
+et
+PQ
+dm
+dR
+et
+ER
 Ua
-gj
+YW
 Ua
-By
-gK
-ny
-Fp
-RI
-ny
-ny
-Vx
-nn
-yx
-yx
-qm
-Gd
-gD
 Yl
-Bm
-ud
-Pz
-Ef
-Dj
+Yh
+Yh
+Yh
+yx
+ot
+qm
+Yl
+Yl
+Yl
+Yl
+Ua
+YW
+Ua
+Ya
 Qu
-lh
+Vb
 ri
 lP
-tx
-tx
-tx
-GU
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Vb
+Vb
+vH
+FD
+Bl
+Bl
+Ci
+cq
+zs
+vE
+ik
+Py
+FR
+Ok
+QH
+Qk
+CO
+cP
+jb
+wF
+wF
+wF
+OG
 aa
 aa
 aa
@@ -13660,83 +11996,64 @@ aa
 aa
 aa
 aa
-EN
+PQ
+bJ
+bU
+cw
+PQ
+PQ
+PQ
 eu
-eT
-fI
-EN
-EN
-EN
-xo
-xo
-xo
-xo
-xo
-xo
+eu
+eu
+eu
+eu
+eu
 Ua
-gj
+YW
 Ua
-hU
-Xq
-Xq
-Xq
-Xq
-Xq
-Xq
-Xq
-Xq
-Xq
-ed
+Yl
+Yh
+Yh
+Yh
+Yh
+Yh
+Yh
+Yh
+Yh
+Yh
+me
 Ua
-gj
+YW
 Ua
-By
-By
-By
-By
-By
-QG
-Ol
-By
-AP
-AP
-AP
-AP
-zG
-AP
-Dx
-Dx
-ud
-Pz
-Pz
-GU
-Qa
-ys
-lx
-qi
+Ya
+Ya
+Ya
+Ya
+Ya
 YX
-tx
-tx
-GU
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hY
+Ya
+Un
+Un
+Un
+Un
+lk
+YF
+tK
+tK
+Py
+FR
+FR
+OG
+sV
+Zv
+Zd
+PY
+Fv
+wF
+wF
+OG
 aa
 aa
 aa
@@ -13764,83 +12081,64 @@ aa
 aa
 aa
 aa
-EN
-EN
-EN
-EN
-EN
+PQ
+PQ
+PQ
+PQ
+PQ
 ZB
 ZB
-lu
-kj
-kQ
-lE
-mV
-Yg
-nV
-gj
-Ua
-hU
-en
-Xq
-Xq
-Xq
-Xq
-Xq
-Xq
-Xq
-hU
-hU
-nU
+fQ
+eO
 tm
-Bf
-Bf
-wv
+fN
+hl
+Ol
 Ey
-gy
-Fi
-DM
-Kr
-Kr
-Bt
-Dp
-Dp
+YW
+Ua
+Yl
+kT
 Yh
-cg
-ud
-ud
-ud
-ud
-GU
-GU
-GU
+Yh
+Yh
+Yh
+Yh
+Yh
+Yh
+Yl
+Yl
+XF
+XR
+Bf
+Bf
 oR
 PI
-GU
+Kg
 tP
-GU
-Bs
-GU
-GU
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+dj
+Tm
+Tm
+CK
+WW
+WW
+vw
+xG
+Py
+Py
+Py
+Py
+OG
+OG
+OG
+OK
+Hh
+OG
+Yx
+OG
+ZF
+OG
+OG
 aa
 aa
 aa
@@ -13875,73 +12173,54 @@ aa
 aa
 ZB
 aa
-lu
-ko
-kR
-lQ
-mY
-nv
-nX
-ol
-fG
-hU
-eo
-Xq
-Xq
-ci
-Xq
-Xq
-Xq
-hI
-hU
-fO
-Ua
-gj
-Ua
-Ua
+fQ
+eP
+ff
+gr
+hm
 Ns
 Kr
 Jd
-GM
-RH
-GM
-CY
-AP
-AP
-AP
-VQ
-AP
-AP
-jp
-Nk
-Nk
-Nk
-Nk
-Nk
+Xv
+Yl
+kU
+Yh
+Yh
+YD
+Yh
+Yh
+Yh
+sb
+Yl
+Lr
+Ua
+YW
+Ua
+Ua
 Vz
 Tm
 lz
 sl
+fZ
+sl
+xn
+YF
+YF
+YF
+pj
+YF
+YF
+ea
+IV
+IV
+IV
+IV
+IV
+pt
+xu
+Kc
+At
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -13979,70 +12258,51 @@ aa
 aa
 ZB
 aa
-lu
-kq
-kS
-lX
-ne
-Yg
-nY
-gj
-Ua
-ci
-ci
-ci
-ci
-ci
-hU
-hU
-QY
-hU
-hU
 fQ
-Ua
-gj
-Ua
-Ua
+eS
+fg
+gC
+hq
 Ol
-Kr
-ox
-GM
-vD
-GM
-uk
-By
-ZB
-Lv
-jC
-Lv
-jp
-Ht
-ZB
-aa
-ZB
-aa
-ZB
+iv
+YW
+Ua
+YD
+YD
+YD
+YD
+YD
+Yl
+Yl
+zh
+Yl
+Yl
+LT
+Ua
+YW
+Ua
+Ua
 XN
+Tm
+lz
+qE
+fZ
+sl
+Pu
+TZ
+ZB
+YF
+Go
+YF
+ea
+pL
 ZB
 aa
+ZB
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ZB
+GS
+ZB
 aa
 aa
 aa
@@ -14083,43 +12343,43 @@ aa
 aa
 ZB
 aa
-lu
-lu
-lu
-lu
-lu
-lu
-Ua
-gj
-Ua
-fe
-HF
-RF
-Sm
-fe
-Sl
-hD
-hD
-Cn
-mJ
+fQ
+fQ
+fQ
+fQ
+fQ
 fQ
 Ua
-gj
+YW
 Ua
-Ua
-Ol
-Kr
-HA
-GM
 PD
-GM
+kV
 ZH
-By
-ZB
-Lv
-BK
-Lv
+UV
+PD
+oy
+Zg
+Zg
 Ji
+mJ
+LT
+Ua
+YW
+Ua
+Ua
+XN
+Tm
+lz
+sl
+fZ
+sl
+JI
+TZ
+ZB
+YF
+Cu
+YF
+Jg
 ZB
 aa
 aa
@@ -14127,25 +12387,6 @@ ZB
 aa
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -14187,69 +12428,50 @@ aa
 aa
 ZB
 aa
-Lr
-kr
-lY
-lY
-Ua
-Ua
-Ua
-gj
-Ua
-fe
-HF
-Sm
-Sm
-fe
-uP
-hD
-hD
-Bx
-mJ
 Ti
-ib
+eT
+kd
 kd
 Ua
 Ua
-Ns
-dt
-Ou
-WU
-zx
-Kr
+Ua
+YW
+Ua
+PD
+kV
 UV
-By
+UV
+PD
+oz
+Zg
+Zg
+Ht
+mJ
+Md
+QK
+tr
+Ua
+Ua
+Vz
+Gq
+Tj
+ym
+yP
+Tm
+Ju
+TZ
 aa
 ZB
-Zg
-Nk
-Ht
+uE
+IV
+pL
 aa
 aa
 aa
-tr
-tr
-tr
-tr
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+vt
+vt
+vt
+vt
 aa
 aa
 aa
@@ -14291,61 +12513,42 @@ aa
 aa
 ZB
 aa
-Lr
+Ti
 Ua
 Ua
 Ua
 Ua
 Ua
 Ua
-gj
+YW
 Ua
-fe
-HF
-Sm
-Sm
-fe
-HN
-hD
-hD
-Wr
+PD
+kV
+UV
+UV
+PD
+oD
+Zg
+Zg
+CC
 mJ
 mJ
-xI
-gj
-Jb
-bV
-By
-By
-Ns
-By
-Ns
-By
-By
-By
+QW
+YW
+us
+Sq
+TZ
+TZ
+Vz
+TZ
+Vz
+TZ
+TZ
+TZ
 aa
 aa
 ZB
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -14395,30 +12598,30 @@ aa
 ZB
 ZB
 ZB
-Lr
-ks
-kT
-lZ
-Ua
-iE
-kT
-on
-kT
-fe
-Ih
-Su
-Su
-fe
-BR
-hD
-hD
-Nv
-Hu
-mJ
+Ti
 ZI
 gk
 Nf
-bV
+Ua
+tZ
+gk
+iI
+gk
+PD
+kZ
+mf
+mf
+PD
+oE
+Zg
+Zg
+CN
+Hl
+mJ
+QY
+XY
+Jk
+Sq
 ZB
 aa
 aa
@@ -14429,26 +12632,7 @@ aa
 aa
 aa
 aa
-rm
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+eM
 aa
 aa
 aa
@@ -14490,39 +12674,39 @@ aa
 aa
 aa
 aa
-FL
-FL
-FL
-FL
-FL
-FL
-FL
-FL
-FL
-fe
-fe
-kU
-vP
-vP
-fe
-fe
-op
-fe
-fe
-yE
-yE
-yE
-fe
-fe
-hD
-hD
-Nv
-FI
-mJ
-tu
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+PD
+PD
 dx
 As
-bV
+As
+PD
+PD
+iJ
+PD
+PD
+tA
+tA
+tA
+PD
+PD
+Zg
+Zg
+CN
+Hu
+mJ
+Rl
+Yg
+rS
+Sq
 mJ
 mJ
 mJ
@@ -14534,25 +12718,6 @@ aa
 aa
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -14594,69 +12759,50 @@ aa
 aa
 aa
 aa
-FL
-bJ
-dL
-mP
-FL
-bJ
-dL
-mP
-FL
-jH
-kB
-kB
-mb
-ng
-OS
-nZ
-dy
-wK
-OS
-Ys
-Ys
-Ys
-Ts
-fe
+Zm
 Ls
-hD
-Nv
-hD
+bu
+Zu
+Zm
+Ls
+bu
+Zu
+Zm
 Hd
 Ob
-dx
 Ob
+gE
 BV
-hb
+WC
 ED
 mK
-Ho
-GK
-hb
+jt
+WC
+NE
+NE
+NE
+nG
+PD
+uz
+Zg
+CN
+Zg
+Mt
+Rr
+Yg
+Rr
+Lm
+Sl
+zQ
+Jp
+Ds
+Oi
+Sl
 aa
 aa
 aa
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -14698,69 +12844,50 @@ aa
 aa
 aa
 aa
-FL
-Vt
-mP
-mP
-FL
-Vt
-mP
-mP
-FL
-jI
-Ys
-Ys
-Ys
-Ys
-OS
-oa
-Wl
-xa
-OS
-Ik
-Ys
-gG
-wx
-fe
+Zm
 Xs
-yd
-fF
-OQ
+Zu
+Zu
+Zm
+Xs
+Zu
+Zu
+Zm
 pc
-ga
-gl
-ga
-yD
-ie
+NE
+NE
+NE
+NE
+WC
 Ng
-Ep
+WA
 Ie
-qo
-hb
+WC
+lc
+NE
+mY
+nH
+PD
+uB
+zo
+Dh
+Hx
+MC
+RF
+YQ
+RF
+kk
+Mm
+TO
+jc
+XV
+Bb
+Sl
 aa
 aa
 aa
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -14802,69 +12929,50 @@ aa
 aa
 aa
 aa
-FL
-Vt
-mP
-mP
-FL
-Vt
-mP
-mP
-FL
-jJ
-Ys
-Ys
-mc
-nh
-OS
-ob
-yI
-xi
-OS
-Jl
-Ys
-mg
-Wz
-fe
-mJ
-fw
-qp
-mJ
-mJ
-gb
-gm
+Zm
+Xs
+Zu
+Zu
+Zm
+Xs
+Zu
+Zu
+Zm
+ex
+NE
+NE
 gz
-mJ
-gL
+hr
+WC
 Gh
 KY
-hD
-Ki
-hb
+ju
+WC
+ld
+NE
+gH
+nI
+PD
+mJ
+zp
+Dn
+mJ
+mJ
+RI
+ZK
+Yt
+mJ
+yQ
+cJ
+zX
+Zg
+UB
+Sl
 ZB
 aa
 aa
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -14906,69 +13014,50 @@ aa
 aa
 aa
 aa
-FL
-YQ
-bR
-Ds
-cd
-YQ
-bR
-Ds
-FL
-jK
-Ys
-Ys
-me
-sk
-OS
-OS
-oq
-OS
-OS
-KN
-Ys
-mg
-Aw
-fe
+Zm
 NJ
-hD
-hD
-rQ
+bv
+Yf
+ca
+NJ
+bv
+Yf
+Zm
 fS
-Du
-gn
+NE
+NE
 RX
-mJ
-BM
-hD
+hx
+WC
+WC
 Gv
-hD
-xy
-hb
+WC
+WC
+li
+NE
+gH
+nJ
+PD
+uP
+Zg
+Zg
+HF
+xp
+RP
+ZM
+qL
+mJ
+Lq
+Zg
+mX
+Zg
+tO
+Sl
 ZB
 ZB
 aa
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -15010,69 +13099,50 @@ aa
 aa
 aa
 aa
-FL
-bM
-dM
-ex
-FL
-bM
-dM
-ex
-FL
-FL
-Ys
-Ys
-mf
-ni
-OS
-gR
-dv
-gR
-OS
-KP
-Ys
-mg
-wT
-fe
+Zm
 Tg
-hD
-hD
-NW
-fS
-gc
-go
+bw
+wT
+Zm
+Tg
+bw
+wT
+Zm
+Zm
+NE
+NE
 od
-mJ
-LF
+hA
+WC
 FO
 mH
-EB
-Lx
+FO
+WC
+lj
+NE
+gH
+nM
+PD
+vf
+Zg
+Zg
+HN
+xp
+Se
+ZO
+ji
+mJ
+Lo
+Nl
+wq
+TX
+Ag
 mJ
 mJ
-hb
+Sl
 mJ
 mJ
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -15114,69 +13184,50 @@ aa
 aa
 aa
 aa
-Ds
-Vn
-Vn
-Vn
-eU
-Vn
-Vn
-Vn
-iV
-FL
-kC
-Ys
-mg
-Ys
-OS
-Oj
-oy
-yE
-OS
-KS
-Ys
-HZ
-IP
-fe
-DF
-hD
-hD
+Yf
+Ty
+Ty
+Ty
+cb
+Ty
+Ty
+Ty
 qz
-mJ
+Zm
 hb
-Jh
-hb
-mJ
-gL
+NE
+gH
+NE
+WC
 ZX
-hb
+iK
 tA
-mJ
-mJ
+WC
+lu
 NE
 IB
 oV
+PD
+vn
+Zg
+Zg
+Ih
+mJ
+Sl
+CL
+Sl
+mJ
+yQ
+HG
+Sl
+XG
 mJ
 mJ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Vm
+JK
+vY
+mJ
+mJ
 aa
 aa
 aa
@@ -15218,69 +13269,50 @@ aa
 aa
 aa
 aa
-Ds
-Vn
-Vn
-Vn
-eV
-fN
-hQ
-hQ
-iW
-jM
-MY
-kV
-ml
-MY
-nA
-oc
-Vv
-zg
-FU
-KT
-SR
-Rb
-bb
+Yf
+Ty
+Ty
+Ty
 Vq
 GA
-hD
-hD
-hD
-hD
-hD
+cV
+cV
+dV
+ey
+Kh
 OZ
-hD
+gR
 Kh
 gM
 zS
-zS
-zS
+iL
+jG
 KG
 Dt
 Mx
 Bx
-hD
+nQ
 Kx
-hb
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+vo
+Zg
+Zg
+Zg
+Zg
+Zg
+On
+Zg
+dp
+uv
+HR
+HR
+HR
+WR
+DW
+hz
+Ht
+Zg
+NR
+Sl
 aa
 aa
 aa
@@ -15322,69 +13354,50 @@ aa
 aa
 aa
 aa
-FL
-cS
-dN
-ey
-FL
-gr
-Vn
-Vn
-iX
-FL
-kF
-lc
-mm
-mm
-OS
-dm
-Wl
-mm
-OS
-Le
+Zm
 TJ
 UY
-IP
-GY
+bM
+Zm
 QB
-hD
-hD
-hD
-QZ
-sN
+Ty
+Ty
+dZ
+Zm
+ZR
 gp
-sN
-OQ
-gN
-sN
-uA
-sN
-OQ
+YV
+YV
+WC
+iw
+WA
+YV
+WC
 Sr
 PP
 IA
-hD
-ia
-hb
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+oV
+YJ
+vC
+Zg
+Zg
+Zg
+MY
+Sm
+TU
+Sm
+Hx
+fv
+Sm
+pT
+Sm
+Hx
+lS
+ur
+YN
+Zg
+rv
+Sl
 aa
 aa
 aa
@@ -15426,69 +13439,50 @@ aa
 aa
 aa
 aa
-FL
-Ds
-dR
-YQ
-FL
-UG
-Vn
-iu
-iY
-FL
-cr
-ld
-KF
-KF
-OS
-kF
-Wl
-mm
-OS
-LX
-Ud
-Ys
-wY
-GY
+Zm
+Yf
+bx
+NJ
+Zm
 HS
-Gf
-hD
+Ty
+dq
 FZ
 Zm
-hD
+eU
 lM
-hD
-hD
-Zm
+gS
+gS
+WC
 ZR
 WA
-qy
-hD
-Dt
-Mx
-rg
-hD
+YV
+WC
+lv
+ml
+NE
+nR
 YJ
-hb
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+vP
+zq
+Zg
+It
+Ni
+Zg
+Za
+Zg
+Zg
+Ni
+IQ
+XZ
+pO
+Zg
+DW
+hz
+ck
+Zg
+DI
+Sl
 aa
 aa
 aa
@@ -15530,69 +13524,50 @@ aa
 aa
 aa
 aa
-FL
-mP
-mP
-Vt
-FL
-gE
-Vn
+Zm
+Zu
+Zu
+Xs
+Zm
+cx
+Ty
+dt
+ec
+Zm
+eV
+aD
+aD
+aD
+WC
 iw
-ja
-FL
-ZM
-Ss
-Ss
-Ss
-OS
-dm
-Wl
-mm
-OS
-ME
-Vg
-Ys
-MA
-GY
-mJ
-mJ
-mJ
-mJ
-VI
-mJ
-mJ
-mJ
-fS
-gO
-mJ
-SU
-hb
-mJ
-mJ
+WA
+YV
+WC
+lC
 LD
-iq
+NE
 uY
+YJ
 mJ
 mJ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mJ
+mJ
+NK
+mJ
+mJ
+mJ
+xp
+Yr
+mJ
+Fy
+Sl
+mJ
+mJ
+VF
+qZ
+ph
+mJ
+mJ
 aa
 aa
 aa
@@ -15634,68 +13609,49 @@ aa
 aa
 aa
 aa
-FL
-mP
-mP
-Vt
-FL
-gH
-Vn
-Vn
-jd
-FL
-cx
-gR
-Ss
-nj
-OS
-dm
-Wl
-mm
-OS
-MQ
-Xu
-Ys
-JC
-GY
+Zm
+Zu
+Zu
+Xs
+Zm
 uW
 Ty
-Ho
-hD
-tF
+Ty
+ef
+Zm
 Or
-mJ
+FO
 aD
-yd
-xK
-mJ
-rN
+hE
+WC
+iw
+WA
 YV
-qP
+WC
+lD
+mm
+NE
+nT
+YJ
+vX
+zB
+Ds
+Zg
+Oj
+Sp
+mJ
+Qx
+zo
+bf
+mJ
+py
+UW
+GV
 mJ
 mJ
-hb
+Sl
 mJ
 mJ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -15738,66 +13694,47 @@ aa
 aa
 aa
 aa
-FL
-mP
-dV
-Ni
-FL
-gT
-hS
-gT
-FL
-FL
-OS
-OS
-OS
-OS
-OS
-dm
-dy
-zp
-OS
-OS
+Zm
 Zu
 dS
 nw
-Ub
+Zm
 TV
-hD
-yd
-fK
-fT
+cW
+dv
+Zm
+Zm
 WC
+WC
+WC
+WC
+WC
+iw
+mK
+jH
+WC
+WC
+mn
+ne
+nV
+pH
+wK
+Zg
+zo
+Jb
+Om
+Ss
 mJ
-Tn
-kn
-Nv
+hK
+PX
+CN
 mJ
-hc
-hD
-DR
+sf
+Zg
+jz
 mJ
 ZB
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -15842,65 +13779,46 @@ aa
 aa
 aa
 aa
-FL
-FL
-FL
-FL
-FL
-Ds
-Ds
-Ds
-FL
-cs
-uz
-li
-mn
-cU
-Ys
-Ys
-oz
-fg
-Gu
-Nx
-za
-Vr
-Wf
-II
-Ql
-hD
+Zm
+Zm
+Zm
+Zm
+Zm
 Yf
-XL
-Nv
+Yf
+Yf
+Zm
+ez
 Pt
-mJ
+fh
 Sd
 YE
-DH
-mJ
+NE
+NE
 ch
-hD
+jI
 jP
+lE
+mo
+ng
+nX
+pV
+xa
+Zg
+DN
+Je
+CN
+Su
+mJ
+Yq
+TF
+Hy
+mJ
+Jq
+Zg
+DT
 mJ
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -15954,56 +13872,37 @@ aa
 aa
 ZB
 ZB
-OS
-jQ
-cA
-lj
-cV
-cV
-nB
-Ys
-Wl
-Ys
-Gz
-OS
-uB
-uy
-Wb
-fe
-Ar
-hD
-hD
-pB
+WC
 VN
 gg
 TS
 wj
-vr
+wj
 sG
-mJ
-oF
-Gs
+NE
+WA
+NE
 yN
+WC
+mr
+nh
+nY
+PD
+xi
+Zg
+Zg
+Jv
+Oz
+SI
+AL
+Wo
+lg
+nm
 mJ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+tT
+yl
+Bw
+mJ
 aa
 aa
 aa
@@ -16058,56 +13957,37 @@ aa
 aa
 aa
 ZB
-OS
-jR
-QW
-li
-cQ
-nk
-nC
-Ys
-Wl
-Ys
-Hl
-OS
+WC
 eB
-eJ
-eO
-fe
-lW
-Md
-hD
-Nt
-hD
 YR
-mJ
+fh
 Kp
-pB
+hG
 SF
-mJ
-Wp
-Bi
+NE
+WA
+NE
 Ix
+WC
+ms
+ni
+nZ
+PD
+xo
+zJ
+Zg
+JD
+Zg
+SS
 mJ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nj
+Jv
+nb
+mJ
+vb
+zW
+OE
+mJ
 aa
 aa
 aa
@@ -16162,56 +14042,37 @@ aa
 aa
 aa
 aa
-OS
-OS
-OS
-OS
-mr
-OS
-nD
-Ys
-oD
-Ys
-OS
-OS
-eP
-eP
-eP
-fe
-fS
-fS
-mJ
-mJ
-fS
-fS
-mJ
-mJ
-fS
-fS
-mJ
+WC
+WC
+WC
+WC
+gT
+WC
+hT
+NE
 uj
-hb
+NE
+WC
+WC
+mt
+mt
+mt
+PD
+xp
+xp
 mJ
 mJ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+xp
+xp
+mJ
+mJ
+xp
+xp
+mJ
+JZ
+Sl
+mJ
+mJ
 aa
 aa
 aa
@@ -16269,14 +14130,14 @@ aa
 aa
 aa
 ZB
-OS
-OS
-OS
-dd
-oe
-oE
-KF
-OS
+WC
+WC
+WC
+hV
+xP
+gW
+gS
+WC
 ZB
 aa
 aa
@@ -16292,27 +14153,8 @@ aa
 aa
 aa
 aa
-xP
-gW
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fz
+UP
 aa
 aa
 aa
@@ -16375,31 +14217,12 @@ aa
 aa
 ZB
 ZB
-OS
-nF
-of
-Ss
-Ss
-vP
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+WC
+hZ
+iz
+aD
+aD
+As
 aa
 aa
 aa
@@ -16479,31 +14302,12 @@ aa
 aa
 aa
 ZB
-OS
-nG
-og
-rC
-dJ
-OS
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+WC
+ic
+iB
+iN
+jJ
+WC
 aa
 aa
 aa
@@ -16583,31 +14387,12 @@ aa
 aa
 aa
 aa
-OS
-nH
-OS
-vP
-vP
-OS
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+WC
+id
+WC
+As
+As
+WC
 aa
 aa
 aa
@@ -16688,27 +14473,8 @@ aa
 aa
 aa
 ZB
-jV
+WS
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -16851,25 +14617,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 "}
 (74,1,1) = {"
 aa
@@ -16898,25 +14645,6 @@ aa
 ZB
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -17059,25 +14787,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 "}
 (76,1,1) = {"
 aa
@@ -17106,25 +14815,6 @@ aa
 aa
 aa
 ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -111,7 +111,9 @@
 /area/ruin/space/derelict/bridge)
 "aG" = (
 /obj/structure/rack,
-/obj/item/inducer,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "aK" = (
@@ -1842,11 +1844,8 @@
 	},
 /area/ruin/space/derelict/research)
 "iy" = (
-/obj/machinery/power/smes{
-	input_attempt = 0;
-	inputting = 0
-	},
 /obj/structure/cable,
+/obj/machinery/power/smes,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "iz" = (
@@ -3242,11 +3241,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "oW" = (
-/obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/engivend,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "oX" = (
@@ -3602,11 +3601,13 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "sr" = (
-/obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
+/obj/effect/spawner/random/engineering/vending_restock,
+/obj/item/stack/cable_coil,
 /turf/open/floor/iron/corner{
 	dir = 4
 	},
@@ -4233,13 +4234,14 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "xh" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/smes{
+	input_attempt = 0;
+	inputting = 0
+	},
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "xi" = (
@@ -5690,12 +5692,9 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/service/janitor)
 "GW" = (
-/obj/machinery/power/smes{
-	input_attempt = 0;
-	inputting = 0
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/machinery/power/smes,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "GX" = (
@@ -6253,7 +6252,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/item/stack/sheet/iron/fifty,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
@@ -6984,10 +6982,9 @@
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/crew)
 "Rg" = (
-/obj/structure/frame/machine,
-/obj/item/stack/cable_coil,
-/obj/effect/spawner/random/engineering/vending_restock,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/inducer,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Rk" = (
@@ -7056,7 +7053,10 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/hallway_primary)
 "RS" = (
-/obj/machinery/vending/engivend,
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "RT" = (

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -6,6 +6,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/emergency,
 /obj/item/wrench,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "af" = (
@@ -16,11 +17,17 @@
 "ag" = (
 /obj/effect/turf_decal/tile/red/half,
 /obj/structure/frame/computer,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
+"ah" = (
+/obj/effect/spawner/random/engineering/canister,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "al" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/computer/terminal/derelict/bridge,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
 "ap" = (
@@ -50,12 +57,14 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
 /area/ruin/space/derelict/bridge)
 "au" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "ax" = (
@@ -65,10 +74,12 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "az" = (
 /obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "aA" = (
@@ -88,6 +99,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "aD" = (
@@ -95,6 +107,7 @@
 /area/ruin/space/derelict/research)
 "aF" = (
 /obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "aG" = (
@@ -111,6 +124,7 @@
 "aL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "aM" = (
@@ -121,6 +135,15 @@
 "aN" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/solarpanel_small,
+/obj/item/circuitboard/machine/smes,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "aO" = (
@@ -131,6 +154,7 @@
 "aP" = (
 /obj/structure/window/spawner/west,
 /obj/machinery/suit_storage_unit/open,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "aQ" = (
@@ -138,12 +162,14 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "aR" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/bridge)
 "aS" = (
@@ -153,22 +179,19 @@
 /obj/structure/plaque/static_plaque/golden/commission/mini,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
 /area/ruin/space/derelict/bridge)
 "aT" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard)
 "aV" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock";
-	req_access_txt = "48"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
 "aW" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -190,6 +213,7 @@
 "aZ" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
 "ba" = (
@@ -211,13 +235,19 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/starboard)
 "bd" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/cargo)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
 "be" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/bridge)
 "bf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -239,19 +269,26 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "bi" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/bridge)
+"bk" = (
+/obj/machinery/computer/launchpad{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 10
+	},
+/area/ruin/space/derelict/research)
 "bl" = (
-/obj/structure/closet/crate,
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/iron,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/effect/turf_decal/tile/blue/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
 "bm" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict2"
@@ -259,24 +296,22 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "bn" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock";
-	req_access_txt = "48"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
 "bp" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/lesser)
 "bq" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -306,6 +341,7 @@
 /area/ruin/space/derelict/security)
 "bu" = (
 /obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
 "bv" = (
@@ -315,6 +351,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
 "bw" = (
@@ -324,6 +361,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research/xenobiology)
 "bx" = (
@@ -333,49 +371,40 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
 "by" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/lesser)
 "bz" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard)
 "bB" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/lesser)
 "bC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/lesser)
 "bD" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard)
 "bF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port)
 "bI" = (
@@ -418,11 +447,14 @@
 	req_access_txt = "48"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/lesser)
 "bR" = (
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port/lesser)
 "bS" = (
 /obj/effect/turf_decal/stripes/line{
@@ -434,6 +466,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "bT" = (
@@ -447,6 +480,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "bU" = (
@@ -454,6 +488,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/security)
 "bV" = (
@@ -463,6 +498,7 @@
 /area/ruin/space/derelict/bridge)
 "bX" = (
 /obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "bZ" = (
@@ -477,14 +513,18 @@
 	dir = 4;
 	pixel_x = -12
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
+"cc" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "cd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard)
 "cf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -498,6 +538,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
@@ -517,6 +560,7 @@
 /area/ruin/space/derelict/medical)
 "cl" = (
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "cm" = (
@@ -524,6 +568,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "co" = (
@@ -548,12 +593,14 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "cr" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -564,6 +611,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "ct" = (
@@ -575,10 +623,16 @@
 "cw" = (
 /obj/structure/rack,
 /obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/security)
 "cx" = (
 /obj/machinery/monkey_recycler,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	start_charge = 0
+	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "cz" = (
@@ -599,13 +653,13 @@
 /area/ruin/space/derelict/service)
 "cC" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/multitool,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "cD" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "cE" = (
@@ -627,6 +681,7 @@
 "cG" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "cH" = (
@@ -636,16 +691,10 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
-/area/ruin/space/derelict/hallway_primary)
-"cI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "cJ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -657,6 +706,7 @@
 /area/ruin/space/derelict/EVA)
 "cK" = (
 /obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "cL" = (
@@ -687,6 +737,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/security)
 "cR" = (
@@ -699,6 +750,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -713,6 +766,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -733,29 +788,35 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "cV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "cW" = (
 /obj/structure/table,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "cY" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "dc" = (
 /obj/machinery/computer/terminal/derelict/cargo,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "dd" = (
@@ -765,6 +826,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -779,13 +841,20 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/arrival)
+"df" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
 "dj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "dk" = (
@@ -795,6 +864,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -816,7 +886,8 @@
 "dp" = (
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
+/obj/item/stack/tile/iron/white,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/medical)
 "dq" = (
 /obj/structure/table,
@@ -825,8 +896,14 @@
 /area/ruin/space/derelict/research/xenobiology)
 "dt" = (
 /obj/structure/chair/stool/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
+"du" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wrench,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "dv" = (
 /obj/structure/table,
 /turf/open/floor/iron/white,
@@ -850,6 +927,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "dz" = (
@@ -892,6 +970,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "dM" = (
@@ -911,27 +990,35 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "dS" = (
 /obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
 "dU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/area/ruin/space/derelict/bridge)
 "dV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "dZ" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "ea" = (
@@ -946,6 +1033,7 @@
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "ee" = (
@@ -964,27 +1052,24 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"eh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+"em" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "en" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "eo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced/spawner/north,
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 8;
-	output_dir = 4
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/cargo)
 "ep" = (
@@ -998,6 +1083,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "er" = (
@@ -1015,6 +1101,7 @@
 /area/ruin/space/derelict/security/detective)
 "ex" = (
 /obj/structure/closet/l3closet/scientist,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "ey" = (
@@ -1024,35 +1111,22 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
-"ez" = (
-/obj/machinery/rnd/server,
-/turf/open/floor/circuit/telecomms/server,
-/area/ruin/space/derelict/research)
 "eB" = (
-/obj/machinery/rnd/server/master,
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/circuit/telecomms/server,
 /area/ruin/space/derelict/research)
-"eC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
-"eD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
 "eE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "eF" = (
@@ -1060,6 +1134,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "eI" = (
@@ -1081,6 +1157,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "eK" = (
@@ -1094,6 +1172,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "eM" = (
@@ -1110,6 +1189,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "eO" = (
@@ -1132,30 +1212,29 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "eU" = (
-/obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "eV" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/rack,
-/obj/item/mod/core/standard,
-/obj/item/mod/core/standard,
-/obj/item/mod/core/standard,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "eX" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/timer,
-/obj/item/assembly/flash/handheld,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "eZ" = (
 /obj/item/shard,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "fb" = (
@@ -1227,7 +1306,7 @@
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
-/area/ruin/space/derelict/maintenance/port/central)
+/area/template_noop)
 "fl" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
@@ -1238,13 +1317,16 @@
 /area/ruin/space/derelict/security)
 "fp" = (
 /obj/structure/window/fulltile,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/ruin/space/derelict/maintenance/port/central)
+/area/ruin/space/derelict/crew)
 "fq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "fr" = (
@@ -1255,6 +1337,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "fv" = (
@@ -1287,6 +1370,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "fM" = (
@@ -1294,10 +1378,10 @@
 	name = "Engineering Maintenance";
 	req_one_access_txt = "10;24"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port)
 "fN" = (
-/obj/structure/closet/secure_closet/detective,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -1307,7 +1391,7 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/security/detective)
 "fS" = (
-/obj/structure/closet/secure_closet/cytology,
+/obj/structure/closet/l3closet/scientist,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "fZ" = (
@@ -1350,12 +1434,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/telecomms,
 /area/ruin/space/derelict/research)
 "gk" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -1372,6 +1458,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -1394,15 +1481,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/rnd/destructive_analyzer,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "gC" = (
 /obj/structure/table/wood,
-/obj/item/camera/detective,
+/obj/item/camera,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
 "gE" = (
@@ -1429,6 +1517,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/multitool,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "gM" = (
@@ -1438,6 +1528,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "gR" = (
@@ -1445,29 +1537,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "gS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "gT" = (
-/obj/machinery/computer/rdservercontrol{
-	dir = 8
-	},
 /obj/machinery/door/window/westleft{
 	req_access_txt = "30"
+	},
+/obj/structure/frame/computer{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "gV" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
 "gW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1476,6 +1568,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "hb" = (
@@ -1485,11 +1578,9 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "hd" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/structure/crate,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
 "he" = (
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs{
@@ -1508,6 +1599,7 @@
 "hg" = (
 /obj/item/stack/sheet/iron/five,
 /obj/item/stack/cable_coil/five,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "hh" = (
@@ -1529,7 +1621,7 @@
 	},
 /area/ruin/space/derelict/departures)
 "hl" = (
-/obj/machinery/vending/wardrobe/det_wardrobe,
+/obj/effect/spawner/random/structure/closet_private,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
 "hm" = (
@@ -1541,13 +1633,17 @@
 /turf/closed/wall/r_wall/rust,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "hq" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east{
+	start_charge = 0
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
 "hr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/computer/rdconsole{
+/obj/structure/frame/computer{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -1566,6 +1662,7 @@
 /area/ruin/space/derelict/arrival)
 "hx" = (
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "hz" = (
@@ -1578,7 +1675,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/rnd/production/circuit_imprinter/offstation,
+/obj/structure/frame/machine,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "hB" = (
@@ -1590,20 +1687,20 @@
 /obj/effect/mob_spawn/ghost_role/drone/derelict,
 /obj/effect/mob_spawn/ghost_role/drone/derelict,
 /obj/effect/mob_spawn/ghost_role/drone/derelict,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "hG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "hJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard)
 "hK" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1616,12 +1713,15 @@
 "hP" = (
 /obj/structure/table/wood,
 /obj/item/toy/beach_ball/holoball,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/crew)
 "hQ" = (
 /obj/structure/table/wood,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "hR" = (
@@ -1638,6 +1738,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "hT" = (
@@ -1663,34 +1764,27 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/service)
-"hZ" = (
-/obj/machinery/mass_driver/ordnance{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/research)
 "ib" = (
 /obj/machinery/suit_storage_unit/open,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "ic" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/research)
 "id" = (
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/research)
 "ie" = (
 /turf/closed/wall/rust,
 /area/ruin/space/derelict/hallway_primary)
 "if" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/area/ruin/space/derelict/security)
 "ik" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -1717,11 +1811,13 @@
 /area/ruin/space/derelict/hallway_primary)
 "ip" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "ir" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "it" = (
@@ -1747,6 +1843,7 @@
 	input_attempt = 0;
 	inputting = 0
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "iz" = (
@@ -1755,9 +1852,6 @@
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 1
-	},
-/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
-	pixel_x = -24
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
@@ -1786,6 +1880,7 @@
 "iD" = (
 /obj/effect/spawner/random/structure/girder,
 /obj/structure/window/spawner,
+/obj/structure/cable,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
@@ -1800,6 +1895,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/derelict/hallway_primary)
+"iG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "iH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -1807,6 +1909,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "iI" = (
@@ -1819,6 +1922,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -1838,6 +1943,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -1852,25 +1959,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "iL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"iN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/doppler_array/research/science{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen/ordnance{
-	dir = 8;
-	pixel_x = 30
-	},
-/turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "iP" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -1879,11 +1976,13 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "iQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "iT" = (
@@ -1926,6 +2025,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east{
+	start_charge = 0
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "jd" = (
@@ -1954,8 +2057,14 @@
 "jj" = (
 /obj/structure/table/wood,
 /obj/item/storage/dice,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/crew)
+"jk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
 "jl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -1965,12 +2074,16 @@
 "jo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "jr" = (
-/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	start_charge = 0
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/area/ruin/space/derelict/security)
 "jt" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
@@ -1986,6 +2099,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "jz" = (
@@ -2003,10 +2117,12 @@
 "jD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "jE" = (
 /obj/machinery/airalarm/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "jG" = (
@@ -2020,19 +2136,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/space/derelict/research)
-"jI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "jJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/research/explosive_compressor,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "jK" = (
@@ -2050,13 +2163,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
 "jP" = (
-/obj/machinery/computer/department_orders/science{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "jQ" = (
@@ -2093,6 +2201,19 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
+"jW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
+"jX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	start_charge = 0
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/central)
 "jY" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -2115,6 +2236,7 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -2160,6 +2282,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "kr" = (
@@ -2173,10 +2296,12 @@
 	pixel_y = 4
 	},
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "ks" = (
 /obj/machinery/bookbinder,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "kt" = (
@@ -2255,16 +2380,12 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "kV" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "toxins"
+/obj/machinery/power/apc/auto_name/directional/north{
+	start_charge = 0
 	},
-/obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/large,
-/area/ruin/space/derelict/research)
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/lesser)
 "kX" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap{
@@ -2275,44 +2396,21 @@
 /turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "kZ" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/door/window/eastright{
-	req_access_txt = "71"
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "toxins"
-	},
-/obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/large,
-/area/ruin/space/derelict/research)
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/lesser)
 "lc" = (
-/obj/structure/tank_dispenser,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "ld" = (
-/obj/structure/table/reinforced,
-/obj/item/assembly/igniter{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -6
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "lg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 9
@@ -2321,88 +2419,36 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "li" = (
-/obj/item/assembly/signaler{
-	pixel_y = 8
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "lj" = (
-/obj/structure/table/reinforced,
-/obj/item/assembly/timer{
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/item/assembly/timer{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/assembly/timer{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/assembly/timer{
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/obj/item/book/manual/wiki/ordnance,
-/obj/item/storage/firstaid/toxin,
-/obj/item/assembly/prox_sensor{
-	pixel_x = 9;
-	pixel_y = -4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/raw_anomaly_core/random{
-	pixel_y = 11
-	},
-/obj/item/raw_anomaly_core/random{
-	pixel_y = -2
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard)
 "lk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "ll" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
 /area/ruin/space/derelict/bridge)
 "lr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east{
+	start_charge = 0
 	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard)
 "lt" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -2412,36 +2458,16 @@
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "lu" = (
-/obj/structure/table/reinforced,
-/obj/item/wrench,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/analyzer,
-/obj/item/pipe_dispenser,
-/obj/item/transfer_valve{
-	pixel_x = -5
-	},
-/obj/item/transfer_valve,
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/item/transfer_valve{
-	pixel_x = -5
-	},
-/obj/item/transfer_valve,
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "lv" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/components/binary/thermomachine/heater/on{
-	dir = 4
+/obj/structure/cable,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/area/template_noop)
 "lw" = (
 /obj/structure/chair/stool/directional/east,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -2464,25 +2490,30 @@
 	},
 /area/ruin/space/derelict/service)
 "lA" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
 /area/ruin/space/derelict/bridge)
 "lB" = (
 /obj/structure/displaycase_chassis,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "lC" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "lD" = (
-/obj/structure/closet/bombcloset,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "lE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/closed/wall,
@@ -2518,6 +2549,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "lP" = (
@@ -2615,61 +2647,56 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "me" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/central)
 "mf" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/door/window/eastright{
-	req_access_txt = "71"
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 50
 	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "toxins"
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/turf/open/floor/iron/large,
-/area/ruin/space/derelict/research)
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "mg" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "ml" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/structure/rack,
+/obj/item/clothing/head/helmet/swat,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "mm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/structure/rack,
+/obj/structure/sign/poster/contraband/gorlex_recruitment{
+	pixel_y = 32
 	},
-/obj/machinery/meter,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "mn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
 	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "mo" = (
-/obj/machinery/airlock_sensor/incinerator_ordmix{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research)
+/area/template_noop)
 "mp" = (
 /obj/machinery/oven,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -2689,20 +2716,27 @@
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "mr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/ruin/space/derelict/research)
+/obj/structure/disposaloutlet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
 "ms" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/engine/vacuum,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/ruin/space/derelict/research/xenobiology)
 "mt" = (
-/turf/open/floor/engine/vacuum,
-/area/ruin/space/derelict/research)
+/obj/item/stack/sheet/mineral/diamond{
+	amount = 5
+	},
+/obj/structure/closet/crate/engineering,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "mw" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
@@ -2750,6 +2784,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "mJ" = (
@@ -2762,8 +2798,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
+"mL" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/central)
+"mO" = (
+/obj/machinery/door/firedoor,
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/west,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
 "mP" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance,
@@ -2797,11 +2846,16 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "mY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "na" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2822,30 +2876,31 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "ne" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
-	name = "Burn Chamber Interior Airlock"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "ng" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
 "nh" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior{
-	name = "Burn Chamber Exterior Airlock"
-	},
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
 "ni" = (
-/obj/machinery/igniter/incinerator_ordmix,
-/turf/open/floor/engine/vacuum,
-/area/ruin/space/derelict/research)
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "nj" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -2879,6 +2934,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "np" = (
@@ -2925,6 +2981,7 @@
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
 "nz" = (
@@ -2973,86 +3030,90 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "nG" = (
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "toxins"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/template_noop)
 "nH" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/machinery/power/apc/auto_name/directional/east{
+	start_charge = 0
+	},
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "nI" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"nJ" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"nM" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/window/reinforced/spawner/east,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"nQ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/vaultcontroller,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"nJ" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"nM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
+"nQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
 "nR" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "nT" = (
-/obj/machinery/airalarm/mixingchamber{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+/obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
-/obj/machinery/meter,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
 "nV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "nX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research)
+/area/template_noop)
 "nY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research/xenobiology)
 "nZ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/ordnance_mixing_input{
-	dir = 8
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/silver{
+	amount = 50
 	},
-/turf/open/floor/engine/vacuum,
-/area/ruin/space/derelict/research)
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "oa" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3082,7 +3143,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/rnd/production/protolathe/offstation,
+/obj/structure/frame/machine,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "oe" = (
@@ -3148,7 +3209,8 @@
 /area/ruin/space/derelict/hallway_primary)
 "ot" = (
 /obj/machinery/space_heater,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/central)
 "oy" = (
 /obj/structure/table,
@@ -3157,6 +3219,7 @@
 	},
 /obj/item/crowbar,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "oz" = (
@@ -3228,6 +3291,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "oS" = (
@@ -3237,13 +3301,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"oV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
 "oW" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/tile/yellow{
@@ -3256,6 +3313,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "pc" = (
@@ -3266,7 +3324,7 @@
 /obj/item/stock_parts/cell/high{
 	pixel_y = 6
 	},
-/obj/item/hand_tele,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "pd" = (
@@ -3274,10 +3332,12 @@
 /obj/item/toy/crayon/spraycan,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/maintenance/port)
 "pg" = (
 /obj/machinery/photocopier,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "pj" = (
@@ -3327,9 +3387,19 @@
 /turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "pD" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/template_noop)
 "pF" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -3338,6 +3408,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "pG" = (
@@ -3348,7 +3419,12 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
+/area/ruin/space/derelict/medical)
+"pJ" = (
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/ruin/space/derelict/maintenance/starboard/central)
 "pL" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -3382,6 +3458,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
+"pR" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "pT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -3397,7 +3476,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
+/area/ruin/space/derelict/medical)
 "qa" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3424,7 +3503,8 @@
 /area/ruin/space/derelict/service)
 "qm" = (
 /obj/effect/spawner/random/engineering/tank,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/central)
 "qr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -3432,6 +3512,11 @@
 	},
 /turf/open/floor/carpet/blue/airless,
 /area/ruin/space/derelict/arrival)
+"qv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
 "qz" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3480,8 +3565,10 @@
 	req_access_txt = "12"
 	},
 /obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/port/central)
+/area/ruin/space/derelict/crew)
 "qO" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/table/reinforced,
@@ -3569,9 +3656,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "rL" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/template_noop)
 "rM" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -3598,7 +3684,8 @@
 /area/ruin/space/derelict/engineering/gravity_generator)
 "sb" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/central)
 "sc" = (
 /obj/structure/chair/stool/directional/east,
@@ -3695,12 +3782,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "sH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "sI" = (
@@ -3711,6 +3803,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"sK" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east{
+	start_charge = 0
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/central)
+"sN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "sO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -3762,6 +3866,7 @@
 	icon_state = "o";
 	pixel_x = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/maintenance/port)
 "ta" = (
@@ -3771,9 +3876,10 @@
 /turf/template_noop,
 /area/template_noop)
 "tb" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/structure/rack,
+/obj/item/inducer/syndicate,
+/turf/open/floor/mineral/plastitanium/airless,
+/area/template_noop)
 "tg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3789,6 +3895,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "tm" = (
@@ -3817,6 +3924,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "tr" = (
@@ -3839,6 +3947,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"tw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	start_charge = 0
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
 "tz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -3850,6 +3966,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/directional/south{
+	start_charge = 0
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "tC" = (
@@ -3874,6 +3995,10 @@
 "tK" = (
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
+"tL" = (
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
 "tM" = (
 /obj/effect/spawner/random/structure/girder,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3889,6 +4014,7 @@
 "tP" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "tQ" = (
@@ -3911,9 +4037,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "ud" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "ue" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/reagent_dispensers/beerkeg,
@@ -3936,6 +4062,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "uo" = (
@@ -3982,6 +4109,9 @@
 	dir = 1
 	},
 /area/ruin/space/derelict/service)
+"uu" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/hallway_primary)
 "uv" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -4052,17 +4182,15 @@
 /obj/machinery/reagentgrinder{
 	pixel_y = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "uY" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/machinery/door/airlock/vault/derelict,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/template_noop)
 "vb" = (
 /obj/machinery/computer/pandemic,
 /obj/structure/disposalpipe/segment{
@@ -4074,6 +4202,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"vc" = (
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/dorms_double{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
 "vd" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
@@ -4099,6 +4240,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "vi" = (
@@ -4131,6 +4273,13 @@
 /obj/machinery/vending/drugs,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"vr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "vs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -4147,6 +4296,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "vx" = (
@@ -4164,10 +4314,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "vC" = (
 /obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "vE" = (
@@ -4176,8 +4328,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
+"vG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
 "vH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -4190,18 +4348,26 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
+"vI" = (
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/template_noop)
 "vN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port)
 "vP" = (
 /obj/machinery/suit_storage_unit/open,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "vU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "vX" = (
@@ -4225,6 +4391,7 @@
 /area/template_noop)
 "wj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "wk" = (
@@ -4257,6 +4424,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
+"wy" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "wz" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/door/firedoor/border_only/closed{
@@ -4309,17 +4483,21 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research/xenobiology)
 "wZ" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/structure/crate,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/template_noop)
 "xa" = (
 /obj/structure/table,
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"xe" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "xh" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -4330,6 +4508,11 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
+"xi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/tile/iron/white,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
 "xj" = (
 /obj/machinery/door/firedoor/border_only/closed{
 	dir = 8
@@ -4344,7 +4527,7 @@
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/service)
 "xp" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/medical)
 "xq" = (
@@ -4402,6 +4585,7 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "xC" = (
@@ -4411,11 +4595,16 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
+"xE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
 "xG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "xI" = (
@@ -4429,6 +4618,12 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"xL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mecha_wreckage/honker,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "xP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall,
@@ -4438,6 +4633,17 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
+"xW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/launchpad,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "xX" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -4450,6 +4656,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "xY" = (
@@ -4477,8 +4686,20 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
+"yj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "yk" = (
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "yl" = (
@@ -4501,8 +4722,8 @@
 	},
 /area/ruin/space/derelict/service)
 "yq" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/structure/crate,
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "yv" = (
@@ -4522,9 +4743,13 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "yx" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
+/obj/structure/rack,
+/obj/structure/sign/poster/contraband/free_drone{
+	pixel_x = -32
+	},
+/obj/item/stack/sheet/titaniumglass/fifty,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "yy" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/arrival)
@@ -4563,12 +4788,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "yN" = (
-/obj/machinery/modular_computer/console/preset/cargochat/science{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "yP" = (
@@ -4587,6 +4807,7 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -4610,6 +4831,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
+"za" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/side{
+	dir = 9
+	},
+/area/ruin/space/derelict/research)
 "zc" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron/smooth_large,
@@ -4623,6 +4850,7 @@
 /area/ruin/space/derelict/engineering)
 "zg" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/EVA)
 "zh" = (
@@ -4634,7 +4862,8 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/central)
 "zn" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -4666,6 +4895,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "zw" = (
@@ -4673,6 +4903,11 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
+"zy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "zz" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/iron,
@@ -4702,6 +4937,11 @@
 /area/ruin/space/derelict/medical)
 "zE" = (
 /obj/structure/barricade/wooden,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"zG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "zJ" = (
@@ -4736,6 +4976,7 @@
 "zS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/ruin/space/derelict/research)
 "zW" = (
@@ -4854,6 +5095,17 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
+"AB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/crew)
 "AF" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 1
@@ -4896,6 +5148,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"AQ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "AS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -4905,6 +5163,14 @@
 	},
 /turf/open/floor/carpet/blue/airless,
 /area/ruin/space/derelict/arrival)
+"AV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/directional/north{
+	start_charge = 0
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
 "AW" = (
 /obj/structure/chair/comfy/lime,
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -4960,6 +5226,7 @@
 "Bo" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port)
 "Bp" = (
@@ -4991,19 +5258,27 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Bx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
 	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/area/template_noop)
 "By" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/obj/structure/rack,
+/obj/item/storage/toolbox/syndicate{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/syndicate{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/storage/toolbox/syndicate{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/turf/open/floor/mineral/plastitanium/airless,
+/area/template_noop)
 "Bz" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5018,6 +5293,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
+"BG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "BI" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -5040,6 +5320,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/trash/mopbucket,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "BU" = (
@@ -5061,10 +5342,15 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
 /area/ruin/space/derelict/research)
+"BX" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
 "Ca" = (
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/iron/smooth_large,
@@ -5134,9 +5420,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "Co" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/structure/railing,
+/turf/open/floor/plating/airless,
+/area/template_noop)
 "Cu" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -5195,7 +5481,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
+/obj/item/stack/tile/iron/white,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/medical)
 "CE" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -5215,6 +5502,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "CL" = (
@@ -5223,7 +5511,6 @@
 	name = "Medbay";
 	req_access_txt = "5"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -5255,6 +5542,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"CS" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east{
+	start_charge = 0
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
 "CT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -5316,11 +5610,23 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Dt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/template_noop)
+"Dz" = (
+/obj/item/stack/cable_coil,
+/obj/structure/closet/crate,
+/obj/item/circuitboard/machine/protolathe/offstation,
+/obj/item/circuitboard/machine/circuit_imprinter/offstation,
+/obj/item/circuitboard/computer/research,
+/obj/item/circuitboard/machine/destructive_analyzer,
+/obj/item/storage/part_replacer/cargo,
+/turf/open/floor/iron/white/side{
+	dir = 9
+	},
 /area/ruin/space/derelict/research)
 "DC" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5394,6 +5700,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "Em" = (
@@ -5407,6 +5714,11 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
+"Eo" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
 "Ex" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -5415,6 +5727,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "EA" = (
@@ -5459,6 +5772,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "EN" = (
@@ -5476,10 +5790,11 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/security)
 "EX" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
 "EZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -5504,6 +5819,11 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
+"Fk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/central)
 "Fm" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -5606,8 +5926,17 @@
 "FZ" = (
 /obj/machinery/processor/slime,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
+"Ga" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "Gb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
@@ -5615,13 +5944,23 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "Ge" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south{
+	start_charge = 0
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
+"Gg" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "Gh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -5630,8 +5969,17 @@
 	pixel_y = 20
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
+"Gj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west{
+	start_charge = 0
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "Gm" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/iron/smooth_large,
@@ -5669,6 +6017,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -5711,12 +6061,26 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
+"GN" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "GO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /turf/template_noop,
 /area/template_noop)
+"GQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "GS" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
@@ -5724,6 +6088,15 @@
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/template_noop)
+"GT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/research)
 "GU" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/service/janitor)
@@ -5740,6 +6113,7 @@
 	inputting = 0
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "GX" = (
@@ -5780,6 +6154,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/maintenance/port)
 "Hk" = (
@@ -5874,9 +6249,22 @@
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "HJ" = (
-/obj/machinery/firealarm/directional/north,
+/obj/structure/rack,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
+"HL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/area/ruin/space/derelict/research)
 "HM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/meter,
@@ -5896,6 +6284,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/crew)
 "HR" = (
@@ -5908,6 +6297,7 @@
 /area/ruin/space/derelict/medical)
 "HS" = (
 /obj/machinery/portable_atmospherics/canister/bz,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "HT" = (
@@ -5928,6 +6318,7 @@
 /area/ruin/space/derelict/EVA)
 "HW" = (
 /obj/machinery/vending/clothing,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "Ia" = (
@@ -5940,16 +6331,13 @@
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "Ih" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"Il" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/cargo)
 "Iq" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
 	dir = 8;
@@ -5974,29 +6362,26 @@
 /area/ruin/space/derelict/maintenance/port)
 "Ix" = (
 /obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "Iy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "IA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 10
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/area/template_noop)
 "IB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/cargo)
 "IG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -6020,6 +6405,7 @@
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor/westleft,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -6049,19 +6435,27 @@
 /area/template_noop)
 "IX" = (
 /obj/structure/chair,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
+"Ja" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"Jd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
 "Je" = (
 /obj/machinery/computer/operating,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6143,6 +6537,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
+"JB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
 "JC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -6210,11 +6608,12 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "JZ" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/window/spawner/east,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/medical)
 "Ka" = (
@@ -6258,16 +6657,22 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/item/cultivator,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west{
+	start_charge = 0
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "Kh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "Kl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/EVA)
 "Kp" = (
@@ -6282,6 +6687,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -6293,6 +6699,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
+"Kv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/side{
+	dir = 10
+	},
+/area/ruin/space/derelict/research)
 "Kw" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -6302,7 +6714,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
+/area/ruin/space/derelict/medical)
 "KF" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
@@ -6315,6 +6727,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "KG" = (
@@ -6325,15 +6738,28 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "KJ" = (
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port)
+"KK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "KR" = (
 /obj/machinery/computer/security{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "KW" = (
@@ -6345,6 +6771,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "Lf" = (
@@ -6376,6 +6803,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"Li" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
 "Lj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -6423,6 +6854,13 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"Lx" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Ly" = (
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -6456,11 +6894,12 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port)
 "LD" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "LG" = (
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "c"
@@ -6484,7 +6923,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
 "LT" = (
-/obj/structure/chair,
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
@@ -6496,6 +6934,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "LY" = (
@@ -6510,6 +6949,7 @@
 "Md" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/siding/thinplating,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/hallway_primary)
 "Mf" = (
@@ -6546,6 +6986,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
+"Mo" = (
+/obj/structure/window/spawner,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "Mq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6572,15 +7017,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"Mw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "Mx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/template_noop,
+/area/template_noop)
 "My" = (
 /obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "MC" = (
@@ -6605,6 +7053,10 @@
 	dir = 1
 	},
 /area/ruin/space/derelict/service)
+"MG" = (
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "MI" = (
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/crowbar,
@@ -6619,6 +7071,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "MV" = (
@@ -6630,12 +7083,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port)
-"MX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
 "MY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -6649,8 +7096,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"Nb" = (
+/obj/effect/spawner/random/structure/chair_maintenance{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "Ne" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "Nf" = (
@@ -6666,15 +7121,9 @@
 /obj/machinery/shower{
 	pixel_y = 16
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"Nh" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Dock";
-	req_access_txt = "48"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
 "Ni" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6717,6 +7166,7 @@
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
 "Nw" = (
@@ -6748,6 +7198,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "ND" = (
@@ -6790,6 +7242,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"NM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "NO" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/bridge)
@@ -6822,6 +7279,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -6865,6 +7323,7 @@
 /area/ruin/space/derelict/engineering)
 "Ol" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/security/detective)
 "Om" = (
@@ -6897,7 +7356,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "Or" = (
-/obj/machinery/mecha_part_fabricator,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "Ot" = (
@@ -6923,7 +7383,16 @@
 	},
 /area/ruin/space/derelict/engineering/gravity_generator)
 "OB" = (
-/turf/closed/mineral/random/stationside/asteroid,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
 /area/template_noop)
 "OE" = (
 /obj/structure/table/glass,
@@ -6944,10 +7413,14 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/engineering)
 "OJ" = (
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "OK" = (
@@ -6966,6 +7439,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"OS" = (
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "OU" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -6992,20 +7468,14 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "Pb" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"Pd" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/cargo)
 "Pe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -7014,6 +7484,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "Pg" = (
@@ -7067,7 +7538,16 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "PB" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south{
+	start_charge = 0
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "PC" = (
@@ -7075,6 +7555,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "PD" = (
@@ -7088,6 +7569,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "PK" = (
@@ -7103,11 +7585,15 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "PP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "PQ" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/security)
@@ -7140,9 +7626,9 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/maintenance/starboard)
 "Qe" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "Qf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -7244,8 +7730,14 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "QO" = (
-/turf/template_noop,
-/area/ruin/space/derelict/maintenance/port/central)
+/obj/structure/sign/poster/contraband/syndicate_pistol{
+	pixel_y = -32
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "QP" = (
 /obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/iron,
@@ -7263,11 +7755,8 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port)
 "QV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/turf/closed/wall/r_wall/syndicate,
+/area/template_noop)
 "QW" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/blue{
@@ -7288,6 +7777,13 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/hallway_primary)
+"QZ" = (
+/obj/effect/spawner/random/structure/closet_private,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/ruin/space/derelict/crew)
 "Rg" = (
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil,
@@ -7295,6 +7791,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"Rj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/tile/iron/white/smooth_edge,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/medical)
 "Rk" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -7321,15 +7822,10 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
 "Rs" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "31"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
+/obj/item/stack/sheet/mineral/uranium/five,
+/obj/structure/closet/crate/radiation,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "Ru" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -7338,6 +7834,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -7354,9 +7851,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
+"RH" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
 "RI" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
 /obj/item/reagent_containers/food/drinks/britcup,
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 8
@@ -7364,6 +7864,7 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/hallway_primary)
 "RJ" = (
@@ -7439,6 +7940,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "RZ" = (
@@ -7449,14 +7951,18 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "Sd" = (
-/obj/machinery/suit_storage_unit/rd,
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "Se" = (
-/obj/machinery/computer/med_data,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/computer/crew,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
+"Sj" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/derelict/medical)
 "Sl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -7483,12 +7989,10 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/hallway_primary)
 "Sr" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Ss" = (
 /obj/structure/table,
 /obj/item/reagent_containers/dropper{
@@ -7500,6 +8004,11 @@
 "St" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	start_charge = 0
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "Su" = (
@@ -7547,6 +8056,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "SG" = (
@@ -7591,8 +8101,8 @@
 /turf/closed/wall/rust,
 /area/ruin/space/derelict/arrival)
 "SX" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/template_noop)
 "SY" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/arrival)
@@ -7659,12 +8169,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "TB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "TC" = (
@@ -7674,6 +8186,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "TF" = (
@@ -7713,6 +8226,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "TO" = (
@@ -7721,8 +8235,10 @@
 	},
 /area/ruin/space/derelict/hallway_primary)
 "TP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/ruin/space/derelict/maintenance/port/central)
+/area/ruin/space/derelict/crew)
 "TQ" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7735,6 +8251,7 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/research)
 "TU" = (
@@ -7750,6 +8267,7 @@
 "TV" = (
 /obj/structure/table,
 /obj/item/slime_extract/grey,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "TW" = (
@@ -7763,6 +8281,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "TZ" = (
@@ -7793,6 +8312,18 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"Ui" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Ul" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/maintenance/port)
@@ -7814,6 +8345,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
+"Ur" = (
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/ruin/space/derelict/medical)
 "Uu" = (
 /obj/effect/turf_decal/siding/thinplating/end,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7826,6 +8362,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"Uy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "Uz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -7841,6 +8385,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "UD" = (
@@ -7868,6 +8413,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "UG" = (
@@ -7891,10 +8437,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "UM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/obj/structure/fluff/oldturret,
+/turf/closed/wall/r_wall/syndicate,
+/area/template_noop)
 "UN" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/mineral/plastitanium,
@@ -7939,16 +8484,16 @@
 	},
 /area/ruin/space/derelict/security)
 "UV" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "toxins"
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/turf/open/floor/iron/large,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/security)
 "UW" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -7970,6 +8515,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research/xenobiology)
 "Va" = (
@@ -8057,6 +8603,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"Vu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
 "Vv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -8095,15 +8646,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "VC" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "31"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/space/derelict/cargo)
+/turf/open/floor/mineral/plastitanium/airless,
+/area/template_noop)
 "VF" = (
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
@@ -8116,6 +8660,7 @@
 "VG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "VH" = (
@@ -8136,9 +8681,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "VN" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/telecomms,
 /area/ruin/space/derelict/research)
 "VO" = (
@@ -8198,6 +8745,10 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/arrival)
+"Wf" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Wi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8262,6 +8813,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
+"Wz" = (
+/obj/structure/cable,
+/turf/open/floor/wood/airless,
+/area/ruin/space/derelict/arrival)
 "WA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -8320,6 +8875,15 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"WM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "WR" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -8331,9 +8895,10 @@
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "WT" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/ruin/space/derelict/maintenance/port/central)
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/security)
 "WU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -8346,8 +8911,19 @@
 /area/ruin/space/derelict/hallway_primary)
 "WW" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
+"Xa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/research)
 "Xc" = (
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -8360,10 +8936,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
+"Xg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Xi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "Xm" = (
@@ -8404,6 +8989,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"Xy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west{
+	start_charge = 0
+	},
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
 "Xz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -8449,6 +9042,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "XS" = (
@@ -8522,7 +9116,8 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
 "Yh" = (
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/central)
 "Yk" = (
 /turf/open/floor/iron/smooth_large,
@@ -8556,7 +9151,6 @@
 /area/ruin/space/derelict/medical)
 "Yt" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
 /obj/item/paper_bin{
 	pixel_y = 4
 	},
@@ -8570,6 +9164,7 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/hallway_primary)
 "Yv" = (
@@ -8599,11 +9194,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/cargo)
+/area/template_noop)
 "YB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -8623,17 +9217,25 @@
 "YE" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "YF" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
+"YI" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "YJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/ruin/space/derelict/research)
+/area/ruin/space/derelict/medical)
 "YK" = (
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port/lesser)
@@ -8665,6 +9267,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/circuit/telecomms/server,
 /area/ruin/space/derelict/research)
 "YT" = (
@@ -8699,7 +9302,7 @@
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
-/area/ruin/space/derelict/maintenance/port/central)
+/area/template_noop)
 "Za" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8738,15 +9341,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port)
 "Zm" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/research/xenobiology)
 "Zo" = (
-/obj/item/stack/sheet/iron/fifty,
-/turf/template_noop,
-/area/template_noop)
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/research)
 "Zr" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -8809,24 +9414,16 @@
 /turf/open/floor/iron/corner,
 /area/ruin/space/derelict/hallway_primary)
 "ZH" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "toxins"
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/large,
-/area/ruin/space/derelict/research)
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/crew)
 "ZI" = (
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "ZK" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
 /obj/item/folder/white,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -8840,6 +9437,7 @@
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/hallway_primary)
 "ZM" = (
@@ -8875,6 +9473,7 @@
 /area/ruin/space/derelict/hallway_primary)
 "ZR" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -8891,6 +9490,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "ZZ" = (
@@ -9261,11 +9861,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+UM
+QV
+QV
+QV
+UM
 aa
 aa
 aa
@@ -9345,13 +9945,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+QV
+QV
+ni
+nZ
+yx
+QV
+QV
 aa
 aa
 aa
@@ -9429,17 +10029,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-Yv
+UM
+QV
+mt
+SX
+VC
+SX
 Rs
-Yv
-Rs
-Yv
-Zo
+QV
+UM
+aa
+aa
 aa
 aa
 iX
@@ -9514,16 +10114,16 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-Yv
+QV
+mf
 SX
-Yv
+VC
+pD
+VC
 SX
-Yv
+Qe
+QV
+ZB
 aa
 aa
 aa
@@ -9593,31 +10193,31 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+QV
+ml
+VC
+nG
+rL
+By
+VC
+QO
+QV
 ZB
-Zj
-Tl
-Tl
-Tl
-Tl
-Tl
-Tl
-Tl
-Tl
-Tl
-Yv
-VC
-Yv
-VC
-Yv
-Tl
-Tl
+ZB
+ZB
 Tl
 iV
 kb
 kK
 kK
-kK
-kK
+CS
+tL
 oe
 kK
 kK
@@ -9670,32 +10270,32 @@ aa
 aa
 "}
 (10,1,1) = {"
-OB
-OB
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+QV
+mm
+SX
+VC
+tb
+VC
+SX
+SX
+QV
 aa
 aa
 ZB
-WS
-WS
-Tl
-bd
-Il
-Il
-Il
-Tl
-ZU
-ZU
-tb
-eh
-Pd
-Pd
-Pd
-gV
-ZU
-ZU
 Zx
 Zx
 Zx
@@ -9755,39 +10355,39 @@ aa
 aa
 "}
 (11,1,1) = {"
-OB
-OB
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-WS
-WS
-Yv
-MX
-MX
-MX
-MX
-Tl
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+UM
+QV
 HJ
-ZU
-ZU
-ZU
-eC
-ZU
-ZU
-ZU
-ZU
-ZU
+SX
+VC
+SX
+SX
+QV
+UM
+aa
+aa
+aa
 Zx
 ja
 kj
 kQ
 Zx
 mD
-YC
+Fk
 of
 aa
 yy
@@ -9847,32 +10447,32 @@ aa
 aa
 aa
 aa
-ZB
-WS
-WS
-Yv
-ZU
-ZU
-by
-ZU
-Nh
-ZU
-ZU
-ZU
-ZU
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 QV
-yk
-ZU
-yk
-ZU
-if
+QV
+nH
+ud
+SX
+QV
+QV
+aa
+aa
+aa
+aa
 Zx
 jd
 jd
 kR
 Zx
 kR
-YC
+Fk
 og
 aa
 qi
@@ -9933,31 +10533,31 @@ aa
 aa
 aa
 aa
-WS
-WS
-Tl
-Qe
-bl
-bz
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ZB
 UM
-cd
+QV
+uY
+QV
 UM
-UM
-UM
-UM
-eD
-wZ
-Co
-wZ
-hJ
-yq
+aa
+aa
+aa
+ZB
+ZB
 Zx
-TP
-YC
-YC
-jB
-TP
-YC
+mL
+Fk
+Fk
+Ga
+mL
+Fk
 Zx
 aa
 yy
@@ -10017,31 +10617,31 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ZB
-WS
-WS
-Yv
-ZU
-ZU
-QV
-ZU
-Nh
-ZU
-ZU
-ZU
-ZU
-YA
-yq
-ZU
-hd
-ZU
-yq
+aa
+nI
+wZ
+Co
+aa
+aa
+aa
+ZB
+ZB
+aa
 Zx
-YC
+Fk
 jd
 kR
 Zx
-YC
+Fk
 jd
 Zx
 GU
@@ -10054,7 +10654,7 @@ Vv
 QL
 Pv
 Ru
-Ru
+Gj
 SV
 ZB
 ZB
@@ -10103,30 +10703,30 @@ aa
 aa
 aa
 aa
-WS
-WS
-Yv
-ZU
-ZU
-QV
-ZU
-Tl
-PB
-ZU
-ZU
-ZU
-YA
+aa
+aa
+aa
+aa
+aa
+aa
+ZB
+ZB
+aa
+nJ
+wZ
+EX
+ZB
+aa
+ZB
+ZB
+aa
+aa
 Zx
-Zx
-Zx
-Zx
-Zx
-Zx
-TP
+mL
 ko
 Zx
 Zx
-jd
+NM
 np
 Zx
 se
@@ -10150,9 +10750,9 @@ Yd
 UQ
 Yd
 UQ
-QU
+Li
 fM
-LB
+df
 aG
 RS
 Rg
@@ -10188,30 +10788,30 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
+aa
 ZB
-WS
-Tl
-EX
-ZU
-QV
-ZU
-Tl
-PB
-ZU
-ZU
-ZU
-YA
-Zx
-QO
-WT
-WT
-QO
+ZB
+aa
+aa
+ZB
+ZB
+aa
+aa
+ZB
+aa
+ZB
+ZB
+aa
 iD
-YC
+Fk
 ko
 Zx
 lZ
-YC
+Fk
 nq
 Zx
 ht
@@ -10224,7 +10824,7 @@ VH
 yA
 Ka
 SY
-VS
+Wz
 VS
 VS
 Ul
@@ -10235,9 +10835,9 @@ DC
 Fg
 AK
 Yd
-ZW
+vG
 Ul
-LB
+df
 LB
 LB
 LB
@@ -10274,29 +10874,29 @@ aa
 aa
 aa
 aa
-WS
-Tl
-Yv
-Tl
-bB
-ZU
-Tl
-pD
-ZU
-ZU
-ZU
+aa
+aa
+aa
+aa
+ZB
+aa
+aa
+ZB
+ZB
+ZB
+aa
 YA
-Zx
-WT
-Zx
-Zx
-Zx
+ZB
+ZB
+Mb
+Mb
+Mb
 Zx
 Zx
 Zx
 Zx
 mb
-TP
+mL
 jd
 Zx
 Oo
@@ -10309,18 +10909,18 @@ VT
 tJ
 Ka
 qi
-VS
+Wz
 oX
-VS
+Wz
 Hj
 pd
 sZ
-ZW
-ZW
-ZW
+vG
+vG
+vG
 ND
 UQ
-ZW
+vG
 Ul
 GW
 hR
@@ -10359,29 +10959,29 @@ aa
 aa
 aa
 aa
-WS
-aV
-be
-bn
-ZU
-ZU
-Tl
-OJ
-ZU
-rL
-ZU
-YA
-Zx
+aa
+aa
+aa
+aa
+ZB
+lv
+ZB
+ZB
+aa
+ZB
+IA
+OB
+aa
 YY
-Zx
+Mb
 hP
-Ch
+vc
 Mb
 jj
 Ch
 Zx
 Zx
-TP
+mL
 nr
 Zx
 sk
@@ -10402,10 +11002,10 @@ qC
 gm
 Yk
 Yk
-ZW
+vG
 DC
 Yd
-ZW
+vG
 BU
 iy
 hR
@@ -10444,9 +11044,9 @@ aa
 aa
 aa
 aa
-WS
-Tl
-Tl
+aa
+aa
+aa
 YO
 YO
 bP
@@ -10456,17 +11056,17 @@ Tl
 Tl
 en
 xX
-Zx
-WT
-Zx
-LY
-HP
+Tl
+ZB
 Mb
 LY
 HP
+Mb
+QZ
+HP
 Zx
-YC
-YC
+Fk
+Fk
 Zx
 Zx
 Zx
@@ -10487,7 +11087,7 @@ UQ
 Yd
 Yd
 Yd
-ZW
+tw
 Yn
 UQ
 Bo
@@ -10533,30 +11133,30 @@ aa
 aa
 ZB
 YO
-YK
-YK
+bB
+kZ
 YO
 cA
 cY
-tb
+yq
 ZU
-YA
-Zx
-WT
-Zx
-Mb
-pF
+OJ
+Tl
+ZB
 Mb
 Mb
 pF
+Mb
+Mb
+pF
 Zx
-YC
+Fk
 mP
 Zx
 oh
 sv
 Zx
-YC
+Fk
 Gm
 Zx
 Ru
@@ -10572,10 +11172,10 @@ Ul
 Yk
 DC
 tM
-ZW
-ZW
-QU
-ZW
+vG
+vG
+Li
+vG
 BU
 ho
 oC
@@ -10618,30 +11218,30 @@ aa
 WS
 ZB
 YO
-YK
-YK
+bB
+kZ
 YO
 cC
-ZU
-ZU
+nM
+nM
 vU
 eE
-Zx
+Tl
 fk
-Zx
+Mb
 HW
 Gb
 wS
 jo
 kq
 Zx
-YC
+Fk
 Zx
 Zx
 on
 sD
 Zx
-YC
+Fk
 YC
 jZ
 Ru
@@ -10660,7 +11260,7 @@ DC
 DC
 Yk
 DC
-ZW
+vG
 Ul
 OA
 cL
@@ -10703,30 +11303,30 @@ YO
 aW
 YO
 YO
-YK
+kV
 bR
 YO
 cD
 db
 SE
-SE
+IB
 eF
-Zx
-WT
-Zx
+Tl
+ZB
+Mb
 QP
-Tq
+xE
 Tz
-Tq
-Tq
+xE
+xE
 Zx
-YC
+Fk
 Zx
 nv
 on
 Zx
 Zx
-YC
+Fk
 Gu
 Zx
 Pv
@@ -10745,7 +11345,7 @@ Yd
 UQ
 UQ
 Yd
-ZW
+vG
 Ul
 RN
 co
@@ -10788,30 +11388,30 @@ YO
 YK
 YO
 bp
-YK
-YK
+kZ
+bB
 YO
 cE
 dc
 dy
 yk
-YA
-Zx
+PB
+Mb
 fp
-Zx
+Mb
 St
-Tq
+xE
 iH
 qa
 kr
 Zx
-YC
+Fk
 Zx
 Oa
 Zx
 Zx
-YC
-TP
+Fk
+mL
 ko
 Zx
 WL
@@ -10830,7 +11430,7 @@ Em
 uq
 LH
 UQ
-ZW
+vG
 BU
 XT
 Uc
@@ -10872,8 +11472,8 @@ YO
 YO
 aX
 YO
-YK
-YK
+bB
+kZ
 YO
 YO
 Yv
@@ -10881,21 +11481,21 @@ Yv
 dz
 eo
 eJ
-Zx
+Mb
 TP
-Zx
+Mb
 hQ
 ip
 PC
-Tq
+xE
 ks
 Zx
-TP
-YC
-YC
-YC
-jB
-YC
+mL
+Fk
+Fk
+Fk
+Ga
+Fk
 Zx
 Zx
 Zx
@@ -10915,7 +11515,7 @@ UQ
 Yd
 Yd
 Yd
-QU
+Li
 BU
 RN
 sa
@@ -10949,33 +11549,33 @@ aa
 Zw
 ad
 as
-ON
+aV
 TK
 ON
 cK
 YO
-YK
-YK
-YK
-YK
-YK
+bp
+bB
+bB
+bB
+kZ
 YO
 cl
 cl
 cl
 My
 eq
-YW
-Zx
-TP
+PP
+Mb
+ZH
 qN
-Tq
-Tq
-Tz
-Tq
+jW
+jW
+AB
+xE
 pg
 Zx
-YC
+jX
 Zx
 nA
 nA
@@ -11033,34 +11633,34 @@ aa
 aa
 Zw
 af
-ON
-ON
-uf
-ON
+aV
+aV
+bd
+aV
 aO
 YO
-YK
-YK
-YK
-YK
-YK
+by
+bB
+YO
+bB
+kZ
 YO
 cm
 io
 io
 io
-Ua
-YW
-Zx
-Zx
-Zx
+kD
+mY
+Mb
+Mb
+Mb
 Mb
 ir
-Tz
+AB
 Tq
 kB
 Zx
-YC
+Fk
 mV
 nB
 op
@@ -11119,9 +11719,9 @@ aa
 Zw
 bV
 ka
-ON
+aV
 uf
-ON
+aV
 oi
 YO
 YO
@@ -11135,7 +11735,7 @@ cH
 dd
 dJ
 Ua
-YW
+mY
 Sq
 Jj
 Ug
@@ -11206,39 +11806,39 @@ ag
 at
 ax
 nt
-ON
-oi
+aV
+bl
 aQ
 ll
 oi
 bh
 bq
+lc
+kD
 Ua
-Ua
-Ua
-dU
-Ua
-Ua
-Ua
-YW
-Ua
-Ua
-Ua
-Oy
-Ua
-YW
-Ua
-Ua
+DD
+kD
+kD
+kD
+mY
+kD
+kD
+kD
+FE
+kD
+PP
+kD
+Wf
 kS
+lc
+zG
+Ua
+xL
+AQ
 Ua
 Ua
 Ua
-Ua
-Kw
-Ua
-Ua
-Ua
-Ua
+kD
 kD
 YW
 Ua
@@ -11292,38 +11892,38 @@ ll
 az
 nu
 aL
-ok
+bn
 aR
 aS
 ok
 bi
 br
-Bf
-Bf
-Bf
-cI
-Bf
-Bf
-Bf
+ld
+ld
+ld
+El
+ld
+ld
+ld
 eN
-Bf
+ld
 fq
-Bf
+xe
 hS
-Bf
+ld
 VG
-Bf
-Bf
-Bf
-Bf
-Bf
-fq
-Bf
+ld
+Xg
+ld
+ld
+vr
+WM
+GQ
 sH
-Bf
+XV
 jD
 jD
-Bf
+XV
 Bf
 iF
 XV
@@ -11376,36 +11976,36 @@ iE
 Rw
 az
 aA
-ON
-oi
+aV
+bl
 aQ
 ll
 aZ
-bh
+dU
 bs
-Ua
+li
 Ua
 yR
-YW
+mY
 yR
 Ua
-Ua
-Ua
-tZ
-lr
-Ua
+kD
+kD
+Sr
+xY
+kD
 Oy
 Ua
-YW
-Ua
-Ua
-Ua
-Ua
-Ua
-lr
-Ua
+mY
+kD
+kD
+kD
+li
+QD
+xY
+MG
 Kw
-tZ
+Sr
 jE
 Ua
 Ua
@@ -11460,9 +12060,9 @@ Zw
 ap
 lA
 ON
-aB
-ON
-oi
+be
+aV
+bl
 hU
 hU
 hU
@@ -11472,16 +12072,16 @@ bD
 Qb
 cp
 cQ
-cp
+nR
 ER
 ER
 ER
 ER
 fr
-By
+na
 Sq
-Ua
-YW
+kD
+mY
 Ua
 Yl
 Yl
@@ -11543,17 +12143,17 @@ aa
 aa
 Zw
 aq
-ON
+aV
 ON
 aB
 ON
 aP
 hU
-Xq
-Xq
-Xq
-Xq
-Xq
+bz
+cd
+hU
+cd
+lj
 Qb
 cr
 cR
@@ -11565,19 +12165,19 @@ ER
 ER
 ER
 ER
-Ua
-YW
+kD
+mY
 Ua
 Yl
 Yh
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
+sN
+em
+YI
+OS
+Mo
+pR
+pJ
+ZB
 Ag
 QK
 Xw
@@ -11631,38 +12231,38 @@ kL
 cG
 ON
 aC
-ON
+aV
 cK
 hU
 aT
-Xq
-Xq
-Xq
-Xq
+cd
+cd
+cd
+lj
 Qb
 iA
 cS
-iA
+nT
 Ot
 QA
-QA
+if
 eX
 fb
 he
 ER
-Ua
-YW
+kD
+mY
 Ua
 Yl
-Yh
+sN
 YD
 YD
 YD
 YD
 YD
 YD
-ud
-Yh
+ZB
+aa
 Bb
 Lo
 Lw
@@ -11714,7 +12314,7 @@ aa
 NO
 NO
 lB
-ON
+aV
 aF
 aM
 NO
@@ -11722,32 +12322,32 @@ hU
 hU
 ba
 hU
-Xq
-Xq
+hU
+lj
 Qb
-fl
+mn
 cQ
 fl
 ER
-QA
-QA
+if
+if
 eZ
 fs
 hf
 ER
 Ua
-YW
-Ua
+mY
+kD
 Yl
-Yh
+sN
 YD
 tz
 JF
 JF
 sO
 YD
-Yh
-sb
+ZB
+Eo
 Yl
 kD
 Oi
@@ -11807,22 +12407,22 @@ ZB
 hU
 Xq
 hU
-Xq
-Xq
+hJ
+lr
 Qb
 Mj
 cU
 dk
 QA
-QA
+if
 yw
 yw
-QA
+if
 hg
 hN
-Ua
-YW
-jr
+kD
+mY
+or
 Yl
 Yh
 YD
@@ -11898,18 +12498,18 @@ Qb
 Ne
 TC
 QA
-QA
+if
 IX
 XS
 fb
 fE
 KR
 ER
-Ua
-YW
-Ua
+kD
+mY
+kD
 Yl
-Yh
+sN
 YD
 UJ
 HB
@@ -11977,24 +12577,24 @@ aa
 ZB
 WS
 PQ
+if
+if
 QA
-QA
-QA
-QA
-TC
-QA
+if
+ne
+if
 dL
 IX
 Mr
 fc
-QA
-QA
+if
+if
 ER
-Ua
-YW
-Ua
+kD
+mY
+kD
 Yl
-Yh
+sN
 YD
 in
 kt
@@ -12062,24 +12662,24 @@ aa
 aa
 ZB
 PQ
-QA
-QA
-QA
-QA
-TC
-QA
+jr
+lu
+lC
+lu
+ne
+if
 dM
-QA
-QA
-QA
-QA
+if
+if
+if
+if
 hh
 ER
-Ua
-YW
+BG
+Ui
 Ua
 Yl
-Yh
+sN
 YD
 cJ
 nC
@@ -12090,7 +12690,7 @@ Cv
 Ak
 Kl
 Mq
-Oi
+mY
 kD
 NB
 PH
@@ -12156,26 +12756,26 @@ SL
 dN
 SL
 SL
-SL
+UV
 fI
 hi
 ER
 Ua
-YW
+mY
 Ua
 Yl
-Yh
+sN
 YD
 cJ
 nD
-HB
+Vu
 sQ
 Zt
 Zt
 Zt
 Zt
 QQ
-Oi
+mY
 Ua
 Ya
 UN
@@ -12246,10 +12846,10 @@ IJ
 Ot
 ER
 XF
-YW
-Ua
+mY
+kD
 Yl
-Yh
+sN
 YD
 HU
 nF
@@ -12319,22 +12919,22 @@ aa
 aa
 PQ
 bI
-vj
+lD
 ct
 PQ
 Bv
-vj
-ct
+lD
+LD
 PQ
-Bv
+WT
 vj
-ct
+LD
 ER
 Ua
-YW
-Ua
+Ui
+Wm
 Yl
-Yh
+sN
 YD
 YD
 YD
@@ -12345,7 +12945,7 @@ Cz
 RQ
 Sq
 kD
-Oi
+mY
 kD
 Ya
 SA
@@ -12407,22 +13007,22 @@ Iy
 fd
 Iy
 PQ
-dm
+nV
 dR
 et
 PQ
 dm
 dR
-et
+cc
 ER
-Ua
-YW
-Ua
+kD
+mY
+kD
 Yl
-Yh
-Yh
-Yh
-yx
+sN
+wy
+Nb
+Yl
 ot
 qm
 Yl
@@ -12430,7 +13030,7 @@ Yl
 Yl
 Yl
 kD
-Oi
+mY
 kD
 Ya
 Qu
@@ -12500,22 +13100,22 @@ eu
 eu
 eu
 eu
-Ua
-YW
-Ua
-Yl
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
-me
+BG
+Ui
 kD
-Oi
+Yl
+sN
+Yh
+sN
+GN
+sK
+sN
+sN
+sN
+sN
+me
+lc
+mY
 kD
 Ya
 Ya
@@ -12531,7 +13131,7 @@ Un
 Un
 lk
 YF
-rI
+AV
 rI
 Py
 FR
@@ -12586,30 +13186,30 @@ fN
 hl
 Ol
 Ey
-YW
-Ua
+mY
+kD
 Yl
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
+Yl
+Mw
+Yl
+Yl
+Yl
+Gg
+sN
+em
 Yl
 Yl
 Lo
 XR
-XV
-XV
+ld
+ld
 oR
 PI
 Kg
 tP
 dj
-Tm
-ar
+RH
+jk
 CK
 WW
 WW
@@ -12671,16 +13271,16 @@ gr
 hm
 Ns
 Kr
-Jd
+UB
 Xv
+Sq
+aa
+ZB
+aa
 Yl
-Yh
-Yh
-Yh
-YD
-Yh
-Yh
-Yh
+ah
+em
+sN
 sb
 Yl
 Lr
@@ -12756,12 +13356,12 @@ gC
 hq
 Ol
 iv
-YW
+mY
 Ua
-YD
-YD
-YD
-YD
+uu
+ZB
+ZB
+ZB
 YD
 Yl
 Yl
@@ -12769,7 +13369,7 @@ zh
 Yl
 Yl
 LT
-kD
+du
 Oi
 Ua
 kD
@@ -12840,17 +13440,17 @@ fQ
 fQ
 fQ
 fQ
+kD
+mY
 Ua
-YW
-Ua
-PD
-kV
-ZH
-UV
-PD
+uu
+aa
+ZB
+aa
+Sj
 oy
-kT
-Zg
+Xy
+BX
 Ji
 mJ
 LT
@@ -12922,19 +13522,19 @@ aa
 Ti
 eT
 kd
-kd
+Lx
 Ua
 Ua
-Ua
-YW
-Ua
-PD
-kV
-UV
-UV
-PD
+kD
+Ui
+BG
+uu
+aa
+ZB
+aa
+Sj
 oz
-kT
+xi
 kT
 Ht
 mJ
@@ -13005,19 +13605,19 @@ aa
 ZB
 aa
 Ti
-Ua
-Ua
-Ua
-Ua
-Ua
-Ua
-YW
-Ua
-PD
-kV
-UV
-UV
-PD
+kD
+kD
+kD
+kD
+kD
+kD
+mY
+kD
+uu
+aa
+ZB
+aa
+Sj
 JK
 Zg
 kT
@@ -13093,16 +13693,16 @@ Ti
 ZI
 gk
 Nf
-Ua
-tZ
+kD
+Sr
 gk
 iI
 gk
-PD
-kZ
-mf
-mf
-PD
+uu
+aa
+ZB
+aa
+Sj
 zJ
 kT
 Zg
@@ -13184,11 +13784,11 @@ PD
 iJ
 PD
 PD
-tA
-tA
-tA
-PD
-PD
+ZB
+ZB
+ZB
+Sj
+Sj
 Zg
 kT
 CN
@@ -13255,7 +13855,7 @@ Ls
 bu
 Zu
 Zm
-Ls
+mr
 bu
 Zu
 Zm
@@ -13269,13 +13869,13 @@ ED
 mK
 jt
 WC
-NE
-NE
-NE
-nG
-PD
+aa
+ZB
+aa
+aa
+Sj
 uz
-kT
+xi
 tO
 kT
 Mt
@@ -13338,27 +13938,27 @@ aa
 Zm
 Xs
 Zu
-Zu
+hd
 Zm
-Xs
-Zu
-Zu
+ms
+hd
+hd
 Zm
 pc
-NE
-NE
-NE
-NE
+yN
+yN
+yN
+yN
 WC
 Ng
-WA
+KK
 Ie
 WC
-lc
-NE
-mY
-nH
-PD
+aa
+ZB
+aa
+aa
+Sj
 uB
 kU
 Dh
@@ -13372,7 +13972,7 @@ Mm
 TO
 ZB
 ZB
-ZB
+vI
 ZB
 aa
 aa
@@ -13422,15 +14022,15 @@ aa
 aa
 Zm
 Xs
-Zu
-Zu
+hd
+hd
 Zm
 Xs
-Zu
-Zu
+hd
+hd
 Zm
 ex
-NE
+yN
 NE
 gz
 hr
@@ -13439,11 +14039,11 @@ Gh
 KY
 ju
 WC
-ld
-NE
-gH
-nI
-PD
+aa
+ZB
+ZB
+ZB
+Sj
 mJ
 zp
 Dn
@@ -13515,7 +14115,7 @@ bv
 Yf
 Zm
 fS
-NE
+yN
 NE
 RX
 hx
@@ -13524,14 +14124,14 @@ WC
 Gv
 WC
 WC
-li
-NE
-gH
-nJ
-PD
+aa
+ZB
+aa
+aa
+Sj
 uP
 Zg
-kT
+xi
 HF
 xp
 RP
@@ -13600,20 +14200,20 @@ bw
 wT
 Zm
 Zm
-NE
-NE
+yN
+yN
 od
 hA
 WC
 FO
 mH
-FO
+Zo
 WC
-lj
-NE
-gH
-nM
-PD
+aa
+ZB
+aa
+aa
+Sj
 vf
 Zg
 mX
@@ -13623,7 +14223,7 @@ Se
 ZO
 ji
 Sq
-aa
+Ur
 aa
 aa
 aa
@@ -13676,17 +14276,17 @@ aa
 aa
 aa
 Yf
-Ty
-Ty
-Ty
+gV
+gV
+gV
 cb
-Ty
-Ty
+gV
+gV
 Ty
 qz
 Zm
 hb
-NE
+yN
 gH
 NE
 WC
@@ -13694,19 +14294,19 @@ ZX
 iK
 tA
 WC
-lu
-NE
-IB
-oV
-PD
+aa
+ZB
+aa
+YY
+Sj
 vn
 kT
 kT
 Ih
 mJ
-Sl
+xp
 CL
-Sl
+xp
 mJ
 yQ
 HG
@@ -13762,18 +14362,18 @@ aa
 aa
 Yf
 Ty
-Ty
-Ty
+gV
+gV
 Vq
 GA
 cV
-cV
+nY
 dV
 ey
 Kh
 OZ
 gR
-Kh
+Uy
 gM
 zS
 iL
@@ -13785,9 +14385,9 @@ Bx
 nQ
 Kx
 vo
-kT
+xi
 Zg
-kT
+xi
 kT
 Zg
 On
@@ -13796,7 +14396,7 @@ dp
 uv
 HD
 HR
-HD
+Rj
 WR
 DW
 dD
@@ -13851,23 +14451,23 @@ UY
 bM
 Zm
 QB
-Ty
+ng
 Ty
 dZ
 Zm
 ZR
 gp
-YV
-YV
+Dz
+za
 WC
 iw
-WA
-YV
+Xa
+za
 WC
-Sr
-PP
-IA
-oV
+aa
+aa
+ZB
+aa
 YJ
 vC
 kT
@@ -13936,7 +14536,7 @@ bx
 NJ
 Zm
 HS
-Ty
+nh
 dq
 FZ
 Zm
@@ -13947,19 +14547,19 @@ gS
 WC
 ZR
 WA
-YV
+za
 WC
-lv
-ml
-NE
-nR
+aa
+aa
+ZB
+aa
 YJ
 vP
 zq
 kT
 It
 Ni
-kT
+xi
 Za
 kT
 Zg
@@ -14016,28 +14616,28 @@ aa
 aa
 aa
 Zm
-Zu
-Zu
+hd
+hd
 Xs
 Zm
 cx
-Ty
+nh
 dt
 ec
 Zm
 eV
 aD
-aD
-aD
+JB
+JB
 WC
-iw
-WA
-YV
 WC
-lC
-LD
-NE
-uY
+GT
+WC
+WC
+ZB
+ZB
+ZB
+aa
 YJ
 mJ
 mJ
@@ -14051,7 +14651,7 @@ xp
 Yr
 mJ
 Fy
-Sl
+xp
 mJ
 mJ
 VF
@@ -14101,28 +14701,28 @@ aa
 aa
 aa
 Zm
-Zu
-Zu
+hd
+hd
 Xs
 Zm
 uW
 Ty
-Ty
+gV
 ef
 Zm
 Or
-FO
-aD
+Zo
+JB
 hE
 WC
-iw
-WA
+bk
+xW
 YV
 WC
-lD
-mm
-NE
-nT
+aa
+aa
+ZB
+aa
 YJ
 vX
 zB
@@ -14200,14 +14800,14 @@ WC
 WC
 WC
 WC
-iw
-mK
+Kv
+yj
 jH
 WC
 WC
-mn
-ne
-nV
+aa
+ZB
+aa
 pH
 wK
 Zg
@@ -14279,19 +14879,19 @@ Yf
 Yf
 Yf
 Zm
-ez
+eB
 Pt
 fh
 Sd
 YE
-NE
-NE
+yN
+yN
 ch
-jI
+jP
 jP
 lE
 mo
-ng
+ZB
 nX
 pV
 xa
@@ -14370,15 +14970,15 @@ TS
 wj
 wj
 sG
-NE
-WA
-NE
+zy
+Ja
+yN
 yN
 WC
-mr
-nh
-nY
-PD
+aa
+ZB
+aa
+Sj
 JK
 mX
 Zg
@@ -14455,15 +15055,15 @@ fh
 Kp
 hG
 SF
-NE
-WA
-NE
+yN
+Xa
+yN
 Ix
 WC
-ms
-ni
-nZ
-PD
+ZB
+ZB
+ZB
+Sj
 JK
 zJ
 kT
@@ -14542,26 +15142,26 @@ WC
 hT
 NE
 uj
-NE
+iG
 WC
 WC
-mt
-mt
-mt
-PD
-xp
-xp
+aa
+aa
+aa
+Sj
 mJ
 mJ
-xp
-xp
 mJ
 mJ
-xp
-xp
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
 mJ
 JZ
-Sl
+mO
 mJ
 mJ
 aa
@@ -14627,7 +15227,7 @@ WC
 hV
 xP
 gW
-gS
+HL
 WC
 ZB
 aa
@@ -14709,10 +15309,10 @@ aa
 ZB
 ZB
 WC
-hZ
+id
 iz
-aD
-aD
+JB
+qv
 As
 aa
 aa
@@ -14796,7 +15396,7 @@ ZB
 WC
 ic
 iB
-iN
+jJ
 jJ
 WC
 aa

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -47,7 +47,6 @@
 /area/ruin/space/derelict/service)
 "as" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "at" = (
@@ -170,6 +169,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/bridge)
 "aS" = (
@@ -180,6 +180,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -274,6 +275,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/bridge)
 "bk" = (
@@ -300,6 +302,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
 "bp" = (
@@ -322,6 +325,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -532,6 +536,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine/airless,
 /area/ruin/space/derelict/engineering)
+"cg" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
 "ch" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -2968,7 +2978,6 @@
 "nt" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/secure/briefcase,
-/obj/item/assembly/flash/handheld,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -3197,6 +3206,7 @@
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
 "on" = (
@@ -3512,6 +3522,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
+"qh" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/directional/south{
+	start_charge = 0
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/edge,
+/area/ruin/space/derelict/bridge)
 "qi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4207,7 +4226,6 @@
 /area/ruin/space/derelict/research/xenobiology)
 "uY" = (
 /obj/machinery/door/airlock/vault/derelict,
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/syndipod)
@@ -6765,6 +6783,14 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
+"KI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south{
+	start_charge = 0
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "KJ" = (
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port)
@@ -12001,7 +12027,7 @@ Rw
 az
 aA
 aV
-bl
+cg
 aQ
 ll
 aZ
@@ -12086,7 +12112,7 @@ lA
 ON
 be
 aV
-bl
+qh
 hU
 hU
 hU
@@ -12970,7 +12996,7 @@ RQ
 Sq
 kD
 mY
-kD
+KI
 Ya
 SA
 Vb

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -30,9 +30,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
-"am" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/research)
 "ap" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/iron/white/side,
@@ -438,6 +435,9 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research/xenobiology)
+"bN" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "bO" = (
 /obj/effect/turf_decal/bot,
 /obj/item/storage/toolbox/mechanical,
@@ -702,6 +702,9 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/hallway_primary)
+"cI" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/maintenance/starboard)
 "cK" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -723,9 +726,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"cO" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/medical)
 "cP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -1601,6 +1601,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/research)
+"gX" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/service/janitor)
 "hb" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_y = 32
@@ -2947,9 +2950,6 @@
 "nv" = (
 /turf/open/floor/wood,
 /area/ruin/space/derelict/maintenance/port/central)
-"nw" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/security)
 "nz" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer";
@@ -2982,7 +2982,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "nD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/airless,
@@ -3063,6 +3063,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
+"nW" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/crew)
 "nX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/plating/airless{
@@ -4067,6 +4070,9 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
+"vl" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/research/xenobiology)
 "vm" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4560,9 +4566,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
-"yU" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/maintenance/starboard)
 "yW" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -4655,6 +4658,9 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
+"zF" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/security)
 "zG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/streak,
@@ -4975,6 +4981,9 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"BH" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/research)
 "BI" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -5220,6 +5229,9 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"CW" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/cargo)
 "CX" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -5590,9 +5602,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"Gk" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/research)
 "Gm" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/iron/smooth_large,
@@ -5655,6 +5664,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
+"GB" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/research)
 "GC" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
@@ -5776,6 +5788,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"Ho" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/bridge)
 "Ht" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -5790,9 +5805,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
-"HH" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/cargo)
 "HI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -5891,9 +5903,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/ruin/space/derelict/security)
-"Iz" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/hallway_primary)
 "IA" = (
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
@@ -6027,6 +6036,9 @@
 /obj/machinery/biogenerator,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/service)
+"JJ" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/hallway_primary)
 "JK" = (
 /obj/structure/table,
 /turf/open/floor/iron/white/airless,
@@ -6273,9 +6285,6 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
-"Lw" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/crew)
 "Lx" = (
 /obj/structure/chair{
 	dir = 4
@@ -6343,9 +6352,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
-"LM" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/security)
 "LT" = (
 /obj/effect/turf_decal/siding/thinplating_new,
 /turf/open/floor/iron/dark/airless,
@@ -6369,9 +6375,6 @@
 "Mb" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/crew)
-"Mc" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/security/detective)
 "Md" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -6524,16 +6527,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
-"Nu" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/security/detective)
 "Nw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
-"Nx" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/bridge)
 "Ny" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -6715,6 +6712,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/engineering)
+"OL" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/starboard)
 "ON" = (
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
@@ -6732,9 +6732,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"OV" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/maintenance/starboard/central)
 "OW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6981,9 +6978,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/ruin/space/derelict/engineering)
-"QG" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/maintenance/port/lesser)
 "QH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/meter,
@@ -7091,9 +7085,6 @@
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/template_noop)
-"RF" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/maintenance/starboard)
 "RH" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -7786,6 +7777,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"VI" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/medical)
 "VL" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -7875,9 +7869,6 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"Wr" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/service/janitor)
 "Wt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -8017,9 +8008,6 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/engineering/gravity_generator)
-"Xe" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/research/xenobiology)
 "Xf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -8051,6 +8039,9 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/hallway_primary)
+"Xn" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/port/lesser)
 "Xp" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless{
@@ -8100,6 +8091,9 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"XG" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/security/detective)
 "XK" = (
 /obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 8
@@ -8196,6 +8190,9 @@
 	icon_state = "floorscorched1"
 	},
 /area/ruin/space/derelict/hallway_primary)
+"Yr" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/security/detective)
 "Yv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8416,6 +8413,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"ZL" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/security)
 "ZN" = (
 /obj/item/bikehorn,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9595,10 +9595,10 @@ Fk
 jd
 Zx
 GU
-Wr
+gX
 GU
 GU
-Wr
+gX
 Bs
 Vv
 QL
@@ -9840,7 +9840,7 @@ ZB
 ZB
 Mb
 Mb
-Lw
+nW
 kM
 Zx
 Zx
@@ -10085,15 +10085,15 @@ ZB
 YO
 FM
 SH
-QG
+Xn
 cA
 cY
 yq
 ZU
 OJ
-HH
+CW
 ZB
-Lw
+nW
 Mb
 pF
 Mb
@@ -10176,9 +10176,9 @@ nM
 nM
 vU
 eE
-HH
+CW
 fk
-Lw
+nW
 HW
 Gb
 wS
@@ -10263,7 +10263,7 @@ IB
 eF
 Tl
 ZB
-Lw
+nW
 QP
 xE
 Tz
@@ -10328,13 +10328,13 @@ aa
 aa
 aa
 NO
-Nx
-Nx
-Nx
-Nx
+Ho
+Ho
+Ho
+Ho
 NO
 ZB
-QG
+Xn
 YK
 YO
 bp
@@ -10412,7 +10412,7 @@ aa
 (24,1,1) = {"
 aa
 NO
-Nx
+Ho
 tH
 au
 bX
@@ -10424,8 +10424,8 @@ aX
 YO
 FM
 kZ
-QG
-QG
+Xn
+Xn
 Yv
 Yv
 dz
@@ -10503,7 +10503,7 @@ aV
 TK
 ON
 cK
-QG
+Xn
 uj
 bB
 FM
@@ -10591,7 +10591,7 @@ aO
 YO
 by
 FM
-QG
+Xn
 FM
 SH
 YO
@@ -10673,10 +10673,10 @@ aV
 uf
 aV
 oi
-QG
+Xn
 YO
-QG
-QG
+Xn
+Xn
 YO
 bC
 YO
@@ -11015,7 +11015,7 @@ aV
 qh
 hU
 hU
-yU
+OL
 hU
 hU
 bD
@@ -11024,8 +11024,8 @@ cp
 cQ
 nR
 ER
-nw
-nw
+zF
+zF
 ER
 fr
 na
@@ -11042,7 +11042,7 @@ Yl
 Yl
 Yl
 Yl
-OV
+bN
 zX
 Yq
 iz
@@ -11112,9 +11112,9 @@ Ot
 er
 ib
 ER
-nw
+zF
 ER
-nw
+zF
 kD
 fv
 eB
@@ -11183,13 +11183,13 @@ ON
 aC
 aV
 cK
-yU
+OL
 aT
 cd
 cd
 cd
 lj
-RF
+cI
 iA
 cS
 nT
@@ -11262,7 +11262,7 @@ aa
 (34,1,1) = {"
 aa
 NO
-Nx
+Ho
 lB
 aV
 aF
@@ -11274,7 +11274,7 @@ ba
 hU
 hU
 lj
-RF
+cI
 mn
 cQ
 fl
@@ -11288,7 +11288,7 @@ ER
 eB
 fz
 kD
-OV
+bN
 sN
 YD
 tz
@@ -11351,15 +11351,15 @@ NO
 NO
 bf
 NO
-Nx
-Nx
+Ho
+Ho
 ZB
 hU
 Xq
-yU
+OL
 hJ
 lr
-RF
+cI
 Mj
 cU
 dk
@@ -11624,7 +11624,7 @@ QA
 QA
 QA
 hh
-nw
+zF
 BG
 fY
 Ua
@@ -11709,7 +11709,7 @@ UV
 UV
 fI
 hi
-nw
+zF
 Ua
 mY
 Ua
@@ -11794,7 +11794,7 @@ PQ
 Ot
 IJ
 Ot
-nw
+zF
 XF
 mY
 kD
@@ -11871,7 +11871,7 @@ PQ
 bI
 ck
 ct
-LM
+ZL
 Bv
 lD
 LD
@@ -11879,7 +11879,7 @@ PQ
 WT
 vj
 LD
-nw
+zF
 Ua
 Ui
 Wm
@@ -11956,7 +11956,7 @@ aa
 ZB
 aa
 Iy
-LM
+ZL
 nV
 dR
 et
@@ -12043,17 +12043,17 @@ aa
 ZB
 PQ
 PQ
-LM
+ZL
 eu
 eu
-Mc
-Mc
-Mc
+Yr
+Yr
+Yr
 eu
 BG
 Ui
 kD
-OV
+bN
 sN
 Yh
 sN
@@ -12308,7 +12308,7 @@ Ol
 iv
 mY
 Ua
-Iz
+JJ
 ZB
 ZB
 ZB
@@ -12317,7 +12317,7 @@ Yl
 Yl
 zh
 Yl
-OV
+bN
 LT
 du
 YW
@@ -12384,7 +12384,7 @@ aa
 aa
 ZB
 aa
-Nu
+XG
 fQ
 fQ
 fQ
@@ -12393,7 +12393,7 @@ fQ
 kD
 mY
 Ua
-Iz
+JJ
 aa
 ZB
 aa
@@ -12402,7 +12402,7 @@ oy
 Xy
 BX
 Ji
-cO
+VI
 LT
 hG
 YW
@@ -12478,7 +12478,7 @@ Ua
 kD
 Ui
 BG
-Iz
+JJ
 aa
 ZB
 aa
@@ -12648,7 +12648,7 @@ Sr
 gk
 iI
 gk
-Iz
+JJ
 aa
 ZB
 aa
@@ -12719,18 +12719,18 @@ bJ
 Zm
 Zm
 Zm
-Xe
-Xe
-Xe
+vl
+vl
+vl
 Zm
 Zm
-am
-am
+BH
+BH
 dx
 As
 As
 PD
-am
+BH
 iJ
 PD
 PD
@@ -12885,11 +12885,11 @@ aa
 aa
 aa
 aa
-Xe
+vl
 Xs
 Zu
 hd
-Xe
+vl
 ms
 hd
 hd
@@ -12970,7 +12970,7 @@ aa
 aa
 aa
 aa
-Xe
+vl
 Xs
 hd
 hd
@@ -12988,7 +12988,7 @@ WC
 Gh
 KY
 ju
-Gk
+GB
 aa
 ZB
 ZB
@@ -13055,7 +13055,7 @@ aa
 aa
 aa
 aa
-Xe
+vl
 NJ
 bv
 Yf
@@ -13073,7 +13073,7 @@ WC
 WC
 Gv
 WC
-Gk
+GB
 aa
 ZB
 aa
@@ -13480,7 +13480,7 @@ aa
 aa
 aa
 aa
-Xe
+vl
 Yf
 bx
 NJ
@@ -13583,7 +13583,7 @@ WC
 fd
 GT
 gT
-Gk
+GB
 ZB
 ZB
 ZB
@@ -13654,7 +13654,7 @@ aa
 aa
 ZB
 vI
-Xe
+vl
 uW
 Ty
 gV
@@ -13668,7 +13668,7 @@ WC
 Kv
 xW
 YV
-Gk
+GB
 aa
 aa
 ZB
@@ -13739,15 +13739,15 @@ aa
 ZB
 ZB
 ZB
-Xe
+vl
 TV
 cW
 dv
 Zm
 Zm
-Gk
-Gk
-Gk
+GB
+GB
+GB
 WC
 WC
 Kv

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -4960,6 +4960,7 @@
 	pixel_x = 1;
 	pixel_y = -2
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/derelict/syndipod)
 "Bz" = (

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -7749,10 +7749,8 @@
 "QE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/gravity_generator/main/station{
-	on = 0
-	},
 /obj/structure/cable,
+/obj/machinery/gravity_generator/main/station/admin,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "QF" = (

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1734,6 +1734,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/structure/bedsheetbin/empty,
+/obj/effect/spawner/random/clothing/backpack,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "hR" = (
@@ -2940,6 +2941,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "nA" = (
@@ -3444,6 +3446,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/hallway_primary)
 "qN" = (
@@ -3899,6 +3902,7 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/cable_coil,
+/obj/effect/spawner/random/clothing/backpack,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/lesser)
 "uo" = (
@@ -5865,6 +5869,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
+"IE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
 "IG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -6514,6 +6526,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "NI" = (
@@ -7136,10 +7149,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Sy" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/spawner/random/clothing/backpack,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port)
 "Sz" = (
@@ -8123,6 +8138,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Yx" = (
@@ -8179,6 +8195,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "YO" = (
@@ -10808,9 +10825,9 @@ XV
 Bf
 WF
 El
-XV
+ld
 NF
-XV
+ld
 qJ
 nz
 Yw
@@ -10899,7 +10916,7 @@ kD
 Sz
 OG
 wF
-OP
+IE
 oS
 BI
 hW
@@ -10984,7 +11001,7 @@ na
 Fz
 SK
 LB
-OP
+IE
 oS
 OG
 pG
@@ -11069,7 +11086,7 @@ SK
 SK
 OG
 OG
-PY
+gc
 uw
 OG
 aa

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -7763,16 +7763,6 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"Wr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway_primary)
 "Wt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -7887,7 +7877,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "WW" = (
@@ -10419,7 +10408,7 @@ jB
 Gz
 Zx
 gW
-Wr
+YW
 gW
 ee
 QU

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -38,17 +38,17 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "ap" = (
-/obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/tile/red/half,
+/obj/structure/frame/computer,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
 "aq" = (
-/obj/machinery/computer/communications,
 /obj/effect/turf_decal/tile/blue/half,
+/obj/structure/frame/computer,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
 "as" = (
-/obj/machinery/modular_computer/console/preset/id,
+/obj/structure/frame/computer,
 /turf/open/floor/iron/white/side,
 /area/ruin/space/derelict/bridge)
 "at" = (
@@ -78,7 +78,6 @@
 /area/ruin/space/derelict/maintenance/port/central)
 "az" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/secure/safe/caps_spare/directional/east,
 /obj/item/multitool,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
@@ -168,9 +167,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "aT" = (
-/obj/structure/fireaxecabinet/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/bridge)
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
 "aV" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -264,14 +265,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "bq" = (
-/obj/machinery/keycard_auth/directional/south,
 /obj/machinery/airalarm/directional/west,
-/obj/item/documents/nanotrasen,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "br" = (
-/obj/machinery/keycard_auth/directional/south,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
@@ -503,10 +501,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"cv" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
 "cw" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -779,7 +773,6 @@
 	dir = 9
 	},
 /obj/structure/table,
-/obj/item/areaeditor/blueprints,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "dR" = (
@@ -845,6 +838,7 @@
 "eg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/arrival)
 "eh" = (
@@ -874,6 +868,12 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
+"er" = (
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/crowbar,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "et" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/spawner/random/maintenance/three,
@@ -1024,21 +1024,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"eY" = (
-/obj/structure/table,
-/obj/item/stack/sheet/rglass{
-	amount = 50
-	},
-/obj/item/stack/sheet/rglass{
-	amount = 50
-	},
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
 "eZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -1054,12 +1039,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "fb" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/departures)
 "fc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -1117,33 +1100,10 @@
 	dir = 10
 	},
 /obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "fm" = (
 /obj/structure/rack,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -1620,10 +1580,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port)
-"hw" = (
-/obj/machinery/vending/cart,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/arrival)
 "hx" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
@@ -1672,29 +1628,17 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"hF" = (
-/obj/structure/chair/office,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
 "hG" = (
 /obj/effect/turf_decal/siding/thinplating/end{
 	dir = 1
 	},
-/obj/machinery/computer/department_orders/security{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/security)
 "hI" = (
@@ -1708,7 +1652,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "hL" = (
@@ -1872,23 +1815,13 @@
 /area/ruin/space/derelict/medical)
 "ir" = (
 /obj/effect/turf_decal/siding/thinplating/end,
-/obj/machinery/modular_computer/console/preset/cargochat/security{
-	dir = 8
-	},
+/obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/security)
 "is" = (
-/obj/machinery/suit_storage_unit/security,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/security)
-"it" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
+/area/ruin/space/derelict/arrival)
 "iu" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma/five,
@@ -1991,25 +1924,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
-"iR" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	dir = 8;
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/security)
 "iT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -2156,18 +2070,12 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "jF" = (
-/obj/machinery/flasher/directional/south{
-	id = "Cell 2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/structure/barricade/sandbags,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/security)
+/area/ruin/space/derelict/hallway_primary)
 "jG" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "jH" = (
@@ -2349,20 +2257,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "ki" = (
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/security)
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/arrival)
 "kj" = (
 /obj/machinery/computer/security/wooden_tv,
 /obj/machinery/airalarm/directional/west,
@@ -2395,8 +2291,7 @@
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
 "kr" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/destructive_scanner,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "ks" = (
@@ -2480,10 +2375,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "kM" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
@@ -2673,11 +2564,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "lD" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	dir = 8;
-	id = "Cell 1";
-	name = "Cell 1"
-	},
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
@@ -2687,6 +2573,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/door/window/brigdoor/westleft,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -2790,7 +2677,9 @@
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
 "lY" = (
-/obj/machinery/lapvend,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "lZ" = (
@@ -3014,14 +2903,15 @@
 	},
 /area/ruin/space/derelict/medical)
 "mI" = (
-/obj/machinery/flasher/directional/south{
-	id = "Cell 1"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/arrival)
 "mJ" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/medical)
@@ -3046,6 +2936,20 @@
 "mP" = (
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
+"mR" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#DE3A3A";
+	icon_state = "a";
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/crayon{
+	color = "#DE3A3A";
+	icon_state = "i"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "mT" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -3082,9 +2986,16 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
 "nf" = (
-/obj/machinery/vending/modularpc,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/arrival)
 "ng" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -3267,6 +3178,7 @@
 /obj/item/flashlight/lamp/green{
 	pixel_y = 4
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/arrival)
 "nL" = (
@@ -3443,7 +3355,7 @@
 /area/ruin/space/derelict/crew)
 "oj" = (
 /obj/machinery/photocopier,
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "ok" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3588,12 +3500,15 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/arrival)
 "oL" = (
-/obj/machinery/gravity_generator/main/station,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/gravity_generator/main/station{
+	on = 0
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "oO" = (
@@ -3687,10 +3602,12 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "pD" = (
-/obj/structure/chair/stool/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/screwdriver,
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "pF" = (
@@ -3698,7 +3615,7 @@
 /obj/structure/frame/computer{
 	dir = 8
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/carpet/blue/airless,
 /area/ruin/space/derelict/arrival)
 "pH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -3725,7 +3642,7 @@
 /area/ruin/space/derelict/engineering)
 "qa" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "qb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -3779,6 +3696,8 @@
 /area/ruin/space/derelict/medical)
 "qv" = (
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "qx" = (
@@ -3814,6 +3733,7 @@
 /area/ruin/space/derelict/medical)
 "qW" = (
 /obj/machinery/firealarm/directional/south,
+/obj/effect/decal/remains/human,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "ra" = (
@@ -3869,6 +3789,8 @@
 /area/ruin/space/derelict/engineering)
 "rk" = (
 /obj/structure/table,
+/obj/item/toy/plush/lizard_plushie,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "rl" = (
@@ -3877,6 +3799,13 @@
 /obj/item/flashlight,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
+"rm" = (
+/obj/structure/lattice,
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
 "rp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -3909,6 +3838,7 @@
 /area/ruin/space/derelict/service)
 "rA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "rB" = (
@@ -3941,6 +3871,7 @@
 /area/ruin/space/derelict/service)
 "rL" = (
 /obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "rN" = (
@@ -3977,10 +3908,10 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "rU" = (
-/obj/machinery/vending/coffee,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "rV" = (
@@ -4003,6 +3934,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict11"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "sa" = (
@@ -4165,6 +4097,9 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/derelict/engineering)
+"td" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/port)
 "tl" = (
 /obj/machinery/telecomms/hub/preset,
 /obj/effect/turf_decal/stripes/line{
@@ -4189,6 +4124,7 @@
 	name = "Escape Airlock";
 	space_dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
 "tr" = (
@@ -4224,9 +4160,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
-"tC" = (
-/turf/open/floor/wood,
-/area/ruin/space/derelict/arrival)
 "tF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -4285,6 +4218,11 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/service)
 "tX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/chair/stool,
+/obj/effect/decal/cleanable/blood/gibs/limb{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "tZ" = (
@@ -4329,8 +4267,6 @@
 "uu" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/item/multitool,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -4519,6 +4455,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"vW" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "vZ" = (
@@ -4528,7 +4472,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/carpet/blue/airless,
 /area/ruin/space/derelict/arrival)
 "wb" = (
 /obj/machinery/door/firedoor,
@@ -4561,7 +4505,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/carpet/blue/airless,
 /area/ruin/space/derelict/arrival)
 "wv" = (
 /obj/machinery/door/airlock/public/glass{
@@ -4602,6 +4546,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "wO" = (
@@ -4616,7 +4562,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "wT" = (
 /obj/machinery/portable_atmospherics/pump,
@@ -4642,6 +4588,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict14"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "xa" = (
@@ -4695,10 +4642,10 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/security/detective)
 "xp" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "xx" = (
@@ -4799,6 +4746,12 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict13"
 	},
+/obj/machinery/vending/coffee{
+	layer = ABOVE_MOB_LAYER;
+	plane = GAME_PLANE_UPPER;
+	tilted = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "yn" = (
@@ -4822,6 +4775,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict16"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "yr" = (
@@ -4848,6 +4802,8 @@
 /area/ruin/space/derelict/engineering)
 "yu" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "yv" = (
@@ -4921,6 +4877,7 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/arrival)
 "yN" = (
@@ -5009,6 +4966,10 @@
 	dir = 9
 	},
 /area/ruin/space/derelict/research)
+"zq" = (
+/obj/item/stack/tile/iron,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "zv" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -5038,6 +4999,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
 "zG" = (
@@ -5053,13 +5015,14 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
 "zK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "zL" = (
 /turf/open/floor/plating,
@@ -5101,10 +5064,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/template_noop,
 /area/ruin/space/derelict/maintenance/port)
-"Ai" = (
-/obj/machinery/pdapainter,
-/turf/open/floor/wood,
-/area/ruin/space/derelict/arrival)
 "Aj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -5160,6 +5119,7 @@
 	},
 /obj/item/pen,
 /obj/item/camera,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/arrival)
 "Av" = (
@@ -5269,10 +5229,10 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "Bd" = (
-/obj/structure/reagent_dispensers/watertank/high,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "Bf" = (
@@ -5282,6 +5242,7 @@
 /area/ruin/space/derelict/hallway_primary)
 "Bg" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "Bh" = (
@@ -5301,6 +5262,9 @@
 "Bm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/frame/computer{
+	dir = 4
 	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
@@ -5397,6 +5361,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "BT" = (
@@ -5419,7 +5384,7 @@
 /obj/structure/frame/computer{
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/carpet/blue/airless,
 /area/ruin/space/derelict/arrival)
 "Cn" = (
 /obj/structure/sink{
@@ -5432,6 +5397,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict6"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "Cq" = (
@@ -5681,6 +5647,11 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/medical)
+"EC" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "ED" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/airalarm/directional/west,
@@ -5695,6 +5666,9 @@
 "EH" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict8"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
@@ -5773,6 +5747,9 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict5"
 	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "FI" = (
@@ -5834,8 +5811,7 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/item/stamp/hop,
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "Gc" = (
 /obj/machinery/door/firedoor,
@@ -5891,6 +5867,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "Gr" = (
@@ -5982,13 +5959,13 @@
 /turf/open/floor/engine,
 /area/ruin/space/derelict/engineering)
 "GT" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
 	req_access_txt = "26"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "GU" = (
@@ -6048,9 +6025,16 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Hr" = (
-/obj/machinery/rnd/production/techfab/department/service,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "Ht" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -6123,7 +6107,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/blue,
+/turf/open/floor/carpet/blue/airless,
 /area/ruin/space/derelict/arrival)
 "HS" = (
 /obj/machinery/suit_storage_unit/cmo,
@@ -6153,7 +6137,7 @@
 	pixel_y = -1
 	},
 /obj/item/hand_labeler,
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "HZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
@@ -6319,6 +6303,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
+"IZ" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/maintenance/port)
 "Jb" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
@@ -6364,6 +6351,10 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"Jj" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Jl" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/igniter{
@@ -6440,6 +6431,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
+"JO" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "JS" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -6783,6 +6781,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict12"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "LC" = (
@@ -6839,7 +6838,14 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict10"
 	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
+"LR" = (
+/turf/closed/wall/r_wall/rust,
 /area/ruin/space/derelict/arrival)
 "LT" = (
 /obj/effect/turf_decal/tile/yellow/half{
@@ -6879,7 +6885,7 @@
 /area/ruin/space/derelict/research)
 "LY" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "LZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -6888,7 +6894,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/carpet/blue/airless,
 /area/ruin/space/derelict/arrival)
 "Mb" = (
 /obj/effect/spawner/random/engineering/tank,
@@ -6940,10 +6946,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/starboard)
 "Mw" = (
-/obj/item/reagent_containers/glass/bucket,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wrench,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "Mx" = (
@@ -7002,7 +7010,12 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
+/area/ruin/space/derelict/arrival)
+"MN" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "MQ" = (
 /obj/structure/closet/bombcloset,
@@ -7015,7 +7028,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/door/firedoor/border_only/closed{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -7174,6 +7187,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
 "NO" = (
@@ -7184,9 +7198,15 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "NP" = (
-/obj/structure/fireaxecabinet/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/barricade/sandbags,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/engineering)
+/area/ruin/space/derelict/hallway_primary)
 "NQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -7196,9 +7216,6 @@
 /area/ruin/space/derelict/engineering)
 "NS" = (
 /obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/crowbar,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -7319,6 +7336,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "OM" = (
@@ -7385,6 +7403,10 @@
 "Pd" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict3"
+	},
+/obj/item/toy/crayon/red,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
@@ -7457,7 +7479,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "PB" = (
-/obj/structure/closet/l3closet/janitor,
+/obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "PC" = (
@@ -7592,11 +7614,12 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "QC" = (
-/obj/machinery/modular_computer/console/preset/cargochat/service{
-	dir = 4
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/derelict/maintenance/starboard/lesser)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "QD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -7619,13 +7642,12 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "QO" = (
-/obj/structure/closet/secure_closet/hop,
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "QP" = (
 /obj/structure/table,
 /obj/item/folder/blue,
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "QQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -7728,10 +7750,11 @@
 	req_access_txt = "57"
 	},
 /obj/effect/turf_decal/siding/wood,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/maintenance/port)
 "RC" = (
-/obj/machinery/vending/wardrobe/jani_wardrobe,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "RF" = (
@@ -7779,11 +7802,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/chair/office{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "RR" = (
-/obj/structure/janitorialcart,
-/obj/item/mop,
+/obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "RT" = (
@@ -7874,7 +7899,7 @@
 /area/ruin/space/derelict/research)
 "St" = (
 /obj/structure/closet/crate/bin,
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "Su" = (
 /obj/structure/window/reinforced/spawner,
@@ -7913,6 +7938,7 @@
 "SJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "SK" = (
@@ -7941,11 +7967,12 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "SS" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -7971,6 +7998,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict1"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "SY" = (
@@ -7997,10 +8025,7 @@
 /area/ruin/space/derelict/hallway_primary)
 "Tl" = (
 /obj/structure/table,
-/obj/item/storage/box/mousetraps,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "Tm" = (
@@ -8036,7 +8061,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "Tr" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -8080,10 +8105,10 @@
 	},
 /area/ruin/space/derelict/medical)
 "Tz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "TA" = (
 /turf/open/floor/iron/freezer,
@@ -8116,6 +8141,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/arrival)
 "TI" = (
@@ -8322,6 +8348,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
+"Vj" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "Vl" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -8572,6 +8608,8 @@
 "WJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "WL" = (
@@ -8586,6 +8624,18 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port/central)
+"WT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "WU" = (
 /obj/structure/sink{
 	dir = 8;
@@ -8610,6 +8660,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "Xi" = (
@@ -8660,8 +8711,27 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
+"Xy" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#DE3A3A";
+	icon_state = "b";
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/crayon{
+	color = "#DE3A3A";
+	icon_state = "a";
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/crayon{
+	color = "#DE3A3A";
+	icon_state = "d";
+	pixel_x = 11
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "Xz" = (
-/obj/structure/chair/office,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -8688,8 +8758,8 @@
 /turf/template_noop,
 /area/template_noop)
 "XR" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "XS" = (
@@ -8762,12 +8832,14 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict9"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "YA" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/door/firedoor/border_only/closed{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "YC" = (
@@ -8837,8 +8909,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"YY" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/arrival)
 "YZ" = (
 /obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/arrival)
 "Zg" = (
@@ -8868,10 +8948,13 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/medical)
+"Zo" = (
+/obj/item/storage/backpack/satchel/flat/empty,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
 "Zt" = (
-/obj/machinery/computer/department_orders/service{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "Zu" = (
@@ -8898,6 +8981,7 @@
 /area/ruin/space/derelict/arrival)
 "Zz" = (
 /obj/structure/chair/comfy/lime,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/arrival)
 "ZB" = (
@@ -8955,6 +9039,9 @@
 "ZU" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict4"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
@@ -9225,9 +9312,9 @@ Hx
 zJ
 cZ
 ZB
-HJ
+ki
 hk
-HJ
+ki
 hk
 hk
 hk
@@ -9328,9 +9415,9 @@ kI
 kI
 kI
 KA
-HJ
-HJ
-Rs
+ki
+ki
+is
 Rs
 rB
 zL
@@ -9425,7 +9512,7 @@ ez
 gV
 iG
 iG
-iG
+aT
 iG
 iG
 vn
@@ -9435,7 +9522,7 @@ iz
 SS
 HJ
 Bg
-Rs
+is
 hk
 hk
 hk
@@ -9529,8 +9616,8 @@ gV
 iG
 iG
 Om
-iG
-iG
+aT
+fb
 Rl
 iG
 Cz
@@ -9538,8 +9625,8 @@ cZ
 KA
 Gm
 TW
-Rs
-Rs
+er
+zq
 Se
 xp
 hk
@@ -9633,7 +9720,7 @@ ZK
 eh
 nl
 iG
-iG
+aT
 iG
 Rr
 ul
@@ -9641,10 +9728,10 @@ Cy
 qx
 Rs
 Xh
-Rs
-Rs
-Rs
-Rs
+QC
+MN
+Zo
+is
 XR
 hk
 aa
@@ -9746,9 +9833,9 @@ Dm
 SJ
 Yv
 SX
-Rs
-Rs
-Rs
+mR
+is
+is
 Vl
 hk
 aa
@@ -9847,11 +9934,11 @@ iG
 iG
 ul
 qx
-Rs
+is
 LO
 VC
-Rs
-Rs
+Xy
+is
 IF
 rU
 hk
@@ -9954,7 +10041,7 @@ KA
 Rs
 rY
 Pd
-Rs
+is
 rb
 hk
 hk
@@ -10055,10 +10142,10 @@ mk
 KQ
 yL
 oK
-Rs
+is
 LA
 ZU
-Rs
+is
 Rs
 rB
 zL
@@ -10159,11 +10246,11 @@ mk
 Zz
 Au
 YZ
-Rs
+is
 yk
 Fw
+is
 Rs
-Rs
 hk
 hk
 hk
@@ -10174,8 +10261,8 @@ aa
 aa
 aa
 aa
-Ug
-Ug
+td
+td
 Ug
 ZB
 aa
@@ -10263,11 +10350,11 @@ mk
 nK
 UM
 YZ
-Rs
+is
 wZ
 Co
-Rs
-Rs
+is
+is
 HJ
 HJ
 ZB
@@ -10278,7 +10365,7 @@ aa
 aa
 aa
 aa
-Ug
+td
 vZ
 jL
 jV
@@ -10371,9 +10458,9 @@ rA
 yq
 EH
 Rs
-Rs
-Rs
-HJ
+is
+is
+ki
 ZB
 ZB
 ZB
@@ -10473,19 +10560,19 @@ RR
 Nh
 YA
 MU
-YA
+vW
 Ff
 pA
 TE
-pA
-pA
+LR
+LR
 PC
 Ug
+td
+td
+td
 Ug
-Ug
-Ug
-Ug
-Ug
+td
 Ug
 vZ
 zz
@@ -10577,11 +10664,11 @@ qv
 Nh
 PE
 vV
-Rs
+JO
 MM
 pA
-tC
-tC
+QO
+QO
 QO
 PC
 vZ
@@ -10590,7 +10677,7 @@ vZ
 vZ
 pv
 ht
-Ug
+td
 vZ
 PC
 tx
@@ -10681,12 +10768,12 @@ WJ
 GT
 SJ
 eg
-Rs
+Vj
 MM
 hk
-tC
+QO
 zK
-tC
+QO
 RB
 vZ
 vZ
@@ -10784,13 +10871,13 @@ AB
 rL
 Nh
 Rs
-xQ
-Rs
+mI
+YY
 MM
 hk
 Ch
 ws
-tC
+QO
 PC
 kv
 vZ
@@ -10798,7 +10885,7 @@ vZ
 vZ
 vZ
 vZ
-Ug
+td
 vZ
 PC
 jY
@@ -10889,17 +10976,17 @@ mk
 mk
 xX
 BS
-SJ
+WT
 Bh
 Gc
 HP
 LZ
 LY
-PC
+IZ
 Ug
-Ug
-Ug
-Ug
+td
+td
+td
 vZ
 vZ
 Ug
@@ -10991,15 +11078,15 @@ mk
 tH
 tH
 mk
-Rs
-xQ
-Rs
-pA
+is
+nf
+YY
+LR
 pA
 pF
 wa
-tC
-hw
+QO
+QO
 PC
 vZ
 vZ
@@ -11095,16 +11182,16 @@ mk
 tH
 tH
 ON
-Rs
+is
 xQ
-Rs
+is
 pA
 HW
 Gb
 wS
-tC
-Ai
-PC
+QO
+QO
+IZ
 KE
 vZ
 vZ
@@ -11200,8 +11287,8 @@ tH
 tH
 mk
 Rs
-vV
-Rs
+Hr
+EC
 pA
 QP
 Tq
@@ -11211,10 +11298,10 @@ PC
 PC
 vZ
 vZ
+td
 Ug
 Ug
-Ug
-Ug
+td
 vZ
 PC
 bk
@@ -11306,10 +11393,10 @@ mk
 wb
 Zx
 wb
-pA
+LR
 St
-tC
-tC
+QO
+QO
 qa
 PC
 pv
@@ -11410,19 +11497,19 @@ mk
 Ua
 gj
 dB
+IZ
+IZ
+IZ
 PC
-PC
-PC
-PC
-PC
-PC
+IZ
+IZ
 Pm
 TP
 vZ
 Ug
-Ug
-Ug
-Ug
+td
+td
+td
 vZ
 PC
 bk
@@ -11618,12 +11705,12 @@ mk
 fD
 DB
 fG
-Ug
+td
 Mb
 Ug
+td
 Ug
-Ug
-Ug
+td
 vZ
 vZ
 vZ
@@ -11719,21 +11806,21 @@ mk
 mk
 mk
 mk
-Ua
-gj
-Ua
+jF
+NP
+Jj
 Ug
 Ug
-Ug
+td
 NC
 TB
+td
+Ug
+td
 Ug
 Ug
-Ug
-Ug
-Ug
-Ug
-Ug
+td
+td
 Ug
 zv
 Ug
@@ -12412,7 +12499,7 @@ aa
 af
 af
 aP
-aT
+bl
 bp
 br
 af
@@ -12441,7 +12528,7 @@ Xq
 ci
 dP
 NS
-eY
+NS
 fl
 ci
 Xq
@@ -12632,7 +12719,7 @@ Sp
 Sp
 Sp
 fr
-hF
+hJ
 Zw
 Zw
 cp
@@ -12841,7 +12928,7 @@ Zw
 Zw
 Zw
 hJ
-is
+Zw
 sH
 Zw
 Zw
@@ -12948,7 +13035,7 @@ hP
 cI
 iL
 cI
-ki
+cI
 cI
 lC
 mD
@@ -12985,7 +13072,7 @@ AP
 JS
 AP
 Zt
-QC
+Dx
 ud
 Pz
 Pz
@@ -13050,7 +13137,7 @@ eF
 EN
 EN
 iv
-iR
+lD
 iv
 EN
 iv
@@ -13065,7 +13152,7 @@ Xq
 ci
 uu
 PQ
-fb
+bT
 fm
 US
 sj
@@ -13155,11 +13242,11 @@ UD
 EN
 ct
 eN
-jF
+UD
 EN
 ct
 eN
-mI
+UD
 pJ
 Ua
 gj
@@ -13257,7 +13344,7 @@ Pb
 eS
 Pb
 EN
-it
+kM
 iT
 jG
 EN
@@ -13400,7 +13487,7 @@ AP
 AP
 zG
 AP
-Hr
+Dx
 Dx
 ud
 Pz
@@ -13412,7 +13499,7 @@ lx
 qi
 YX
 tx
-NP
+tx
 GU
 aa
 aa
@@ -13885,9 +13972,9 @@ ZB
 aa
 Lr
 kr
-cv
 lY
-nf
+lY
+Ua
 Ua
 Ua
 gj
@@ -14125,7 +14212,7 @@ aa
 aa
 aa
 aa
-ZB
+rm
 aa
 aa
 aa
@@ -16776,630 +16863,6 @@ aa
 aa
 "}
 (76,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(77,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(78,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(79,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(80,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(81,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(82,1,1) = {"
 aa
 aa
 aa

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -471,7 +471,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "bU" = (
 /turf/open/floor/plating/airless{
@@ -872,7 +872,7 @@
 /area/ruin/space/derelict/security)
 "dp" = (
 /obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway_primary)
 "dq" = (
 /obj/structure/table,
@@ -2821,7 +2821,7 @@
 /area/ruin/space/derelict/syndipod)
 "nj" = (
 /obj/structure/grille/broken,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/departures)
 "nk" = (
 /obj/effect/turf_decal/tile/red{

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -5208,7 +5208,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Do" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/engine/air,
 /area/ruin/space/derelict/engineering)
 "Dq" = (
@@ -5258,9 +5258,6 @@
 /area/ruin/space/derelict/hallway_primary)
 "DU" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
@@ -5345,6 +5342,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "EF" = (
@@ -6587,7 +6585,7 @@
 /turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "Ok" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on,
 /turf/open/floor/engine/air,
 /area/ruin/space/derelict/engineering)
 "Ol" = (
@@ -7725,10 +7723,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "VO" = (
-/obj/machinery/power/smes{
-	input_attempt = 0;
-	inputting = 0
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -11159,7 +11153,7 @@ CT
 tg
 CT
 pq
-ZF
+DU
 YM
 oS
 ZF
@@ -11244,7 +11238,7 @@ wF
 PK
 gd
 LB
-ZF
+DU
 yF
 oS
 ZF
@@ -11414,7 +11408,7 @@ tQ
 EF
 Ec
 LB
-ZF
+DU
 yF
 oS
 ZF

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -62,6 +62,10 @@
 /obj/item/assembly/signaler,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
+"av" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "aw" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
@@ -3535,6 +3539,9 @@
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "oO" = (
@@ -3558,6 +3565,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
+"oU" = (
+/obj/structure/window/fulltile,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/central)
 "oV" = (
 /obj/item/storage/firstaid/brute{
 	pixel_x = 3;
@@ -3598,6 +3609,15 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/service)
+"pg" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port)
 "pk" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/north,
@@ -3672,6 +3692,9 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
+"pV" = (
+/turf/template_noop,
 /area/ruin/space/derelict/maintenance/port/central)
 "pZ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3753,11 +3776,19 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"qI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
 "qN" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port)
 "qO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -4220,6 +4251,9 @@
 	req_access_txt = "26"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "tK" = (
@@ -4488,6 +4522,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/research)
+"vU" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "vV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -5537,6 +5579,11 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"Dh" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/derelict/maintenance/port/central)
 "Dj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/meter,
@@ -5752,6 +5799,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
+"EX" = (
+/obj/effect/spawner/random/structure/chair_maintenance,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "EZ" = (
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port/lesser)
@@ -6265,6 +6316,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "Is" = (
@@ -6518,6 +6572,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"JP" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/derelict/maintenance/port/central)
 "JS" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -6545,6 +6604,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
+"Ke" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/ruin/space/derelict/maintenance/port/central)
 "Kh" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
@@ -6978,7 +7041,7 @@
 /area/ruin/space/derelict/arrival)
 "Mb" = (
 /obj/effect/spawner/random/engineering/tank,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port)
 "Md" = (
 /obj/structure/table,
@@ -7121,7 +7184,7 @@
 /area/template_noop)
 "MX" = (
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/smooth_large,
+/turf/closed/wall,
 /area/ruin/space/derelict/maintenance/port/central)
 "MY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -7379,6 +7442,9 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
+"Ov" = (
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port)
 "Oy" = (
 /obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
@@ -7434,7 +7500,8 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/turf/open/floor/catwalk_floor/iron_smooth,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "OQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -7750,6 +7817,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/engineering)
+"QV" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
 "QW" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
@@ -10159,8 +10230,8 @@ jv
 mk
 Il
 mk
-mk
-jv
+KA
+cZ
 qx
 qx
 KA
@@ -10263,8 +10334,8 @@ mk
 tb
 tH
 MX
-OT
-mk
+aa
+HJ
 KQ
 yL
 oK
@@ -10366,9 +10437,9 @@ OT
 mk
 OT
 tH
-OT
-OT
-mk
+qI
+aa
+hk
 Zz
 Au
 YZ
@@ -10470,9 +10541,9 @@ tH
 vX
 tH
 tH
-OT
-OT
 mk
+aa
+HJ
 nK
 UM
 YZ
@@ -10575,8 +10646,8 @@ mk
 tH
 OT
 mk
-mk
-mk
+Nh
+Nh
 Nh
 Nh
 Nh
@@ -10677,7 +10748,7 @@ WS
 mk
 mk
 tH
-OT
+QV
 mk
 RC
 PB
@@ -10771,15 +10842,15 @@ xU
 xU
 gC
 mk
-tH
-tH
-tH
-tH
-tH
+pV
+Ke
+Ke
+pV
+mk
 tH
 WS
 mk
-OT
+EX
 tH
 OT
 mk
@@ -10875,7 +10946,7 @@ xU
 xU
 gC
 mk
-tH
+Ke
 mk
 mk
 mk
@@ -10883,7 +10954,7 @@ mk
 mk
 mk
 mk
-OT
+av
 tH
 OT
 mk
@@ -10979,7 +11050,7 @@ SV
 xU
 gC
 mk
-tH
+JP
 mk
 no
 nN
@@ -11083,7 +11154,7 @@ iD
 jj
 jU
 mk
-tH
+Ke
 mk
 np
 nO
@@ -11187,7 +11258,7 @@ Ux
 xU
 gC
 mk
-tH
+Ke
 mk
 uf
 nQ
@@ -11291,7 +11362,7 @@ xU
 jo
 kb
 mk
-tH
+Dh
 mk
 nq
 nR
@@ -11307,7 +11378,7 @@ po
 mk
 ow
 ow
-oM
+vU
 is
 xQ
 is
@@ -11395,7 +11466,7 @@ lv
 lv
 yy
 mk
-tH
+Ke
 mk
 nr
 TK
@@ -11499,7 +11570,7 @@ Ft
 BT
 gC
 mk
-tH
+oU
 mk
 ns
 TK
@@ -11728,11 +11799,11 @@ Ua
 Cr
 Ua
 qN
-vZ
-vZ
-vZ
-vZ
-vZ
+Ov
+Ov
+Ov
+Ov
+pg
 vZ
 hX
 jf

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -30,6 +30,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/bridge)
+"am" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/research)
 "ap" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/iron/white/side,
@@ -720,6 +723,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"cO" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/medical)
 "cP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -804,9 +810,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"da" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/hallway_primary)
 "db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -898,6 +901,7 @@
 /area/ruin/space/derelict/hallway_primary)
 "dv" = (
 /obj/structure/table,
+/obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "dw" = (
@@ -2776,9 +2780,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
-"mE" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/security/detective)
 "mF" = (
 /obj/machinery/gibber,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2946,6 +2947,9 @@
 "nv" = (
 /turf/open/floor/wood,
 /area/ruin/space/derelict/maintenance/port/central)
+"nw" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/security)
 "nz" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer";
@@ -3307,9 +3311,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
-"po" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/security)
 "pq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3328,9 +3329,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
-"pB" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/research)
 "pD" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -3497,9 +3495,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
-"qT" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/security/detective)
 "qW" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -3510,9 +3505,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/hallway_primary)
-"ra" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/bridge)
 "re" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -3532,9 +3524,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
-"rm" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/medical)
 "rs" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3643,9 +3632,6 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/engineering)
-"st" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/service/janitor)
 "sv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -3907,9 +3893,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"tU" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/maintenance/starboard)
 "tZ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -4165,9 +4148,6 @@
 	icon_state = "panelscorched"
 	},
 /area/template_noop)
-"vL" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/security)
 "vN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -4248,9 +4228,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"wQ" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/maintenance/starboard)
 "wS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -4405,9 +4382,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
-"xV" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/research/xenobiology)
 "xW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -4586,6 +4560,9 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
+"yU" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/starboard)
 "yW" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -5281,9 +5258,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/template_noop)
-"Du" = (
-/turf/closed/wall/r_wall/rust,
-/area/ruin/space/derelict/research)
 "Dz" = (
 /obj/item/stack/cable_coil,
 /obj/structure/closet/crate,
@@ -5616,6 +5590,9 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"Gk" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/research)
 "Gm" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/iron/smooth_large,
@@ -5762,6 +5739,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -5809,6 +5790,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
+"HH" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/cargo)
 "HI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -5907,6 +5891,9 @@
 	icon_state = "platingdmg2"
 	},
 /area/ruin/space/derelict/security)
+"Iz" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/hallway_primary)
 "IA" = (
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
@@ -5991,9 +5978,6 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"Js" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/cargo)
 "Jt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6289,6 +6273,9 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
+"Lw" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/crew)
 "Lx" = (
 /obj/structure/chair{
 	dir = 4
@@ -6356,6 +6343,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
+"LM" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/security)
 "LT" = (
 /obj/effect/turf_decal/siding/thinplating_new,
 /turf/open/floor/iron/dark/airless,
@@ -6379,6 +6369,9 @@
 "Mb" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/crew)
+"Mc" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/security/detective)
 "Md" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -6531,10 +6524,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
+"Nu" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/security/detective)
 "Nw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
+"Nx" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/bridge)
 "Ny" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -6733,6 +6732,9 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"OV" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "OW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6867,9 +6869,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"PO" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/maintenance/starboard/central)
 "PP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6982,6 +6981,9 @@
 	icon_state = "platingdmg2"
 	},
 /area/ruin/space/derelict/engineering)
+"QG" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/port/lesser)
 "QH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/meter,
@@ -7022,9 +7024,6 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
-"QR" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/crew)
 "QU" = (
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port)
@@ -7092,6 +7091,9 @@
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/template_noop)
+"RF" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/maintenance/starboard)
 "RH" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -7873,6 +7875,9 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"Wr" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/service/janitor)
 "Wt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -8012,6 +8017,9 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/engineering/gravity_generator)
+"Xe" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/research/xenobiology)
 "Xf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -8311,9 +8319,6 @@
 "Zg" = (
 /turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
-"Zi" = (
-/turf/closed/wall/rust,
-/area/ruin/space/derelict/maintenance/port/lesser)
 "Zj" = (
 /turf/closed/wall,
 /area/template_noop)
@@ -9590,10 +9595,10 @@ Fk
 jd
 Zx
 GU
-st
+Wr
 GU
 GU
-st
+Wr
 Bs
 Vv
 QL
@@ -9835,7 +9840,7 @@ ZB
 ZB
 Mb
 Mb
-QR
+Lw
 kM
 Zx
 Zx
@@ -10080,15 +10085,15 @@ ZB
 YO
 FM
 SH
-Zi
+QG
 cA
 cY
 yq
 ZU
 OJ
-Js
+HH
 ZB
-QR
+Lw
 Mb
 pF
 Mb
@@ -10171,9 +10176,9 @@ nM
 nM
 vU
 eE
-Js
+HH
 fk
-QR
+Lw
 HW
 Gb
 wS
@@ -10258,7 +10263,7 @@ IB
 eF
 Tl
 ZB
-QR
+Lw
 QP
 xE
 Tz
@@ -10323,13 +10328,13 @@ aa
 aa
 aa
 NO
-ra
-ra
-ra
-ra
+Nx
+Nx
+Nx
+Nx
 NO
 ZB
-Zi
+QG
 YK
 YO
 bp
@@ -10407,7 +10412,7 @@ aa
 (24,1,1) = {"
 aa
 NO
-ra
+Nx
 tH
 au
 bX
@@ -10419,8 +10424,8 @@ aX
 YO
 FM
 kZ
-Zi
-Zi
+QG
+QG
 Yv
 Yv
 dz
@@ -10498,7 +10503,7 @@ aV
 TK
 ON
 cK
-Zi
+QG
 uj
 bB
 FM
@@ -10586,7 +10591,7 @@ aO
 YO
 by
 FM
-Zi
+QG
 FM
 SH
 YO
@@ -10668,10 +10673,10 @@ aV
 uf
 aV
 oi
-Zi
+QG
 YO
-Zi
-Zi
+QG
+QG
 YO
 bC
 YO
@@ -11010,7 +11015,7 @@ aV
 qh
 hU
 hU
-wQ
+yU
 hU
 hU
 bD
@@ -11019,8 +11024,8 @@ cp
 cQ
 nR
 ER
-vL
-vL
+nw
+nw
 ER
 fr
 na
@@ -11037,7 +11042,7 @@ Yl
 Yl
 Yl
 Yl
-PO
+OV
 zX
 Yq
 iz
@@ -11107,9 +11112,9 @@ Ot
 er
 ib
 ER
-vL
+nw
 ER
-vL
+nw
 kD
 fv
 eB
@@ -11178,13 +11183,13 @@ ON
 aC
 aV
 cK
-wQ
+yU
 aT
 cd
 cd
 cd
 lj
-tU
+RF
 iA
 cS
 nT
@@ -11257,7 +11262,7 @@ aa
 (34,1,1) = {"
 aa
 NO
-ra
+Nx
 lB
 aV
 aF
@@ -11269,7 +11274,7 @@ ba
 hU
 hU
 lj
-tU
+RF
 mn
 cQ
 fl
@@ -11283,7 +11288,7 @@ ER
 eB
 fz
 kD
-PO
+OV
 sN
 YD
 tz
@@ -11346,15 +11351,15 @@ NO
 NO
 bf
 NO
-ra
-ra
+Nx
+Nx
 ZB
 hU
 Xq
-wQ
+yU
 hJ
 lr
-tU
+RF
 Mj
 cU
 dk
@@ -11619,7 +11624,7 @@ QA
 QA
 QA
 hh
-vL
+nw
 BG
 fY
 Ua
@@ -11704,7 +11709,7 @@ UV
 UV
 fI
 hi
-vL
+nw
 Ua
 mY
 Ua
@@ -11789,7 +11794,7 @@ PQ
 Ot
 IJ
 Ot
-vL
+nw
 XF
 mY
 kD
@@ -11866,7 +11871,7 @@ PQ
 bI
 ck
 ct
-po
+LM
 Bv
 lD
 LD
@@ -11874,7 +11879,7 @@ PQ
 WT
 vj
 LD
-vL
+nw
 Ua
 Ui
 Wm
@@ -11951,7 +11956,7 @@ aa
 ZB
 aa
 Iy
-po
+LM
 nV
 dR
 et
@@ -12038,17 +12043,17 @@ aa
 ZB
 PQ
 PQ
-po
+LM
 eu
 eu
-qT
-qT
-qT
+Mc
+Mc
+Mc
 eu
 BG
 Ui
 kD
-PO
+OV
 sN
 Yh
 sN
@@ -12303,7 +12308,7 @@ Ol
 iv
 mY
 Ua
-da
+Iz
 ZB
 ZB
 ZB
@@ -12312,7 +12317,7 @@ Yl
 Yl
 zh
 Yl
-PO
+OV
 LT
 du
 YW
@@ -12379,7 +12384,7 @@ aa
 aa
 ZB
 aa
-mE
+Nu
 fQ
 fQ
 fQ
@@ -12388,7 +12393,7 @@ fQ
 kD
 mY
 Ua
-da
+Iz
 aa
 ZB
 aa
@@ -12397,7 +12402,7 @@ oy
 Xy
 BX
 Ji
-rm
+cO
 LT
 hG
 YW
@@ -12473,7 +12478,7 @@ Ua
 kD
 Ui
 BG
-da
+Iz
 aa
 ZB
 aa
@@ -12643,7 +12648,7 @@ Sr
 gk
 iI
 gk
-da
+Iz
 aa
 ZB
 aa
@@ -12714,18 +12719,18 @@ bJ
 Zm
 Zm
 Zm
-xV
-xV
-xV
+Xe
+Xe
+Xe
 Zm
 Zm
-Du
-Du
+am
+am
 dx
 As
 As
 PD
-Du
+am
 iJ
 PD
 PD
@@ -12880,11 +12885,11 @@ aa
 aa
 aa
 aa
-xV
+Xe
 Xs
 Zu
 hd
-xV
+Xe
 ms
 hd
 hd
@@ -12965,7 +12970,7 @@ aa
 aa
 aa
 aa
-xV
+Xe
 Xs
 hd
 hd
@@ -12983,7 +12988,7 @@ WC
 Gh
 KY
 ju
-pB
+Gk
 aa
 ZB
 ZB
@@ -13050,7 +13055,7 @@ aa
 aa
 aa
 aa
-xV
+Xe
 NJ
 bv
 Yf
@@ -13068,7 +13073,7 @@ WC
 WC
 Gv
 WC
-pB
+Gk
 aa
 ZB
 aa
@@ -13475,7 +13480,7 @@ aa
 aa
 aa
 aa
-xV
+Xe
 Yf
 bx
 NJ
@@ -13578,7 +13583,7 @@ WC
 fd
 GT
 gT
-pB
+Gk
 ZB
 ZB
 ZB
@@ -13649,7 +13654,7 @@ aa
 aa
 ZB
 vI
-xV
+Xe
 uW
 Ty
 gV
@@ -13663,7 +13668,7 @@ WC
 Kv
 xW
 YV
-pB
+Gk
 aa
 aa
 ZB
@@ -13734,15 +13739,15 @@ aa
 ZB
 ZB
 ZB
-xV
+Xe
 TV
 cW
 dv
 Zm
 Zm
-pB
-pB
-pB
+Gk
+Gk
+Gk
 WC
 WC
 Kv

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -144,6 +144,7 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
+/obj/item/stack/cable_coil,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "aO" = (
@@ -1713,7 +1714,6 @@
 /area/ruin/space/derelict/crew)
 "hQ" = (
 /obj/structure/table/wood,
-/obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/structure/bedsheetbin/empty,
@@ -3839,6 +3839,12 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
+"uj" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/cable_coil,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/lesser)
 "uo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -3892,6 +3898,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/item/stack/cable_coil,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "uE" = (
@@ -10336,7 +10343,7 @@ TK
 ON
 cK
 YO
-bp
+uj
 bB
 FM
 FM

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1357,6 +1357,12 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"fD" = (
+/obj/machinery/computer/terminal/derelict/syndicatecargopod{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/derelict/syndipod)
 "fE" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -1477,6 +1483,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
+"gx" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/syndipod)
 "gz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2663,7 +2676,7 @@
 	amount = 50
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "mg" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -2672,7 +2685,7 @@
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/swat,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "mm" = (
 /obj/structure/rack,
 /obj/structure/sign/poster/contraband/gorlex_recruitment{
@@ -2680,7 +2693,7 @@
 	},
 /obj/item/stack/sheet/mineral/wood/fifty,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "mn" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
@@ -2736,7 +2749,7 @@
 	},
 /obj/structure/closet/crate/engineering,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "mw" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
@@ -2900,7 +2913,7 @@
 /obj/item/stack/sheet/mineral/plasma/thirty,
 /obj/item/stack/sheet/mineral/plasma/thirty,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "nj" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -3042,27 +3055,34 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "nH" = (
 /obj/machinery/power/apc/auto_name/directional/east{
 	start_charge = 0
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "nI" = (
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/computer/vaultcontroller,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "nJ" = (
 /obj/structure/railing{
 	dir = 5
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "nM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -3113,7 +3133,7 @@
 	amount = 50
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "oa" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3399,7 +3419,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "pF" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -3657,7 +3677,7 @@
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "rL" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "rM" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -3879,7 +3899,7 @@
 /obj/structure/rack,
 /obj/item/inducer/syndicate,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "tg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4039,7 +4059,7 @@
 "ud" = (
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "ue" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/reagent_dispensers/beerkeg,
@@ -4190,7 +4210,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "vb" = (
 /obj/machinery/computer/pandemic,
 /obj/structure/disposalpipe/segment{
@@ -4485,7 +4505,7 @@
 "wZ" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "xa" = (
 /obj/structure/table,
 /obj/machinery/light/directional/north,
@@ -4749,7 +4769,7 @@
 	},
 /obj/item/stack/sheet/titaniumglass/fifty,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "yy" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/arrival)
@@ -5278,7 +5298,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/mineral/plastitanium/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "Bz" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5421,8 +5441,9 @@
 /area/ruin/space/derelict/EVA)
 "Co" = (
 /obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "Cu" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -5793,8 +5814,11 @@
 /obj/structure/railing{
 	dir = 6
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plating/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "EZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -6254,7 +6278,7 @@
 /obj/item/stack/sheet/plasteel/fifty,
 /obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "HL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -7628,7 +7652,7 @@
 "Qe" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "Qf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -7737,7 +7761,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "QP" = (
 /obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/iron,
@@ -7756,7 +7780,7 @@
 /area/ruin/space/derelict/maintenance/port)
 "QV" = (
 /turf/closed/wall/r_wall/syndicate,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "QW" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/blue{
@@ -7825,7 +7849,7 @@
 /obj/item/stack/sheet/mineral/uranium/five,
 /obj/structure/closet/crate/radiation,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "Ru" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -8102,7 +8126,7 @@
 /area/ruin/space/derelict/arrival)
 "SX" = (
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "SY" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/arrival)
@@ -8439,7 +8463,7 @@
 "UM" = (
 /obj/structure/fluff/oldturret,
 /turf/closed/wall/r_wall/syndicate,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "UN" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/mineral/plastitanium,
@@ -8647,7 +8671,7 @@
 /area/ruin/space/derelict/engineering)
 "VC" = (
 /turf/open/floor/mineral/plastitanium/airless,
-/area/template_noop)
+/area/ruin/space/derelict/syndipod)
 "VF" = (
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
@@ -10291,7 +10315,7 @@ VC
 tb
 VC
 SX
-SX
+fD
 QV
 aa
 aa
@@ -10713,7 +10737,7 @@ ZB
 ZB
 aa
 nJ
-wZ
+gx
 EX
 ZB
 aa

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -327,7 +327,7 @@
 "bt" = (
 /obj/machinery/photocopier,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "bu" = (
 /obj/machinery/light/small/directional/west,
@@ -462,30 +462,18 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "bT" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Armory";
-	req_access_txt = "3"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "bU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
@@ -558,9 +546,16 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "ck" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/derelict/security)
 "cl" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -615,8 +610,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "ct" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -625,10 +619,10 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "cw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/spawner/north,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/obj/structure/lattice,
+/obj/structure/door_assembly/door_assembly_com,
+/turf/template_noop,
+/area/template_noop)
 "cx" = (
 /obj/machinery/monkey_recycler,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -785,9 +779,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "cV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -861,10 +854,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "dl" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -881,10 +871,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "dp" = (
-/turf/open/floor/plating/airless{
-	icon_state = "panelscorched"
-	},
-/area/ruin/space/derelict/research)
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
 "dq" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma/five,
@@ -939,9 +928,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "dD" = (
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/spawner/north,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "dI" = (
@@ -965,24 +953,23 @@
 	},
 /area/ruin/space/derelict/hallway_primary)
 "dL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "dM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "dN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "dR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -992,9 +979,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "dS" = (
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/iron/white/side/airless{
-	dir = 10
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
 	},
 /area/ruin/space/derelict/research)
 "dU" = (
@@ -1088,7 +1074,7 @@
 "er" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/suit_storage_unit/open,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "et" = (
 /obj/structure/bed,
@@ -1115,11 +1101,11 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "eB" = (
-/obj/effect/mob_spawn/corpse/human/skeleton,
-/turf/open/floor/plating/airless{
-	icon_state = "panelscorched"
+/obj/structure/railing{
+	dir = 8
 	},
-/area/ruin/space/derelict/research)
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "eE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -1230,38 +1216,28 @@
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/timer,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "eZ" = (
 /obj/item/shard,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "fb" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "fc" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "fd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron/white/side/airless{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/area/ruin/space/derelict/research)
 "ff" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -1287,19 +1263,11 @@
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
 "fh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/area/ruin/space/derelict/research)
 "fi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -1353,19 +1321,37 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "fv" = (
-/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "fz" = (
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/iron/white/side/airless{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "fD" = (
 /obj/machinery/computer/terminal/derelict/syndicatecargopod{
 	dir = 8
@@ -1376,7 +1362,7 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "fI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -1385,8 +1371,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "fM" = (
 /obj/machinery/door/airlock/maintenance{
@@ -1446,9 +1431,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "gg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "gk" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
@@ -1572,18 +1557,19 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "gT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/EVA)
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron/white/side/airless{
+	dir = 9
+	},
+/area/ruin/space/derelict/research)
 "gV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "gW" = (
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway_primary)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/derelict/research)
 "hb" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_y = 32
@@ -1600,33 +1586,31 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "hf" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/computer/terminal/derelict/security{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "hg" = (
 /obj/item/stack/sheet/iron/five,
 /obj/item/stack/cable_coil/five,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "hh" = (
 /obj/structure/filingcabinet/security,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "hi" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
 /obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/edge{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "hj" = (
 /turf/open/floor/plating/airless{
@@ -1681,8 +1665,9 @@
 "hz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway_primary)
+/area/ruin/space/derelict/EVA)
 "hA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1703,7 +1688,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "hG" = (
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "hJ" = (
@@ -1714,7 +1698,7 @@
 "hK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/template_noop,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "hN" = (
 /obj/effect/decal/cleanable/plasma,
@@ -1753,14 +1737,15 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "hT" = (
-/turf/template_noop,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "hU" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/maintenance/starboard)
 "hV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/lattice,
 /turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "hW" = (
@@ -1773,35 +1758,20 @@
 /area/ruin/space/derelict/service)
 "ib" = (
 /obj/machinery/suit_storage_unit/open,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "ic" = (
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "id" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg1"
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/lattice,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "ie" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
-"if" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
 "ik" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -1863,10 +1833,12 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "iz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/space/derelict/hallway_primary)
 "iA" = (
 /obj/effect/turf_decal/tile/red/half{
@@ -1877,7 +1849,13 @@
 	},
 /area/ruin/space/derelict/security)
 "iB" = (
-/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "iC" = (
@@ -1902,8 +1880,10 @@
 /turf/open/floor/iron/white/side,
 /area/ruin/space/derelict/bridge)
 "iG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/template_noop,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "iH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -2050,9 +2030,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
 "ji" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "jj" = (
@@ -2083,7 +2061,7 @@
 /obj/machinery/power/apc/auto_name/directional/north{
 	start_charge = 0
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "jt" = (
 /obj/structure/closet/emcloset,
@@ -2104,10 +2082,9 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "jz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/decal/cleanable/blood/splatter/over_window,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/template_noop,
+/area/ruin/space/derelict/hallway_primary)
 "jB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
@@ -2142,9 +2119,10 @@
 	},
 /area/ruin/space/derelict/research)
 "jJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/tank/internals/oxygen/empty,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "jK" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -2256,9 +2234,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "kk" = (
-/obj/structure/window/spawner/east,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/maintenance/port)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
 "km" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -2300,6 +2279,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
+"kt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/tank/internals/oxygen/empty,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "kA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -2359,6 +2343,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"kU" = (
+/obj/structure/window/spawner/east,
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/maintenance/port)
 "kV" = (
 /obj/machinery/power/apc/auto_name/directional/north{
 	start_charge = 0
@@ -2432,11 +2420,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
-"lu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
 "lv" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless{
@@ -2477,7 +2460,7 @@
 /area/ruin/space/derelict/bridge)
 "lC" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "lD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -2821,17 +2804,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"ne" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/security)
 "ng" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
@@ -4423,7 +4395,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "yx" = (
 /obj/structure/rack,
@@ -5874,8 +5846,7 @@
 /area/template_noop)
 "IX" = (
 /obj/structure/chair,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "Jg" = (
 /obj/structure/lattice/catwalk,
@@ -5972,7 +5943,7 @@
 "JV" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/rack,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "Ka" = (
 /obj/effect/turf_decal/bot_white,
@@ -6117,8 +6088,7 @@
 /obj/machinery/computer/security{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "KW" = (
 /obj/machinery/light/directional/south,
@@ -6300,9 +6270,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "Mn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -6330,7 +6298,7 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "Mw" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6395,8 +6363,7 @@
 /area/ruin/space/derelict/maintenance/starboard/central)
 "Ne" = (
 /obj/machinery/airalarm/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "Nf" = (
 /obj/effect/turf_decal/tile/purple{
@@ -6843,7 +6810,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
 "QA" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "QB" = (
 /obj/machinery/firealarm/directional/north,
@@ -7136,14 +7103,13 @@
 /turf/closed/wall/r_wall/rust,
 /area/ruin/space/derelict/engineering)
 "SL" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/edge{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "SO" = (
 /obj/effect/turf_decal/siding/thinplating/end{
@@ -7241,7 +7207,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "TH" = (
 /obj/machinery/door/airlock/external{
@@ -7486,9 +7452,6 @@
 	name = "Cell 2";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -7496,20 +7459,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/edge{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "UV" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/edge{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "UX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -8003,7 +7966,7 @@
 /area/ruin/space/derelict/hallway_primary)
 "XS" = (
 /obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "XT" = (
 /obj/machinery/light/directional/north,
@@ -9564,8 +9527,8 @@ Is
 Ul
 UQ
 Yd
-kk
-kk
+kU
+kU
 UQ
 Yd
 UQ
@@ -9812,7 +9775,7 @@ Pv
 VV
 oo
 Ka
-jz
+kk
 RJ
 qr
 VS
@@ -10318,9 +10281,9 @@ Fk
 Zx
 Zx
 Zx
-gW
+hG
 YW
-iB
+ji
 BU
 BU
 BU
@@ -10403,9 +10366,9 @@ jd
 jB
 Gz
 Zx
-gW
+hG
 YW
-gW
+hG
 ee
 QU
 ZW
@@ -10573,7 +10536,7 @@ Zx
 Zx
 Zx
 Zx
-hT
+ic
 ZD
 zE
 UQ
@@ -10654,13 +10617,13 @@ zG
 Ua
 xL
 AQ
-gW
-gW
+hG
+hG
 Oi
 Oi
-hT
+ic
 Oi
-hT
+ic
 FE
 kD
 kD
@@ -10739,13 +10702,13 @@ vr
 WM
 GQ
 sH
-hz
-jD
 hK
+jD
 hV
+id
 Oi
 Oi
-iG
+jz
 Qf
 XV
 WF
@@ -10824,18 +10787,18 @@ QD
 xY
 MG
 Kw
-hG
+hT
 jE
-hT
-gW
-hT
+ic
+hG
+ic
 Oi
 Oi
 FE
 kD
 Ua
 xY
-jJ
+kt
 kD
 kD
 kD
@@ -10913,9 +10876,9 @@ Yl
 Yl
 Yl
 zX
-gW
-id
-hT
+hG
+iz
+ic
 Ya
 Ya
 CG
@@ -10985,8 +10948,8 @@ ER
 ER
 ER
 kD
-fd
-dD
+fv
+eB
 Yl
 Yh
 sN
@@ -11000,7 +10963,7 @@ ZB
 Ag
 QK
 Xw
-gW
+hG
 XD
 wk
 Vb
@@ -11064,14 +11027,14 @@ cS
 nT
 Ot
 QA
-if
+QA
 eX
 fb
 he
 ER
 kD
 mY
-fv
+gg
 Yl
 sN
 YD
@@ -11085,7 +11048,7 @@ aa
 Bb
 Lo
 YW
-gW
+hG
 Ya
 Cd
 Mf
@@ -11148,14 +11111,14 @@ mn
 cQ
 fl
 ER
-if
-if
+QA
+QA
 eZ
 fs
 hf
 ER
-dD
-fh
+eB
+fz
 kD
 Yl
 sN
@@ -11168,9 +11131,9 @@ YD
 ZB
 Eo
 Yl
-gW
+hG
 YW
-gW
+hG
 Ya
 wG
 Ly
@@ -11233,10 +11196,10 @@ Mj
 cU
 dk
 QA
-if
+QA
 yw
 yw
-if
+QA
 hg
 hN
 kD
@@ -11317,7 +11280,7 @@ Qb
 Ne
 TC
 QA
-if
+QA
 IX
 XS
 fb
@@ -11340,7 +11303,7 @@ sE
 Kl
 Mq
 YW
-gW
+hG
 NB
 ZN
 jh
@@ -11396,18 +11359,18 @@ aa
 ZB
 WS
 PQ
-if
-if
 QA
-if
-ne
-if
+QA
+QA
+QA
+TC
+QA
 dL
 IX
 Mr
 fc
-if
-if
+QA
+QA
 ER
 kD
 mY
@@ -11418,14 +11381,14 @@ YD
 in
 YY
 iP
-gT
+hz
 vB
 Xi
 Xi
 KF
 tl
 TX
-hz
+hK
 Ww
 re
 mW
@@ -11482,16 +11445,16 @@ aa
 ZB
 PQ
 jr
-lu
 lC
-lu
-ne
-if
+lC
+lC
+TC
+QA
 dM
-if
-if
-if
-if
+QA
+QA
+QA
+QA
 hh
 ER
 BG
@@ -11509,8 +11472,8 @@ Cv
 Ak
 Kl
 Mq
-ie
-gW
+iB
+hG
 NB
 PH
 Ku
@@ -11573,8 +11536,8 @@ cs
 US
 SL
 dN
-SL
-SL
+UV
+UV
 UV
 fI
 hi
@@ -11594,8 +11557,8 @@ Zt
 Zt
 Zt
 QQ
-ie
-gW
+iB
+hG
 Ya
 UN
 sc
@@ -11652,7 +11615,7 @@ ZB
 aa
 PQ
 PQ
-PQ
+bU
 bT
 PQ
 PQ
@@ -11678,8 +11641,8 @@ Zt
 Cy
 Xz
 qW
-hz
-iz
+hK
+iG
 RZ
 Ya
 Ya
@@ -11738,7 +11701,7 @@ aa
 aa
 PQ
 bI
-bU
+ck
 ct
 PQ
 Bv
@@ -11763,8 +11726,8 @@ YD
 Cz
 RQ
 Sq
-gW
-ie
+hG
+iB
 KI
 Ya
 SA
@@ -11848,9 +11811,9 @@ Yl
 Yl
 Yl
 Yl
-gW
-ie
-gW
+hG
+iB
+hG
 Ya
 Qu
 Vb
@@ -11933,9 +11896,9 @@ sN
 sN
 sN
 me
-ic
 ie
-gW
+iB
+hG
 Ya
 Ya
 Ya
@@ -12020,8 +11983,8 @@ Yl
 Yl
 Lo
 XR
-ji
-ji
+jJ
+jJ
 oR
 PI
 Kg
@@ -12103,10 +12066,10 @@ sN
 sb
 Yl
 Lr
-gW
+hG
 YW
-gW
-gW
+hG
+hG
 Vz
 ar
 lz
@@ -12190,8 +12153,8 @@ Yl
 LT
 du
 YW
-gW
-gW
+hG
+hG
 XN
 Tm
 lz
@@ -12273,10 +12236,10 @@ BX
 Ji
 mJ
 LT
-gW
+hG
 YW
-gW
-gW
+hG
+hG
 Kf
 Tm
 lz
@@ -12360,8 +12323,8 @@ mJ
 Md
 QK
 Xw
-gW
-gW
+hG
+hG
 Vz
 Gq
 Tj
@@ -12423,8 +12386,8 @@ aa
 aa
 ZB
 aa
-ck
-cw
+dp
+dD
 kD
 kD
 kD
@@ -12503,7 +12466,7 @@ aa
 aa
 ZB
 ZB
-ZB
+cw
 aa
 ZB
 ZB
@@ -13449,9 +13412,9 @@ aD
 JB
 JB
 WC
-dS
+fd
 GT
-fz
+gT
 WC
 ZB
 ZB
@@ -13703,11 +13666,11 @@ aa
 aa
 aa
 aa
-dp
-eB
+dS
+fh
 ch
 jP
-gg
+gW
 lE
 mo
 ZB

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1397,6 +1397,18 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
+"fY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/item/shard,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "fZ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green/half{
@@ -1542,6 +1554,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "gR" = (
@@ -1740,7 +1753,9 @@
 /area/ruin/space/derelict/hallway_primary)
 "hT" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/airless,
+/turf/open/floor/iron/airless{
+	icon_state = "damaged1"
+	},
 /area/ruin/space/derelict/hallway_primary)
 "hU" = (
 /turf/closed/wall,
@@ -2065,6 +2080,11 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
+"js" = (
+/turf/open/floor/iron/airless{
+	icon_state = "damaged3"
+	},
+/area/ruin/space/derelict/hallway_primary)
 "jt" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
@@ -2381,6 +2401,29 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"le" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/head/bandana,
+/obj/item/clothing/head/bearpelt,
+/obj/item/clothing/head/beekeeper_head,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bomb_hood,
+/obj/item/clothing/head/bowler,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/head/chicken,
+/obj/item/clothing/head/collectable/captain,
+/obj/item/clothing/head/collectable/hos,
+/obj/item/clothing/head/collectable/kitty,
+/obj/item/clothing/head/collectable/tophat,
+/obj/item/clothing/head/cowboy_hat_brown,
+/obj/item/clothing/head/hardhat/cakehat,
+/obj/item/clothing/head/mailman,
+/obj/item/clothing/head/papersack/smiley,
+/obj/item/clothing/head/soft/grey,
+/obj/item/clothing/head/syndicatefake,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/derelict/syndipod)
 "li" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -2620,7 +2663,9 @@
 /area/ruin/space/derelict/engineering/gravity_generator)
 "ml" = (
 /obj/structure/rack,
+/obj/item/melee/baton,
 /obj/item/clothing/head/helmet/swat,
+/obj/item/grenade/empgrenade,
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/derelict/syndipod)
 "mm" = (
@@ -2736,6 +2781,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "mJ" = (
@@ -3692,6 +3740,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
+"th" = (
+/turf/open/floor/iron/airless{
+	icon_state = "floorscorched2"
+	},
+/area/ruin/space/derelict/hallway_primary)
 "tl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4603,6 +4656,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/iron/white/side,
 /area/ruin/space/derelict/research)
 "zX" = (
@@ -5550,6 +5604,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -6463,6 +6520,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"NI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "NJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -6478,6 +6542,11 @@
 "NO" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/bridge)
+"NQ" = (
+/turf/open/floor/iron/airless{
+	icon_state = "damaged4"
+	},
+/area/ruin/space/derelict/hallway_primary)
 "NU" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator Chamber";
@@ -6650,7 +6719,9 @@
 /area/ruin/space/derelict/engineering)
 "Pi" = (
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/airless,
+/turf/open/floor/iron/airless{
+	icon_state = "damaged4"
+	},
 /area/ruin/space/derelict/hallway_primary)
 "Pm" = (
 /obj/structure/cable,
@@ -7024,6 +7095,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/ai_module/core/full/drone,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "RZ" = (
@@ -7369,6 +7441,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/toolbox/mechanical,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "Uz" = (
@@ -7847,7 +7920,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/airless,
+/turf/open/floor/iron/airless{
+	icon_state = "damaged2"
+	},
 /area/ruin/space/derelict/hallway_primary)
 "WW" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8041,6 +8116,11 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port)
+"Yq" = (
+/turf/open/floor/iron/airless{
+	icon_state = "floorscorched1"
+	},
+/area/ruin/space/derelict/hallway_primary)
 "Yv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -9168,7 +9248,7 @@ HJ
 SX
 VC
 SX
-SX
+le
 QV
 UM
 aa
@@ -10629,7 +10709,7 @@ Ua
 xL
 AQ
 hG
-hG
+js
 Oi
 Oi
 ic
@@ -10801,7 +10881,7 @@ Kw
 hT
 jE
 ic
-hG
+th
 ic
 Oi
 Oi
@@ -10887,7 +10967,7 @@ Yl
 Yl
 Yl
 zX
-hG
+Yq
 iz
 ic
 Ya
@@ -10974,7 +11054,7 @@ ZB
 Ag
 QK
 Xw
-hG
+NQ
 XD
 wk
 Vb
@@ -11385,7 +11465,7 @@ QA
 ER
 kD
 mY
-kD
+NI
 Yl
 sN
 YD
@@ -11469,7 +11549,7 @@ QA
 hh
 ER
 BG
-Ui
+fY
 Ua
 Yl
 sN

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -251,17 +251,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "bf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/medical)
+/obj/structure/window/fulltile,
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/bridge)
 "bh" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -279,14 +271,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/bridge)
-"bk" = (
-/obj/machinery/computer/launchpad{
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 10
-	},
-/area/ruin/space/derelict/research)
 "bl" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -560,7 +544,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/research)
 "cj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -570,12 +554,11 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "ck" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/area/ruin/space/derelict/research/xenobiology)
 "cl" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -716,14 +699,6 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/hallway_primary)
-"cJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/suit_storage_unit/open,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
 "cK" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -905,11 +880,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "dp" = (
-/obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/tile/iron/white,
+/obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
+/area/ruin/space/derelict/hallway_primary)
 "dq" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma/five,
@@ -921,9 +894,8 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "du" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/wrench,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "dv" = (
 /obj/structure/table,
@@ -965,12 +937,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "dD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/structure/window/spawner/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "dI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -1019,10 +989,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "dS" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research/xenobiology)
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/ruin/space/derelict/research)
 "dU" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -1141,10 +1111,11 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "eB" = (
-/obj/structure/frame/machine,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/circuit/telecomms/server,
-/area/ruin/space/derelict/research)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "eE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -1306,9 +1277,10 @@
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
 "fh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron/white/side/airless{
+	dir = 10
+	},
 /area/ruin/space/derelict/research)
 "fi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -1367,22 +1339,26 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "fv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/area/ruin/space/derelict/research)
 "fz" = (
-/obj/structure/disposalpipe/trunk,
-/obj/structure/lattice/catwalk,
-/obj/structure/disposaloutlet{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/template_noop,
-/area/template_noop)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "fD" = (
 /obj/machinery/computer/terminal/derelict/syndicatecargopod{
 	dir = 8
@@ -1463,12 +1439,19 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "gg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark/telecomms,
-/area/ruin/space/derelict/research)
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "gk" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
@@ -1592,28 +1575,18 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "gT" = (
-/obj/machinery/door/window/westleft{
-	req_access_txt = "30"
-	},
-/obj/structure/frame/computer{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "gV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "gW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron/white/side/airless{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "hb" = (
 /obj/structure/sign/warning/biohazard{
@@ -1710,11 +1683,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "hz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/derelict/research)
 "hA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1735,24 +1706,22 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "hG" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/EVA)
 "hJ" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard)
 "hK" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway_primary)
 "hN" = (
 /obj/effect/decal/cleanable/plasma,
+/obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/security)
 "hP" = (
@@ -1764,9 +1733,9 @@
 "hQ" = (
 /obj/structure/table/wood,
 /obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/structure/bedsheetbin/empty,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "hR" = (
@@ -1787,20 +1756,17 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "hT" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway_primary)
 "hU" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/maintenance/starboard)
 "hV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/ruin/space/derelict/research)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway_primary)
 "hW" = (
 /turf/open/floor/engine/airless,
 /area/ruin/space/derelict/engineering)
@@ -1815,16 +1781,17 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "ic" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/template_noop,
+/area/ruin/space/derelict/hallway_primary)
 "id" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/research)
+/turf/template_noop,
+/area/ruin/space/derelict/hallway_primary)
 "ie" = (
-/turf/closed/wall/rust,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/lattice,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "if" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1847,8 +1814,7 @@
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/open,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "io" = (
 /obj/effect/spawner/structure/window,
@@ -1892,14 +1858,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "iz" = (
-/obj/machinery/door/window/northleft{
-	req_access_txt = "8"
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway_primary)
 "iA" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
@@ -1909,10 +1870,9 @@
 	},
 /area/ruin/space/derelict/security)
 "iB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway_primary)
 "iC" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -1934,19 +1894,14 @@
 /obj/structure/frame/computer,
 /turf/open/floor/iron/white/side,
 /area/ruin/space/derelict/bridge)
-"iF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/textured_large,
-/area/ruin/space/derelict/hallway_primary)
 "iG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/derelict/hallway_primary)
 "iH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2020,15 +1975,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "iQ" = (
 /obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "iT" = (
 /turf/closed/wall/rust,
@@ -2069,12 +2022,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east{
 	start_charge = 0
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "jd" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2095,9 +2047,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
 "ji" = (
-/obj/machinery/vending/medical,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "jj" = (
 /obj/structure/table/wood,
@@ -2148,10 +2105,11 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "jz" = (
-/obj/structure/closet/l3closet/virology,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway_primary)
 "jB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
@@ -2162,13 +2120,13 @@
 "jD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/iron,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/space/derelict/hallway_primary)
 "jE" = (
 /obj/machinery/airalarm/directional/east,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "jG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -2181,18 +2139,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/side{
+/turf/open/floor/iron/white/side/airless{
 	dir = 9
 	},
 /area/ruin/space/derelict/research)
 "jJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway_primary)
 "jK" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2209,8 +2163,9 @@
 /area/ruin/space/derelict/departures)
 "jP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/space/derelict/research)
 "jQ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -2302,11 +2257,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "kk" = (
-/obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "km" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -2350,14 +2302,12 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "kt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway_primary)
 "kA" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -2365,6 +2315,7 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "kB" = (
@@ -2415,15 +2366,11 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"kT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "kU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
 "kV" = (
 /obj/machinery/power/apc/auto_name/directional/north{
 	start_charge = 0
@@ -2457,12 +2404,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "lg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/item/tank/internals/oxygen/empty,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "li" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -2623,16 +2568,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
 "lS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/structure/window/spawner/east,
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/maintenance/port)
 "lT" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine/air,
@@ -2854,13 +2792,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port/central)
-"mO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/window/spawner/east,
-/obj/structure/window/spawner/west,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
 "mP" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance,
@@ -2888,11 +2819,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
-"mX" = (
-/obj/machinery/iv_drip,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "mY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2909,13 +2835,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"nb" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "nc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -2966,14 +2885,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
-"nm" = (
-/obj/machinery/vending/wallmed/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "no" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -3021,16 +2932,6 @@
 "nv" = (
 /turf/open/floor/wood,
 /area/ruin/space/derelict/maintenance/port/central)
-"nw" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/engine,
-/area/ruin/space/derelict/research/xenobiology)
 "nz" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer";
@@ -3059,22 +2960,20 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "nD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "nF" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "nG" = (
 /obj/structure/rack,
@@ -3121,11 +3020,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"nQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
 "nR" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
@@ -3250,13 +3144,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/maintenance/port/central)
-"oq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
 "or" = (
 /obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3273,9 +3160,7 @@
 	pixel_y = 4
 	},
 /obj/item/crowbar,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
 "oz" = (
 /obj/structure/table,
@@ -3284,8 +3169,7 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/neck/stethoscope,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
 "oC" = (
 /turf/closed/wall/r_wall,
@@ -3422,22 +3306,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/template_noop,
 /area/template_noop)
-"py" = (
-/obj/effect/turf_decal/tile/green/half{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/medical)
 "pz" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood/airless,
@@ -3470,12 +3338,6 @@
 "pG" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/engineering)
-"pH" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/medical)
 "pJ" = (
 /turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
@@ -3500,13 +3362,6 @@
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"pO" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "pQ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -3517,22 +3372,6 @@
 "pR" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/maintenance/starboard/central)
-"pT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/flat_white,
-/area/ruin/space/derelict/medical)
-"pV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/medical)
 "qa" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3577,11 +3416,6 @@
 	},
 /turf/open/floor/carpet/blue/airless,
 /area/ruin/space/derelict/arrival)
-"qv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
 "qz" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3611,19 +3445,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
-/area/ruin/space/derelict/hallway_primary)
-"qL" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
 /area/ruin/space/derelict/hallway_primary)
 "qN" = (
 /obj/machinery/door/airlock/maintenance{
@@ -3664,10 +3485,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/hallway_primary)
-"qZ" = (
-/obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "re" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -3692,12 +3509,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/service)
-"rv" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "rz" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
@@ -3734,13 +3545,6 @@
 /obj/structure/musician/piano,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
-"rS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
 "sa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -3768,14 +3572,6 @@
 /obj/item/mop/advanced,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
-"sf" = (
-/obj/machinery/vending/wallmed/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "sk" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3844,21 +3640,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
-"sG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/mob_spawn/corpse/human/skeleton,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
 "sH" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "sI" = (
@@ -3886,12 +3673,11 @@
 	dir = 10
 	},
 /obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "sQ" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "sR" = (
 /turf/open/floor/plating,
@@ -3911,8 +3697,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "sY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -3960,9 +3745,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "tm" = (
 /obj/structure/filingcabinet,
@@ -3979,8 +3763,7 @@
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "tp" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "tq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -3991,14 +3774,6 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"tr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "ts" = (
@@ -4027,7 +3802,7 @@
 	dir = 9
 	},
 /obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "tA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4075,8 +3850,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/space/derelict/medical)
 "tP" = (
 /obj/machinery/light/directional/west,
@@ -4089,16 +3865,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"tT" = (
-/obj/structure/table/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "tZ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -4122,16 +3888,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"uj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
 "uo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -4153,18 +3909,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/template_noop,
 /area/ruin/space/derelict/maintenance/port)
-"ur" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "us" = (
 /obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "ut" = (
 /obj/effect/turf_decal/tile/green/half{
@@ -4179,13 +3926,6 @@
 "uu" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/hallway_primary)
-"uv" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "uw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -4201,17 +3941,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
-"uz" = (
-/obj/machinery/computer/crew,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"uB" = (
-/obj/structure/frame/computer,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "uE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -4232,12 +3963,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
-"uP" = (
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "uV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4257,17 +3982,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/syndipod)
-"vb" = (
-/obj/machinery/computer/pandemic,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "vc" = (
 /obj/structure/bed{
 	dir = 1
@@ -4279,6 +3993,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/crew)
 "vd" = (
@@ -4290,13 +4005,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"vf" = (
-/obj/structure/table,
-/obj/item/reagent_containers/dropper{
-	pixel_y = -6
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "vh" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -4330,16 +4038,6 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/engineering/gravity_generator)
-"vn" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"vo" = (
-/obj/machinery/vending/drugs,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "vr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -4380,15 +4078,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
-"vC" = (
-/obj/machinery/recharge_station,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "vE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -4427,24 +4119,11 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port)
-"vP" = (
-/obj/machinery/suit_storage_unit/open,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "vU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"vX" = (
-/obj/structure/table,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/side{
-	dir = 5
-	},
-/area/ruin/space/derelict/medical)
 "wc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/north,
@@ -4456,25 +4135,12 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/template_noop,
 /area/template_noop)
-"wj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
 "wk" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
-"wq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "wr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -4512,12 +4178,6 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
-"wK" = (
-/obj/structure/table,
-/obj/item/clothing/suit/apron/surgical,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "wM" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -4553,12 +4213,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/syndipod)
-"xa" = (
-/obj/structure/table,
-/obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "xe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -4576,9 +4230,8 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "xi" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/tile/iron/white,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/medical)
 "xj" = (
 /obj/machinery/door/firedoor/border_only/closed{
@@ -4593,10 +4246,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/service)
-"xp" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
 "xq" = (
 /turf/closed/wall/rust,
 /area/ruin/space/derelict/service)
@@ -4691,10 +4340,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"xP" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall,
-/area/ruin/space/derelict/research)
 "xT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/barricade/wooden,
@@ -4707,9 +4352,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/launchpad,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/research)
 "xX" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -4760,21 +4403,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/research)
 "yk" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"yl" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "ym" = (
 /obj/structure/sink{
 	dir = 8;
@@ -4867,10 +4503,6 @@
 /obj/effect/spawner/random/trash/bucket,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
-"yQ" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
-/area/ruin/space/derelict/medical)
 "yR" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
@@ -4940,20 +4572,6 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
-"zo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"zp" = (
-/obj/machinery/firealarm/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"zq" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "zs" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -4971,11 +4589,6 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
-"zy" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
 "zz" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/iron,
@@ -4996,27 +4609,15 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
-"zB" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
 "zE" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "zG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"zJ" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "zM" = (
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
@@ -5036,23 +4637,12 @@
 	},
 /turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
-"zQ" = (
-/turf/open/floor/plating/airless{
-	icon_state = "panelscorched"
-	},
-/area/ruin/space/derelict/hallway_primary)
 "zS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/ruin/space/derelict/research)
-"zW" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "zX" = (
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "r";
@@ -5085,7 +4675,6 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/maintenance/starboard/central)
 "Aj" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -5093,6 +4682,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "Ak" = (
@@ -5208,19 +4798,15 @@
 /obj/item/stack/sheet/mineral/plasma/thirty,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port)
-"AL" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall,
-/area/ruin/space/derelict/medical)
 "AN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "AQ" = (
-/obj/machinery/door/firedoor,
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "AS" = (
@@ -5311,27 +4897,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"Bw" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/infections{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Bx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
-	},
-/area/template_noop)
 "By" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/syndicate{
@@ -5418,7 +4983,7 @@
 /area/ruin/space/derelict/research)
 "BX" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
 "Ca" = (
 /obj/effect/spawner/random/engineering/tank,
@@ -5550,9 +5115,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/tile/iron/white,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/medical)
 "CE" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -5575,26 +5142,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
-"CL" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"CN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "CO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 8
@@ -5608,8 +5155,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
 "CR" = (
-/obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "CS" = (
@@ -5642,19 +5189,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"Dh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Dn" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Do" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
 /turf/open/floor/engine/air,
@@ -5674,11 +5208,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
-"Ds" = (
-/obj/machinery/firealarm/directional/west,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Dt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -5709,23 +5238,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"DI" = (
-/obj/structure/table,
-/obj/machinery/light/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"DN" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"DT" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/machinery/light/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "DU" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/power/terminal{
@@ -5741,12 +5253,6 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
-"DW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
 "Ea" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -5930,20 +5436,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"Fy" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Virology";
-	req_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Fz" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/rust,
@@ -6172,18 +5664,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/closed/wall,
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/research)
 "GU" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/service/janitor)
-"GV" = (
-/obj/machinery/vending/medical,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "GW" = (
 /obj/machinery/power/smes{
 	input_attempt = 0;
@@ -6241,23 +5727,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"Hl" = (
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/bot_white/right,
-/turf/open/floor/iron/white/smooth_large,
-/area/ruin/space/derelict/medical)
 "Ht" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Hu" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/structure/window/spawner/east,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
 "Hw" = (
 /obj/structure/table/wood,
@@ -6267,47 +5741,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
-"Hx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Hy" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"HB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
-"HD" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/medical)
-"HF" = (
-/obj/machinery/stasis,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"HG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	dir = 8;
-	name = "Pharmacy Desk";
-	req_access_txt = "69"
-	},
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
 "HI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -6332,28 +5765,11 @@
 /obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/derelict/syndipod)
-"HL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/research)
 "HM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/engineering)
-"HN" = (
-/obj/machinery/stasis{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "HP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -6364,14 +5780,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/crew)
-"HR" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/medical)
 "HS" = (
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6391,7 +5799,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "HW" = (
 /obj/machinery/vending/clothing,
@@ -6411,10 +5819,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"Ih" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Iq" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
 	dir = 8;
@@ -6425,23 +5829,11 @@
 "Is" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/space/derelict/arrival)
-"It" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Iu" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port)
-"Ix" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
 "Iy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6492,13 +5884,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
-"IQ" = (
-/obj/effect/turf_decal/tile/green,
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "IT" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -6515,29 +5900,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"Ja" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Jb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Je" = (
-/obj/machinery/computer/operating,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Jg" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -6550,37 +5912,12 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
 "Jj" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"Jk" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/ruin/space/derelict/hallway_primary)
-"Jp" = (
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/space/derelict/hallway_primary)
-"Jq" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Jt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6597,11 +5934,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/service)
-"Jv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Jx" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -6623,26 +5955,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"JD" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12
-	},
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
 "JF" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "JI" = (
 /obj/effect/turf_decal/tile/yellow/half,
@@ -6651,7 +5969,7 @@
 /area/ruin/space/derelict/service)
 "JK" = (
 /obj/structure/table,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
 "JP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -6659,11 +5977,6 @@
 /obj/machinery/door/firedoor/closed,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/departures)
-"JQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
 "JR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -6684,15 +5997,6 @@
 /obj/structure/rack,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"JZ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/window/spawner/east,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
 "Ka" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/siding/thinplating{
@@ -6722,9 +6026,9 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/arrival)
 "Kf" = (
-/obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/structure/barricade/wooden,
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/service)
 "Kg" = (
@@ -6758,12 +6062,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/EVA)
-"Kp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
 "Kr" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
@@ -6783,21 +6081,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
 "Kv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/side{
+/turf/open/floor/iron/white/side/airless{
 	dir = 10
 	},
 /area/ruin/space/derelict/research)
 "Kw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"Kx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/medical)
 "KF" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
@@ -6825,12 +6116,11 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "KI" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south{
 	start_charge = 0
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "KJ" = (
 /turf/open/floor/plating,
@@ -6908,26 +6198,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"Lm" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge,
-/area/ruin/space/derelict/hallway_primary)
 "Lo" = (
 /obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"Lq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "Lr" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/dark/airless,
 /area/ruin/space/derelict/hallway_primary)
 "Ls" = (
 /obj/structure/disposalpipe/trunk{
@@ -6936,15 +6214,6 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/research/xenobiology)
-"Lw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/space/derelict/hallway_primary)
 "Lx" = (
 /obj/structure/chair{
 	dir = 4
@@ -7014,9 +6283,8 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
 "LT" = (
-/obj/effect/turf_decal/siding/thinplating,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/dark/airless,
 /area/ruin/space/derelict/hallway_primary)
 "LV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -7039,9 +6307,9 @@
 /area/ruin/space/derelict/crew)
 "Md" = (
 /obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/siding/thinplating,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron/dark/airless,
 /area/ruin/space/derelict/hallway_primary)
 "Mf" = (
 /obj/structure/chair/comfy/black{
@@ -7059,16 +6327,6 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/security)
-"Mm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft{
-	req_access_txt = "69"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
 "Mn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -7086,8 +6344,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "Mr" = (
 /obj/structure/table,
@@ -7098,16 +6355,6 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"Mt" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Mw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7122,18 +6369,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"MC" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "MD" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green/half{
@@ -7174,19 +6409,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port)
-"MY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Nb" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 4
@@ -7215,29 +6437,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
-"Ni" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
-"Nj" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Nl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/flat_white,
-/area/ruin/space/derelict/medical)
 "Nn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -7316,23 +6515,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/research/xenobiology)
-"NK" = (
-/obj/machinery/door/airlock/medical{
-	name = "Surgery";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "NM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
@@ -7341,11 +6523,6 @@
 "NO" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/bridge)
-"NR" = (
-/obj/structure/table,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "NU" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator Chamber";
@@ -7381,33 +6558,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "Oi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/obj/structure/lattice,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
-"Oj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/medical)
 "Ok" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output,
 /turf/open/floor/engine/air,
@@ -7417,29 +6573,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/security/detective)
-"Om" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"On" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Oo" = (
 /obj/structure/table,
 /obj/item/toy/plush/lizard_plushie,
@@ -7461,13 +6594,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"Oz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "OA" = (
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -7485,21 +6611,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/template_noop)
-"OE" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/science,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes,
-/obj/structure/reagent_dispensers/wall/virusfood/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "OG" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/engineering)
@@ -7584,8 +6695,7 @@
 /area/ruin/space/derelict/engineering)
 "Pi" = (
 /obj/machinery/airalarm/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "Pm" = (
 /obj/structure/cable,
@@ -7611,12 +6721,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"Pt" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ruin/space/derelict/research)
 "Pu" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/seed_extractor,
@@ -7696,13 +6800,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"PX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "PY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -7768,11 +6865,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
-"Qx" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "QA" = (
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
@@ -7807,8 +6899,7 @@
 /area/ruin/space/derelict/engineering)
 "QK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "QL" = (
 /obj/effect/turf_decal/plaque{
@@ -7839,7 +6930,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "QU" = (
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -7852,19 +6943,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "QY" = (
-/obj/structure/sign/departments/medbay/alt{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/side{
-	dir = 4
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
 	},
 /area/ruin/space/derelict/hallway_primary)
 "QZ" = (
@@ -7881,11 +6964,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"Rj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/tile/iron/white/smooth_edge,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
 "Rk" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -7893,24 +6971,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
-"Rl" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/moth_epi{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
 "Ro" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
-"Rr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
 "Rs" = (
 /obj/item/stack/sheet/mineral/uranium/five,
 /obj/structure/closet/crate/radiation,
@@ -7936,27 +7000,10 @@
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/template_noop)
-"RF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
 "RH" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
-"RI" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
 "RJ" = (
 /obj/structure/frame/computer{
 	dir = 4
@@ -7974,15 +7021,6 @@
 "RN" = (
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
-"RP" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/hallway_primary)
 "RQ" = (
 /obj/machinery/shower{
 	dir = 8
@@ -8037,31 +7075,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"Sd" = (
-/obj/machinery/suit_storage_unit/open,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
-"Se" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/computer/crew,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "Sj" = (
 /turf/closed/wall/r_wall,
-/area/ruin/space/derelict/medical)
-"Sl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
-"Sm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/flat_white,
 /area/ruin/space/derelict/medical)
 "Sn" = (
 /obj/effect/turf_decal/bot,
@@ -8071,10 +7088,6 @@
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
-"Sp" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Sq" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/hallway_primary)
@@ -8083,14 +7096,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"Ss" = (
-/obj/structure/table,
-/obj/item/reagent_containers/dropper{
-	pixel_y = -6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "St" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical,
@@ -8099,13 +7104,9 @@
 /obj/machinery/power/apc/auto_name/directional/north{
 	start_charge = 0
 	},
+/obj/item/stack/cable_coil,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
-"Su" = (
-/obj/structure/table,
-/obj/machinery/vending/wallmed/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Sx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -8142,13 +7143,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
-"SF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
 "SG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -8161,12 +7155,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port/lesser)
-"SI" = (
-/obj/machinery/smartfridge/organ,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "SK" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/space/derelict/engineering)
@@ -8187,11 +7175,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
-"SS" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "SV" = (
 /turf/closed/wall/rust,
 /area/ruin/space/derelict/arrival)
@@ -8247,13 +7230,12 @@
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "Tx" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/EVA)
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
 "Ty" = (
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
@@ -8284,10 +7266,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
-"TF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "TH" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -8324,11 +7302,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
-"TO" = (
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/space/derelict/hallway_primary)
 "TP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
@@ -8339,30 +7312,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
-"TS" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/research)
 "TT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
-"TU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/flat_white,
-/area/ruin/space/derelict/medical)
 "TV" = (
 /obj/structure/table,
 /obj/item/slime_extract/grey,
@@ -8379,9 +7332,8 @@
 "TX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "TZ" = (
 /turf/closed/wall,
@@ -8445,11 +7397,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
-"Ur" = (
-/turf/open/floor/plating/airless{
-	icon_state = "panelscorched"
-	},
-/area/ruin/space/derelict/medical)
 "Uu" = (
 /obj/effect/turf_decal/siding/thinplating/end,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8534,7 +7481,7 @@
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/open,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "UM" = (
 /obj/structure/fluff/oldturret,
@@ -8553,13 +7500,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
-"UP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/template_noop)
 "UQ" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/maintenance/port)
@@ -8594,13 +7534,6 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/security)
-"UW" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "UX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -8661,13 +7594,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
-"Vm" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Vn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -8704,9 +7630,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "Vu" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/EVA)
 "Vv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
@@ -8748,15 +7673,6 @@
 "VC" = (
 /turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/derelict/syndipod)
-"VF" = (
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "VG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8784,10 +7700,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"VN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark/telecomms,
-/area/ruin/space/derelict/research)
 "VO" = (
 /obj/machinery/power/smes{
 	input_attempt = 0;
@@ -8870,11 +7782,6 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"Wo" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -8883,7 +7790,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "Wt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -8984,13 +7891,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"WR" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "WS" = (
 /turf/open/floor/plating/airless,
 /area/template_noop)
@@ -9007,7 +7907,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "WW" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9087,16 +7987,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "Xy" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west{
 	start_charge = 0
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
 "Xz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -9112,14 +8010,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"XG" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Pharmacy";
-	req_access_txt = "69"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "XK" = (
 /obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 8
@@ -9130,9 +8020,9 @@
 	},
 /area/ruin/space/derelict/hallway_primary)
 "XN" = (
-/obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/structure/barricade/wooden/crude,
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/service)
 "XR" = (
@@ -9142,9 +8032,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "XS" = (
 /obj/structure/table,
@@ -9177,26 +8066,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/side{
-	dir = 4
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
 	},
 /area/ruin/space/derelict/hallway_primary)
-"XZ" = (
-/obj/effect/turf_decal/tile/green/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
 "Ya" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/derelict/service)
@@ -9211,12 +8084,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
 "Yh" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -9231,44 +8101,6 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port)
-"Yq" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Yr" = (
-/obj/machinery/door/airlock/medical{
-	name = "Cryogenic";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"Yt" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/obj/item/pen,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
 "Yv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -9316,12 +8148,6 @@
 "YD" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/maintenance/starboard/central)
-"YE" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/recharge_station,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/research)
 "YF" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
@@ -9332,12 +8158,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/central)
-"YJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/derelict/medical)
 "YK" = (
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port/lesser)
@@ -9347,31 +8167,9 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
-"YN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "YO" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/maintenance/port/lesser)
-"YQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
-"YR" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/circuit/telecomms/server,
-/area/ruin/space/derelict/research)
 "YT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/side{
@@ -9383,7 +8181,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "YV" = (
-/turf/open/floor/iron/white/side{
+/turf/open/floor/iron/white/side/airless{
 	dir = 9
 	},
 /area/ruin/space/derelict/research)
@@ -9394,7 +8192,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "YX" = (
 /obj/machinery/smartfridge,
@@ -9406,11 +8204,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/template_noop)
-"Za" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "Zb" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict6"
@@ -9427,7 +8220,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "Zg" = (
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
 "Zj" = (
 /turf/closed/wall,
@@ -9494,8 +8287,9 @@
 	dir = 4
 	},
 /obj/structure/barricade/sandbags,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
 /area/ruin/space/derelict/hallway_primary)
 "ZE" = (
 /obj/effect/decal/cleanable/crayon{
@@ -9525,55 +8319,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"ZK" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/white,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
-"ZM" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/ruin/space/derelict/hallway_primary)
 "ZN" = (
 /obj/item/bikehorn,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
-"ZO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/hallway_primary)
 "ZR" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10848,8 +9598,8 @@ Is
 Ul
 UQ
 Yd
-Yd
-Yd
+lS
+lS
 UQ
 Yd
 UQ
@@ -11096,7 +9846,7 @@ Pv
 VV
 oo
 Ka
-qi
+kU
 RJ
 qr
 VS
@@ -11602,9 +10352,9 @@ Fk
 Zx
 Zx
 Zx
-Ua
+hK
 YW
-or
+jJ
 BU
 BU
 BU
@@ -11687,9 +10437,9 @@ jd
 jB
 Gz
 Zx
-Ua
+hK
 Wr
-kD
+hK
 ee
 QU
 ZW
@@ -11774,7 +10524,7 @@ Hi
 Zx
 Pi
 WU
-Xv
+RZ
 Yd
 Ca
 UQ
@@ -11857,7 +10607,7 @@ Zx
 Zx
 Zx
 Zx
-QD
+id
 ZD
 zE
 UQ
@@ -11938,13 +10688,13 @@ zG
 Ua
 xL
 AQ
-Ua
-Ua
-Ua
-kD
-kD
-YW
-Ua
+hK
+hK
+Oi
+Oi
+id
+Oi
+id
 FE
 kD
 kD
@@ -12023,13 +10773,13 @@ vr
 WM
 GQ
 sH
-XV
+hT
 jD
-jD
-XV
-Bf
-iF
-XV
+ic
+ie
+Oi
+Oi
+kk
 Qf
 XV
 WF
@@ -12108,18 +10858,18 @@ QD
 xY
 MG
 Kw
-Sr
+hV
 jE
-Ua
-Ua
-kD
+id
+hK
+id
 Oi
-kD
+Oi
 FE
 kD
 Ua
 xY
-kD
+lg
 kD
 kD
 kD
@@ -12197,9 +10947,9 @@ Yl
 Yl
 Yl
 zX
-Ua
-YW
-kD
+hK
+iG
+id
 Ya
 Ya
 CG
@@ -12269,8 +11019,8 @@ ER
 ER
 ER
 kD
-mY
-Ua
+fz
+eB
 Yl
 Yh
 sN
@@ -12284,7 +11034,7 @@ ZB
 Ag
 QK
 Xw
-kD
+hK
 XD
 wk
 Vb
@@ -12355,7 +11105,7 @@ he
 ER
 kD
 mY
-Ua
+gT
 Yl
 sN
 YD
@@ -12368,8 +11118,8 @@ ZB
 aa
 Bb
 Lo
-Lw
-Ua
+YW
+hK
 Ya
 Cd
 Mf
@@ -12438,8 +11188,8 @@ eZ
 fs
 hf
 ER
-Ua
-mY
+eB
+gg
 kD
 Yl
 sN
@@ -12452,9 +11202,9 @@ YD
 ZB
 Eo
 Yl
-kD
-Oi
-Ua
+hK
+YW
+hK
 Ya
 wG
 Ly
@@ -12502,7 +11252,7 @@ aa
 aa
 NO
 NO
-NO
+bf
 NO
 NO
 NO
@@ -12530,8 +11280,8 @@ Yl
 Yh
 YD
 Of
-HB
-oq
+ZB
+aa
 sQ
 YD
 YD
@@ -12615,7 +11365,7 @@ Yl
 sN
 YD
 UJ
-HB
+ZB
 Tx
 sX
 zg
@@ -12623,8 +11373,8 @@ Cn
 sE
 Kl
 Mq
-Oi
-kD
+YW
+hK
 NB
 ZN
 jh
@@ -12700,16 +11450,16 @@ Yl
 sN
 YD
 in
-kt
+YY
 iP
-Xi
+hG
 vB
 Xi
 Xi
 KF
 tl
 TX
-XV
+hT
 Ww
 re
 mW
@@ -12784,7 +11534,7 @@ Ua
 Yl
 sN
 YD
-cJ
+UJ
 nC
 iQ
 tp
@@ -12793,8 +11543,8 @@ Cv
 Ak
 Kl
 Mq
-mY
-kD
+ji
+hK
 NB
 PH
 Ku
@@ -12869,7 +11619,7 @@ Ua
 Yl
 sN
 YD
-cJ
+UJ
 nD
 Vu
 sQ
@@ -12878,8 +11628,8 @@ Zt
 Zt
 Zt
 QQ
-mY
-Ua
+ji
+hK
 Ya
 UN
 sc
@@ -12962,8 +11712,8 @@ Zt
 Cy
 Xz
 qW
-Bf
-UB
+hT
+jz
 RZ
 Ya
 Ya
@@ -13047,8 +11797,8 @@ YD
 Cz
 RQ
 Sq
-kD
-mY
+hK
+ji
 KI
 Ya
 SA
@@ -13132,9 +11882,9 @@ Yl
 Yl
 Yl
 Yl
-kD
-mY
-kD
+hK
+ji
+hK
 Ya
 Qu
 Vb
@@ -13217,9 +11967,9 @@ sN
 sN
 sN
 me
-lc
-mY
-kD
+iz
+ji
+hK
 Ya
 Ya
 Ya
@@ -13304,8 +12054,8 @@ Yl
 Yl
 Lo
 XR
-ld
-ld
+kt
+kt
 oR
 PI
 Kg
@@ -13387,10 +12137,10 @@ sN
 sb
 Yl
 Lr
-kD
+hK
 YW
-kD
-kD
+hK
+hK
 Vz
 ar
 lz
@@ -13473,9 +12223,9 @@ Yl
 Yl
 LT
 du
-Oi
-Ua
-kD
+YW
+hK
+hK
 XN
 Tm
 lz
@@ -13557,10 +12307,10 @@ BX
 Ji
 mJ
 LT
-kD
-Oi
-kD
-kD
+hK
+YW
+hK
+hK
 Kf
 Tm
 lz
@@ -13638,14 +12388,14 @@ aa
 Sj
 oz
 xi
-kT
+Zg
 Ht
 mJ
 Md
-QK
-tr
-kD
-Ua
+iB
+Xw
+hK
+hK
 Vz
 Gq
 Tj
@@ -13707,8 +12457,8 @@ aa
 aa
 ZB
 aa
-Ti
-kD
+dp
+dD
 kD
 kD
 kD
@@ -13723,12 +12473,12 @@ aa
 Sj
 JK
 Zg
-kT
+Zg
 CC
 mJ
-mJ
+Sq
 QW
-Oi
+YW
 us
 Sq
 xq
@@ -13806,17 +12556,17 @@ aa
 ZB
 aa
 Sj
-zJ
-kT
-Zg
+ZB
+aa
+ZB
 tO
-Hl
-mJ
+aa
+Sq
 QY
 XY
-Jk
-ie
 ZB
+ZB
+aa
 aa
 aa
 aa
@@ -13868,7 +12618,7 @@ aa
 aa
 aa
 aa
-Zm
+ck
 Zm
 Zm
 Zm
@@ -13890,19 +12640,19 @@ PD
 ZB
 ZB
 ZB
-Sj
-Sj
-Zg
-kT
-CN
-Hu
-mJ
-Rl
+ZB
+ZB
+ZB
+ZB
+aa
+aa
+aa
+aa
 Yg
-rS
-Sq
-Sq
-Sq
+aa
+ZB
+aa
+aa
 aa
 aa
 ZB
@@ -13976,19 +12726,19 @@ aa
 ZB
 aa
 aa
-Sj
-uz
-xi
-tO
-kT
-Mt
-Rr
-Yg
-Rr
-Lm
-JQ
-zQ
-Jp
+ZB
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+ZB
+aa
+aa
+aa
+aa
 aa
 ZB
 aa
@@ -14060,21 +12810,21 @@ WC
 aa
 ZB
 aa
+ZB
+ZB
+ZB
+ZB
 aa
-Sj
-uB
-kU
-Dh
-Hx
-MC
-Lq
-YQ
-RF
-kk
-Mm
-TO
+aa
+aa
+aa
+aa
 ZB
-ZB
+aa
+aa
+aa
+aa
+aa
 vI
 ZB
 aa
@@ -14146,19 +12896,19 @@ aa
 ZB
 ZB
 ZB
-Sj
-mJ
-zp
-Dn
-mJ
-mJ
-RI
-ZK
-Yt
-Sq
-Sq
+aa
+aa
+ZB
+aa
+aa
+aa
+aa
 ZB
 ZB
+aa
+aa
+aa
+aa
 aa
 aa
 ZB
@@ -14231,18 +12981,18 @@ aa
 ZB
 aa
 aa
-Sj
-uP
-Zg
-xi
-HF
-xp
-RP
-ZM
-qL
-Sq
+aa
+aa
 ZB
 ZB
+aa
+aa
+aa
+ZB
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14316,27 +13066,27 @@ aa
 ZB
 aa
 aa
-Sj
-vf
-Zg
-mX
-HN
-xp
-Se
-ZO
-ji
-Sq
-Ur
 aa
 aa
 aa
-aa
-mJ
-mJ
-Sl
-mJ
-mJ
 ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14400,28 +13150,28 @@ WC
 aa
 ZB
 aa
-YY
-Sj
-vn
-kT
-kT
-Ih
-mJ
-xp
-CL
-xp
-mJ
-yQ
-HG
-Sl
-XG
-mJ
-mJ
-Vm
-JK
-JK
-mJ
-mJ
+aa
+aa
+aa
+aa
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14484,29 +13234,29 @@ jG
 KG
 Dt
 Mx
-Bx
-nQ
-Kx
-vo
-xi
-Zg
-xi
-kT
-Zg
-On
-Zg
-dp
-uv
-HD
-HR
-Rj
-WR
-DW
-dD
-Ht
-kT
-NR
-Sl
+fk
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14571,27 +13321,27 @@ aa
 aa
 ZB
 aa
-YJ
-vC
-kT
-kT
-kT
-MY
-Nl
-TU
-Nl
-Hx
-fv
-Nl
-pT
-Sm
-Hx
-lS
-ur
-YN
-kT
-rv
-Sl
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14656,27 +13406,27 @@ aa
 aa
 ZB
 aa
-YJ
-vP
-zq
-kT
-It
-Ni
-xi
-Za
-kT
-Zg
-Ni
-IQ
-XZ
-pO
-kT
-DW
-hz
-ck
-kT
-DI
-Sl
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14718,10 +13468,10 @@ aa
 aa
 aa
 aa
-Zm
-hd
-hd
-Xs
+ZB
+ZB
+YY
+fk
 Zm
 cx
 nh
@@ -14733,35 +13483,35 @@ aD
 JB
 JB
 WC
-WC
+fh
 GT
-WC
+gW
 WC
 ZB
 ZB
 ZB
 aa
-YJ
-mJ
-mJ
-mJ
-mJ
-NK
-mJ
-mJ
-mJ
-xp
-Yr
-mJ
-Fy
-xp
-mJ
-mJ
-VF
-qZ
-qZ
-mJ
-mJ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14803,10 +13553,10 @@ aa
 aa
 aa
 aa
-Zm
-hd
-hd
-Xs
+aa
+aa
+ZB
+vI
 Zm
 uW
 Ty
@@ -14818,7 +13568,7 @@ Zo
 JB
 hE
 WC
-bk
+Kv
 xW
 YV
 WC
@@ -14826,26 +13576,26 @@ aa
 aa
 ZB
 aa
-YJ
-vX
-zB
-Ds
-Zg
-Oj
-Sp
-mJ
-Qx
-zo
-bf
-mJ
-py
-UW
-GV
-mJ
-mJ
-Sl
-mJ
-mJ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14888,10 +13638,10 @@ aa
 aa
 aa
 aa
-Zm
-Zu
-dS
-nw
+aa
+ZB
+ZB
+ZB
 Zm
 TV
 cW
@@ -14910,25 +13660,25 @@ WC
 WC
 aa
 ZB
+ZB
 aa
-pH
-wK
-Zg
-wq
-Jb
-Om
-Ss
-mJ
-hK
-PX
-tO
-mJ
-sf
-kT
-jz
-mJ
+aa
 ZB
 ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14973,46 +13723,46 @@ aa
 aa
 aa
 aa
-Zm
-Zm
-Zm
-Zm
+aa
+aa
+aa
+ZB
 Zm
 Yf
 Yf
 Yf
 Zm
-eB
-Pt
-fh
-Sd
-YE
-yN
-yN
+aa
+aa
+aa
+aa
+aa
+dS
+fv
 ch
 jP
-jP
+hz
 lE
 mo
 ZB
 nX
-pV
-xa
-Zg
-DN
-Je
-tO
-Su
-mJ
-Yq
-TF
-Hy
-mJ
-Jq
-kT
-DT
-mJ
+aa
 ZB
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -15066,37 +13816,37 @@ aa
 aa
 ZB
 ZB
-WC
-VN
-gg
-TS
-wj
-wj
-sG
-zy
-Ja
-yN
-yN
-WC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Yg
+aa
+aa
+aa
 aa
 ZB
 aa
-Sj
-JK
-mX
-Zg
-Jv
-Oz
-SI
-AL
-Wo
-lg
-nm
-mJ
-tT
-yl
-Bw
-mJ
+ZB
+ZB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -15151,251 +13901,6 @@ aa
 aa
 aa
 ZB
-WC
-eB
-YR
-fh
-Kp
-hG
-SF
-yN
-Xa
-yN
-Ix
-WC
-ZB
-ZB
-ZB
-Sj
-JK
-zJ
-kT
-JD
-Zg
-SS
-mJ
-Nj
-Jv
-nb
-mJ
-vb
-zW
-OE
-mJ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(67,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-WC
-WC
-WC
-WC
-gT
-WC
-hT
-NE
-uj
-iG
-WC
-WC
-aa
-aa
-aa
-Sj
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
-JZ
-mO
-mJ
-mJ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(68,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-WC
-WC
-WC
-hV
-xP
-gW
-HL
-WC
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-fz
-UP
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(69,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -15411,612 +13916,7 @@ aa
 aa
 ZB
 ZB
-WC
-id
-iz
-JB
-qv
-As
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(70,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ZB
-WC
-ic
-iB
-jJ
-jJ
-WC
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(71,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-WC
-id
-WC
-As
-As
-WC
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(72,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-WS
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(73,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(74,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(75,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(76,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ZB
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -405,13 +405,14 @@
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/spawner/random/maintenance/three,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "bJ" = (
-/obj/structure/rack,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/security)
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/derelict/research/xenobiology)
 "bL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -479,12 +480,15 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "bU" = (
-/obj/structure/rack,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/space/derelict/security)
 "bV" = (
 /obj/machinery/computer/security,
@@ -554,11 +558,9 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "ck" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/space/derelict/research/xenobiology)
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
 "cl" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -620,14 +622,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/security)
 "cw" = (
-/obj/structure/rack,
-/obj/machinery/airalarm/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/ruin/space/derelict/security)
+/obj/structure/window/spawner/north,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "cx" = (
 /obj/machinery/monkey_recycler,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -880,9 +881,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "dp" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/hallway_primary)
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/ruin/space/derelict/research)
 "dq" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma/five,
@@ -937,8 +939,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "dD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/spawner/north,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "dI" = (
@@ -989,8 +992,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "dS" = (
-/turf/open/floor/plating/airless{
-	icon_state = "panelscorched"
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron/white/side/airless{
+	dir = 10
 	},
 /area/ruin/space/derelict/research)
 "dU" = (
@@ -1111,11 +1115,11 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "eB" = (
-/obj/structure/railing{
-	dir = 8
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
 	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/area/ruin/space/derelict/research)
 "eE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -1244,14 +1248,20 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "fd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron,
-/area/ruin/space/derelict/security)
+/area/ruin/space/derelict/hallway_primary)
 "ff" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -1277,11 +1287,19 @@
 /turf/open/floor/carpet,
 /area/ruin/space/derelict/security/detective)
 "fh" = (
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/iron/white/side/airless{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "fi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -1339,26 +1357,15 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "fv" = (
-/obj/effect/mob_spawn/corpse/human/skeleton,
-/turf/open/floor/plating/airless{
-	icon_state = "panelscorched"
-	},
-/area/ruin/space/derelict/research)
-"fz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"fz" = (
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/iron/white/side/airless{
+	dir = 9
+	},
+/area/ruin/space/derelict/research)
 "fD" = (
 /obj/machinery/computer/terminal/derelict/syndicatecargopod{
 	dir = 8
@@ -1439,19 +1446,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "gg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white/airless,
+/area/ruin/space/derelict/research)
 "gk" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
@@ -1575,19 +1572,18 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "gT" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/EVA)
 "gV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research/xenobiology)
 "gW" = (
-/obj/machinery/door/firedoor/closed,
-/turf/open/floor/iron/white/side/airless{
-	dir = 9
-	},
-/area/ruin/space/derelict/research)
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway_primary)
 "hb" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_y = 32
@@ -1684,8 +1680,9 @@
 /area/ruin/space/derelict/research)
 "hz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white/airless,
-/area/ruin/space/derelict/research)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway_primary)
 "hA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1706,18 +1703,18 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "hG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/airless,
-/area/ruin/space/derelict/EVA)
+/area/ruin/space/derelict/hallway_primary)
 "hJ" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard)
 "hK" = (
-/turf/open/floor/iron/airless,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "hN" = (
 /obj/effect/decal/cleanable/plasma,
@@ -1756,16 +1753,15 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "hT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/airless,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "hU" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/maintenance/starboard)
 "hV" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/airless,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/lattice,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "hW" = (
 /turf/open/floor/engine/airless,
@@ -1781,17 +1777,20 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "ic" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/template_noop,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "id" = (
-/turf/template_noop,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "ie" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/lattice,
-/turf/template_noop,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
 /area/ruin/space/derelict/hallway_primary)
 "if" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1858,6 +1857,12 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "iz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
@@ -1870,7 +1875,9 @@
 	},
 /area/ruin/space/derelict/security)
 "iB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "iC" = (
@@ -1895,12 +1902,8 @@
 /turf/open/floor/iron/white/side,
 /area/ruin/space/derelict/bridge)
 "iG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg1"
-	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "iH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -2047,14 +2050,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
 "ji" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "jj" = (
 /obj/structure/table/wood,
@@ -2105,8 +2102,8 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "jz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
@@ -2144,9 +2141,10 @@
 	},
 /area/ruin/space/derelict/research)
 "jJ" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway_primary)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
 "jK" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2257,8 +2255,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "kk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/template_noop,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/tank/internals/oxygen/empty,
+/turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "km" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -2302,11 +2301,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
 "kt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway_primary)
+/obj/structure/window/spawner/east,
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/maintenance/port)
 "kA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -2366,11 +2363,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
-"kU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/decal/cleanable/blood/splatter/over_window,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
 "kV" = (
 /obj/machinery/power/apc/auto_name/directional/north{
 	start_charge = 0
@@ -2401,11 +2393,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
-"lg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/tank/internals/oxygen/empty,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "li" = (
@@ -2567,10 +2554,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
-"lS" = (
-/obj/structure/window/spawner/east,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/maintenance/port)
 "lT" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine/air,
@@ -5835,11 +5818,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port)
 "Iy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "IA" = (
 /turf/open/floor/plating/airless{
@@ -9598,8 +9579,8 @@ Is
 Ul
 UQ
 Yd
-lS
-lS
+kt
+kt
 UQ
 Yd
 UQ
@@ -9846,7 +9827,7 @@ Pv
 VV
 oo
 Ka
-kU
+jJ
 RJ
 qr
 VS
@@ -10352,9 +10333,9 @@ Fk
 Zx
 Zx
 Zx
-hK
+gW
 YW
-jJ
+iG
 BU
 BU
 BU
@@ -10437,9 +10418,9 @@ jd
 jB
 Gz
 Zx
-hK
+gW
 Wr
-hK
+gW
 ee
 QU
 ZW
@@ -10607,7 +10588,7 @@ Zx
 Zx
 Zx
 Zx
-id
+hT
 ZD
 zE
 UQ
@@ -10688,13 +10669,13 @@ zG
 Ua
 xL
 AQ
-hK
-hK
+gW
+gW
 Oi
 Oi
-id
+hT
 Oi
-id
+hT
 FE
 kD
 kD
@@ -10773,13 +10754,13 @@ vr
 WM
 GQ
 sH
-hT
+hz
 jD
-ic
-ie
+hK
+hV
 Oi
 Oi
-kk
+ji
 Qf
 XV
 WF
@@ -10858,18 +10839,18 @@ QD
 xY
 MG
 Kw
-hV
+hG
 jE
-id
-hK
-id
+hT
+gW
+hT
 Oi
 Oi
 FE
 kD
 Ua
 xY
-lg
+kk
 kD
 kD
 kD
@@ -10947,9 +10928,9 @@ Yl
 Yl
 Yl
 zX
-hK
-iG
-id
+gW
+ie
+hT
 Ya
 Ya
 CG
@@ -11019,8 +11000,8 @@ ER
 ER
 ER
 kD
-fz
-eB
+fd
+dD
 Yl
 Yh
 sN
@@ -11034,7 +11015,7 @@ ZB
 Ag
 QK
 Xw
-hK
+gW
 XD
 wk
 Vb
@@ -11105,7 +11086,7 @@ he
 ER
 kD
 mY
-gT
+fv
 Yl
 sN
 YD
@@ -11119,7 +11100,7 @@ aa
 Bb
 Lo
 YW
-hK
+gW
 Ya
 Cd
 Mf
@@ -11188,8 +11169,8 @@ eZ
 fs
 hf
 ER
-eB
-gg
+dD
+fh
 kD
 Yl
 sN
@@ -11202,9 +11183,9 @@ YD
 ZB
 Eo
 Yl
-hK
+gW
 YW
-hK
+gW
 Ya
 wG
 Ly
@@ -11339,7 +11320,7 @@ aa
 aa
 aa
 aa
-aa
+ZB
 aa
 aa
 hU
@@ -11374,7 +11355,7 @@ sE
 Kl
 Mq
 YW
-hK
+gW
 NB
 ZN
 jh
@@ -11424,7 +11405,7 @@ aa
 aa
 aa
 aa
-aa
+ZB
 aa
 aa
 ZB
@@ -11452,14 +11433,14 @@ YD
 in
 YY
 iP
-hG
+gT
 vB
 Xi
 Xi
 KF
 tl
 TX
-hT
+hz
 Ww
 re
 mW
@@ -11509,8 +11490,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+ZB
+ZB
 aa
 aa
 ZB
@@ -11543,8 +11524,8 @@ Cv
 Ak
 Kl
 Mq
-ji
-hK
+iz
+gW
 NB
 PH
 Ku
@@ -11595,8 +11576,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+ZB
+ZB
 aa
 aa
 PQ
@@ -11628,8 +11609,8 @@ Zt
 Zt
 Zt
 QQ
-ji
-hK
+iz
+gW
 Ya
 UN
 sc
@@ -11681,8 +11662,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+ZB
+ZB
 aa
 PQ
 PQ
@@ -11712,8 +11693,8 @@ Zt
 Cy
 Xz
 qW
-hT
-jz
+hz
+iB
 RZ
 Ya
 Ya
@@ -11767,12 +11748,12 @@ aa
 aa
 aa
 aa
-aa
+ZB
 aa
 aa
 PQ
 bI
-lD
+bU
 ct
 PQ
 Bv
@@ -11797,8 +11778,8 @@ YD
 Cz
 RQ
 Sq
-hK
-ji
+gW
+iz
 KI
 Ya
 SA
@@ -11852,12 +11833,12 @@ aa
 aa
 aa
 aa
+ZB
+ZB
 aa
 aa
+ZB
 aa
-PQ
-Iy
-fd
 Iy
 PQ
 nV
@@ -11882,9 +11863,9 @@ Yl
 Yl
 Yl
 Yl
-hK
-ji
-hK
+gW
+iz
+gW
 Ya
 Qu
 Vb
@@ -11938,12 +11919,12 @@ aa
 aa
 aa
 aa
+ZB
 aa
 aa
-PQ
-bJ
-bU
-cw
+aa
+aa
+ZB
 PQ
 PQ
 PQ
@@ -11967,9 +11948,9 @@ sN
 sN
 sN
 me
+ic
 iz
-ji
-hK
+gW
 Ya
 Ya
 Ya
@@ -12024,11 +12005,11 @@ aa
 aa
 aa
 aa
+ZB
 aa
-PQ
-PQ
-PQ
-PQ
+aa
+aa
+aa
 PQ
 ZB
 ZB
@@ -12054,8 +12035,8 @@ Yl
 Yl
 Lo
 XR
-kt
-kt
+jz
+jz
 oR
 PI
 Kg
@@ -12109,12 +12090,12 @@ aa
 aa
 aa
 aa
-aa
-aa
+ZB
+ZB
 ZB
 aa
-aa
-aa
+ZB
+ZB
 ZB
 aa
 fQ
@@ -12137,10 +12118,10 @@ sN
 sb
 Yl
 Lr
-hK
+gW
 YW
-hK
-hK
+gW
+gW
 Vz
 ar
 lz
@@ -12195,10 +12176,10 @@ aa
 aa
 aa
 aa
-aa
 ZB
-aa
-aa
+ZB
+ZB
+ZB
 aa
 ZB
 aa
@@ -12224,8 +12205,8 @@ Yl
 LT
 du
 YW
-hK
-hK
+gW
+gW
 XN
 Tm
 lz
@@ -12307,10 +12288,10 @@ BX
 Ji
 mJ
 LT
-hK
+gW
 YW
-hK
-hK
+gW
+gW
 Kf
 Tm
 lz
@@ -12392,10 +12373,10 @@ Zg
 Ht
 mJ
 Md
-iB
+id
 Xw
-hK
-hK
+gW
+gW
 Vz
 Gq
 Tj
@@ -12457,8 +12438,8 @@ aa
 aa
 ZB
 aa
-dp
-dD
+ck
+cw
 kD
 kD
 kD
@@ -12618,7 +12599,7 @@ aa
 aa
 aa
 aa
-ck
+bJ
 Zm
 Zm
 Zm
@@ -13483,9 +13464,9 @@ aD
 JB
 JB
 WC
-fh
+dS
 GT
-gW
+fz
 WC
 ZB
 ZB
@@ -13737,11 +13718,11 @@ aa
 aa
 aa
 aa
-dS
-fv
+dp
+eB
 ch
 jP
-hz
+gg
 lE
 mo
 ZB

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -111,6 +111,7 @@
 /area/ruin/space/derelict/bridge)
 "aG" = (
 /obj/structure/rack,
+/obj/item/inducer,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "aK" = (
@@ -307,6 +308,7 @@
 /area/ruin/space/derelict/bridge)
 "bp" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/lesser)
 "bq" = (
@@ -380,10 +382,12 @@
 /area/ruin/space/derelict/research/xenobiology)
 "by" = (
 /obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/lesser)
 "bz" = (
 /obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard)
 "bB" = (
@@ -401,6 +405,7 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard)
 "bF" = (
@@ -458,6 +463,7 @@
 "bR" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port/lesser)
 "bS" = (
@@ -527,6 +533,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "cd" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard)
 "cf" = (
@@ -585,6 +592,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "cp" = (
@@ -723,6 +731,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -949,6 +958,10 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/cargo)
+"dA" = (
+/obj/item/stack/sheet/iron/five,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "dD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1299,6 +1312,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -1722,6 +1736,7 @@
 /area/ruin/space/derelict/research)
 "hJ" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard)
 "hK" = (
@@ -2447,6 +2462,7 @@
 /area/ruin/space/derelict/hallway_primary)
 "lj" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard)
 "lk" = (
@@ -2470,6 +2486,7 @@
 /obj/machinery/power/apc/auto_name/directional/east{
 	start_charge = 0
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard)
 "lt" = (
@@ -2689,6 +2706,7 @@
 /area/ruin/space/derelict/syndipod)
 "mg" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "ml" = (
@@ -3355,6 +3373,7 @@
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/inducer/sci,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "pd" = (
@@ -3719,6 +3738,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "sb" = (
@@ -3975,6 +3995,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "ts" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -4297,6 +4318,7 @@
 /area/ruin/space/derelict/security)
 "vm" = (
 /obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -5175,6 +5197,7 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/mineral/plasma/thirty,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port)
 "AL" = (
@@ -5951,6 +5974,10 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
+"FM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/lesser)
 "FO" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -6711,6 +6738,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
+"Ki" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
 "Kl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -7551,6 +7584,7 @@
 /obj/machinery/power/apc/auto_name/directional/east{
 	start_charge = 0
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -8114,6 +8148,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"SH" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/lesser)
 "SI" = (
 /obj/machinery/smartfridge/organ,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -8302,6 +8341,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/research)
+"TT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
 "TU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -8346,6 +8389,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "Ue" = (
@@ -8973,6 +9017,7 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "Xc" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -9099,6 +9144,7 @@
 /area/ruin/space/derelict/security)
 "XT" = (
 /obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "XU" = (
@@ -9319,6 +9365,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/ruin/space/derelict/research)
 "YT" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -10517,7 +10564,7 @@ aa
 Zx
 jd
 jd
-kR
+jd
 Zx
 kR
 Fk
@@ -10687,7 +10734,7 @@ aa
 Zx
 Fk
 jd
-kR
+dA
 Zx
 Fk
 jd
@@ -11181,8 +11228,8 @@ aa
 aa
 ZB
 YO
-bB
-kZ
+FM
+SH
 YO
 cA
 cY
@@ -11266,8 +11313,8 @@ aa
 WS
 ZB
 YO
-bB
-kZ
+FM
+SH
 YO
 cC
 nM
@@ -11312,7 +11359,7 @@ vG
 Ul
 OA
 cL
-OA
+Ki
 vm
 Ex
 Jx
@@ -11395,9 +11442,9 @@ UQ
 Yd
 vG
 Ul
-RN
+TT
 co
-RN
+TT
 YT
 Ex
 xh
@@ -11436,7 +11483,7 @@ YO
 YK
 YO
 bp
-kZ
+SH
 bB
 YO
 cE
@@ -11520,7 +11567,7 @@ YO
 YO
 aX
 YO
-bB
+FM
 kZ
 YO
 YO
@@ -11604,9 +11651,9 @@ cK
 YO
 bp
 bB
-bB
-bB
-kZ
+FM
+FM
+SH
 YO
 cl
 cl
@@ -11688,10 +11735,10 @@ aV
 aO
 YO
 by
-bB
+FM
 YO
-bB
-kZ
+FM
+SH
 YO
 cm
 io

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -73,9 +73,9 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/service)
 "ax" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/port/central)
+/obj/item/stack/sheet/iron/fifty,
+/turf/template_noop,
+/area/template_noop)
 "az" = (
 /obj/structure/table/reinforced,
 /obj/item/multitool,
@@ -990,6 +990,11 @@
 "eP" = (
 /turf/open/floor/engine/vacuum,
 /area/ruin/space/derelict/research)
+"eR" = (
+/obj/effect/spawner/random/trash/bin,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "eS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1796,6 +1801,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
+"io" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "ip" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
@@ -1994,7 +2003,7 @@
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "jm" = (
 /obj/machinery/space_heater,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "jo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -2115,7 +2124,7 @@
 	name = "External Access"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "engimaintport"
+	cycle_id = "dereengimaintport"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port)
@@ -2508,6 +2517,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"lq" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "lr" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -3426,6 +3441,10 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"ow" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/port/central)
 "ox" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green/half{
@@ -3511,6 +3530,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
+"oM" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "oO" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -3581,6 +3607,14 @@
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
+"po" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
 "pu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -3634,6 +3668,11 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/derelict/engineering)
+"pS" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "pZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4088,7 +4127,7 @@
 /area/ruin/space/derelict/maintenance/starboard)
 "tb" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "tc" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -4172,7 +4211,7 @@
 	},
 /area/ruin/space/derelict/medical)
 "tH" = (
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port/central)
 "tI" = (
 /obj/machinery/door/firedoor,
@@ -4180,7 +4219,8 @@
 	name = "Custodial Maintenance";
 	req_access_txt = "26"
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "tK" = (
 /obj/structure/closet/toolcloset,
@@ -4233,7 +4273,7 @@
 /area/ruin/space/derelict/engineering)
 "uc" = (
 /obj/effect/spawner/random/engineering/tank,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "ud" = (
 /turf/closed/wall/r_wall,
@@ -4465,6 +4505,12 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"vX" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "vZ" = (
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port)
@@ -4954,6 +5000,11 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
+"zi" = (
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/maintenance/port/central)
 "zo" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
@@ -5153,6 +5204,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/effect/spawner/random/trash/mopbucket,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "AG" = (
@@ -5634,6 +5686,9 @@
 /obj/machinery/computer/bookmanagement,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
+"Ew" = (
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
 "Ey" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -5707,6 +5762,13 @@
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/template_noop)
+"Fe" = (
+/obj/effect/spawner/random/engineering/tank,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/maintenance/port/central)
 "Ff" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 4
@@ -5733,6 +5795,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/service)
+"Fq" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
 "Fr" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -5752,6 +5818,10 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"Fz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "FI" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -6101,6 +6171,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"HO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
 "HP" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -6187,6 +6261,12 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
+"Il" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "Is" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator Chamber";
@@ -6961,8 +7041,8 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "My" = (
-/obj/machinery/vending/assist,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "MA" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
@@ -7041,7 +7121,7 @@
 /area/template_noop)
 "MX" = (
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "MY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -7354,7 +7434,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port/central)
 "OQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -7365,8 +7445,7 @@
 /turf/closed/wall,
 /area/ruin/space/derelict/research)
 "OT" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "OU" = (
 /obj/effect/turf_decal/tile/bar,
@@ -7575,6 +7654,13 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
+"Qe" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "Ql" = (
 /obj/structure/table,
 /obj/machinery/light/directional/north,
@@ -7707,6 +7793,13 @@
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/template_noop)
+"Rh" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/port/central)
 "Ri" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 10
@@ -7744,6 +7837,17 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"RA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 12;
+	pixel_y = 9
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
 "RB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "head of personnel's office maintenance";
@@ -7755,6 +7859,9 @@
 /area/ruin/space/derelict/maintenance/port)
 "RC" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet,
+/obj/effect/spawner/random/exotic/tool,
+/obj/item/mop/advanced,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service/janitor)
 "RF" = (
@@ -7922,6 +8029,11 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
+"SE" = (
+/obj/effect/spawner/random/structure/girder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/maintenance/port/central)
 "SF" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -8622,7 +8734,7 @@
 "WS" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "WT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -8873,9 +8985,23 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"YK" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/space/derelict/maintenance/port/central)
 "YO" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/ruin/space/derelict/maintenance/port/central)
 "YQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -9711,7 +9837,7 @@ bw
 ef
 bw
 ef
-aa
+ax
 aa
 aa
 he
@@ -10031,7 +10157,7 @@ mk
 jv
 jv
 mk
-ON
+Il
 mk
 mk
 jv
@@ -10137,7 +10263,7 @@ mk
 tb
 tH
 MX
-tH
+OT
 mk
 KQ
 yL
@@ -10234,14 +10360,14 @@ BT
 xU
 nM
 mk
+OT
+OT
+OT
+mk
+OT
 tH
-tH
-tH
-tH
-tH
-tH
-tH
-tH
+OT
+OT
 mk
 Zz
 Au
@@ -10341,11 +10467,11 @@ mk
 tH
 tH
 tH
+vX
 tH
 tH
-tH
-tH
-tH
+OT
+OT
 mk
 nK
 UM
@@ -10443,11 +10569,11 @@ xU
 kK
 mk
 tH
+OT
+OT
+mk
 tH
-tH
-tH
-tH
-tH
+OT
 mk
 mk
 mk
@@ -10551,7 +10677,7 @@ WS
 mk
 mk
 tH
-tH
+OT
 mk
 RC
 PB
@@ -10655,7 +10781,7 @@ WS
 mk
 OT
 tH
-tH
+OT
 mk
 yu
 tX
@@ -10759,7 +10885,7 @@ mk
 mk
 OT
 tH
-tH
+OT
 mk
 rk
 pD
@@ -10863,7 +10989,7 @@ nN
 mk
 mk
 tH
-tH
+OT
 mk
 Tl
 OJ
@@ -10967,7 +11093,7 @@ nO
 mk
 tH
 tH
-tH
+mk
 mk
 mk
 mk
@@ -11070,13 +11196,13 @@ uf
 nQ
 mk
 tH
-tH
-tH
-tH
+pS
+mk
+RA
 YO
 mk
-tH
-tH
+ow
+tb
 mk
 is
 nf
@@ -11174,14 +11300,14 @@ QQ
 Ba
 mk
 tH
-tH
-tH
-tH
-YO
 mk
-tH
-tH
-ON
+mk
+HO
+po
+mk
+ow
+ow
+oM
 is
 xQ
 is
@@ -11278,13 +11404,13 @@ TK
 TK
 mk
 tH
-tH
-tH
-tH
+mk
+Ew
+HO
 mk
 mk
-tH
-tH
+ow
+SE
 mk
 Rs
 Hr
@@ -11382,13 +11508,13 @@ vC
 DE
 mk
 tH
+mk
+YK
+mk
+mk
+ow
 tH
-tH
-tH
-tH
-tH
-tH
-tH
+lq
 mk
 wb
 Zx
@@ -11486,13 +11612,13 @@ TK
 DX
 mk
 tH
-tH
-tH
-tH
-tH
-tH
-tH
-ax
+ow
+ow
+ow
+Qe
+ow
+mk
+mk
 mk
 Ua
 gj
@@ -11589,13 +11715,13 @@ cK
 TK
 El
 mk
-tH
-tH
-tH
-tH
-tH
-tH
-tH
+ow
+mk
+Rh
+Rh
+mk
+Fz
+Qe
 My
 mk
 Ua
@@ -11693,14 +11819,14 @@ cK
 TK
 Ev
 mk
-tH
-tH
-tH
-tH
-tH
-tH
-tH
-tb
+ow
+Fq
+Fe
+zi
+mk
+io
+mk
+eR
 mk
 fD
 DB
@@ -11797,7 +11923,7 @@ oi
 vG
 gJ
 mk
-ON
+oM
 mk
 mk
 mk

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -145,6 +145,8 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/item/stack/cable_coil,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "aO" = (
@@ -4386,6 +4388,8 @@
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/solarpanel_small,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "yv" = (

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1781,16 +1781,22 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "id" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway_primary)
-"ie" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
+/area/ruin/space/derelict/hallway_primary)
+"ie" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "if" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1857,12 +1863,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "iz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
@@ -1875,9 +1877,7 @@
 	},
 /area/ruin/space/derelict/security)
 "iB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "iC" = (
@@ -1902,8 +1902,8 @@
 /turf/open/floor/iron/white/side,
 /area/ruin/space/derelict/bridge)
 "iG" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/airless,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/template_noop,
 /area/ruin/space/derelict/hallway_primary)
 "iH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -2051,7 +2051,9 @@
 /area/ruin/space/derelict/service)
 "ji" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/template_noop,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "jj" = (
 /obj/structure/table/wood,
@@ -2102,11 +2104,10 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
 "jz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/airless,
-/area/ruin/space/derelict/hallway_primary)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/arrival)
 "jB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
@@ -2141,10 +2142,10 @@
 	},
 /area/ruin/space/derelict/research)
 "jJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/decal/cleanable/blood/splatter/over_window,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/arrival)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/tank/internals/oxygen/empty,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "jK" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2255,10 +2256,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
 "kk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/tank/internals/oxygen/empty,
-/turf/open/floor/iron,
-/area/ruin/space/derelict/hallway_primary)
+/obj/structure/window/spawner/east,
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/maintenance/port)
 "km" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -2300,10 +2300,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
-"kt" = (
-/obj/structure/window/spawner/east,
-/turf/open/floor/plating/airless,
-/area/ruin/space/derelict/maintenance/port)
 "kA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -6879,7 +6875,7 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/engineering)
 "QK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway_primary)
 "QL" = (
@@ -9568,8 +9564,8 @@ Is
 Ul
 UQ
 Yd
-kt
-kt
+kk
+kk
 UQ
 Yd
 UQ
@@ -9816,7 +9812,7 @@ Pv
 VV
 oo
 Ka
-jJ
+jz
 RJ
 qr
 VS
@@ -10324,7 +10320,7 @@ Zx
 Zx
 gW
 YW
-iG
+iB
 BU
 BU
 BU
@@ -10749,7 +10745,7 @@ hK
 hV
 Oi
 Oi
-ji
+iG
 Qf
 XV
 WF
@@ -10839,7 +10835,7 @@ FE
 kD
 Ua
 xY
-kk
+jJ
 kD
 kD
 kD
@@ -10918,7 +10914,7 @@ Yl
 Yl
 zX
 gW
-ie
+id
 hT
 Ya
 Ya
@@ -11513,7 +11509,7 @@ Cv
 Ak
 Kl
 Mq
-iz
+ie
 gW
 NB
 PH
@@ -11598,7 +11594,7 @@ Zt
 Zt
 Zt
 QQ
-iz
+ie
 gW
 Ya
 UN
@@ -11683,7 +11679,7 @@ Cy
 Xz
 qW
 hz
-iB
+iz
 RZ
 Ya
 Ya
@@ -11768,7 +11764,7 @@ Cz
 RQ
 Sq
 gW
-iz
+ie
 KI
 Ya
 SA
@@ -11853,7 +11849,7 @@ Yl
 Yl
 Yl
 gW
-iz
+ie
 gW
 Ya
 Qu
@@ -11938,7 +11934,7 @@ sN
 sN
 me
 ic
-iz
+ie
 gW
 Ya
 Ya
@@ -12024,8 +12020,8 @@ Yl
 Yl
 Lo
 XR
-jz
-jz
+ji
+ji
 oR
 PI
 Kg
@@ -12362,7 +12358,7 @@ Zg
 Ht
 mJ
 Md
-id
+QK
 Xw
 gW
 gW

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -34,6 +34,10 @@
 /obj/item/assembly/signaler,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
+"ar" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/service)
 "as" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -101,6 +105,7 @@
 /obj/structure/closet/secure_closet/freezer/fridge{
 	req_access = list(25)
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "aL" = (
@@ -115,6 +120,7 @@
 /area/ruin/space/derelict/bridge)
 "aN" = (
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "aO" = (
@@ -131,9 +137,6 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "bridge"
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
@@ -222,6 +225,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -230,9 +234,6 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "bridge"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -408,6 +409,7 @@
 "bO" = (
 /obj/effect/turf_decal/bot,
 /obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "bP" = (
@@ -487,6 +489,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine/airless,
 /area/ruin/space/derelict/engineering)
 "ch" = (
@@ -501,12 +504,15 @@
 "cj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "ck" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "cl" = (
@@ -532,9 +538,6 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
 "cq" = (
@@ -544,6 +547,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "cr" = (
@@ -644,9 +648,13 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "cJ" = (
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
 "cK" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
@@ -663,6 +671,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "cP" = (
@@ -776,6 +785,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "dk" = (
@@ -796,6 +806,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "dm" = (
@@ -804,6 +815,7 @@
 /area/ruin/space/derelict/security)
 "dp" = (
 /obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "dq" = (
@@ -849,6 +861,13 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/cargo)
+"dD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
 "dI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -972,6 +991,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "eq" = (
@@ -1046,6 +1066,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "eJ" = (
@@ -1072,6 +1093,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "eM" = (
@@ -1187,6 +1209,7 @@
 "fi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -1210,9 +1233,6 @@
 	id_tag = "innerbrig";
 	name = "Brig";
 	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/security)
@@ -1299,10 +1319,18 @@
 	dir = 1
 	},
 /area/ruin/space/derelict/service)
+"gc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
 "gd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "gf" = (
@@ -1315,6 +1343,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "gg" = (
@@ -1331,6 +1360,14 @@
 	dir = 4
 	},
 /area/ruin/space/derelict/hallway_primary)
+"gl" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
+"gm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/maintenance/port)
 "gp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1500,6 +1537,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
+"ho" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/engineering/gravity_generator)
 "hq" = (
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
@@ -1538,9 +1578,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/machinery/rnd/production/circuit_imprinter/offstation,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
+"hB" = (
+/obj/structure/cable,
+/turf/open/floor/engine/airless,
+/area/ruin/space/derelict/engineering)
 "hE" = (
 /obj/machinery/drone_dispenser/derelict,
 /obj/effect/mob_spawn/ghost_role/drone/derelict,
@@ -1562,6 +1606,7 @@
 /area/ruin/space/derelict/cargo)
 "hK" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "hN" = (
@@ -1583,6 +1628,8 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "hS" = (
@@ -1636,6 +1683,9 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/research)
+"ie" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/hallway_primary)
 "if" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/south,
@@ -1648,6 +1698,7 @@
 /obj/structure/frame/computer{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "in" = (
@@ -1657,6 +1708,7 @@
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/open,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "io" = (
@@ -1672,6 +1724,9 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
+"it" = (
+/turf/open/floor/iron,
+/area/ruin/space/derelict/maintenance/port)
 "iu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1687,6 +1742,13 @@
 	dir = 10
 	},
 /area/ruin/space/derelict/research)
+"iy" = (
+/obj/machinery/power/smes{
+	input_attempt = 0;
+	inputting = 0
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
 "iz" = (
 /obj/machinery/door/window/northleft{
 	req_access_txt = "8"
@@ -1735,6 +1797,7 @@
 "iF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/textured_large,
 /area/ruin/space/derelict/hallway_primary)
 "iH" = (
@@ -1815,10 +1878,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "iQ" = (
 /obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "iT" = (
@@ -1853,19 +1918,29 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "jc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/EVA)
 "jd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/central)
+"je" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/ruin/space/derelict/hallway_primary)
 "jh" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1873,6 +1948,7 @@
 /area/ruin/space/derelict/service)
 "ji" = (
 /obj/machinery/vending/medical,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
 "jj" = (
@@ -2062,6 +2138,7 @@
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge,
 /area/ruin/space/derelict/hallway_primary)
 "km" = (
@@ -2106,6 +2183,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "kA" = (
@@ -2116,6 +2194,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "kB" = (
@@ -2167,13 +2246,14 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "kT" = (
-/obj/machinery/vending/assist,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
 "kU" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/maintenance/starboard/central)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/ruin/space/derelict/medical)
 "kV" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/north,
@@ -2237,6 +2317,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "li" = (
@@ -2327,6 +2408,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "lu" = (
@@ -2376,6 +2458,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -2468,6 +2551,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "lT" = (
@@ -2553,6 +2637,10 @@
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/large,
 /area/ruin/space/derelict/research)
+"mg" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering/gravity_generator)
 "ml" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -2597,6 +2685,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "mr" = (
@@ -2622,6 +2711,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/service)
 "mA" = (
@@ -2649,6 +2739,7 @@
 /area/ruin/space/derelict/maintenance/port/central)
 "mF" = (
 /obj/machinery/gibber,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/service)
 "mH" = (
@@ -2684,6 +2775,8 @@
 	dir = 9
 	},
 /obj/structure/frame/machine,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "mV" = (
@@ -2699,9 +2792,8 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
 "mX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "mY" = (
@@ -2710,6 +2802,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
+"na" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "nb" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -2721,6 +2818,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "ne" = (
@@ -2770,6 +2868,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "no" = (
@@ -2835,6 +2934,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "nA" = (
@@ -2855,12 +2955,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "nD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "nF" = (
@@ -2977,10 +3079,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/rnd/production/protolathe/department/science,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/rnd/production/protolathe/offstation,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
 "oe" = (
@@ -3036,6 +3138,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "or" = (
@@ -3053,6 +3156,7 @@
 	pixel_y = 4
 	},
 /obj/item/crowbar,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "oz" = (
@@ -3062,25 +3166,12 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/neck/stethoscope,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "oC" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/engineering/gravity_generator)
-"oD" = (
-/obj/machinery/modular_computer/console/preset/cargochat/medical,
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
-"oE" = (
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 4
-	},
-/obj/machinery/computer/department_orders/medical,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "oG" = (
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
@@ -3095,6 +3186,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/engineering)
 "oL" = (
@@ -3127,6 +3219,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "oR" = (
@@ -3141,6 +3234,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "oV" = (
@@ -3155,6 +3249,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "oX" = (
@@ -3174,14 +3269,17 @@
 /obj/item/hand_tele,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/research)
+"pd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/toy/crayon/spraycan,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/maintenance/port)
 "pg" = (
 /obj/machinery/photocopier,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/crew)
-"ph" = (
-/obj/machinery/rnd/production/techfab/department/medical,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "pj" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -3219,6 +3317,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -3261,6 +3360,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "pN" = (
@@ -3272,12 +3372,14 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "pQ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "pT" = (
@@ -3287,6 +3389,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/ruin/space/derelict/medical)
 "pV" = (
@@ -3340,13 +3443,14 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/item/tank/internals/emergency_oxygen/empty,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/ruin/space/derelict/maintenance/port)
 "qE" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 1
 	},
 /obj/item/shovel/spade,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -3355,6 +3459,7 @@
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/hallway_primary)
 "qL" = (
@@ -3365,6 +3470,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -3392,6 +3498,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "qW" = (
@@ -3400,12 +3508,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/hallway_primary)
 "qZ" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/item/defibrillator/loaded,
-/obj/item/clothing/gloves/color/latex/nitrile,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "re" = (
@@ -3429,22 +3537,13 @@
 /area/ruin/space/derelict/service)
 "rs" = (
 /obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/service)
 "rv" = (
 /obj/structure/table,
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
 /obj/item/reagent_containers/spray/cleaner,
-/obj/item/blood_filter,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "rz" = (
@@ -3465,6 +3564,10 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/hallway_primary)
+"rI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
 "rL" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -3484,6 +3587,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
 "sa" = (
@@ -3516,6 +3620,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "sk" = (
@@ -3542,6 +3647,8 @@
 	dir = 10
 	},
 /obj/structure/frame/machine,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "sr" = (
@@ -3549,6 +3656,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/corner{
 	dir = 4
 	},
@@ -3562,10 +3670,10 @@
 /turf/open/floor/wood,
 /area/ruin/space/derelict/maintenance/port/central)
 "sC" = (
-/obj/machinery/computer/atmos_control/tank/air_tank,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "sD" = (
@@ -3580,6 +3688,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "sG" = (
@@ -3594,8 +3703,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"sI" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/engineering)
 "sJ" = (
 /obj/effect/decal/cleanable/robot_debris/down,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "sO" = (
@@ -3607,6 +3720,7 @@
 /area/ruin/space/derelict/EVA)
 "sQ" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "sR" = (
@@ -3627,14 +3741,29 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "sY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/engineering)
+"sZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating_new,
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "g";
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "o";
+	pixel_x = 10
+	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/maintenance/port)
 "ta" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -3645,12 +3774,21 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
+"tg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
 "tl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "tm" = (
@@ -3668,6 +3806,7 @@
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "tp" = (
 /obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "tq" = (
@@ -3677,6 +3816,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "tr" = (
@@ -3684,6 +3824,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "ts" = (
@@ -3739,7 +3880,10 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/port)
 "tO" = (
-/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "tP" = (
@@ -3749,6 +3893,7 @@
 /area/ruin/space/derelict/service)
 "tQ" = (
 /obj/effect/decal/cleanable/robot_debris/up,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "tT" = (
@@ -3775,6 +3920,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/service)
 "uf" = (
@@ -3819,16 +3965,28 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "us" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"ut" = (
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/melee/baseball_bat,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
 "uv" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "uw" = (
@@ -3838,6 +3996,7 @@
 /obj/structure/sign/poster/official/wtf_is_co2{
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "uy" = (
@@ -3849,10 +4008,11 @@
 /area/ruin/space/derelict/EVA)
 "uz" = (
 /obj/machinery/computer/crew,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "uB" = (
-/obj/machinery/computer/med_data,
+/obj/structure/frame/computer,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "uE" = (
@@ -3872,6 +4032,7 @@
 /obj/structure/closet/secure_closet/bar{
 	req_access_txt = "25"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "uP" = (
@@ -3910,15 +4071,20 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "vd" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"ve" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "vf" = (
 /obj/structure/table,
-/obj/item/gun/syringe,
 /obj/item/reagent_containers/dropper{
 	pixel_y = -6
 	},
@@ -3932,10 +4098,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "vi" = (
 /obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/service)
 "vj" = (
@@ -3955,11 +4123,12 @@
 /area/ruin/space/derelict/engineering/gravity_generator)
 "vn" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/vending/drugs,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "vo" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "vs" = (
@@ -3982,6 +4151,8 @@
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "vx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "vB" = (
@@ -3992,6 +4163,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "vC" = (
@@ -4003,6 +4175,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "vH" = (
@@ -4014,6 +4187,7 @@
 	req_access_txt = "25"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "vN" = (
@@ -4023,7 +4197,7 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port)
 "vP" = (
-/obj/machinery/suit_storage_unit/cmo,
+/obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "vU" = (
@@ -4033,22 +4207,10 @@
 "vX" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/space/derelict/medical)
-"vY" = (
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table,
-/turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "wc" = (
 /obj/effect/turf_decal/stripes/line,
@@ -4072,15 +4234,12 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/service)
 "wq" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "wr" = (
 /obj/machinery/door/firedoor,
@@ -4115,6 +4274,7 @@
 "wK" = (
 /obj/structure/table,
 /obj/item/clothing/suit/apron/surgical,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "wM" = (
@@ -4128,6 +4288,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "wS" = (
@@ -4156,6 +4317,7 @@
 "xa" = (
 /obj/structure/table,
 /obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "xh" = (
@@ -4165,13 +4327,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
-"xi" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/latex,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "xj" = (
 /obj/machinery/door/firedoor/border_only/closed{
 	dir = 8
@@ -4182,19 +4340,16 @@
 "xn" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/vending/hydronutrients,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/service)
-"xo" = (
-/obj/structure/table,
-/obj/item/storage/box/masks{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
 "xp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/medical)
+"xq" = (
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/service)
 "xr" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -4224,6 +4379,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "xx" = (
@@ -4252,12 +4408,14 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "xG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "xI" = (
@@ -4294,6 +4452,13 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
+"xY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "yc" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -4309,6 +4474,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "yk" = (
@@ -4329,6 +4495,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -4343,6 +4510,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -4367,6 +4535,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"yF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
 "yH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -4400,6 +4575,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/bucket,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "yQ" = (
@@ -4441,6 +4618,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine/airless,
 /area/ruin/space/derelict/engineering)
 "zg" = (
@@ -4471,10 +4649,12 @@
 /area/ruin/space/derelict/medical)
 "zp" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "zq" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "zs" = (
@@ -4485,6 +4665,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "zw" = (
@@ -4514,7 +4695,7 @@
 /area/ruin/space/derelict/service)
 "zB" = (
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -4525,6 +4706,7 @@
 /area/ruin/space/derelict/hallway_primary)
 "zJ" = (
 /obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "zM" = (
@@ -4536,6 +4718,8 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "zP" = (
@@ -4545,10 +4729,10 @@
 /turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
 "zQ" = (
-/obj/machinery/chem_dispenser,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/ruin/space/derelict/hallway_primary)
 "zS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -4557,15 +4741,22 @@
 "zW" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "zX" = (
-/obj/machinery/chem_master,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "r";
+	pixel_x = -6;
+	pixel_y = 3
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "e";
+	pixel_x = 8;
+	pixel_y = -1
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "zY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -4573,12 +4764,17 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port)
 "Ag" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "c";
+	pixel_x = -9;
+	pixel_y = -3
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "a";
+	pixel_x = 4
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "Aj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -4587,6 +4783,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "Ak" = (
@@ -4595,6 +4792,24 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
+"An" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "l";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "e"
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "t";
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/thinplating_new,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/maintenance/port)
 "Ao" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -4606,6 +4821,14 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/departures)
+"Ap" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Ar" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/iron/airless,
@@ -4631,10 +4854,27 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/departures)
+"AF" = (
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
 "AG" = (
 /obj/machinery/door/firedoor/closed,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/departures)
+"AI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/item/stack/sheet/mineral/plasma/five,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
 "AJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -4653,6 +4893,7 @@
 /area/ruin/space/derelict/medical)
 "AN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "AS" = (
@@ -4688,12 +4929,17 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/arrival)
 "Bb" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 7
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "l";
+	pixel_x = -9
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "l";
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/maintenance/starboard/central)
 "Bf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -4708,6 +4954,7 @@
 /area/ruin/space/derelict/service/janitor)
 "Bl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "Bo" = (
@@ -4740,6 +4987,7 @@
 	pixel_x = -2;
 	pixel_y = 2
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Bx" = (
@@ -4754,6 +5002,11 @@
 /area/ruin/space/derelict/research)
 "By" = (
 /obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
+"Bz" = (
+/obj/effect/spawner/random/vending/colavend,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "BB" = (
@@ -4833,6 +5086,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/ruin/space/derelict/engineering)
 "Ch" = (
@@ -4854,6 +5108,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "Cj" = (
@@ -4866,6 +5121,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "Cn" = (
@@ -4873,6 +5130,7 @@
 	dir = 8
 	},
 /obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "Co" = (
@@ -4898,6 +5156,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "Cy" = (
@@ -4907,6 +5166,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/ai_core/deactivated,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/hallway_primary)
 "Cz" = (
@@ -4918,6 +5179,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/hallway_primary)
 "CB" = (
@@ -4932,6 +5194,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "CE" = (
@@ -4945,6 +5208,7 @@
 "CH" = (
 /obj/item/stack/sheet/animalhide/monkey,
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/service)
 "CK" = (
@@ -4978,6 +5242,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "CQ" = (
@@ -4985,6 +5250,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
+"CR" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "CT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4996,15 +5266,29 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
+"CX" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/engineering)
+"Da" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east{
+	start_charge = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
 "Dh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Dn" = (
 /obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Do" = (
@@ -5023,10 +5307,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "Ds" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Dt" = (
@@ -5040,20 +5326,28 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port)
+"DD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "DI" = (
 /obj/structure/table,
-/obj/item/reagent_containers/hypospray/cmo,
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "DN" = (
 /obj/structure/table/optable,
-/obj/item/defibrillator/loaded,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "DT" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "DU" = (
@@ -5061,6 +5355,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "DV" = (
@@ -5093,6 +5388,14 @@
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
 /area/ruin/space/derelict/departures)
+"El" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Em" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -5134,6 +5437,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "EF" = (
@@ -5154,6 +5458,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "EN" = (
@@ -5243,14 +5548,27 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"Fz" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/rust,
+/area/ruin/space/derelict/hallway_primary)
 "FD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
+"FE" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "FF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -5322,11 +5640,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "Gq" = (
 /obj/machinery/airalarm/directional/east,
 /obj/item/hatchet,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "Gu" = (
@@ -5356,6 +5676,7 @@
 "Gx" = (
 /obj/machinery/processor,
 /obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "Gz" = (
@@ -5415,8 +5736,10 @@
 /area/ruin/space/derelict/medical)
 "GW" = (
 /obj/machinery/power/smes{
-	charge = 5e+006
+	input_attempt = 0;
+	inputting = 0
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "GX" = (
@@ -5459,9 +5782,15 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/maintenance/port)
+"Hk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
 "Hl" = (
 /obj/structure/bed/roller,
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/iron/white/smooth_large,
 /area/ruin/space/derelict/medical)
@@ -5469,13 +5798,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Hu" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/bot_white/left,
 /obj/structure/window/spawner/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_large,
 /area/ruin/space/derelict/medical)
 "Hw" = (
@@ -5483,11 +5812,13 @@
 /obj/machinery/reagentgrinder{
 	pixel_y = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "Hx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Hy" = (
@@ -5495,23 +5826,34 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "HB" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
+"HD" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/ruin/space/derelict/medical)
 "HF" = (
 /obj/machinery/stasis,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "HG" = (
-/obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
 	dir = 8;
 	name = "Pharmacy Desk";
 	req_access_txt = "69"
 	},
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/medical)
 "HI" = (
@@ -5528,6 +5870,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "HJ" = (
@@ -5543,6 +5886,7 @@
 /obj/machinery/stasis{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "HP" = (
@@ -5589,6 +5933,7 @@
 "Ia" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Ie" = (
@@ -5619,6 +5964,7 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Iu" = (
@@ -5656,6 +6002,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "IH" = (
@@ -5679,6 +6026,7 @@
 /area/ruin/space/derelict/security)
 "IN" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "IQ" = (
@@ -5705,6 +6053,8 @@
 /area/ruin/space/derelict/security)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Jd" = (
@@ -5714,6 +6064,7 @@
 /area/ruin/space/derelict/hallway_primary)
 "Je" = (
 /obj/machinery/computer/operating,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Jg" = (
@@ -5728,6 +6079,7 @@
 	dir = 4;
 	pixel_x = -12
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Jj" = (
@@ -5742,10 +6094,10 @@
 	},
 /area/ruin/space/derelict/hallway_primary)
 "Jp" = (
-/obj/machinery/chem_heater/withbuffer,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/derelict/hallway_primary)
 "Jq" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -5755,6 +6107,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Jt" = (
@@ -5764,15 +6117,18 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/service)
 "Ju" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/vending/hydroseeds,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/service)
 "Jv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Jx" = (
@@ -5783,7 +6139,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
+/area/ruin/space/derelict/engineering)
+"JC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "JD" = (
 /obj/structure/sink{
@@ -5793,6 +6156,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -5802,6 +6166,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "JI" = (
@@ -5810,15 +6175,6 @@
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/service)
 "JK" = (
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
@@ -5828,6 +6184,11 @@
 /obj/machinery/door/firedoor/closed,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/departures)
+"JQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway_primary)
 "JR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -5839,6 +6200,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "JV" = (
@@ -5882,12 +6245,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/arrival)
+"Kf" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/service)
 "Kg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/item/cultivator,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "Kh" = (
@@ -5944,6 +6314,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "KG" = (
@@ -6012,29 +6383,25 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Lm" = (
 /obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge,
 /area/ruin/space/derelict/hallway_primary)
 "Lo" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/yellow,
-/obj/item/hand_labeler,
-/obj/item/stack/package_wrap,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Lq" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes{
-	pixel_y = 8
-	},
-/obj/structure/sign/poster/official/moth_meth{
-	pixel_y = 32
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/area/ruin/space/derelict/hallway_primary)
 "Lr" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/siding/thinplating,
@@ -6074,6 +6441,11 @@
 	dir = 4
 	},
 /obj/item/stack/sheet/iron/fifty,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"LB" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "LC" = (
@@ -6114,6 +6486,7 @@
 "LT" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/siding/thinplating,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/hallway_primary)
 "LV" = (
@@ -6156,26 +6529,28 @@
 	},
 /area/ruin/space/derelict/security)
 "Mm" = (
-/obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southleft{
 	req_access_txt = "69"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plating,
-/area/ruin/space/derelict/medical)
+/area/ruin/space/derelict/hallway_primary)
 "Mn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "Mq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "Mr" = (
@@ -6194,6 +6569,7 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Mx" = (
@@ -6216,14 +6592,35 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"MD" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/ruin/space/derelict/service)
 "MI" = (
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/crowbar,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
+"ML" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
 "MV" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -6246,6 +6643,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Ne" = (
@@ -6292,13 +6693,10 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Nl" = (
-/obj/structure/chair/stool/directional/north,
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/flat_white,
 /area/ruin/space/derelict/medical)
 "Nn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -6307,6 +6705,7 @@
 /obj/structure/sign/poster/official/moth_delam{
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Ns" = (
@@ -6321,6 +6720,7 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/space/derelict/security/detective)
 "Nw" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "Ny" = (
@@ -6363,6 +6763,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "NJ" = (
@@ -6383,6 +6784,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "NO" = (
@@ -6390,9 +6795,6 @@
 /area/ruin/space/derelict/bridge)
 "NR" = (
 /obj/structure/table,
-/obj/item/defibrillator/loaded{
-	pixel_y = 3
-	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
@@ -6403,6 +6805,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "Oa" = (
@@ -6432,12 +6835,15 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "Oi" = (
-/obj/machinery/chem_mass_spec,
-/obj/structure/sign/poster/official/periodic_table{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Oj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6445,6 +6851,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -6464,6 +6874,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "On" = (
@@ -6473,6 +6887,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Oo" = (
@@ -6496,9 +6911,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "Oz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "OA" = (
@@ -6521,6 +6937,7 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/structure/reagent_dispensers/wall/virusfood/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "OG" = (
@@ -6542,6 +6959,13 @@
 "ON" = (
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
+"OP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
 "OU" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -6589,6 +7013,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "Pg" = (
@@ -6600,6 +7025,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
+"Pm" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east{
+	start_charge = 0
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/derelict/engineering/gravity_generator)
 "Po" = (
 /obj/effect/decal/cleanable/crayon{
 	color = "#DE3A3A";
@@ -6623,6 +7057,7 @@
 "Pu" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/edge,
 /area/ruin/space/derelict/service)
 "Pv" = (
@@ -6652,10 +7087,12 @@
 "PI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/service)
 "PK" = (
 /obj/effect/decal/cleanable/robot_debris/limb,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "PN" = (
@@ -6678,18 +7115,25 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "PX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "PY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
+"Qa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Qb" = (
@@ -6699,6 +7143,15 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
+"Qf" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Qk" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air to Distro"
@@ -6706,6 +7159,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "Qn" = (
@@ -6716,6 +7170,8 @@
 "Qo" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Qt" = (
@@ -6735,24 +7191,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
 "Qx" = (
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/storage/pill_bottle/mannitol,
 /obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "QA" = (
@@ -6776,6 +7216,7 @@
 /obj/machinery/gravity_generator/main/station{
 	on = 0
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering/gravity_generator)
 "QF" = (
@@ -6790,6 +7231,7 @@
 /area/ruin/space/derelict/engineering)
 "QK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "QL" = (
@@ -6831,6 +7273,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "QY" = (
@@ -6840,12 +7283,16 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
 /area/ruin/space/derelict/hallway_primary)
 "Rg" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil,
+/obj/effect/spawner/random/engineering/vending_restock,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Rk" = (
@@ -6862,6 +7309,7 @@
 /obj/structure/sign/poster/official/moth_epi{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
 "Ro" = (
@@ -6869,6 +7317,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/derelict/service)
 "Rr" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
 "Rs" = (
@@ -6927,6 +7376,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "RN" = (
@@ -6936,6 +7387,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -6945,6 +7397,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/hallway_primary)
 "RS" = (
@@ -6965,6 +7418,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "RW" = (
@@ -6987,6 +7441,13 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
+"RZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "Sd" = (
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/iron/white,
@@ -7030,12 +7491,10 @@
 /area/ruin/space/derelict/research)
 "Ss" = (
 /obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_y = 7
-	},
 /obj/item/reagent_containers/dropper{
 	pixel_y = -6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "St" = (
@@ -7045,15 +7504,13 @@
 /area/ruin/space/derelict/crew)
 "Su" = (
 /obj/structure/table,
-/obj/item/storage/box/syringes{
-	pixel_y = 8
-	},
 /obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Sx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Sy" = (
@@ -7062,6 +7519,7 @@
 /area/ruin/space/derelict/maintenance/port)
 "Sz" = (
 /obj/effect/turf_decal/tile/yellow/anticorner,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
@@ -7078,6 +7536,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "SE" = (
@@ -7094,12 +7553,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "SI" = (
 /obj/machinery/smartfridge/organ,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
+"SK" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/engineering)
 "SL" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
@@ -7114,10 +7579,12 @@
 /obj/effect/turf_decal/siding/thinplating/end{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "SS" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "SV" = (
@@ -7171,6 +7638,7 @@
 /area/ruin/space/derelict/crew)
 "Tr" = (
 /obj/machinery/griddle,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "Tx" = (
@@ -7178,6 +7646,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "Ty" = (
@@ -7247,18 +7716,16 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge)
 "TO" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/area/ruin/space/derelict/hallway_primary)
 "TP" = (
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/port/central)
 "TQ" = (
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "TS" = (
@@ -7277,6 +7744,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/ruin/space/derelict/medical)
 "TV" = (
@@ -7292,13 +7760,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "TX" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/ruin/space/derelict/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "TZ" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/service)
@@ -7320,6 +7786,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/service)
 "Ug" = (
@@ -7349,6 +7816,7 @@
 /area/ruin/space/derelict/service)
 "Uu" = (
 /obj/effect/turf_decal/siding/thinplating/end,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/ruin/space/derelict/engineering)
 "Ux" = (
@@ -7370,40 +7838,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "UB" = (
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/stack/cable_coil,
-/obj/item/screwdriver{
-	pixel_x = 2;
-	pixel_y = 11
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "UD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -7428,6 +7867,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "UG" = (
@@ -7519,6 +7959,8 @@
 "UX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/engineering)
 "UY" = (
@@ -7545,6 +7987,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
+"Vd" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/derelict/maintenance/starboard/lesser)
 "Ve" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -7571,15 +8016,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "Vm" = (
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -7654,6 +8090,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "VC" = (
@@ -7670,7 +8108,6 @@
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
-/obj/item/gun/syringe,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -7692,7 +8129,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/arrival)
 "VL" = (
-/obj/machinery/air_sensor/atmos/air_tank,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
 /area/ruin/space/derelict/engineering)
@@ -7705,6 +8141,15 @@
 "VN" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/ruin/space/derelict/research)
+"VO" = (
+/obj/machinery/power/smes{
+	input_attempt = 0;
+	inputting = 0
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
 "VS" = (
 /turf/open/floor/wood/airless,
 /area/ruin/space/derelict/arrival)
@@ -7776,6 +8221,7 @@
 /area/ruin/space/derelict/hallway_primary)
 "Wo" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Wr" = (
@@ -7793,6 +8239,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Ww" = (
@@ -7802,6 +8249,14 @@
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/service)
+"Wx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/engineering)
 "Wy" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7831,6 +8286,12 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
+"WE" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/ruin/space/derelict/engineering)
 "WF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -7849,6 +8310,7 @@
 /area/ruin/space/derelict/arrival)
 "WK" = (
 /obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "WL" = (
@@ -7862,6 +8324,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "WS" = (
@@ -7882,6 +8345,7 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "WW" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "Xc" = (
@@ -7893,11 +8357,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ruin/space/derelict/service)
 "Xi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/EVA)
 "Xm" = (
@@ -7910,6 +8376,7 @@
 	},
 /area/ruin/space/derelict/hallway_primary)
 "Xp" = (
+/obj/structure/cable,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
@@ -7934,11 +8401,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "Xz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/derelict/hallway_primary)
 "XD" = (
@@ -7954,12 +8423,14 @@
 	name = "Pharmacy";
 	req_access_txt = "69"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "XK" = (
 /obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/corner{
 	dir = 4
 	},
@@ -7967,6 +8438,7 @@
 "XN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/service)
 "XR" = (
@@ -7976,6 +8448,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/hallway_primary)
 "XS" = (
@@ -7990,16 +8463,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
 /area/ruin/space/derelict/engineering)
 "XV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/derelict/medical)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/ruin/space/derelict/hallway_primary)
 "XY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -8007,6 +8481,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -8021,6 +8496,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -8042,6 +8518,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
 "Yh" = (
@@ -8059,8 +8536,8 @@
 /area/ruin/space/derelict/maintenance/port)
 "Yq" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Yr" = (
@@ -8074,6 +8551,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Yt" = (
@@ -8101,6 +8579,7 @@
 "Yw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/engineering)
 "Yx" = (
@@ -8113,6 +8592,7 @@
 "Yy" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard/lesser)
 "YA" = (
@@ -8178,6 +8658,7 @@
 "YQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
 "YR" = (
@@ -8191,6 +8672,10 @@
 	dir = 1
 	},
 /area/ruin/space/derelict/engineering/gravity_generator)
+"YU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/engineering)
 "YV" = (
 /turf/open/floor/iron/white/side{
 	dir = 9
@@ -8217,6 +8702,7 @@
 /area/ruin/space/derelict/maintenance/port/central)
 "Za" = (
 /obj/machinery/airalarm/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/medical)
 "Zb" = (
@@ -8231,6 +8717,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/structure/rack,
 /obj/item/pipe_dispenser,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "Zg" = (
@@ -8277,6 +8764,7 @@
 /obj/machinery/atmospherics/components/binary/thermomachine/heater/on{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/engineering)
 "Zw" = (
@@ -8317,6 +8805,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/corner,
 /area/ruin/space/derelict/hallway_primary)
 "ZH" = (
@@ -8366,6 +8855,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -8380,6 +8870,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/ruin/space/derelict/hallway_primary)
 "ZR" = (
@@ -9576,19 +10067,19 @@ ZB
 UQ
 MV
 Ul
-OG
+SK
 ZF
 ZF
 ZF
 ZF
 OG
+SK
+SK
+SK
 OG
-OG
-OG
-OG
-OG
-OG
-OG
+SK
+SK
+SK
 ZB
 rM
 GO
@@ -9661,7 +10152,7 @@ Yd
 UQ
 QU
 fM
-wF
+LB
 aG
 RS
 Rg
@@ -9671,9 +10162,9 @@ AY
 pN
 wF
 CU
-wF
+LB
 PN
-OG
+SK
 aa
 rM
 DV
@@ -9737,8 +10228,8 @@ VS
 VS
 VS
 Ul
-Yk
-DC
+it
+An
 Yk
 DC
 Fg
@@ -9746,13 +10237,13 @@ AK
 Yd
 ZW
 Ul
-wF
-wF
-wF
-wF
-wF
+LB
+LB
+LB
+LB
+LB
 dl
-AY
+sI
 aN
 gd
 Ia
@@ -9822,8 +10313,8 @@ VS
 oX
 VS
 Hj
-ZW
-ZW
+pd
+sZ
 ZW
 ZW
 ZW
@@ -9833,18 +10324,18 @@ ZW
 Ul
 GW
 hR
-wF
-wF
-wF
+LB
+LB
+LB
 PY
-AY
+sI
 Sn
 wP
 cM
 Lz
 up
-OG
-OG
+SK
+SK
 rM
 GO
 rM
@@ -9908,24 +10399,24 @@ qr
 VS
 Ul
 qC
-DC
+gm
 Yk
 Yk
 ZW
 DC
 Yd
 ZW
-Ul
-GW
+BU
+iy
 hR
 wF
-wF
-wF
+LB
+LB
+OP
+LB
+LB
 PY
-wF
-wF
-PY
-wF
+LB
 oS
 wF
 yc
@@ -10000,21 +10491,21 @@ ZW
 Yn
 UQ
 Bo
-Ul
-GW
+BU
+iy
 hR
 Qo
 vx
-vx
+JC
 Wt
 JU
 Cm
 qR
 zN
-PW
+Hk
 AY
 AY
-OG
+SK
 rM
 GO
 rM
@@ -10085,17 +10576,17 @@ ZW
 ZW
 QU
 ZW
-Ul
+BU
+ho
 oC
+ho
+ho
 oC
-oC
-oC
-oC
-PY
+Wx
 oS
+LB
 wF
-wF
-PY
+gc
 wF
 Vc
 sR
@@ -10177,13 +10668,13 @@ OA
 vm
 Ex
 Jx
-oS
+AI
 wF
 ZF
 oH
 ZF
 OG
-OG
+SK
 OG
 JR
 aa
@@ -10340,7 +10831,7 @@ uq
 LH
 UQ
 ZW
-Ul
+BU
 XT
 Uc
 QE
@@ -10425,13 +10916,13 @@ Yd
 Yd
 Yd
 QU
-Ul
+BU
 RN
 sa
-RN
+mg
 YT
 Ex
-YM
+yF
 oS
 ZF
 aa
@@ -10513,10 +11004,10 @@ vN
 Ul
 Xc
 yH
-Xc
+Pm
 ts
 Ex
-YM
+yF
 oS
 ZF
 ZB
@@ -10596,11 +11087,11 @@ UQ
 DC
 bF
 Ul
+ho
 oC
 oC
-oC
-oC
-oC
+ho
+ho
 PY
 oS
 OG
@@ -10681,16 +11172,16 @@ Yd
 UQ
 Zl
 UQ
-Jj
+Bz
 Ug
 rz
 OG
-wF
-PY
+LB
+OP
 Nn
 OG
 pG
-pG
+CX
 aa
 aa
 ZB
@@ -10748,34 +11239,34 @@ Ua
 Ua
 Ua
 Ua
-Ua
+kD
 YW
 Ua
-Oy
-Ua
-Ua
-Ua
-Ua
-Ua
+FE
+kD
+kD
+kD
+kD
+kD
 Wm
 vd
-Ua
-Ua
+kD
+kD
 GC
 Ua
 rF
 VM
 yv
-dU
+DD
 Ua
 XK
 OG
-wF
+LB
 PY
 oS
 BI
 hW
-hW
+hB
 oG
 ZB
 ZB
@@ -10835,24 +11326,24 @@ jD
 Bf
 Bf
 iF
-Bf
-hS
+XV
+Qf
+XV
+WF
+Ap
+XV
+XV
+WF
+XV
+XV
+WF
+XV
 Bf
 WF
-fq
-Bf
-Bf
-WF
-Bf
-Bf
-WF
-Bf
-Bf
-WF
-cI
-Bf
+El
+XV
 NF
-Bf
+XV
 qJ
 nz
 Yw
@@ -10860,7 +11351,7 @@ Sx
 AN
 ZF
 hW
-pG
+CX
 aa
 aa
 aa
@@ -10918,30 +11409,30 @@ tZ
 jE
 Ua
 Ua
+kD
+Oi
+kD
+FE
+kD
 Ua
-YW
-Ua
-Oy
-Ua
-Ua
-lr
-Ua
-Ua
-Ua
-Ua
+xY
+kD
+kD
+kD
+kD
 tZ
 Wm
-VA
-Ua
-VA
+je
+kD
+je
 tq
 VA
 Ua
-Ua
+kD
 Sz
 OG
 wF
-PY
+OP
 oS
 BI
 hW
@@ -11002,10 +11493,10 @@ Yl
 Yl
 Yl
 Yl
-Yl
+zX
 Ua
 YW
-Ua
+kD
 Ya
 Ya
 CG
@@ -11018,15 +11509,15 @@ Ya
 Ya
 Ya
 Un
-YF
+gl
 eK
 YF
-fr
-By
-rz
-OG
-wF
-PY
+ve
+na
+Fz
+SK
+LB
+OP
 oS
 OG
 pG
@@ -11087,10 +11578,10 @@ Yh
 Yh
 Yh
 Yh
-Yl
+Ag
 QK
 Xw
-Ua
+kD
 XD
 wk
 Vb
@@ -11107,8 +11598,8 @@ EL
 Pe
 Py
 OG
-OG
-OG
+SK
+SK
 OG
 OG
 PY
@@ -11172,8 +11663,8 @@ YD
 YD
 ud
 Yh
-Yl
-XF
+Bb
+Lo
 Lw
 Ua
 Ya
@@ -11188,11 +11679,11 @@ Ue
 CH
 rs
 Un
-LV
+ML
 Py
-Py
+Vd
 CT
-CT
+tg
 CT
 pq
 ZF
@@ -11258,8 +11749,8 @@ YD
 Yh
 sb
 Yl
-Ua
-YW
+kD
+Oi
 Ua
 Ya
 wG
@@ -11274,14 +11765,14 @@ mw
 mF
 Un
 LV
-Py
+Vd
 To
 wF
 PK
 gd
-wF
+LB
 ZF
-YM
+yF
 oS
 ZF
 aa
@@ -11345,7 +11836,7 @@ YD
 YD
 kA
 Aj
-Kw
+CR
 Ya
 Va
 WG
@@ -11358,8 +11849,8 @@ HI
 Ya
 Ya
 Un
-LV
-Py
+ML
+Vd
 wc
 sJ
 pM
@@ -11429,8 +11920,8 @@ Cn
 sE
 Kl
 Mq
-YW
-Ua
+Oi
+kD
 NB
 ZN
 jh
@@ -11443,15 +11934,15 @@ WD
 Nw
 uO
 Un
-LV
+ML
 Py
-To
+WE
 tQ
 EF
 Ec
-wF
+LB
 ZF
-YM
+yF
 oS
 ZF
 ZF
@@ -11514,8 +12005,8 @@ Xi
 Xi
 KF
 tl
-VG
-Bf
+TX
+XV
 Ww
 re
 mW
@@ -11530,11 +12021,11 @@ ql
 Un
 UE
 Py
-To
-wF
+WE
+Da
 mT
 sp
-GW
+VO
 DU
 xC
 oS
@@ -11542,7 +12033,7 @@ wF
 ZF
 Ce
 ZF
-OG
+SK
 OG
 aa
 aa
@@ -11590,7 +12081,7 @@ Ua
 Yl
 Yh
 YD
-UJ
+cJ
 nC
 iQ
 tp
@@ -11599,8 +12090,8 @@ Cv
 Ak
 Kl
 Mq
-YW
-Ua
+Oi
+kD
 NB
 PH
 Ku
@@ -11615,19 +12106,19 @@ Hw
 Un
 LV
 Py
-Py
+Vd
 Py
 Py
 OG
-OG
+SK
 OG
 RU
 VB
-vx
+JC
 RM
 PW
 wF
-wF
+LB
 ZF
 hW
 aa
@@ -11675,7 +12166,7 @@ Ua
 Yl
 Yh
 YD
-UJ
+cJ
 nD
 HB
 sQ
@@ -11684,7 +12175,7 @@ Zt
 Zt
 Zt
 QQ
-YW
+Oi
 Ua
 Ya
 UN
@@ -11702,7 +12193,7 @@ vh
 YF
 TQ
 tK
-Py
+Vd
 FR
 FR
 OG
@@ -11711,8 +12202,8 @@ IG
 SO
 gf
 Uu
-wF
-wF
+LB
+LB
 oP
 hW
 hW
@@ -11762,15 +12253,15 @@ Yh
 YD
 HU
 nF
-Ak
+jc
 uy
 Zt
 Cy
 Xz
 qW
 Bf
-Jd
-Xv
+UB
+RZ
 Ya
 Ya
 cB
@@ -11783,7 +12274,7 @@ mq
 Nw
 aK
 Un
-LV
+ML
 YF
 xw
 Yy
@@ -11795,9 +12286,9 @@ Iq
 pQ
 oQ
 YB
+Qa
 Cj
-Cj
-Cj
+Qa
 Pg
 IH
 ZB
@@ -11853,9 +12344,9 @@ YD
 Cz
 RQ
 Sq
-Ua
-YW
-Ua
+kD
+Oi
+kD
 Ya
 SA
 Vb
@@ -11868,7 +12359,7 @@ SC
 Xf
 Gx
 Un
-LV
+ML
 YF
 tn
 WK
@@ -11877,13 +12368,13 @@ lT
 VL
 ZF
 sC
-sR
+YU
 IN
 Lj
 ep
 wF
-wF
-OG
+LB
+SK
 ZB
 aa
 aa
@@ -11938,9 +12429,9 @@ Yl
 Yl
 Yl
 Yl
-Ua
-YW
-Ua
+kD
+Oi
+kD
 Ya
 Qu
 Vb
@@ -11965,10 +12456,10 @@ Qk
 CO
 cP
 jb
-wF
-wF
-wF
-OG
+LB
+LB
+LB
+SK
 aa
 aa
 aa
@@ -12023,9 +12514,9 @@ Yh
 Yh
 Yh
 me
-Ua
-YW
-Ua
+kD
+Oi
+kD
 Ya
 Ya
 Ya
@@ -12040,8 +12531,8 @@ Un
 Un
 lk
 YF
-tK
-tK
+rI
+rI
 Py
 FR
 FR
@@ -12049,10 +12540,10 @@ OG
 sV
 Zv
 Zd
-PY
+OP
 Fv
-wF
-wF
+LB
+LB
 OG
 aa
 aa
@@ -12098,7 +12589,7 @@ Ey
 YW
 Ua
 Yl
-kT
+Yh
 Yh
 Yh
 Yh
@@ -12108,36 +12599,36 @@ Yh
 Yh
 Yl
 Yl
-XF
+Lo
 XR
-Bf
-Bf
+XV
+XV
 oR
 PI
 Kg
 tP
 dj
 Tm
-Tm
+ar
 CK
 WW
 WW
 vw
 xG
+Vd
 Py
 Py
-Py
-Py
+Vd
 OG
-OG
-OG
+SK
+SK
 OK
 Hh
-OG
+SK
 Yx
 OG
 ZF
-OG
+SK
 OG
 aa
 aa
@@ -12183,7 +12674,7 @@ Kr
 Jd
 Xv
 Yl
-kU
+Yh
 Yh
 Yh
 YD
@@ -12193,20 +12684,20 @@ Yh
 sb
 Yl
 Lr
-Ua
+kD
 YW
-Ua
-Ua
+kD
+kD
 Vz
-Tm
+ar
 lz
-sl
+AF
 fZ
 sl
 xn
 YF
-YF
-YF
+gl
+gl
 pj
 YF
 YF
@@ -12278,22 +12769,22 @@ zh
 Yl
 Yl
 LT
+kD
+Oi
 Ua
-YW
-Ua
-Ua
+kD
 XN
 Tm
 lz
 qE
-fZ
-sl
+MD
+AF
 Pu
-TZ
+xq
 ZB
-YF
+gl
 Go
-YF
+gl
 ea
 pL
 ZB
@@ -12358,27 +12849,27 @@ ZH
 UV
 PD
 oy
-Zg
+kT
 Zg
 Ji
 mJ
 LT
-Ua
-YW
-Ua
-Ua
-XN
+kD
+Oi
+kD
+kD
+Kf
 Tm
 lz
-sl
-fZ
-sl
+ut
+MD
+AF
 JI
 TZ
 ZB
 YF
 Cu
-YF
+gl
 Jg
 ZB
 aa
@@ -12443,23 +12934,23 @@ UV
 UV
 PD
 oz
-Zg
-Zg
+kT
+kT
 Ht
 mJ
 Md
 QK
 tr
-Ua
+kD
 Ua
 Vz
 Gq
 Tj
 ym
 yP
-Tm
+ar
 Ju
-TZ
+xq
 aa
 ZB
 uE
@@ -12527,24 +13018,24 @@ kV
 UV
 UV
 PD
-oD
+JK
 Zg
-Zg
+kT
 CC
 mJ
 mJ
 QW
-YW
+Oi
 us
 Sq
-TZ
-TZ
+xq
+xq
 Vz
 TZ
 Vz
 TZ
-TZ
-TZ
+xq
+xq
 aa
 aa
 ZB
@@ -12612,16 +13103,16 @@ kZ
 mf
 mf
 PD
-oE
+zJ
+kT
 Zg
-Zg
-CN
+tO
 Hl
 mJ
 QY
 XY
 Jk
-Sq
+ie
 ZB
 aa
 aa
@@ -12699,7 +13190,7 @@ tA
 PD
 PD
 Zg
-Zg
+kT
 CN
 Hu
 mJ
@@ -12707,12 +13198,12 @@ Rl
 Yg
 rS
 Sq
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
+Sq
+Sq
+aa
+aa
+ZB
+ZB
 aa
 aa
 aa
@@ -12784,20 +13275,20 @@ NE
 nG
 PD
 uz
-Zg
-CN
-Zg
+kT
+tO
+kT
 Mt
 Rr
 Yg
 Rr
 Lm
-Sl
+JQ
 zQ
 Jp
-Ds
-Oi
-Sl
+aa
+ZB
+aa
 aa
 aa
 aa
@@ -12869,20 +13360,20 @@ mY
 nH
 PD
 uB
-zo
+kU
 Dh
 Hx
 MC
-RF
+Lq
 YQ
 RF
 kk
 Mm
 TO
-jc
-XV
-Bb
-Sl
+ZB
+ZB
+ZB
+ZB
 aa
 aa
 aa
@@ -12961,13 +13452,13 @@ mJ
 RI
 ZK
 Yt
-mJ
-yQ
-cJ
-zX
-Zg
-UB
-Sl
+Sq
+Sq
+ZB
+ZB
+aa
+aa
+ZB
 ZB
 aa
 aa
@@ -13040,19 +13531,19 @@ nJ
 PD
 uP
 Zg
-Zg
+kT
 HF
 xp
 RP
 ZM
 qL
-mJ
-Lq
-Zg
-mX
-Zg
-tO
-Sl
+Sq
+ZB
+ZB
+aa
+aa
+aa
+aa
 ZB
 ZB
 aa
@@ -13125,18 +13616,18 @@ nM
 PD
 vf
 Zg
-Zg
+mX
 HN
 xp
 Se
 ZO
 ji
-mJ
-Lo
-Nl
-wq
-TX
-Ag
+Sq
+aa
+aa
+aa
+aa
+aa
 mJ
 mJ
 Sl
@@ -13209,8 +13700,8 @@ IB
 oV
 PD
 vn
-Zg
-Zg
+kT
+kT
 Ih
 mJ
 Sl
@@ -13225,7 +13716,7 @@ mJ
 mJ
 Vm
 JK
-vY
+JK
 mJ
 mJ
 aa
@@ -13294,23 +13785,23 @@ Bx
 nQ
 Kx
 vo
+kT
 Zg
-Zg
-Zg
-Zg
+kT
+kT
 Zg
 On
 Zg
 dp
 uv
+HD
 HR
-HR
-HR
+HD
 WR
 DW
-hz
+dD
 Ht
-Zg
+kT
 NR
 Sl
 aa
@@ -13379,23 +13870,23 @@ IA
 oV
 YJ
 vC
-Zg
-Zg
-Zg
+kT
+kT
+kT
 MY
-Sm
+Nl
 TU
-Sm
+Nl
 Hx
 fv
-Sm
+Nl
 pT
 Sm
 Hx
 lS
 ur
 YN
-Zg
+kT
 rv
 Sl
 aa
@@ -13465,22 +13956,22 @@ nR
 YJ
 vP
 zq
-Zg
+kT
 It
 Ni
-Zg
+kT
 Za
-Zg
+kT
 Zg
 Ni
 IQ
 XZ
 pO
-Zg
+kT
 DW
 hz
 ck
-Zg
+kT
 DI
 Sl
 aa
@@ -13565,7 +14056,7 @@ mJ
 mJ
 VF
 qZ
-ph
+qZ
 mJ
 mJ
 aa
@@ -13720,17 +14211,17 @@ nV
 pH
 wK
 Zg
-zo
+wq
 Jb
 Om
 Ss
 mJ
 hK
 PX
-CN
+tO
 mJ
 sf
-Zg
+kT
 jz
 mJ
 ZB
@@ -13807,7 +14298,7 @@ xa
 Zg
 DN
 Je
-CN
+tO
 Su
 mJ
 Yq
@@ -13815,7 +14306,7 @@ TF
 Hy
 mJ
 Jq
-Zg
+kT
 DT
 mJ
 ZB
@@ -13888,8 +14379,8 @@ mr
 nh
 nY
 PD
-xi
-Zg
+JK
+mX
 Zg
 Jv
 Oz
@@ -13973,9 +14464,9 @@ ms
 ni
 nZ
 PD
-xo
+JK
 zJ
-Zg
+kT
 JD
 Zg
 SS

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -9744,7 +9744,7 @@ aa
 aa
 aa
 aa
-aa
+YO
 ZB
 lv
 ZB

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -386,8 +386,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/port/lesser)
 "bz" = (
-/obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/radiation,
+/obj/item/stack/sheet/mineral/uranium/five,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/derelict/maintenance/starboard)
 "bB" = (
@@ -678,6 +679,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stock_parts/cell/hyper,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "cE" = (
@@ -1525,6 +1527,11 @@
 /obj/structure/frame/machine,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/research)
+"gA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/derelict/maintenance/starboard)
 "gC" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -4784,6 +4791,7 @@
 "yq" = (
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/cargo)
 "yv" = (
@@ -12245,7 +12253,7 @@ ON
 aP
 hU
 bz
-cd
+gA
 hU
 cd
 lj

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -198,6 +198,7 @@
 	suffix = "thederelict.dmm"
 	name = "Kosmicheskaya Stantsiya 13"
 	description = "The true fate of Kosmicheskaya Stantsiya 13 is an open question to this day. Most corporations deny its existence, for fear of questioning on what became of its crew."
+	always_place = TRUE //Keeping a little bit of the static space level days alive
 
 /datum/map_template/ruin/space/abandonedteleporter
 	id = "abandonedteleporter"

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -388,6 +388,11 @@
 /area/ruin/space/derelict/maintenance/starboard/lesser
 	name = "\improper Derelict Lesser Starboard Maintenance"
 
+//Derelict Syndicate Pod
+/area/ruin/space/derelict/syndipod
+	name = "\improper Crashed Syndicate Cargo Pod"
+	icon_state = "syndie-ship"
+
 
 //DJSTATION
 

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -299,72 +299,95 @@
 	name = "\improper Derelict Station"
 	icon_state = "storage"
 
-/area/ruin/space/derelict/hallway/primary
+//Derelict Halls
+
+/area/ruin/space/derelict/hallway_primary
 	name = "\improper Derelict Primary Hallway"
 	icon_state = "hallP"
-
-/area/ruin/space/derelict/hallway/secondary
-	name = "\improper Derelict Secondary Hallway"
-	icon_state = "hallS"
-
-/area/ruin/space/derelict/hallway/primary/port
-	name = "\improper Derelict Port Hallway"
-	icon_state = "hallFP"
 
 /area/ruin/space/derelict/arrival
 	name = "\improper Derelict Arrival Centre"
 	icon_state = "yellow"
 
-/area/ruin/space/derelict/storage/equipment
-	name = "\improper Derelict Equipment Storage"
+/area/ruin/space/derelict/departures
+	name = "\improper Derelict Departures Wing"
+	icon_state = "escape"
+
+//Derelict Departments
+
+/area/ruin/space/derelict/cargo
+	name = "\improper Derelict Cargo Department"
+	icon_state = "cargo_bay"
 
 /area/ruin/space/derelict/bridge
-	name = "\improper Derelict Control Room"
+	name = "\improper Derelict Bridge"
 	icon_state = "bridge"
 
-/area/ruin/space/derelict/bridge/access
-	name = "\improper Derelict Control Room Access"
-	icon_state = "auxstorage"
-
-/area/ruin/space/derelict/bridge/ai_upload
-	name = "\improper Derelict Computer Core"
-	icon_state = "ai"
-
-/area/ruin/space/derelict/solar_control
-	name = "\improper Derelict Solar Control"
-	icon_state = "engine"
-
-/area/ruin/space/derelict/se_solar
-	name = "\improper South East Solars"
-	icon_state = "engine"
+/area/ruin/space/derelict/EVA
+	name = "\improper Derelict EVA Storage"
+	icon_state = "bridge"
 
 /area/ruin/space/derelict/medical
 	name = "\improper Derelict Medbay"
 	icon_state = "medbay"
 
-/area/ruin/space/derelict/medical/chapel
-	name = "\improper Derelict Chapel"
-	icon_state = "chapel"
+/area/ruin/space/derelict/research
+	name = "\improper Derelict Research Wing"
+	icon_state = "research"
 
-/area/solars/derelict_starboard
-	name = "\improper Derelict Starboard Solar Array"
-	icon_state = "panelsS"
+/area/ruin/space/derelict/research/xenobiology
+	name = "\improper Derelict Xenobiology Wing"
+	icon_state = "xenobio"
 
-/area/solars/derelict_aft
-	name = "\improper Derelict Aft Solar Array"
-	icon_state = "yellow"
-
-/area/ruin/space/derelict/singularity_engine
+/area/ruin/space/derelict/engineering
 	name = "\improper Derelict Singularity Engine"
 	icon_state = "engine"
 
-/area/ruin/space/derelict/gravity_generator
+/area/ruin/space/derelict/engineering/gravity_generator
 	name = "\improper Derelict Gravity Generator Room"
-	icon_state = "red"
 
-/area/ruin/space/derelict/atmospherics
-	name = "Derelict Atmospherics"
-	icon_state = "red"
+/area/ruin/space/derelict/service
+	name = "\improper Derelict Service Wing"
+	icon_state = "bar"
+
+/area/ruin/space/derelict/service/janitor
+	name = "\improper Derelict Janitor's Closet"
+	icon_state = "janitor"
+
+/area/ruin/space/derelict/security
+	name = "\improper Derelict Security Department"
+	icon_state = "security"
+
+/area/ruin/space/derelict/security/detective
+	name = "\improper Derelict Detective's Office"
+	icon_state = "detective"
+
+/area/ruin/space/derelict/crew
+	name = "\improper Derelict Crew Quarters"
+	icon_state = "crew_quarters"
+
+//Derelict Maint
+
+/area/ruin/space/derelict/maintenance/port
+	name = "\improper Derelict Port Maintenance"
+	icon_state = "portmaint"
+
+/area/ruin/space/derelict/maintenance/port/central
+	name = "\improper Derelict Central Port Maintenance"
+
+/area/ruin/space/derelict/maintenance/port/lesser
+	name = "\improper Derelict Lesser Port Maintenance"
+
+/area/ruin/space/derelict/maintenance/starboard
+	name = "\improper Derelict Starboard Maintenance"
+	icon_state = "starboardmaint"
+
+/area/ruin/space/derelict/maintenance/starboard/central
+	name = "\improper Derelict Central Starboard Maintenance"
+
+/area/ruin/space/derelict/maintenance/starboard/lesser
+	name = "\improper Derelict Lesser Starboard Maintenance"
+
 
 //DJSTATION
 

--- a/code/game/machinery/computer/terminal.dm
+++ b/code/game/machinery/computer/terminal.dm
@@ -1,15 +1,15 @@
+//Basic computer meant for basic detailing in ruins and away missions, NOT meant for the station
 /obj/machinery/computer/terminal
 	name = "terminal"
 	desc = "A relatively low-tech solution for internal computing, internal network mail, and logging. This model appears to be quite old."
-///Text this terminal contains, not dissimilar to paper. Unlike paper, players cannot add or edit existing info.
-///Essentially: Ruins and gateways only if you don't wanna look like a dweeb
-	var/info = "Congratulations on your purchase of a NanoSoft-TM terminal! Further instructions on setup available in \
-	user manual. For license and registration, please contact your licensed NanoSoft vendor and repair service representative."
+	circuit = /obj/item/circuitboard/computer/terminal //Deconstruction still wipes contents but this is easier than smashing the console
 ///Text that displays on top of the actual 'lore' funnies.
 	var/upperinfo = "COPYRIGHT 2487 NANOSOFT-TM - DO NOT REDISTRIBUTE"
+///Text this terminal contains, not dissimilar to paper. Unlike paper, players cannot add or edit existing info.
+	var/info = "Congratulations on your purchase of a NanoSoft-TM terminal! Further instructions on setup available in \
+	user manual. For license and registration, please contact your licensed NanoSoft vendor and repair service representative."
 
 /obj/machinery/computer/terminal/ui_interact(mob/user, datum/tgui/ui)
-	// Update the UI
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Terminal", name) //The paper tgui file scares me, so new type of UI

--- a/code/game/machinery/computer/terminal.dm
+++ b/code/game/machinery/computer/terminal.dm
@@ -8,6 +8,8 @@
 ///Text this terminal contains, not dissimilar to paper. Unlike paper, players cannot add or edit existing info.
 	var/info = "Congratulations on your purchase of a NanoSoft-TM terminal! Further instructions on setup available in \
 	user manual. For license and registration, please contact your licensed NanoSoft vendor and repair service representative."
+///The TGUI theme this console uses. Defaults to hackerman, a retro greeny pallete which should fit most terminals.
+	var/tguitheme = "hackerman"
 
 /obj/machinery/computer/terminal/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -19,3 +21,4 @@
 	. = list()
 	.["text"] = info
 	.["uppertext"] = upperinfo
+	.["tguitheme"] = tguitheme

--- a/code/game/machinery/computer/terminal.dm
+++ b/code/game/machinery/computer/terminal.dm
@@ -1,0 +1,21 @@
+/obj/machinery/computer/terminal
+	name = "terminal"
+	desc = "A relatively low-tech solution for internal computing, internal network mail, and logging. This model appears to be quite old."
+///Text this terminal contains, not dissimilar to paper. Unlike paper, players cannot add or edit existing info.
+///Essentially: Ruins and gateways only if you don't wanna look like a dweeb
+	var/info = "Congratulations on your purchase of a NanoSoft-TM terminal! Further instructions on setup available in \
+	user manual. For license and registration, please contact your licensed NanoSoft vendor and repair service representative."
+///Text that displays on top of the actual 'lore' funnies.
+	var/upperinfo = "COPYRIGHT 2487 NANOSOFT-TM - DO NOT REDISTRIBUTE"
+
+/obj/machinery/computer/terminal/ui_interact(mob/user, datum/tgui/ui)
+	// Update the UI
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "Terminal", name) //The paper tgui file scares me, so new type of UI
+		ui.open()
+
+/obj/machinery/computer/terminal/ui_static_data(mob/user)
+	. = list()
+	.["text"] = info
+	.["uppertext"] = upperinfo

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -320,6 +320,10 @@
 	name = "Tram Controls (Computer Board)"
 	build_path = /obj/machinery/computer/tram_controls
 
+/obj/item/circuitboard/computer/terminal
+	name = "Terminal (Computer Board)"
+	build_path = /obj/machinery/computer/terminal
+
 //Medical
 
 /obj/item/circuitboard/computer/crew

--- a/code/modules/ruins/spaceruin_code/TheDerelict.dm
+++ b/code/modules/ruins/spaceruin_code/TheDerelict.dm
@@ -1,24 +1,20 @@
-/////////// thederelict items
+///The Derelict Terminals
+/obj/machinery/computer/terminal/derelict/bridge
+	icon_screen = "comm"
+	icon_keyboard = "tech_key"
+	info = "Central Command Status Summary -- Impending Doom -- Your station is somehow in the middle of hostile territory, in clear view of any enemy of the corporation. Your likelihood to survive is low, \
+	and station destruction is expected and almost inevitable. Secure any sensitive material and neutralize any enemy you will come across. It is important that you at least try to maintain the station. \
+	Good luck. -- Special Orders for KC13: Our military presence is inadequate in your sector. We need you to construct BSA-87 Artillery position aboard your station. Base parts are available for shipping via cargo. \
+	-Nanotrasen Naval Command -- Identified Shift Divergences: Overflow bureaucracy mistake - It seems for some reason we put out the wrong job-listing for the overflow role this shift...I hope you like captains."
 
-/obj/item/paper/fluff/ruins/thederelict/equipment
-	info = "If the equipment breaks there should be enough spare parts in our engineering storage near the north east solar array."
-	name = "Equipment Inventory"
+/obj/machinery/computer/terminal/derelict/cargo
+	info = "INTER-MAIL - #789 - Cargo Technician I. Miller -> J. Holmes -- Jake, with all due respect, I don't know how you guys can keep this shit up. Robotics has made not one, but THREE AIs, \
+	and at least one of them either has combat upgrades or isn't telling us the whole story. Not that we can even get close enough to tell, mind, they're doing everything in their power to keep us away. It's \
+	unnerving. Meanwhile, a little birdie tells me one of your officers has been spending all shift trying to get their baton back from the clown with.. lethal force. This place is a fucking powder keg, Jake, \
+	you know as well as I do. Either stop fucking around or we'll take matters into our own hands."
 
-/obj/item/paper/fluff/ruins/thederelict/syndie_mission
-	name = "Mission Objectives"
-	info = "The Syndicate have cunningly disguised a Syndicate Uplink as your PDA. Simply enter the code \"678 Bravo\" into the ringtone select to unlock its hidden features. <br><br><b>Objective #1</b>. Kill the God damn AI in a fire blast that it rocks the station. <b>Success!</b>  <br><b>Objective #2</b>. Escape alive. <b>Failed.</b>"
-
-/obj/item/paper/fluff/ruins/thederelict/nukie_objectives
-	name = "Objectives of a Nuclear Operative"
-	info = "<b>Objective #1</b>: Destroy the station with a nuclear device."
-
-/obj/item/paper/crumpled/bloody/ruins/thederelict/unfinished
-	name = "unfinished paper scrap"
-	desc = "Looks like someone started shakily writing a will in space common, but were interrupted by something bloody..."
-	info = "I, Victor Belyakov, do hereby leave my _- "
-/obj/item/paper/fluff/ruins/thederelict/vaultraider
-	name = "Vault Raider Objectives"
-	info = "<b>Objectives #1</b>: Find out what is hidden in Kosmicheskaya Stantsiya 13s Vault"
+/obj/machinery/computer/terminal/derelict/security
+	info = "INTER-MAIL - #790 - Cargo Technician J. Holmes -> I. Miller -- HOT SINGLE SILICONS IN YOUR AREA, CLICK ->HERE<- FOR MORE INFORMATION!"
 
 /// Vault controller for use on the derelict/KS13.
 /obj/machinery/computer/vaultcontroller

--- a/code/modules/ruins/spaceruin_code/TheDerelict.dm
+++ b/code/modules/ruins/spaceruin_code/TheDerelict.dm
@@ -16,6 +16,15 @@
 /obj/machinery/computer/terminal/derelict/security
 	info = "INTER-MAIL - #790 - Cargo Technician J. Holmes -> I. Miller -- HOT SINGLE SILICONS IN YOUR AREA, CLICK ->HERE<- FOR MORE INFORMATION!"
 
+/obj/machinery/computer/terminal/derelict/syndicatecargopod
+	icon_screen = "tcboss"
+	icon_keyboard = "syndie_key"
+	upperinfo = "RUNNING SYNDIX ON FORK 48756A - REMEMBER TO OPEN AN ISSUE REPORT FOR ANY BUGS YOU ENCOUNTER"
+	info = "Logged In As Operative S. Martins -- Incident Report -- So, there was a minor hitch with the whole giant cargopod idea we were prepping for greenlight. As it turns out, the pressure we used was too \
+	low for our use case - pod ran off course at 0300 hours, but thankfully the tracking system's functioning just fine. Less fortunately, the pod's seem to have hit something, so I'm going to have to go EVA \
+	for pickup... High Command assures me that everything's fine, but something about the way we stopped's got me on edge. Jules, when you inevitably review this, tell /her/ that she'd be better off in service than RND."
+	tguitheme = "syndicate"
+
 /// Vault controller for use on the derelict/KS13.
 /obj/machinery/computer/vaultcontroller
 	name = "vault controller"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1253,6 +1253,7 @@
 #include "code\game\machinery\computer\security.dm"
 #include "code\game\machinery\computer\station_alert.dm"
 #include "code\game\machinery\computer\teleporter.dm"
+#include "code\game\machinery\computer\terminal.dm"
 #include "code\game\machinery\computer\tram_controls.dm"
 #include "code\game\machinery\computer\warrant.dm"
 #include "code\game\machinery\computer\arcade\arcade.dm"

--- a/tgui/packages/tgui/interfaces/Terminal.js
+++ b/tgui/packages/tgui/interfaces/Terminal.js
@@ -1,0 +1,19 @@
+import { useBackend } from '../backend';
+import { NoticeBox } from '../components';
+import { Window } from '../layouts';
+import { sanitizeText } from '../sanitize';
+
+export const Terminal = (props, context) => {
+  const { act, data } = useBackend(context);
+  return (
+   <Window theme="hackerman" title="Terminal" width={600} height={600}>
+    <Window.Content scrollable>
+     <NoticeBox textAlign="left">
+      {data.uppertext}
+     </NoticeBox>
+      {sanitizeText(data.text)}
+    </Window.Content>
+   </Window>
+  );
+};
+

--- a/tgui/packages/tgui/interfaces/Terminal.js
+++ b/tgui/packages/tgui/interfaces/Terminal.js
@@ -6,14 +6,14 @@ import { sanitizeText } from '../sanitize';
 export const Terminal = (props, context) => {
   const { act, data } = useBackend(context);
   return (
-   <Window theme={data.tguitheme} title="Terminal" width={600} height={600}>
-    <Window.Content scrollable>
-     <NoticeBox textAlign="left">
-      {data.uppertext}
-     </NoticeBox>
-      {sanitizeText(data.text)}
-    </Window.Content>
-   </Window>
+    <Window theme={data.tguitheme} title="Terminal" width={600} height={600}>
+      <Window.Content scrollable>
+        <NoticeBox textAlign="left">
+          {data.uppertext}
+        </NoticeBox>
+        {sanitizeText(data.text)}
+      </Window.Content>
+    </Window>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/Terminal.js
+++ b/tgui/packages/tgui/interfaces/Terminal.js
@@ -9,7 +9,7 @@ export const Terminal = (props, context) => {
     <Window theme={data.tguitheme} title="Terminal" width={600} height={600}>
       <Window.Content scrollable>
         <NoticeBox textAlign="left">
-          {data.uppertext}
+          {sanitizeText(data.uppertext)}
         </NoticeBox>
         {sanitizeText(data.text)}
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/Terminal.js
+++ b/tgui/packages/tgui/interfaces/Terminal.js
@@ -1,19 +1,42 @@
-import { useBackend } from '../backend';
-import { NoticeBox } from '../components';
-import { Window } from '../layouts';
-import { sanitizeText } from '../sanitize';
+import {
+  useBackend
+} from '../backend';
+import {
+  NoticeBox
+} from '../components';
+import {
+  Window
+} from '../layouts';
+import {
+  sanitizeText
+} from '../sanitize';
 
 export const Terminal = (props, context) => {
-  const { act, data } = useBackend(context);
-  return (
-   <Window theme={data.tguitheme} title="Terminal" width={600} height={600}>
-    <Window.Content scrollable>
-     <NoticeBox textAlign="left">
-      {data.uppertext}
-     </NoticeBox>
-      {sanitizeText(data.text)}
-    </Window.Content>
-   </Window>
+  const {
+      act,
+      data
+  } = useBackend(context);
+  return ( <
+      Window theme = {
+          data.tguitheme
+      }
+      title = "Terminal"
+      width = {
+          600
+      }
+      height = {
+          600
+      } >
+      <
+      Window.Content scrollable >
+      <
+      NoticeBox textAlign = "left" > {
+          data.uppertext
+      } <
+      /NoticeBox> {
+          sanitizeText(data.text)
+      } <
+      /Window.Content> <
+      /Window>
   );
 };
-

--- a/tgui/packages/tgui/interfaces/Terminal.js
+++ b/tgui/packages/tgui/interfaces/Terminal.js
@@ -6,7 +6,7 @@ import { sanitizeText } from '../sanitize';
 export const Terminal = (props, context) => {
   const { act, data } = useBackend(context);
   return (
-   <Window theme="hackerman" title="Terminal" width={600} height={600}>
+   <Window theme={data.tguitheme} title="Terminal" width={600} height={600}>
     <Window.Content scrollable>
      <NoticeBox textAlign="left">
       {data.uppertext}

--- a/tgui/packages/tgui/interfaces/Terminal.js
+++ b/tgui/packages/tgui/interfaces/Terminal.js
@@ -1,42 +1,19 @@
-import {
-  useBackend
-} from '../backend';
-import {
-  NoticeBox
-} from '../components';
-import {
-  Window
-} from '../layouts';
-import {
-  sanitizeText
-} from '../sanitize';
+import { useBackend } from '../backend';
+import { NoticeBox } from '../components';
+import { Window } from '../layouts';
+import { sanitizeText } from '../sanitize';
 
 export const Terminal = (props, context) => {
-  const {
-      act,
-      data
-  } = useBackend(context);
-  return ( <
-      Window theme = {
-          data.tguitheme
-      }
-      title = "Terminal"
-      width = {
-          600
-      }
-      height = {
-          600
-      } >
-      <
-      Window.Content scrollable >
-      <
-      NoticeBox textAlign = "left" > {
-          data.uppertext
-      } <
-      /NoticeBox> {
-          sanitizeText(data.text)
-      } <
-      /Window.Content> <
-      /Window>
+  const { act, data } = useBackend(context);
+  return (
+   <Window theme={data.tguitheme} title="Terminal" width={600} height={600}>
+    <Window.Content scrollable>
+     <NoticeBox textAlign="left">
+      {data.uppertext}
+     </NoticeBox>
+      {sanitizeText(data.text)}
+    </Window.Content>
+   </Window>
   );
 };
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Remaps KC13 from the ground up - It's now based on Ministation rather than Oldstation, has a bunch of extra detailing, terminals, additional things to do... Oh, and the gameplay loop is different now. Setup time is both drastically shorter and slightly more involved.

In addition: This PR Introduces a new mapper object: Terminals! They're weirdo computers that display text for their reader, but can't be edited in game. They're meant for ruin and away mission mappers primarily.
<details>
<summary>The Map Itself</summary>

![oceea94](https://user-images.githubusercontent.com/50649185/157375217-23cd7581-f785-4079-8a84-187c87d70a27.png)


</details>

<details>
<summary>Terminals In-Game</summary>

![image](https://user-images.githubusercontent.com/50649185/157374387-3902fbb4-f3cf-43ac-acf9-7b2b2c353b07.png)

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
KC13, ironically, is aging fast. I tried my darndest to get it up to standards originally, but I ultimately decided a full remap was in order. This *also* gives derelict drones more to do in the bounds of their laws with some setup, so drone players don't speedrun getting bored as they seem want to do.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: KC13 Has been entirely remapped! Don't ask me how this one works out in context, I have no answers.
add: Mappers can now play with a new object: Terminals! You can now do "the lore dump" in "the video game" and work at "the company with gears in the logo that makes the bugs".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
