### PR TITLE
Fixes conflicting pride pin reskin bind

### DIFF
--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -92,7 +92,7 @@
 /obj/item/clothing/accessory/proc/on_uniform_dropped(obj/item/clothing/under/U, user)
 	return
 
-/obj/item/clothing/accessory/AltClick(mob/user)
+/obj/item/clothing/accessory/CtrlClick(mob/user)
 	if(initial(above_suit) && user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
 		above_suit = !above_suit
 		to_chat(user, "[src] will be worn [above_suit ? "above" : "below"] your suit.")
@@ -104,7 +104,7 @@
 	. = ..()
 	. += span_notice("\The [src] can be attached to a uniform. Alt-click to remove it once attached.")
 	if(initial(above_suit))
-		. += span_notice("\The [src] can be worn above or below your suit. Alt-click to toggle.")
+		. += span_notice("\The [src] can be worn above or below your suit. Ctrl-click to toggle.")
 
 /obj/item/clothing/accessory/waistcoat
 	name = "waistcoat"


### PR DESCRIPTION
## About The Pull Request

This PR switches the bind to change whether it appears above the suit to be ctrl click rather than alt click. Alt click is currently used for reskinning so it's currently impossible to reskin a pride pin.

## Why It's Good For The Game

Fixes broken content.

## Changelog

:cl:
fix: Fixes pride pin
/:cl:
