### PR TITLE
Adds optional automatic ceiling generation for map templates and gives bluespace shelters ceilings

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -21,6 +21,11 @@
 	var/list/created_atoms = list()
 	//make sure this list is accounted for/cleared if you request it from ssatoms!
 
+	// vars for automatic ceiling generation
+	var/has_ceiling = FALSE
+	var/turf/ceiling_turf = /turf/open/floor/plating
+	var/list/ceiling_baseturfs = list()
+
 /datum/map_template/New(path = null, rename = null, cache = FALSE)
 	if(path)
 		mappath = path
@@ -176,8 +181,22 @@
 	//initialize things that are normally initialized after map load
 	initTemplateBounds(bounds)
 
+	if(has_ceiling)
+		var/affected_turfs = get_affected_turfs(T, FALSE)
+		generate_ceiling(affected_turfs)
+
 	log_game("[name] loaded at [T.x],[T.y],[T.z]")
 	return bounds
+
+/datum/map_template/proc/generate_ceiling(affected_turfs)
+	var/list/baseturfs = list(null)
+	baseturfs.Add(ceiling_baseturfs)
+	for (var/turf/turf in affected_turfs)
+		var/turf/ceiling = get_step_multiz(turf, UP)
+		if (ceiling)
+			if (istype(ceiling, /turf/open/openspace) || istype(ceiling, /turf/open/space/openspace))
+				baseturfs[1] = ceiling.type
+				ceiling.ChangeTurf(ceiling_turf, baseturfs, CHANGETURF_INHERIT_AIR)
 
 /datum/map_template/proc/post_load()
 	return

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -33,6 +33,7 @@
 		preload_size(mappath, cache)
 	if(rename)
 		name = rename
+	ceiling_baseturfs.Insert(1, /turf/baseturf_bottom)
 
 /datum/map_template/proc/preload_size(path, cache = FALSE)
 	var/datum/parsed_map/parsed = new(file(path))
@@ -189,14 +190,11 @@
 	return bounds
 
 /datum/map_template/proc/generate_ceiling(affected_turfs)
-	var/list/baseturfs = list(null)
-	baseturfs.Add(ceiling_baseturfs)
 	for (var/turf/turf in affected_turfs)
 		var/turf/ceiling = get_step_multiz(turf, UP)
 		if (ceiling)
 			if (istype(ceiling, /turf/open/openspace) || istype(ceiling, /turf/open/space/openspace))
-				baseturfs[1] = ceiling.type
-				ceiling.ChangeTurf(ceiling_turf, baseturfs, CHANGETURF_INHERIT_AIR)
+				ceiling.ChangeTurf(ceiling_turf, ceiling_baseturfs, CHANGETURF_INHERIT_AIR)
 
 /datum/map_template/proc/post_load()
 	return

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -5,6 +5,9 @@
 	var/list/whitelisted_turfs
 	var/list/banned_areas
 	var/list/banned_objects
+	has_ceiling = TRUE
+	ceiling_turf = /turf/open/floor/engine/hull
+	ceiling_baseturfs = list(/turf/open/floor/plating)
 
 /datum/map_template/shelter/New()
 	. = ..()
@@ -38,15 +41,6 @@
 		return SHELTER_DEPLOY_OUTSIDE_MAP
 
 	return SHELTER_DEPLOY_ALLOWED
-
-/datum/map_template/shelter/load(turf/T, centered)
-	. = ..()
-	var/affected = get_affected_turfs(T, centered)
-	for (var/turf/turf in affected)
-		var/turf/ceiling = get_step_multiz(turf, UP)
-		if (ceiling)
-			if (istype(ceiling, /turf/open/openspace) || istype(ceiling, /turf/open/space/openspace))
-				ceiling.ChangeTurf(/turf/open/floor/engine/hull, list(ceiling.type, /turf/open/floor/plating), CHANGETURF_INHERIT_AIR)
 
 /datum/map_template/shelter/alpha
 	name = "Shelter Alpha"

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -39,6 +39,15 @@
 
 	return SHELTER_DEPLOY_ALLOWED
 
+/datum/map_template/shelter/load(turf/T, centered)
+	. = ..()
+	var/affected = get_affected_turfs(T, centered)
+	for (var/turf/turf in affected)
+		var/turf/ceiling = get_step_multiz(turf, UP)
+		if (ceiling)
+			if (istype(ceiling, /turf/open/openspace) || istype(ceiling, /turf/open/space/openspace))
+				ceiling.ChangeTurf(/turf/open/floor/engine/hull, list(ceiling.type, /turf/open/floor/plating), CHANGETURF_INHERIT_AIR)
+
 /datum/map_template/shelter/alpha
 	name = "Shelter Alpha"
 	shelter_id = "shelter_alpha"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds optional automatic ceiling generation for map templates enabled with the has_ceiling var, with ceiling_turf and ceiling_baseturfs vars for customising the ceiling turfs for each template.

Uses this to give bluespace shelters a ceiling so they don't leak all their air out when used on multi-z maps
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #65482, could be used to easily fix similar issues with multi-z maps such as #65593
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Bluespace shelters now come with a ceiling.
code: Added optional automatic ceiling generation for map templates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
