### PR TITLE
Makes Clown tears reagent FINALLY obtainable through grinding. Makes clowns cry harder too.

### DIFF
--- a/code/game/objects/items/food/soup.dm
+++ b/code/game/objects/items/food/soup.dm
@@ -64,7 +64,7 @@
 	name = "clown's tears"
 	desc = "Not very funny."
 	icon_state = "clownstears"
-	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/banana = 10, /datum/reagent/water = 5, /datum/reagent/consumable/nutriment/vitamin = 16, /datum/reagent/consumable/clownstears = 10)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/banana = 10, /datum/reagent/lube = 5, /datum/reagent/consumable/nutriment/vitamin = 16, /datum/reagent/consumable/clownstears = 10)
 	tastes = list("a bad joke" = 1)
 	foodtypes = FRUIT | SUGAR
 

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
@@ -149,7 +149,7 @@
 /datum/crafting_recipe/food/clownstears
 	name = "Clowns tears"
 	reqs = list(
-		/datum/reagent/water = 10,
+		/datum/reagent/lube = 10,
 		/obj/item/reagent_containers/glass/bowl = 1,
 		/obj/item/food/grown/banana = 1,
 		/obj/item/stack/sheet/mineral/bananium = 1


### PR DESCRIPTION
## About The Pull Request

What does a clown love even more than bananium to grief the crew with their infinite bananas shoes and obnoxious honk? LUBE, torment the clown by making a soup with their two most beloved things in the world. 

Help sec with tasty quintuple sec all while tormenting the clown by letting him know he will NEVER have this bananium and lube.

## Why It's Good For The Game

This, this was never a workable way to get clown tears. How did we never realize that a recipe mixing potassium and water would lead to reagents deleting themselves? 

Solves #65436 

## Changelog


:cl:
fix: Clown tears will no longer explode on creation.
/:cl: