### PR TITLE
Halon's slowdown removal

### DIFF
--- a/code/modules/movespeed/modifiers/reagent.dm
+++ b/code/modules/movespeed/modifiers/reagent.dm
@@ -28,9 +28,6 @@
 /datum/movespeed_modifier/reagent/freon
 	multiplicative_slowdown = 1.6
 
-/datum/movespeed_modifier/reagent/halon
-	multiplicative_slowdown = 1.8
-
 /datum/movespeed_modifier/reagent/lenturi
 	multiplicative_slowdown = 1.5
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1516,11 +1516,9 @@
 
 /datum/reagent/halon/on_mob_metabolize(mob/living/L)
 	. = ..()
-	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/halon)
 	ADD_TRAIT(L, TRAIT_RESISTHEAT, type)
 
 /datum/reagent/halon/on_mob_end_metabolize(mob/living/L)
-	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/halon)
 	REMOVE_TRAIT(L, TRAIT_RESISTHEAT, type)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Halon provides the breather with a heat resistance trait (I bet most people don't know about this) which is useful for fire fighting except for the slowdown it gives. You are better off using the fire fighting gear instead of synthesizing this gas and huffing it for the heat immunity. 

## Why It's Good For The Game

Removes one of the more annoying and quite unneeded drawback of halon and gives more incentive for players to synthesize it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 
balance: Remove the atrocious slowdown from breathing Halon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
