### PR TITLE
You can now see the plant's health with a plant analyzer.

### DIFF
--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -171,6 +171,7 @@
 	if(scanned_tray.myseed)
 		returned_message += "*** [span_bold("[scanned_tray.myseed.plantname]")] ***\n"
 		returned_message += "- Plant Age: [span_notice("[scanned_tray.age]")]\n"
+		returned_message += "- Plant Health: [span_notice("[scanned_tray.plant_health]")]\n"
 		returned_message += scan_plant_stats(scanned_tray.myseed)
 	else
 		returned_message += span_bold("No plant found.\n")


### PR DESCRIPTION
## About The Pull Request
You can now see the plant's health with a plant analyzer because literally who the fuck thought it was a good idea to base so much stuff on the plant health and have so many chemicals involving the plant's health and then not letting you see the plant's health? Like, god, this is painful. I sat for 30 minutes feeding some rainbow weed, a fresh seed, cryoxadone, diethylamine, and saltpetre and still got the stupid "ITS TOO UNHEALTHY FOR GENE SHEARS" prompt, so I want to know why my plants are goddamn unhealthy despite being fed so much damn fertilizer.

## Why It's Good For The Game

I fucking hate using the gene shears because there's no way to tell what the plant health is.

## Changelog
:cl:
qol: You can now see the plant's health with a plant analyzer.
/:cl: