### PR TITLE
Removes Erratic Poster on KiloStation

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -82116,13 +82116,6 @@
 "wGF" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/port/aft)
-"wGJ" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/sign/poster/contraband/fun_police{
-	pixel_y = -32
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "wGL" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/neutral,
@@ -101477,7 +101470,7 @@ euM
 euM
 jiK
 cmU
-wGJ
+cmU
 cmU
 aeU
 aeU

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -52443,6 +52443,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"mUJ" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/item/poster/random_contraband,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "mUT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -101471,7 +101476,7 @@ euM
 jiK
 cmU
 cmU
-cmU
+mUJ
 aeU
 aeU
 aeU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/34697715/159213059-05a9eb8f-2574-41db-838b-3eafe79ddced.png)

I have no idea how this even got here.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

On the tin, having floating posters are not good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nanotrasen decided that today was a good day to remove the random floating poster on the exterior of Security on KiloStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
