### PR TITLE
Some rebalances to the scipaper experiments and partners. Fixed the access bug.

### DIFF
--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -98,7 +98,7 @@
 	name = "Reactionless Explosives"
 	description = "Gases with high specific heat can heat up those with a low one and produce a lot of pressure. Perform research and publish papers on this field. No gas reactions are allowed."
 	gain = list(10,50,100)
-	target_amount = list(20,75,200)
+	target_amount = list(20,50,100)
 	experiment_proper = TRUE
 	sanitized_misc = FALSE
 	sanitized_reactions = TRUE

--- a/code/modules/research/ordnance/scipaper_partner.dm
+++ b/code/modules/research/ordnance/scipaper_partner.dm
@@ -62,7 +62,7 @@
 	accepted_experiments=list(
 		/datum/experiment/ordnance/gaseous/noblium,
 		/datum/experiment/ordnance/explosive/nobliumbomb,
-		/datum/experiment/ordnance/explosive/halon,
+		/datum/experiment/ordnance/gaseous/halon,
 	)
 	boosted_nodes=list(
 		"engineering" = 5000,

--- a/code/modules/research/ordnance/scipaper_partner.dm
+++ b/code/modules/research/ordnance/scipaper_partner.dm
@@ -34,6 +34,10 @@
 		"weaponry" = 2500,
 		"sec_basic" = 1250, 
 		"explosive_weapons" = 1250,
+		"electronic_weapons" = 1250,
+		"radioactive_weapons" = 1250,
+		"beam_weapons" = 1250,
+		"explosive_weapons" = 1250,
 	)
 
 /datum/scientific_partner/medical

--- a/code/modules/research/ordnance/scipaper_partner.dm
+++ b/code/modules/research/ordnance/scipaper_partner.dm
@@ -1,47 +1,71 @@
-/datum/scientific_partner/spinward_science
-	name="Spinward Science"
-	flufftext="A local scientific community started by the diverse inhabitants of the Spinward Sector. Not generally advanced, but they will gladly work with us."
-	multipliers=list(SCIPAPER_COOPERATION_INDEX = 1, SCIPAPER_FUNDING_INDEX=0.75)
-	boosted_nodes=list("emp_basic" = 500, "NVGtech" = 1500, "integrated_HUDs" = 500)
+/datum/scientific_partner/mining
+	name="Mining Corps"
+	flufftext="A local group of miners are looking for ways to improve their mining output. They are interested in smaller scale explosives."
+	accepted_experiments = list(/datum/experiment/ordnance/explosive/lowyieldbomb)
+	multipliers=list(SCIPAPER_COOPERATION_INDEX = 0.75, SCIPAPER_FUNDING_INDEX=0.75)
+	boosted_nodes=list(
+		"bluespace_basic" = 2000,
+		"NVGtech" = 1500,
+		"practical_bluespace" = 2500,
+		"basic_plasma" = 2000,
+		"basic_mining" = 2000,
+		"adv_mining" = 2000,
+	)
 
 /datum/scientific_partner/baron
 	name = "Ghost Writing"
 	flufftext="A nearby research station ran by a very wealthy captain seems to be struggling with their scientific output. They might reward us handsomely if we ghostwrite for them."
 	multipliers = list(SCIPAPER_COOPERATION_INDEX = 0.25, SCIPAPER_FUNDING_INDEX=5)
-	boosted_nodes = list("comp_recordkeeping" = 500, "computer_hardware_basic"=500)
+	boosted_nodes = list(
+		"comp_recordkeeping" = 500, 
+		"computer_hardware_basic" = 500,
+	)
 
 /datum/scientific_partner/defense
 	name="Defense Partnership"
 	flufftext="We can work directly for Nanotrasen's \[REDACTED\] division, potentially providing us access with advanced defensive gadgets."
-	accepted_experiments=list(/datum/experiment/ordnance/explosive/lowyieldbomb, /datum/experiment/ordnance/explosive/highyieldbomb, /datum/experiment/ordnance/explosive/pressurebomb)
-	boosted_nodes = list("adv_weaponry" = 5000, "weaponry" = 2500, "sec_basic" = 1250, "explosive_weapons"=1250)
-
-/datum/scientific_partner/energy
-	name="High-Energy Research"
-	flufftext="A recently established high-energy research concern started by Nanotrasen. They might be able to assist our energy-based research."
-	accepted_experiments=list(/datum/experiment/ordnance/explosive/hydrogenbomb, /datum/experiment/ordnance/explosive/nobliumbomb)
-	boosted_nodes = list("adv_beam_weapons" = 1250, "beam_weapons" = 1250, "electronic_weapons"=1250, "mech_laser"=1250, "mech_laser_heavy"=1250)
-
-/datum/scientific_partner/engineering
-	name="Corps of Engineers"
-	flufftext = "Many engineers are interested in the application of exotic gases in their day-to-day work. They might be able to offer us information on some their gadgets in return."
-	accepted_experiments=list(/datum/experiment/ordnance/gaseous/halon, /datum/experiment/ordnance/gaseous/noblium, /datum/experiment/ordnance/explosive/lowyieldbomb)
-	boosted_nodes=list(/datum/techweb_node/adv_engi=2500, /datum/techweb_node/adv_power=1500, /datum/techweb_node/bluespace_power=2000, /datum/techweb_node/high_efficiency=2500, /datum/techweb_node/micro_bluespace=2500)
+	accepted_experiments=list(
+		/datum/experiment/ordnance/explosive/highyieldbomb, 
+		/datum/experiment/ordnance/explosive/pressurebomb,
+		/datum/experiment/ordnance/explosive/hydrogenbomb,
+	)
+	boosted_nodes = list(
+		"adv_weaponry" = 5000, 
+		"weaponry" = 2500,
+		"sec_basic" = 1250, 
+		"explosive_weapons" = 1250,
+	)
 
 /datum/scientific_partner/medical
 	name="Biological Research Division"
-	flufftext="A collegiate of the best medical researchers Nanotrason employs. They seem to be interested in the biological effects of some more exotic gases."
-	accepted_experiments=list(/datum/experiment/ordnance/gaseous/nitrium, /datum/experiment/ordnance/gaseous/bz)
-	boosted_nodes=list("cyber_organs"=750, "cyber_organs_upgraded"=1000, "genetics"=500, "subdermal_implants"=1250, "adv_biotech"=1000)
+	flufftext="A collegiate of the best medical researchers Nanotrason employs. They seem to be interested in the biological effects of some more exotic gases. Especially stimulants and neurosupressants."
+	accepted_experiments=list(
+		/datum/experiment/ordnance/gaseous/nitrium, 
+		/datum/experiment/ordnance/gaseous/bz,
+	)
+	boosted_nodes=list(
+		"cyber_organs" = 750, 
+		"cyber_organs_upgraded" = 1000, 
+		"genetics" = 500, 
+		"subdermal_implants" = 1250, 
+		"adv_biotech" = 1000,
+		"biotech" = 1000,
+	)
 
-/datum/scientific_partner/ordnance
-	name="Ordnance Partners"
-	flufftext="There are other stations tasked with researching the more esoteric reactions. We might be able to exchange some information with them."
-	accepted_experiments=list(/datum/experiment/ordnance/explosive/pressurebomb, /datum/experiment/ordnance/explosive/nobliumbomb)
-	boosted_nodes=list("gravity_gun"=1250, "mecha_phazon"=1500, "mech_wormhole_gen"=1250, "bluespace_travel"=1000, "micro_bluespace"=3000, "basic_plasma"=1000, "adv_plasma"=1000)
-
-/datum/scientific_partner/cold_physics
-	name="Low Temperature Research"
-	flufftext="A Nanotrasen division researching matter interactions at very low temperatures. Very interested in our hyper-noblium research."
-	accepted_experiments=list(/datum/experiment/ordnance/gaseous/noblium, /datum/experiment/ordnance/explosive/nobliumbomb)
-	boosted_nodes=list("emp_super" = 3000, "emp_adv"=1250, "cryotech"=1500)
+/datum/scientific_partner/physics
+	name="NT Physics Quarterly"
+	flufftext="A prestigious physics journal managed by Nanotrasen. The main journal for publishing cutting-edge physics research conducted by Nanotrasen, given that they aren't classified."
+	accepted_experiments=list(
+		/datum/experiment/ordnance/gaseous/noblium,
+		/datum/experiment/ordnance/explosive/nobliumbomb,
+		/datum/experiment/ordnance/explosive/halon,
+	)
+	boosted_nodes=list(
+		"engineering" = 5000,
+		"adv_engi" = 5000,
+		"emp_super" = 3000, 
+		"emp_adv" = 1250,
+		"high_efficiency" = 5000,
+		"micro_bluespace" = 5000,
+		"adv_power" = 1500,
+	)

--- a/code/modules/research/ordnance/scipaper_publisher.dm
+++ b/code/modules/research/ordnance/scipaper_publisher.dm
@@ -8,7 +8,7 @@
 	program_icon_state = "research"
 	tgui_id = "NtosScipaper"
 	program_icon = "paper-plane"
-	transfer_access = ACCESS_ORDNANCE
+	transfer_access = list(ACCESS_ORDNANCE)
 
 	var/datum/techweb/linked_techweb
 	/// Unpublished, temporary paper datum.

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1156,6 +1156,7 @@
 		"cybernetic_stomach_tier2",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
+	required_experiments = list(/datum/experiment/ordnance/gaseous/bz)
 
 /datum/techweb_node/cyber_organs_upgraded
 	id = "cyber_organs_upgraded"
@@ -1170,7 +1171,6 @@
 		"cybernetic_stomach_tier3",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
-	required_experiments = list(/datum/experiment/ordnance/gaseous/bz)
 
 /datum/techweb_node/cyber_implants
 	id = "cyber_implants"
@@ -1200,7 +1200,6 @@
 		"ci-toolset",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	required_experiments = list(/datum/experiment/ordnance/gaseous/nitrium)
 
 /datum/techweb_node/combat_cyber_implants
 	id = "combat_cyber_implants"
@@ -1353,6 +1352,7 @@
 		"tele_shield",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	required_experiments = list(/datum/experiment/ordnance/explosive/pressurebomb)
 
 /datum/techweb_node/adv_weaponry
 	id = "adv_weaponry"
@@ -1363,7 +1363,6 @@
 		"pin_loyalty",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	required_experiments = list(/datum/experiment/ordnance/explosive/highyieldbomb)
 
 /datum/techweb_node/electric_weapons
 	id = "electronic_weapons"


### PR DESCRIPTION
## About The Pull Request
People complained that departments shouldn't be gated by things that are usually outside their control. I agree to some extent.

Experiment changes:
- That extent being the absolutely easy stuffs like bz shells. I really want them to stay as a required experiment, where doesn't really matter. They are the hooks that I explicitly added to make people try toxins out.
Currently moved to the even more common t2 organs, If you want to suggest a pretty common node with more intersection to atmos/xenobio than what i have right now feel free to down below. The only reason that i chose organs is bz -> nervous system -> medical -> any medical node that is common but not critical

- Axed nitrium as a required experiment entirely. I see no reason to keep them around for medbay stuffs where doctors cant even repipe cryo properly. 
I would very much prefer substituting this gas, so I might open another pr in the future locking some other node with some other gas. 
Someone suggested having freon be required but i still feel like thats quite hard. I want something harder than steal from xenobio but easier than freon. Old nitryl was great for this but alas.

- Axed highyieldbomb from weapon 2.
Added pressurebomb to weapon 1. 
Just substitute oxygen for nitrogen and your tritless maxcap recipes should mostly do fine.

- Very happy with hypernob right now. t4 is absolutely not needed every round, but seeing the number go lower on freezers is nice enough to warrant making nob every once in a while.

Some more boost changes too along the way. 
- Added a new mining partner that gives bonuses to a lot of the mining techs and accept only lowyield bombs (if you didnt catch the hint: haul gibtonite to science for discounts)
- Streamlined a lot of the partners, consolidated engi and low temp into a physics partner, with many engi related boosts.
- Removed the basic partner. They currently serve no purpose.
- Added more available nodes to purchase. Ill see if i can rework how the boost system works in the future to use sliders instead of these hardcoded numbers. A bit busy with other PRs right now.

A very common complaint i heard is that toxins cant do the experiments / needs atmos' help. This is absolutely false. You can do everything with toxins' roundstart cans. Just maybe not all in the same round but that's intended and I'm sure someone will prove me wrong. 
A holofan would make things much nicer though.

## Why It's Good For The Game
Most of my reasoning is found above, but ill resummarize them if you want a condensed version here.

- BZ: I didnt go hard enough. I want it as the hook, the tutorial/starting gas, what everyone starts doing. Which is why i moved it to a more common node.
- Nitrium: Nitrium is a pretty annoying gas to make, needs quite a lot of intermediate stuffs. Also don't feel very good about locking medbay too much with something they have zero control over. Dependency with the BZ stuff is enough i feel.
- Pressure bomb: Pressure bomb is easier to make than highyield, while weapon 1 is more important to lock than weapon 2. A reasonable tradeoff i hope.

- The boost stuffs: Added a lot of nodes there. Most of the experiments are actually implemented in the boosts. I want them to have a bigger role on the round and i feel like this is a fine way of encouraging the harder experiments. Many of the nodes listed are pretty annoying to purchase unless you do a good job which i feel should be fine. 
The numbers can always be tweaked but i feel like the nodes are going to stay in place. Maybe one or two adjacent nodes will get added.
- Mining partner: Miners dragging gibtonite over to science so they get discounts is pretty funny I think.

## Changelog
:cl:
balance: Made organ 2  tech node require bz shells as an experiment instead of organ 3.
balance: Made the advanced implant tech node not require nitrium shell.
balance: Relocked sec 1 tech node to need pressure bombs, sec 2 unlocked.
balance: Made advanced pressure bombs easier to do without funny fusion gases.
balance: Added a new mining partner that accepts smaller (even non-atmos/non-ordnance related) bombs
balance: Added more options to purchase nodes in the paper partners. Your point gain stays the same though.
fix: Fixed NT frontier being downloadable by everyone
/:cl: