### PR TITLE
deletes a duplicate airlock on tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2189,10 +2189,6 @@
 	id_tag = "private_c";
 	name = "Private Quarters C"
 	},
-/obj/machinery/door/airlock{
-	id_tag = "private_d";
-	name = "Private Quarters D"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,


### PR DESCRIPTION
## About The Pull Request

removes duplicate dorm airlock at tram dorms.

## Why It's Good For The Game

mapping goof

## Changelog
:cl:
fix: removes duplicate dorm airlock on tramstation.
/:cl: