### PR TITLE
[NO GBP] Fixes zeta shuttle's brig for real this time I promise

### DIFF
--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -290,7 +290,9 @@
 	name = "Transport Ship Zeta"
 	},
 /obj/docking_port/mobile/emergency{
-	name = "Zeta emergency shuttle"
+	height = 21;
+	name = "Zeta emergency shuttle";
+	width = 21
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After many hours we finally know why Zeta's brig area was being left behind.

It was the docking port not having the right dimensions; when we were checking the shuttle to see what areas we needed to include, the brig wasn't part of the area being checked because the port's width and height values were, by default, not including them. Please set your docking ports.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #65711
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Zeta emergency shuttle's brig now travels with the rest of the shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
