### PR TITLE
re-adds the assistant traitor toolbox

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -111,8 +111,8 @@
 
 /obj/item/storage/toolbox/mechanical/old/clean/proc/calc_damage()
 	var/power = 0
-	for (var/obj/item/stack/telecrystal/TC in get_all_contents())
-		power += TC.amount
+	for (var/obj/item/stack/telecrystal/stored_crystals in get_all_contents())
+		power += (stored_crystals.amount / 2)
 	force = 19 + power
 	throwforce = 22 + power
 

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -43,6 +43,14 @@
 	restricted_roles = list(JOB_ASSISTANT)
 	surplus = 0
 
+/datum/uplink_item/role_restricted/oldtoolboxclean
+	name = "Ancient Toolbox"
+	desc = "An iconic toolbox design notorious with Assistants everywhere, this design was especially made to become more robust the more telecrystals it has inside it! Tools and insulated gloves included."
+	item = /obj/item/storage/toolbox/mechanical/old/clean
+	cost = 2
+	restricted_roles = list(JOB_ASSISTANT)
+	surplus = 0
+
 // Low progression cost
 
 /datum/uplink_item/role_restricted/clownpin


### PR DESCRIPTION
## About The Pull Request

Removed in https://github.com/tgstation/tgstation/pull/63588
![image](https://user-images.githubusercontent.com/53777086/160232666-33873485-6e60-467a-b3bd-8efd38d5a13e.png)

Not sure if its removal was intentional, so I'm gonna give it a shot and try to re-add it.

## Why It's Good For The Game

It's a cool traitor item and, although I dislike encouraging people to play Assistant, I still like seeing this item in game.
We also don't know if this removal was intentional or not, so I'm restoring previous features that might've been accidentally removed.

## Changelog

:cl:
fix: Assistant Traitors can now purchase the Ancient Toolbox again.
/:cl: