### PR TITLE
Small improvements to scipapers

### DIFF
--- a/code/modules/experisci/experiment/types/ordnance.dm
+++ b/code/modules/experisci/experiment/types/ordnance.dm
@@ -7,7 +7,7 @@
 	name = "Toxin Research"
 	description = "An experiment conducted in the ordnance subdepartment."
 	exp_tag = "ordnance"
-	performance_hint = "Perform or purchase research experiments in the ordnance lab."
+	performance_hint = "Perform research experiments in the ordnance lab and publish them with NT Frontier."
 	/// Lookup experiments are initialized using subtypes, 
 	/// this lets us ignore the ones made for subtyping.
 	var/experiment_proper = FALSE

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -330,6 +330,22 @@
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/board/anomaly_refinery
+	name = "Machine Design (Anomaly Refinery Board)"
+	desc = "The circuit board for an anomaly refinery"
+	id = "anomaly_refinery"
+	build_path = /obj/item/circuitboard/machine/anomaly_refinery
+	category = list("Research Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/board/tank_compressor
+	name = "Machine Design (Tank Compressor Board)"
+	desc = "The circuit board for a tank compressor"
+	id = "tank_compressor"
+	build_path = /obj/item/circuitboard/machine/tank_compressor
+	category = list("Research Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/board/microwave
 	name = "Machine Design (Microwave Board)"
 	desc = "The circuit board for a microwave."

--- a/code/modules/research/ordnance/tank_compressor.dm
+++ b/code/modules/research/ordnance/tank_compressor.dm
@@ -342,10 +342,9 @@
 	data["transferRate"] = transfer_rate
 	data["lastPressure"] = last_recorded_pressure
 
-	data["portData"] = list()
-	data["portData"] += list(gas_mixture_parser(airs[2], "Input Port"))
-	data["portData"] += list(gas_mixture_parser(airs[1], "Ouput Port"))
-	data["portData"] += list(gas_mixture_parser(leaked_gas_buffer, "Gas Buffer"))
+	data["inputData"] = gas_mixture_parser(airs[2], "Input Port")
+	data["outputData"] = gas_mixture_parser(airs[1], "Ouput Port")
+	data["bufferData"] = gas_mixture_parser(leaked_gas_buffer, "Gas Buffer")
 
 	data["disk"] = inserted_disk?.name
 	data["storage"] = "[inserted_disk?.used_capacity] / [inserted_disk?.max_capacity] GQ"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -508,8 +508,11 @@
 		"stack_machine",
 		"tesla_coil",
 		"thermomachine",
-		"w-recycler" , "emitter",
+		"w-recycler", 
+		"emitter",
 		"welding_goggles",
+		"anomaly_refinery",
+		"tank_compressor",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500)
 	discount_experiments = list(/datum/experiment/scanning/random/material/easy = 7500)

--- a/tgui/packages/tgui/interfaces/TankCompressor.js
+++ b/tgui/packages/tgui/interfaces/TankCompressor.js
@@ -99,9 +99,9 @@ const TankCompressorControls = (props, context) => {
     active,
     transferRate,
     ejectPressure,
-    inputData = [],
-    outputData = [],
-    bufferData = [],
+    inputData,
+    outputData,
+    bufferData,
   } = data;
   const pressure = tankPresent ? tankPressure : lastPressure;
   const usingLastData = !!(lastPressure && !tankPresent);

--- a/tgui/packages/tgui/interfaces/TankCompressor.js
+++ b/tgui/packages/tgui/interfaces/TankCompressor.js
@@ -99,7 +99,9 @@ const TankCompressorControls = (props, context) => {
     active,
     transferRate,
     ejectPressure,
-    portData = [],
+    inputData = [],
+    outputData = [],
+    bufferData = [],
   } = data;
   const pressure = tankPresent ? tankPressure : lastPressure;
   const usingLastData = !!(lastPressure && !tankPresent);
@@ -215,16 +217,33 @@ const TankCompressorControls = (props, context) => {
       </Stack.Item>
       <Stack.Item grow>
         <Stack fill>
-          {portData.map((individualGasmix) => (
-            <Stack.Item grow key={individualGasmix.ref}>
-              <Section fill scrollable title={individualGasmix.name}>
-                {!individualGasmix.total_moles && (
-                  <Modal>{'No Gas Present'}</Modal>
-                )}
-                <GasmixParser {...individualGasmix} />
-              </Section>
-            </Stack.Item>
-          ))}
+          <Stack.Item grow>
+            <Section fill scrollable title={inputData.name}>
+              {!inputData.total_moles && <Modal>{'No Gas Present'}</Modal>}
+              <GasmixParser {...inputData} />
+            </Section>
+          </Stack.Item>
+          <Stack.Item grow>
+            <Section fill scrollable title={outputData.name}>
+              {!outputData.inputData && <Modal>{'No Gas Present'}</Modal>}
+              <GasmixParser {...outputData} />
+            </Section>
+          </Stack.Item>
+          <Stack.Item grow>
+            <Section
+              fill
+              scrollable
+              title={bufferData.name}
+              buttons={
+                <Button
+                  icon="exclamation"
+                  tooltip="The buffer gas mixture will be recorded when a tank is destroyed or ejected. The printed records will refer to this port for it's experimental data."
+                />
+              }>
+              {!bufferData.total_moles && <Modal>{'No Gas Present'}</Modal>}
+              <GasmixParser {...bufferData} />
+            </Section>
+          </Stack.Item>
         </Stack>
       </Stack.Item>
     </>
@@ -239,15 +258,16 @@ const TankCompressorRecords = (props, context) => {
     'recordRef',
     records[0]?.ref
   );
-  const activeRecord = !!activeRecordRef && records.find((record) => 
-    activeRecordRef === record.ref);
+  const activeRecord
+    = !!activeRecordRef
+    && records.find((record) => activeRecordRef === record.ref);
   if (records.length === 0) {
     return (
       <Stack.Item grow>
         <NoticeBox>No Records</NoticeBox>
-      </Stack.Item>);
-  } 
-  else {
+      </Stack.Item>
+    );
+  } else {
     return (
       <Stack.Item grow>
         <Stack fill>


### PR DESCRIPTION
## About The Pull Request
A bit of a mixed pr really. Added the boards to the techweb, added tooltips to the compressor, and then removed some outdated tips.

Boosts are also in a pretty bad state, I'm unsatisfied with how it works, I'll get to them once my currently open PRs are merged (or closed).
Left a few comments in #62284, you can read them to see my reasoning for stuffs.

<details closed>
<summary> Tooltip </summary>
<img src="https://user-images.githubusercontent.com/54709710/158021837-8df9610f-ba3e-4cea-83af-02b70f7cb880.png">
<img src="https://user-images.githubusercontent.com/54709710/158021854-80789213-e85b-49d3-a628-075b224f0046.png">
</details>

## Why It's Good For The Game
Lets folks spend less time worrying about unimportant stuffs and actually play the content.

## Changelog
:cl:
fix: fixed an outdated quip about purchasing an ordnance paper.
fix: added the ordnance circuitboards to the techweb, forgot about this in the original pr.
qol: added a small tooltip to the compressor buffer port.
/:cl: