### PR TITLE
Bounds bounty board payout values to prevent negative values.

### DIFF
--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -432,6 +432,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			bounty_value = text2num(params["bountyval"])
 			if(!bounty_value)
 				bounty_value = 1
+			bounty_value = clamp(bounty_value, 1, 1000)
 
 		if("bountyText")
 			var/pre_bounty_text = params["bountytext"]


### PR DESCRIPTION

## About The Pull Request

This adds a clamp to the creation process for bounty boards, to prevent people from using it to create infinite funds magically through the power of bounty boards.

## Why It's Good For The Game

Fixes #65682. Prevents an old bug of something that appeared a bit late AFTER a big refactor.

## Changelog

:cl:
fix: You can no longer create money out of thin air using bounty boards.
/:cl:
