### PR TITLE
Allows you to offer an item to only one person with Shift+Ctrl+Click

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -331,7 +331,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	add_overlay(receiving)
 	src.receiving = receiving
 	src.offerer = offerer
-	RegisterSignal(taker, COMSIG_MOVABLE_MOVED, .proc/check_in_range, override = TRUE) //Override to prevent runtimes when people offer a item multiple times
 
 /atom/movable/screen/alert/give/Click(location, control, params)
 	. = ..()
@@ -347,14 +346,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/give/proc/handle_transfer()
 	var/mob/living/carbon/taker = owner
 	taker.take(offerer, receiving)
-
-/// Simply checks if the other person is still in range
-/atom/movable/screen/alert/give/proc/check_in_range(atom/taker)
-	SIGNAL_HANDLER
-
-	if(!offerer.CanReach(taker))
-		to_chat(owner, span_warning("You moved out of range of [offerer]!"))
-		owner.clear_alert("[offerer]")
 
 /atom/movable/screen/alert/give/highfive/setup(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	. = ..()
@@ -415,7 +406,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	add_overlay(receiving)
 	src.receiving = receiving
 	src.offerer = offerer
-	RegisterSignal(taker, COMSIG_MOVABLE_MOVED, .proc/check_in_range, override = TRUE) //Override to prevent runtimes when people offer a item multiple times
 
 /// Gives the player the option to succumb while in critical condition
 /atom/movable/screen/alert/succumb

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -164,7 +164,7 @@
 	/// The type of alert given to people when offered, in case you need to override some behavior (like for high-fives)
 	var/give_alert_type = /atom/movable/screen/alert/give
 
-/datum/status_effect/offering/on_creation(mob/living/new_owner, obj/item/offer, give_alert_override)
+/datum/status_effect/offering/on_creation(mob/living/new_owner, obj/item/offer, give_alert_override, mob/living/carbon/offered)
 	. = ..()
 	if(!.)
 		return
@@ -172,10 +172,13 @@
 	if(give_alert_override)
 		give_alert_type = give_alert_override
 
-	for(var/mob/living/carbon/possible_taker in orange(1, owner))
-		if(!owner.CanReach(possible_taker) || IS_DEAD_OR_INCAP(possible_taker) || !possible_taker.can_hold_items())
-			continue
-		register_candidate(possible_taker)
+	if(offered && owner.CanReach(offered) && !IS_DEAD_OR_INCAP(offered) && offered.can_hold_items())
+		register_candidate(offered)
+	else
+		for(var/mob/living/carbon/possible_taker in orange(1, owner))
+			if(!owner.CanReach(possible_taker) || IS_DEAD_OR_INCAP(possible_taker) || !possible_taker.can_hold_items())
+				continue
+			register_candidate(possible_taker)
 
 	if(!possible_takers) // no one around
 		qdel(src)
@@ -215,6 +218,7 @@
 	if(owner.CanReach(taker) && !IS_DEAD_OR_INCAP(taker))
 		return
 
+	to_chat(taker, span_warning("You moved out of range of [owner]!"))
 	remove_candidate(taker)
 
 /// The offerer moved, see if anyone is out of range now

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -85,6 +85,12 @@
 
 	return ..()
 
+/mob/living/carbon/CtrlShiftClick(mob/user)
+	..()
+	if(iscarbon(user))
+		var/mob/living/carbon/carbon_user = user
+		carbon_user.give(src)
+
 /mob/living/carbon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	var/hurt = TRUE

--- a/code/modules/mob/living/carbon/carbon_context.dm
+++ b/code/modules/mob/living/carbon/carbon_context.dm
@@ -2,7 +2,8 @@
 	. = ..()
 
 	if (!isnull(held_item))
-		return .
+		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Offer item"
+		return CONTEXTUAL_SCREENTIP_SET
 
 	if (!ishuman(user))
 		return .
@@ -19,9 +20,6 @@
 
 	if (human_user != src)
 		context[SCREENTIP_CONTEXT_RMB] = "Shove"
-
-		if(human_user.get_active_held_item())
-			context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Offer item"
 
 		if (body_position == STANDING_UP)
 			context[SCREENTIP_CONTEXT_LMB] = "Comfort"

--- a/code/modules/mob/living/carbon/carbon_context.dm
+++ b/code/modules/mob/living/carbon/carbon_context.dm
@@ -20,6 +20,9 @@
 	if (human_user != src)
 		context[SCREENTIP_CONTEXT_RMB] = "Shove"
 
+		if(human_user.get_active_held_item())
+			context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Offer item"
+
 		if (body_position == STANDING_UP)
 			context[SCREENTIP_CONTEXT_LMB] = "Comfort"
 		else if (health >= 0 && !HAS_TRAIT(src, TRAIT_FAKEDEATH))

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -163,22 +163,31 @@
  * This handles creating an alert and adding an overlay to it
  */
 /mob/living/carbon/proc/give(mob/living/carbon/offered)
-	var/obj/item/offered_item = get_active_held_item()
-	if(!offered_item)
-		to_chat(src, span_warning("You're not holding anything to give!"))
+	if(has_status_effect(/datum/status_effect/offering))
+		to_chat(src, span_warning("You're already offering up something!"))
 		return
 
 	if(IS_DEAD_OR_INCAP(src))
 		to_chat(src, span_warning("You're unable to offer anything in your current state!"))
 		return
 
-	if(offered && IS_DEAD_OR_INCAP(offered))
-		to_chat(src, span_warning("They're unable to take anything in their current state!"))
+	var/obj/item/offered_item = get_active_held_item()
+	if(!offered_item)
+		to_chat(src, span_warning("You're not holding anything to give!"))
 		return
 
-	if(has_status_effect(/datum/status_effect/offering))
-		to_chat(src, span_warning("You're already offering up something!"))
-		return
+	if(offered)
+		if(IS_DEAD_OR_INCAP(offered))
+			to_chat(src, span_warning("They're unable to take anything in their current state!"))
+			return
+
+		if(!CanReach(offered))
+			to_chat(src, span_warning("You have to be adjacent to offer things!"))
+			return
+	else
+		if(!(locate(/mob/living/carbon) in orange(1, src)))
+			to_chat(src, span_warning("There's nobody adjacent to offer it to!"))
+			return
 
 	if(offered_item.on_offered(src)) // see if the item interrupts with its own behavior
 		return

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -195,6 +195,8 @@
  */
 /mob/living/carbon/proc/take(mob/living/carbon/offerer, obj/item/I)
 	clear_alert("[offerer]")
+	if(IS_DEAD_OR_INCAP(src))
+		return
 	if(get_dist(src, offerer) > 1)
 		to_chat(src, span_warning("[offerer] is out of range!"))
 		return

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -200,6 +200,7 @@
 /mob/living/carbon/proc/take(mob/living/carbon/offerer, obj/item/I)
 	clear_alert("[offerer]")
 	if(IS_DEAD_OR_INCAP(src))
+		to_chat(src, span_warning("You're unable to take anything in your current state!"))
 		return
 	if(get_dist(src, offerer) > 1)
 		to_chat(src, span_warning("[offerer] is out of range!"))

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -162,7 +162,7 @@
  *
  * This handles creating an alert and adding an overlay to it
  */
-/mob/living/carbon/proc/give()
+/mob/living/carbon/proc/give(mob/living/carbon/offered)
 	var/obj/item/offered_item = get_active_held_item()
 	if(!offered_item)
 		to_chat(src, span_warning("You're not holding anything to give!"))
@@ -179,10 +179,10 @@
 	if(offered_item.on_offered(src)) // see if the item interrupts with its own behavior
 		return
 
-	visible_message(span_notice("[src] is offering [offered_item]."), \
-					span_notice("You offer [offered_item]."), null, 2)
+	visible_message(span_notice("[src] is offering [offered ? "[offered] " : ""][offered_item]."), \
+					span_notice("You offer [offered ? "[offered] " : ""][offered_item]."), null, 2)
 
-	apply_status_effect(/datum/status_effect/offering, offered_item)
+	apply_status_effect(/datum/status_effect/offering, offered_item, null, offered)
 
 /**
  * Proc called when the player clicks the give alert

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -172,6 +172,10 @@
 		to_chat(src, span_warning("You're unable to offer anything in your current state!"))
 		return
 
+	if(offered && IS_DEAD_OR_INCAP(offered))
+		to_chat(src, span_warning("They're unable to take anything in their current state!"))
+		return
+
 	if(has_status_effect(/datum/status_effect/offering))
 		to_chat(src, span_warning("You're already offering up something!"))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can click someone directly with shift+ctrl+click to offer an item only to them. This is in contrast with pressing G, which offers the item to every adjacent carbon mob.

Also fixes a runtime where the Give screen alert on a potential recipient was trying to remove itself on proximity loss to the giver after the Offering status effect had already done it.

Removes duplicate range check on Give screen alert that was causing the runtime as Offering status effect takes care of it.

Also adds a check after clicking the screen alert to take something to make sure we're not dead or incapacitated, so dead people can no longer take things.

Also adds a screentip for this functionality.

Also adds some more checks to give() to make sure we can do it before sending the message to players that we're offering something.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It always felt like you should be able to offer things to people directly, instead of anybody adjacent being able to take it. It felt like it wasn't done that way to avoid having to pick a name from a pop-up window to offer to, which is clunky and steals focus.

This makes it so people don't accidentally take something that wasn't intended for them and piss off the players involved. 

Also lowers incidences of theft, because you should be able to choose who you're giving something to without having to move to a tile with nobody else adjacent.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Can Shift+Ctrl+Click people to give items to them directly now
fix: Fixed runtime on Give screen alert where a proximity check was happening twice
fix: Fixed being able to take things as a dead person
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
