### PR TITLE
grenade error message bugfix

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -113,11 +113,13 @@
 			stage_change(GRENADE_READY)
 			to_chat(user, span_notice("You lock the [initial(name)] assembly."))
 			tool.play_tool_sound(src, 25)
-			if(landminemode)
-				landminemode.timing = FALSE
-				if(!landminemode.secured)
-					landminemode.toggle_secure()
-				landminemode.toggle_scan(FALSE)
+		else if(landminemode)
+			landminemode.timing = FALSE
+			if(!landminemode.secured)
+				landminemode.toggle_secure()
+			landminemode.toggle_scan(FALSE)
+			to_chat(user, span_notice("You disarm the [landminemode.name]."))
+			tool.play_tool_sound(src, 25)
 		else
 			to_chat(user, span_warning("You need to add at least one beaker before locking the [initial(name)] assembly!"))
 	else if(stage == GRENADE_READY)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -113,11 +113,11 @@
 			stage_change(GRENADE_READY)
 			to_chat(user, span_notice("You lock the [initial(name)] assembly."))
 			tool.play_tool_sound(src, 25)
-		if(landminemode)
-			landminemode.timing = FALSE
-			if(!landminemode.secured)
-				landminemode.toggle_secure()
-			landminemode.toggle_scan(FALSE)
+			if(landminemode)
+				landminemode.timing = FALSE
+				if(!landminemode.secured)
+					landminemode.toggle_secure()
+				landminemode.toggle_scan(FALSE)
 		else
 			to_chat(user, span_warning("You need to add at least one beaker before locking the [initial(name)] assembly!"))
 	else if(stage == GRENADE_READY)


### PR DESCRIPTION
## About The Pull Request

![bug1](https://user-images.githubusercontent.com/50628162/160352307-1e30be38-5aca-4d3d-80ff-cbf15d239e8a.png)
![bug2](https://user-images.githubusercontent.com/50628162/160352327-409cb85f-487e-473d-bbc7-ee91fc84ed8a.png)
currently there's a bug which causes the game to print out "You need to add at least one beaker before locking the chemical grenade assembly!" whenever you try to use a screwdriver on a grenade without a proximity sensor

## Why It's Good For The Game

![bug3](https://user-images.githubusercontent.com/50628162/160351998-fc0a0cf9-c445-4f89-983d-34e8623003c7.png)
bugs bad, bugfixes good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: finishing grenades no longer prints the error message when it shouldn't
/:cl: