### PR TITLE
Simplifies and fixes bot modes

### DIFF
--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -121,51 +121,49 @@
 /// Vibe bots
 #define VIBE_BOT "Vibebot"
 
-//Mode defines. If you add a new one make sure you update mode_name in /mob/living/simple_animal/bot
-
 // General Bot modes //
 /// Idle
-#define BOT_IDLE 0
+#define BOT_IDLE "Idle"
 /// Found target, hunting
-#define BOT_HUNT 1
+#define BOT_HUNT "In Pursuit"
 /// Currently tipped over.
-#define BOT_TIPPED 2
+#define BOT_TIPPED "Tipped"
 /// Start patrol
-#define BOT_START_PATROL 3
+#define BOT_START_PATROL "Beginning Patrol"
 /// Patrolling
-#define BOT_PATROL 4
+#define BOT_PATROL "Patrolling"
 /// Summoned to a location
-#define BOT_SUMMON 5
+#define BOT_SUMMON "Summoned by PDA"
+/// Responding to a call from the AI
+#define BOT_RESPONDING "Proceeding to AI waypoint"
 /// Currently moving
-#define BOT_MOVING 6
+#define BOT_MOVING "Moving"
 
 // Unique modes //
 /// Secbot - At target, preparing to arrest
-#define BOT_PREP_ARREST 7
+#define BOT_PREP_ARREST "Preparing to Arrest"
 /// Secbot - Arresting target
-#define BOT_ARREST 8
+#define BOT_ARREST "Arresting"
 /// Cleanbot - Cleaning
-#define BOT_CLEANING 9
+#define BOT_CLEANING "Cleaning"
 /// Hygienebot - Cleaning unhygienic humans
-#define BOT_SHOWERSTANCE 10
+#define BOT_SHOWERSTANCE "Chasing filth"
 /// Floorbots - Repairing hull breaches
-#define BOT_REPAIRING 11
+#define BOT_REPAIRING "Repairing"
 /// Medibots - Healing people
-#define BOT_HEALING 12
-/// Responding to a call from the AI
-#define BOT_RESPONDING 13
+#define BOT_HEALING "Healing"
 /// MULEbot - Moving to deliver
-#define BOT_DELIVER 14
+#define BOT_DELIVER "Navigating to Delivery Location"
 /// MULEbot - Returning to home
-#define BOT_GO_HOME 15
+#define BOT_GO_HOME "Proceeding to work site"
 /// MULEbot - Blocked
-#define BOT_BLOCKED 16
+#define BOT_BLOCKED "No Route"
 /// MULEbot - Computing navigation
-#define BOT_NAV 17
+#define BOT_NAV "Unable to reach destination"
 /// MULEbot - Waiting for nav computation
-#define BOT_WAIT_FOR_NAV 18
+#define BOT_WAIT_FOR_NAV "Calculating navigation path"
 /// MULEbot - No destination beacon found (or no route)
-#define BOT_NO_ROUTE 19
+#define BOT_NO_ROUTE "Navigating to Home"
 
 //SecBOT defines on arresting
 ///Whether arrests should be broadcasted over the Security radio

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -104,28 +104,6 @@
 	var/beacon_freq = FREQ_NAV_BEACON
 	///The type of data HUD the bot uses. Diagnostic by default.
 	var/data_hud_type = DATA_HUD_DIAGNOSTIC_BASIC
-	//This holds text for what the bot is mode doing, reported on the remote bot control interface.
-	var/list/mode_name = list(
-		"In Pursuit",
-		"Preparing to Arrest",
-		"Arresting",
-		"Beginning Patrol",
-		"Patrolling",
-		"Summoned by PDA",
-		"Cleaning",
-		"Repairing",
-		"Proceeding to work site",
-		"Healing",
-		"Proceeding to AI waypoint",
-		"Navigating to Delivery Location",
-		"Navigating to Home",
-		"Waiting for clear path",
-		"Calculating navigation path",
-		"Pinging beacon network",
-		"Unable to reach destination",
-		"Chasing filth",
-		"No Route",
-	)
 	var/datum/atom_hud/data/bot_path/path_hud = new /datum/atom_hud/data/bot_path()
 	var/path_image_icon = 'icons/mob/aibots.dmi'
 	var/path_image_icon_state = "path_indicator"
@@ -141,10 +119,8 @@
 			return "<b>Autonomous</b>"
 	else if(!(bot_mode_flags & BOT_MODE_ON))
 		return "<span class='bad'>Inactive</span>"
-	else if(!mode)
-		return "<span class='good'>Idle</span>"
 	else
-		return "<span class='average'>[mode_name[mode]]</span>"
+		return "<span class='average'>[mode]</span>"
 
 /**
  * Returns a status string about the bot's current status, if it's moving, manually controlled, or idle.
@@ -154,10 +130,8 @@
 		return paicard ? "pAI Controlled" : "Autonomous"
 	else if(!(bot_mode_flags & BOT_MODE_ON))
 		return "Inactive"
-	else if(!mode)
-		return "Idle"
 	else
-		return "[mode_name[mode]]"
+		return "[mode]"
 
 /mob/living/simple_animal/bot/proc/turn_on()
 	if(stat)

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -234,11 +234,11 @@
 		target = scan(/obj/item/food/deadmouse)
 
 	if(!target && bot_mode_flags & BOT_MODE_AUTOPATROL) //Search for cleanables it can see.
-		if(mode == BOT_IDLE || mode == BOT_START_PATROL)
-			start_patrol()
-
-		if(mode == BOT_PATROL)
-			bot_patrol()
+		switch(mode)
+			if(BOT_IDLE, BOT_START_PATROL)
+				start_patrol()
+			if(BOT_PATROL)
+				bot_patrol()
 
 	if(target)
 		if(QDELETED(target) || !isturf(target.loc))

--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -239,11 +239,11 @@
 		frustration++
 
 	if(bot_mode_flags & BOT_MODE_AUTOPATROL && !target_fire)
-		if(mode == BOT_IDLE || mode == BOT_START_PATROL)
-			start_patrol()
-
-		if(mode == BOT_PATROL)
-			bot_patrol()
+		switch(mode)
+			if(BOT_IDLE, BOT_START_PATROL)
+				start_patrol()
+			if(BOT_PATROL)
+				bot_patrol()
 
 
 //Look for burning people or turfs around the bot

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -220,11 +220,11 @@
 	if(!target)
 
 		if(bot_mode_flags & BOT_MODE_AUTOPATROL)
-			if(mode == BOT_IDLE || mode == BOT_START_PATROL)
-				start_patrol()
-
-			if(mode == BOT_PATROL)
-				bot_patrol()
+			switch(mode)
+				if(BOT_IDLE, BOT_START_PATROL)
+					start_patrol()
+				if(BOT_PATROL)
+					bot_patrol()
 
 	if(target)
 		if(loc == target || loc == get_turf(target))

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -338,12 +338,12 @@
 	if(!.)
 		return
 
-	if(mode == BOT_TIPPED)
-		handle_panic()
-		return
-
-	if(mode == BOT_HEALING)
-		return
+	switch(mode)
+		if(BOT_TIPPED)
+			handle_panic()
+			return
+		if(BOT_HEALING)
+			return
 
 	if(IsStun() || IsParalyzed())
 		oldpatient = patient
@@ -405,11 +405,11 @@
 		frustration++
 
 	if(bot_mode_flags & BOT_MODE_AUTOPATROL && !(medical_mode_flags & MEDBOT_STATIONARY_MODE) && !patient)
-		if(mode == BOT_IDLE || mode == BOT_START_PATROL)
-			start_patrol()
-
-		if(mode == BOT_PATROL)
-			bot_patrol()
+		switch(mode)
+			if(BOT_IDLE, BOT_START_PATROL)
+				start_patrol()
+			if(BOT_PATROL)
+				bot_patrol()
 
 /mob/living/simple_animal/bot/medbot/proc/assess_patient(mob/living/carbon/C)
 	. = FALSE

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -249,7 +249,7 @@
 	data["on"] = bot_mode_flags & BOT_MODE_ON
 	data["locked"] = bot_cover_flags & BOT_COVER_LOCKED
 	data["siliconUser"] = user.has_unlimited_silicon_privilege
-	data["mode"] = mode ? mode_name[mode] : "Ready"
+	data["mode"] = mode ? "[mode]" : "Ready"
 	data["modeStatus"] = ""
 	switch(mode)
 		if(BOT_IDLE, BOT_DELIVER, BOT_GO_HOME)
@@ -302,7 +302,7 @@
 
 	switch(command)
 		if("stop")
-			if(mode >= BOT_DELIVER)
+			if(mode != BOT_IDLE)
 				bot_reset()
 		if("go")
 			if(mode == BOT_IDLE)

--- a/code/modules/mob/living/simple_animal/bot/vibebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/vibebot.dm
@@ -43,10 +43,11 @@
 	if(!(bot_mode_flags & BOT_MODE_AUTOPATROL))
 		return
 
-	if(mode == BOT_IDLE || mode == BOT_START_PATROL)
-		start_patrol()
-	if(mode == BOT_PATROL)
-		bot_patrol()
+	switch(mode)
+		if(BOT_IDLE, BOT_START_PATROL)
+			start_patrol()
+		if(BOT_PATROL)
+			bot_patrol()
 
 /mob/living/simple_animal/bot/vibebot/turn_off()
 	vibe_ability.remove_colors()


### PR DESCRIPTION
## About The Pull Request

Deletes mode_name and just makes the name be the define, which is now what is used to say what mode they are on.
This also technically de-hardcodes bot modes, making it easier for downstreams to add their own... kinda.

![image](https://user-images.githubusercontent.com/53777086/159573740-93486f70-0f5f-4a05-bcf7-fb7432e29310.png)

## Why It's Good For The Game

This was more complicated than it could be for really no reason. It being numbered only ever came in use a single time, which was by mulebot's stop command, which was easily replaced.

Closes https://github.com/tgstation/tgstation/issues/65547

## Changelog

:cl:
fix: Bot's modes have been fixed, Medibots will no longer be on 'arrest' mode.
/:cl: