### PR TITLE
[MDB IGNORE] Shuttle Mapping QoL

### DIFF
--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -36,9 +36,9 @@
 /area/shuttle/escape)
 "al" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "am" = (
@@ -143,9 +143,9 @@
 /area/shuttle/escape)
 "aP" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aQ" = (
@@ -233,9 +233,9 @@
 /area/shuttle/escape)
 "bg" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
+	name = "Emergency Shuttle Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bi" = (
@@ -281,9 +281,9 @@
 /area/shuttle/escape)
 "bq" = (
 /obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary";
-	req_access_txt = "5"
+	name = "Escape Shuttle Infirmary"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "br" = (

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -127,9 +127,9 @@
 /area/shuttle/escape)
 "az" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
+	name = "Emergency Shuttle Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "aC" = (
@@ -188,20 +188,20 @@
 /area/shuttle/escape/brig)
 "aJ" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron,
 /area/shuttle/escape/brig)
 "aK" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aL" = (

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -90,9 +90,9 @@
 /area/shuttle/escape)
 "as" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "bridge door";
-	req_access_txt = "19"
+	name = "bridge door"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "at" = (
@@ -125,9 +125,9 @@
 /area/shuttle/escape/brig)
 "az" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "security airlock";
-	req_access_txt = "63"
+	name = "security airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aA" = (
@@ -281,9 +281,9 @@
 /area/shuttle/escape)
 "aZ" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "bridge door";
-	req_access_txt = "19"
+	name = "bridge door"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/brig)
 "iP" = (

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -98,9 +98,9 @@
 /area/shuttle/escape)
 "ay" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
+	name = "Emergency Shuttle Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aA" = (
@@ -148,16 +148,16 @@
 /area/shuttle/escape/brig)
 "aH" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/brig)
 "aI" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aJ" = (

--- a/_maps/shuttles/emergency_casino.dmm
+++ b/_maps/shuttles/emergency_casino.dmm
@@ -10,7 +10,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "aj" = (
-/obj/structure/chair/stool/bar/directional/west,
+/obj/structure/chair/stool/bar/directional/east,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -31,7 +31,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
 "bl" = (
-/obj/structure/chair/stool/directional/west,
+/obj/structure/chair/stool/directional/east,
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
@@ -44,7 +44,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/west,
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "bT" = (
@@ -58,7 +58,7 @@
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "cb" = (
-/obj/structure/chair/stool/bar/directional/south,
+/obj/structure/chair/stool/bar/directional/north,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
@@ -312,7 +312,7 @@
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "iV" = (
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
@@ -376,7 +376,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "kA" = (
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -431,7 +431,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "ly" = (
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "lA" = (
@@ -448,7 +448,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
 "lB" = (
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -687,13 +687,17 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
+"rH" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "sd" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "2"
+	name = "Brig"
 	},
 /obj/item/grown/bananapeel,
 /obj/item/bikehorn,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "sj" = (
@@ -776,9 +780,9 @@
 /area/shuttle/escape)
 "vK" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "2"
+	name = "Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "vL" = (
@@ -878,14 +882,18 @@
 /area/shuttle/escape)
 "ye" = (
 /obj/machinery/door/airlock/command{
-	name = "Pet Daycare";
-	req_access_txt = "19"
+	name = "Pet Daycare"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium/purple,
 /area/shuttle/escape)
 "yl" = (
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /obj/item/radio/intercom/directional/west,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"yo" = (
+/obj/structure/chair/stool/directional/east,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "yy" = (
@@ -947,10 +955,17 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "AA" = (
-/obj/structure/chair/stool/bar/directional/south,
+/obj/structure/chair/stool/bar/directional/north,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"AS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "Bf" = (
@@ -1025,9 +1040,9 @@
 /area/shuttle/escape)
 "Ec" = (
 /obj/machinery/door/airlock/command{
-	name = "Casino Office";
-	req_access_txt = "19"
+	name = "Casino Office"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "Eh" = (
@@ -1139,6 +1154,10 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood,
+/area/shuttle/escape)
+"Hy" = (
+/obj/structure/chair/stool/bar/directional/north,
+/turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "Ih" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -1265,7 +1284,7 @@
 /turf/open/floor/sepia,
 /area/shuttle/escape)
 "NN" = (
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
 	},
@@ -1361,7 +1380,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "PS" = (
-/obj/structure/chair/stool/directional/west,
+/obj/structure/chair/stool/directional/east,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
@@ -1376,7 +1395,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
 "QY" = (
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/sign/departments/security{
 	pixel_y = -32
@@ -1423,7 +1442,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "Tb" = (
-/obj/structure/chair/stool/directional/south,
+/obj/structure/chair/stool/directional/north,
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
@@ -1437,6 +1456,13 @@
 /area/shuttle/escape)
 "Uu" = (
 /turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"UA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/wood,
 /area/shuttle/escape)
 "Vj" = (
 /obj/machinery/light/directional/north,
@@ -1483,9 +1509,9 @@
 /area/shuttle/escape)
 "Xg" = (
 /obj/machinery/door/airlock/command{
-	name = "Casino Office";
-	req_access_txt = "19"
+	name = "Casino Office"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Xl" = (
@@ -1749,7 +1775,7 @@ gm
 yc
 YF
 yc
-gm
+Hy
 Wp
 la
 Kx
@@ -1833,7 +1859,7 @@ Lz
 Lz
 qx
 Zj
-qx
+UA
 Lz
 Lz
 Lz
@@ -1855,8 +1881,8 @@ RZ
 RZ
 RZ
 RZ
-kz
-kz
+rH
+rH
 RZ
 Ab
 mz
@@ -1981,8 +2007,8 @@ aS
 Gf
 AA
 RZ
-kz
-kz
+rH
+rH
 RZ
 Ab
 mz
@@ -2043,7 +2069,7 @@ gI
 gI
 jS
 Xv
-jS
+AS
 gI
 gI
 gI
@@ -2086,9 +2112,9 @@ lB
 Wp
 Wp
 Wp
-Ws
-Ws
-Ws
+yo
+yo
+yo
 Wp
 mz
 vZ

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -198,9 +198,9 @@
 /area/shuttle/escape)
 "aR" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
+	name = "Emergency Shuttle Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "aS" = (
@@ -287,9 +287,9 @@
 /area/shuttle/escape/brig)
 "bn" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bo" = (
@@ -307,9 +307,9 @@
 /area/shuttle/escape/brig)
 "bq" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bs" = (
@@ -346,9 +346,9 @@
 /area/shuttle/escape)
 "bv" = (
 /obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating,
 /area/shuttle/escape/brig)
 "bw" = (
@@ -875,10 +875,11 @@
 /area/shuttle/escape)
 "cP" = (
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engine Room";
-	req_one_access_txt = "10;24"
+	name = "Engine Room"
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cQ" = (

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -767,9 +767,9 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "Gv" = (

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -630,27 +630,27 @@
 /area/shuttle/escape)
 "bt" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
+	name = "Holding Area"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bu" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
+	name = "Cockpit"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bv" = (
 /obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/white,
 /area/shuttle/escape/brig)
 "bw" = (
@@ -828,12 +828,12 @@
 /area/shuttle/escape)
 "bY" = (
 /obj/machinery/door/airlock/command{
-	name = "Emergency Recovery Airlock";
-	req_access_txt = "19"
+	name = "Emergency Recovery Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bZ" = (

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -80,9 +80,8 @@
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape)
 "p" = (
-/obj/machinery/door/airlock/gold{
-	req_access_txt = "19"
-	},
+/obj/machinery/door/airlock/gold,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape)
 "q" = (

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -103,9 +103,9 @@
 /area/shuttle/escape)
 "au" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "av" = (
@@ -152,9 +152,9 @@
 /area/shuttle/escape/brig)
 "aD" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Containment Cell";
-	req_access_txt = "2"
+	name = "Containment Cell"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aE" = (
@@ -200,9 +200,9 @@
 /area/shuttle/escape/brig)
 "aL" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/brig)
 "aM" = (
@@ -219,9 +219,9 @@
 /area/shuttle/escape)
 "aP" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating,
 /area/shuttle/escape/brig)
 "aQ" = (

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -148,9 +148,9 @@
 /area/shuttle/escape)
 "E" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
+	name = "Emergency Shuttle Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "F" = (
@@ -185,9 +185,9 @@
 /area/shuttle/escape/brig)
 "K" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "L" = (

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -327,9 +327,9 @@
 "aJ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_one_access_txt = "19"
+	name = "Holding Area"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape/brig)
 "aK" = (
@@ -375,9 +375,9 @@
 "aN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/command{
-	name = "Shuttle Control";
-	req_one_access_txt = "19"
+	name = "Shuttle Control"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "aO" = (
@@ -547,8 +547,7 @@
 /area/shuttle/escape)
 "bb" = (
 /obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_one_access_txt = "63"
+	name = "Emergency Shuttle Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -556,6 +555,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape/brig)
 "bc" = (
@@ -657,9 +657,9 @@
 "bm" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
+	name = "Holding Area"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape/brig)
 "bn" = (

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -38,9 +38,9 @@
 /area/shuttle/escape/luxury)
 "af" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell";
-	req_access_txt = "2"
+	name = "Escape Shuttle Cell"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "ag" = (
@@ -905,10 +905,10 @@
 /area/shuttle/escape/luxury)
 "Lt" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell";
-	req_access_txt = "2"
+	name = "Escape Shuttle Cell"
 	},
 /obj/machinery/scanner_gate/luxury_shuttle,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 

--- a/_maps/shuttles/emergency_medisim.dmm
+++ b/_maps/shuttles/emergency_medisim.dmm
@@ -583,9 +583,9 @@
 /area/shuttle/escape/simulation)
 "Aw" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Engine Maintenance Access";
-	req_access_txt = "19"
+	name = "Engine Maintenance Access"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Bd" = (
@@ -968,9 +968,9 @@
 /area/shuttle/escape/simulation)
 "NN" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "NR" = (
@@ -1082,9 +1082,9 @@
 /area/shuttle/escape/simulation)
 "RK" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "2"
+	name = "Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "RV" = (

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -227,9 +227,9 @@
 /area/shuttle/escape)
 "aH" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aL" = (
@@ -293,17 +293,17 @@
 /area/shuttle/escape)
 "aW" = (
 /obj/machinery/door/airlock/command{
-	name = "Emergency Recovery Airlock";
-	req_access_txt = "19"
+	name = "Emergency Recovery Airlock"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aY" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "2"
+	name = "Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aZ" = (

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -75,9 +75,9 @@
 /area/shuttle/escape)
 "o" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell";
-	req_access_txt = "2"
+	name = "Escape Shuttle Cell"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "p" = (
@@ -165,9 +165,9 @@
 /area/shuttle/escape)
 "I" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit";
-	req_access_txt = "19"
+	name = "Escape Shuttle Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "J" = (

--- a/_maps/shuttles/emergency_nature.dmm
+++ b/_maps/shuttles/emergency_nature.dmm
@@ -695,9 +695,9 @@
 /area/shuttle/escape)
 "zE" = (
 /obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "63; 42"
+	name = "Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape/brig)
 "Ai" = (
@@ -722,9 +722,9 @@
 /area/shuttle/escape)
 "Bm" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Bo" = (

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -43,8 +43,7 @@
 /area/shuttle/escape/brig)
 "am" = (
 /obj/machinery/door/airlock/command{
-	name = "Emergency Recovery Airlock";
-	req_access_txt = "19"
+	name = "Emergency Recovery Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52,12 +51,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron,
 /area/shuttle/escape/brig)
 "aq" = (
 /obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -65,6 +64,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/white,
 /area/shuttle/escape/brig)
 "ar" = (
@@ -74,9 +74,9 @@
 /area/shuttle/escape/brig)
 "av" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
+	name = "Holding Area"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aw" = (
@@ -85,13 +85,13 @@
 /area/shuttle/escape)
 "ax" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
+	name = "Cockpit"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "ay" = (

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -614,9 +614,8 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bA" = (
-/obj/machinery/door/airlock/public/glass{
-	req_access_txt = "2"
-	},
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bB" = (
@@ -679,9 +678,9 @@
 /area/shuttle/escape)
 "bO" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bQ" = (
@@ -692,9 +691,9 @@
 /area/shuttle/escape)
 "bT" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Brig";
-	req_access_txt = "2"
+	name = "Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating,
 /area/shuttle/escape/brig)
 "xt" = (

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -319,9 +319,9 @@
 /area/shuttle/escape/brig)
 "aS" = (
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "aT" = (
@@ -479,9 +479,9 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
+	name = "Holding Area"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape/brig)
 "bl" = (
@@ -549,9 +549,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary";
-	req_one_access_txt = "2;19"
+	name = "Escape Shuttle Infirmary"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "bp" = (
@@ -618,9 +618,9 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_one_access_txt = "2;19"
+	name = "Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "by" = (
@@ -1811,6 +1811,8 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Emergency Shutle Engineering"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dB" = (

--- a/_maps/shuttles/emergency_rollerdome.dmm
+++ b/_maps/shuttles/emergency_rollerdome.dmm
@@ -36,9 +36,8 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "hD" = (
-/obj/machinery/door/airlock/gold/glass{
-	req_access_txt = "19"
-	},
+/obj/machinery/door/airlock/gold/glass,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "hF" = (

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -110,9 +110,9 @@
 /area/shuttle/escape)
 "at" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Glorious Leaders";
-	req_access_txt = "19"
+	name = "Glorious Leaders"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "au" = (
@@ -179,9 +179,9 @@
 /area/shuttle/escape/brig)
 "aI" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape/brig)
 "aJ" = (
@@ -213,9 +213,9 @@
 /area/shuttle/escape)
 "aO" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating,
 /area/shuttle/escape/brig)
 "aP" = (

--- a/_maps/shuttles/emergency_scrapheap.dmm
+++ b/_maps/shuttles/emergency_scrapheap.dmm
@@ -85,22 +85,21 @@
 /area/shuttle/escape)
 "aq" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "ar" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
+	name = "Emergency Shuttle Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "as" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -146,9 +145,9 @@
 "az" = (
 /obj/structure/grille,
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aA" = (
@@ -160,9 +159,9 @@
 /area/shuttle/escape)
 "aC" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating,
 /area/shuttle/escape/brig)
 "aD" = (

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -136,9 +136,9 @@
 /area/shuttle/escape)
 "aL" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Emergency Launch Catwalk";
-	req_access_txt = "10"
+	name = "Emergency Launch Catwalk"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aM" = (

--- a/_maps/shuttles/emergency_tram.dmm
+++ b/_maps/shuttles/emergency_tram.dmm
@@ -105,9 +105,9 @@
 /area/shuttle/escape)
 "aw" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
+	name = "Emergency Shuttle Cockpit"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "ax" = (
@@ -180,9 +180,9 @@
 /area/shuttle/escape/brig)
 "aJ" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aK" = (
@@ -205,9 +205,9 @@
 /area/shuttle/escape)
 "aM" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aN" = (

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -105,9 +105,9 @@
 /area/shuttle/escape)
 "ax" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating,
 /area/shuttle/escape/brig)
 "ay" = (
@@ -132,9 +132,9 @@
 /area/shuttle/escape)
 "aB" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
+	name = "Emergency Shuttle Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aC" = (

--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -1,183 +1,20 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/template_noop,
-/area/template_noop)
-"b" = (
-/turf/closed/wall/mineral/abductor,
-/area/shuttle/escape)
-"c" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+"an" = (
+/obj/structure/chair/comfy/shuttle,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"d" = (
-/obj/structure/table/abductor,
-/obj/item/abductor/mind_device{
-	desc = "Just holding this makes your head ache."
+"aO" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Transport Ship Zeta"
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"e" = (
-/obj/structure/table/abductor,
-/obj/item/anomaly_neutralizer{
-	pixel_x = -15
-	},
-/obj/item/food/soylentgreen,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"f" = (
-/obj/machinery/abductor/console,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"g" = (
-/obj/machinery/computer/emergency_shuttle,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"h" = (
-/obj/structure/table/abductor,
-/obj/machinery/recharger,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"i" = (
-/obj/structure/table/abductor,
-/obj/item/gun/energy/alien,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"j" = (
+"eD" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"k" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"l" = (
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"m" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"n" = (
-/obj/structure/table/abductor,
-/obj/machinery/recharger,
-/obj/item/melee/baton/abductor{
-	desc = "Even aliens can see the use of a good old-fashioned beating stick."
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"o" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"p" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"q" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"r" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"s" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"t" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Command Center";
-	req_access_txt = "19"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"u" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"v" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Transport Ship Zeta"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Zeta emergency shuttle"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"w" = (
-/obj/structure/table/abductor,
-/obj/item/storage/box/alienhandcuffs,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"x" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Holding Facility";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"y" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light/directional/west,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"z" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Repair Bay"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"A" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Transport Ship Zeta"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"B" = (
-/obj/machinery/abductor/experiment,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"C" = (
-/obj/structure/chair/office,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"D" = (
-/obj/structure/table/abductor,
-/obj/item/screwdriver/abductor{
-	pixel_y = -5
-	},
-/obj/item/weldingtool/abductor{
-	pixel_y = 3
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"E" = (
-/obj/structure/table/abductor,
-/obj/item/crowbar/abductor{
-	pixel_x = -13
-	},
-/obj/item/multitool/abductor,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"F" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Experimentation Lab"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"G" = (
+"eU" = (
 /obj/structure/table/abductor,
 /obj/item/stock_parts/subspace/crystal{
 	pixel_x = -8
@@ -191,29 +28,238 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"H" = (
+"gf" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape/brig)
+"hh" = (
+/obj/structure/table/abductor,
+/obj/item/gun/energy/alien,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"jj" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"jI" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Holding Facility"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape/brig)
+"jJ" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Command Center"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"jV" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape/brig)
+"lK" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"nH" = (
+/turf/closed/wall/mineral/abductor,
+/area/shuttle/escape)
+"nJ" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"oa" = (
+/obj/machinery/abductor/gland_dispenser{
+	desc = "A tank filled with grotesque bits of flesh."
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"qD" = (
+/obj/structure/table/abductor,
+/obj/machinery/recharger,
+/obj/item/melee/baton/abductor{
+	desc = "Even aliens can see the use of a good old-fashioned beating stick."
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape/brig)
+"sG" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"tb" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape/brig)
+"ue" = (
+/obj/machinery/fat_sucker,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"ui" = (
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape/brig)
+"uW" = (
+/obj/structure/chair/office,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"vw" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"wk" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"xd" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"xg" = (
+/obj/structure/table/abductor,
+/obj/machinery/recharger,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"yR" = (
+/obj/machinery/harvester,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"zx" = (
+/obj/structure/table/abductor,
+/obj/item/abductor/mind_device{
+	desc = "Just holding this makes your head ache."
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"zC" = (
+/obj/structure/table/abductor,
+/obj/item/screwdriver/abductor{
+	pixel_y = -5
+	},
+/obj/item/weldingtool/abductor{
+	pixel_y = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"AJ" = (
+/obj/machinery/abductor/console,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"Bj" = (
+/obj/structure/table/abductor,
+/obj/item/crowbar/abductor{
+	pixel_x = -13
+	},
+/obj/item/multitool/abductor,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"Bv" = (
+/obj/machinery/abductor/experiment,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"Ct" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Repair Bay"
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"Cv" = (
+/turf/template_noop,
+/area/template_noop)
+"CT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"GO" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"HK" = (
+/obj/structure/table/abductor,
+/obj/item/storage/box/alienhandcuffs,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape/brig)
+"IL" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape/brig)
+"IM" = (
+/obj/structure/table/abductor,
+/obj/item/organ/heart/gland/access{
+	pixel_x = 10
+	},
+/obj/item/organ/heart/gland/egg,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"JK" = (
+/obj/item/lazarus_injector,
+/obj/structure/table/abductor,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"Lo" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"Nz" = (
+/obj/structure/table/abductor,
+/obj/item/anomaly_neutralizer{
+	pixel_x = -15
+	},
+/obj/item/food/soylentgreen,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"On" = (
+/obj/machinery/stasis/survival_pod,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"OR" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"I" = (
-/obj/structure/table/abductor,
-/obj/item/abductor/gizmo,
-/obj/item/wirecutters/abductor{
-	pixel_y = 13
+"Qf" = (
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"J" = (
-/obj/machinery/stasis/survival_pod,
+"Ro" = (
+/obj/structure/bed/abductor,
+/obj/machinery/iv_drip,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"K" = (
-/obj/machinery/harvester,
+"Sg" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"L" = (
+"Tn" = (
+/obj/structure/table/optable/abductor,
+/obj/item/surgical_drapes,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"Um" = (
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"Uo" = (
 /obj/structure/closet/abductor,
 /obj/item/clothing/under/misc/pj/blue,
 /obj/item/clothing/shoes/sneakers/white,
@@ -222,53 +268,7 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"N" = (
-/obj/machinery/abductor/pad{
-	desc = "A funky looking disc, built into the floor."
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"O" = (
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"P" = (
-/obj/structure/closet/abductor,
-/obj/item/stack/sheet/mineral/abductor{
-	amount = 50
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"Q" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light/directional/south,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"S" = (
-/obj/item/lazarus_injector,
-/obj/structure/table/abductor,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"T" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"U" = (
-/obj/machinery/abductor/gland_dispenser{
-	desc = "A tank filled with grotesque bits of flesh."
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"V" = (
-/obj/structure/table/optable/abductor,
-/obj/item/surgical_drapes,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"W" = (
+"VR" = (
 /obj/structure/table/abductor,
 /obj/item/scalpel/alien,
 /obj/item/cautery/alien,
@@ -278,504 +278,527 @@
 /obj/item/surgicaldrill/alien,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"X" = (
-/obj/structure/table/abductor,
-/obj/item/organ/heart/gland/access{
-	pixel_x = 10
+"VY" = (
+/obj/structure/closet/abductor,
+/obj/item/stack/sheet/mineral/abductor{
+	amount = 50
 	},
-/obj/item/organ/heart/gland/egg,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"Y" = (
-/obj/machinery/fat_sucker,
+"XI" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Transport Ship Zeta"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Zeta emergency shuttle"
+	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"Z" = (
-/obj/structure/bed/abductor,
-/obj/machinery/iv_drip,
+"XW" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"Ya" = (
+/obj/structure/table/abductor,
+/obj/item/abductor/gizmo,
+/obj/item/wirecutters/abductor{
+	pixel_y = 13
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"YK" = (
+/obj/machinery/abductor/pad{
+	desc = "A funky looking disc, built into the floor."
+	},
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"ZJ" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Experimentation Lab"
+	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-b
-b
-v
-c
-b
-c
-b
-c
-A
-b
-b
-a
-a
-a
-a
-a
+Cv
+Cv
+Cv
+Cv
+Cv
+nH
+nH
+XI
+jj
+nH
+jj
+nH
+jj
+aO
+nH
+nH
+Cv
+Cv
+Cv
+Cv
+Cv
 "}
 (2,1,1) = {"
-a
-a
-a
-a
-b
-b
-l
-l
-l
-y
-l
-y
-l
-l
-l
-b
-b
-a
-a
-a
-a
+Cv
+Cv
+Cv
+Cv
+nH
+nH
+Um
+Um
+Um
+Lo
+Um
+Lo
+Um
+Um
+Um
+nH
+nH
+Cv
+Cv
+Cv
+Cv
 "}
 (3,1,1) = {"
-a
-a
-a
-b
-b
-o
-l
-l
-l
-l
-l
-l
-l
-l
-l
-m
-b
-b
-a
-a
-a
+Cv
+Cv
+Cv
+nH
+nH
+an
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+xd
+nH
+nH
+Cv
+Cv
+Cv
 "}
 (4,1,1) = {"
-a
-a
-b
-b
-o
-l
-l
-l
-r
-r
-r
-r
-r
-l
-l
-l
-m
-b
-b
-a
-a
+Cv
+Cv
+nH
+nH
+an
+Um
+Um
+Um
+CT
+CT
+CT
+CT
+CT
+Um
+Um
+Um
+xd
+nH
+nH
+Cv
+Cv
 "}
 (5,1,1) = {"
-a
-b
-b
-o
-l
-l
-l
-l
-b
-b
-c
-b
-b
-l
-l
-l
-l
-m
-b
-b
-a
+Cv
+nH
+nH
+an
+Um
+Um
+Um
+Um
+nH
+nH
+jj
+nH
+nH
+Um
+Um
+Um
+Um
+xd
+nH
+nH
+Cv
 "}
 (6,1,1) = {"
-b
-b
-j
-l
-r
-r
-r
-l
-u
-u
-u
-u
-u
-l
-r
-r
-r
-l
-Q
-b
-b
+nH
+nH
+eD
+Um
+CT
+CT
+CT
+Um
+Sg
+Sg
+Sg
+Sg
+Sg
+Um
+CT
+CT
+CT
+Um
+GO
+nH
+nH
 "}
 (7,1,1) = {"
-b
-b
-b
-b
-b
-b
-b
-l
-l
-l
-l
-l
-l
-l
-b
-b
-b
-b
-b
-b
-b
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+Um
+Um
+Um
+Um
+Um
+Um
+Um
+nH
+nH
+nH
+nH
+nH
+nH
+nH
 "}
 (8,1,1) = {"
-b
-d
-k
-p
-s
-b
-s
-l
-l
-l
-q
-l
-l
-l
-s
-b
-J
-J
-L
-U
-b
+nH
+zx
+wk
+lK
+vw
+nH
+vw
+Um
+Um
+Um
+sG
+Um
+Um
+Um
+vw
+nH
+On
+On
+Uo
+oa
+nH
 "}
 (9,1,1) = {"
-c
-e
-l
-l
-l
-b
-l
-l
-l
-m
-b
-o
-l
-l
-l
-c
-l
-l
-l
-V
-c
+jj
+Nz
+Um
+Um
+Um
+nH
+Um
+Um
+Um
+xd
+nH
+an
+Um
+Um
+Um
+jj
+Um
+Um
+Um
+Tn
+jj
 "}
 (10,1,1) = {"
-c
-f
-k
-l
-l
-b
-l
-l
-l
-m
-b
-o
-l
-l
-l
-c
-l
-l
-l
-W
-c
+jj
+AJ
+wk
+Um
+Um
+nH
+Um
+Um
+Um
+xd
+nH
+an
+Um
+Um
+Um
+jj
+Um
+Um
+Um
+VR
+jj
 "}
 (11,1,1) = {"
-c
-g
-m
-l
-l
-t
-l
-l
-l
-m
-c
-o
-l
-l
-l
-F
-l
-l
-l
-X
-c
+jj
+nJ
+xd
+Um
+Um
+jJ
+Um
+Um
+Um
+xd
+jj
+an
+Um
+Um
+Um
+ZJ
+Um
+Um
+Um
+IM
+jj
 "}
 (12,1,1) = {"
-c
-f
-k
-l
-l
-b
-l
-l
-l
-m
-b
-o
-l
-l
-l
-c
-l
-l
-l
-Y
-c
+jj
+AJ
+wk
+Um
+Um
+nH
+Um
+Um
+Um
+xd
+nH
+an
+Um
+Um
+Um
+jj
+Um
+Um
+Um
+ue
+jj
 "}
 (13,1,1) = {"
-c
-h
-l
-l
-l
-b
-l
-l
-l
-m
-b
-o
-l
-l
-l
-c
-l
-l
-l
-l
-c
+jj
+xg
+Um
+Um
+Um
+nH
+Um
+Um
+Um
+xd
+nH
+an
+Um
+Um
+Um
+jj
+Um
+Um
+Um
+Um
+jj
 "}
 (14,1,1) = {"
-b
-i
-k
-q
-s
-b
-s
-l
-l
-l
-p
-l
-l
-q
-s
-b
-K
-O
-S
-Z
-b
+nH
+hh
+wk
+sG
+vw
+nH
+vw
+Um
+Um
+Um
+lK
+Um
+Um
+sG
+vw
+nH
+yR
+Qf
+JK
+Ro
+nH
 "}
 (15,1,1) = {"
-b
-b
-b
-b
-b
-b
-b
-b
-b
-l
-l
-l
-b
-b
-b
-b
-b
-b
-b
-b
-b
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+Um
+Um
+Um
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
+nH
 "}
 (16,1,1) = {"
-b
-b
-n
-l
-p
-u
-u
-u
-c
-l
-l
-l
-c
-B
-l
-G
-p
-l
-T
-b
-b
+nH
+nH
+qD
+ui
+gf
+jV
+jV
+jV
+jj
+Um
+Um
+Um
+jj
+Bv
+Um
+eU
+lK
+Um
+XW
+nH
+nH
 "}
 (17,1,1) = {"
-a
-b
-b
-o
-l
-l
-l
-l
-c
-l
-l
-l
-c
-l
-l
-l
-l
-P
-b
-b
-a
+Cv
+nH
+nH
+tb
+ui
+ui
+ui
+ui
+jj
+Um
+Um
+Um
+jj
+Um
+Um
+Um
+Um
+VY
+nH
+nH
+Cv
 "}
 (18,1,1) = {"
-a
-a
-b
-b
-o
-l
-l
-l
-x
-l
-l
-l
-z
-l
-l
-H
-N
-b
-b
-a
-a
+Cv
+Cv
+nH
+nH
+tb
+ui
+ui
+ui
+jI
+Um
+Um
+Um
+Ct
+Um
+Um
+OR
+YK
+nH
+nH
+Cv
+Cv
 "}
 (19,1,1) = {"
-a
-a
-a
-b
-b
-r
-l
-l
-c
-l
-l
-l
-c
-l
-D
-I
-b
-b
-a
-a
-a
+Cv
+Cv
+Cv
+nH
+nH
+IL
+ui
+ui
+jj
+Um
+Um
+Um
+jj
+Um
+zC
+Ya
+nH
+nH
+Cv
+Cv
+Cv
 "}
 (20,1,1) = {"
-a
-a
-a
-a
-b
-b
-r
-w
-c
-r
-r
-r
-c
-C
-E
-b
-b
-a
-a
-a
-a
+Cv
+Cv
+Cv
+Cv
+nH
+nH
+IL
+HK
+jj
+CT
+CT
+CT
+jj
+uW
+Bj
+nH
+nH
+Cv
+Cv
+Cv
+Cv
 "}
 (21,1,1) = {"
-a
-a
-a
-a
-a
-b
-b
-b
-b
-c
-c
-c
-b
-b
-b
-b
-a
-a
-a
-a
-a
+Cv
+Cv
+Cv
+Cv
+Cv
+nH
+nH
+nH
+nH
+jj
+jj
+jj
+nH
+nH
+nH
+nH
+Cv
+Cv
+Cv
+Cv
+Cv
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR replaces all door access varedits with mapping helper replacements, fixes the chairs on the casino shuttle to face the right direction, and adds the shuttle brig area to the Zeta shuttle brig.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stage 1 of the door access wave as introduced in #65580... also misc fixes. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The chairs on the casino shuttle are now facing the proper directions
fix: The Zeta shuttle brig now uses the brig shuttle area
qol: Shuttle doors that previously had varedited accesses now use preset access helpers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
