### PR TITLE
[NO GBP] Fixes the zeta shuttle

### DIFF
--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -210,6 +210,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
+"Km" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape/brig)
 "Lo" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/machinery/light/directional/west,
@@ -560,7 +564,7 @@ Um
 Um
 Um
 xd
-jj
+Km
 an
 Um
 Um

--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -28,10 +28,6 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"gf" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape/brig)
 "hh" = (
 /obj/structure/table/abductor,
 /obj/item/gun/energy/alien,
@@ -47,7 +43,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating/abductor,
-/area/shuttle/escape/brig)
+/area/shuttle/escape)
 "jJ" = (
 /obj/machinery/door/airlock/abductor{
 	name = "Command Center"
@@ -55,12 +51,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"jV" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape/brig)
 "lK" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/abductor,
@@ -85,22 +75,15 @@
 	desc = "Even aliens can see the use of a good old-fashioned beating stick."
 	},
 /turf/open/floor/plating/abductor,
-/area/shuttle/escape/brig)
+/area/shuttle/escape)
 "sG" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"tb" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape/brig)
 "ue" = (
 /obj/machinery/fat_sucker,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"ui" = (
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape/brig)
 "uW" = (
 /obj/structure/chair/office,
 /obj/machinery/light/directional/east,
@@ -189,13 +172,7 @@
 /obj/item/storage/box/alienhandcuffs,
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/abductor,
-/area/shuttle/escape/brig)
-"IL" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape/brig)
+/area/shuttle/escape)
 "IM" = (
 /obj/structure/table/abductor,
 /obj/item/organ/heart/gland/access{
@@ -210,10 +187,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"Km" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape/brig)
 "Lo" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/machinery/light/directional/west,
@@ -564,7 +537,7 @@ Um
 Um
 Um
 xd
-Km
+jj
 an
 Um
 Um
@@ -672,11 +645,11 @@ nH
 nH
 nH
 qD
-ui
-gf
-jV
-jV
-jV
+Um
+lK
+Sg
+Sg
+Sg
 jj
 Um
 Um
@@ -695,11 +668,11 @@ nH
 Cv
 nH
 nH
-tb
-ui
-ui
-ui
-ui
+an
+Um
+Um
+Um
+Um
 jj
 Um
 Um
@@ -719,10 +692,10 @@ Cv
 Cv
 nH
 nH
-tb
-ui
-ui
-ui
+an
+Um
+Um
+Um
 jI
 Um
 Um
@@ -743,9 +716,9 @@ Cv
 Cv
 nH
 nH
-IL
-ui
-ui
+CT
+Um
+Um
 jj
 Um
 Um
@@ -767,7 +740,7 @@ Cv
 Cv
 nH
 nH
-IL
+CT
 HK
 jj
 CT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- After I added the brig shuttle area to the zeta shuttle in #65615, the brig ceased spawning when the shuttle was summoned (every single other brig area on the other shuttles works)
- I replaced all of the turfs with `/turf/open/floor/plating/abductor` to `/turf/open/floor/mineral/abductor` which, on spawn, saws the Zeta shuttle in half instead of removing the brig
- Placing a brig area ANYWHERE ELSE on the ship makes the brig load

This reverts the change made in the above PR where Zeta got the emergency brig area. 

I have no idea how to fix it at this point, so in the meantime I want to make it not broken for players while we work it out.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I have no idea how to fix it at this point, so in the meantime I want to make it not broken for players while we work it out.
#65711

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Zeta's emergency brig actually loads!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
