### PR TITLE
Changes the default ghost lighting, makes it a preference

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -231,6 +231,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Can hear observers
 #define TRAIT_SIXTHSENSE "sixth_sense"
 #define TRAIT_FEARLESS "fearless"
+/// Ignores darkness for hearing
+#define TRAIT_HEAR_THROUGH_DARKNESS "hear_through_darkness"
 /// These are used for brain-based paralysis, where replacing the limb won't fix it
 #define TRAIT_PARALYSIS_L_ARM "para-l-arm"
 #define TRAIT_PARALYSIS_R_ARM "para-r-arm"

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -390,9 +390,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	for (var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antag_hud in GLOB.active_alternate_appearances)
 		antag_hud.add_hud_to(mob)
 
-	if (prefs.toggles & COMBOHUD_LIGHTING)
-		mob.lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
-
+	mob.lighting_alpha = mob.default_lighting_alpha()
 	mob.update_sight()
 
 /client/proc/disable_combo_hud()
@@ -408,9 +406,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	for (var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antag_hud in GLOB.active_alternate_appearances)
 		antag_hud.remove_hud_from(mob)
 
-	if (prefs.toggles & COMBOHUD_LIGHTING)
-		mob.lighting_alpha = initial(mob.lighting_alpha)
-
+	mob.lighting_alpha = mob.default_lighting_alpha()
 	mob.update_sight()
 
 /datum/admins/proc/show_traitor_panel(mob/target_mob in GLOB.mob_list)

--- a/code/modules/client/preferences/ghost_lighting.dm
+++ b/code/modules/client/preferences/ghost_lighting.dm
@@ -1,9 +1,9 @@
 GLOBAL_LIST_INIT(ghost_lighting_options, list(
-		"Fullbright" = LIGHTING_PLANE_ALPHA_INVISIBLE,
-		"Night Vision" = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE,
-		"Darker" = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE,
-		"Normal" = LIGHTING_PLANE_ALPHA_VISIBLE
-	))
+	"Fullbright" = LIGHTING_PLANE_ALPHA_INVISIBLE,
+	"Night Vision" = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE,
+	"Darker" = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE,
+	"Normal" = LIGHTING_PLANE_ALPHA_VISIBLE,
+))
 
 /// How bright a ghost's lighting plane is
 /datum/preference/choiced/ghost_lighting

--- a/code/modules/client/preferences/ghost_lighting.dm
+++ b/code/modules/client/preferences/ghost_lighting.dm
@@ -1,0 +1,28 @@
+GLOBAL_LIST_INIT(ghost_lighting_options, list(
+		"Fullbright" = LIGHTING_PLANE_ALPHA_INVISIBLE,
+		"Night Vision" = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE,
+		"Darker" = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE,
+		"Normal" = LIGHTING_PLANE_ALPHA_VISIBLE
+	))
+
+/// How bright a ghost's lighting plane is
+/datum/preference/choiced/ghost_lighting
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "ghost_lighting"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/choiced/ghost_lighting/create_default_value()
+	return "Darker"
+
+/datum/preference/choiced/ghost_lighting/init_possible_values()
+	var/list/values = list()
+	for(var/option_name in GLOB.ghost_lighting_options)
+		values += option_name
+	return values
+
+/datum/preference/choiced/ghost_lighting/apply_to_client(client/client, value)
+	var/mob/current_mob = client?.mob
+	if(!isobserver(current_mob))
+		return
+	current_mob.lighting_alpha = current_mob.default_lighting_alpha()
+	current_mob.update_sight()

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -21,5 +21,7 @@
 	update_icon(ALL, preferred_form)
 	updateghostimages()
 	client.set_right_click_menu_mode(FALSE)
+	lighting_alpha = default_lighting_alpha()
+	update_sight()
 
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -150,6 +150,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	data_huds_on = 1
 
 	SSpoints_of_interest.make_point_of_interest(src)
+	ADD_TRAIT(src, TRAIT_HEAR_THROUGH_DARKNESS, ref(src))
 
 /mob/dead/observer/get_photo_description(obj/item/camera/camera)
 	if(!invisibility || camera.see_ghosts)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -13,7 +13,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	density = FALSE
 	see_invisible = SEE_INVISIBLE_OBSERVER
 	see_in_dark = 100
-	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	invisibility = INVISIBILITY_OBSERVER
 	hud_type = /datum/hud/ghost
 	movement_type = GROUND | FLYING
@@ -1041,3 +1041,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			client.images += t_ray_images
 		else
 			client.images -= stored_t_ray_images
+
+/mob/dead/observer/default_lighting_alpha()
+	var/datum/preferences/prefs = client?.prefs
+	if(!prefs || (client?.combo_hud_enabled && prefs.toggles & COMBOHUD_LIGHTING))
+		return ..()
+	return GLOB.ghost_lighting_options[prefs.read_preference(/datum/preference/choiced/ghost_lighting)]

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -220,7 +220,7 @@
 			if(M != loc) // Only give the blind message to hearers that aren't the location
 				msg = blind_message
 				msg_type = MSG_AUDIBLE
-		else if(M.lighting_alpha > LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE && T.is_softly_lit() && !in_range(T,M) && !isobserver(M)) //if it is too dark, unless we're right next to them.
+		else if(!HAS_TRAIT(M, TRAIT_HEAR_THROUGH_DARKNESS) && M.lighting_alpha > LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE && T.is_softly_lit() && !in_range(T,M)) //if it is too dark, unless we're right next to them.
 			msg = blind_message
 			msg_type = MSG_AUDIBLE
 		if(!msg)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -220,7 +220,7 @@
 			if(M != loc) // Only give the blind message to hearers that aren't the location
 				msg = blind_message
 				msg_type = MSG_AUDIBLE
-		else if(M.lighting_alpha > LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE && T.is_softly_lit() && !in_range(T,M)) //if it is too dark, unless we're right next to them.
+		else if(M.lighting_alpha > LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE && T.is_softly_lit() && !in_range(T,M) && !isobserver(M)) //if it is too dark, unless we're right next to them.
 			msg = blind_message
 			msg_type = MSG_AUDIBLE
 		if(!msg)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -532,3 +532,9 @@
 ///Can this mob hold items
 /mob/proc/can_hold_items(obj/item/I)
 	return length(held_items)
+
+/// Returns this mob's default lighting alpha
+/mob/proc/default_lighting_alpha()
+	if(client?.combo_hud_enabled && client?.prefs?.toggles & COMBOHUD_LIGHTING)
+		return LIGHTING_PLANE_ALPHA_INVISIBLE
+	return initial(lighting_alpha)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2405,6 +2405,7 @@
 #include "code\modules\client\preferences\fps.dm"
 #include "code\modules\client\preferences\gender.dm"
 #include "code\modules\client\preferences\ghost.dm"
+#include "code\modules\client\preferences\ghost_lighting.dm"
 #include "code\modules\client\preferences\glasses.dm"
 #include "code\modules\client\preferences\hotkeys.dm"
 #include "code\modules\client\preferences\item_outlines.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost_lighting.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost_lighting.tsx
@@ -1,0 +1,8 @@
+import { FeatureChoiced, FeatureDropdownInput } from "../base";
+
+export const ghost_lighting: FeatureChoiced = {
+  name: "Ghost Lighting",
+  component: FeatureDropdownInput,
+  category: "GHOST",
+  description: "Effects the brightness of lights for ghosts",
+};


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I think the way ghost lighting looks right now is really crummy.
It's dark enough you can see where the shadows should be, but it's just bright enough for everything to look like dog poo

A lot of what makes the game look nice is the depth of the lighting and if we just hide that for observers we're shooting ourselves in the foot.

I'm also making it a game preference, so if someone wants to have bad opinions they can easily.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

https://user-images.githubusercontent.com/58055496/157390981-40758fbc-480e-43be-8a91-0234d68f423f.mp4



## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Ghost darkness is now a game preference, and will persist between rounds
balance: Ghost darkness defaults to a bit darker then currently. I think it looks better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
