### PR TITLE
Gives shuttles ceilings so that they no longer vent if docked below the top z-level and get ejected during the emergency meeting.

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -2,6 +2,7 @@
 
 /datum/map_template/shuttle
 	name = "Base Shuttle Template"
+	has_ceiling = TRUE
 	var/prefix = "_maps/shuttles/"
 	var/suffix
 	var/port_id


### PR DESCRIPTION
## About The Pull Request

Shuttles now have ceilings.

## Why It's Good For The Game

Downstream players on the 3 z-level station Blueshift, and future /tg/ engineering players when we add a map that has a shuttle dock below the top z-level will now no longer have to put "build a ceiling for the shuttle" into their workflow for the shift so that the escape shuttle doesn't vent and get ejected during the emergency meeting.

## Changelog
:cl:
fix: Shuttles now have ceilings.
/:cl:
