### PR TITLE
Fixes Posters in Lower Chapel Maintenance on IceBoxStation

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -10048,10 +10048,6 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
-"Gx" = (
-/obj/structure/sign/poster/contraband/random/directional/north,
-/turf/closed/wall,
-/area/maintenance/department/chapel)
 "Gz" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -63395,7 +63391,7 @@ ak
 ak
 Et
 Et
-Gx
+UK
 dE
 bg
 Ro
@@ -63652,7 +63648,7 @@ ak
 Et
 Et
 Et
-Gx
+UK
 Qj
 zo
 cD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ok, this is DEFINITELY my fault. Definitely a casualty of #65267

Fixes #65514.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Posters shouldn't show up there!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nanotrasen has decided to quit installling posters on ice turfs near Lower Chapel Maintenance on IceBoxStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
