### PR TITLE
Prevents the recycler eating its own parts when dismantled

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -213,7 +213,6 @@
 	L.adjustBruteLoss(crush_damage)
 
 /obj/machinery/recycler/on_deconstruction()
-	. = ..()
 	safety_mode = TRUE
 
 /obj/machinery/recycler/deathtrap

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -212,6 +212,10 @@
 	L.Unconscious(100)
 	L.adjustBruteLoss(crush_damage)
 
+/obj/machinery/recycler/on_deconstruction()
+	. = ..()
+	safety_mode = TRUE
+
 /obj/machinery/recycler/deathtrap
 	name = "dangerous old crusher"
 	obj_flags = CAN_BE_HIT | EMAGGED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #64632
Makes the recycler enter safety mode immediately before being dismantled to prevent it eating its own parts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not getting the board when you dismantle it kinda sucks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Recyclers no longer eat their own parts when dismantled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
