### PR TITLE
Bandaid Fix for issues with dynamically loaded multitile objects

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -52,6 +52,9 @@ SUBSYSTEM_DEF(atoms)
 
 	set_tracked_initalized(INITIALIZATION_INNEW_MAPLOAD)
 
+	// Reset atoms locs to ensure turf contents correctly include multitiles
+	fix_atoms_locs(atoms)
+
 	// This may look a bit odd, but if the actual atom creation runtimes for some reason, we absolutely need to set initialized BACK
 	CreateAtoms(atoms, atoms_to_return)
 	clear_tracked_initalize()
@@ -152,6 +155,15 @@ SUBSYSTEM_DEF(atoms)
 			created_atoms += A.get_all_contents()
 
 	return qdeleted || QDELING(A)
+
+/// Force reset atoms loc, as map expansion can botch turf contents for multitiles
+/datum/controller/subsystem/atoms/proc/fix_atoms_locs(list/atoms)
+	if(atoms)
+		for(var/atom/movable/A in atoms)
+			A.loc = A.loc
+	else
+		for(var/atom/movable/A in world)
+			A.loc = A.loc
 
 /datum/controller/subsystem/atoms/proc/map_loader_begin()
 	set_tracked_initalized(INITIALIZATION_INSSATOMS)

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -73,9 +73,9 @@
 	..()
 
 /obj/item/energy_katana/Destroy()
+	. = ..()
 	QDEL_NULL(spark_system)
 	QDEL_NULL(jaunt)
-	return ..()
 
 /**
  * Proc called when the katana is recalled to its space ninja.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

**Q: What the hell is this ?**
A: This is a patch to address a caveat between BYOND, map expansion, maploading, and multitiles.

**Q: Why in the world--**
A: Well people complained about collision lacking with multitile props in CM13 for no apparent reason, so i just dived in. After a few hours, i found it ! It turns out that **contents of turfs they should be on didn't match the props locs** !

**Q: What are you on about ?!**
A: I think a picture speaks a thousand words so here you go. Basically during mapload, as multitile objects are placed, adjacent turfs might not exist (at all) yet because we're still performing map expansion. So contents can't be set on them. Then you expand map with fresh turfs, and they don't get it.

![image](https://user-images.githubusercontent.com/604624/159689930-a9617d30-1ee0-4b8f-a03f-b316edc27788.png)

**Q: Okay but i meant, what the hell is this *code* ???**
A: Well uuuuuuuuh... Setting loc updates contents accordingly... And it has to be done before Init proper since other objects might rely on your multitile being nearby...

**Q: That's all you have to say about it ?!**
A: This only addreses main map loading via SSatoms init. You might want to do something similar in  `/datum/map_template/proc/initTemplateBounds` if you want to account for map templates loading causing expansion. Thanksfully, they normally can't! 

**Q: And you think you're gonna get away with this ?!**
A: Well, any other option I could think of would involve adding more mess in the map loading code proper and/or were dubious - eg. tracking what's a multitile and what's not, selectively doing this, pre-expanding the map by guessing object sizes, and so on. This is simple. Simple things are good!

**Q: Well. Any last words ? -cocks pistol-**
A: I hate BYOND.


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Sanity, consistency, dependability. Dependable behavior is good. Otherwise next thing you know, issues have crept up on you for the past four years, slam you, and leave you in a locker in maint. I don't know. It's just something too basic to stay broken.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Firartix

bugfix: Added a bandaid for a BYOND issue around dynamically loaded multitile objects.

bugfix: Fix out-of-order deletion interactions with the energy katana.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
