### PR TITLE
Wound repair surgeries no longer spontaneously end mid-surgery

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -75,8 +75,6 @@
 
 	/// What status effect we assign on application
 	var/status_effect_type
-	/// If we're operating on this wound and it gets healed, we'll nix the surgery too
-	var/datum/surgery/attached_surgery
 	/// if you're a lazy git and just throw them in cryo, the wound will go away after accumulating severity * 25 power
 	var/cryo_progress
 
@@ -91,8 +89,6 @@
 	var/wound_flags = (FLESH_WOUND | BONE_WOUND | ACCEPTS_GAUZE)
 
 /datum/wound/Destroy()
-	if(attached_surgery)
-		QDEL_NULL(attached_surgery)
 	remove_wound()
 	set_limb(null)
 	victim = null

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -37,13 +37,11 @@
 	operated_bodypart = surgery_bodypart
 	if(targetable_wound)
 		operated_wound = operated_bodypart.get_wound_type(targetable_wound)
-		operated_wound.attached_surgery = src
 
 	SEND_SIGNAL(surgery_target, COMSIG_MOB_SURGERY_STARTED, src, surgery_location, surgery_bodypart)
 
 /datum/surgery/Destroy()
 	if(operated_wound)
-		operated_wound.attached_surgery = null
 		operated_wound = null
 	if(target)
 		target.surgeries -= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ever wondered why fracture repair surgery doesn't need closed after you fix the bone? Turns out, wounds store any active surgeries on them, and qdel the surgery if the wound disappears. Since wound healing surgeries qdel the wound, this ends the surgery as soon as the wound is healed. This functionality isn't needed, as the "repair wound" steps already have a check to see if the wound disappeared, so by getting rid of it we can stop the surgeries from spontaneously ending.

## Why It's Good For The Game

It annoys me personally

## Changelog

:cl: Bumtickley00
fix: Fracture repair surgery no longer magically closes itself
/:cl:
