### PR TITLE
Halon formation balance.

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -186,11 +186,11 @@
 
 // Halon:
 /// The minimum temperature required for halon to form from tritium and BZ.
-#define HALON_FORMATION_MIN_TEMPERATURE 30
+#define HALON_FORMATION_MIN_TEMPERATURE 9
 /// The maximum temperature required for halon to form from tritium and BZ.
 #define HALON_FORMATION_MAX_TEMPERATURE 55
 /// The amount of energy 4.25 moles of halon forming from tritium and BZ releases.
-#define HALON_FORMATION_ENERGY 300
+#define HALON_FORMATION_ENERGY 30000
 
 /// How much energy a mole of halon combusting consumes.
 #define HALON_COMBUSTION_ENERGY 2500

--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -186,7 +186,7 @@
 
 // Halon:
 /// The minimum temperature required for halon to form from tritium and BZ.
-#define HALON_FORMATION_MIN_TEMPERATURE 9
+#define HALON_FORMATION_MIN_TEMPERATURE 15
 /// The maximum temperature required for halon to form from tritium and BZ.
 #define HALON_FORMATION_MAX_TEMPERATURE 55
 /// The amount of energy 4.25 moles of halon forming from tritium and BZ releases.

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -782,7 +782,7 @@
 /datum/gas_reaction/halon_formation/react(datum/gas_mixture/air, datum/holder)
 	var/list/cached_gases = air.gases
 	var/temperature = air.temperature
-	var/heat_efficency = min(temperature * 0.01, cached_gases[/datum/gas/tritium][MOLES] * INVERSE(4), cached_gases[/datum/gas/bz][MOLES] * INVERSE(0.25))
+	var/heat_efficency = min(1 / (1 + temperature) * cached_gases[/datum/gas/bz][MOLES] * INVERSE(0.25), cached_gases[/datum/gas/tritium][MOLES] * INVERSE(4), cached_gases[/datum/gas/bz][MOLES] * INVERSE(0.25))
 	if (heat_efficency <= 0 || (cached_gases[/datum/gas/tritium][MOLES] - heat_efficency * 4 < 0 ) || (cached_gases[/datum/gas/bz][MOLES] - heat_efficency * 0.25 < 0)) //Shouldn't produce gas from nothing.
 		return NO_REACTION
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes halon formation reaction to be easier and faster to produce.

Reduces the minimum temperature to 15K. Changes reaction to be more efficient at lower temperatures and higher bz content.

Increases thermal energy released from the reaction to 30,000 from 300. This is a significantly higher value, but the product from the reaction has a significantly higher heat capacity than the consumed gases, which would quickly lower the temperature. It will now converge to slightly over 40K instead of plummeting down.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Halon is rarely used for fighting plasmafires, which is sad. These changes should make it take less time to create the gas, which will allow for more opportunity for it to be used.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Reduces minimum temperature for halon formation from 30K to 15K.
balance: Halon formation's efficiency increases at lower temperatures and higher bz content.
balance: Increases halon formation's thermal energy release to 30,000J per 4.25 moles formed from 300J per 4.25 moles formed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
