### PR TITLE
makes vibebots pAI controllable

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/vibebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/vibebot.dm
@@ -13,7 +13,6 @@
 	light_power = 3
 
 	hackables = "vibing scanners"
-	bot_mode_flags = ~BOT_MODE_PAI_CONTROLLABLE
 	radio_key = /obj/item/encryptionkey/headset_service
 	radio_channel = RADIO_CHANNEL_SERVICE
 	bot_type = VIBE_BOT


### PR DESCRIPTION
## About The Pull Request

No GBP update tag please
I made vibebots unable to be controlled by pAIs here https://github.com/tgstation/tgstation/pull/62671

This was an error on my part, as I confused them with hygienebot, another bot that INTENTIONALLY isn't pAI controllable.
It's also a better time now more than ever to let them control vibebots as they have the ability to actually change their color now, thanks to https://github.com/tgstation/tgstation/pull/65196

## Why It's Good For The Game

Fixes an accidental bug I caused.

## Changelog

:cl:
fix: pAIs can be inserted into Vibebots again.
/:cl:
