### PR TITLE
Removes two stray lattices from CentCom.dmm

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10040,10 +10040,6 @@
 /obj/structure/speaking_tile,
 /turf/closed/mineral/ash_rock,
 /area/awaymission/errorroom)
-"Mc" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "Mh" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdome";
@@ -79629,6 +79625,6 @@ aa
 aa
 aa
 aa
-Mc
-Mc
+aa
+ad
 "}


### PR DESCRIPTION
These were just kinda THERE and they SHOULDN'T BE


![image](https://user-images.githubusercontent.com/16159590/158877222-9b110a81-9609-4299-b6e5-e60957c1751e.png)


:cl:
fix: Fixes two random lattices in the bottom corner of the Cent Com map
/:cl: