### PR TITLE
Fixes a runtime in build mode's KABOOM

### DIFF
--- a/code/modules/buildmode/submodes/boom.dm
+++ b/code/modules/buildmode/submodes/boom.dm
@@ -22,21 +22,10 @@
 	to_chat(c, span_notice("***********************************************************"))
 
 /datum/buildmode_mode/boom/change_settings(client/c)
-	explosions[BOOM_DEVASTATION] = input(c, "Range of total devastation. 0 to none", text("Input")) as num|null
-	if(explosions[BOOM_DEVASTATION] == null || explosions[BOOM_DEVASTATION] < 0)
-		explosions[BOOM_DEVASTATION] = 0
-	explosions[BOOM_HEAVY] = input(c, "Range of heavy impact. 0 to none", text("Input")) as num|null
-	if(explosions[BOOM_HEAVY] == null || explosions[BOOM_HEAVY] < 0)
-		explosions[BOOM_HEAVY] = 0
-	explosions[BOOM_LIGHT] = input(c, "Range of light impact. 0 to none", text("Input")) as num|null
-	if(explosions[BOOM_LIGHT] == null || explosions[BOOM_LIGHT] < 0)
-		explosions[BOOM_LIGHT] = 0
-	explosions[BOOM_FLASH] = input(c, "Range of flash. 0 to none", text("Input")) as num|null
-	if(explosions[BOOM_FLASH] == null || explosions[BOOM_FLASH] < 0)
-		explosions[BOOM_FLASH] = 0
-	explosions[BOOM_FLAMES] = input(c, "Range of flames. 0 to none", text("Input")) as num|null
-	if(explosions[BOOM_FLAMES] == null || explosions[BOOM_FLAMES] < 0)
-		explosions[BOOM_FLAMES] = 0
+	for (var/explosion_level in explosions)
+		explosions[explosion_level] = input(c, "Range of total [explosion_level]. 0 to none", text("Input")) as num|null
+		if(explosions[explosion_level] == null || explosions[explosion_level] < 0)
+			explosions[explosion_level] = 0
 
 /datum/buildmode_mode/boom/handle_click(client/c, params, obj/object)
 	var/list/modifiers = params2list(params)

--- a/code/modules/buildmode/submodes/boom.dm
+++ b/code/modules/buildmode/submodes/boom.dm
@@ -1,11 +1,19 @@
+#define BOOM_DEVASTATION "devastation"
+#define BOOM_HEAVY "heavy"
+#define BOOM_LIGHT "light"
+#define BOOM_FLASH "flash"
+#define BOOM_FLAMES "flames"
+
 /datum/buildmode_mode/boom
 	key = "boom"
 
-	var/devastation = -1
-	var/heavy = -1
-	var/light = -1
-	var/flash = -1
-	var/flames = -1
+	var/list/explosions = list(
+		BOOM_DEVASTATION = 0,
+		BOOM_HEAVY = 0,
+		BOOM_LIGHT = 0,
+		BOOM_FLASH = 0,
+		BOOM_FLAMES = 0
+		)
 
 /datum/buildmode_mode/boom/show_help(client/c)
 	to_chat(c, span_notice("***********************************************************"))
@@ -14,25 +22,39 @@
 	to_chat(c, span_notice("***********************************************************"))
 
 /datum/buildmode_mode/boom/change_settings(client/c)
-	devastation = input(c, "Range of total devastation. 0 to none", text("Input")) as num|null
-	if(devastation == null)
-		devastation = 0
-	heavy = input(c, "Range of heavy impact. 0 to none", text("Input")) as num|null
-	if(heavy == null)
-		heavy = 0
-	light = input(c, "Range of light impact. 0 to none", text("Input")) as num|null
-	if(light == null)
-		light = 0
-	flash = input(c, "Range of flash. 0 to none", text("Input")) as num|null
-	if(flash == null)
-		flash = 0
-	flames = input(c, "Range of flames. 0 to none", text("Input")) as num|null
-	if(flames == null)
-		flames = 0
+	explosions[BOOM_DEVASTATION] = input(c, "Range of total devastation. 0 to none", text("Input")) as num|null
+	if(explosions[BOOM_DEVASTATION] == null || explosions[BOOM_DEVASTATION] < 0)
+		explosions[BOOM_DEVASTATION] = 0
+	explosions[BOOM_HEAVY] = input(c, "Range of heavy impact. 0 to none", text("Input")) as num|null
+	if(explosions[BOOM_HEAVY] == null || explosions[BOOM_HEAVY] < 0)
+		explosions[BOOM_HEAVY] = 0
+	explosions[BOOM_LIGHT] = input(c, "Range of light impact. 0 to none", text("Input")) as num|null
+	if(explosions[BOOM_LIGHT] == null || explosions[BOOM_LIGHT] < 0)
+		explosions[BOOM_LIGHT] = 0
+	explosions[BOOM_FLASH] = input(c, "Range of flash. 0 to none", text("Input")) as num|null
+	if(explosions[BOOM_FLASH] == null || explosions[BOOM_FLASH] < 0)
+		explosions[BOOM_FLASH] = 0
+	explosions[BOOM_FLAMES] = input(c, "Range of flames. 0 to none", text("Input")) as num|null
+	if(explosions[BOOM_FLAMES] == null || explosions[BOOM_FLAMES] < 0)
+		explosions[BOOM_FLAMES] = 0
 
 /datum/buildmode_mode/boom/handle_click(client/c, params, obj/object)
 	var/list/modifiers = params2list(params)
 
+	var/value_valid = FALSE
+	for (var/explosion_type in explosions)
+		if (explosions[explosion_type] > 0)
+			value_valid = TRUE
+			break
+	if (!value_valid)
+		return
+
 	if(LAZYACCESS(modifiers, LEFT_CLICK))
-		explosion(object, devastation, heavy, light, flames, flash, adminlog = FALSE, ignorecap = TRUE)
-		log_admin("Build Mode: [key_name(c)] caused an explosion(dev=[devastation], hvy=[heavy], lgt=[light], flash=[flash], flames=[flames]) at [AREACOORD(object)]")
+		log_admin("Build Mode: [key_name(c)] caused an explosion(dev=[explosions[BOOM_DEVASTATION]], hvy=[explosions[BOOM_HEAVY]], lgt=[explosions[BOOM_LIGHT]], flash=[explosions[BOOM_FLASH]], flames=[explosions[BOOM_FLAMES]]) at [AREACOORD(object)]")
+		explosion(object, explosions[BOOM_DEVASTATION], explosions[BOOM_HEAVY], explosions[BOOM_LIGHT], explosions[BOOM_FLASH], explosions[BOOM_FLAMES], adminlog = FALSE, ignorecap = TRUE)
+
+#undef BOOM_DEVASTATION
+#undef BOOM_HEAVY
+#undef BOOM_LIGHT
+#undef BOOM_FLASH
+#undef BOOM_FLAMES

--- a/code/modules/buildmode/submodes/boom.dm
+++ b/code/modules/buildmode/submodes/boom.dm
@@ -14,21 +14,21 @@
 	to_chat(c, span_notice("***********************************************************"))
 
 /datum/buildmode_mode/boom/change_settings(client/c)
-	devastation = input(c, "Range of total devastation. -1 to none", text("Input")) as num|null
+	devastation = input(c, "Range of total devastation. 0 to none", text("Input")) as num|null
 	if(devastation == null)
-		devastation = -1
-	heavy = input(c, "Range of heavy impact. -1 to none", text("Input")) as num|null
+		devastation = 0
+	heavy = input(c, "Range of heavy impact. 0 to none", text("Input")) as num|null
 	if(heavy == null)
-		heavy = -1
-	light = input(c, "Range of light impact. -1 to none", text("Input")) as num|null
+		heavy = 0
+	light = input(c, "Range of light impact. 0 to none", text("Input")) as num|null
 	if(light == null)
-		light = -1
-	flash = input(c, "Range of flash. -1 to none", text("Input")) as num|null
+		light = 0
+	flash = input(c, "Range of flash. 0 to none", text("Input")) as num|null
 	if(flash == null)
-		flash = -1
-	flames = input(c, "Range of flames. -1 to none", text("Input")) as num|null
+		flash = 0
+	flames = input(c, "Range of flames. 0 to none", text("Input")) as num|null
 	if(flames == null)
-		flames = -1
+		flames = 0
 
 /datum/buildmode_mode/boom/handle_click(client/c, params, obj/object)
 	var/list/modifiers = params2list(params)


### PR DESCRIPTION
These values will runtime because eventually they get passed into
explode code which square roots them (WHICH IS IMPOSISBLE!!!)

:cl:
fix: Fixes a runtime in build mode's KABOOM.
/:cl: