### PR TITLE
Blob mobs use astar/jps for automated movement pathing, no longer get blocked by blob tiles

### DIFF
--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -18,6 +18,7 @@
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	initial_language_holder = /datum/language_holder/empty
+	retreat_distance = null //! retreat doesn't obey pass_flags, so won't work on blob mobs.
 	var/mob/camera/blob/overmind = null
 	var/obj/structure/blob/special/factory = null
 	var/independent = FALSE
@@ -66,6 +67,18 @@
 	. = ..()
 	if(istype(mover, /obj/structure/blob))
 		return TRUE
+
+///override to use astar/JPS instead of walk_to so we can path around our blob targets
+/mob/living/simple_animal/hostile/blob/Goto(target, delay, minimum_distance)
+	if(prevent_goto_movement)
+		return FALSE
+	if(target == src.target)
+		approaching_target = TRUE
+	else
+		approaching_target = FALSE
+
+	SSmove_manager.jps_move(moving = src, chasing = target, delay = delay, repath_delay = 2 SECONDS, minimum_distance = minimum_distance, simulated_only = FALSE, skip_first = TRUE, flags = MOVEMENT_LOOP_IGNORE_GLIDE)
+	return TRUE
 
 /mob/living/simple_animal/hostile/blob/Process_Spacemove(movement_dir = 0)
 	for(var/obj/structure/blob/B in range(1, src))

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -68,7 +68,7 @@
 	if(istype(mover, /obj/structure/blob))
 		return TRUE
 
-///override to use astar/JPS instead of walk_to so we can path around our blob targets
+///override to use astar/JPS instead of walk_to so we can take our blob pass_flags into account.
 /mob/living/simple_animal/hostile/blob/Goto(target, delay, minimum_distance)
 	if(prevent_goto_movement)
 		return FALSE
@@ -77,7 +77,7 @@
 	else
 		approaching_target = FALSE
 
-	SSmove_manager.jps_move(moving = src, chasing = target, delay = delay, repath_delay = 2 SECONDS, minimum_distance = minimum_distance, simulated_only = FALSE, skip_first = TRUE, flags = MOVEMENT_LOOP_IGNORE_GLIDE)
+	SSmove_manager.jps_move(moving = src, chasing = target, delay = delay, repath_delay = 2 SECONDS, minimum_distance = minimum_distance, simulated_only = FALSE, skip_first = TRUE, timeout = 5 SECONDS, flags = MOVEMENT_LOOP_IGNORE_GLIDE)
 	return TRUE
 
 /mob/living/simple_animal/hostile/blob/Process_Spacemove(movement_dir = 0)


### PR DESCRIPTION
I could easily make all hostile mobs do this, but there are *concerns*. behavior isn't the same, performance would be bad, requires more careful testing.

Whereas overriding this just for blobs fixes a mob that is functionally broken right now as they think they can't cross blob tiles because they use byond's walk_to and that checks density


:cl:
fix: blob spores and game-controlled blobbernuts no longer get stuck thinking they can't walk thru blob tiles. This has been broken for over a year and so you should expect blob spores to be more of a threat then you are used to.
/:cl:

fixes #56742