### PR TITLE
shy component now has variables for being shy around keyless and clientless bodies

### DIFF
--- a/code/datums/components/shy.dm
+++ b/code/datums/components/shy.dm
@@ -11,6 +11,10 @@
 	var/list/machine_whitelist = null
 	/// Message shown when you are is_shy
 	var/message = "You find yourself too shy to do that around %TARGET!"
+	/// Are you shy around bodies with no key?
+	var/keyless_shy = FALSE
+	/// Are you shy around bodies with no client?
+	var/clientless_shy = TRUE
 	/// Are you shy around a dead body?
 	var/dead_shy = FALSE
 	/// If dead_shy is false and this is true, you're only shy when right next to a dead target
@@ -20,7 +24,7 @@
 	/// What was our last result?
 	var/last_result = FALSE
 
-/datum/component/shy/Initialize(mob_whitelist, shy_range, message, dead_shy, dead_shy_immediate, machine_whitelist)
+/datum/component/shy/Initialize(mob_whitelist, shy_range, message, keyless_shy, clientless_shy, dead_shy, dead_shy_immediate, machine_whitelist)
 	if(!ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 	src.mob_whitelist = mob_whitelist
@@ -28,6 +32,10 @@
 		src.shy_range = shy_range
 	if(message)
 		src.message = message
+	if(keyless_shy)
+		src.keyless_shy = keyless_shy
+	if(clientless_shy)
+		src.clientless_shy = clientless_shy
 	if(dead_shy)
 		src.dead_shy = dead_shy
 	if(dead_shy_immediate)
@@ -82,6 +90,10 @@
 			if(person == owner)
 				continue
 			if(!is_type_in_typecache(person, mob_whitelist))
+				continue
+			if(!person.key && !keyless_shy)
+				continue
+			if(!person.client && !clientless_shy)
 				continue
 			if(person.stat == DEAD && !dead_shy)
 				if(!dead_shy_immediate)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -338,7 +338,7 @@
 	var/static/list/not_shy_of = typecacheof(list(/mob/living/simple_animal/drone, /mob/living/simple_animal/bot))
 	if(shy)
 		ADD_TRAIT(src, TRAIT_PACIFISM, DRONE_SHY_TRAIT)
-		LoadComponent(/datum/component/shy, mob_whitelist=not_shy_of, shy_range=3, message="Your laws prevent this action near %TARGET.", dead_shy=FALSE, dead_shy_immediate=TRUE, machine_whitelist=shy_machine_whitelist)
+		LoadComponent(/datum/component/shy, mob_whitelist=not_shy_of, shy_range=3, message="Your laws prevent this action near %TARGET.", keyless_shy=FALSE, clientless_shy=TRUE, dead_shy=FALSE, dead_shy_immediate=TRUE, machine_whitelist=shy_machine_whitelist)
 		LoadComponent(/datum/component/shy_in_room, drone_bad_areas, "Touching anything in %ROOM could break your laws.")
 		LoadComponent(/datum/component/technoshy, 1 MINUTES, "%TARGET was touched by a being recently, using it could break your laws.")
 		LoadComponent(/datum/component/itempicky, drone_good_items, "Using %TARGET could break your laws.")


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
what the title says, by default keyless shy is false and clientless shy is true

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![image](https://user-images.githubusercontent.com/23585223/158019710-e3974e0e-07c8-4dec-a0de-9f69dbfbf216.png)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: drones are no longer shy around maint rats and such
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
