### PR TITLE
Adds search to supply console

### DIFF
--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -1,5 +1,7 @@
+import { flow } from 'common/fp';
+import { filter, sortBy } from 'common/collections';
 import { useBackend, useSharedState } from '../backend';
-import { AnimatedNumber, Box, Button, Flex, LabeledList, NoticeBox, Section, Table, Tabs } from '../components';
+import { AnimatedNumber, Box, Button, Flex, Icon, Input, LabeledList, NoticeBox, Section, Stack, Table, Tabs } from '../components';
 import { formatMoney } from '../format';
 import { Window } from '../layouts';
 
@@ -138,21 +140,52 @@ const CargoStatus = (props, context) => {
   );
 };
 
+/**
+ * Take entire supplies tree
+ * and return a flat supply pack list that matches search,
+ * sorted by name and only the first page.
+ * @param {category[]} supplies Supplies list.
+ * @param {string} search The search term
+ * @returns {pack[]} The flat list of supply packs.
+ */
+const searchForSupplies = (supplies, search) => {
+  search = search.toLowerCase();
+
+  return flow([
+    categories => categories.flatMap(category => category.packs),
+    filter(pack =>
+      pack.name?.toLowerCase().includes(search.toLowerCase())
+      || pack.desc?.toLowerCase().includes(search.toLowerCase())),
+    sortBy(pack => pack.name),
+    packs => packs.slice(0, 20),
+  ])(supplies);
+};
+
 export const CargoCatalog = (props, context) => {
   const { express } = props;
   const { act, data } = useBackend(context);
+
   const {
     self_paid,
     app_cost,
   } = data;
+
   const supplies = Object.values(data.supplies);
+
   const [
     activeSupplyName,
     setActiveSupplyName,
   ] = useSharedState(context, 'supply', supplies[0]?.name);
-  const activeSupply = supplies.find(supply => {
-    return supply.name === activeSupplyName;
-  });
+
+  const [
+    searchText,
+    setSearchText,
+  ] = useSharedState(context, "search_text", "");
+
+  const activeSupply = activeSupplyName === "search_results"
+    ? { packs: searchForSupplies(supplies, searchText) }
+    : supplies.find(supply => supply.name === activeSupplyName);
+
   return (
     <Section
       title="Catalog"
@@ -169,11 +202,49 @@ export const CargoCatalog = (props, context) => {
       <Flex>
         <Flex.Item ml={-1} mr={1}>
           <Tabs vertical>
+            <Tabs.Tab
+              key="search_results"
+              selected={activeSupplyName === "search_results"}>
+              <Stack align="baseline">
+                <Stack.Item>
+                  <Icon name="search" />
+                </Stack.Item>
+                <Stack.Item grow>
+                  <Input fluid
+                    placeholder="Search..."
+                    value={searchText}
+                    onInput={(e, value) => {
+                      if (value === searchText) {
+                        return;
+                      }
+
+                      if (value.length) {
+                        // Start showing results
+                        setActiveSupplyName("search_results");
+                      } else if (activeSupplyName === "search_results") {
+                        // return to normal category
+                        setActiveSupplyName(supplies[0]?.name);
+                      }
+                      setSearchText(value);
+                    }}
+                    onChange={(e, value) => {
+                      // Allow edge cases like the X button to work
+                      const onInput = e.target?.props?.onInput;
+                      if (onInput) {
+                        onInput(e, value);
+                      }
+                    }} />
+                </Stack.Item>
+              </Stack>
+            </Tabs.Tab>
             {supplies.map(supply => (
               <Tabs.Tab
                 key={supply.name}
                 selected={supply.name === activeSupplyName}
-                onClick={() => setActiveSupplyName(supply.name)}>
+                onClick={() => {
+                  setActiveSupplyName(supply.name);
+                  setSearchText("");
+                }}>
                 {supply.name} ({supply.packs.length})
               </Tabs.Tab>
             ))}

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -144,9 +144,9 @@ const CargoStatus = (props, context) => {
  * Take entire supplies tree
  * and return a flat supply pack list that matches search,
  * sorted by name and only the first page.
- * @param {category[]} supplies Supplies list.
+ * @param {any[]} supplies Supplies list.
  * @param {string} search The search term
- * @returns {pack[]} The flat list of supply packs.
+ * @returns {any[]} The flat list of supply packs.
  */
 const searchForSupplies = (supplies, search) => {
   search = search.toLowerCase();

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -157,7 +157,7 @@ const searchForSupplies = (supplies, search) => {
       pack.name?.toLowerCase().includes(search.toLowerCase())
       || pack.desc?.toLowerCase().includes(search.toLowerCase())),
     sortBy(pack => pack.name),
-    packs => packs.slice(0, 20),
+    packs => packs.slice(0, 25),
   ])(supplies);
 };
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Every other civilized console has a search feature at this point. Now the supply console does too.

### Normal categories still work normally of course.
![image](https://user-images.githubusercontent.com/1185434/159822752-76739714-33ec-4339-b5f3-3141529f76af.png)

### Note that searching for fish also pull up Aquarium Kit
![image](https://user-images.githubusercontent.com/1185434/159822509-8d90217b-4f09-4bc2-9510-e21b24fb3ac4.png)

### Where's ma floor tiles??
![image](https://user-images.githubusercontent.com/1185434/159822944-8511666b-d4c6-4608-814c-c0e72fb578c1.png)

The search checks both the name of the crate, and its description, and shows the first page's worth alphabetically, so we don't get weird scrolling nonsense.

Clicking away from the search clears it, and erasing the search term all the way, or clicking the little X when typing, bounces back to the first real category so you don't end up with shitty half-states.

I suppose this means that squeezing keywords into crate descriptions would be useful now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more customers squinting at the request console for 5 minutes trying to find beer.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The supply and supply request consoles now have a search bar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
