### PR TITLE
Low/no power screen alert tooltips tell you where the recharging stations actually are

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -52,4 +52,5 @@ GLOBAL_LIST_EMPTY(alert_consoles) // Station alert consoles, /obj/machinery/comp
 GLOBAL_LIST_EMPTY(air_scrub_names) // Name list of all air scrubbers
 GLOBAL_LIST_EMPTY(air_vent_names) // Name list of all air vents
 
-GLOBAL_LIST_EMPTY(roundstart_station_borgcharger_areas) // List of area names of roundstart station cyborg rechargers, for the low charge/no charge screen alert tooltips.
+GLOBAL_LIST_EMPTY(roundstart_station_borgcharger_areas) // List of area names of roundstart station cyborg rechargers, for the low charge/no charge cyborg screen alert tooltips.
+GLOBAL_LIST_EMPTY(roundstart_station_mechcharger_areas) // List of area names of roundstart station mech rechargers, for the low charge/no charge mech screen alert tooltips.

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -52,5 +52,4 @@ GLOBAL_LIST_EMPTY(alert_consoles) // Station alert consoles, /obj/machinery/comp
 GLOBAL_LIST_EMPTY(air_scrub_names) // Name list of all air scrubbers
 GLOBAL_LIST_EMPTY(air_vent_names) // Name list of all air vents
 
-GLOBAL_LIST_EMPTY(station_recharging_stations) // List of all station recharging stations. Sorry, Charlie Station borgs.
-GLOBAL_LIST_EMPTY(station_recharging_station_area_names) // List of all station recharging station area names, for the low charge/no charge screen alert tooltips.
+GLOBAL_LIST_EMPTY(roundstart_station_borgcharger_areas) // List of area names of roundstart station cyborg rechargers, for the low charge/no charge screen alert tooltips.

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -52,4 +52,5 @@ GLOBAL_LIST_EMPTY(alert_consoles) // Station alert consoles, /obj/machinery/comp
 GLOBAL_LIST_EMPTY(air_scrub_names) // Name list of all air scrubbers
 GLOBAL_LIST_EMPTY(air_vent_names) // Name list of all air vents
 
-GLOBAL_LIST_EMPTY(recharging_station_area_names) // List of all recharging station areas, for the low charge/no charge screen alert tooltips.
+GLOBAL_LIST_EMPTY(recharging_stations) // List of all recharging stations.
+GLOBAL_LIST_EMPTY(recharging_station_area_names) // List of all recharging station area names, for the low charge/no charge screen alert tooltips.

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -51,3 +51,5 @@ GLOBAL_LIST_EMPTY(alert_consoles) // Station alert consoles, /obj/machinery/comp
 
 GLOBAL_LIST_EMPTY(air_scrub_names) // Name list of all air scrubbers
 GLOBAL_LIST_EMPTY(air_vent_names) // Name list of all air vents
+
+GLOBAL_LIST_EMPTY(recharging_station_area_names) // List of all recharging station areas, for the low charge/no charge screen alert tooltips.

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -52,5 +52,5 @@ GLOBAL_LIST_EMPTY(alert_consoles) // Station alert consoles, /obj/machinery/comp
 GLOBAL_LIST_EMPTY(air_scrub_names) // Name list of all air scrubbers
 GLOBAL_LIST_EMPTY(air_vent_names) // Name list of all air vents
 
-GLOBAL_LIST_EMPTY(recharging_stations) // List of all recharging stations.
-GLOBAL_LIST_EMPTY(recharging_station_area_names) // List of all recharging station area names, for the low charge/no charge screen alert tooltips.
+GLOBAL_LIST_EMPTY(station_recharging_stations) // List of all station recharging stations. Sorry, Charlie Station borgs.
+GLOBAL_LIST_EMPTY(station_recharging_station_area_names) // List of all recharging station area names, for the low charge/no charge screen alert tooltips.

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -53,4 +53,4 @@ GLOBAL_LIST_EMPTY(air_scrub_names) // Name list of all air scrubbers
 GLOBAL_LIST_EMPTY(air_vent_names) // Name list of all air vents
 
 GLOBAL_LIST_EMPTY(station_recharging_stations) // List of all station recharging stations. Sorry, Charlie Station borgs.
-GLOBAL_LIST_EMPTY(station_recharging_station_area_names) // List of all recharging station area names, for the low charge/no charge screen alert tooltips.
+GLOBAL_LIST_EMPTY(station_recharging_station_area_names) // List of all station recharging station area names, for the low charge/no charge screen alert tooltips.

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -605,8 +605,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/emptycell
 	name = "Out of Power"
-	icon_state = "empty_cell"
 	desc = "Unit's power cell has no charge remaining."
+	icon_state = "empty_cell"
 
 /atom/movable/screen/alert/emptycell/MouseEntered(location,control,params)
 	update_appearance(updates=UPDATE_DESC)
@@ -620,8 +620,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/lowcell
 	name = "Low Charge"
-	icon_state = "low_cell"
 	desc = "Unit's power cell is running low."
+	icon_state = "low_cell"
 
 /atom/movable/screen/alert/lowcell/MouseEntered(location,control,params)
 	update_appearance(updates=UPDATE_DESC)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -613,8 +613,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	update_appearance(updates=UPDATE_DESC)
 
 /atom/movable/screen/alert/emptycell/update_desc()
-	desc = initial(desc)
 	. = ..()
+	desc = initial(desc)
 	if(length(GLOB.roundstart_station_borgcharger_areas))
 		desc += " Recharging stations are available in [english_list(GLOB.roundstart_station_borgcharger_areas)]."
 
@@ -628,10 +628,24 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	update_appearance(updates=UPDATE_DESC)
 
 /atom/movable/screen/alert/lowcell/update_desc()
-	desc = initial(desc)
 	. = ..()
+	desc = initial(desc)
 	if(length(GLOB.roundstart_station_borgcharger_areas))
 		desc += " Recharging stations are available in [english_list(GLOB.roundstart_station_borgcharger_areas)]."
+
+//MECH
+
+/atom/movable/screen/alert/lowcell/mech/update_desc()
+	. = ..()
+	desc = initial(desc)
+	if(length(GLOB.roundstart_station_mechcharger_areas))
+		desc += " Power ports are available in [english_list(GLOB.roundstart_station_mechcharger_areas)]."
+
+/atom/movable/screen/alert/emptycell/mech/update_desc()
+	. = ..()
+	desc = initial(desc)
+	if(length(GLOB.roundstart_station_mechcharger_areas))
+		desc += " Power ports are available in [english_list(GLOB.roundstart_station_mechcharger_areas)]."
 
 //Ethereal
 
@@ -659,9 +673,17 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "Unit's plasma core has no charge remaining. No modules available until plasma core is recharged. \
 		Unit can be refilled through plasma ore."
 
+/atom/movable/screen/alert/emptycell/plasma/update_desc()
+	. = ..()
+	desc = initial(desc)
+
 /atom/movable/screen/alert/lowcell/plasma
 	name = "Low Charge"
 	desc = "Unit's plasma core is running low. Unit can be refilled through plasma ore."
+
+/atom/movable/screen/alert/lowcell/plasma/update_desc()
+	. = ..()
+	desc = initial(desc)
 
 //Need to cover all use cases - emag, illegal upgrade module, malf AI hack, traitor cyborg
 /atom/movable/screen/alert/hacked

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -609,10 +609,24 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		Recharging stations are available in robotics, the dormitory bathrooms, and the AI satellite."
 	icon_state = "empty_cell"
 
+/atom/movable/screen/alert/emptycell/Initialize()
+	. = ..()
+	if(length(GLOB.recharging_station_area_names))
+		desc = "Unit's power cell is running low. Recharging stations are available in [english_list(GLOB.recharging_station_area_names)]."
+	else
+		desc = "Unit's power cell is running low. Recharging stations are not available. Better beg someone to build one!"
+
 /atom/movable/screen/alert/lowcell
 	name = "Low Charge"
 	desc = "Unit's power cell is running low. Recharging stations are available in robotics, the dormitory bathrooms, and the AI satellite."
 	icon_state = "low_cell"
+
+/atom/movable/screen/alert/lowcell/Initialize()
+	. = ..()
+	if(length(GLOB.recharging_station_area_names))
+		desc = "Unit's power cell is running low. Recharging stations are available in [english_list(GLOB.recharging_station_area_names)]."
+	else
+		desc = "Unit's power cell is running low. Recharging stations are not available. Better beg someone to build one!"
 
 //Ethereal
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -608,7 +608,12 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "Unit's power cell has no charge remaining. No modules available until power cell is recharged."
 	icon_state = "empty_cell"
 
+/atom/movable/screen/alert/emptycell/Initialize(mapload)
+	. = ..()
+	update_appearance(updates=UPDATE_DESC)
+
 /atom/movable/screen/alert/emptycell/update_desc()
+	desc = initial(desc)
 	. = ..()
 	if(length(GLOB.roundstart_station_borgcharger_areas))
 		desc += " Recharging stations are available in [english_list(GLOB.roundstart_station_borgcharger_areas)]."
@@ -618,7 +623,12 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "Unit's power cell is running low."
 	icon_state = "low_cell"
 
+/atom/movable/screen/alert/lowcell/Initialize(mapload)
+	. = ..()
+	update_appearance(updates=UPDATE_DESC)
+
 /atom/movable/screen/alert/lowcell/update_desc()
+	desc = initial(desc)
 	. = ..()
 	if(length(GLOB.roundstart_station_borgcharger_areas))
 		desc += " Recharging stations are available in [english_list(GLOB.roundstart_station_borgcharger_areas)]."

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -615,8 +615,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/emptycell/update_desc()
 	. = ..()
 	desc = initial(desc)
-	if(length(GLOB.recharging_station_area_names))
-		desc += " Recharging stations are available in [english_list(GLOB.recharging_station_area_names)]."
+	if(length(GLOB.station_recharging_station_area_names))
+		desc += " Recharging stations are available in [english_list(GLOB.station_recharging_station_area_names)]."
 
 /atom/movable/screen/alert/lowcell
 	name = "Low Charge"
@@ -630,8 +630,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/lowcell/update_desc()
 	. = ..()
 	desc = initial(desc)
-	if(length(GLOB.recharging_station_area_names))
-		desc += " Recharging stations are available in [english_list(GLOB.recharging_station_area_names)]."
+	if(length(GLOB.station_recharging_station_area_names))
+		desc += " Recharging stations are available in [english_list(GLOB.station_recharging_station_area_names)]."
 
 //Ethereal
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -605,28 +605,33 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/emptycell
 	name = "Out of Power"
-	desc = "Unit's power cell has no charge remaining. No modules available until power cell is recharged. \
-		Recharging stations are available in robotics, the dormitory bathrooms, and the AI satellite."
 	icon_state = "empty_cell"
+	desc = "Unit's power cell has no charge remaining."
 
-/atom/movable/screen/alert/emptycell/Initialize()
+/atom/movable/screen/alert/emptycell/MouseEntered(location,control,params)
+	update_appearance(updates=UPDATE_DESC)
+	return ..()
+
+/atom/movable/screen/alert/emptycell/update_desc()
 	. = ..()
+	desc = initial(desc)
 	if(length(GLOB.recharging_station_area_names))
-		desc = "Unit's power cell is running low. Recharging stations are available in [english_list(GLOB.recharging_station_area_names)]."
-	else
-		desc = "Unit's power cell is running low. Recharging stations are not available. Better beg someone to build one!"
+		desc += " Recharging stations are available in [english_list(GLOB.recharging_station_area_names)]."
 
 /atom/movable/screen/alert/lowcell
 	name = "Low Charge"
-	desc = "Unit's power cell is running low. Recharging stations are available in robotics, the dormitory bathrooms, and the AI satellite."
 	icon_state = "low_cell"
+	desc = "Unit's power cell is running low."
 
-/atom/movable/screen/alert/lowcell/Initialize()
+/atom/movable/screen/alert/lowcell/MouseEntered(location,control,params)
+	update_appearance(updates=UPDATE_DESC)
+	return ..()
+
+/atom/movable/screen/alert/lowcell/update_desc()
 	. = ..()
+	desc = initial(desc)
 	if(length(GLOB.recharging_station_area_names))
-		desc = "Unit's power cell is running low. Recharging stations are available in [english_list(GLOB.recharging_station_area_names)]."
-	else
-		desc = "Unit's power cell is running low. Recharging stations are not available. Better beg someone to build one!"
+		desc += " Recharging stations are available in [english_list(GLOB.recharging_station_area_names)]."
 
 //Ethereal
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -608,32 +608,20 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "Unit's power cell has no charge remaining. No modules available until power cell is recharged."
 	icon_state = "empty_cell"
 
-/atom/movable/screen/alert/emptycell/MouseEntered(location,control,params)
-	update_appearance(updates=UPDATE_DESC)
-	return ..()
-
 /atom/movable/screen/alert/emptycell/update_desc()
 	. = ..()
-	desc = initial(desc)
-	var/turf/owner_turf = get_turf(owner)
-	if(is_station_level(owner_turf.z) && length(GLOB.station_recharging_station_area_names))
-		desc += " Recharging stations are available in [english_list(GLOB.station_recharging_station_area_names)]."
+	if(length(GLOB.roundstart_station_borgcharger_areas))
+		desc += " Recharging stations are available in [english_list(GLOB.roundstart_station_borgcharger_areas)]."
 
 /atom/movable/screen/alert/lowcell
 	name = "Low Charge"
 	desc = "Unit's power cell is running low."
 	icon_state = "low_cell"
 
-/atom/movable/screen/alert/lowcell/MouseEntered(location,control,params)
-	update_appearance(updates=UPDATE_DESC)
-	return ..()
-
 /atom/movable/screen/alert/lowcell/update_desc()
 	. = ..()
-	desc = initial(desc)
-	var/turf/owner_turf = get_turf(owner)
-	if(is_station_level(owner_turf.z) && length(GLOB.station_recharging_station_area_names))
-		desc += " Recharging stations are available in [english_list(GLOB.station_recharging_station_area_names)]."
+	if(length(GLOB.roundstart_station_borgcharger_areas))
+		desc += " Recharging stations are available in [english_list(GLOB.roundstart_station_borgcharger_areas)]."
 
 //Ethereal
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -615,7 +615,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/emptycell/update_desc()
 	. = ..()
 	desc = initial(desc)
-	if(length(GLOB.station_recharging_station_area_names))
+	var/turf/owner_turf = get_turf(owner)
+	if(is_station_level(owner_turf.z) && length(GLOB.station_recharging_station_area_names))
 		desc += " Recharging stations are available in [english_list(GLOB.station_recharging_station_area_names)]."
 
 /atom/movable/screen/alert/lowcell
@@ -630,7 +631,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/lowcell/update_desc()
 	. = ..()
 	desc = initial(desc)
-	if(length(GLOB.station_recharging_station_area_names))
+	var/turf/owner_turf = get_turf(owner)
+	if(is_station_level(owner_turf.z) && length(GLOB.station_recharging_station_area_names))
 		desc += " Recharging stations are available in [english_list(GLOB.station_recharging_station_area_names)]."
 
 //Ethereal

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -605,7 +605,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/emptycell
 	name = "Out of Power"
-	desc = "Unit's power cell has no charge remaining."
+	desc = "Unit's power cell has no charge remaining. No modules available until power cell is recharged."
 	icon_state = "empty_cell"
 
 /atom/movable/screen/alert/emptycell/MouseEntered(location,control,params)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -33,7 +33,7 @@
 		var/area_name = get_area_name(charge_station, format_text = TRUE)
 		if(!(area_name in GLOB.station_recharging_station_area_names))
 			GLOB.station_recharging_station_area_names += area_name
-	sort_list(GLOB.station_recharging_station_area_names)
+	GLOB.station_recharging_station_area_names = sort_list(GLOB.station_recharging_station_area_names)
 
 /obj/machinery/recharge_station/Destroy()
 	GLOB.station_recharging_stations -= src

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -22,6 +22,17 @@
 	if(is_operational)
 		begin_processing()
 
+	if(SSmapping.level_trait(z, ZTRAIT_STATION))
+		var/area_name = get_area_name(src, format_text = TRUE)
+		if(!(area_name in GLOB.recharging_station_area_names))
+			GLOB.recharging_station_area_names += area_name
+
+/obj/machinery/recharge_station/Destroy()
+	if(SSmapping.level_trait(z, ZTRAIT_STATION))
+		var/area_name = get_area_name(src, format_text = TRUE)
+		if(area_name in GLOB.recharging_station_area_names)
+			GLOB.recharging_station_area_names -= area_name
+	return ..()
 
 /obj/machinery/recharge_station/RefreshParts()
 	recharge_speed = 0

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -22,16 +22,22 @@
 	if(is_operational)
 		begin_processing()
 
-	if(SSmapping.level_trait(z, ZTRAIT_STATION))
-		var/area_name = get_area_name(src, format_text = TRUE)
+	var/area/my_area = get_area(src)
+	if(my_area.type in GLOB.the_station_areas)
+		GLOB.recharging_stations += src
+		update_area_names()
+
+/obj/machinery/recharge_station/proc/update_area_names()
+	GLOB.recharging_station_area_names.Cut()
+	sort_list(GLOB.recharging_stations) //makes it harder to infer built chargers because they no longer appear at the end of the list
+	for(var/atom/charge_station in GLOB.recharging_stations)
+		var/area_name = get_area_name(charge_station, format_text = TRUE)
 		if(!(area_name in GLOB.recharging_station_area_names))
 			GLOB.recharging_station_area_names += area_name
 
 /obj/machinery/recharge_station/Destroy()
-	if(SSmapping.level_trait(z, ZTRAIT_STATION))
-		var/area_name = get_area_name(src, format_text = TRUE)
-		if(area_name in GLOB.recharging_station_area_names)
-			GLOB.recharging_station_area_names -= area_name
+	GLOB.recharging_stations -= src
+	update_area_names()
 	return ..()
 
 /obj/machinery/recharge_station/RefreshParts()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -22,23 +22,17 @@
 	if(is_operational)
 		begin_processing()
 
+	if(!mapload)
+		return
+
 	var/area/my_area = get_area(src)
-	if(my_area.type in GLOB.the_station_areas)
-		GLOB.station_recharging_stations += src
-		update_area_names()
+	if(!(my_area.type in GLOB.the_station_areas))
+		return
 
-/obj/machinery/recharge_station/proc/update_area_names()
-	GLOB.station_recharging_station_area_names.Cut()
-	for(var/atom/charge_station in GLOB.station_recharging_stations)
-		var/area_name = get_area_name(charge_station, format_text = TRUE)
-		if(!(area_name in GLOB.station_recharging_station_area_names))
-			GLOB.station_recharging_station_area_names += area_name
-	GLOB.station_recharging_station_area_names = sort_list(GLOB.station_recharging_station_area_names)
-
-/obj/machinery/recharge_station/Destroy()
-	GLOB.station_recharging_stations -= src
-	update_area_names()
-	return ..()
+	var/area_name = get_area_name(src, format_text = TRUE)
+	if(area_name in GLOB.roundstart_station_borgcharger_areas)
+		return
+	GLOB.roundstart_station_borgcharger_areas += area_name
 
 /obj/machinery/recharge_station/RefreshParts()
 	recharge_speed = 0

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -24,19 +24,19 @@
 
 	var/area/my_area = get_area(src)
 	if(my_area.type in GLOB.the_station_areas)
-		GLOB.recharging_stations += src
+		GLOB.station_recharging_stations += src
 		update_area_names()
 
 /obj/machinery/recharge_station/proc/update_area_names()
-	GLOB.recharging_station_area_names.Cut()
-	sort_list(GLOB.recharging_stations) //makes it harder to infer built chargers because they no longer appear at the end of the list
-	for(var/atom/charge_station in GLOB.recharging_stations)
+	GLOB.station_recharging_station_area_names.Cut()
+	for(var/atom/charge_station in GLOB.station_recharging_stations)
 		var/area_name = get_area_name(charge_station, format_text = TRUE)
-		if(!(area_name in GLOB.recharging_station_area_names))
-			GLOB.recharging_station_area_names += area_name
+		if(!(area_name in GLOB.station_recharging_station_area_names))
+			GLOB.station_recharging_station_area_names += area_name
+	sort_list(GLOB.station_recharging_station_area_names)
 
 /obj/machinery/recharge_station/Destroy()
-	GLOB.recharging_stations -= src
+	GLOB.station_recharging_stations -= src
 	update_area_names()
 	return ..()
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -457,13 +457,13 @@
 				if(0.75 to INFINITY)
 					occupant.clear_alert(ALERT_CHARGE)
 				if(0.5 to 0.75)
-					occupant.throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell, 1)
+					occupant.throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell/mech, 1)
 				if(0.25 to 0.5)
-					occupant.throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell, 2)
+					occupant.throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell/mech, 2)
 				if(0.01 to 0.25)
-					occupant.throw_alert(ALERT_NEW_LAW, /atom/movable/screen/alert/lowcell, 3)
+					occupant.throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/lowcell/mech, 3)
 				else
-					occupant.throw_alert(ALERT_NEW_LAW, /atom/movable/screen/alert/emptycell)
+					occupant.throw_alert(ALERT_CHARGE, /atom/movable/screen/alert/emptycell/mech)
 
 		var/integrity = atom_integrity/max_integrity*100
 		switch(integrity)

--- a/code/modules/vehicles/mecha/mech_bay.dm
+++ b/code/modules/vehicles/mecha/mech_bay.dm
@@ -19,6 +19,18 @@
 	. = ..()
 	recharging_turf = get_step(loc, dir)
 
+	if(!mapload)
+		return
+
+	var/area/my_area = get_area(src)
+	if(!(my_area.type in GLOB.the_station_areas))
+		return
+
+	var/area_name = get_area_name(src, format_text = TRUE)
+	if(area_name in GLOB.roundstart_station_mechcharger_areas)
+		return
+	GLOB.roundstart_station_mechcharger_areas += area_name
+
 /obj/machinery/mech_bay_recharge_port/Destroy()
 	if (recharge_console?.recharge_port == src)
 		recharge_console.recharge_port = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![](https://i.imgur.com/Qc31y40.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Tells you the actual locations of roundstart rechargers on the station, instead of just saying they're available in robotics, the dormitory bathrooms, and the AI satellite.

No longer includes built rechargers and no longer removes destroyed rechargers from the list, keeping it in parity with what came before.

I understand there may be some reservations due to the length of the list, but I think it's important to have every charger area on it in the event some are broken/destroyed/inaccessible/without power.

Closes https://github.com/tgstation/tgstation/issues/65558
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Tooltips of low/no power screen alerts (used by cyborgs, MODsuits, mechs and ethereals) will tell you the actual locations of the roundstart station chargers
fix: Fixes issue with low/no power screen alerts not clearing after leaving a mech
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
