### PR TITLE
Adds two buttons to the admin traitor panel

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -482,12 +482,20 @@
 
 	if(href_list["add_antag"])
 		add_antag_wrapper(text2path(href_list["add_antag"]),usr)
+
 	if(href_list["remove_antag"])
 		var/datum/antagonist/A = locate(href_list["remove_antag"]) in antag_datums
 		if(!istype(A))
 			to_chat(usr,span_warning("Invalid antagonist ref to be removed."))
 			return
 		A.admin_remove(usr)
+
+	if(href_list["open_antag_vv"])
+		var/datum/antagonist/to_vv = locate(href_list["open_antag_vv"]) in antag_datums
+		if(!istype(to_vv))
+			to_chat(usr, span_warning("Invalid antagonist ref to be vv'd."))
+			return
+		usr.client?.debug_variables(to_vv)
 
 	if (href_list["role_edit"])
 		var/new_role = input("Select new role", "Assigned role", assigned_role.title) as null|anything in sort_list(SSjob.name_occupations)
@@ -597,6 +605,15 @@
 			return
 		objective.completed = !objective.completed
 		log_admin("[key_name(usr)] toggled the win state for [current]'s objective: [objective.explanation_text]")
+
+
+	else if(href_list["is_obj_completed"])
+		var/datum/objective/objective = locate(href_list["is_obj_completed"]) in get_all_objectives()
+		if(!objective)
+			to_chat(usr, "Invalid objective.")
+			return
+
+		to_chat(usr, span_boldnotice("[current]'s objective, [objective], is currently [objective.check_completion() ? "completed":"not completed"]."))
 
 	else if (href_list["silicon"])
 		switch(href_list["silicon"])

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -605,15 +605,7 @@
 			return
 		objective.completed = !objective.completed
 		log_admin("[key_name(usr)] toggled the win state for [current]'s objective: [objective.explanation_text]")
-
-
-	else if(href_list["is_obj_completed"])
-		var/datum/objective/objective = locate(href_list["is_obj_completed"]) in get_all_objectives()
-		if(!objective)
-			to_chat(usr, "Invalid objective.")
-			return
-
-		to_chat(usr, span_boldnotice("[current]'s objective, [objective], is currently [objective.check_completion() ? "completed":"not completed"]."))
+		to_chat(usr, "You have toggled the win state for [current]'s objective, \"[objective]\". Note that not all objectives will take this into account.")
 
 	else if (href_list["silicon"])
 		switch(href_list["silicon"])

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -605,7 +605,6 @@
 			return
 		objective.completed = !objective.completed
 		log_admin("[key_name(usr)] toggled the win state for [current]'s objective: [objective.explanation_text]")
-		to_chat(usr, "You have toggled the win state for [current]'s objective, \"[objective]\". Note that not all objectives will take this into account.")
 
 	else if (href_list["silicon"])
 		switch(href_list["silicon"])

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -49,8 +49,7 @@ GLOBAL_VAR(antag_prototypes)
 			result += "<B>[obj_count]</B>: [objective.explanation_text] \
 				<a href='?src=[REF(owner)];obj_edit=[REF(objective)]'>Edit</a> \
 				<a href='?src=[REF(owner)];obj_delete=[REF(objective)]'>Delete</a> \
-				<a href='?src=[REF(owner)];obj_completed=[REF(objective)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Mark as incomplete" : "Mark as complete"]</font></a> \
-				<a href='?src=[REF(owner)];is_obj_completed=[REF(objective)]'>Check Completion</a> \
+				<a href='?src=[REF(owner)];obj_completed=[REF(objective)]'><font color=[objective.check_completion() ? "green" : "red"]>[objective.completed ? "Mark as incomplete" : "Mark as complete"]</font></a> \
 				<br>"
 			obj_count++
 	result += "<a href='?src=[REF(owner)];obj_add=1;target_antag=[REF(src)]'>Add objective</a><br>"

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -46,7 +46,12 @@ GLOBAL_VAR(antag_prototypes)
 	else
 		var/obj_count = 1
 		for(var/datum/objective/objective as anything in objectives)
-			result += "<B>[obj_count]</B>: [objective.explanation_text] <a href='?src=[REF(owner)];obj_edit=[REF(objective)]'>Edit</a> <a href='?src=[REF(owner)];obj_delete=[REF(objective)]'>Delete</a> <a href='?src=[REF(owner)];obj_completed=[REF(objective)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Mark as incomplete" : "Mark as complete"]</font></a><br>"
+			result += "<B>[obj_count]</B>: [objective.explanation_text] \
+				<a href='?src=[REF(owner)];obj_edit=[REF(objective)]'>Edit</a> \
+				<a href='?src=[REF(owner)];obj_delete=[REF(objective)]'>Delete</a> \
+				<a href='?src=[REF(owner)];obj_completed=[REF(objective)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Mark as incomplete" : "Mark as complete"]</font></a> \
+				<a href='?src=[REF(owner)];is_obj_completed=[REF(objective)]'>Check completion</a> \
+				<br>"
 			obj_count++
 	result += "<a href='?src=[REF(owner)];obj_add=1;target_antag=[REF(src)]'>Add objective</a><br>"
 	result += "<a href='?src=[REF(owner)];obj_announce=1'>Announce objectives</a><br>"
@@ -148,6 +153,7 @@ GLOBAL_VAR(antag_prototypes)
 			priority_sections |= antag_category
 			antag_header_parts += "<span class='bad'>[current_antag.name]</span>"
 			antag_header_parts += "<a href='?src=[REF(src)];remove_antag=[REF(current_antag)]'>Remove</a>"
+			antag_header_parts += "<a href='?src=[REF(src)];open_antag_vv=[REF(current_antag)]'>Open VV</a>"
 
 
 		//We aren't antag of this category, grab first prototype to check the prefs (This is pretty vague but really not sure how else to do this)

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -50,7 +50,7 @@ GLOBAL_VAR(antag_prototypes)
 				<a href='?src=[REF(owner)];obj_edit=[REF(objective)]'>Edit</a> \
 				<a href='?src=[REF(owner)];obj_delete=[REF(objective)]'>Delete</a> \
 				<a href='?src=[REF(owner)];obj_completed=[REF(objective)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Mark as incomplete" : "Mark as complete"]</font></a> \
-				<a href='?src=[REF(owner)];is_obj_completed=[REF(objective)]'>Check completion</a> \
+				<a href='?src=[REF(owner)];is_obj_completed=[REF(objective)]'>Check Completion</a> \
 				<br>"
 			obj_count++
 	result += "<a href='?src=[REF(owner)];obj_add=1;target_antag=[REF(src)]'>Add objective</a><br>"


### PR DESCRIPTION
## About The Pull Request

- Adds "Open VV" to the admin traitor panel, which opens that antagonist's VV panel.
- The "Mark as in/complete" button in the traitor panel now updates color based on whether the objective is completed, instead of whether an admin has marked it to be complete. 
  - In most cases, it'll end up looking the same / similar as it does currently.
  - If the objective is complete without admin intervention, it'll also show up as green
  - Some objectives disregard the admin completion value, in which case it will not change color, only text

## Why It's Good For The Game

- More complex antags, like lings or heretics, often require that admins view the datum's variables to debug, This makes it easier / faster to locate them. 
- People will often ask if their objective is complete or not, and heretics straight up require complete objectives. This makes it easier for admins to see which are complete or not by the code's standards. 

## Changelog

:cl: Melbert
admin: Adds "Open VV" to traitor panel antags, which opens that antag's vv panel.
admin: "Mark as in/completed" by objectives in the traitor panel now changes color based on whether the objective is determined to be "complete", instead of whether an admin has marked it to be complete. For some objectives, it might not update color (only text) when an admin marks it as completed - this means the objective disregards whether an admin has marked it as complete. 
/:cl:

