### PR TITLE
Fixes Abandoned Crates exploding on right click + Code improvements.

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -43,8 +43,12 @@
 					if(sanitised[i] == sanitised[j])
 						sanitycheck = FALSE //if a digit is repeated, reject the input
 			if(input == code)
+				to_chat(user, span_notice("A green light flashes."))
 				if(!spawned_loot)
 					spawn_loot()
+				if(qdel_on_open)
+					qdel(src)
+					return
 				tamperproof = 0 // set explosion chance to zero, so we dont accidently hit it with a multitool and instantly die
 				togglelock(user)
 			else if(!input || !sanitycheck || length(sanitised) != codelen)
@@ -55,8 +59,9 @@
 				attempts--
 				if(attempts == 0)
 					boom(user)
-	else
-		return ..()
+		return
+
+	. = ..()
 
 /obj/structure/closet/crate/secure/loot/AltClick(mob/living/user)
 	if(!user.canUseTopic(src, BE_CLOSE))
@@ -96,36 +101,32 @@
 
 				to_chat(user, span_notice("Last code attempt, [lastattempt], had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions."))
 			return
-	return ..()
+	. = ..()
 
 /obj/structure/closet/crate/secure/loot/emag_act(mob/user)
 	if(locked)
 		boom(user)
 		return
-	return ..()
+	. = ..()
 
 /obj/structure/closet/crate/secure/loot/togglelock(mob/user, silent = FALSE)
-	if(!locked)
-		. = ..()
-		if(locked)
+	if(!locked) //We're currently unlocked.
+		. = ..() //Run the normal code.
+		if(locked) //Double check if the crate actually locked itself when the normal code ran.
 			//reset the anti-tampering, number of attempts and last attempt when the lock is re-enabled.
 			tamperproof = initial(tamperproof)
 			attempts = initial(attempts)
 			lastattempt = null
 		return
-	if(tamperproof)
-		boom(user)
+	if(tamperproof) //Can't force an unlock through other means.
 		return
-	if (qdel_on_open)
-		qdel(src)
-		return
-	return ..()
+	. = ..()
 
 /obj/structure/closet/crate/secure/loot/deconstruct(disassembled = TRUE)
 	if(locked)
-		boom()
+		boom() //Bad idea to hit it with a welder.
 		return
-	return ..()
+	. = ..()
 
 /obj/structure/closet/crate/secure/loot/proc/spawn_loot()
 	var/loot = rand(1,100) //100 different crates with varying chances of spawning

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -117,13 +117,13 @@
 			attempts = initial(attempts)
 			lastattempt = null
 		return
-	if(tamperproof) //Can't force an unlock through other means.
+	if(tamperproof)
 		return
 	return ..()
 
 /obj/structure/closet/crate/secure/loot/deconstruct(disassembled = TRUE)
 	if(locked)
-		boom() //Bad idea to hit it with a welder.
+		boom()
 		return
 	return ..()
 

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -43,7 +43,6 @@
 					if(sanitised[i] == sanitised[j])
 						sanitycheck = FALSE //if a digit is repeated, reject the input
 			if(input == code)
-				to_chat(user, span_notice("A green light flashes."))
 				if(!spawned_loot)
 					spawn_loot()
 				if(qdel_on_open)
@@ -61,7 +60,7 @@
 					boom(user)
 		return
 
-	. = ..()
+	return ..()
 
 /obj/structure/closet/crate/secure/loot/AltClick(mob/living/user)
 	if(!user.canUseTopic(src, BE_CLOSE))
@@ -101,16 +100,16 @@
 
 				to_chat(user, span_notice("Last code attempt, [lastattempt], had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions."))
 			return
-	. = ..()
+	return ..()
 
 /obj/structure/closet/crate/secure/loot/emag_act(mob/user)
 	if(locked)
 		boom(user)
 		return
-	. = ..()
+	return ..()
 
 /obj/structure/closet/crate/secure/loot/togglelock(mob/user, silent = FALSE)
-	if(!locked) //We're currently unlocked.
+	if(!locked)
 		. = ..() //Run the normal code.
 		if(locked) //Double check if the crate actually locked itself when the normal code ran.
 			//reset the anti-tampering, number of attempts and last attempt when the lock is re-enabled.
@@ -120,13 +119,13 @@
 		return
 	if(tamperproof) //Can't force an unlock through other means.
 		return
-	. = ..()
+	return ..()
 
 /obj/structure/closet/crate/secure/loot/deconstruct(disassembled = TRUE)
 	if(locked)
 		boom() //Bad idea to hit it with a welder.
 		return
-	. = ..()
+	return ..()
 
 /obj/structure/closet/crate/secure/loot/proc/spawn_loot()
 	var/loot = rand(1,100) //100 different crates with varying chances of spawning


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes abandoned crates exploding on empty-hand right click regardless of intent.
- Moves the qdel() on open code to a place that actually makes sense.

## Why It's Good For The Game

Technically a salt PR because I ended up getting fucked to an abandoned crate as I right clicked on it with an empty hand as I'm used to another server's controls. I did an investigation and it turns out some things were scuffled with the intents removal so that feature is likely not intended. Fucking around with the lock via welder or guns will still detonate it, and trying to open it with an ID will not work.

## Changelog

:cl: BurgerBB
fix: Fixes abandoned crates exploding on empty-hand right click regardless of intent.
/:cl:
