### PR TITLE
Surgery step consistency

### DIFF
--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -3,8 +3,8 @@
 	name = "Amputation"
 	steps = list(
 		/datum/surgery_step/incise,
-		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/saw,
 		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/sever_limb)

--- a/code/modules/surgery/bone_mending.dm
+++ b/code/modules/surgery/bone_mending.dm
@@ -26,8 +26,8 @@
 	name = "Repair Compound Fracture"
 	steps = list(
 		/datum/surgery_step/incise,
-		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/reset_compound_fracture,
 		/datum/surgery_step/repair_bone_compound,
 		/datum/surgery_step/close)

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -2,8 +2,8 @@
 	name = "Cavity implant"
 	steps = list(
 		/datum/surgery_step/incise,
-		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/incise,
 		/datum/surgery_step/handle_cavity,
 		/datum/surgery_step/close)

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -42,8 +42,8 @@
 	name = "Augmentation"
 	steps = list(
 		/datum/surgery_step/incise,
-		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/replace_limb)
 	target_mobtypes = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -2,8 +2,8 @@
 	name = "Prosthetic replacement"
 	steps = list(
 		/datum/surgery_step/incise,
-		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/add_prosthetic)
 	target_mobtypes = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD)


### PR DESCRIPTION
## About The Pull Request

Makes five surgeries more consistent with the other surgeries, no changes to more involved surgeries just makes them follow the same incise, retract, clamp steps.

## Why It's Good For The Game

Frequently doctors do surgery without a computer telling them what to do, correcting the steps will make it less frustrating for newer doctors.

## Changelog

Fixed some inconsistent surgery steps. Now follows incise, retract, clamp like most surgeries.
Amputation, bone mending, cavity implant, limb aug, and prosthetic replacement surgeries changed.

:cl:
qol: Amputation, Compound Fracture Repair, Cavity Implantation, Augmentation, and Prosthetic Replacement surgeries now all clamp bleeders after retracting skin like most surgeries, rather than before.
/:cl:


