### PR TITLE
Fixes Glass booze bottles and molotovs not splashing their contents when broken via throwing

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -137,7 +137,9 @@
 /obj/item/reagent_containers/food/drinks/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(!.) //if the bottle wasn't caught
-		smash(hit_atom, throwingdatum?.thrower, TRUE)
+		SplashReagents(hit_atom, override_spillable = TRUE)
+		smash(hit_atom)
+
 
 /obj/item/reagent_containers/food/drinks/proc/smash(atom/target, mob/thrower, ranged = FALSE)
 	if(!isGlass)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -20,6 +20,7 @@
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	isGlass = TRUE
 	foodtype = ALCOHOL
+	resistance_flags = ACID_PROOF
 	age_restricted = TRUE // wrryy can't set an init value to see if foodtype contains ALCOHOL so here we go
 	///Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
 	var/bottle_knockdown_duration = 1.3 SECONDS
@@ -140,6 +141,7 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY
+	custom_materials = list(/datum/material/glass=350)
 	inhand_icon_state = "broken_beer"
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -20,7 +20,6 @@
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	isGlass = TRUE
 	foodtype = ALCOHOL
-	resistance_flags = ACID_PROOF
 	age_restricted = TRUE // wrryy can't set an init value to see if foodtype contains ALCOHOL so here we go
 	///Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
 	var/bottle_knockdown_duration = 1.3 SECONDS
@@ -141,7 +140,6 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY
-	custom_materials = list(/datum/material/glass=350)
 	inhand_icon_state = "broken_beer"
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Since most other codebases' booze bottles splash their contents when broken via throwing them at things, i thought i'd straighten this inconsistency out so that booze bottles can splash when smashed via throwing them at things since i noticed that  this doesn't happen in-game for this codebase although drinking glasses splash when smashed via being thrown at things. Quite the inconsistency, i decided to fix it.
## About The Pull Request
Makes all booze bottles and Molotov cocktails splash their contents upon being smashed via throwing them at things, fixing an inconsistency where shot/drinking glasses would splash upon being smashed via throw while booze bottles and molotovs would not.
Footage is right here: https://streamable.com/rjg7dr

## Why It's Good For The Game
Molotov Cocktails currently are currently seen as "not worth using" by most of the playerbase due to only being able to light one tile on fire for a brief moment on impact and not splashing their contents when thrown, by fixing this inconsistency between shot/drinking glasses and booze bottles/molotovs, this makes them slightly more powerful. 


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed an inconsistency where booze bottles and molotovs wouldn't splash their contents when thrown at things while drinking and shot glasses do.
/:cl:
