### PR TITLE
Enables public access to escape pod on KiloStation

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -40479,7 +40479,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Apiary";
-	req_one_access_txt = 0
+	req_one_access_txt = "22;35"
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12547,6 +12547,10 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"bvy" = (
+/obj/structure/sign/warning/pods,
+/turf/closed/wall,
+/area/commons/fitness/recreation)
 "bvB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -19290,8 +19294,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cnJ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/door/airlock/grunge{
+	name = "Escape Pod Access"
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/port/greater)
@@ -40475,7 +40479,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Apiary";
-	req_one_access_txt = "22;35"
+	req_one_access_txt = 0
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
@@ -84866,6 +84870,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
+"yef" = (
+/obj/structure/sign/warning/pods,
+/turf/closed/wall,
+/area/commons/locker)
 "yeh" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
@@ -103940,7 +103948,7 @@ hBN
 qcg
 tfC
 kdG
-hBN
+bvy
 hBN
 gcs
 csS
@@ -108308,7 +108316,7 @@ tNZ
 ePs
 xXg
 dJU
-tNZ
+yef
 tNZ
 cKI
 gYB

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -44390,6 +44390,21 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
+"kfz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5"
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/greater)
 "kfE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -97772,7 +97787,7 @@ bmt
 cGH
 amA
 amR
-jBp
+kfz
 amA
 bzX
 ryM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the west-side escape pod accessible to general crew without the need for maintenance access. ~~Makes the Apiary/Public Garden also general access.~~

Adds extra signage for pods to make it clearer where they are from the main hallway.

## Why It's Good For The Game

Gives the crew at least one escape pod that everyone can access. ~~Gives the crew the ability to utilize the public garden without being the chaplain or a botanist.~~

Improves basic access to features that were intended to be generalized.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Enabled general access to escape pod on KiloStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
