### PR TITLE
Liches can't use Soul Tap (again)

### DIFF
--- a/code/modules/spells/spell_types/soultap.dm
+++ b/code/modules/spells/spell_types/soultap.dm
@@ -24,7 +24,7 @@
 
 /obj/effect/proc_holder/spell/self/tap/cast(list/targets, mob/living/user = usr)
 	if(HAS_TRAIT(user, TRAIT_NO_SOUL))
-		to_chat(user, span_danger("You have no soul to tap into!"))
+		to_chat(user, span_warning("You have no soul to tap into!"))
 		return
 
 	to_chat(user, span_danger("Your body feels drained and there is a burning pain in your chest."))

--- a/code/modules/spells/spell_types/soultap.dm
+++ b/code/modules/spells/spell_types/soultap.dm
@@ -1,9 +1,14 @@
+/// The amount of health taken per tap.
 #define HEALTH_LOST_PER_SOUL_TAP 20
 
-//SOUL TAP!//
-//Trades 20 max health for a refresh on all of your spells. I was considering making it depend on the cooldowns of your spells, but I want to support "Big spell wizard" with this loadout.
-//the two spells that sound most problematic with this is mindswap and lichdom, but soul tap requires clothes for mindswap and lichdom takes your soul.
-
+/**
+ * SOUL TAP!
+ *
+ * Trades 20 max health for a refresh on all of your spells.
+ * I was considering making it depend on the cooldowns of your spells, but I want to support "Big spell wizard" with this loadout.
+ * The two spells that sound most problematic with this is mindswap and lichdom,
+ * but soul tap requires clothes for mindswap and lichdom takes your soul.
+ */
 /obj/effect/proc_holder/spell/self/tap
 	name = "Soul Tap"
 	desc = "Fuel your spells using your own soul!"
@@ -18,13 +23,20 @@
 	action_icon_state = "soultap"
 
 /obj/effect/proc_holder/spell/self/tap/cast(list/targets, mob/living/user = usr)
+	if(HAS_TRAIT(user, TRAIT_NO_SOUL))
+		to_chat(user, span_danger("You have no soul to tap into!"))
+		return
+
 	to_chat(user, span_danger("Your body feels drained and there is a burning pain in your chest."))
 	user.maxHealth -= HEALTH_LOST_PER_SOUL_TAP
 	user.health = min(user.health, user.maxHealth)
 	if(user.maxHealth <= 0)
 		to_chat(user, span_userdanger("Your weakened soul is completely consumed by the tap!"))
 		return
+
 	for(var/obj/effect/proc_holder/spell/spell in user.mind.spell_list)
 		spell.charge_counter = spell.charge_max
 		spell.recharging = FALSE
 		spell.update_appearance()
+
+#undef HEALTH_LOST_PER_SOUL_TAP

--- a/code/modules/spells/spell_types/soultap.dm
+++ b/code/modules/spells/spell_types/soultap.dm
@@ -32,6 +32,7 @@
 	user.health = min(user.health, user.maxHealth)
 	if(user.maxHealth <= 0)
 		to_chat(user, span_userdanger("Your weakened soul is completely consumed by the tap!"))
+		ADD_TRAIT(user, TRAIT_NO_SOUL, MAGIC_TRAIT)
 		return
 
 	for(var/obj/effect/proc_holder/spell/spell in user.mind.spell_list)

--- a/code/modules/spells/spell_types/soultap.dm
+++ b/code/modules/spells/spell_types/soultap.dm
@@ -17,8 +17,8 @@
 	invocation = "AT ANY COST!"
 	invocation_type = INVOCATION_SHOUT
 	school = SCHOOL_NECROMANCY //i could see why this wouldn't be necromancy but messing with souls or whatever. ectomancy?
-	cooldown_min = 1 SECONDS
 	charge_max = 1 SECONDS
+	cooldown_min = 1 SECONDS
 	level_max = 0
 
 /obj/effect/proc_holder/spell/self/tap/cast(list/targets, mob/living/user = usr)

--- a/code/modules/spells/spell_types/soultap.dm
+++ b/code/modules/spells/spell_types/soultap.dm
@@ -12,15 +12,14 @@
 /obj/effect/proc_holder/spell/self/tap
 	name = "Soul Tap"
 	desc = "Fuel your spells using your own soul!"
-	school = SCHOOL_NECROMANCY //i could see why this wouldn't be necromancy but messing with souls or whatever. ectomancy?
-	charge_max = 10
-	invocation = "AT ANY COST!"
-	invocation_type = INVOCATION_SHOUT
-	level_max = 0
-	cooldown_min = 10
-
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "soultap"
+	invocation = "AT ANY COST!"
+	invocation_type = INVOCATION_SHOUT
+	school = SCHOOL_NECROMANCY //i could see why this wouldn't be necromancy but messing with souls or whatever. ectomancy?
+	cooldown_min = 1 SECONDS
+	charge_max = 1 SECONDS
+	level_max = 0
 
 /obj/effect/proc_holder/spell/self/tap/cast(list/targets, mob/living/user = usr)
 	if(HAS_TRAIT(user, TRAIT_NO_SOUL))


### PR DESCRIPTION
## About The Pull Request

#53612 removed the check for liches in soul tap and never replaced it
no one noticed for like 2 years because soul tap is ~~so bad~~ underused

Re-adds the check for people without souls to soul-tap
Re-adds users losing their soul on tapping themselves out
Cleans up the code around soul-tap a bit - better arrangement of vars, better docs, etc

## Why It's Good For The Game

It's not really intended sooo

## Changelog

:cl: Melbert
fix: Casters who sold their soul can no longer use Soul Tap
/:cl:
