### PR TITLE
Fixes water vapor and cleans up some req defines.

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -129,6 +129,8 @@
 #define N2O_DECOMPOSITION_ENERGY 200000
 
 // BZ:
+/// The maximum temperature BZ can form at. Deliberately set lower than the minimum burn temperature for most combustible gases in an attempt to prevent long fuse singlecaps.
+#define BZ_FORMATION_MAX_TEMPERATURE (FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 60) // Yes, someone used this as a bomb timer. I hate players.
 /// The amount of energy ~2.5 moles of BZ forming from N2O and plasma releases.
 #define BZ_FORMATION_ENERGY FIRE_CARBON_ENERGY_RELEASED
 
@@ -159,7 +161,7 @@
 
 // Freon:
 /// The minimum temperature freon can form from plasma, CO2, and BZ at.
-#define FREON_FORMATION_MIN_TEMPERATURE FIRE_MINIMUM_TEMPERATURE_TO_EXIST
+#define FREON_FORMATION_MIN_TEMPERATURE FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 100
 /// A scaling divisor for the rate of freon formation relative to mix temperature.
 #define FREON_FORMATION_TEMP_DIVISOR (FIRE_MINIMUM_TEMPERATURE_TO_EXIST * 10)
 /// The amount of energy 2.5 moles of freon forming from plasma, CO2, and BZ consumes.

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -77,14 +77,16 @@
 	id = "vapor"
 
 /datum/gas_reaction/water_vapor/init_reqs()
-	requirements = list(/datum/gas/water_vapor = MOLES_GAS_VISIBLE)
+	requirements = list(
+		/datum/gas/water_vapor = MOLES_GAS_VISIBLE,
+		"MAX_TEMP" = WATER_VAPOR_CONDENSATION_POINT,
+	)
 
-/datum/gas_reaction/water_vapor/react(datum/gas_mixture/air, datum/holder)
+/datum/gas_reaction/water_vapor/react(datum/gas_mixture/air, turf/open/location)
 	. = NO_REACTION
-	if(isturf(holder))
+	if(!isturf(location))
 		return
 
-	var/turf/open/location = holder
 	switch(air.temperature)
 		if(-INFINITY to WATER_VAPOR_DEPOSITION_POINT)
 			if(location?.freeze_turf())
@@ -110,7 +112,7 @@
 /datum/gas_reaction/miaster/init_reqs()
 	requirements = list(
 		/datum/gas/miasma = MINIMUM_MOLE_COUNT,
-		"MIN_TEMP" = MIASTER_STERILIZATION_TEMP
+		"MIN_TEMP" = MIASTER_STERILIZATION_TEMP,
 	)
 
 /datum/gas_reaction/miaster/react(datum/gas_mixture/air, datum/holder)
@@ -228,7 +230,7 @@
 	requirements = list(
 		/datum/gas/hydrogen = MINIMUM_MOLE_COUNT,
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
-		"MIN_TEMP" = HYDROGEN_MINIMUM_BURN_TEMPERATURE
+		"MIN_TEMP" = HYDROGEN_MINIMUM_BURN_TEMPERATURE,
 	)
 
 /datum/gas_reaction/h2fire/react(datum/gas_mixture/air, datum/holder)
@@ -291,7 +293,7 @@
 	requirements = list(
 		/datum/gas/tritium = MINIMUM_MOLE_COUNT,
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
-		"MIN_TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST,
+		"MIN_TEMP" = TRITIUM_MINIMUM_BURN_TEMPERATURE,
 	)
 
 /datum/gas_reaction/tritfire/react(datum/gas_mixture/air, datum/holder)
@@ -511,7 +513,7 @@
 	requirements = list(
 		/datum/gas/nitrous_oxide = 10,
 		/datum/gas/plasma = 10,
-		"MAX_TEMP" = T20C + 20 // Yes, someone used this as a bomb timer. I hate players
+		"MAX_TEMP" = BZ_FORMATION_MAX_TEMPERATURE,
 	)
 
 /datum/gas_reaction/bzformation/react(datum/gas_mixture/air)
@@ -649,7 +651,7 @@
 	requirements = list(
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
 		/datum/gas/nitrium = MINIMUM_MOLE_COUNT,
-		"MAX_TEMP" = NITRIUM_DECOMPOSITION_MAX_TEMP
+		"MAX_TEMP" = NITRIUM_DECOMPOSITION_MAX_TEMP,
 	)
 
 /datum/gas_reaction/nitrium_decomposition/react(datum/gas_mixture/air)
@@ -692,7 +694,7 @@
 		/datum/gas/plasma = 40,
 		/datum/gas/carbon_dioxide = 20,
 		/datum/gas/bz = 20,
-		"MIN_TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 100
+		"MIN_TEMP" = FREON_FORMATION_MIN_TEMPERATURE,
 	)
 
 /datum/gas_reaction/freonformation/react(datum/gas_mixture/air)
@@ -936,7 +938,7 @@
 /datum/gas_reaction/zauker_decomp/init_reqs()
 	requirements = list(
 		/datum/gas/nitrogen = MINIMUM_MOLE_COUNT,
-		/datum/gas/zauker = MINIMUM_MOLE_COUNT
+		/datum/gas/zauker = MINIMUM_MOLE_COUNT,
 	)
 
 /datum/gas_reaction/zauker_decomp/react(datum/gas_mixture/air, datum/holder)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -82,11 +82,12 @@
 		"MAX_TEMP" = WATER_VAPOR_CONDENSATION_POINT,
 	)
 
-/datum/gas_reaction/water_vapor/react(datum/gas_mixture/air, turf/open/location)
+/datum/gas_reaction/water_vapor/react(datum/gas_mixture/air, datum/holder)
 	. = NO_REACTION
-	if(!isturf(location))
+	if(!isturf(holder))
 		return
 
+	var/turf/open/location = holder
 	switch(air.temperature)
 		if(-INFINITY to WATER_VAPOR_DEPOSITION_POINT)
 			if(location?.freeze_turf())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the turf check on water vapor condensation being inverted.
Re-uses the define for tritium combustion temperature.
Makes a define for the maximum BZ formation temperature. Makes it more clearly in reference to combustion temps.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We want slippery floors, not slippery pipes.
Also, the define for the max BZ formation temperature should be more clearly in reference to combustion temps when it's relative to them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Water vapor should wet and freeze floors once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
