### PR TITLE
Fixes being able to use revival surgery on blacklisted defib victims

### DIFF
--- a/code/modules/surgery/revival.dm
+++ b/code/modules/surgery/revival.dm
@@ -21,6 +21,8 @@
 		return FALSE
 	if(target.suiciding || HAS_TRAIT(target, TRAIT_HUSK))
 		return FALSE
+	if(HAS_TRAIT(target, TRAIT_DEFIB_BLACKLISTED))
+		return FALSE
 	var/obj/item/organ/brain/target_brain = target.getorganslot(ORGAN_SLOT_BRAIN)
 	if(!target_brain)
 		return FALSE


### PR DESCRIPTION
Just added a check to revival surgeries' can_start

Fixes https://github.com/tgstation/tgstation/issues/65542

:cl:
fix: Fixes being able to use revival surgery on blacklisted defib victims
/:cl: