### PR TITLE
Fixes assistants going to medium priority when other job is selected

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -442,9 +442,16 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/character_preview_view)
 		return FALSE
 
 	if (level == JP_HIGH)
+		var/datum/job/overflow_role = SSjob.overflow_role
+		var/overflow_role_title = initial(overflow_role.title)
+
 		for(var/other_job in job_preferences)
 			if(job_preferences[other_job] == JP_HIGH)
-				job_preferences[other_job] = JP_MEDIUM
+				// Overflow role needs to go to NEVER, not medium!
+				if(other_job == overflow_role_title)
+					job_preferences[other_job] = null
+				else
+					job_preferences[other_job] = JP_MEDIUM
 
 	job_preferences[job.title] = level
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The assistant option has acted weird for a while (staying selected when you pick another high priority role, being rolled if you don't have a high priority set, sometimes).

Turns out it's because when you select a new high priority role, it makes assistant medium priority like with every other role, instead of off, confusing everyone. This PR fixes it so assistant gets turned *off* if you pick a new high priority role.

Closes #60167
Closes #60499

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Job selection working correctly

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Picking a high priority role in character creation no longer breaks assistant selection behind the scenes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
