### PR TITLE
Re-sanitizes atmos reaction result list.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -195,7 +195,6 @@
 		cached_gases[/datum/gas/water_vapor][MOLES] += plasma_burn_rate * 0.25
 
 	SET_REACTION_RESULTS((plasma_burn_rate) * (1 + oxygen_burn_ratio))
-	air.reaction_results["fire"] += plasma_burn_rate * (1 + oxygen_burn_ratio)
 	var/energy_released = FIRE_PLASMA_ENERGY_RELEASED * plasma_burn_rate
 	var/new_heat_capacity = air.heat_capacity()
 	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
@@ -255,7 +254,6 @@
 		cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel / HYDROGEN_BURN_H2_FACTOR
 
 	SET_REACTION_RESULTS(burned_fuel * fire_scale) // This is actually a lie. We use 10x less moles here but make 10x more energy.
-	air.reaction_results["fire"] += burned_fuel * fire_scale
 
 	var/energy_released = FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel * fire_scale
 	if(energy_released > 0)
@@ -319,7 +317,6 @@
 
 
 	SET_REACTION_RESULTS(burned_fuel * effect_scale)
-	air.reaction_results["fire"] += burned_fuel * effect_scale
 
 	var/turf/open/location
 	if(istype(holder, /datum/pipeline)) //Find the tile the reaction is occuring on, or a random part of the network if it's a pipenet.


### PR DESCRIPTION
## About The Pull Request
We now use the reaction result list for things outside of fires now, they cant go there.

## Why It's Good For The Game
Fixes a bug 

## Changelog
:cl:
fix: fixes the doppler array nullifying some of your bombs.
/:cl: