### PR TITLE
Fixes petri dishes not changing sprites after being washed

### DIFF
--- a/code/modules/research/xenobiology/vatgrowing/petri_dish.dm
+++ b/code/modules/research/xenobiology/vatgrowing/petri_dish.dm
@@ -12,6 +12,17 @@
 	. = ..()
 	QDEL_NULL(sample)
 
+/obj/item/petri_dish/handle_atom_del(atom/deleting_atom)
+	if(deleting_atom == sample)
+		sample = null
+		update_appearance()
+	return ..()
+
+/obj/item/petri_dish/vv_edit_var(vname, vval)
+	. = ..()
+	if(vname == NAMEOF(src, sample))
+		update_appearance()
+
 /obj/item/petri_dish/examine(mob/user)
 	. = ..()
 	if(!sample)
@@ -27,7 +38,6 @@
 		return FALSE
 	to_chat(user, span_notice("You wash the sample out of [src]."))
 	QDEL_NULL(sample)
-	update_appearance()
 
 /obj/item/petri_dish/update_overlays()
 	. = ..()

--- a/code/modules/research/xenobiology/vatgrowing/petri_dish.dm
+++ b/code/modules/research/xenobiology/vatgrowing/petri_dish.dm
@@ -12,12 +12,6 @@
 	. = ..()
 	QDEL_NULL(sample)
 
-/obj/item/petri_dish/handle_atom_del(atom/deleting_atom)
-	if(deleting_atom == sample)
-		sample = null
-		update_appearance()
-	return ..()
-
 /obj/item/petri_dish/vv_edit_var(vname, vval)
 	. = ..()
 	if(vname == NAMEOF(src, sample))
@@ -38,6 +32,7 @@
 		return FALSE
 	to_chat(user, span_notice("You wash the sample out of [src]."))
 	QDEL_NULL(sample)
+	update_appearance()
 
 /obj/item/petri_dish/update_overlays()
 	. = ..()

--- a/code/modules/research/xenobiology/vatgrowing/petri_dish.dm
+++ b/code/modules/research/xenobiology/vatgrowing/petri_dish.dm
@@ -26,7 +26,8 @@
 	if(!sample || !istype(A, /obj/structure/sink))
 		return FALSE
 	to_chat(user, span_notice("You wash the sample out of [src]."))
-	sample = null
+	QDEL_NULL(sample)
+	update_appearance()
 
 /obj/item/petri_dish/update_overlays()
 	. = ..()

--- a/code/modules/research/xenobiology/vatgrowing/petri_dish.dm
+++ b/code/modules/research/xenobiology/vatgrowing/petri_dish.dm
@@ -31,7 +31,7 @@
 	if(!sample || !istype(A, /obj/structure/sink))
 		return FALSE
 	to_chat(user, span_notice("You wash the sample out of [src]."))
-	QDEL_NULL(sample)
+	sample = null
 	update_appearance()
 
 /obj/item/petri_dish/update_overlays()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #65603.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Petri dish cultures no longer stay behind on the sprite like some sort of ghost after being washed out of it. Cells don't have souls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
