### PR TITLE
Stacks of 50 bamboo sheets

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -350,6 +350,9 @@ GLOBAL_LIST_INIT(bamboo_recipes, list ( \
 /obj/item/stack/sheet/mineral/bamboo/get_main_recipes()
 	. = ..()
 	. += GLOB.bamboo_recipes
+	
+/obj/item/stack/sheet/mineral/bamboo/fifty
+	amount = 50
 
 /*
  * Cloth


### PR DESCRIPTION
## About The Pull Request
Adds a 50 stack variant of bamboo

## Why It's Good For The Game

Consistency, all the other ones had a 50 stack, makes it less annoying to spawn.

## Changelog

:cl:
qol: Added a 50 count bamboo stack to base stack types
/:cl:
