### PR TITLE
Fixes airlock cheese

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -210,8 +210,8 @@
 	add_fingerprint(user)
 	if(operating || (obj_flags & EMAGGED))
 		return
-	access_bypass |= !requiresID()
-	if(access_bypass || allowed(user))
+	access_bypass |= requiresID()
+	if(access_bypass && allowed(user))
 		if(density)
 			open()
 		else

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -210,8 +210,7 @@
 	add_fingerprint(user)
 	if(operating || (obj_flags & EMAGGED))
 		return
-	access_bypass |= requiresID()
-	if(access_bypass && allowed(user))
+	if(access_bypass || (requiresID() && allowed(user)))
 		if(density)
 			open()
 		else

--- a/html/changelogs/AutoChangeLog-pr-65575.yml
+++ b/html/changelogs/AutoChangeLog-pr-65575.yml
@@ -1,0 +1,4 @@
+author: "GoblinBackwards"
+delete-after: True
+changes: 
+  - bugfix: "Prevents iron/adamantine/yellow slime cookies from being to able to stack their bonuses."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes: [65620](https://github.com/tgstation/tgstation/issues/65620)

## Why It's Good For The Game

it is cringe that cutting one wire allows everyone to open airlock
![b3fd4215bea80088a083615aadf0e80c04673023](https://user-images.githubusercontent.com/35225170/159524420-54ec66e7-2e2d-4d20-b64d-d4c1ce91cbdd.gif)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Clicking on airlock with ID Scan wire cut, should not open airlock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
