### PR TITLE
removes blackbox's magical indestructibility 

### DIFF
--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -66,6 +66,7 @@
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 #define MESSAGE_SERVER_FUNCTIONING_MESSAGE "This is an automated message. The messaging system is functioning correctly."
 

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -66,7 +66,6 @@
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 #define MESSAGE_SERVER_FUNCTIONING_MESSAGE "This is an automated message. The messaging system is functioning correctly."
 


### PR DESCRIPTION
## About The Pull Request

Removes blackbox's (the item) magical indestructable-ness with oranges' I-assume permission?

![image](https://user-images.githubusercontent.com/53777086/158501987-582d7b3c-ccb8-4a06-a6f2-c5a68501b5fe.png)
![image](https://user-images.githubusercontent.com/53777086/158501993-61d4bebc-feb1-4891-ab6c-85f91376ef44.png)

## Why It's Good For The Game

It's an antag objective yet antags have to go out of their way to SM it just to destroy it because stuff like X4, which traitors have to purchase, isn't enough to destroy it. There's no reason for this to be the case.

## Changelog

:cl:
fix: The blackbox is no longer indestructable to anything.
/:cl: