### PR TITLE
Fixes explosion sounds.

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -210,7 +210,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 		switch(soundin)
 			if (SFX_SHATTER)
 				soundin = pick('sound/effects/glassbr1.ogg','sound/effects/glassbr2.ogg','sound/effects/glassbr3.ogg')
-			if (SFX_EXPLOSION_CREAKING)
+			if (SFX_EXPLOSION)
 				soundin = pick('sound/effects/explosion1.ogg','sound/effects/explosion2.ogg')
 			if (SFX_EXPLOSION_CREAKING)
 				soundin = pick('sound/effects/explosioncreak1.ogg', 'sound/effects/explosioncreak2.ogg')


### PR DESCRIPTION

## About The Pull Request
This PR fixes a quick type in the new get_SFX changes to defines.
Explosions are paired with a creaking sound effect, and the creeking sound define was used twice in the get_sfx proc.

## Why It's Good For The Game

bugs bad.

## Changelog

:cl:
fix: explosions once again have the correct sound effects.
/:cl:
