### PR TITLE
Adds format (associative) list wiremod component

### DIFF
--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -73,6 +73,11 @@
 	id = "comp_delay"
 	build_path = /obj/item/circuit_component/delay
 
+/datum/design/component/format
+	name = "Format Component"
+	id = "comp_format"
+	build_path = /obj/item/circuit_component/format
+
 /datum/design/component/index
 	name = "Index Component"
 	id = "comp_index"

--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -74,9 +74,14 @@
 	build_path = /obj/item/circuit_component/delay
 
 /datum/design/component/format
-	name = "Format Component"
+	name = "Format List Component"
 	id = "comp_format"
 	build_path = /obj/item/circuit_component/format
+
+/datum/design/component/format_assoc
+	name = "Format Associative List Component"
+	id = "comp_format_assoc"
+	build_path = /obj/item/circuit_component/format/assoc
 
 /datum/design/component/index
 	name = "Index Component"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -236,6 +236,7 @@
 		"comp_filter_list",
 		"comp_foreach",
 		"comp_format",
+		"comp_format_assoc",
 		"comp_get_column",
 		"comp_gps",
 		"comp_health",

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -235,6 +235,7 @@
 		"comp_element_find",
 		"comp_filter_list",
 		"comp_foreach",
+		"comp_format",
 		"comp_get_column",
 		"comp_gps",
 		"comp_health",

--- a/code/modules/wiremod/components/list/format.dm
+++ b/code/modules/wiremod/components/list/format.dm
@@ -9,12 +9,10 @@
 	desc = "A component that formats lists, replacing %n in the format string with corresponding nth list item."
 	category = "List"
 
-	var/static/regex/list_param_regex = new(@"%([0-9]+)", "g")
-	// Used to provide what src should be in the regex replace proc. Necessary due to terrible byond API.
-	var/static/obj/item/circuit_component/format/regex_context
+	var/static/regex/format_component/list_param_regex = new(@"%([0-9]+)", "g")
 
 	/// The regex used to find a parameter.
-	var/regex/param_regex
+	var/regex/format_component/param_regex
 
 	var/datum/port/input/format_port
 	var/datum/port/input/param_list_port
@@ -53,42 +51,12 @@
 
 	return param_list[index]
 
-/**
- * Replace %n with the actual param, as a string.
- * Arguments:
- * * match - The full %1 regex match. Unused.
- * * index_string - Just the "1" of the %1 format, actually used.
- */
-/obj/item/circuit_component/format/proc/process_param(match, index_string)
-	// The static regex_context var is what you'd expect src to be, but src is actually the regex instance.
-	var/list/param_list = regex_context.param_list_port.value
-	if(!islist(param_list))
-		return @"[NO LIST]"
-
-	var/value = regex_context.get_list_item(param_list, index_string)
-	if(value == null)
-		return @"[BAD INDEX]"
-
-	// If this is a datum or atom, it's likely wrapped in a weakref.
-	if(isweakref(value))
-		var/datum/weakref/weak_value = value
-		value = weak_value.resolve()
-
-	// Working with entities is constrained by range, just as with To String.
-	if(isatom(value))
-		var/turf/location = regex_context.get_location()
-		var/turf/target_location = get_turf(value)
-		if(target_location.z != location.z || get_dist(location, target_location) > regex_context.max_range)
-			return @"[OUT OF RANGE]"
-
-	return "[value]"
-
 /obj/item/circuit_component/format/input_received(datum/port/input/port, list/return_values)
 	. = ..()
 
 	// Inject the parameters.
-	regex_context = src
-	output.set_output(param_regex.Replace(format_port.value, .proc/process_param))
+	param_regex.context = src
+	output.set_output(param_regex.Replace(format_port.value, /regex/format_component/proc/process_format_component_param))
 
 /**
  * # Format Associative List Component
@@ -100,7 +68,7 @@
 	display_name = "Format Associative List"
 	desc = "A component that formats associative lists, replacing %key in the format string with corresponding list\[key] item."
 
-	var/static/regex/assoc_param_regex = new(@"%([a-zA-Z0-9_]+)", "g")
+	var/static/regex/format_component/assoc_param_regex = new(@"%([a-zA-Z0-9_]+)", "g")
 
 /obj/item/circuit_component/format/assoc/Initialize(mapload)
 	. = ..()
@@ -111,3 +79,39 @@
 
 /obj/item/circuit_component/format/assoc/make_params_port()
 	param_list_port = add_input_port("Params", PORT_TYPE_ASSOC_LIST(PORT_TYPE_STRING, PORT_TYPE_ANY))
+
+/**
+ * # Subtype of regex that holds context to /obj/item/circuit_component/format
+ */
+/regex/format_component
+	var/obj/item/circuit_component/format/context
+
+/**
+ * Replace %n with the actual param, as a string.
+ * Arguments:
+ * * match - The full %1 regex match. Unused.
+ * * index_string - Just the "1" of the %1 format, actually used.
+ */
+/regex/format_component/proc/process_format_component_param(match, index_string)
+	// The static regex_context var is what you'd expect src to be, but src is actually the regex instance.
+	var/list/param_list = context.param_list_port.value
+	if(!islist(param_list))
+		return @"[NO LIST]"
+
+	var/value = context.get_list_item(param_list, index_string)
+	if(value == null)
+		return @"[BAD INDEX]"
+
+	// If this is a datum or atom, it's likely wrapped in a weakref.
+	if(isweakref(value))
+		var/datum/weakref/weak_value = value
+		value = weak_value.resolve()
+
+	// Working with entities is constrained by range, just as with To String.
+	if(isatom(value))
+		var/turf/location = context.get_location()
+		var/turf/target_location = get_turf(value)
+		if(target_location.z != location.z || get_dist(location, target_location) > context.max_range)
+			return @"[OUT OF RANGE]"
+
+	return "[value]"

--- a/code/modules/wiremod/components/list/format.dm
+++ b/code/modules/wiremod/components/list/format.dm
@@ -57,6 +57,7 @@
 	// Inject the parameters.
 	param_regex.context = src
 	output.set_output(param_regex.Replace(format_port.value, /regex/format_component/proc/process_format_component_param))
+	param_regex.context = null
 
 /**
  * # Format Associative List Component

--- a/code/modules/wiremod/components/list/format.dm
+++ b/code/modules/wiremod/components/list/format.dm
@@ -1,0 +1,68 @@
+/**
+ * # String Format Component
+ *
+ * Formats strings by replacing %n with nth parameter.
+ * Alternative to the Concatenate component.
+ */
+/obj/item/circuit_component/format
+	display_name = "Format"
+	desc = "A component that formats strings, replacing %n in the format string with corresponding nth list item."
+	category = "List"
+
+	var/static/regex/param_regex = new(@"%([0-9]+)", "g")
+	// Used to provide what src should be in the regex replace proc. Necessary due to terrible byond API.
+	var/static/obj/item/circuit_component/format/regex_context
+
+	var/datum/port/input/format_port
+	var/datum/port/input/param_list_port
+
+	// Range for entity tostring to work, same mechanic as the To String component
+	var/max_range = 7
+
+	/// The result from the output
+	var/datum/port/output/output
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
+
+/obj/item/circuit_component/format/populate_ports()
+	format_port = add_input_port("Format", PORT_TYPE_STRING)
+	param_list_port = add_input_port("Params", PORT_TYPE_LIST(PORT_TYPE_ANY))
+
+	output = add_output_port("Output", PORT_TYPE_STRING)
+
+/**
+ * Replace %n with the actual param, as a string.
+ * Arguments:
+ * * match - The full %1 regex match. Unused.
+ * * index_string - Just the "1" of the %1 format, actually used.
+ */
+/obj/item/circuit_component/format/proc/process_param(match, index_string)
+	var/param_list = regex_context.param_list_port.value
+	var/index = text2num(index_string)
+
+	if(!islist(param_list))
+		return @"[NO LIST]"
+	if(index < 1 || index > length(param_list))
+		return @"[BAD INDEX]"
+
+	var/value = param_list[index]
+
+	// If this is a datum or atom, it's likely wrapped in a weakref.
+	if(isweakref(value))
+		var/datum/weakref/weak_value = value
+		value = weak_value.resolve()
+
+	// Working with entities is constrained by range, just as with To String.
+	if(isatom(value))
+		var/turf/location = regex_context.get_location()
+		var/turf/target_location = get_turf(value)
+		if(target_location.z != location.z || get_dist(location, target_location) > regex_context.max_range)
+			return @"[OUT OF RANGE]"
+
+	return "[value]"
+
+/obj/item/circuit_component/format/input_received(datum/port/input/port, list/return_values)
+	. = ..()
+
+	// Inject the parameters.
+	regex_context = src
+	output.set_output(param_regex.Replace(format_port.value, .proc/process_param))

--- a/code/modules/wiremod/components/list/format.dm
+++ b/code/modules/wiremod/components/list/format.dm
@@ -9,9 +9,12 @@
 	desc = "A component that formats lists, replacing %n in the format string with corresponding nth list item."
 	category = "List"
 
-	var/regex/param_regex = new(@"%([0-9]+)", "g")
+	var/static/regex/list_param_regex = new(@"%([0-9]+)", "g")
 	// Used to provide what src should be in the regex replace proc. Necessary due to terrible byond API.
 	var/static/obj/item/circuit_component/format/regex_context
+
+	/// The regex used to find a parameter.
+	var/regex/param_regex
 
 	var/datum/port/input/format_port
 	var/datum/port/input/param_list_port
@@ -22,6 +25,10 @@
 	/// The result from the output
 	var/datum/port/output/output
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
+
+/obj/item/circuit_component/format/Initialize(mapload)
+	. = ..()
+	param_regex = list_param_regex
 
 /obj/item/circuit_component/format/proc/make_params_port()
 	param_list_port = add_input_port("Params", PORT_TYPE_LIST(PORT_TYPE_ANY))
@@ -92,7 +99,12 @@
 /obj/item/circuit_component/format/assoc
 	display_name = "Format Associative List"
 	desc = "A component that formats associative lists, replacing %key in the format string with corresponding list\[key] item."
-	param_regex = new(@"%([a-zA-Z0-9_]+)", "g")
+
+	var/static/regex/assoc_param_regex = new(@"%([a-zA-Z0-9_]+)", "g")
+
+/obj/item/circuit_component/format/assoc/Initialize(mapload)
+	. = ..()
+	param_regex = assoc_param_regex
 
 /obj/item/circuit_component/format/assoc/get_list_item(list/param_list, index_string)
 	return param_list[index_string]

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4236,6 +4236,7 @@
 #include "code\modules\wiremod\components\list\concat.dm"
 #include "code\modules\wiremod\components\list\filter.dm"
 #include "code\modules\wiremod\components\list\foreach.dm"
+#include "code\modules\wiremod\components\list\format.dm"
 #include "code\modules\wiremod\components\list\get_column.dm"
 #include "code\modules\wiremod\components\list\index.dm"
 #include "code\modules\wiremod\components\list\index_table.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a wiremod component called "Format List" and one called "Format Associative List" that you get at round-start.

It accepts a format string and a list of parameters.
* For "Format List":
  * The format string contains normal text, and codes of the form %n (eg. %1, %2, %3) that correlate to indexes in the param list.
* For "Format Associative List":
  * The format string contains normal text, and codes of the form %key (eg. %name, %health) that correlate to keys in the associative param list.
* The param list can contain any types, which will be automatically converted to strings.
  * Conversion of entities to strings still follows the range rule of To String. Important to keep in mind if you're formatting an NTNet transmission.
  * For the associative version, the keys must be strings comprised of letters, numbers, or underscore.

Simplest example that says "Bob McToolbox pressed the button.":
![image](https://user-images.githubusercontent.com/1185434/157998468-739f239a-5280-4603-b59a-dbd267eb45dd.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

"That's dumb, I could have just used a Concatenate for that." I'm sure you're saying. Fine, I'll give use cases where this is a massive QOL improvement.

### Mob damage Readout comparison

Here's an example that states the 4 damage levels of the user that presses the button, ie. "Bob McToolbox has (23/0/0/0) damage."
As you can see, if there's a large number of items, Format List is much cleaner.

#### With just Concatenates:
![image](https://user-images.githubusercontent.com/1185434/157996330-c7644ba9-6996-4fea-9f79-5fc2d0ee1a5a.png)

#### With Format List:
![image](https://user-images.githubusercontent.com/1185434/157998552-63144399-9b30-484e-a4da-bf035dc13dee.png)

#### With Format Associative List (for fun):
![image](https://user-images.githubusercontent.com/1185434/157998982-0be2d4b2-3c0c-4d7a-ab8e-c122dcf99f34.png)

### With NT Receiver

Notably, NTNet *already* requires data to be put into a list, so you can just go ahead and transmit the raw data as a list, then quickly format it on the output device in a single intermediary component.

![image](https://user-images.githubusercontent.com/1185434/157996736-e0fa3ff4-615f-476d-9609-9056fe1e9fe9.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds the Format List and Format Associate List wiremod component, for ease of formatting lists of items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
