### PR TITLE
Fixing a couple issues I've introduced with canvases.

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -366,8 +366,8 @@
 	height = 24
 	pixel_x = 2
 	pixel_y = 1
-	framed_offset_x = 2
-	framed_offset_y = 2
+	framed_offset_x = 4
+	framed_offset_y = 4
 
 /obj/item/wallframe/painting
 	name = "painting frame"

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -255,6 +255,7 @@ export const Canvas = (props, context) => {
             )}
             {!!data.finalized && !!data.show_plaque && (
               <Flex.Item
+				basis="content"
                 p={2}
                 width="60%"
                 textColor="black"

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -255,7 +255,7 @@ export const Canvas = (props, context) => {
             )}
             {!!data.finalized && !!data.show_plaque && (
               <Flex.Item
-				basis="content"
+                basis="content"
                 p={2}
                 width="60%"
                 textColor="black"


### PR DESCRIPTION
## About The Pull Request
This will fix the plaque being 24px tall circa instead of taking enough space so that its contents don't spill out (from #65577, perhaps related to flex bugs, in particular the one about circular dependency on h/w mentioned in our component reference MD) and 24x24 paintings not having the right framed pixel offsets (An omission from #65305).

## Why It's Good For The Game
See above. No GBP update.

## Changelog

:cl:
fix: Fixed the size of plaques on the painting UI. They were awfully thin.
fix: Fixed 24x24 paintings not being centered inside their frames.
/:cl:
