### PR TITLE
soulscythe snow/ashstorm immunity

### DIFF
--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -587,6 +587,7 @@
 	gender = NEUTER
 	mob_biotypes = MOB_SPIRIT
 	faction = list()
+	weather_immunities = list(TRAIT_ASHSTORM_IMMUNE, TRAIT_SNOWSTORM_IMMUNE)
 	/// Blood level, used for movement and abilities in a soulscythe
 	var/blood_level = MAX_BLOOD_LEVEL
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

soulscythes are now immune to mining planet storms.

fixes #65446

## Why It's Good For The Game

anything born from the rock should be immune to the rock's wrath.

## Changelog

:cl:
fix: soulscythes are now immune to mining planet storms
/:cl: