### PR TITLE
Flesh heretics summon objective now counts all summoned, alive or dead

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -679,21 +679,10 @@
 	name = "summon monsters"
 	target_amount = 2
 	explanation_text = "Summon 2 monsters from the Mansus into this realm."
+	var/num_summoned = 0
 
 /datum/objective/heretic_summon/check_completion()
-
-	var/num_we_have = 0
-	for(var/datum/antagonist/heretic_monster/monster in GLOB.antagonists)
-		if(!monster.master)
-			continue
-		if(ishuman(monster.owner.current))
-			continue
-		if(monster.master != owner)
-			continue
-
-		num_we_have++
-
-	return completed || (num_we_have >= target_amount)
+	return completed || (num_summoned >= target_amount)
 
 /datum/outfit/heretic
 	name = "Heretic (Preview only)"

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -679,6 +679,7 @@
 	name = "summon monsters"
 	target_amount = 2
 	explanation_text = "Summon 2 monsters from the Mansus into this realm."
+	/// The total number of summons the objective owner has done
 	var/num_summoned = 0
 
 /datum/objective/heretic_summon/check_completion()

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -307,6 +307,9 @@
 	var/datum/antagonist/heretic_monster/heretic_monster = summoned.mind.add_antag_datum(/datum/antagonist/heretic_monster)
 	heretic_monster.set_owner(user.mind)
 
+	var/datum/objective/heretic_summon/summon_objective = locate() in user.mind.get_all_objectives()
+	summon_objective?.num_summoned++
+
 	return TRUE
 
 /// The amount of knowledge points the knowledge ritual gives on success.


### PR DESCRIPTION
## About The Pull Request

The additional "summon monster" objective given to flesh heretics will now count for ALL summons, alive or dead, the heretic has completed, instead of just alive summons.

## Why It's Good For The Game

People have stated that it's unfun having to babysit your summons, and I think they have a point. 
This makes it a tad easier to ascend as a flesh heretic. Also is a bit more intuitive. 

## Changelog

:cl: Melbert
balance: Flesh Heretic's summon objective now counts all summons done, alive or dead, instead of all alive summons. Still does not include flesh ghouls or voiceless dead. 
/:cl:
