### PR TITLE
Fix - Removes ORM from golem ship

### DIFF
--- a/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
@@ -83,7 +83,9 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "p" = (
-/obj/machinery/mineral/ore_redemption,
+/obj/item/circuitboard/machine/ore_redemption,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "q" = (
@@ -149,6 +151,14 @@
 	},
 /obj/item/storage/medkit/fire,
 /obj/item/storage/medkit/fire,
+/obj/item/stock_parts/matter_bin,
+/obj/item/assembly/igniter,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "B" = (


### PR DESCRIPTION

## About The Pull Request

Replaces the Golem ship ORM with a circuit board and parts


## Why It's Good For The Game

Removes the automatic resource link to the station to avoid both accidental deletion of mined materials from the Golems as well as removing the opportunity to steal or purposefully cripple the stations supply.

## Changelog


:cl:
add: Parts and Machine frame to build an ORM from the golem ship
del: Removed Prebuilt ORM from the golem ship
/:cl:


