### PR TITLE
fixes duplicate charlie station APCs

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -7471,15 +7471,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/delta/hall)
-"ZY" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/east{
-	start_charge = 0
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/charlie/dorms)
 
 (1,1,1) = {"
 aa
@@ -9524,7 +9515,7 @@ ht
 iZ
 jJ
 FV
-ZY
+jS
 Fv
 bN
 kE


### PR DESCRIPTION
## About The Pull Request

capsaicinz has a shiny new repo after fucking up his last one!
remvoes a duplicate APC in the charlie station dorms.

## Why It's Good For The Game

one less map fucky-wucky.

## Changelog
:cl:
fix: charlie station dorms now only has one APC, as god intended
/:cl: