### PR TITLE
Adds a var to add prog uplink or not

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -15,6 +15,8 @@
 	var/give_uplink = TRUE
 	///if TRUE, this traitor will always get hijacking as their final objective
 	var/is_hijacker = FALSE
+	///Whether this Traitor has a progression uplink
+	var/progression_uplink = TRUE
 
 	///the name of the antag flavor this traitor has.
 	var/employer
@@ -47,7 +49,8 @@
 			uplink.uplink_handler = uplink_handler
 		else
 			uplink_handler = uplink.uplink_handler
-		uplink_handler.has_progression = TRUE
+		if(progression_uplink)
+			uplink_handler.has_progression = TRUE
 		SStraitor.register_uplink_handler(uplink_handler)
 
 		uplink_handler.has_objectives = TRUE


### PR DESCRIPTION
## About The Pull Request

Small change to add a var on whether traitor's uplink should have progression in it, just like the var on whether they should get an uplink at all.

## Why It's Good For The Game

Just a small change to benefit traitor subtypes that don't get progression objectives like normal traitors do.

## Changelog

Not player facing.