### PR TITLE
Fixes nonhuman head of departments showing up as their original species in security records

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -360,16 +360,16 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 		security_records_out += list(crew_record)
 	return security_records_out
 
-/datum/datacore/proc/get_id_photo(mob/living/carbon/human/H, client/C, show_directions = list(SOUTH))
-	var/datum/job/J = H.mind.assigned_role
-	var/datum/preferences/P
-	if(!C)
-		C = H.client
-	if(C)
-		P = C.prefs
-	if (!H.dna.species.forced_change)
-		return get_flat_human_icon(null, J, P, DUMMY_HUMAN_SLOT_MANIFEST, show_directions)
+/datum/datacore/proc/get_id_photo(mob/living/carbon/human/human, client/client, show_directions = list(SOUTH))
+	var/datum/job/humans_job = human.mind.assigned_role
+	var/datum/preferences/humans_prefs
+	if(!client)
+		client = human.client
+	if(client)
+		humans_prefs = client.prefs
+	if (human.dna.species.roundstart_changed)
+		return get_flat_human_icon(null, humans_job, null, DUMMY_HUMAN_SLOT_MANIFEST, show_directions)
 	else
-		return get_flat_human_icon(null, J, null, DUMMY_HUMAN_SLOT_MANIFEST, show_directions)
+		return get_flat_human_icon(null, humans_job, humans_prefs, DUMMY_HUMAN_SLOT_MANIFEST, show_directions)
 
 #undef DUMMY_HUMAN_SLOT_MANIFEST

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -367,6 +367,9 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 		C = H.client
 	if(C)
 		P = C.prefs
-	return get_flat_human_icon(null, J, P, DUMMY_HUMAN_SLOT_MANIFEST, show_directions)
+	if (!H.dna.species.forced_change)
+		return get_flat_human_icon(null, J, P, DUMMY_HUMAN_SLOT_MANIFEST, show_directions)
+	else
+		return get_flat_human_icon(null, J, null, DUMMY_HUMAN_SLOT_MANIFEST, show_directions)
 
 #undef DUMMY_HUMAN_SLOT_MANIFEST

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -53,19 +53,31 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	///Stores the hashed values of traits such as skin tones, hair style, and gender
 	var/unique_identity
 	var/blood_type
-	var/datum/species/species = new /datum/species/human //The type of mutant race the player is if applicable (i.e. potato-man)
-	var/list/features = list("FFF") //first value is mutant color
+	///The type of mutant race the player is if applicable (i.e. potato-man)
+	var/datum/species/species = new /datum/species/human
+	///first value is mutant color
+	var/list/features = list("FFF")
 	///Stores the hashed values of the person's non-human features
 	var/unique_features
-	var/real_name //Stores the real name of the person who originally got this dna datum. Used primarely for changelings,
-	var/list/mutations = list()   //All mutations are from now on here
-	var/list/temporary_mutations = list() //Temporary changes to the UE
-	var/list/previous = list() //For temporary name/ui/ue/blood_type modifications
+	///Stores the real name of the person who originally got this dna datum. Used primarely for changelings,
+	var/real_name
+	///All mutations are from now on here
+	var/list/mutations = list()
+	///Temporary changes to the UE
+	var/list/temporary_mutations = list()
+	///For temporary name/ui/ue/blood_type modifications
+	var/list/previous = list()
 	var/mob/living/holder
-	var/mutation_index[DNA_MUTATION_BLOCKS] //List of which mutations this carbon has and its assigned block
-	var/default_mutation_genes[DNA_MUTATION_BLOCKS] //List of the default genes from this mutation to allow DNA Scanner highlighting
+	///List of which mutations this carbon has and its assigned block
+	var/mutation_index[DNA_MUTATION_BLOCKS]
+	///List of the default genes from this mutation to allow DNA Scanner highlighting
+	var/default_mutation_genes[DNA_MUTATION_BLOCKS]
 	var/stability = 100
-	var/scrambled = FALSE //Did we take something like mutagen? In that case we cant get our genes scanned to instantly cheese all the powers.
+	///Did we take something like mutagen? In that case we cant get our genes scanned to instantly cheese all the powers.
+	var/scrambled = FALSE
+	///Was the species forcefully changed from its original type?
+	var/forced_change = FALSE
+
 
 /datum/dna/New(mob/living/new_holder)
 	if(istype(new_holder))
@@ -466,6 +478,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 		var/datum/species/old_species = dna.species
 		dna.species = new_race
 		dna.species.on_species_gain(src, old_species, pref_load)
+		dna.sepcies.forced_change = TRUE
 		if(ishuman(src))
 			qdel(language_holder)
 			var/species_holder = initial(mrace.species_language_holder)

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -75,8 +75,6 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	var/stability = 100
 	///Did we take something like mutagen? In that case we cant get our genes scanned to instantly cheese all the powers.
 	var/scrambled = FALSE
-	///Was the species forcefully changed from its original type?
-	var/forced_change = FALSE
 
 
 /datum/dna/New(mob/living/new_holder)
@@ -478,7 +476,6 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 		var/datum/species/old_species = dna.species
 		dna.species = new_race
 		dna.species.on_species_gain(src, old_species, pref_load)
-		dna.sepcies.forced_change = TRUE
 		if(ishuman(src))
 			qdel(language_holder)
 			var/species_holder = initial(mrace.species_language_holder)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -436,7 +436,7 @@
 
 		if (require_human)
 			set_species(/datum/species/human)
-			dna.species.forced_change = TRUE
+			dna.species.roundstart_changed = TRUE
 
 		if(GLOB.current_anonymous_theme)
 			fully_replace_character_name(null, GLOB.current_anonymous_theme.anonymous_name(src))
@@ -447,7 +447,7 @@
 		player_client.prefs.safe_transfer_prefs_to(src, TRUE, is_antag)
 		if (require_human && !ishumanbasic(src))
 			set_species(/datum/species/human)
-			dna.species.forced_change = TRUE
+			dna.species.roundstart_changed = TRUE
 			apply_pref_name(/datum/preference/name/backup_human, player_client)
 		if(CONFIG_GET(flag/force_random_names))
 			var/species_type = player_client.prefs.read_preference(/datum/preference/choiced/species)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -436,6 +436,7 @@
 
 		if (require_human)
 			set_species(/datum/species/human)
+			dna.species.forced_change = TRUE
 
 		if(GLOB.current_anonymous_theme)
 			fully_replace_character_name(null, GLOB.current_anonymous_theme.anonymous_name(src))
@@ -446,6 +447,7 @@
 		player_client.prefs.safe_transfer_prefs_to(src, TRUE, is_antag)
 		if (require_human && !ishumanbasic(src))
 			set_species(/datum/species/human)
+			dna.species.forced_change = TRUE
 			apply_pref_name(/datum/preference/name/backup_human, player_client)
 		if(CONFIG_GET(flag/force_random_names))
 			var/species_type = player_client.prefs.read_preference(/datum/preference/choiced/species)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -223,8 +223,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	/// Do we try to prevent reset_perspective() from working? Useful for Dullahans to stop perspective changes when they're looking through their head.
 	var/prevent_perspective_change = FALSE
 
-	///Was the species forcefully changed from its original type?
-	var/forced_change = FALSE
+	///Was the species changed from its original type at the start of the round?
+	var/roundstart_changed = FALSE
 
 ///////////
 // PROCS //

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -223,6 +223,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	/// Do we try to prevent reset_perspective() from working? Useful for Dullahans to stop perspective changes when they're looking through their head.
 	var/prevent_perspective_change = FALSE
 
+	///Was the species forcefully changed from its original type?
+	var/forced_change = FALSE
+
 ///////////
 // PROCS //
 ///////////


### PR DESCRIPTION
`get_flat_human_icon` was passing preferences which chose their
original, so i added a var to `/datum/species` to check if the species
was forcefully changed

also updates dna code to use dmdocs

Fixes #65428 

:cl:
Fix: Fixes nonhuman head of departments showing up as their original species in security records.
/:cl: