### PR TITLE
Fixes Bar Stool Directionality in Nuclear Operative Base

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5220,6 +5220,15 @@
 	},
 /turf/open/floor/iron,
 /area/syndicate_mothership/control)
+"qi" = (
+/obj/structure/chair/stool/directional/west,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/landmark/start/nukeop,
+/turf/open/floor/iron,
+/area/syndicate_mothership/control)
 "qm" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/tile/neutral{
@@ -5948,12 +5957,12 @@
 /turf/open/floor/iron,
 /area/syndicate_mothership/control)
 "sh" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/landmark/start/nukeop,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/structure/chair/stool/directional/east,
+/obj/effect/landmark/start/nukeop,
 /turf/open/floor/iron,
 /area/syndicate_mothership/control)
 "si" = (
@@ -35375,8 +35384,8 @@ pF
 qa
 pZ
 pZ
-sh
-sh
+qi
+qi
 pZ
 rg
 Qd


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

WHEN I BLOW UP THE STATION, I WANT EVERYTHING BEING TIP-TOP SHAPE.

![image](https://user-images.githubusercontent.com/34697715/157599753-26ee3e84-f7a0-4eb4-b83d-b33449e2013b.png)

THOSE BARSTOOLS ARE NOT TIP-TOP SHAPE. LET'S FIX THAT.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/157599788-4f9bef5e-cdfd-4e1d-b309-cb4adc13dfb8.png)

Much better!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The barstools in the Nuclear Operative's Base now point the correct direction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
