### PR TITLE
Fixes persistent painting patron name not being loaded

### DIFF
--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -74,6 +74,7 @@
 	creation_round_id = json_data["creation_round_id"]
 	tags = json_data["tags"]
 	patron_ckey = json_data["patron_ckey"]
+	patron_name = json_data["patron_name"]
 	credit_value = json_data["credit_value"]
 	width = json_data["width"]
 	height = json_data["height"]


### PR DESCRIPTION
Noticed this when checking if the frames work.