### PR TITLE
Allows Plasma Fixation to heal in any amount of plasma gas

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -484,7 +484,9 @@
 
 	. = 0
 
-#define HEALING_PER_MOL 1.1 //Determines the rate at which Plasma Fixation heals based on the amount of plasma in the air
+#define HEALING_PER_MOL 1.1
+
+///Determines the rate at which Plasma Fixation heals based on the amount of plasma in the air
 
 	if(M.loc)
 		environment = M.loc.return_air()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -484,14 +484,18 @@
 
 	. = 0
 
+#define HEALING_PER_MOL 1.1 //Determines the rate at which Plasma Fixation heals based on the amount of plasma in the air
+
 	if(M.loc)
 		environment = M.loc.return_air()
 	if(environment)
 		gases = environment.gases
 		if(gases[/datum/gas/plasma])
-			. += power * min(0.5, gases[/datum/gas/plasma][MOLES] * 1.1)
+			. += power * min(0.5, gases[/datum/gas/plasma][MOLES] * HEALING_PER_MOL)
 	if(M.reagents.has_reagent(/datum/reagent/toxin/plasma, needs_metabolizing = TRUE))
-		. += power * 0.75
+		. += power * 0.75 //Determines how much the symptom heals if injected or ingested
+
+#undef HEALING_PER_MOL
 
 /datum/symptom/heal/plasma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = 4 * actual_power

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -484,9 +484,9 @@
 
 	. = 0
 
-#define HEALING_PER_MOL 1.1
-
 ///Determines the rate at which Plasma Fixation heals based on the amount of plasma in the air
+
+#define HEALING_PER_MOL 1.1
 
 	if(M.loc)
 		environment = M.loc.return_air()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -485,7 +485,6 @@
 	. = 0
 
 ///Determines the rate at which Plasma Fixation heals based on the amount of plasma in the air
-
 #define HEALING_PER_MOL 1.1
 
 	if(M.loc)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -453,6 +453,9 @@
 		return TRUE
 	return FALSE
 
+///Determines the rate at which Plasma Fixation heals based on the amount of plasma in the air
+#define HEALING_PER_MOL 1.1
+
 /datum/symptom/heal/plasma
 	name = "Plasma Fixation"
 	desc = "The virus draws plasma from the atmosphere and from inside the body to heal and stabilize body temperature."
@@ -484,10 +487,6 @@
 
 	. = 0
 
-///Determines the rate at which Plasma Fixation heals based on the amount of plasma in the air
-
-#define HEALING_PER_MOL 1.1
-
 	if(M.loc)
 		environment = M.loc.return_air()
 	if(environment)
@@ -496,8 +495,6 @@
 			. += power * min(0.5, gases[/datum/gas/plasma][MOLES] * HEALING_PER_MOL)
 	if(M.reagents.has_reagent(/datum/reagent/toxin/plasma, needs_metabolizing = TRUE))
 		. += power * 0.75 //Determines how much the symptom heals if injected or ingested
-
-#undef HEALING_PER_MOL
 
 /datum/symptom/heal/plasma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = 4 * actual_power
@@ -527,6 +524,8 @@
 			M.update_damage_overlays()
 	return 1
 
+///Plasma End
+#undef HEALING_PER_MOL
 
 /datum/symptom/heal/radiation
 	name = "Radioactive Resonance"

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -488,10 +488,8 @@
 		environment = M.loc.return_air()
 	if(environment)
 		gases = environment.gases
-		if(gases[/datum/gas/plasma] && gases[/datum/gas/plasma][MOLES] > gases[/datum/gas/plasma][GAS_META][META_GAS_MOLES_VISIBLE]) //if there's enough plasma in the air to see
-			. += power * 0.5
-		if(gases[/datum/gas/plasma] && gases[/datum/gas/plasma][MOLES] <= gases[/datum/gas/plasma][GAS_META][META_GAS_MOLES_VISIBLE]) //if there's *not* enough plasma in the air to see
-			. += power * 0.1
+		if(gases[/datum/gas/plasma])
+			. += power * min(0.5, gases[/datum/gas/plasma][MOLES] * 1.1)
 	if(M.reagents.has_reagent(/datum/reagent/toxin/plasma, needs_metabolizing = TRUE))
 		. += power * 0.75
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -490,7 +490,7 @@
 		gases = environment.gases
 		if(gases[/datum/gas/plasma] && gases[/datum/gas/plasma][MOLES] > gases[/datum/gas/plasma][GAS_META][META_GAS_MOLES_VISIBLE]) //if there's enough plasma in the air to see
 			. += power * 0.5
-		if(gases[/datum/gas/plasma] && gases[/datum/gas/plasma][MOLES] < gases[/datum/gas/plasma][GAS_META][META_GAS_MOLES_VISIBLE]) //if there's *not* enough plasma in the air to see
+		if(gases[/datum/gas/plasma] && gases[/datum/gas/plasma][MOLES] <= gases[/datum/gas/plasma][GAS_META][META_GAS_MOLES_VISIBLE]) //if there's *not* enough plasma in the air to see
 			. += power * 0.1
 	if(M.reagents.has_reagent(/datum/reagent/toxin/plasma, needs_metabolizing = TRUE))
 		. += power * 0.75

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -490,6 +490,8 @@
 		gases = environment.gases
 		if(gases[/datum/gas/plasma] && gases[/datum/gas/plasma][MOLES] > gases[/datum/gas/plasma][GAS_META][META_GAS_MOLES_VISIBLE]) //if there's enough plasma in the air to see
 			. += power * 0.5
+		if(gases[/datum/gas/plasma] && gases[/datum/gas/plasma][MOLES] < gases[/datum/gas/plasma][GAS_META][META_GAS_MOLES_VISIBLE]) //if there's *not* enough plasma in the air to see
+			. += power * 0.1
 	if(M.reagents.has_reagent(/datum/reagent/toxin/plasma, needs_metabolizing = TRUE))
 		. += power * 0.75
 


### PR DESCRIPTION
## About The Pull Request

It allows for a very small amount of healing if there's a non-visible amount of gas in the atmosphere, compared to the current plasma fixation which only heals if plasma is visible.

## Why It's Good For The Game

Considering that you can take toxin damage even if plasma gas isn't visible but it's in the air, it tracks that if you have a plasma fixation virus you would still be able to heal, albeit a minor amount.

## Changelog
:cl:
balance: allows you to heal using plasma fixation in minor amounts of plasma such as in Icebox's atmosphere
/:cl: