### PR TITLE
Bleeding alerts now throw a balloon alert to viewers.

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -158,6 +158,7 @@
 					continue
 
 	to_chat(src, span_warning("[bleeding_severity][rate_of_change]"))
+	balloon_alert_to_viewers("continues to bleed!")
 	COOLDOWN_START(src, bleeding_message_cd, next_cooldown)
 
 /mob/living/carbon/human/bleed_warn(bleed_amt = 0, forced = FALSE)


### PR DESCRIPTION
I hate dying of bloodloss in medbay for 45 minutes because the doctors dont know why my oxygen damage is going up rapidly on the surgery table because they aren't using a health analyzer like a dumbass.

:cl:
qol: Bleeding now throws a balloon alert.
/:cl: