### PR TITLE
Slime cookie stacking fixes

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -285,6 +285,10 @@
 		var/mob/living/carbon/human/H = owner
 		H.physiology.brute_mod /= 0.9
 
+/datum/status_effect/metalcookie/be_replaced()
+	on_remove()
+	return ..()
+
 /datum/status_effect/sparkcookie
 	id = "sparkcookie"
 	status_type = STATUS_EFFECT_REPLACE
@@ -303,6 +307,10 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.physiology.siemens_coeff = original_coeff
+
+/datum/status_effect/sparkcookie/be_replaced()
+	on_remove()
+	return ..()
 
 /datum/status_effect/toxincookie
 	id = "toxincookie"
@@ -430,6 +438,10 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.physiology.burn_mod /= 0.9
+
+/datum/status_effect/adamantinecookie/be_replaced()
+	on_remove()
+	return ..()
 
 ///////////////////////////////////////////////////////
 //////////////////STABILIZED EXTRACTS//////////////////

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -270,7 +270,7 @@
 
 /datum/status_effect/metalcookie
 	id = "metalcookie"
-	status_type = STATUS_EFFECT_REPLACE
+	status_type = STATUS_EFFECT_REFRESH
 	alert_type = null
 	duration = 100
 
@@ -285,13 +285,9 @@
 		var/mob/living/carbon/human/H = owner
 		H.physiology.brute_mod /= 0.9
 
-/datum/status_effect/metalcookie/be_replaced()
-	on_remove()
-	return ..()
-
 /datum/status_effect/sparkcookie
 	id = "sparkcookie"
-	status_type = STATUS_EFFECT_REPLACE
+	status_type = STATUS_EFFECT_REFRESH
 	alert_type = null
 	duration = 300
 	var/original_coeff
@@ -307,10 +303,6 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.physiology.siemens_coeff = original_coeff
-
-/datum/status_effect/sparkcookie/be_replaced()
-	on_remove()
-	return ..()
 
 /datum/status_effect/toxincookie
 	id = "toxincookie"
@@ -424,7 +416,7 @@
 
 /datum/status_effect/adamantinecookie
 	id = "adamantinecookie"
-	status_type = STATUS_EFFECT_REPLACE
+	status_type = STATUS_EFFECT_REFRESH
 	alert_type = null
 	duration = 100
 
@@ -438,10 +430,6 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.physiology.burn_mod /= 0.9
-
-/datum/status_effect/adamantinecookie/be_replaced()
-	on_remove()
-	return ..()
 
 ///////////////////////////////////////////////////////
 //////////////////STABILIZED EXTRACTS//////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an issue where adamantine, metal and yellow slime cookie status effects weren't resetting the changes they made to the users physiology when eaten while the status was already active, allowing players to stack their bonuses to permanently become completely immune to brute dmg/burn dmg/shocks.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pretty self explanatory why permanent damage immunity is a bad thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Prevents iron/adamantine/yellow slime cookies from being to able to stack their bonuses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
