### PR TITLE
Switches the GasmixParser component reaction list to be block

### DIFF
--- a/tgui/packages/tgui/interfaces/common/GasmixParser.tsx
+++ b/tgui/packages/tgui/interfaces/common/GasmixParser.tsx
@@ -110,7 +110,7 @@ export const GasmixParser = (props: GasmixParserProps, context) => {
                     onClick={() => reactionOnClick(reaction[0])}
                   />
                 </Box>
-              ) : (reaction[1])
+              ) : (<p>reaction[1]</p>)
             )
             : 'No reactions detected'}
         </LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/common/GasmixParser.tsx
+++ b/tgui/packages/tgui/interfaces/common/GasmixParser.tsx
@@ -110,7 +110,7 @@ export const GasmixParser = (props: GasmixParserProps, context) => {
                     onClick={() => reactionOnClick(reaction[0])}
                   />
                 </Box>
-              ) : (<p>reaction[1]</p>)
+              ) : (<p>{reaction[1]}</p>)
             )
             : 'No reactions detected'}
         </LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/common/GasmixParser.tsx
+++ b/tgui/packages/tgui/interfaces/common/GasmixParser.tsx
@@ -110,7 +110,7 @@ export const GasmixParser = (props: GasmixParserProps, context) => {
                     onClick={() => reactionOnClick(reaction[0])}
                   />
                 </Box>
-              ) : (<p>{reaction[1]}</p>)
+              ) : (<div>{reaction[1]}</div>)
             )
             : 'No reactions detected'}
         </LabeledList.Item>


### PR DESCRIPTION
## About The Pull Request
Woops, my bad here. Might need a no gbp tag.
Noticed this when observing earlier.

Have I tested this? Nope. Will do later, I have 24h anyway.

## Why It's Good For The Game
Looks better (probably)

## Changelog
:cl:
spellcheck: made the reaction list on a few machines' ui (compressor, atmos control) to be newlined.
/:cl: