### PR TITLE
Mansus grasp now applies cultslurring, Void path minor compensatory buff

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -505,7 +505,7 @@
 
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.silent += 2
+		carbon_owner.silent += 4
 
 	return ..()
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -505,7 +505,7 @@
 
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.silent += 4
+		carbon_owner.silent += 5
 
 	return ..()
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -505,7 +505,7 @@
 
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.silent += 5
+		carbon_owner.silent += 2
 
 	return ..()
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -505,7 +505,7 @@
 
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.silent += 10
+		carbon_owner.silent += 5
 
 	return ..()
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -505,7 +505,7 @@
 
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.silent += 4
+		carbon_owner.silent += 10
 
 	return ..()
 

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -89,7 +89,7 @@
 	var/turf/open/target_turf = get_turf(carbon_target)
 	target_turf.TakeTemperature(-20)
 	carbon_target.adjust_bodytemperature(-40)
-	carbon_target.silent += 4
+	carbon_target.silent += 5
 
 /datum/heretic_knowledge/cold_snap
 	name = "Aristocrat's Way"

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -89,7 +89,7 @@
 	var/turf/open/target_turf = get_turf(carbon_target)
 	target_turf.TakeTemperature(-20)
 	carbon_target.adjust_bodytemperature(-40)
-	carbon_target.silent += 2
+	carbon_target.silent += 4
 
 /datum/heretic_knowledge/cold_snap
 	name = "Aristocrat's Way"

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -89,7 +89,7 @@
 	var/turf/open/target_turf = get_turf(carbon_target)
 	target_turf.TakeTemperature(-20)
 	carbon_target.adjust_bodytemperature(-40)
-	carbon_target.silent += 5
+	carbon_target.silent += 2
 
 /datum/heretic_knowledge/cold_snap
 	name = "Aristocrat's Way"

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -89,7 +89,7 @@
 	var/turf/open/target_turf = get_turf(carbon_target)
 	target_turf.TakeTemperature(-20)
 	carbon_target.adjust_bodytemperature(-40)
-	carbon_target.silent += 4
+	carbon_target.silent += 10
 
 /datum/heretic_knowledge/cold_snap
 	name = "Aristocrat's Way"

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -89,7 +89,7 @@
 	var/turf/open/target_turf = get_turf(carbon_target)
 	target_turf.TakeTemperature(-20)
 	carbon_target.adjust_bodytemperature(-40)
-	carbon_target.silent += 10
+	carbon_target.silent += 5
 
 /datum/heretic_knowledge/cold_snap
 	name = "Aristocrat's Way"

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -90,7 +90,7 @@
 	hit.adjustBruteLoss(10)
 	if(iscarbon(hit))
 		var/mob/living/carbon/carbon_hit = hit
-		carbon_hit.cultslurring += 6
+		carbon_hit.cultslurring += 2
 		carbon_hit.AdjustKnockdown(5 SECONDS)
 		carbon_hit.adjustStaminaLoss(80)
 

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -90,6 +90,7 @@
 	hit.adjustBruteLoss(10)
 	if(iscarbon(hit))
 		var/mob/living/carbon/carbon_hit = hit
+		carbon_hit.silent += 4
 		carbon_hit.AdjustKnockdown(5 SECONDS)
 		carbon_hit.adjustStaminaLoss(80)
 

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -90,7 +90,7 @@
 	hit.adjustBruteLoss(10)
 	if(iscarbon(hit))
 		var/mob/living/carbon/carbon_hit = hit
-		carbon_hit.silent += 4
+		carbon_hit.cultslurring += 6
 		carbon_hit.AdjustKnockdown(5 SECONDS)
 		carbon_hit.adjustStaminaLoss(80)
 


### PR DESCRIPTION
## About The Pull Request
What it says on the tin, the default grasp now silences

## Why It's Good For The Game
Since heretics are pretty weak unless they wait for 60 minutes to get more points, as to encourage an active playstyle I have decided to let the heretics have an easier time getting away with the crime. You see, it is already hard to drag a bloody body across maintenance into a secluded place to use with a big rune, what's even harder is to keep them quiet as you try to stab them. As such, a short mute rewards good heretic play without punishing the target too much, as the mute does NOT guarantee the heretic will kill you in time before you alert security and your coworkers.

edit: As I have switched out muting for cultslur, the target will now have a fair chance at calling for help, although it is upon the crew's deciphering idea to understand what a garbled version of "help engineering heretic now" will mean. I have decided to increase the silence by a really small value just so that void doesn't feel stripped of it's identity. Still, regular heretic raises alarm a bit instead of greatly, while void does not at all if you don't have eyewitnesses.
Values changed:
Regular mansus grasp now applies cultslur
Void mark now has a +5  value for it's mute instead of +5, and so does the Void grasp

## Changelog
:cl:
balance: Regular mansus grasp now inflicts cultslur on the target for 4 seconds.
balance: Increased void mark and void grasp silence duration from 8 seconds each to 10 seconds each.
/:cl: