### PR TITLE
Removes bits of floaty rock from KiloStation's Northwest Quadrant

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -61150,9 +61150,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/lobby)
-"pOb" = (
-/turf/closed/mineral/random/labormineral,
-/area/space)
 "pOl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -98063,7 +98060,7 @@ aaa
 aaa
 aaa
 aaa
-pOb
+aaa
 aaa
 aaa
 aaa
@@ -100124,7 +100121,7 @@ aaa
 aaa
 aaa
 aaa
-pOb
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Some bits of floaty rock have been detected on KiloStation. I got a hammer and blew them up.

![image](https://user-images.githubusercontent.com/34697715/158717717-74c1c0ea-589f-45e6-8f5c-07a0cd3ae284.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No bad bits of floaty rock with the /area/space on it! If you want bits of floaty rock please be so kind as to use /area/nearstation.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nanotrasen busted out some pulse rifles to get rid of some loose rock debris in the Northwestern Quadrant of KiloStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
