### PR TITLE
Fixes 2 adjacent newscasters.

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -27027,7 +27027,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/newscaster/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)


### PR DESCRIPTION

## About The Pull Request
 #65038 introduced a lot of widespread map changes all at once, and I appear to have missed that an old bounty board and an old newscaster were next to each other on the map, resulting in... 2 of them being next to each other.

Oops.

## Why It's Good For The Game
I messed up, but admittedly there will probably be a few more of these that I missed, so in such cases feel free to remove a duplicate.

## Changelog

:cl:
fix: Fixed 2 newscasters that were accidently mapped next to each other on tram.
/:cl:
