### PR TITLE
Lets telekinesis open the genetics scanner console GUI from within the scanner.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -239,7 +239,7 @@
 	return ..() + get_all_contents()
 
 /atom/proc/AllowClick()
-	return FALSE
+	return TRUE
 
 /turf/AllowClick()
 	return TRUE

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -244,8 +244,11 @@
 
 
 /proc/tkMaxRangeCheck(mob/user, atom/target)
-	var/d = get_dist(user, target)
-	if(d > TK_MAXRANGE)
+	var/turf/user_turf = get_turf(user)
+	var/turf/target_turf = get_turf(target)
+	to_chat(user, span_info("user, _turf, .z: [user], [user_turf || "NULL"], [user_turf?.z]; target, _turf, .z: [target], [target_turf || "NULL"], [target_turf?.z]"))
+	to_chat(user, span_info("too far: [get_dist(user, target) > TK_MAXRANGE]; missing turf: [!(user_turf && target_turf)]; diff z: [user_turf.z != target_turf.z]"))
+	if((get_dist(user, target) > TK_MAXRANGE) || !(user_turf && target_turf) || (user_turf.z != target_turf.z))
 		user.balloon_alert(user, "can't TK, too far!")
 		return
 	return TRUE

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -128,12 +128,15 @@ SUBSYSTEM_DEF(throwing)
 
 /datum/thrownthing/proc/tick()
 	var/atom/movable/AM = thrownthing
-	if (!isturf(AM.loc) || !AM.throwing)
+	if(!AM.throwing)
 		finalize()
 		return
-
 	if(paused)
 		delayed_time += world.time - last_move
+		return
+
+	if(!isturf(AM.loc))
+		finalize(hit = TRUE, target = AM.loc)
 		return
 
 	var/atom/movable/actual_target = initial_target?.resolve()

--- a/code/datums/mutations/telekinesis.dm
+++ b/code/datums/mutations/telekinesis.dm
@@ -35,6 +35,6 @@
 	SIGNAL_HANDLER
 	if(is_type_in_typecache(target, blacklisted_atoms))
 		return
-	if(!tkMaxRangeCheck(source, target) || source.z != target.z)
+	if(!tkMaxRangeCheck(source, target))
 		return
 	return target.attack_tk(source)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -348,7 +348,7 @@
 		return FALSE
 	visible_message(span_danger("[src] manages to [cuff_break ? "break" : "remove"] [I]!"))
 	to_chat(src, span_notice("You successfully [cuff_break ? "break" : "remove"] [I]."))
-	
+
 	if(cuff_break)
 		. = !((I == handcuffed) || (I == legcuffed))
 		qdel(I)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -154,7 +154,7 @@
 /mob/living/carbon/throw_item(atom/target)
 	. = ..()
 	throw_mode_off(THROW_MODE_TOGGLE)
-	if(!target || !isturf(loc))
+	if(!target)
 		return
 	if(istype(target, /atom/movable/screen))
 		return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -808,6 +808,10 @@
 	for(var/i in 1 to SSprojectiles.global_iterations_per_move)
 		if(QDELETED(src))
 			return
+		var/atom/location = loc
+		if(!isturf(location) && !CanPass(location)) // Can we leave without ramming into the container wall?
+			Bump(location)
+			return
 		trajectory.increment(trajectory_multiplier)
 		var/turf/T = trajectory.return_turf()
 		if(!istype(T))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -875,8 +875,9 @@
 		stack_trace("WARNING: Projectile [type] fired with non-list modifiers, likely was passed click params.")
 		modifiers = null
 
-	var/turf/source_loc = get_turf(source)
-	var/turf/target_loc = get_turf(target)
+	var/atom/source_loc = drop_location(source)
+	var/turf/source_turf = get_turf(source)
+	var/turf/target_turf = get_turf(target)
 	if(isnull(source_loc))
 		stack_trace("WARNING: Projectile [type] fired from nullspace.")
 		qdel(src)
@@ -886,22 +887,22 @@
 	forceMove(source_loc)
 	trajectory_ignore_forcemove = FALSE
 
-	starting = source_loc
+	starting = source_turf
 	pixel_x = source.pixel_x
 	pixel_y = source.pixel_y
 	original = target
 	if(length(modifiers))
-		var/list/calculated = calculate_projectile_angle_and_pixel_offsets(source, target_loc && target, modifiers)
+		var/list/calculated = calculate_projectile_angle_and_pixel_offsets(source, target_turf && target, modifiers)
 
 		p_x = calculated[2]
 		p_y = calculated[3]
 		set_angle(calculated[1] + deviation)
 		return TRUE
 
-	if(target_loc)
-		yo = target_loc.y - source_loc.y
-		xo = target_loc.x - source_loc.x
-		set_angle(get_angle(src, target_loc) + deviation)
+	if(target_turf)
+		yo = target_turf.y - source_turf.y
+		xo = target_turf.x - source_turf.x
+		set_angle(get_angle(src, target_turf) + deviation)
 		return TRUE
 
 	stack_trace("WARNING: Projectile [type] fired without a target or mouse parameters to aim with.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As it stands a person with telekinesis can manipulate the genetics console GUI from inside of the gene scanner, but cannot open the UI from inside of the gene scanner. As I do not see why being contained in the scanner would prevent telekinesis acting on the console this PR makes it possible to open the consoles UI from within the scanner.

There may be side effects.

TODO:
- [ ] Find and fix bugs with the implementation.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Slightly more consistent TK interactions.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Telekinesis can be used to open the gene scanner console UI from within the gene scanner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
