### PR TITLE
Decomposition now has mold first, then ants, instead of both.

### DIFF
--- a/code/datums/components/food/decomposition.dm
+++ b/code/datums/components/food/decomposition.dm
@@ -73,7 +73,7 @@
 
 	var/turf/open/open_turf = food.loc
 
-	if(!istype(open_turf) || istype(open_turf, /turf/open/lava)) //Are we actually in a valid open turf?
+	if(!istype(open_turf) || istype(open_turf, /turf/open/lava) || istype(open_turf, /turf/open/floor/plating/asteroid/basalt)) //Are we actually in a valid open turf?
 		remove_timer()
 		return
 

--- a/code/datums/components/food/decomposition.dm
+++ b/code/datums/components/food/decomposition.dm
@@ -21,9 +21,9 @@
 	/// Use for determining what kind of item the food decomposes into.
 	var/decomp_result
 	/// Does our food attract ants?
-	var/produce_ants = TRUE
+	var/produce_ants = FALSE
 
-/datum/component/decomposition/Initialize(mapload, decomp_req_handle, decomp_flags = NONE, decomp_result, ant_attracting = TRUE, custom_time = 0)
+/datum/component/decomposition/Initialize(mapload, decomp_req_handle, decomp_flags = NONE, decomp_result, ant_attracting = FALSE, custom_time = 0)
 	if(!isobj(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -31,8 +31,7 @@
 	src.decomp_result = decomp_result
 	if(mapload || decomp_req_handle)
 		handled = FALSE
-	if(!ant_attracting)
-		produce_ants = FALSE
+	src.produce_ants = ant_attracting
 
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/handle_movement)
 	RegisterSignal(parent, list(
@@ -111,8 +110,9 @@
 	var/obj/decomp = parent //Lets us spawn things at decomp
 	if(produce_ants)
 		new /obj/effect/decal/cleanable/ants(decomp.loc)
-	new decomp_result(decomp.loc)
-	decomp.visible_message("<span class='notice'>[decomp] gets overtaken by mold and ants! Gross!</span>")
+	if(decomp_result)
+		new decomp_result(decomp.loc)
+	decomp.visible_message("<span class='notice'>[decomp] gets overtaken by mold[produce_ants ? " and ants":""]! Gross!</span>")
 	qdel(decomp)
 	return
 

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -2,24 +2,32 @@
 	gender = PLURAL
 	layer = ABOVE_NORMAL_TURF_LAYER
 	var/list/random_icon_states = null
-	var/blood_state = "" //I'm sorry but cleanable/blood code is ass, and so is blood_DNA
-	var/bloodiness = 0 //0-100, amount of blood in this decal, used for making footprints and affecting the alpha of bloody footprints
-	var/mergeable_decal = TRUE //when two of these are on a same tile or do we need to merge them into just one?
+	///I'm sorry but cleanable/blood code is ass, and so is blood_DNA
+	var/blood_state = ""
+	///0-100, amount of blood in this decal, used for making footprints and affecting the alpha of bloody footprints
+	var/bloodiness = 0
+	///When two of these are on a same tile or do we need to merge them into just one?
+	var/mergeable_decal = TRUE
 	var/beauty = 0
 	///The type of cleaning required to clean the decal. See __DEFINES/cleaning.dm for the options
 	var/clean_type = CLEAN_TYPE_LIGHT_DECAL
+	///The reagent this decal holds. Leave blank for none.
+	var/datum/reagent/decal_reagent
+	///The amount of reagent this decal holds, if decal_reagent is defined
+	var/reagent_amount = 0
 
 /obj/effect/decal/cleanable/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
 	if (random_icon_states && (icon_state == initial(icon_state)) && length(random_icon_states) > 0)
 		icon_state = pick(random_icon_states)
 	create_reagents(300)
+	if(decal_reagent)
+		reagents.add_reagent(decal_reagent, reagent_amount)
 	if(loc && isturf(loc))
 		for(var/obj/effect/decal/cleanable/C in loc)
 			if(C != src && C.type == type && !QDELETED(C))
 				if (replace_decal(C))
-					if(C.reagents && reagents)
-						reagents.trans_to(C, reagents.total_volume)
+					handle_merge_decal(C)
 					return INITIALIZE_HINT_QDEL
 
 	if(LAZYLEN(diseases))
@@ -101,3 +109,9 @@
 		return bloodiness
 	else
 		return 0
+
+/obj/effect/decal/cleanable/proc/handle_merge_decal(obj/effect/decal/cleanable/merger)
+	if(!merger)
+		return
+	if(merger.reagents && reagents)
+		reagents.trans_to(merger, reagents.total_volume)

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -18,6 +18,8 @@
 		for(var/obj/effect/decal/cleanable/C in loc)
 			if(C != src && C.type == type && !QDELETED(C))
 				if (replace_decal(C))
+					if(C.reagents && reagents)
+						reagents.trans_to(C, reagents.total_volume)
 					return INITIALIZE_HINT_QDEL
 
 	if(LAZYLEN(diseases))

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -106,12 +106,13 @@
 
 	dryname = "rotting gibs"
 	drydesc = "They look bloody and gruesome while some terrible smell fills the air."
+	decal_reagent = /datum/reagent/liquidgibs
+	reagent_amount = 5
 	///Information about the diseases our streaking spawns
 	var/list/streak_diseases
 
 /obj/effect/decal/cleanable/blood/gibs/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
-	reagents.add_reagent(/datum/reagent/liquidgibs, 5)
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, .proc/on_pipe_eject)
 
 /obj/effect/decal/cleanable/blood/gibs/replace_decal(obj/effect/decal/cleanable/C)

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -12,10 +12,11 @@
 	icon_state = "ash"
 	mergeable_decal = FALSE
 	beauty = -50
+	decal_reagent = /datum/reagent/ash
+	reagent_amount = 30
 
 /obj/effect/decal/cleanable/ash/Initialize(mapload)
 	. = ..()
-	reagents.add_reagent(/datum/reagent/ash, 30)
 	pixel_x = base_pixel_x + rand(-5, 5)
 	pixel_y = base_pixel_y + rand(-5, 5)
 
@@ -27,10 +28,8 @@
 	name = "large pile of ashes"
 	icon_state = "big_ash"
 	beauty = -100
-
-/obj/effect/decal/cleanable/ash/large/Initialize(mapload)
-	. = ..()
-	reagents.add_reagent(/datum/reagent/ash, 30) //double the amount of ash.
+	decal_reagent = /datum/reagent/ash
+	reagent_amount = 60
 
 /obj/effect/decal/cleanable/glass
 	name = "tiny shards"
@@ -91,9 +90,13 @@
 /obj/effect/decal/cleanable/greenglow/ex_act()
 	return FALSE
 
+/obj/effect/decal/cleanable/greenglow/filled
+	decal_reagent = /datum/reagent/uranium
+	reagent_amount = 5
+
 /obj/effect/decal/cleanable/greenglow/filled/Initialize(mapload)
+	decal_reagent = pick(/datum/reagent/uranium, /datum/reagent/uranium/radium)
 	. = ..()
-	reagents.add_reagent(pick(/datum/reagent/uranium, /datum/reagent/uranium/radium), 5)
 
 /obj/effect/decal/cleanable/greenglow/ecto
 	name = "ectoplasmic puddle"
@@ -268,22 +271,23 @@
 	beauty = -150
 	plane = GAME_PLANE
 	layer = LOW_OBJ_LAYER
-	/// The damage the ants will do when you step on them
-	var/ant_bite_damage = 0.1
-	/// The amount of ant reagent inside the ant cluster
-	var/ant_volume
+	decal_reagent = /datum/reagent/ants
+	reagent_amount = 5
 	/// Sound the ants make when biting
 	var/bite_sound = 'sound/weapons/bite.ogg'
 
 /obj/effect/decal/cleanable/ants/Initialize(mapload)
+	reagent_amount = rand(3, 5)
 	. = ..()
-	ant_volume = rand(3, 5)
-	reagents.add_reagent(/datum/reagent/ants, ant_volume)
 	update_ant_damage()
 
-/obj/effect/decal/cleanable/ants/proc/update_ant_damage(spilled_ants)
-	ant_volume += spilled_ants
-	ant_bite_damage = min(10, round((ant_volume * 0.1),0.1)) // 100u ants = 10 max_damage
+/obj/effect/decal/cleanable/ants/handle_merge_decal(obj/effect/decal/cleanable/merger)
+	. = ..()
+	var/obj/effect/decal/cleanable/ants/ants = merger
+	ants.update_ant_damage()
+
+/obj/effect/decal/cleanable/ants/proc/update_ant_damage()
+	var/ant_bite_damage = min(10, round((reagents.get_reagent_amount(/datum/reagent/ants) * 0.1),0.1)) // 100u ants = 10 max_damage
 
 	var/ant_flags = (CALTROP_NOCRAWL | CALTROP_NOSTUN) /// Small amounts of ants won't be able to bite through shoes.
 	if(ant_bite_damage > 1)

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -79,10 +79,8 @@
 	bloodiness = BLOOD_AMOUNT_PER_DECAL
 	beauty = -100
 	clean_type = CLEAN_TYPE_BLOOD
-
-/obj/effect/decal/cleanable/oil/Initialize(mapload)
-	. = ..()
-	reagents.add_reagent(/datum/reagent/fuel/oil, 30)
+	decal_reagent = /datum/reagent/fuel/oil
+	reagent_amount = 30
 
 /obj/effect/decal/cleanable/oil/attackby(obj/item/I, mob/living/user)
 	var/attacked_by_hot_thing = I.get_temperature()

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -41,7 +41,7 @@
 	///Food that's immune to decomposition.
 	var/preserved_food = FALSE
 	///Does our food normally attract ants?
-	var/ant_attracting = TRUE
+	var/ant_attracting = FALSE
 	///What our food decomposes into.
 	var/decomp_type = /obj/item/food/badrecipe/moldy
 	///Food that needs to be picked up in order to decompose.

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -206,6 +206,10 @@
 	name = "moldy mess"
 	desc = "A rancid, disgusting culture of mold and ants. Somewhere under there, at <i>some point,</i> there was food."
 	food_reagents = list(/datum/reagent/consumable/mold = 30)
+	preserved_food = FALSE
+	ant_attracting = TRUE
+	decomp_type = null
+	decomposition_time = 30 SECONDS
 
 /obj/item/food/badrecipe/moldy/bacteria
 	name = "bacteria rich moldy mess"
@@ -269,7 +273,7 @@
 	icon_state = "spidereggs"
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4)
 	tastes = list("cobwebs" = 1)
-	foodtypes = MEAT 
+	foodtypes = MEAT
 	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/food/spiderling

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2817,7 +2817,7 @@
 		pests = new(exposed_turf)
 	var/spilled_ants = (round(reac_volume,1) - 5) // To account for ant decals giving 3-5 ants on initialize.
 	pests.reagents.add_reagent(/datum/reagent/ants, spilled_ants)
-	pests.update_ant_damage(spilled_ants)
+	pests.update_ant_damage()
 
 //This is intended to a be a scarce reagent to gate certain drugs and toxins with. Do not put in a synthesizer. Renewable sources of this reagent should be inefficient.
 /datum/reagent/lead


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Someone made a suggestion to me that fixed a problem I've been trying to work around, and now that I've made it so people can set custom decompose times, that made this WAY EASIER.

When most foods decay, they will turn into the generic moldy food sprite you've become accustomed to, without the ants. After 30 seconds, that moldy food will get consumed by ants, leaving only the anthill.

Ants also no longer spawn on lavaland's basalt, by Fikou request.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes anthills more visible, while still keeping the chance for people to grab some moldy food if they want to get the mold reagent for whatever reason.
Also reduced clutter, since multiple pieces of food decomposing on the same tile will conglomerate into one big anthill instead of several piles of mold.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Wallem
qol: Most foods decompose into JUST moldy food, which then gets eaten by ants, leaving only the anthills and ultimately making them more visible.
fix: Cleanable decals will try to merge their reagents before they delete if they have mergeable_decal = TRUE, meaning ants will now properly stack their reagents when they spawn on the same tile.
qol: Ants no longer spawn on lavaland's basalt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
