### PR TITLE
[No GBP] Makes adding additional modular bookstates easier for downstreams

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -222,6 +222,10 @@
 	var/unique = FALSE //false - Normal book, true - Should not be treated as normal book, unable to be copied, unable to be modified
 	var/title //The real name of the book.
 	var/window_size = null // Specific window size for the book, i.e: "1920x1080", Size x Width
+	/// Minimum icon state number
+	var/minimum_book_state = 1
+	/// Maximum icon state number
+	var/maximum_book_state = 8
 
 
 /obj/item/book/attack_self(mob/user)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -222,8 +222,6 @@
 	var/unique = FALSE //false - Normal book, true - Should not be treated as normal book, unable to be copied, unable to be modified
 	var/title //The real name of the book.
 	var/window_size = null // Specific window size for the book, i.e: "1920x1080", Size x Width
-	/// Minimum icon state number
-	var/minimum_book_state = 1
 	/// Maximum icon state number
 	var/maximum_book_state = 8
 

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -484,7 +484,7 @@
 					B.title = title
 					B.author = author
 					B.dat = content
-					B.icon_state = "book[rand(B.minimum_book_state,B.maximum_book_state)]"
+					B.icon_state = "book[rand(1,B.maximum_book_state)]"
 					visible_message(span_notice("[src]'s printer hums as it produces a completely bound book. How did it do that?"))
 				break
 			qdel(query_library_print)
@@ -603,7 +603,7 @@
 			var/obj/item/book/B = new(src.loc)
 			B.dat = P.info
 			B.name = "Print Job #" + "[rand(100, 999)]"
-			B.icon_state = "book[rand(B.minimum_book_state,B.maximum_book_state)]"
+			B.icon_state = "book[rand(1,B.maximum_book_state)]"
 			qdel(P)
 		else
 			P.forceMove(drop_location())

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -484,7 +484,7 @@
 					B.title = title
 					B.author = author
 					B.dat = content
-					B.icon_state = "book[rand(1,8)]"
+					B.icon_state = "book[rand(B.minimum_book_state,B.maximum_book_state)]"
 					visible_message(span_notice("[src]'s printer hums as it produces a completely bound book. How did it do that?"))
 				break
 			qdel(query_library_print)
@@ -603,7 +603,7 @@
 			var/obj/item/book/B = new(src.loc)
 			B.dat = P.info
 			B.name = "Print Job #" + "[rand(100, 999)]"
-			B.icon_state = "book[rand(1,7)]"
+			B.icon_state = "book[rand(B.minimum_book_state,B.maximum_book_state)]"
 			qdel(P)
 		else
 			P.forceMove(drop_location())

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -17,7 +17,7 @@
 
 /obj/item/book/random/Initialize(mapload)
 	. = ..()
-	icon_state = "book[rand(minimum_book_state,maximum_book_state)]"
+	icon_state = "book[rand(1,maximum_book_state)]"
 
 /obj/item/book/random/attack_self()
 	if(!random_loaded)
@@ -64,7 +64,7 @@
 			B.dat = query_get_random_books.item[3]
 			B.name = "Book: [B.title]"
 			if(!existing_book)
-				B.icon_state= "book[rand(B.minimum_book_state,B.maximum_book_state)]"
+				B.icon_state= "book[rand(1,B.maximum_book_state)]"
 	qdel(query_get_random_books)
 
 /obj/structure/bookcase/random/fiction

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -14,10 +14,14 @@
 	var/random_category = null
 	/// If this book has already been 'generated' yet.
 	var/random_loaded = FALSE
+	/// Minimum icon state number
+	var/minimum_book_state = 1
+	/// Maximum icon state number
+	var/maximum_book_state = 8
 
 /obj/item/book/random/Initialize(mapload)
 	. = ..()
-	icon_state = "book[rand(1,8)]"
+	icon_state = "book[rand(minimum_book_state,maximum_book_state)]"
 
 /obj/item/book/random/attack_self()
 	if(!random_loaded)
@@ -64,7 +68,7 @@
 			B.dat = query_get_random_books.item[3]
 			B.name = "Book: [B.title]"
 			if(!existing_book)
-				B.icon_state= "book[rand(1,8)]"
+				B.icon_state= "book[rand(minimum_book_state,maximum_book_state)]"
 	qdel(query_get_random_books)
 
 /obj/structure/bookcase/random/fiction

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -14,10 +14,6 @@
 	var/random_category = null
 	/// If this book has already been 'generated' yet.
 	var/random_loaded = FALSE
-	/// Minimum icon state number
-	var/minimum_book_state = 1
-	/// Maximum icon state number
-	var/maximum_book_state = 8
 
 /obj/item/book/random/Initialize(mapload)
 	. = ..()
@@ -68,7 +64,7 @@
 			B.dat = query_get_random_books.item[3]
 			B.name = "Book: [B.title]"
 			if(!existing_book)
-				B.icon_state= "book[rand(minimum_book_state,maximum_book_state)]"
+				B.icon_state= "book[rand(B.minimum_book_state,B.maximum_book_state)]"
 	qdel(query_get_random_books)
 
 /obj/structure/bookcase/random/fiction


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
De-hardcodes the random icon state generator for random books.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Doesn't really affect our game, but any downstreams where they wanna add additional book icons would probably be grateful.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Wallem
code: De-hardcodes random book icon state generation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
