### PR TITLE
Adds a cooldown to the deliver_first crates deny sound

### DIFF
--- a/code/datums/elements/deliver_first.dm
+++ b/code/datums/elements/deliver_first.dm
@@ -6,6 +6,8 @@
  *
  * for the future coders or just me: please convert this into a component to allow for more feedback on the crate's status (clicking when unlocked, overlays, etc)
  */
+
+#define DENY_SOUND_COOLDOWN (2 SECONDS)
 /datum/element/deliver_first
 	element_flags = ELEMENT_DETACH | ELEMENT_BESPOKE
 	id_arg_index = 2
@@ -13,6 +15,8 @@
 	var/goal_area_type
 	///how much is earned on delivery of the crate
 	var/payment
+	///cooldown for the deny sound
+	COOLDOWN_DECLARE(deny_cooldown)
 
 /datum/element/deliver_first/Attach(datum/target, goal_area_type, payment)
 	. = ..()
@@ -75,7 +79,9 @@
 			return BLOCK_OPEN
 	if(user)
 		target.balloon_alert(user, "access denied until delivery!")
-	playsound(target, 'sound/machines/buzz-two.ogg', 30, TRUE)
+	if(COOLDOWN_FINISHED(src, deny_cooldown))
+		playsound(target, 'sound/machines/buzz-two.ogg', 30, TRUE)
+		COOLDOWN_START(src, deny_cooldown, DENY_SOUND_COOLDOWN)
 	return BLOCK_OPEN
 
 ///signal called by successfully opening target
@@ -95,3 +101,5 @@
 	spark_system.start()
 	playsound(src, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	target.RemoveElement(/datum/element/deliver_first, goal_area_type, payment)
+
+#undef DENY_SOUND_COOLDOWN


### PR DESCRIPTION
This is really annoying, byond sound sucks, etc
Fixes https://github.com/tgstation/tgstation/issues/64338

:cl:
fix: Fixes being able to spam deny sounds on deliver first crates.
/:cl: