### PR TITLE
Fix crystallizer gas consumption

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -141,7 +141,7 @@
 
 	var/median_temperature = (selected_recipe.max_temp + selected_recipe.min_temp) / 2
 	if(internal.temperature >= (median_temperature * MIN_DEVIATION_RATE) && internal.temperature <= (median_temperature * MAX_DEVIATION_RATE))
-		quality_loss = max(quality_loss - 5.5, -100)
+		quality_loss = max(quality_loss - 5.5, -85)
 
 	internal.temperature = max(internal.temperature + (selected_recipe.energy_release / internal.heat_capacity()), TCMB)
 	update_parents()
@@ -196,7 +196,8 @@
 	progress_bar = 0
 
 	for(var/gas_type in selected_recipe.requirements)
-		var/amount_consumed = selected_recipe.requirements[gas_type] + quality_loss * 5
+		var/required_gas_moles = selected_recipe.requirements[gas_type]
+		var/amount_consumed = required_gas_moles + (required_gas_moles * (quality_loss * 0.01))
 		if(internal.gases[gas_type][MOLES] < amount_consumed)
 			quality_loss = min(quality_loss + 10, 100)
 		internal.remove_specific(gas_type, amount_consumed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix an overlooked crystallizer issue where gases wouldn't get consumed because of a fixed rate of removal instead of an percentage based one. 
Instead of removing a max of 500 moles from the final gas consumption (allowing some recipes to not consume gases at all) the quality removes a percentage of the recipe requirement maxing at 85% decrease (on poor quality you will still consume double the amount)
gbp no update please
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix an exploit with the machine
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix an overlooked crystallizer issue where gases wouldn't get consumed because of a fixed rate of removal instead of an percentage based one. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
