### PR TITLE
Quality of Life fix for Security: Anyone who has access to the cells and the gulag shuttle can now use the gulag teleporter

### DIFF
--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -4,7 +4,7 @@
 	desc = "Used to send criminals to the Labor Camp."
 	icon_screen = "explosive"
 	icon_keyboard = "security_key"
-	req_access = list(ACCESS_ARMORY)
+	req_access = list(ACCESS_BRIG)
 	circuit = /obj/item/circuitboard/computer/gulag_teleporter_console
 	light_color = COLOR_SOFT_RED
 


### PR DESCRIPTION
## About The Pull Request

Anyone with ACCESS_BRIG(which is *not* the front door access) can now use the gulag teleporter.

## Why It's Good For The Game

I was capable of manually gulagging people as a Security Officer because I have all the access needed to do that, but I wasn't able to use the teleporter to do it, which prevented prisoners I manually gulag'd from being able to do their gulag.

We want players to use the gulag instead of brig cells because brig cells are immensely unfun for both the security player and the prisoner(see: DarkRP as to why "afk in a box" is bad design), and the Warden and HoS being the only people who can beam people to the gulag to allow them to actually use the gulag automation is a huge pain that made the gulag rarely used outside of the occasional veteran Warden player.

## Changelog
:cl:
qol: Anyone who has access to the cells and the gulag shuttle can now use the gulag teleporter
/:cl:
