### PR TITLE
Fixes offering things to yourself

### DIFF
--- a/code/modules/mob/living/carbon/carbon_context.dm
+++ b/code/modules/mob/living/carbon/carbon_context.dm
@@ -22,7 +22,12 @@
 		context[SCREENTIP_CONTEXT_RMB] = "Shove"
 
 		if (body_position == STANDING_UP)
-			context[SCREENTIP_CONTEXT_LMB] = "Comfort"
+			if(check_zone(user.zone_selected) == BODY_ZONE_HEAD && get_bodypart(BODY_ZONE_HEAD))
+				context[SCREENTIP_CONTEXT_LMB] = "Headpat"
+			else if(check_zone(user.zone_selected) == BODY_ZONE_PRECISE_GROIN && !isnull(getorgan(/obj/item/organ/tail)))
+				context[SCREENTIP_CONTEXT_LMB] = "Pull tail"
+			else
+				context[SCREENTIP_CONTEXT_LMB] = "Hug"
 		else if (health >= 0 && !HAS_TRAIT(src, TRAIT_FAKEDEATH))
 			context[SCREENTIP_CONTEXT_LMB] = "Shake"
 		else

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -414,8 +414,7 @@
 						null, span_hear("You hear the rustling of clothes."), DEFAULT_MESSAGE_RANGE, list(M, src))
 		to_chat(M, span_notice("You shake [src] trying to pick [p_them()] up!"))
 		to_chat(src, span_notice("[M] shakes you to get you up!"))
-
-	else if(check_zone(M.zone_selected) == BODY_ZONE_HEAD) //Headpats!
+	else if(check_zone(M.zone_selected) == BODY_ZONE_HEAD && get_bodypart(BODY_ZONE_HEAD)) //Headpats!
 		SEND_SIGNAL(src, COMSIG_CARBON_HEADPAT, M)
 		M.visible_message(span_notice("[M] gives [src] a pat on the head to make [p_them()] feel better!"), \
 					null, span_hear("You hear a soft patter."), DEFAULT_MESSAGE_RANGE, list(M, src))

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -164,7 +164,7 @@
  */
 /mob/living/carbon/proc/give(mob/living/carbon/offered)
 	if(has_status_effect(/datum/status_effect/offering))
-		to_chat(src, span_warning("You're already offering up something!"))
+		to_chat(src, span_warning("You're already offering something!"))
 		return
 
 	if(IS_DEAD_OR_INCAP(src))
@@ -173,20 +173,31 @@
 
 	var/obj/item/offered_item = get_active_held_item()
 	if(!offered_item)
-		to_chat(src, span_warning("You're not holding anything to give!"))
+		to_chat(src, span_warning("You're not holding anything to offer!"))
 		return
 
 	if(offered)
+		if(offered == src)
+			if(!swap_hand(get_inactive_hand_index())) //have to swap hands first to take something
+				to_chat(src, span_warning("You try to take [offered_item] from yourself, but fail."))
+				return
+			if(!put_in_active_hand(offered_item))
+				to_chat(src, span_warning("You try to take [offered_item] from yourself, but fail."))
+				return
+			else
+				to_chat(src, span_notice("You take [offered_item] from yourself."))
+				return
+
 		if(IS_DEAD_OR_INCAP(offered))
-			to_chat(src, span_warning("They're unable to take anything in their current state!"))
+			to_chat(src, span_warning("[offered.p_theyre(TRUE)] unable to take anything in [offered.p_their()] current state!"))
 			return
 
 		if(!CanReach(offered))
-			to_chat(src, span_warning("You have to be adjacent to offer things!"))
+			to_chat(src, span_warning("You have to be beside [offered.p_them()]!"))
 			return
 	else
 		if(!(locate(/mob/living/carbon) in orange(1, src)))
-			to_chat(src, span_warning("There's nobody adjacent to offer it to!"))
+			to_chat(src, span_warning("There's nobody beside you to take it!"))
 			return
 
 	if(offered_item.on_offered(src)) // see if the item interrupts with its own behavior


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Takes them directly if possible, or prints an error message to the chat (it's tongue-in-cheek)
- Punches up some give() failure messages
- Adds screentips for headpatting, pulling tails and hugging while I'm in the area (instead of just saying "Comfort")
- Adds a check for a head when headpatting, fixing the ability I presume exists to give headpats to mobs without them

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes an oversight I somehow missed in testing which allows you to offer items to yourself, without removing the ability to do it entirely. I like when games "yes, and" the player and take their inputs to the natural conclusion. 

Here you switch to the other hand and take the item from yourself, which is probably useless but it's slightly humourous.

I think the Comfort screentip is a bit inaccurate, and changing it to the actual actions in the right contexts alleviates that.

You shouldn't be able to headpat mobs without heads.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can no longer offer things to yourself, choosing instead to take them directly
fix: Can no longer headpat mobs without heads
expansion: Adds screentips for headpatting, hugging and tail pulling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
