### PR TITLE
Restores the Persistent Scars preference

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -423,7 +423,7 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/SaveScars()
 	for(var/i in GLOB.joined_player_list)
 		var/mob/living/carbon/human/ending_human = get_mob_by_ckey(i)
-		if(!istype(ending_human) || !ending_human.mind?.original_character_slot_index || !ending_human.client || !ending_human.client.prefs || !ending_human.client.prefs.persistent_scars)
+		if(!istype(ending_human) || !ending_human.mind?.original_character_slot_index || !ending_human.client?.prefs.read_preference(/datum/preference/toggle/persistent_scars))
 			continue
 
 		var/mob/living/carbon/human/original_human = ending_human.mind.original_character.resolve()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -57,8 +57,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/hearted
 	///If we have a hearted commendations, we honor it every time the player loads preferences until this time has been passed
 	var/hearted_until
-	/// If we have persistent scars enabled
-	var/persistent_scars = TRUE
 	///What outfit typepaths we've favorited in the SelectEquipment menu
 	var/list/favorite_outfits = list()
 

--- a/code/modules/client/preferences/persistent_scars.dm
+++ b/code/modules/client/preferences/persistent_scars.dm
@@ -4,4 +4,6 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 
 /datum/preference/toggle/persistent_scars/apply_to_human(mob/living/carbon/human/target, value)
-	target.persistent_scars = sanitize_integer(value)
+	// This proc doesn't do anything, due to the nature of persistent scars, we ALWAYS need to have a client to be able to use them properly. Or at the very least, a ckey.
+	// So we don't need to store this anywhere else, we simply search the preference when we need it.
+	return

--- a/code/modules/client/preferences/persistent_scars.dm
+++ b/code/modules/client/preferences/persistent_scars.dm
@@ -1,0 +1,7 @@
+/datum/preference/toggle/persistent_scars
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_key = "persistent_scars"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/toggle/persistent_scars/apply_to_human(mob/living/carbon/human/target, value)
+	target.persistent_scars = sanitize_integer(value)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -307,7 +307,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//Character
 	READ_FILE(S["randomise"],  randomise)
-	READ_FILE(S["persistent_scars"] , persistent_scars)
 
 	//Load prefs
 	READ_FILE(S["job_preferences"], job_preferences)
@@ -323,7 +322,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Sanitize
 	randomise = SANITIZE_LIST(randomise)
 
-	persistent_scars = sanitize_integer(persistent_scars)
 
 	//Validate job prefs
 	for(var/j in job_preferences)
@@ -367,7 +365,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//Character
 	WRITE_FILE(S["randomise"] , randomise)
-	WRITE_FILE(S["persistent_scars"] , persistent_scars)
 
 	//Write prefs
 	WRITE_FILE(S["job_preferences"] , job_preferences)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -114,7 +114,7 @@
 /// When we're joining the game in [/mob/dead/new_player/proc/create_character], we increment our scar slot then store the slot in our mind datum.
 /mob/living/carbon/human/proc/increment_scar_slot()
 	var/check_ckey = ckey || client?.ckey
-	if(!check_ckey || !mind || !client?.prefs.persistent_scars)
+	if(!check_ckey || !mind || !client?.prefs.read_preference(/datum/preference/toggle/persistent_scars))
 		return
 
 	var/path = "data/player_saves/[check_ckey[1]]/[check_ckey]/scars.sav"
@@ -159,7 +159,7 @@
 
 /// Read all the scars we have for the designated character/scar slots, verify they're good/dump them if they're old/wrong format, create them on the user, and write the scars that passed muster back to the file
 /mob/living/carbon/human/proc/load_persistent_scars()
-	if(!ckey || !mind?.original_character_slot_index || !client?.prefs.persistent_scars)
+	if(!ckey || !mind?.original_character_slot_index || !client?.prefs.read_preference(/datum/preference/toggle/persistent_scars))
 		return
 
 	var/path = "data/player_saves/[ckey[1]]/[ckey]/scars.sav"
@@ -184,8 +184,8 @@
 	WRITE_FILE(F["scar[char_index]-[scar_index]"], sanitize_text(valid_scars))
 
 /// Save any scars we have to our designated slot, then write our current slot so that the next time we call [/mob/living/carbon/human/proc/increment_scar_slot] (the next round we join), we'll be there
-/mob/living/carbon/human/proc/save_persistent_scars(nuke=FALSE)
-	if(!ckey || !mind?.original_character_slot_index || !client?.prefs.persistent_scars)
+/mob/living/carbon/human/proc/save_persistent_scars(nuke = FALSE)
+	if(!ckey || !mind?.original_character_slot_index || !client?.prefs.read_preference(/datum/preference/toggle/persistent_scars))
 		return
 
 	var/path = "data/player_saves/[ckey[1]]/[ckey]/scars.sav"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2414,6 +2414,7 @@
 #include "code\modules\client\preferences\ooc.dm"
 #include "code\modules\client\preferences\parallax.dm"
 #include "code\modules\client\preferences\pda.dm"
+#include "code\modules\client\preferences\persistent_scars.dm"
 #include "code\modules\client\preferences\phobia.dm"
 #include "code\modules\client\preferences\pixel_size.dm"
 #include "code\modules\client\preferences\playtime_reward_cloak.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/persistent_scars.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/persistent_scars.tsx
@@ -1,0 +1,6 @@
+import { CheckboxInput, FeatureToggle } from "../base";
+
+export const persistent_scars: FeatureToggle = {
+  name: "Persistent Scars",
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin. This was an oversight, mothblocks simply forgot to convert them to the new preference system. I'm still surprised at how long it took for someone to finally do it, and that it ultimately had to be me.

I also had to remove some raw READ_FILE()s because that was now useless. 
I was thus able to remove the persistent_scars variable from the prefs, as it is now a standalone preference.

Fixes https://github.com/tgstation/tgstation/issues/61810

## Why It's Good For The Game
It's weird that you were affected by a preference that you set prior to the prefs rework, and that affected basically all of your characters, and you couldn't change it. Now you can. And it's by-character, too.

## Changelog

:cl: GoldenAlpharex
refactor: A minor refactor was done to the persistent scars preference, allowing it to finally be available in the preferences menu once again.
/:cl: