### PR TITLE
Renames Lean to Funky Cold Purple Drank so that admins aren't stopped from banning users engaging in flavor-of-the-month memes by the paper-thin shield of "but Lean is in the video game so its not OOC in IC"

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -750,7 +750,7 @@
 		playsound(get_turf(src), 'sound/effects/bubbles2.ogg', 25, TRUE)
 
 /obj/item/reagent_containers/food/drinks/colocup/lean
-	name = "lean"
+	name = "Funky Cold Purple Drank"
 	desc = "A cup of that purple drank, the stuff that makes you go WHEEZY BABY."
 	icon_state = "lean"
 	list_reagents = list(/datum/reagent/consumable/lean = 20)

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
@@ -146,7 +146,7 @@
 	category = CAT_DRINK
 
 /datum/crafting_recipe/lean
-	name = "lean"
+	name = "funky cold purple drank"
 	result = /obj/item/reagent_containers/food/drinks/colocup/lean
 	time = 30
 	reqs = list(/obj/item/reagent_containers/food/drinks/colocup = 1,

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -1148,7 +1148,7 @@
 	. = TRUE
 
 /datum/reagent/consumable/lean
-	name = "Lean"
+	name = "Funky Cold Purple Drank"
 	description = "The drank that makes you go wheezy."
 	color = "#DE55ED"
 	quality = DRINK_NICE


### PR DESCRIPTION
## About The Pull Request

Renames Lean to Funky Cold Purple Drank so that admins aren't stopped from banning users engaging in flavor-of-the-month memes by the paper-thin shield of "but Lean is in the video game so its not OOC in IC"

## Why It's Good For The Game

Admins being able to crack down on flavor of the month memes is good, actually.

## Changelog
:cl:
admin: Renames Lean to Funky Cold Purple Drank so that admins aren't stopped from banning users engaging in flavor-of-the-month memes by the paper-thin shield of "but Lean is in the video game so its not OOC in IC"
/:cl: