### PR TITLE
TGUI & Tooltip browser windows now properly support DPI scaling

### DIFF
--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -216,8 +216,13 @@
 
 				$wrap.width($wrap.width() + 2); //Dumb hack to fix a bizarre sizing bug
 
-				var docWidth	= $wrap.outerWidth(),
-					docHeight	= $wrap.outerHeight();
+				var pixelRatio = 1;
+				if (window.devicePixelRatio) {
+					pixelRatio = window.devicePixelRatio;
+				}
+
+				var docWidth	= Math.floor($wrap.outerWidth() * pixelRatio),
+					docHeight	= Math.floor($wrap.outerHeight() * pixelRatio);
 
 				if (posY + docHeight > map.size.y) { //Is the bottom edge below the window? Snap it up if so
 					posY = (posY - docHeight) - realIconSizeY - tooltip.padding;

--- a/tgui/packages/tgui/components/ByondUi.js
+++ b/tgui/packages/tgui/components/ByondUi.js
@@ -54,18 +54,19 @@ window.addEventListener('beforeunload', () => {
 });
 
 /**
- * Get the bounding box of the DOM element.
+ * Get the bounding box of the DOM element in display-pixels.
  */
 const getBoundingBox = element => {
+  const pixelRatio = window.devicePixelRatio ?? 1;
   const rect = element.getBoundingClientRect();
   return {
     pos: [
-      rect.left,
-      rect.top,
+      rect.left * pixelRatio,
+      rect.top * pixelRatio,
     ],
     size: [
-      rect.right - rect.left,
-      rect.bottom - rect.top,
+      (rect.right - rect.left) * pixelRatio,
+      (rect.bottom - rect.top) * pixelRatio,
     ],
   };
 };

--- a/tgui/packages/tgui/drag.js
+++ b/tgui/packages/tgui/drag.js
@@ -5,10 +5,11 @@
  */
 
 import { storage } from 'common/storage';
-import { vecAdd, vecInverse, vecMultiply, vecScale } from 'common/vector';
+import { vecAdd, vecSubtract, vecMultiply, vecScale } from 'common/vector';
 import { createLogger } from './logging';
 
 const logger = createLogger('drag');
+const pixelRatio = window.devicePixelRatio ?? 1;
 
 let windowKey = window.__windowId__;
 let dragging = false;
@@ -24,37 +25,37 @@ export const setWindowKey = key => {
   windowKey = key;
 };
 
-export const getWindowPosition = () => [
-  window.screenLeft,
-  window.screenTop,
+const getWindowPosition = () => [
+  window.screenLeft * pixelRatio,
+  window.screenTop * pixelRatio,
 ];
 
-export const getWindowSize = () => [
-  window.innerWidth,
-  window.innerHeight,
+const getWindowSize = () => [
+  window.innerWidth * pixelRatio,
+  window.innerHeight * pixelRatio,
 ];
 
-export const setWindowPosition = vec => {
+const setWindowPosition = vec => {
   const byondPos = vecAdd(vec, screenOffset);
   return Byond.winset(window.__windowId__, {
     pos: byondPos[0] + ',' + byondPos[1],
   });
 };
 
-export const setWindowSize = vec => {
+const setWindowSize = vec => {
   return Byond.winset(window.__windowId__, {
     size: vec[0] + 'x' + vec[1],
   });
 };
 
-export const getScreenPosition = () => [
+const getScreenPosition = () => [
   0 - screenOffset[0],
   0 - screenOffset[1],
 ];
 
-export const getScreenSize = () => [
-  window.screen.availWidth,
-  window.screen.availHeight,
+const getScreenSize = () => [
+  window.screen.availWidth * pixelRatio,
+  window.screen.availHeight * pixelRatio,
 ];
 
 /**
@@ -83,7 +84,7 @@ const touchRecents = (recents, touchedItem, limit = 50) => {
   return [nextRecents, trimmedItem];
 };
 
-export const storeWindowGeometry = async () => {
+const storeWindowGeometry = async () => {
   logger.log('storing geometry');
   const geometry = {
     pos: getWindowPosition(),
@@ -106,17 +107,22 @@ export const recallWindowGeometry = async (options = {}) => {
   if (geometry) {
     logger.log('recalled geometry:', geometry);
   }
+  // options.pos is assumed to already be in display-pixels
   let pos = geometry?.pos || options.pos;
   let size = options.size;
+  // Convert size from css-pixels to display-pixels
+  if (size) {
+    size = [
+      size[0] * pixelRatio,
+      size[1] * pixelRatio,
+    ];
+  }
   // Wait until screen offset gets resolved
   await screenOffsetPromise;
-  const areaAvailable = [
-    window.screen.availWidth,
-    window.screen.availHeight,
-  ];
+  const areaAvailable = getScreenSize();
   // Set window size
   if (size) {
-    // Constraint size to not exceed available screen area.
+    // Constraint size to not exceed available screen area
     size = [
       Math.min(areaAvailable[0], size[0]),
       Math.min(areaAvailable[1], size[1]),
@@ -143,10 +149,12 @@ export const recallWindowGeometry = async (options = {}) => {
 
 export const setupDrag = async () => {
   // Calculate screen offset caused by the windows taskbar
+  let windowPosition = getWindowPosition();
+
   screenOffsetPromise = Byond.winget(window.__windowId__, 'pos')
     .then(pos => [
-      pos.x - window.screenLeft,
-      pos.y - window.screenTop,
+      pos.x - windowPosition[0],
+      pos.y - windowPosition[1],
     ]);
   screenOffset = await screenOffsetPromise;
   logger.debug('screen offset', screenOffset);
@@ -179,10 +187,10 @@ const constraintPosition = (pos, size) => {
 export const dragStartHandler = event => {
   logger.log('drag start');
   dragging = true;
-  dragPointOffset = [
-    window.screenLeft - event.screenX,
-    window.screenTop - event.screenY,
-  ];
+  let windowPosition = getWindowPosition();
+  dragPointOffset = vecSubtract(
+    [event.screenX, event.screenY],
+    getWindowPosition());
   // Focus click target
   event.target?.focus();
   document.addEventListener('mousemove', dragMoveHandler);
@@ -204,7 +212,7 @@ const dragMoveHandler = event => {
     return;
   }
   event.preventDefault();
-  setWindowPosition(vecAdd(
+  setWindowPosition(vecSubtract(
     [event.screenX, event.screenY],
     dragPointOffset));
 };
@@ -213,14 +221,10 @@ export const resizeStartHandler = (x, y) => event => {
   resizeMatrix = [x, y];
   logger.log('resize start', resizeMatrix);
   resizing = true;
-  dragPointOffset = [
-    window.screenLeft - event.screenX,
-    window.screenTop - event.screenY,
-  ];
-  initialSize = [
-    window.innerWidth,
-    window.innerHeight,
-  ];
+  dragPointOffset = vecSubtract(
+    [event.screenX, event.screenY],
+    getWindowPosition());
+  initialSize = getWindowSize();
   // Focus click target
   event.target?.focus();
   document.addEventListener('mousemove', resizeMoveHandler);
@@ -242,13 +246,19 @@ const resizeMoveHandler = event => {
     return;
   }
   event.preventDefault();
-  size = vecAdd(initialSize, vecMultiply(resizeMatrix, vecAdd(
+  const currentOffset = vecSubtract(
     [event.screenX, event.screenY],
-    vecInverse([window.screenLeft, window.screenTop]),
-    dragPointOffset,
-    [1, 1])));
+    getWindowPosition());
+  const delta = vecSubtract(
+    currentOffset,
+    dragPointOffset);
+  // Extra 1x1 area is added to ensure the browser can see the cursor
+  size = vecAdd(
+    initialSize,
+    vecMultiply(resizeMatrix, delta),
+    [1, 1]);
   // Sane window size values
-  size[0] = Math.max(size[0], 150);
-  size[1] = Math.max(size[1], 50);
+  size[0] = Math.max(size[0], 150 * pixelRatio);
+  size[1] = Math.max(size[1], 50 * pixelRatio);
   setWindowSize(size);
 };


### PR DESCRIPTION
## About The Pull Request
### This change does not enable DPI scaling in byond! That's a [separate thing](https://gist.github.com/willox/aa9e2af03a862d902dc464dbcb776d45), please let me have this!
People who are using Chromium through black magick or who have manually enabled DPI scaling for IWebBrowser2 in BYOND by modifying the registry currently suffer from the following:
- TGUI resizing & dragging is broken
- TGUI windows default to being too small (content cut off)
- Tooltips are too small (content cut off)

This makes that all work.

## Why It's Good For The Game
I just wanna be able to play on my monitor without squinting

tgstation at 4k without dpi aware browser:
![image](https://user-images.githubusercontent.com/1499676/160160590-64b2068d-236f-4669-97b6-d78c20afa962.png)

tgstation at 4k with dpi aware browser:
![image](https://user-images.githubusercontent.com/1499676/160160645-6e635c13-3e5a-4c09-86a1-bf786afd8498.png)

## Changelog
:cl:
fix: TGUI and Tooltip windows now work with high-dpi web browsers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
