### PR TITLE
Consistent names and spelling for chemical analyzers and voice analyzers.

### DIFF
--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -96,7 +96,7 @@
 * pH meter that will give a detailed or truncated analysis of all the reagents in of an object with a reagents datum attached to it. Only way of detecting purity for now.
 */
 /obj/item/ph_meter
-	name = "Chemistry Analyser"
+	name = "Chemical Analyzer"
 	desc = "An electrode attached to a small circuit box that will display details of a solution. Can be toggled to provide a description of each of the reagents. The screen currently displays nothing."
 	icon_state = "pHmeter"
 	icon = 'icons/obj/chemical.dmi'

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -733,9 +733,9 @@
 	build_path = /obj/item/assembly/timer
 	category = list("initial", "Misc")
 
-/datum/design/voice_analyser
-	name = "Voice Analyser"
-	id = "voice_analyser"
+/datum/design/voice_analyzer
+	name = "Voice Analyzer"
+	id = "voice_analyzer"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 50)
 	build_path = /obj/item/assembly/voice

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -72,7 +72,7 @@
 	category = list("Medical Designs")
 
 /datum/design/ph_meter
-	name = "Chemical analyser"
+	name = "Chemical Analyzer"
 	id = "ph_meter"
 	build_type = PROTOLATHE | AWAY_LATHE
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL

--- a/code/modules/ruins/spaceruin_code/oldstation.dm
+++ b/code/modules/ruins/spaceruin_code/oldstation.dm
@@ -20,10 +20,10 @@
 		monochromatic cyan, leaving the user unable to see long distances. However, the way the helmet retracts is pretty cool."
 
 /obj/item/paper/fluff/ruins/oldstation/protohealth
-	name = "Health Analyser Report"
-	info = "<b>*Health Analyser*</b><br><br>The portable Health Analyser is essentially a handheld variant of a health analyser. Years of research have concluded with this device which is \
+	name = "Health Analyzer Report"
+	info = "<b>*Health Analyzer*</b><br><br>The portable Health Analyzer is essentially a handheld variant of a health analyzer. Years of research have concluded with this device which is \
 	capable of diagnosing even the most critical, obscure or technical injuries any humanoid entity is suffering in an easy to understand format that even a non-trained health professional \
-	can understand.<br><br>The health analyser is expected to go into full production as standard issue medical kit."
+	can understand.<br><br>The health analyzer is expected to go into full production as standard issue medical kit."
 
 /obj/item/paper/fluff/ruins/oldstation/protogun
 	name = "K14 Energy Gun Report"

--- a/strings/chemistrytips.txt
+++ b/strings/chemistrytips.txt
@@ -1,5 +1,5 @@
 A reaction can be slowed down by cooling the beaker it's in!
-Chemical analysers scan more than just pH. They can tell you the purity of each reagent.
+Chemical analyzers scan more than just pH. They can tell you the purity of each reagent.
 The infomation depth of pH meter readouts can be reduced by using it in hand!
 ChemMaster 3000s can tell you the optimal pH of a reagent's reaction with their analyze function.
 Oculine slightly improves your eyesight while it's in your system, to a degree based on its purity.
@@ -10,7 +10,7 @@ Inverse Neurine will not delete an imaginary friend. Once a friend, always a fri
 Overdosing on Mannitol will give you pro tips from your newfound enlightenment. Perhaps you know that already, though!
 Eigenstasium's wild ride can be halted by taking more eigenstasium, bluespace dust, or stabilising agent.
 The longer synthtissue has been growing, the more stuff it can do!
-Exact organ health values can be determined by using a health analyser while Technetium 99 is in their system.
+Exact organ health values can be determined by using a health analyzer while Technetium 99 is in their system.
 100% pure inacusiate will let you hear whispers from a distance while it's in your system.
 Turning sugar into caramel before attempting to make Eigenstasium makes it much easier to create.
 Thermometers crafted in the chemistry section will let you detect the temperature of anything that has a reagent temperature. This includes people too!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Chemistry analy**s**ers are now called chemical analy**z**ers to be consistent with the names used in techfabs and tips as well as other usages of the word analy**z**er. Relatedly voice analy**s**ers are now called voice analy**z**ers in the autolathe and a fluff report. 

## Why It's Good For The Game

Consistency is good. In this case having consistent spelling and names makes searching for chemical and voice analyzers in autolathes and techfabs a bit more intuitive. I failed to find either before because I was used to the spelling analy**z**er that's used everywhere else in the codebase.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Voice and chemical analyzers now have more consistent names and spelling.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
