### PR TITLE
Mystery boxes no longer cut off each other's audio

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -7,7 +7,6 @@
 #define CHANNEL_AMBIENCE 1019
 #define CHANNEL_BUZZ 1018
 #define CHANNEL_TRAITOR 1017
-#define CHANNEL_MBOX 1016
 
 ///Default range of a sound.
 #define SOUND_RANGE 17

--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -137,7 +137,7 @@ GLOBAL_LIST_INIT(mystery_box_extended, list(
 	presented_item = new(loc)
 	presented_item.start_animation(src)
 	current_sound_channel = SSsounds.reserve_sound_channel(src)
-	playsound(src, open_sound, 80, FALSE, channel = current_sound_channel)
+	playsound(src, open_sound, 70, FALSE, channel = current_sound_channel, falloff_exponent = 10)
 	playsound(src, crate_open_sound, 80)
 
 /// The box has finished choosing, mark it as available for grabbing
@@ -185,7 +185,7 @@ GLOBAL_LIST_INIT(mystery_box_extended, list(
 				user.put_in_hands(extra_mag)
 
 	user.visible_message(span_notice("[user] takes [presented_item] from [src]."), span_notice("You take [presented_item] from [src]."), vision_distance = COMBAT_MESSAGE_RANGE)
-	playsound(src, grant_sound, 80, FALSE, channel = current_sound_channel)
+	playsound(src, grant_sound, 70, FALSE, channel = current_sound_channel, falloff_exponent = 10)
 	close_box()
 
 

--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -104,6 +104,12 @@ GLOBAL_LIST_INIT(mystery_box_extended, list(
 	. = ..()
 	generate_valid_types()
 
+/obj/structure/mystery_box/Destroy()
+	QDEL_NULL(presented_item)
+	if(current_sound_channel)
+		SSsounds.free_sound_channel(current_sound_channel)
+	return ..()
+
 /obj/structure/mystery_box/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	switch(box_state)
@@ -227,8 +233,8 @@ GLOBAL_LIST_INIT(mystery_box_extended, list(
 	add_filter("weapon_rays", 3, list("type" = "rays", "size" = 28, "color" = COLOR_VIVID_YELLOW))
 
 /obj/mystery_box_item/Destroy(force)
-	. = ..()
 	parent_box = null
+	return ..()
 
 // this way, clicking on the prize will work the same as clicking on the box
 /obj/mystery_box_item/attack_hand(mob/living/user, list/modifiers)

--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -97,6 +97,8 @@ GLOBAL_LIST_INIT(mystery_box_extended, list(
 	var/list/valid_types
 	/// If the prize is a ballistic gun with an external magazine, should we grant the user a spare mag?
 	var/grant_extra_mag = TRUE
+	/// Stores the current sound channel we're using so we can cut off our own sounds as needed. Randomized after each roll
+	var/current_sound_channel
 
 /obj/structure/mystery_box/Initialize(mapload)
 	. = ..()
@@ -134,7 +136,8 @@ GLOBAL_LIST_INIT(mystery_box_extended, list(
 	update_icon_state()
 	presented_item = new(loc)
 	presented_item.start_animation(src)
-	playsound(src, open_sound, 80, FALSE, channel = CHANNEL_MBOX)
+	current_sound_channel = SSsounds.reserve_sound_channel(src)
+	playsound(src, open_sound, 80, FALSE, channel = current_sound_channel)
 	playsound(src, crate_open_sound, 80)
 
 /// The box has finished choosing, mark it as available for grabbing
@@ -162,6 +165,8 @@ GLOBAL_LIST_INIT(mystery_box_extended, list(
 
 /// The cooldown between activations has finished, shake to show that
 /obj/structure/mystery_box/proc/ready_again()
+	SSsounds.free_sound_channel(current_sound_channel)
+	current_sound_channel = null
 	box_state = MYSTERY_BOX_STANDBY
 	Shake(10, 0, 0.5 SECONDS)
 
@@ -180,7 +185,7 @@ GLOBAL_LIST_INIT(mystery_box_extended, list(
 				user.put_in_hands(extra_mag)
 
 	user.visible_message(span_notice("[user] takes [presented_item] from [src]."), span_notice("You take [presented_item] from [src]."), vision_distance = COMBAT_MESSAGE_RANGE)
-	playsound(src, grant_sound, 80, FALSE, channel = CHANNEL_MBOX)
+	playsound(src, grant_sound, 80, FALSE, channel = current_sound_channel)
 	close_box()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I put mystery boxes on their own sound channel so they could cancel out the full music clip when someone took an item from them, but this causes issues because only one box could be playing a sound clip at a time, and they'd cut each other off if there were multiple. Now they reserve their own channels for their duration, then release them, so they can all play at the same time. Accordingly, their sounds now fall off quicker so having multiple of them nearby won't destroy your ear drums.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes having multiple mystery boxes less jarring
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ryll/Shaps
qol: Mystery boxes no longer cut off each other's sound clips when playing their own
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
