### PR TITLE
Cleans up some varedit procs using strings for var names instead of the proper helper

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -62,7 +62,7 @@ SUBSYSTEM_DEF(blackbox)
 
 //no touchie
 /datum/controller/subsystem/blackbox/vv_get_var(var_name)
-	if(var_name == "feedback")
+	if(var_name == NAMEOF(src, feedback))
 		return debug_variable(var_name, deep_copy_list(feedback), 0, src)
 	return ..()
 

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -13,7 +13,7 @@
 
 /datum/proc/vv_get_var(var_name)
 	switch(var_name)
-		if ("vars")
+		if (NAMEOF(src, vars))
 			return debug_variable(var_name, list(), 0, src)
 	return debug_variable(var_name, vars[var_name], 0, src)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -281,9 +281,9 @@
 	return destination //used by some child types checks and zMove()
 
 /atom/movable/vv_edit_var(var_name, var_value)
-	var/static/list/banned_edits = list("step_x" = TRUE, "step_y" = TRUE, "step_size" = TRUE, "bounds" = TRUE)
-	var/static/list/careful_edits = list("bound_x" = TRUE, "bound_y" = TRUE, "bound_width" = TRUE, "bound_height" = TRUE)
-	var/static/list/not_falsey_edits = list("bound_width" = TRUE, "bound_height" = TRUE)
+	var/static/list/banned_edits = list(NAMEOF(src, step_x) = TRUE, NAMEOF(src, step_y) = TRUE, NAMEOF(src, step_size) = TRUE, NAMEOF(src, bounds) = TRUE)
+	var/static/list/careful_edits = list(NAMEOF(src, bound_x) = TRUE, NAMEOF(src, bound_y) = TRUE, NAMEOF(src, bound_width) = TRUE, NAMEOF(src, bound_height) = TRUE)
+	var/static/list/not_falsey_edits = list(NAMEOF(src, bound_width) = TRUE, NAMEOF(src, bound_height) = TRUE)
 	if(banned_edits[var_name])
 		return FALSE //PLEASE no.
 	if(careful_edits[var_name] && (var_value % world.icon_size) != 0)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -967,7 +967,7 @@
 	take_damage(500, BRUTE, MELEE, 1)
 
 /obj/machinery/vv_edit_var(vname, vval)
-	if(vname == "occupant")
+	if(vname == NAMEOF(src, occupant))
 		set_occupant(vval)
 		datum_flags |= DF_VAR_EDITED
 		return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -74,7 +74,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	var/rcd_memory
 
 /turf/vv_edit_var(var_name, new_value)
-	var/static/list/banned_edits = list("x", "y", "z")
+	var/static/list/banned_edits = list(NAMEOF(src, x), NAMEOF(src, y), NAMEOF(src, z))
 	if(var_name in banned_edits)
 		return FALSE
 	. = ..()

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -21,13 +21,13 @@
 
 /area/vv_edit_var(var_name, var_value)
 	switch(var_name)
-		if("base_lighting_color")
+		if(NAMEOF(src, base_lighting_color))
 			set_base_lighting(new_base_lighting_color = var_value)
 			return TRUE
-		if("base_lighting_alpha")
+		if(NAMEOF(src, base_lighting_alpha))
 			set_base_lighting(new_alpha = var_value)
 			return TRUE
-		if("static_lighting")
+		if(NAMEOF(src, static_lighting))
 			if(!static_lighting)
 				create_area_lighting_objects()
 			else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1230,7 +1230,7 @@
  */
 /mob/vv_get_var(var_name)
 	switch(var_name)
-		if("logging")
+		if(NAMEOF(src, logging))
 			return debug_variable(var_name, logging, 0, src, FALSE)
 	. = ..()
 


### PR DESCRIPTION
Although these vars are unlikely to ever change, if the vars _were_ ever renamed it would result in these strings not erroring properly if they weren't updated as well.