### PR TITLE
hopefully fixes unit test failures from things in the spatial grid not having their refs cleared from it

### DIFF
--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -349,7 +349,7 @@ SUBSYSTEM_DEF(spatial_grid)
 ///find the spatial map cell that target belongs to, then add target's important_recusive_contents to it.
 ///make sure to provide the turf new_target is "in"
 /datum/controller/subsystem/spatial_grid/proc/enter_cell(atom/movable/new_target, turf/target_turf)
-	if(!target_turf || !new_target?.important_recursive_contents)
+	if(!target_turf || QDELETING(new_target) || !new_target?.important_recursive_contents)
 		CRASH("/datum/controller/subsystem/spatial_grid/proc/enter_cell() was given null arguments or a new_target without important_recursive_contents!")
 
 	var/x_index = ROUND_UP(target_turf.x / SPATIAL_GRID_CELLSIZE)

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -351,8 +351,11 @@ SUBSYSTEM_DEF(spatial_grid)
 /datum/controller/subsystem/spatial_grid/proc/enter_cell(atom/movable/new_target, turf/target_turf)
 	if(!initialized)
 		return
-	if(!target_turf || QDELING(new_target) || !new_target?.important_recursive_contents)
-		CRASH("/datum/controller/subsystem/spatial_grid/proc/enter_cell() was given null arguments or a new_target without important_recursive_contents!")
+	if(QDELETED(new_target))
+		CRASH("qdeleted or null target trying to enter the spatial grid!")
+
+	if(!target_turf || !new_target.important_recursive_contents)
+		CRASH("null turf loc or a new_target without important_recursive_contents trying to enter the spatial grid!")
 
 	var/x_index = ROUND_UP(target_turf.x / SPATIAL_GRID_CELLSIZE)
 	var/y_index = ROUND_UP(target_turf.y / SPATIAL_GRID_CELLSIZE)

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -351,7 +351,7 @@ SUBSYSTEM_DEF(spatial_grid)
 /datum/controller/subsystem/spatial_grid/proc/enter_cell(atom/movable/new_target, turf/target_turf)
 	if(!initialized)
 		return
-	if(!target_turf || QDELETING(new_target) || !new_target?.important_recursive_contents)
+	if(!target_turf || QDELING(new_target) || !new_target?.important_recursive_contents)
 		CRASH("/datum/controller/subsystem/spatial_grid/proc/enter_cell() was given null arguments or a new_target without important_recursive_contents!")
 
 	var/x_index = ROUND_UP(target_turf.x / SPATIAL_GRID_CELLSIZE)

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -349,6 +349,8 @@ SUBSYSTEM_DEF(spatial_grid)
 ///find the spatial map cell that target belongs to, then add target's important_recusive_contents to it.
 ///make sure to provide the turf new_target is "in"
 /datum/controller/subsystem/spatial_grid/proc/enter_cell(atom/movable/new_target, turf/target_turf)
+	if(!initialized)
+		return
 	if(!target_turf || QDELETING(new_target) || !new_target?.important_recursive_contents)
 		CRASH("/datum/controller/subsystem/spatial_grid/proc/enter_cell() was given null arguments or a new_target without important_recursive_contents!")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
things being held inside the spatial grid while they should be deleted causes a rareish unit test failure for create_and_destroy. hopefully this fixes it by checking for if the entering movable is being qdeleted as well as early returning in enter_cell if the spatial grid isnt initialized. 

Im not sure what exactly causes the hanging refs, but i suspect its something to do with not properly catching qdeleting objects if they for whatever reason enter another part of the spatial grid instead of nullspacing
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
