### PR TITLE
Door Ownership For DeltaStation Ordnance Storage

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -25277,7 +25277,7 @@
 	name = "Ordnance Lab Shutters"
 	},
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "dDw" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple{
@@ -33726,7 +33726,7 @@
 	name = "Ordnance Lab Shutters"
 	},
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "eTp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hello there,

This is mostly on-the-tin. Have a photograph.

![image](https://user-images.githubusercontent.com/34697715/157520605-98ca3cb9-1f46-4080-9155-979404d47900.png)

We usually like having doors be owned by the rooms they terminally connect to, so let's just put that in.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/157520677-0826a1e3-c213-455e-b7cf-2c680dcfb7d7.png)

Door ownership by the room it mainly gives access to is good. This is a continuation of me doing the changes declarated in PR #65276.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: On DeltaStation, the Ordnance storage room now owns it's own doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
