### PR TITLE
Fixes pathfinding not checking diagonal passability properly.

### DIFF
--- a/code/__HELPERS/path.dm
+++ b/code/__HELPERS/path.dm
@@ -44,7 +44,7 @@
  * Note that this can only be used inside the [datum/pathfind][pathfind datum] since it uses variables from said datum.
  * If you really want to optimize things, optimize this, cuz this gets called a lot.
  */
-#define CAN_STEP(cur_turf, next) (next && !next.density && cur_turf.Adjacent(next) && !(simulated_only && SSpathfinder.space_type_cache[next.type]) && !cur_turf.LinkBlockedWithAccess(next,caller, id) && (next != avoid))
+#define CAN_STEP(cur_turf, next) (next && !next.density && !(simulated_only && SSpathfinder.space_type_cache[next.type]) && !cur_turf.LinkBlockedWithAccess(next,caller, id) && (next != avoid))
 /// Another helper macro for JPS, for telling when a node has forced neighbors that need expanding
 #define STEP_NOT_HERE_BUT_THERE(cur_turf, dirA, dirB) ((!CAN_STEP(cur_turf, get_step(cur_turf, dirA)) && CAN_STEP(cur_turf, get_step(cur_turf, dirB))))
 
@@ -352,6 +352,11 @@
 
 	var/actual_dir = get_dir(src, destination_turf)
 
+	// Source border object checks
+	for(var/obj/structure/window/iter_window in src)
+		if(!iter_window.CanAStarPass(ID, actual_dir))
+			return TRUE
+
 	for(var/obj/structure/window/iter_window in src)
 		if(!iter_window.CanAStarPass(ID, actual_dir))
 			return TRUE
@@ -364,6 +369,11 @@
 		if(!iter_rail.CanAStarPass(ID, actual_dir))
 			return TRUE
 
+	for(var/obj/machinery/door/firedoor/border_only/firedoor in src)
+		if(!firedoor.CanAStarPass(ID, actual_dir))
+			return TRUE
+
+	// Destination blockers check
 	var/reverse_dir = get_dir(destination_turf, src)
 	for(var/obj/iter_object in destination_turf)
 		if(!iter_object.CanAStarPass(ID, reverse_dir, caller))

--- a/code/__HELPERS/path.dm
+++ b/code/__HELPERS/path.dm
@@ -338,6 +338,18 @@
  * * simulated_only: Do we only worry about turfs with simulated atmos, most notably things that aren't space?
 */
 /turf/proc/LinkBlockedWithAccess(turf/destination_turf, caller, ID)
+	if(destination_turf.x != x && destination_turf.y != y) //diagonal
+		var/in_dir = get_dir(destination_turf,src) // eg. northwest (1+8) = 9 (00001001)
+		var/first_step_direction_a = in_dir & 3      // eg. north   (1+8)&3 (0000 0011) = 1 (0000 0001)
+		var/first_step_direction_b = in_dir & 12  // eg. west   (1+8)&12 (0000 1100) = 8 (0000 1000)
+
+		for(var/first_step_direction in list(first_step_direction_a,first_step_direction_b))
+			var/turf/midstep_turf = get_step(destination_turf,first_step_direction)
+			var/way_blocked = LinkBlockedWithAccess(midstep_turf,caller,ID) || midstep_turf.LinkBlockedWithAccess(destination_turf,caller,ID)
+			if(!way_blocked)
+				return FALSE
+		return TRUE
+
 	var/actual_dir = get_dir(src, destination_turf)
 
 	for(var/obj/structure/window/iter_window in src)

--- a/code/__HELPERS/path.dm
+++ b/code/__HELPERS/path.dm
@@ -357,10 +357,6 @@
 		if(!iter_window.CanAStarPass(ID, actual_dir))
 			return TRUE
 
-	for(var/obj/structure/window/iter_window in src)
-		if(!iter_window.CanAStarPass(ID, actual_dir))
-			return TRUE
-
 	for(var/obj/machinery/door/window/iter_windoor in src)
 		if(!iter_windoor.CanAStarPass(ID, actual_dir))
 			return TRUE

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -577,6 +577,9 @@
 	if(!(border_dir == dir)) //Make sure looking at appropriate border
 		return TRUE
 
+/obj/machinery/door/firedoor/border_only/CanAStarPass(obj/item/card/id/ID, to_dir)
+	return !density || (dir != to_dir)
+
 /obj/machinery/door/firedoor/border_only/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 	if(leaving.movement_type & PHASING)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -316,7 +316,7 @@
 			call_mode()
 			return FALSE
 		if(BOT_SUMMON) //Called to a location
-			bot_summon()
+			summon_step()
 			return FALSE
 	return TRUE //Successful completion. Used to prevent child process() continuing if this one is ended early.
 
@@ -783,8 +783,6 @@ Pass a positive integer as an argument to override a bot's default speed.
 			mode = BOT_SUMMON
 			speak("Responding.", radio_channel)
 
-			calc_summon_path()
-
 		if("ejectpai")
 			ejectpairemote(user)
 	return
@@ -810,9 +808,6 @@ Pass a positive integer as an argument to override a bot's default speed.
 			return
 		else
 			to_chat(src, span_warning("Unidentified control sequence received:[command]"))
-
-/mob/living/simple_animal/bot/proc/bot_summon() // summoned to PDA
-	summon_step()
 
 // calculates a path to the current destination
 // given an optional turf to avoid


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4047233/159989100-0785c2b4-b83b-4336-a03e-2dcf5866ee3a.png)

In short, it was checking diagonal passability directly instead of every partial-step.
Now this obviously makes this pricier.
Partially alleviates the secbot pathing doomstack stacks since they will now properly fail to path but i still need to find the breakpoint where the image churn causes the actual client crash.
Also removes redundant path calculation in bot code that would be overwritten on step anyway.