### PR TITLE
Pingbus changes and improvements

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -604,7 +604,7 @@
 
 /datum/config_entry/string/urgent_adminhelp_webhook_url
 
-/datum/config_entry/string/adminhelp_webhook_url
+/datum/config_entry/string/regular_adminhelp_webhook_url
 
 /datum/config_entry/string/adminhelp_webhook_pfp
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -596,8 +596,13 @@
 /datum/config_entry/string/urgent_ahelp_message
 	default = "This ahelp is urgent!"
 
+/datum/config_entry/string/ahelp_message
+	default = ""
+
 /datum/config_entry/string/urgent_ahelp_user_prompt
 	default = "There are no admins currently on. Do not press the button below if your ahelp is a joke, a request or a question. Use it only for cases of obvious grief."
+
+/datum/config_entry/string/urgent_adminhelp_webhook_url
 
 /datum/config_entry/string/adminhelp_webhook_url
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -289,7 +289,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		var/datum/discord_embed/embed = format_embed_discord(message)
 		embed.content = extra_message
 		embed.footer = "This player requested an admin"
-		send2adminchat_webhook(embed, TRUE)
+		send2adminchat_webhook(embed, urgent = TRUE)
 		webhook_sent = WEBHOOK_URGENT
 	//send it to TGS if nobody is on and tell us how many were on
 	var/admin_number_present = send2tgs_adminless_only(initiator_ckey, "Ticket #[id]: [message_to_send]")
@@ -301,7 +301,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		var/datum/discord_embed/embed = format_embed_discord(message)
 		embed.content = extra_message
 		embed.footer = "This player sent an ahelp when no admins are available [urgent? "and also requested an admin": ""]"
-		send2adminchat_webhook(embed, FALSE)
+		send2adminchat_webhook(embed, urgent = FALSE)
 		webhook_sent = WEBHOOK_NON_URGENT
 
 /proc/send2adminchat_webhook(message_or_embed, urgent)
@@ -596,7 +596,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			ahelp_link = replacetext(ahelp_link, "$TID", id)
 			embed.url = ahelp_link
 		embed.description = "[key_name(usr)] has sent an action to this ahelp. Action ID: [action]"
-		send2adminchat_webhook(embed, webhook_sent == WEBHOOK_URGENT)
+		if(webhook_sent == WEBHOOK_URGENT)
+			send2adminchat_webhook(embed, urgent = TRUE)
+		send2adminchat_webhook(embed, urgent = FALSE)
 		webhook_sent = WEBHOOK_NONE
 	switch(action)
 		if("ticket")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -598,7 +598,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			var/ahelp_link = replacetext(CONFIG_GET(string/adminhelp_ahelp_link), "$RID", GLOB.round_id)
 			ahelp_link = replacetext(ahelp_link, "$TID", id)
 			embed.url = ahelp_link
-		embed.description = "[key_name(usr)] has sent an action to this ahelp. Action ID: [action]"
+		embed.description = "[key_name(usr)] has sent an action to this ticket. Action ID: [action]"
 		if(webhook_sent == WEBHOOK_URGENT)
 			send2adminchat_webhook(embed, urgent = TRUE)
 		if(webhook_sent == WEBHOOK_NON_URGENT || CONFIG_GET(string/regular_adminhelp_webhook_url) != CONFIG_GET(string/urgent_adminhelp_webhook_url))

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -240,7 +240,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 /datum/admin_help/proc/format_embed_discord(message)
 	var/datum/discord_embed/embed = new()
 	embed.title = "Ticket #[id]"
-	embed.description = "<byond://[world.address]:[world.port]>"
+	embed.description = "<byond://[world.internet_address]:[world.port]>"
 	embed.author = key_name(initiator_ckey)
 	var/round_state
 	switch(SSticker.current_state)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -159,6 +159,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 /obj/effect/statclick/ticket_list/proc/Action()
 	Click()
 
+#define WEBHOOK_NONE 0
+#define WEBHOOK_URGENT 1
+#define WEBHOOK_NON_URGENT 2
+
 /**
  * # Adminhelp Ticket
  */
@@ -189,6 +193,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/static/ticket_counter = 0
 	/// The list of clients currently responding to the opening ticket before it gets a response
 	var/list/opening_responders
+	/// Whether this ahelp has sent a webhook or not, and what type
+	var/webhook_sent = WEBHOOK_NONE
 
 /**
  * Call this on its own to create a ticket, don't manually assign current_ticket
@@ -231,62 +237,79 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		send_message_to_tgs(msg, urgent)
 	GLOB.ahelp_tickets.active_tickets += src
 
+/datum/admin_help/proc/format_embed_discord(message)
+	var/datum/discord_embed/embed = new()
+	embed.title = "Ticket #[id]"
+	embed.author = key_name(initiator_ckey)
+	var/round_state
+	switch(SSticker.current_state)
+		if(GAME_STATE_STARTUP, GAME_STATE_PREGAME, GAME_STATE_SETTING_UP)
+			round_state = "Round has not started"
+		if(GAME_STATE_PLAYING)
+			round_state = "Round is ongoing."
+			if(SSshuttle.emergency.getModeStr())
+				round_state += "\n[SSshuttle.emergency.getModeStr()]: [SSshuttle.emergency.getTimerStr()]"
+				if(SSticker.emergency_reason)
+					round_state += ", Shuttle call reason: [SSticker.emergency_reason]"
+		if(GAME_STATE_FINISHED)
+			round_state = "Round has ended"
+	var/list/admin_counts = get_admin_counts(R_BAN)
+	var/stealth_admins = jointext(admin_counts["stealth"], ", ")
+	var/afk_admins = jointext(admin_counts["afk"], ", ")
+	var/other_admins = jointext(admin_counts["noflags"], ", ")
+	var/admin_text = ""
+	var/player_count = "**Total**: [length(GLOB.clients)], **Living**: [length(GLOB.alive_player_list)], **Dead**: [length(GLOB.dead_player_list)], **Observers**: [length(GLOB.current_observers_list)]"
+	if(stealth_admins)
+		admin_text += "**Stealthed**: [stealth_admins]\n"
+	if(afk_admins)
+		admin_text += "**AFK**: [afk_admins]\n"
+	if(other_admins)
+		admin_text += "**Lacks +BAN**: [other_admins]\n"
+	embed.fields = list(
+		"CKEY" = initiator_ckey,
+		"PLAYERS" = player_count,
+		"ROUND STATE" = round_state,
+		"ROUND ID" = GLOB.round_id,
+		"ROUND TIME" = ROUND_TIME,
+		"MESSAGE" = message,
+		"ADMINS" = admin_text,
+	)
+	if(CONFIG_GET(string/adminhelp_ahelp_link))
+		var/ahelp_link = replacetext(CONFIG_GET(string/adminhelp_ahelp_link), "$RID", GLOB.round_id)
+		ahelp_link = replacetext(ahelp_link, "$TID", id)
+		embed.url = ahelp_link
+	return embed
+
 /datum/admin_help/proc/send_message_to_tgs(message, urgent = FALSE)
 	var/message_to_send = message
 
 	if(urgent)
 		var/extra_message = CONFIG_GET(string/urgent_ahelp_message)
 		to_chat(initiator, span_boldwarning("Notified admins to prioritize your ticket"))
-		var/datum/discord_embed/embed = new()
-		embed.title = "Ticket #[id]"
-		embed.author = key_name(initiator_ckey)
-		var/round_state
-		switch(SSticker.current_state)
-			if(GAME_STATE_STARTUP, GAME_STATE_PREGAME, GAME_STATE_SETTING_UP)
-				round_state = "Round has not started"
-			if(GAME_STATE_PLAYING)
-				round_state = "Round is ongoing."
-				if(SSshuttle.emergency.getModeStr())
-					round_state += "\n[SSshuttle.emergency.getModeStr()]: [SSshuttle.emergency.getTimerStr()]"
-					if(SSticker.emergency_reason)
-						round_state += ", Shuttle call reason: [SSticker.emergency_reason]"
-			if(GAME_STATE_FINISHED)
-				round_state = "Round has ended"
-		var/list/admin_counts = get_admin_counts(R_BAN)
-		var/stealth_admins = jointext(admin_counts["stealth"], ", ")
-		var/afk_admins = jointext(admin_counts["afk"], ", ")
-		var/other_admins = jointext(admin_counts["noflags"], ", ")
-		var/admin_text = ""
-		if(stealth_admins)
-			admin_text += "**Stealthed**: [stealth_admins]\n"
-		if(afk_admins)
-			admin_text += "**AFK**: [afk_admins]\n"
-		if(other_admins)
-			admin_text += "**Lacks +BAN**: [other_admins]\n"
-		embed.fields = list(
-			"CKEY" = initiator_ckey,
-			"ROUND STATE" = round_state,
-			"ROUND ID" = GLOB.round_id,
-			"ROUND TIME" = ROUND_TIME,
-			"MESSAGE" = message,
-			"ADMINS" = admin_text,
-		)
+		var/datum/discord_embed/embed = format_embed_discord(message)
 		embed.content = extra_message
-		if(CONFIG_GET(string/adminhelp_ahelp_link))
-			var/ahelp_link = replacetext(CONFIG_GET(string/adminhelp_ahelp_link), "$RID", GLOB.round_id)
-			ahelp_link = replacetext(ahelp_link, "$TID", id)
-			embed.url = ahelp_link
 		embed.footer = "This player requested an admin"
-		send2adminchat_webhook(embed)
+		send2adminchat_webhook(embed, TRUE)
+		webhook_sent = WEBHOOK_URGENT
 	//send it to TGS if nobody is on and tell us how many were on
 	var/admin_number_present = send2tgs_adminless_only(initiator_ckey, "Ticket #[id]: [message_to_send]")
 	log_admin_private("Ticket #[id]: [key_name(initiator)]: [name] - heard by [admin_number_present] non-AFK admins who have +BAN.")
 	if(admin_number_present <= 0)
 		to_chat(initiator, span_notice("No active admins are online, your adminhelp was sent to admins who are available through IRC or Discord."), confidential = TRUE)
 		heard_by_no_admins = TRUE
+		var/extra_message = CONFIG_GET(string/ahelp_message)
+		var/datum/discord_embed/embed = format_embed_discord(message)
+		embed.content = extra_message
+		embed.footer = "This player sent an ahelp when no admins are available [urgent? "and also requested an admin": ""]"
+		send2adminchat_webhook(embed, FALSE)
+		webhook_sent = WEBHOOK_NON_URGENT
 
-/proc/send2adminchat_webhook(message_or_embed)
-	if(!CONFIG_GET(string/adminhelp_webhook_url))
+/proc/send2adminchat_webhook(message_or_embed, urgent)
+	var/webhook = CONFIG_GET(string/urgent_adminhelp_webhook_url)
+	if(!urgent)
+		webhook = CONFIG_GET(string/adminhelp_webhook_url)
+
+	if(!webhook)
 		return
 	var/list/webhook_info = list()
 	if(istext(message_or_embed))
@@ -307,7 +330,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/list/headers = list()
 	headers["Content-Type"] = "application/json"
 	var/datum/http_request/request = new()
-	request.prepare(RUSTG_HTTP_METHOD_POST, CONFIG_GET(string/adminhelp_webhook_url), json_encode(webhook_info), headers, "tmp/response.json")
+	request.prepare(RUSTG_HTTP_METHOD_POST, webhook, json_encode(webhook_info), headers, "tmp/response.json")
 	request.begin_async()
 
 /datum/admin_help/Destroy()
@@ -565,6 +588,16 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 //Forwarded action from admin/Topic
 /datum/admin_help/proc/Action(action)
 	testing("Ahelp action: [action]")
+	if(webhook_sent != WEBHOOK_NONE)
+		var/datum/discord_embed/embed = new()
+		embed.title = "Ticket #[id]"
+		if(CONFIG_GET(string/adminhelp_ahelp_link))
+			var/ahelp_link = replacetext(CONFIG_GET(string/adminhelp_ahelp_link), "$RID", GLOB.round_id)
+			ahelp_link = replacetext(ahelp_link, "$TID", id)
+			embed.url = ahelp_link
+		embed.description = "[key_name(usr)] has sent an action to this ahelp. Action ID: [action]"
+		send2adminchat_webhook(embed, webhook_sent == WEBHOOK_URGENT)
+		webhook_sent = WEBHOOK_NONE
 	switch(action)
 		if("ticket")
 			TicketPanel()
@@ -1000,3 +1033,7 @@ GLOBAL_DATUM_INIT(admin_help_ui_handler, /datum/admin_help_ui_handler, new)
 	if(length(datums_to_ref))
 		datums_to_ref[ADMINSAY_LINK_DATUM_REF] = jointext(msglist, " ") // without tuples, we must make do!
 		return datums_to_ref
+
+#undef WEBHOOK_URGENT
+#undef WEBHOOK_NONE
+#undef WEBHOOK_NON_URGENT

--- a/config/config.txt
+++ b/config/config.txt
@@ -564,13 +564,19 @@ DEFAULT_VIEW_SQUARE 15x15
 
 ## The URL to the webhook for adminhelps to relay the urgent ahelp message to
 ## If not set, will disable urgent ahelps.
+#URGENT_ADMINHELP_WEBHOOK_URL
+
+## See above, but for non-urgent ahelps
 #ADMINHELP_WEBHOOK_URL
 
 ## The urgent ahelp cooldown for a given player if they're alone on a server and need to send an urgent ahelp.
 URGENT_AHELP_COOLDOWN 300
 
 ## The message that is sent to the discord if an urgent ahelp is sent. Useful for sending a role ping.
-#URGENT_AHELP_MESSAGE Ban ban ban ban
+#URGENT_AHELP_MESSAGE
+
+## See above, but for non-urgent ahelps.
+#AHELP_MESSAGE
 
 ## The message that the player receives whenever prompted whether they want to send an urgent ahelp or not.
 #URGENT_AHELP_USER_PROMPT This'll ping the admins!

--- a/config/config.txt
+++ b/config/config.txt
@@ -567,7 +567,7 @@ DEFAULT_VIEW_SQUARE 15x15
 #URGENT_ADMINHELP_WEBHOOK_URL
 
 ## See above, but for non-urgent ahelps
-#ADMINHELP_WEBHOOK_URL
+#REGULAR_ADMINHELP_WEBHOOK_URL
 
 ## The urgent ahelp cooldown for a given player if they're alone on a server and need to send an urgent ahelp.
 URGENT_AHELP_COOLDOWN 300


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds new configs for non-urgent ahelps to be sent to a channel when no admins are on. This will include urgent ahelps too.
Adds a response message that is sent to discord when an ahelp is responded to in any way
Player counts are now sent in the embed. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Improvements to the pingbus system

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Admins can now see the number of players when someone sends an urgent ahelp.
admin: Added an option to config send non-urgent ahelps to a channel (where there are no available admins on).
admin: Added a response that is sent by the server when an ahelp is responded to in any way by an admin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

**WARNING: This changes ADMINHELP_WEBHOOK_URL config to URGENT_ADMINHELP_WEBHOOK_URL. If you are using this system, please make changes accordingly**
