### PR TITLE
Cryocell works with all gases now ; Cryox requires being KOd

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -24014,7 +24014,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/anestetic_mix,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron,
 /area/medical/cryo)
 "fll" = (
@@ -73851,7 +73851,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/anestetic_mix,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron,
 /area/medical/cryo)
 "tBo" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -24008,13 +24008,13 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "flk" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/anestetic_mix,
 /turf/open/floor/iron,
 /area/medical/cryo)
 "fll" = (
@@ -73845,13 +73845,13 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "tBh" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/anestetic_mix,
 /turf/open/floor/iron,
 /area/medical/cryo)
 "tBo" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -11668,7 +11668,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/anestetic_mix,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "dgf" = (
@@ -52474,7 +52474,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/anestetic_mix,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "xwY" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -11668,7 +11668,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/anestetic_mix,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "dgf" = (
@@ -52474,7 +52474,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/anestetic_mix,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "xwY" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -5866,13 +5866,13 @@
 /turf/closed/wall,
 /area/medical/exam_room)
 "aFp" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/anestetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/central)
 "aFq" = (
@@ -7876,9 +7876,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/anestetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/central)
 "aSe" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -5872,7 +5872,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/anestetic_mix,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/central)
 "aFq" = (
@@ -7878,7 +7878,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/anestetic_mix,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/central)
 "aSe" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21471,10 +21471,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/anestetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/cryo)
 "gts" = (
@@ -30122,13 +30122,13 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "jJq" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/anestetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/cryo)
 "jJP" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21474,7 +21474,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/anestetic_mix,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/cryo)
 "gts" = (
@@ -30128,7 +30128,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/anestetic_mix,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/cryo)
 "jJP" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17096,8 +17096,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/directional/east,
+/obj/machinery/portable_atmospherics/canister/anestetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "eNN" = (
@@ -33417,7 +33417,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/anestetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "kCT" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17097,7 +17097,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/portable_atmospherics/canister/anestetic_mix,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "eNN" = (
@@ -33417,7 +33417,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/anestetic_mix,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "kCT" = (

--- a/code/__DEFINES/atmospherics/atmos_core.dm
+++ b/code/__DEFINES/atmospherics/atmos_core.dm
@@ -151,6 +151,11 @@
 /// liters in a cell
 #define CELL_VOLUME 2500
 
+///O2 value for anestetic canister
+#define O2_ANESTETIC 0.65
+///N2O value for anestetic canister
+#define N2O_ANESTETIC 0.35
+
 //CANATMOSPASS
 #define ATMOS_PASS_YES 1
 #define ATMOS_PASS_NO 0

--- a/code/__DEFINES/atmospherics/atmos_core.dm
+++ b/code/__DEFINES/atmospherics/atmos_core.dm
@@ -151,10 +151,10 @@
 /// liters in a cell
 #define CELL_VOLUME 2500
 
-///O2 value for anestetic canister
-#define O2_ANESTETIC 0.65
-///N2O value for anestetic canister
-#define N2O_ANESTETIC 0.35
+///O2 value for anesthetic canister
+#define O2_ANESTHETIC 0.65
+///N2O value for anesthetic canister
+#define N2O_ANESTHETIC 0.35
 
 //CANATMOSPASS
 #define ATMOS_PASS_YES 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -316,12 +316,14 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/handle_internal_lifeform(mob/lifeform_inside_me, breath_request)
 
-	if(breath_request > 0)
-		var/datum/gas_mixture/air1 = airs[1]
-		var/breath_percentage = breath_request / air1.volume
-		return air1.remove(air1.total_moles() * breath_percentage)
-	else
+	if(breath_request <= 0)
 		return null
+	var/datum/gas_mixture/air1 = airs[1]
+	var/breath_percentage = breath_request / air1.volume
+	return air1.remove(air1.total_moles() * breath_percentage)
+
+/obj/machinery/atmospherics/components/unary/cryo_cell/assume_air(datum/gas_mixture/giver)
+	airs[1].merge(giver)
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/relaymove(mob/living/user, direction)
 	if(message_cooldown <= world.time)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -121,6 +121,7 @@
 
 	occupant_vis = new(null, src)
 	vis_contents += occupant_vis
+	airs[1].volume = CELL_VOLUME * 0.5
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/set_occupant(atom/movable/new_occupant)
 	. = ..()
@@ -262,10 +263,7 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 
 	var/datum/gas_mixture/air1 = airs[1]
 
-	if(air1.gases[/datum/gas/oxygen][MOLES] > CRYO_MIN_GAS_MOLES)
-		if(mob_occupant.bodytemperature < T0C) // Sleepytime. Why? More cryo magic.
-			mob_occupant.Sleeping((mob_occupant.bodytemperature * sleep_factor) * 1000 * delta_time)
-			mob_occupant.Unconscious((mob_occupant.bodytemperature * unconscious_factor) * 1000 * delta_time)
+	if(air1.total_moles() > CRYO_MIN_GAS_MOLES)
 		if(beaker)
 			beaker.reagents.trans_to(occupant, (CRYO_TX_QTY / (efficiency * CRYO_MULTIPLY_FACTOR)) * delta_time, efficiency * CRYO_MULTIPLY_FACTOR, methods = VAPOR) // Transfer reagents.
 			consume_gas = TRUE
@@ -279,7 +277,7 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 
 	var/datum/gas_mixture/air1 = airs[1]
 
-	if(!nodes[1] || !airs[1] || !air1.gases.len || air1.gases[/datum/gas/oxygen][MOLES] < CRYO_MIN_GAS_MOLES) // Turn off if the machine won't work.
+	if(!nodes[1] || !airs[1] || !air1.gases.len || air1.total_moles() < CRYO_MIN_GAS_MOLES) // Turn off if the machine won't work.
 		var/msg = "Insufficient cryogenic gas, shutting down."
 		radio.talk_into(src, msg, radio_channel)
 		set_on(FALSE)
@@ -307,17 +305,22 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 				var/mob/living/carbon/human/humi = mob_occupant
 				humi.adjust_coretemperature(humi.bodytemperature - humi.coretemperature)
 
-		if(consume_gas) // Transferring reagent costs us extra gas
-			air1.gases[/datum/gas/oxygen][MOLES] -= max(0, 2 / efficiency + 1 / efficiency) // Magically consume gas? Why not, we run on cryo magic.
-			consume_gas = FALSE
-		if(!consume_gas)
-			air1.gases[/datum/gas/oxygen][MOLES] -= max(0, 2 / efficiency)
+
 		air1.garbage_collect()
 
 		if(air1.temperature > 2000)
 			take_damage(clamp((air1.temperature)/200, 10, 20), BURN)
 
 		update_parents()
+
+/obj/machinery/atmospherics/components/unary/cryo_cell/handle_internal_lifeform(mob/lifeform_inside_me, breath_request)
+
+	if(breath_request > 0)
+		var/datum/gas_mixture/air1 = airs[1]
+		var/breath_percentage = breath_request / air1.volume
+		return air1.remove(air1.total_moles() * breath_percentage)
+	else
+		return null
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/relaymove(mob/living/user, direction)
 	if(message_cooldown <= world.time)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -121,7 +121,8 @@
 
 	occupant_vis = new(null, src)
 	vis_contents += occupant_vis
-	airs[1].volume = CELL_VOLUME * 0.5
+	if(airs[1])
+		airs[1].volume = CELL_VOLUME * 0.5
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/set_occupant(atom/movable/new_occupant)
 	. = ..()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -297,6 +297,18 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	air_contents.temperature = 10000
 	SSair.start_processing_machine(src)
 
+/obj/machinery/portable_atmospherics/canister/anestetic_mix
+	name = "Anestetic mix"
+	desc = "A mixture of N2O and Oxygen"
+	greyscale_config = /datum/greyscale_config/canister/double_stripe
+	greyscale_colors = "#9fba6c#3d4680"
+
+/obj/machinery/portable_atmospherics/canister/anestetic_mix/create_gas()
+	air_contents.add_gases(/datum/gas/oxygen, /datum/gas/nitrous_oxide)
+	air_contents.gases[/datum/gas/oxygen][MOLES] = (O2_ANESTETIC * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
+	air_contents.gases[/datum/gas/nitrous_oxide][MOLES] = (N2O_ANESTETIC * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
+	SSair.start_processing_machine(src)
+
 /**
  * Getter for the amount of time left in the timer of prototype canisters
  */
@@ -413,7 +425,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 		if((10) to (5 * ONE_ATMOSPHERE))
 			. += mutable_appearance(canister_overlay_file, "can-0")
 			. += emissive_appearance(canister_overlay_file, "can-0-light", alpha = src.alpha)
-	
+
 	update_window()
 
 /obj/machinery/portable_atmospherics/canister/update_greyscale()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -297,16 +297,16 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	air_contents.temperature = 10000
 	SSair.start_processing_machine(src)
 
-/obj/machinery/portable_atmospherics/canister/anestetic_mix
-	name = "Anestetic mix"
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix
+	name = "Anesthetic mix"
 	desc = "A mixture of N2O and Oxygen"
 	greyscale_config = /datum/greyscale_config/canister/double_stripe
 	greyscale_colors = "#9fba6c#3d4680"
 
-/obj/machinery/portable_atmospherics/canister/anestetic_mix/create_gas()
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix/create_gas()
 	air_contents.add_gases(/datum/gas/oxygen, /datum/gas/nitrous_oxide)
-	air_contents.gases[/datum/gas/oxygen][MOLES] = (O2_ANESTETIC * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
-	air_contents.gases[/datum/gas/nitrous_oxide][MOLES] = (N2O_ANESTETIC * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
+	air_contents.gases[/datum/gas/oxygen][MOLES] = (O2_ANESTHETIC * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
+	air_contents.gases[/datum/gas/nitrous_oxide][MOLES] = (N2O_ANESTHETIC * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 	SSair.start_processing_machine(src)
 
 /**

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -73,8 +73,6 @@
 	var/obj/item/organ/lungs = getorganslot(ORGAN_SLOT_LUNGS)
 	if(reagents.has_reagent(/datum/reagent/toxin/lexorin, needs_metabolizing = TRUE))
 		return
-	if(istype(loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
-		return
 
 	var/datum/gas_mixture/environment
 	if(loc)
@@ -119,6 +117,11 @@
 				loc_as_obj.handle_internal_lifeform(src,0)
 
 	check_breath(breath)
+
+	if(istype(loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
+		var/obj/machinery/atmospherics/components/unary/cryo_cell/loc_as_cryo = loc
+		loc_as_cryo.airs[1].merge(breath)
+		return
 
 	if(breath)
 		loc.assume_air(breath)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -118,11 +118,6 @@
 
 	check_breath(breath)
 
-	if(istype(loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
-		var/obj/machinery/atmospherics/components/unary/cryo_cell/loc_as_cryo = loc
-		loc_as_cryo.airs[1].merge(breath)
-		return
-
 	if(breath)
 		loc.assume_air(breath)
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -161,18 +161,19 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	var/power = -0.00003 * (M.bodytemperature ** 2) + 3
-	if(M.bodytemperature < T0C)
-		M.adjustOxyLoss(-3 * power * REM * delta_time, 0)
-		M.adjustBruteLoss(-power * REM * delta_time, 0)
-		M.adjustFireLoss(-power * REM * delta_time, 0)
-		M.adjustToxLoss(-power * REM * delta_time, 0, TRUE) //heals TOXINLOVERs
-		M.adjustCloneLoss(-power * REM * delta_time, 0)
-		for(var/i in M.all_wounds)
-			var/datum/wound/iter_wound = i
-			iter_wound.on_xadone(power * REAGENTS_EFFECT_MULTIPLIER * delta_time)
-		REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC) //fixes common causes for disfiguration
-		. = TRUE
+	if(M.IsSleeping() || M.IsUnconscious())
+		var/power = -0.00003 * (M.bodytemperature ** 2) + 3
+		if(M.bodytemperature < T0C)
+			M.adjustOxyLoss(-3 * power * REM * delta_time, 0)
+			M.adjustBruteLoss(-power * REM * delta_time, 0)
+			M.adjustFireLoss(-power * REM * delta_time, 0)
+			M.adjustToxLoss(-power * REM * delta_time, 0, TRUE) //heals TOXINLOVERs
+			M.adjustCloneLoss(-power * REM * delta_time, 0)
+			for(var/i in M.all_wounds)
+				var/datum/wound/iter_wound = i
+				iter_wound.on_xadone(power * REAGENTS_EFFECT_MULTIPLIER * delta_time)
+			REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC) //fixes common causes for disfiguration
+			. = TRUE
 	metabolization_rate = REAGENTS_METABOLISM * (0.00001 * (M.bodytemperature ** 2) + 0.5)
 	..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cryocells now can operate with any gases you want. 
Removed magic sleep when put inside the tube, provided a roundstart canister with a mix of O2 and N2O to sleep the user inside the tube
Gases don't get consumed without reason anymore, the mob inside will use up the various gases and the mix will need a replacement when the CO2 buildup gets too high
You can use any gas to help the mob in the tube (yes even plasma for plasmamen and healium)
Cryoxadone only heals if the patient is sleeping, so the anesthetic is not only for fluff but is an actual requirement for cryox use.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cryotubes now properly work with any provided gas, plus you can add extra care for the patient by providing a sleep gas or a gas where the mob is comfortable with (eg plasmamen in plasma gas)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: cryotubes can now work with any gases
expansion: cryotubes patients will actually breathe the air inside the tube and will respond to the gas accordingly (they'll suffer from breath loss if not in proper atmosphere inside the tube)
expansion: cryoxadone heals only if the patient is alseep, making the use of the anesthetic no longer just fluff but also functional
qol: replaced oxygen canisters with anesthetic ones (a mix of oxygen and n2o at 65-35 ratio) for allowing the patient to sleep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
