### PR TITLE
Debug Mapping Verb for Invalid/Non-Standard Access Txt

### DIFF
--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -54,6 +54,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug_mapping, list(
 	/client/proc/place_ruin,
 	/client/proc/station_food_debug,
 	/client/proc/station_stack_debug,
+	/client/proc/invalid_airlock_access,
 ))
 GLOBAL_PROTECT(admin_verbs_debug_mapping)
 
@@ -422,3 +423,21 @@ GLOBAL_VAR_INIT(say_disabled, FALSE)
 	popup.set_content(page_contents)
 	popup.open()
 
+/client/proc/invalid_airlock_access()
+	set name = "Find Invalid Airlock Access"
+	set category = "Mapping"
+
+	var/page_contents = {"<b>List of airlocks with invalid accesses set:</b><br>"}
+	var/static/regex/check_regex = new(@"^(\d{1,3};)*\d{1,3}$","g") // Match valid door accesses
+
+	for(var/obj/machinery/door/airlock/airlock in world)
+		if(airlock.req_access_txt && !check_regex.Find(airlock.req_access_txt))
+			var/turf/location = get_turf(airlock)
+			page_contents += "[ADMIN_VERBOSEJMP(location)]\n\tREQ_ACCESS_TXT = \"[airlock.req_access_txt]\"<br>"
+		if(airlock.req_one_access_txt && !check_regex.Find(airlock.req_one_access_txt))
+			var/turf/location = get_turf(airlock)
+			page_contents += "[ADMIN_VERBOSEJMP(location)]\n\tREQ_ONE_ACCESS_TXT = \"[airlock.req_one_access_txt]\"<br>"
+
+	var/datum/browser/popup = new(mob, "invalidairlock", "Invalid Door Accesses", 600, 400)
+	popup.set_content(page_contents)
+	popup.open()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Creates a new debug mapping verb to quickly find doors with either invalid or non-standard access txts.

What req_access_txt and req_one_access_txt should look like: 
`"5;33"`, `"12;63"`, `"24"`

What some of our existing doors have:
`"null"`, `"9, 12"`, `"12; 35"`

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it easier to find doors with these errors, push for standardization.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: debug mapping verbs has a new verb, invalid airlock access, which provides a list of airlocks with invalid/non-standard req_access_txt and req_one_access_txt values
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
