### PR TITLE
Fixes nukies being able to lock their uplink

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -247,6 +247,8 @@
 				item = SStraitor.uplink_items_by_type[item_path]
 			uplink_handler.purchase_item(ui.user, item)
 		if("lock")
+			if(!lockable)
+				return TRUE
 			active = FALSE
 			locked = TRUE
 			SStgui.close_uis(src)

--- a/tgui/packages/tgui/interfaces/Uplink/index.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/index.tsx
@@ -27,6 +27,7 @@ type UplinkItem = {
 type UplinkData = {
   telecrystals: number,
   progression_points: number,
+  lockable: BooleanLike,
   current_expected_progression: number,
   progression_scaling_deviance: number,
   current_progression_scaling: number,
@@ -152,6 +153,7 @@ export class Uplink extends Component<{}, UplinkState> {
       extra_purchasable,
       extra_purchasable_stock,
       current_stock,
+      lockable,
     } = data;
     const {
       allItems,
@@ -309,14 +311,16 @@ export class Uplink extends Component<{}, UplinkState> {
                       </Tabs.Tab>
                     </Tabs>
                   </Stack.Item>
-                  <Stack.Item mr={1}>
-                    <Button
-                      icon="times"
-                      content="Lock"
-                      color="transparent"
-                      onClick={() => act("lock")}
-                    />
-                  </Stack.Item>
+                  {!!lockable && (
+                    <Stack.Item mr={1}>
+                      <Button
+                        icon="times"
+                        content="Lock"
+                        color="transparent"
+                        onClick={() => act("lock")}
+                      />
+                    </Stack.Item>
+                  )}
                 </Stack>
               </Section>
             </Stack.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
See title. Nukies shouldn't have been able to lock their own uplink.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugfix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nukies can no longer lock their own uplink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
