### PR TITLE
Cyborgs can no longer hand mine snow turfs with non-mining modules

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -23,11 +23,11 @@
 	var/mineralAmt = 3
 	var/scan_state = "" //Holder for the image we display when we're pinged by a mining scanner
 	var/defer_change = 0
-	// If true you can mine the mineral turf with your hands
+	// If true you can mine the mineral turf without tools.
 	var/weak_turf = FALSE
 	///How long it takes to mine this turf with tools, before the tool's speed and the user's skill modifier are factored in.
 	var/tool_mine_speed = 4 SECONDS
-	///How long it takes to mine this turf with hands, if it's weak.
+	///How long it takes to mine this turf without tools, if it's weak.
 	var/hand_mine_speed = 15 SECONDS
 
 /turf/closed/mineral/Initialize(mapload)
@@ -88,8 +88,6 @@
 			to_chat(user, span_notice("You finish cutting into the rock."))
 			gets_drilled(user, TRUE)
 			SSblackbox.record_feedback("tally", "pick_used_mining", 1, I.type)
-	else
-		return attack_hand(user)
 
 /turf/closed/mineral/attack_hand(mob/user)
 	if(!weak_turf)
@@ -102,13 +100,17 @@
 	TIMER_COOLDOWN_START(src, REF(user), hand_mine_speed)
 	var/skill_modifier = 1
 	skill_modifier = user?.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
-	to_chat(user, span_notice("You start pulling out pieces of [src] with your hands..."))
+	to_chat(user, span_notice("You start pulling out pieces of [src]..."))
 	if(!do_after(user, hand_mine_speed * skill_modifier, target = src))
 		TIMER_COOLDOWN_END(src, REF(user)) //if we fail we can start again immediately
 		return
 	if(ismineralturf(src))
 		to_chat(user, span_notice("You finish pulling apart [src]."))
 		gets_drilled(user)
+
+/turf/closed/mineral/attack_robot(mob/living/silicon/robot/user)
+	if(user.Adjacent(src))
+		attack_hand(user)
 
 /turf/closed/mineral/proc/gets_drilled(user, give_exp = FALSE)
 	if (mineralType && (mineralAmt > 0))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- `attackby()` on mineral turfs no longer calls `attack_hand()` if the attacking item isn't suitable for mining
- `attack_robot()` now calls `attack_hand()`on mineral turfs if the cyborg is adjacent
- Changes hand mining `to_chat` message to remove reference to hands
- Removes references to hands in hand mining code comments (var still calls it hand mining because I couldn't think of a better name for it)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Clicking a weak mineral turf with an object not suitable for mining will no longer hand mine it (have to click with an empty hand)
- Makes hand mining for cyborgs work off attack_robot() because it's useful for them to have on Ice Box if they fall through the floor and it's pretty weak because it takes fifteen seconds per turf
- Hand mining message no longer references hands because cyborgs don't have them
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes hitting snow turfs with a non-mining item to trigger hand mining (which was something all cyborgs could do to mine)
add: Cyborgs can left-click with no active module to manually mine snow turfs instead (takes 15 seconds per turf, good luck)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
