### PR TITLE
Mapping in Bed Directional Rotated Variants [MDB IGNORE]

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
@@ -454,8 +454,12 @@
 	},
 /area/ruin/plasma_facility/operations)
 "gD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/black{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
@@ -416,8 +416,12 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "LZ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/random{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/ruin/powered)
 "Nq" = (
@@ -527,8 +531,12 @@
 /area/icemoon/underground/explored)
 "WH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed,
-/obj/item/bedsheet/cult,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/cult{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/ruin/powered)
 "Ze" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -288,8 +288,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/item/bedsheet/dorms,
-/obj/structure/bed,
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "hy" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
@@ -244,6 +244,15 @@
 /obj/machinery/light/directional/south,
 /turf/open/misc/ice,
 /area/ruin/powered/snow_biodome)
+"di" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/blue{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/powered/snow_biodome)
 "dS" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/pod/dark,
@@ -278,6 +287,15 @@
 /turf/open/floor/pod/dark{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},
+/area/ruin/powered/snow_biodome)
+"mZ" = (
+/obj/item/bedsheet/blue{
+	dir = 4
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/ruin/powered/snow_biodome)
 "og" = (
 /turf/open/floor/iron/stairs{
@@ -782,8 +800,8 @@ ac
 am
 aq
 aq
-au
-au
+mZ
+di
 aq
 aq
 aq

--- a/_maps/RandomRuins/SpaceRuins/DJstation/quarters_1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/quarters_1.dmm
@@ -19,6 +19,15 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/djstation)
+"o" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/space/djstation)
 "p" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Rest Room"
@@ -103,7 +112,7 @@ W
 a
 a
 i
-k
+o
 Z
 u
 i

--- a/_maps/RandomRuins/SpaceRuins/DJstation/quarters_3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/quarters_3.dmm
@@ -110,8 +110,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
 "L" = (
-/obj/structure/bed,
-/obj/item/bedsheet/purple,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/purple{
+	dir = 4
+	},
 /turf/open/floor/carpet/purple,
 /area/ruin/space/djstation)
 "N" = (

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -2067,7 +2067,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/iron/white/airless,
 /area/ruin/space/derelict/medical)
 "jB" = (
@@ -2310,7 +2312,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
 "kN" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/hallway/primary)
 "kO" = (
@@ -3658,6 +3662,12 @@
 	dir = 8
 	},
 /area/ruin/space/derelict/medical/chapel)
+"Ru" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/derelict/hallway/primary/port)
 "Rw" = (
 /obj/structure/plaque/static_plaque/golden/commission/ks13,
 /turf/open/floor/iron/airless,
@@ -9949,8 +9959,8 @@ fZ
 KN
 Vz
 Vz
-lE
-lE
+Ru
+Ru
 Vz
 OT
 Vz

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -181,8 +181,12 @@
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bp" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/green{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)

--- a/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
@@ -851,8 +851,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cL" = (
-/obj/item/bedsheet/brown,
-/obj/structure/bed,
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cM" = (

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -65,7 +65,9 @@
 /turf/open/floor/engine,
 /area/tcommsat/oldaisat)
 "ap" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/iron/airless,
 /area/tcommsat/oldaisat)
 "aq" = (
@@ -186,7 +188,9 @@
 /turf/open/floor/iron/airless,
 /area/tcommsat/oldaisat)
 "aN" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/effect/decal/remains/human,
 /turf/open/floor/iron/airless,
 /area/tcommsat/oldaisat)

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -985,6 +985,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/onehalf/bridge)
+"Nc" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/black{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/onehalf/dorms_med)
 "Vh" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -1214,9 +1223,9 @@ aa
 aa
 ab
 ag
-ao
+Nc
 aC
-ao
+Nc
 ag
 bj
 bz

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -466,8 +466,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "eD" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/purple,
+/obj/structure/bed/pod{
+	dir = 4
+	},
+/obj/item/bedsheet/purple{
+	dir = 4
+	},
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
 "eF" = (
@@ -1417,8 +1421,12 @@
 /turf/open/floor/carpet/royalblue,
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
 "mm" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/blue,
+/obj/structure/bed/pod{
+	dir = 4
+	},
+/obj/item/bedsheet/blue{
+	dir = 4
+	},
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "mq" = (
@@ -3490,8 +3498,12 @@
 /turf/open/floor/carpet/green,
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
 "LN" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/green,
+/obj/structure/bed/pod{
+	dir = 4
+	},
+/obj/item/bedsheet/green{
+	dir = 4
+	},
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/hotel/guestroom/room_5)
 "LS" = (

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -171,8 +171,12 @@
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
 "BG" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1059,7 +1059,9 @@
 /turf/open/floor/plating,
 /area/awaymission/caves/listeningpost)
 "fq" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron,
 /area/awaymission/caves/bmp_asteroid)
@@ -1089,7 +1091,9 @@
 	},
 /area/awaymission/caves/bmp_asteroid)
 "fA" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/awaymission/caves/bmp_asteroid)
 "fB" = (

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -1147,8 +1147,12 @@
 	},
 /area/awaymission/moonoutpost19/syndicate)
 "cZ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/syndie,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/syndie{
+	dir = 4
+	},
 /obj/machinery/button/door/directional/north{
 	id = "awaydorm4";
 	name = "Door Bolt Control";
@@ -1337,8 +1341,12 @@
 	},
 /area/awaymission/moonoutpost19/syndicate)
 "ds" = (
-/obj/structure/bed,
-/obj/item/bedsheet/syndie,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/syndie{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
 	heat_capacity = 1e+006
@@ -4811,8 +4819,12 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "lK" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
 	},
@@ -5304,8 +5316,12 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "na" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
@@ -5583,8 +5599,12 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "nH" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
 /obj/effect/decal/remains/human{
 	desc = "They look like human remains. The skeleton is laid out on its side and there seems to have been no sign of struggle.";
 	layer = 4.1

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -2088,9 +2088,13 @@
 /turf/open/misc/asteroid/snow,
 /area/awaymission/snowdin/cave)
 "gg" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/effect/landmark/awaystart,
-/obj/item/bedsheet/nanotrasen,
+/obj/item/bedsheet/nanotrasen{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/awaymission/snowdin/post/dorm)
 "gh" = (
@@ -5626,7 +5630,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/snowdin/post/cavern2)
 "pi" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/secpost)
@@ -6945,6 +6951,16 @@
 /mob/living/simple_animal/hostile/skeleton/ice,
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
+"tB" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/turf/open/misc/asteroid/snow{
+	floor_variance = 0;
+	icon_state = "snow_dug";
+	slowdown = 1
+	},
+/area/awaymission/snowdin/cave)
 "tE" = (
 /turf/closed/indestructible/rock/snow,
 /area/awaymission/snowdin/cave)
@@ -6966,7 +6982,9 @@
 /turf/closed/wall/rust,
 /area/awaymission/snowdin/post/cavern1)
 "ub" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
@@ -10287,8 +10305,12 @@
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/mining_main/mechbay)
 "Iq" = (
-/obj/structure/bed,
-/obj/item/bedsheet/grey,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/grey{
+	dir = 4
+	},
 /turf/open/floor/iron/grimy,
 /area/awaymission/snowdin/post/mining_main)
 "Ir" = (
@@ -12359,7 +12381,9 @@
 /turf/open/misc/asteroid/snow/ice,
 /area/awaymission/snowdin/cave/cavern)
 "Ri" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /mob/living/simple_animal/hostile/skeleton/ice{
 	name = "Privateer Jones"
 	},
@@ -44537,9 +44561,9 @@ ae
 ae
 ae
 aj
-SF
+tB
 RP
-SF
+tB
 aj
 aj
 aj

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -1875,8 +1875,12 @@
 /turf/open/floor/iron/white,
 /area/awaymission/spacebattle/cruiser)
 "hJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/captain{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/awaymission/spacebattle/cruiser)
 "hK" = (

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -5964,8 +5964,12 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "na" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
 	},
@@ -7561,8 +7565,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
 	},
@@ -10991,8 +10999,12 @@
 /area/awaymission/undergroundoutpost45/mining)
 "wV" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
 /turf/open/floor/carpet{
 	heat_capacity = 1e+006
 	},

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -725,8 +725,12 @@
 /turf/open/space,
 /area/space/nearstation)
 "dp" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/awaymission/wildwest/gov)
 "dq" = (
@@ -1729,6 +1733,12 @@
 	},
 /turf/open/floor/iron,
 /area/awaymission/wildwest/refine)
+"Tj" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/awaymission/wildwest/mines)
 "Ua" = (
 /obj/machinery/door/airlock/sandstone,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -39141,7 +39151,7 @@ bj
 bj
 aT
 bu
-bB
+Tj
 bj
 bj
 bu

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3479,16 +3479,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/white,
 /area/commons/fitness/recreation)
-"aSC" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/blindfold,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "aSD" = (
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -14697,12 +14687,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
-"deH" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "deM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -17557,6 +17541,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"dAa" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/report_crimes{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/escape)
 "dAg" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/east,
@@ -21038,6 +21035,16 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"dZJ" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/hop{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/grimy,
+/area/command/heads_quarters/hop)
 "dZS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/bag/bio,
@@ -21127,16 +21134,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"eav" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/iv_drip,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery/aft)
 "eaw" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -21169,14 +21166,6 @@
 "eaL" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/r_wall,
-/area/medical/virology)
-"eaM" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
 /area/medical/virology)
 "eaO" = (
 /obj/structure/sign/nanotrasen,
@@ -22240,19 +22229,6 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/security/checkpoint/escape)
-"egn" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/report_crimes{
-	pixel_y = -32
-	},
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "ego" = (
@@ -28808,6 +28784,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"gdp" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/camera/directional/north{
+	c_tag = "Permabrig - Isolation";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "gdu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -36028,6 +36015,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"ifx" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/blindfold,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "ifF" = (
 /obj/structure/bed/roller,
 /turf/open/floor/iron/white,
@@ -37963,6 +37962,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hos)
+"iIo" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "iIt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -41386,15 +41397,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"jIP" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/camera/directional/north{
-	c_tag = "Permabrig - Isolation";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "jIU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57756,12 +57758,6 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"oCs" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hop,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/grimy,
-/area/command/heads_quarters/hop)
 "oCI" = (
 /obj/structure/cable,
 /turf/open/floor/iron{
@@ -80400,6 +80396,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lobby)
+"vqa" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "vqp" = (
 /turf/closed/wall/r_wall,
 /area/engineering/storage/tech)
@@ -80645,6 +80651,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
+"vtA" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery/aft)
 "vtG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm/directional/south,
@@ -122783,7 +122803,7 @@ nPB
 jXl
 nPB
 xxi
-deH
+vqa
 gBi
 nPB
 qYo
@@ -124763,7 +124783,7 @@ mEu
 fiS
 wpW
 cgY
-oCs
+dZJ
 lvY
 wpW
 oaS
@@ -128438,7 +128458,7 @@ iQq
 eeb
 eeN
 efB
-egn
+dAa
 egE
 qYo
 xTK
@@ -136633,7 +136653,7 @@ lVw
 cKQ
 heV
 heV
-eav
+vtA
 cHU
 dLm
 tir
@@ -138709,7 +138729,7 @@ dYe
 eJl
 dZC
 dPr
-eaM
+iIo
 ebv
 eci
 dPq
@@ -139626,7 +139646,7 @@ xjZ
 xjZ
 xjZ
 aQW
-aSC
+ifx
 kbv
 mRz
 aFn
@@ -139879,7 +139899,7 @@ aad
 qYo
 qYo
 xjZ
-jIP
+gdp
 rDI
 xjZ
 aQX

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3479,6 +3479,16 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/white,
 /area/commons/fitness/recreation)
+"aSx" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "aSD" = (
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -17541,19 +17551,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"dAa" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/report_crimes{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/escape)
 "dAg" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/east,
@@ -21035,16 +21032,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"dZJ" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/hop{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/grimy,
-/area/command/heads_quarters/hop)
 "dZS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/bag/bio,
@@ -26528,6 +26515,16 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/fore)
+"fvs" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/hop{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/grimy,
+/area/command/heads_quarters/hop)
 "fvw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -28784,17 +28781,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"gdp" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/camera/directional/north{
-	c_tag = "Permabrig - Isolation";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "gdu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -36015,18 +36001,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"ifx" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/blindfold,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "ifF" = (
 /obj/structure/bed/roller,
 /turf/open/floor/iron/white,
@@ -37962,18 +37936,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hos)
-"iIo" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/medical{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "iIt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -45011,6 +44973,18 @@
 	},
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
+"kOM" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "kOP" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/delivery,
@@ -50044,6 +50018,20 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/medical/morgue)
+"mgp" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery/aft)
 "mgJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64837,6 +64825,18 @@
 /obj/item/clothing/mask/cigarette/pipe,
 /turf/open/floor/carpet/green,
 /area/commons/lounge)
+"qMw" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/blindfold,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "qMG" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -68114,6 +68114,19 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/medical/break_room)
+"rIE" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/report_crimes{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/escape)
 "rJj" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -69627,6 +69640,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"sfX" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/camera/directional/north{
+	c_tag = "Permabrig - Isolation";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "sfY" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -80396,16 +80420,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lobby)
-"vqa" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "vqp" = (
 /turf/closed/wall/r_wall,
 /area/engineering/storage/tech)
@@ -80651,20 +80665,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
-"vtA" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/medical{
-	dir = 4
-	},
-/obj/machinery/iv_drip,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery/aft)
 "vtG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm/directional/south,
@@ -122803,7 +122803,7 @@ nPB
 jXl
 nPB
 xxi
-vqa
+aSx
 gBi
 nPB
 qYo
@@ -124783,7 +124783,7 @@ mEu
 fiS
 wpW
 cgY
-dZJ
+fvs
 lvY
 wpW
 oaS
@@ -128458,7 +128458,7 @@ iQq
 eeb
 eeN
 efB
-dAa
+rIE
 egE
 qYo
 xTK
@@ -136653,7 +136653,7 @@ lVw
 cKQ
 heV
 heV
-vtA
+mgp
 cHU
 dLm
 tir
@@ -138729,7 +138729,7 @@ dYe
 eJl
 dZC
 dPr
-iIo
+kOM
 ebv
 eci
 dPq
@@ -139646,7 +139646,7 @@ xjZ
 xjZ
 xjZ
 aQW
-ifx
+qMw
 kbv
 mRz
 aFn
@@ -139899,7 +139899,7 @@ aad
 qYo
 qYo
 xjZ
-gdp
+sfX
 rDI
 xjZ
 aQX

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10017,22 +10017,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"dNz" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher/directional/west{
-	id = "Cell 2"
-	},
-/turf/open/openspace/icemoon/keep_below,
-/area/icemoon/surface/outdoors/nospawn)
 "dND" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -15285,28 +15269,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"gtA" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/closed/mineral/random/snow,
-/area/icemoon/surface/outdoors/nospawn)
 "gum" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -18157,28 +18119,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"hLk" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher/directional/west{
-	id = "Cell 1"
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "hLW" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23688,23 +23628,6 @@
 /obj/item/stack/pipe_cleaner_coil/random,
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"kzl" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/flasher/directional/west{
-	id = "Cell 3"
-	},
-/turf/open/openspace/icemoon/keep_below,
-/area/icemoon/surface/outdoors/nospawn)
 "kzp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/chair{
@@ -27429,30 +27352,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"mzM" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/bedsheet/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "mzO" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -45723,18 +45622,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "vAX" = (
@@ -72299,10 +72186,10 @@ qLO
 qLO
 qLO
 qLO
-gtA
+qLO
 jnk
 jnk
-mzM
+jnk
 vxr
 jnk
 qLO
@@ -77461,7 +77348,7 @@ fbC
 agn
 hvk
 gzw
-hLk
+jFt
 oWZ
 eGS
 eGS
@@ -78489,7 +78376,7 @@ aIF
 utQ
 gmK
 pqV
-dNz
+eGS
 eGS
 eGS
 eGS
@@ -79517,7 +79404,7 @@ lyi
 fQy
 gDY
 lyi
-kzl
+eGS
 eGS
 eGS
 eGS

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -43,19 +43,24 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"acz" = (
+/obj/effect/gibspawner/human,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"adQ" = (
+/obj/machinery/flasher/portable,
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "2";
+	dir = 1;
+	name = "Flash Storage"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "adY" = (
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"aek" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_large,
-/area/command/heads_quarters/hos)
 "afb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -138,15 +143,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
-"ahp" = (
-/obj/effect/turf_decal/tile/red/anticorner{
-	dir = 8
-	},
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/dark/textured_corner{
+"ahv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/area/security/office)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "ahx" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -176,6 +182,10 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
+"ahV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/security/lockers)
 "ahX" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -307,6 +317,12 @@
 "amb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/processing)
+"ame" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/processing)
@@ -704,6 +720,20 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/fore)
+"asl" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/rag,
+/obj/item/clothing/head/collectable/tophat{
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/obj/effect/spawner/random/entertainment/gambling{
+	pixel_x = -13
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/maintenance/fore/lesser)
 "asn" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -783,11 +813,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"asR" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "atn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -901,13 +926,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"auA" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/sunnybush,
-/turf/open/floor/grass,
-/area/security/warden)
 "auD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -953,6 +971,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"avh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "avi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1012,9 +1035,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"avJ" = (
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "avN" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -1056,16 +1076,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"awp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "awq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1144,10 +1154,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"awX" = (
-/obj/structure/flora/tree/dead,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "awZ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -1212,6 +1218,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
+"aya" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/processing)
 "ayd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -1292,6 +1310,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"azr" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "azs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -1501,6 +1526,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
+"aCs" = (
+/obj/structure/table/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/storage/box/deputy,
+/turf/open/floor/wood/large,
+/area/command/heads_quarters/hos)
 "aCt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -1550,18 +1583,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
-"aDu" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fitness Maintenance"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "aDA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -1574,6 +1595,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aEM" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	shuttledocked = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/processing)
 "aES" = (
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
@@ -1581,17 +1609,6 @@
 	dir = 1
 	},
 /area/engineering/lobby)
-"aET" = (
-/obj/item/gun/energy/laser/practice{
-	pixel_y = 5
-	},
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice{
-	pixel_y = -5
-	},
-/obj/structure/rack,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "aFa" = (
 /turf/open/floor/iron/white,
 /area/medical/storage)
@@ -1672,12 +1689,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"aHi" = (
-/obj/structure/sign/departments/court{
-	pixel_y = 32
-	},
-/turf/open/openspace,
-/area/hallway/primary/fore)
 "aHn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -1688,17 +1699,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"aHD" = (
-/obj/machinery/gulag_teleporter,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
-"aHI" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/structure/closet/firecloset,
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
+"aHw" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "aHM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1725,6 +1731,16 @@
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
+"aIz" = (
+/obj/structure/railing,
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "aIF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -1748,11 +1764,24 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"aIX" = (
+/obj/machinery/gulag_teleporter,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "aJd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"aJi" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "aJn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1810,17 +1839,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"aJU" = (
+"aJF" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Transport Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/security/processing)
+/area/maintenance/fore/greater)
 "aJV" = (
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -1882,14 +1909,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"aKO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "aKV" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -1955,6 +1974,12 @@
 "aLE" = (
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"aLH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "aLK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -2223,6 +2248,18 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
+"aPb" = (
+/obj/machinery/computer/warrant{
+	dir = 4
+	},
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "Security - Checkpoint"
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "aPp" = (
 /turf/open/openspace,
 /area/service/bar/atrium)
@@ -2303,26 +2340,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"aQO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/camera/directional/west{
-	c_tag = "Dormitory South"
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
-"aQT" = (
-/obj/machinery/space_heater,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/wood{
-	icon_state = "wood-broken2"
-	},
-/area/maintenance/fore/lesser)
 "aQX" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
@@ -2363,10 +2380,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"aSc" = (
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "aSf" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Arrivals Hallway"
@@ -2379,6 +2392,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"aSV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	freq = 1400;
+	location = "Security"
+	},
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "aTg" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2537,6 +2560,13 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
+"aWu" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "aWH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue,
@@ -2685,12 +2715,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"aZA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "aZO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -2788,6 +2812,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/lobby)
+"bbO" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "MiniSat External NorthWest";
+	network = list("minisat");
+	start_active = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/ai_monitored/turret_protected/aisat/maint)
 "bbS" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
@@ -2833,9 +2865,6 @@
 /obj/machinery/keycard_auth/directional/south,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"bcO" = (
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "bcP" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
@@ -2891,6 +2920,15 @@
 	icon_state = "wood-broken6"
 	},
 /area/service/library)
+"bdT" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "bed" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -2969,15 +3007,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos/pumproom)
-"beS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "beX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -3003,16 +3032,23 @@
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/large,
 /area/medical/storage)
-"bfE" = (
-/obj/structure/sign/warning/xeno_mining,
-/turf/closed/wall/ice,
-/area/icemoon/surface/outdoors/nospawn)
 "bfF" = (
 /turf/closed/wall,
 /area/medical/pharmacy)
 "bfK" = (
 /turf/closed/wall,
 /area/security/checkpoint/medical)
+"bfL" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/inspector,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "bfT" = (
 /turf/closed/wall,
 /area/science/robotics/mechbay)
@@ -3135,26 +3171,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
-"bhS" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "bhY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/science/genetics)
-"bij" = (
-/obj/item/beacon,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "bik" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -3215,18 +3237,6 @@
 "biL" = (
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"biM" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/processing)
 "biP" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/red{
@@ -3244,6 +3254,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"biU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/security/lockers)
 "biW" = (
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -3348,6 +3365,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"blq" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Desk"
+	},
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/checkpoint/auxiliary)
 "blv" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -3420,6 +3453,15 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/large,
 /area/engineering/atmos)
+"bmT" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "bnb" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -3500,12 +3542,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
-"bnZ" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "boi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3567,6 +3603,12 @@
 "boM" = (
 /turf/open/floor/iron/white/corner,
 /area/science/research)
+"boQ" = (
+/obj/structure/cable,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/maintenance/fore/lesser)
 "boV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -3586,15 +3628,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"bpj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "bpm" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -3603,6 +3636,12 @@
 "bpI" = (
 /turf/closed/wall,
 /area/medical/psychology)
+"bpQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "bpR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -3678,38 +3717,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
-"brC" = (
-/turf/closed/wall,
-/area/security/interrogation)
-"brJ" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/fore/lesser)
-"brN" = (
-/obj/machinery/button/door/directional/east{
-	id = "armory";
-	name = "Armory Shutters";
-	req_access_txt = "3";
-	pixel_x = -9;
-	pixel_y = 30
-	},
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "brT" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon,
@@ -3845,18 +3852,6 @@
 	},
 /turf/open/floor/plating/icemoon,
 /area/science/test_area)
-"buw" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
-	width = 9
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "buy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3935,14 +3930,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"bvz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Courtroom";
-	name = "security shutters"
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/fore)
 "bvC" = (
 /obj/structure/chair{
 	dir = 8
@@ -4043,12 +4030,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"bwq" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "bwB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4167,22 +4148,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"byI" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Checkpoint";
-	id_tag = "outerbrig"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigoutpost"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "byK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -4388,17 +4353,14 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"bCn" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+"bCg" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 8
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "riot";
-	name = "security shutters"
-	},
-/turf/open/floor/glass/reinforced,
-/area/hallway/primary/fore)
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "bCq" = (
 /turf/closed/wall,
 /area/maintenance/port/aft)
@@ -4498,21 +4460,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"bDC" = (
-/obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "bDF" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -4549,6 +4496,9 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"bEn" = (
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/processing)
 "bEo" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4611,6 +4561,9 @@
 /obj/machinery/atmospherics/pipe/color_adapter,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"bFd" = (
+/turf/closed/wall,
+/area/hallway/primary/fore)
 "bFf" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -4629,6 +4582,13 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/plating/icemoon,
 /area/science/test_area)
+"bFH" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "bFU" = (
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -4730,6 +4690,13 @@
 /obj/machinery/microwave,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"bHm" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "bHw" = (
 /obj/item/target,
 /obj/structure/window/reinforced,
@@ -4738,6 +4705,19 @@
 	},
 /turf/open/floor/plating/icemoon,
 /area/science/test_area)
+"bHz" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Upper Hallway North"
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "bHB" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
@@ -4917,12 +4897,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"bKc" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_edge,
-/area/security/lockers)
 "bKp" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -4932,19 +4906,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"bKD" = (
-/obj/effect/gibspawner/human/bodypartless,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"bKM" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Port Hallway"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "bKQ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -5023,10 +4984,6 @@
 "bLU" = (
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
-"bMa" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "bMi" = (
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -5034,13 +4991,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"bMs" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "bMu" = (
 /obj/machinery/door/poddoor/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
@@ -5135,6 +5085,15 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"bOA" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "bOJ" = (
 /obj/item/target,
 /obj/structure/window/reinforced{
@@ -5198,15 +5157,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
 /area/construction)
-"bQe" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "bQg" = (
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -5324,20 +5274,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"bSB" = (
-/obj/structure/railing,
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = 4
-	},
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "bST" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -5355,6 +5291,11 @@
 /obj/structure/noticeboard/directional/west,
 /turf/open/floor/engine/cult,
 /area/service/library)
+"bTa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/processing)
 "bTc" = (
 /obj/machinery/conveyor{
 	dir = 6;
@@ -5492,15 +5433,6 @@
 "bVJ" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
-"bVP" = (
-/obj/structure/bed/dogbed/lia,
-/mob/living/simple_animal/hostile/carp/lia,
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - HoS Office"
-	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
 "bVW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -5568,15 +5500,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"bWL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "bWM" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -5599,12 +5522,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/misc_lab)
-"bXv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "bXw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -5644,6 +5561,12 @@
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"bYg" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light/directional/east,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "bYi" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -5739,6 +5662,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"bYT" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp_home";
+	name = "fore bay 1";
+	roundstart_template = /datum/map_template/shuttle/labour/box;
+	width = 9
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "bZa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5792,6 +5727,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"bZT" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "cad" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -5940,28 +5882,6 @@
 "ccp" = (
 /turf/closed/wall,
 /area/science/mixing/hallway)
-"ccL" = (
-/obj/item/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -6;
-	pixel_y = 16
-	},
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/stamp/hos{
-	pixel_y = 6;
-	pixel_x = 10
-	},
-/obj/machinery/recharger{
-	pixel_y = -1;
-	pixel_x = -4
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/wood/large,
-/area/command/heads_quarters/hos)
 "ccP" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -6101,6 +6021,15 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cdX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "cdZ" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/iron/dark/telecomms,
@@ -6169,18 +6098,11 @@
 "cfw" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
-"cfT" = (
-/obj/machinery/computer/warrant{
-	dir = 4
-	},
-/obj/machinery/camera/motion/directional/west{
-	c_tag = "Security - Checkpoint"
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
+"cfx" = (
+/obj/structure/closet/l3closet/security,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "cfV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -6190,19 +6112,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"cge" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Walkway"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigentrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+"cgm" = (
+/obj/structure/window/reinforced,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "cgp" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating,
@@ -6234,19 +6148,18 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cgW" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "chc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
+"chn" = (
+/obj/structure/sign/departments/court{
+	pixel_y = 32
+	},
+/turf/open/openspace,
+/area/hallway/primary/fore)
 "chw" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -6268,10 +6181,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"cik" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "ciB" = (
 /obj/structure/railing/corner,
 /obj/machinery/firealarm/directional/west,
@@ -6352,19 +6261,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"ckv" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/processing)
 "ckT" = (
 /obj/structure/table,
 /obj/item/folder/blue{
@@ -6374,10 +6270,6 @@
 /obj/item/folder/yellow,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
-"ckU" = (
-/obj/structure/flora/rock/icy,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "ckX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -6498,18 +6390,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"cnx" = (
+/turf/open/openspace,
+/area/security/brig/upper)
 "cnF" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
 	},
 /turf/open/floor/engine/cult,
 /area/service/library)
-"cnP" = (
-/obj/structure/cable,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/maintenance/fore/lesser)
 "cnT" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
@@ -6716,22 +6605,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
-"csk" = (
-/obj/structure/table,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "csr" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -7248,17 +7121,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"cwO" = (
-/obj/item/storage/medkit/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/medkit/regular,
-/obj/structure/table/glass,
-/obj/structure/window/reinforced,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "cwP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7283,6 +7145,12 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
 /area/commons/vacant_room/commissary)
+"cyh" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "cyl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -7527,15 +7395,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"cBH" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/glass/reinforced,
-/area/security/checkpoint/auxiliary)
 "cBL" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -7587,23 +7446,6 @@
 "cCA" = (
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"cCI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig/upper)
-"cCN" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Equipment Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/security/lockers)
 "cDg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -7617,12 +7459,6 @@
 	dir = 1
 	},
 /area/engineering/atmos)
-"cDS" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/processing)
 "cEk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/plating/snowed/icemoon,
@@ -7632,9 +7468,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"cEs" = (
-/turf/open/floor/glass/reinforced,
-/area/security/checkpoint/auxiliary)
 "cEt" = (
 /obj/machinery/computer/upload/ai{
 	dir = 1
@@ -7651,22 +7484,21 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"cEI" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
+"cEM" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"cEL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
+"cER" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Courtroom";
+	name = "security shutters"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/fore)
 "cFA" = (
 /obj/structure/table/optable,
 /obj/machinery/light/directional/east,
@@ -7768,6 +7600,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage)
+"cGX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "Interrogation";
+	name = "Interrogation Shutters"
+	},
+/turf/open/floor/plating,
+/area/security/interrogation)
 "cHo" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/light/small/directional/north,
@@ -7919,12 +7760,15 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/upper)
-"cIX" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
+"cIP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/security/lockers)
 "cJg" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "pharmacy_shutters";
@@ -7995,6 +7839,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"cKO" = (
+/obj/machinery/vending/security,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth_edge,
+/area/security/lockers)
 "cKW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -8019,6 +7868,13 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/heads_quarters/cmo)
+"cLn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "cLo" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -8054,6 +7910,15 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
+"cMK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/smooth_large,
+/area/command/heads_quarters/hos)
 "cMO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8114,23 +7979,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "cNy" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_x = -22
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
-"cNz" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/fore/greater)
+/area/security/office)
 "cNW" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
@@ -8147,12 +7999,6 @@
 "cOe" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cOi" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "cOp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8209,43 +8055,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"cPB" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
-"cPL" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"cPS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "cPW" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/cargo/storage)
-"cQi" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/fore/lesser)
 "cQo" = (
 /obj/machinery/door/airlock/external{
 	name = "Common Mining Shuttle Bay";
@@ -8296,13 +8109,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"cSp" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "cSv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/white,
@@ -8315,19 +8121,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/commons/storage/mining)
-"cSN" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "cTE" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -8443,10 +8236,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cWc" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+"cVZ" = (
+/obj/machinery/space_heater,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/maintenance/fore/lesser)
 "cWt" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
@@ -8493,6 +8289,19 @@
 /obj/item/lipstick/random,
 /turf/open/floor/iron,
 /area/commons/locker)
+"cXv" = (
+/obj/machinery/flasher/directional/east{
+	id = "brigentry"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"cXS" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "cXW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8540,13 +8349,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"cYS" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
 "cZv" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/cable,
@@ -8592,6 +8394,20 @@
 	},
 /turf/open/floor/carpet/red,
 /area/commons/vacant_room/office)
+"cZP" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "cZR" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/tile/red{
@@ -8606,14 +8422,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
-"cZW" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/checkpoint/auxiliary)
 "cZY" = (
 /obj/machinery/announcement_system,
 /obj/machinery/status_display/evac/directional/north,
@@ -8642,6 +8450,11 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/textured,
 /area/medical/medbay/central)
+"das" = (
+/obj/item/kirbyplants/random,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/security/processing)
 "daz" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -8687,6 +8500,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
+"dbB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "dbF" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -8738,33 +8560,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
-"dcr" = (
-/obj/item/grenade/barrier{
-	pixel_x = 4
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "dct" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"dcz" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/security/lockers)
 "dcA" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating{
@@ -8775,6 +8576,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
+"dcI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "dcQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -8979,6 +8788,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
+"diA" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "diC" = (
 /obj/machinery/light/directional/east,
 /obj/structure/closet/secure_closet/exile,
@@ -8987,6 +8803,11 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
+"diK" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "diN" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -9009,14 +8830,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"diX" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "dju" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -9035,6 +8848,18 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
+"djN" = (
+/obj/machinery/door/airlock/external{
+	name = "Security Yard";
+	space_dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "dki" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/matches,
@@ -9130,17 +8955,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/medical/break_room)
-"dlI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "dlN" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -9168,6 +8982,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/textured_large,
 /area/science/storage)
+"dmF" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore/lesser)
 "dnf" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "MiniSat External SouthEast";
@@ -9176,9 +8999,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"dnj" = (
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "dno" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -9198,6 +9018,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"dnD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "dnI" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/line{
@@ -9302,6 +9130,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"dpT" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fitness Maintenance"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "dpX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -9347,9 +9187,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"dqQ" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/security/armory/upper)
+"dqM" = (
+/obj/machinery/computer/security/labor{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "drD" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9382,12 +9225,6 @@
 /obj/machinery/air_sensor/air_tank,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
-"dsH" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "dsK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9433,13 +9270,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"duE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"dux" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/machinery/light/directional/south,
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/security/lockers)
 "duF" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -9477,13 +9317,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/science/misc_lab)
-"dvd" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "dvz" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 4
@@ -9507,6 +9340,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"dvN" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "EVA Maintenance"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "dvV" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -9536,13 +9376,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dwD" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "dwF" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
@@ -9585,6 +9418,17 @@
 "dyq" = (
 /turf/closed/wall,
 /area/cargo/office)
+"dyt" = (
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "dyC" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -9605,10 +9449,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/engineering/main)
-"dyS" = (
-/obj/structure/closet/secure_closet/warden,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "dzl" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -9733,19 +9573,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"dBS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory/upper)
-"dBV" = (
-/obj/machinery/door/window/brigdoor/right/directional/north{
-	name = "Flash Storage";
-	req_access_txt = "3"
-	},
-/obj/machinery/recharge_station,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "dBX" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -9778,13 +9605,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"dCG" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "dDd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9811,6 +9631,16 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"dDv" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "dEh" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/igniter{
@@ -9925,6 +9755,20 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dGq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
+"dGy" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "dGF" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
@@ -9943,6 +9787,24 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"dHv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
+"dHx" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Head of Security"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/hos,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth_large,
+/area/command/heads_quarters/hos)
 "dHD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -9989,6 +9851,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
+"dIK" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Port Hallway"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "dJA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10049,6 +9920,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/maintenance/starboard/fore)
+"dKH" = (
+/turf/open/floor/carpet,
+/area/security/processing)
 "dKK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -10056,13 +9930,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"dKO" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "dKW" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/tile/blue{
@@ -10144,17 +10011,28 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/maintenance/department/medical)
-"dMQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/processing)
 "dNq" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light/directional/south,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
+"dNz" = (
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/flasher/directional/west{
+	id = "Cell 2"
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "dND" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -10220,6 +10098,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"dPm" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "dPx" = (
 /obj/structure/table/glass,
 /obj/item/storage/medkit/fire{
@@ -10296,16 +10180,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"dQT" = (
-/obj/machinery/flasher/portable,
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "2";
-	dir = 1;
-	name = "Flash Storage"
+"dQV" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "N2O Storage"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "dRb" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -10378,19 +10261,19 @@
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
 /area/engineering/transit_tube)
-"dTm" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/checkpoint/auxiliary)
 "dTn" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
 /obj/item/pen,
 /turf/open/floor/wood,
 /area/service/library)
+"dTw" = (
+/obj/docking_port/stationary/random/icemoon{
+	id = "pod_3_lavaland";
+	name = "lavaland"
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "dTz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -10404,10 +10287,6 @@
 "dTN" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/central)
-"dUf" = (
-/obj/structure/flora/grass/green,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "dUi" = (
 /obj/structure/grille,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -10456,6 +10335,23 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/command/bridge)
+"dWQ" = (
+/obj/structure/table,
+/obj/item/folder/red{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/folder/red{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "dXd" = (
 /obj/structure/chair{
 	dir = 1
@@ -10536,18 +10432,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
-"dYa" = (
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"dYd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "dYy" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/rack,
@@ -10555,6 +10439,11 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"dYF" = (
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/checkpoint/auxiliary)
 "dYL" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/east,
@@ -10570,19 +10459,15 @@
 /obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"dZy" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "dZH" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/maint)
-"eaa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "eay" = (
 /obj/structure/railing{
 	dir = 1
@@ -10634,6 +10519,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
+"ebC" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "ecr" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -10674,6 +10569,13 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"edW" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "eeh" = (
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
@@ -10692,6 +10594,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+"eey" = (
+/turf/closed/wall/r_wall,
+/area/security/checkpoint/auxiliary)
 "eeA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -10699,6 +10604,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/mixing)
+"eeC" = (
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
 "eeI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -10788,10 +10696,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"egY" = (
-/obj/structure/sign/warning/gasmask,
-/turf/closed/wall,
-/area/maintenance/fore/greater)
 "ehb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10807,6 +10711,27 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
+"eho" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore/lesser)
+"ehp" = (
+/obj/structure/table,
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/storage/lockbox/loyalty,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "ehA" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -10819,11 +10744,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
-"ehD" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "ehF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -10832,11 +10752,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"ehN" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/office)
 "ehY" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/o2,
@@ -10922,12 +10837,10 @@
 /obj/machinery/seed_extractor,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"ejL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"ejE" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
+/area/ai_monitored/security/armory/upper)
 "ejY" = (
 /obj/effect/decal/cleanable/insectguts,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -10975,6 +10888,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
+"ekU" = (
+/obj/structure/table,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/obj/item/key/security,
+/obj/machinery/light/directional/east,
+/obj/item/radio/intercom/prison/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
+"elf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/radio/intercom/prison/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "elr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -11045,6 +10974,15 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"emI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/camera/directional/north,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "emL" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -11136,20 +11074,22 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
-"eoh" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
+"enZ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Walkway";
+	id_tag = "innerbrig"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigoutpost"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner{
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
-/area/security/processing)
+/area/security/checkpoint/auxiliary)
 "eoo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11173,6 +11113,20 @@
 /obj/item/reagent_containers/food/drinks/waterbottle,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ept" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"epx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "epN" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
@@ -11453,6 +11407,17 @@
 /obj/item/flashlight,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"ewM" = (
+/obj/item/storage/medkit/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/regular,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "ewN" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/shower{
@@ -11470,14 +11435,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"exB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "eyy" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -11526,6 +11483,16 @@
 	dir = 8
 	},
 /area/service/chapel)
+"ezx" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/captain{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet,
+/area/command/heads_quarters/captain)
 "ezB" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "MiniSat External South";
@@ -11643,6 +11610,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
+"eCt" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Central Hallway North-West"
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "eCu" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/tile/red,
@@ -11653,20 +11628,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"eCF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "eCP" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "eDq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11714,16 +11681,31 @@
 	},
 /turf/open/floor/iron,
 /area/service/janitor)
-"eEH" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+"eET" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "eFk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/cargo/qm)
+"eFz" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigentrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "eFN" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/siding/yellow{
@@ -11756,23 +11738,14 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"eGQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+"eGS" = (
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "eGW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/service/library)
-"eHc" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - EVA"
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "eHe" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/medical_all,
@@ -11825,18 +11798,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"eIH" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "eIL" = (
 /turf/closed/wall,
 /area/commons/toilet)
@@ -11929,17 +11890,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"eLK" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/light/directional/south,
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/security/lockers)
 "eLP" = (
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/circuit,
@@ -11962,13 +11912,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"eMI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "eMK" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Head of Personnel's Office"
@@ -11981,6 +11924,20 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
+"eNk" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used to access the various cameras on the station.";
+	layer = 3.1;
+	name = "Security Camera Monitor";
+	network = list("ss13");
+	pixel_y = 2;
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "eNs" = (
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
@@ -12015,6 +11972,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/science/misc_lab)
+"eOA" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security EVA"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "eOE" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -12048,10 +12013,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
-"ePl" = (
-/obj/structure/railing,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "ePS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12061,10 +12022,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
+"ePT" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "eQf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/pumproom)
+"eQh" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "eQN" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -12083,11 +12063,9 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
 /area/science/storage)
-"eRl" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
+"eRb" = (
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "eRv" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -12120,18 +12098,21 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/medical/treatment_center)
+"eRS" = (
+/obj/structure/closet/secure_closet/warden,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "eSj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"eSC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
+"eSo" = (
+/obj/structure/chair/office,
+/obj/effect/landmark/start/warden,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "eSD" = (
 /obj/machinery/computer/med_data,
 /obj/effect/turf_decal/tile/green,
@@ -12143,14 +12124,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"eSG" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "eSK" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -12208,6 +12181,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"eUW" = (
+/obj/structure/cable,
+/obj/item/radio/intercom/prison/directional/east,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "eVj" = (
 /obj/structure/filingcabinet,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -12316,6 +12297,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"eXS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "eYz" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -12370,14 +12355,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"eZf" = (
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "2";
-	dir = 1;
-	name = "Security Delivery"
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "eZt" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -12390,6 +12367,14 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engineering/storage/tech)
+"fab" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "faf" = (
 /obj/structure/window/reinforced,
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -12440,6 +12425,17 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
+"fbb" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Transport Maintenance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/plating,
+/area/security/processing)
 "fbf" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Captain's Office Maintenance";
@@ -12463,6 +12459,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"fbC" = (
+/obj/machinery/computer/prisoner/management{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "fbK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12490,6 +12493,13 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
+"fcv" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "fcL" = (
 /obj/structure/railing{
 	dir = 4
@@ -12595,15 +12605,6 @@
 /obj/effect/landmark/start/psychologist,
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
-"feP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "ffa" = (
 /obj/structure/tank_holder/oxygen/red,
 /turf/open/floor/plating,
@@ -12657,6 +12658,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/pumproom)
+"fgj" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "fgA" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
@@ -12713,6 +12720,10 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
+"fhK" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
 "fhM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -12824,21 +12835,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"flc" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 1;
-	freq = 1400;
-	location = "Security"
-	},
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
-"flg" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "flm" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/research,
@@ -12858,6 +12854,15 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
+"fmk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Security Medpost"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "fmm" = (
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 1
@@ -12924,6 +12929,14 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"fof" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "fok" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
@@ -12952,6 +12965,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"fpf" = (
+/obj/structure/chair/office,
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "fpu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12966,6 +12988,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/storage/gas)
+"fqh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "fql" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -12992,6 +13023,17 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"fqP" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security EVA"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth,
+/area/security/processing)
 "fqX" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
@@ -13045,15 +13087,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"ftp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "ftr" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Public Mining Ladder"
@@ -13124,13 +13157,14 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"fwp" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+"fwi" = (
+/obj/item/storage/box/seccarts{
+	pixel_x = 9;
+	pixel_y = 9
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/large,
+/area/command/heads_quarters/hos)
 "fwq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -13151,6 +13185,12 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
+"fwJ" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "fwM" = (
 /obj/structure/chair,
 /turf/open/floor/iron/cafeteria,
@@ -13258,13 +13298,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"fyd" = (
-/obj/structure/bed/dogbed/mcgriff,
-/mob/living/simple_animal/pet/dog/pug/mcgriff,
-/obj/item/food/beef_wellington_slice,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "fyi" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -13275,6 +13308,13 @@
 "fym" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/upper)
+"fyy" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Three";
+	space_dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/processing)
 "fyM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13284,11 +13324,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"fyT" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/landmark/start/head_of_security,
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
 "fyU" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
@@ -13337,6 +13372,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"fzG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "fzJ" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm2";
@@ -13404,6 +13444,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"fBz" = (
+/obj/structure/sign/warning/gasmask,
+/turf/closed/wall,
+/area/maintenance/fore/greater)
 "fBL" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13486,6 +13530,15 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"fEY" = (
+/obj/machinery/modular_computer/console/preset/cargochat/security{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "fFg" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13521,6 +13574,15 @@
 	dir = 8
 	},
 /area/science/research)
+"fFH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "fFO" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 4;
@@ -13595,10 +13657,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/engineering/main)
-"fHK" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/glass/reinforced,
-/area/security/lockers)
+"fHG" = (
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "fHZ" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon,
@@ -13609,10 +13672,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
-"fIi" = (
-/obj/item/paper/fluff/jobs/security/beepsky_mom,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "fIE" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -13693,16 +13752,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"fKc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/security/processing)
 "fKn" = (
 /obj/structure/ladder,
 /turf/open/floor/wood,
@@ -13756,15 +13805,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"fLH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "fMz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13795,6 +13835,39 @@
 "fMZ" = (
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"fNg" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/button/door/directional/west{
+	id = "briggate";
+	name = "Brig Shutters";
+	pixel_y = -2;
+	pixel_x = -6
+	},
+/obj/machinery/button/flasher{
+	id = "brigentry";
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/machinery/button/door/directional/west{
+	id = "innerbrig";
+	name = "Brig Interior Doors Control";
+	normaldoorcontrol = 1;
+	req_access_txt = "63";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/machinery/button/door/directional/west{
+	id = "outerbrig";
+	name = "Brig Exterior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_y = -2;
+	req_access_txt = "63";
+	pixel_x = 6
+	},
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/checkpoint/auxiliary)
 "fNY" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -13829,12 +13902,24 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/cargo/lobby)
+"fOS" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "fOZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
+"fPD" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "fPJ" = (
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/east,
@@ -13847,6 +13932,16 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/locker)
+"fQc" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "fQk" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -13888,6 +13983,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"fQy" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/closet/firecloset,
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "fQD" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -13907,6 +14008,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery/aft)
+"fQW" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "fQX" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -13967,12 +14075,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"fRL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "fSa" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -14034,11 +14136,24 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos/storage/gas)
+"fTx" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "fTI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"fUb" = (
+/mob/living/simple_animal/bot/secbot/beepsky,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore/lesser)
 "fUu" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -14100,15 +14215,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"fVq" = (
-/obj/machinery/button/flasher{
-	id = "cell4";
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "fVt" = (
 /obj/structure/railing{
 	dir = 1
@@ -14141,6 +14247,12 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/sepia,
 /area/service/library)
+"fWt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "fWx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -14169,6 +14281,12 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
+"fWL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "fWQ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -14227,12 +14345,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"fYn" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "fYw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -14270,13 +14382,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
-"fYM" = (
-/obj/structure/table/wood,
-/obj/item/paicard,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/fore/lesser)
 "fYO" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Research Division Access";
@@ -14308,13 +14413,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"fZG" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/obj/effect/gibspawner/human,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "gai" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14353,6 +14451,11 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/engineering/storage_shared)
+"gaF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "gaT" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -14415,6 +14518,13 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"gbH" = (
+/obj/machinery/camera/motion/directional/north{
+	c_tag = "Armory - External"
+	},
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "gbZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -14434,6 +14544,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/storage)
+"gcj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "gcq" = (
 /turf/closed/wall/r_wall,
 /area/medical/treatment_center)
@@ -14490,6 +14607,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+"gdC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "gdK" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -14539,6 +14662,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"geQ" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "gfi" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
@@ -14586,6 +14715,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"ggs" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/bottle/amaretto{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/fernet{
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/sol_dry,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 10
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/fore/lesser)
 "ggA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -14683,6 +14830,9 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"giV" = (
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "giZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -14730,13 +14880,6 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"gjq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "gjy" = (
 /obj/structure/table,
 /obj/machinery/light/directional/east,
@@ -14770,16 +14913,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"gkn" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "gkS" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"gld" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "glg" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 4
@@ -14843,12 +14984,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
-"gme" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "gmp" = (
 /obj/structure/chair{
 	dir = 1
@@ -14859,14 +14994,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
-"gmq" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/structure/cable,
-/obj/structure/noticeboard/directional/east,
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
+"gmu" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/glass/reinforced,
+/area/security/lockers)
 "gmx" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -14887,6 +15018,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
+"gmK" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "gmL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/securearea{
@@ -14953,15 +15091,6 @@
 "gnC" = (
 /turf/open/floor/carpet,
 /area/command/meeting_room)
-"gnF" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/rack,
-/obj/item/storage/crayons,
-/turf/open/floor/iron,
-/area/security/processing)
 "gnP" = (
 /turf/closed/wall,
 /area/cargo/storage)
@@ -14975,6 +15104,13 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"goR" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "goU" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -15005,11 +15141,31 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
+"gpw" = (
+/obj/machinery/computer/security,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "gpI" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/mixing/launch)
+"gpK" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "gpU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -15034,12 +15190,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
-"grm" = (
-/obj/effect/spawner/random/trash/moisture_trap,
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/maintenance/fore/lesser)
 "grt" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance{
@@ -15062,6 +15212,10 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/department/medical/central)
+"gsa" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "gsx" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -15131,10 +15285,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"gtB" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+"gtA" = (
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/closed/mineral/random/snow,
+/area/icemoon/surface/outdoors/nospawn)
 "gum" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -15173,6 +15345,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/locker)
+"gvf" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "gvi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -15209,6 +15393,13 @@
 	icon_state = "damaged2"
 	},
 /area/icemoon/surface/outdoors/nospawn)
+"gwy" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "gwW" = (
 /obj/machinery/meter/monitored/distro_loop,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
@@ -15248,6 +15439,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
+"gxY" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "gye" = (
 /obj/machinery/computer/atmos_control/oxygen_tank{
 	dir = 1
@@ -15262,9 +15460,6 @@
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
-"gyh" = (
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "gyJ" = (
 /obj/machinery/power/terminal,
 /obj/machinery/light/small/directional/east,
@@ -15285,13 +15480,10 @@
 /obj/item/stack/sheet/iron/five,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"gzz" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
+"gzw" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
+/area/security/brig/upper)
 "gzD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15317,15 +15509,6 @@
 /obj/item/clothing/suit/ianshirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"gAb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "gAl" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -15343,6 +15526,25 @@
 "gAK" = (
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"gAN" = (
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory/upper)
+"gAP" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Checkpoint";
+	id_tag = "outerbrig"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigoutpost"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "gAQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15368,6 +15570,17 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"gBE" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "gBO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Stbd";
@@ -15388,6 +15601,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"gCa" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "gCg" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -15504,6 +15728,14 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"gDY" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "gEi" = (
 /obj/structure/cable,
 /turf/open/floor/iron/corner{
@@ -15531,6 +15763,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
+"gFp" = (
+/obj/effect/landmark/observer_start,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L8"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "gFq" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
@@ -15582,12 +15827,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"gGe" = (
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/fore/lesser)
 "gGl" = (
 /turf/closed/wall/r_wall,
 /area/command/meeting_room)
@@ -15645,13 +15884,6 @@
 /obj/item/trash/popcorn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"gIs" = (
-/obj/item/radio/intercom/prison/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "gIF" = (
 /obj/structure/tank_dispenser{
 	pixel_x = -1
@@ -15687,25 +15919,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"gJd" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/security/detective,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "gJg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/storage)
-"gJA" = (
-/obj/effect/gibspawner/human,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "gJM" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "EVA Motion Sensor"
@@ -15956,12 +16174,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/commons/storage/mining)
-"gOT" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/fore/lesser)
 "gPg" = (
 /obj/machinery/keycard_auth/directional/west,
 /obj/machinery/computer/cargo{
@@ -15985,24 +16197,15 @@
 /obj/effect/spawner/random/clothing/costume,
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
-"gPn" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"gPD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"gPM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 5
 	},
-/turf/open/floor/iron/smooth_large,
-/area/command/heads_quarters/hos)
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "gPW" = (
 /obj/effect/turf_decal/siding/yellow/corner,
 /obj/structure/cable,
@@ -16032,6 +16235,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"gQu" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/processing)
 "gQv" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -16084,21 +16300,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"gRV" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - Vestibule"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/processing)
 "gSm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16142,12 +16343,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/aft)
-"gSS" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/closet/secure_closet/hos,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
 "gTp" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -16241,12 +16436,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
-"gVc" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "gVp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -16254,15 +16443,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"gVs" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/processing)
 "gVO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16332,17 +16512,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"gWW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "gXg" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -16358,6 +16527,13 @@
 /obj/structure/barricade/wooden/crude/snow,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
+"gXp" = (
+/obj/machinery/space_heater,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "gXv" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16535,6 +16711,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"hbp" = (
+/obj/effect/landmark/start/head_of_security,
+/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "hbB" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
@@ -16554,19 +16738,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
-"hcn" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
-"hco" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "hcp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -16618,14 +16789,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"hdl" = (
-/obj/structure/chair/comfy{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
-/area/security/processing)
 "hdm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -16652,13 +16815,6 @@
 /obj/item/seeds/watermelon,
 /turf/open/floor/grass,
 /area/maintenance/starboard/fore)
-"hen" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "heo" = (
 /turf/closed/wall/r_wall,
 /area/security/lockers)
@@ -16810,19 +16966,6 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"hgG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/bluespace_vendor/directional/west,
-/obj/machinery/camera/directional/west{
-	c_tag = "Fore Primary Hallway"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "hgK" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Science Ordnance Launch";
@@ -16848,16 +16991,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing/launch)
-"hgS" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "hgT" = (
 /obj/effect/landmark/start/librarian,
 /obj/structure/chair/office,
@@ -16898,24 +17031,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/commons/storage/mining)
-"hiB" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
-"hiT" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "hiV" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
@@ -16930,13 +17045,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"hjg" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/warden,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "hjz" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -16948,10 +17056,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/lab)
-"hjU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "hkc" = (
 /obj/structure/table,
 /turf/open/floor/carpet,
@@ -16972,6 +17076,16 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"hlW" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "hlZ" = (
 /obj/machinery/meter,
 /obj/effect/turf_decal/delivery,
@@ -17104,6 +17218,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"hoT" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear{
+	name = "Louie";
+	move_force = 999
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "hoX" = (
 /obj/structure/table,
 /obj/item/grenade/chem_grenade/cleaner,
@@ -17164,11 +17285,11 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "hqi" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "hqr" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/poster/contraband/random/directional/east,
@@ -17226,13 +17347,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
-"hrR" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "hsa" = (
 /obj/item/chair/plastic{
 	pixel_y = 10
@@ -17365,6 +17479,17 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/treatment_center)
+"hvk" = (
+/obj/machinery/door/airlock/external{
+	name = "Security Yard";
+	space_dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "hvI" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/wood,
@@ -17375,6 +17500,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"hvW" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "hwc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17425,6 +17559,12 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"hxA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "hxE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17474,6 +17614,9 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
+"hyK" = (
+/turf/open/floor/glass/reinforced,
+/area/ai_monitored/security/armory/upper)
 "hyP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17488,6 +17631,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"hzb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "hzd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -17519,12 +17671,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
-"hzI" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "hzM" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxToilet4";
@@ -17537,6 +17683,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"hzR" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/maintenance/fore/lesser)
 "hzW" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/west,
@@ -17577,15 +17728,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"hBb" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "hBf" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Holding Area";
@@ -17638,9 +17780,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
-"hCj" = (
-/turf/open/floor/glass/reinforced,
-/area/ai_monitored/security/armory/upper)
+"hCI" = (
+/obj/item/storage/box/bodybags,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/reagent_containers/syringe{
+	name = "steel point"
+	},
+/obj/item/reagent_containers/glass/bottle/multiver,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "hDe" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -17699,12 +17850,11 @@
 	dir = 4
 	},
 /area/science/genetics)
-"hFb" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+"hFd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "hFj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/closed/wall,
@@ -17757,6 +17907,19 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"hGg" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/commons/storage/tools)
 "hGz" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
@@ -17833,10 +17996,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hIx" = (
-/obj/structure/sign/warning/coldtemp,
-/turf/closed/wall,
-/area/maintenance/fore/greater)
 "hIB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -17861,6 +18020,13 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/heads_quarters/ce)
+"hIK" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear{
+	name = "Huey";
+	move_force = 999
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "hIO" = (
 /obj/structure/railing{
 	dir = 1
@@ -17869,15 +18035,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"hIX" = (
-/turf/closed/wall/r_wall,
-/area/security/medical)
-"hJm" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "hJo" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
@@ -18000,6 +18157,28 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"hLk" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/flasher/directional/west{
+	id = "Cell 1"
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "hLW" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18064,13 +18243,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"hNd" = (
-/obj/item/radio/intercom/directional/north,
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "hNZ" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics North East"
@@ -18092,20 +18264,33 @@
 "hOt" = (
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"hOT" = (
-/turf/closed/wall/r_wall,
-/area/icemoon/surface/outdoors/nospawn)
+"hOK" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "hPg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"hPu" = (
-/turf/closed/wall,
-/area/hallway/primary/fore)
 "hPN" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
+"hQb" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/glass/reinforced,
+/area/security/checkpoint/auxiliary)
 "hQd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -18145,11 +18330,6 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"hQT" = (
-/obj/structure/bookcase,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet,
-/area/security/processing)
 "hRf" = (
 /obj/structure/ladder,
 /obj/machinery/light/small/directional/east,
@@ -18174,14 +18354,17 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"hRD" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "hRG" = (
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
+"hRM" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/camera/directional/south,
+/turf/open/floor/iron/white/corner,
+/area/hallway/secondary/entry)
 "hRT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18236,6 +18419,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"hTu" = (
+/obj/machinery/computer/department_orders/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "hTB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -18276,9 +18469,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
-"hUF" = (
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "hVo" = (
 /turf/open/floor/glass/reinforced,
 /area/medical/treatment_center)
@@ -18290,19 +18480,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/openspace,
 /area/science/xenobiology)
-"hVX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - Transport Parlor"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
-/area/security/processing)
 "hWh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
@@ -18406,6 +18583,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"hYb" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "hYi" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -18428,13 +18612,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"hZc" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "hZf" = (
 /obj/machinery/shower{
 	dir = 8
@@ -18647,6 +18824,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"idE" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "idW" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -18684,6 +18868,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"ifd" = (
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/lockers)
 "ifh" = (
 /obj/machinery/power/emitter/welded{
 	dir = 8
@@ -18817,6 +19007,11 @@
 "iim" = (
 /turf/open/openspace,
 /area/service/chapel)
+"iiu" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "iiD" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -18832,24 +19027,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/upper)
-"ijJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/item/restraints/handcuffs,
-/obj/item/radio/off,
-/obj/structure/cable,
-/obj/machinery/door/window/brigdoor/left/directional/west{
-	req_one_access_txt = "1";
-	name = "Brig Reception"
-	},
-/obj/machinery/door/window/right/directional/east{
-	name = "Brig Reception"
-	},
-/turf/open/floor/iron/dark,
-/area/security/checkpoint/auxiliary)
 "ijO" = (
 /obj/structure/table/reinforced,
 /obj/item/screwdriver{
@@ -18880,22 +19057,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"ikn" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Security Checkpoint"
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/light_switch/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "ikv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
@@ -18920,6 +19081,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"ilh" = (
+/obj/item/beacon,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "iln" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -18978,34 +19146,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"imM" = (
-/obj/structure/chair/comfy{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/carpet,
-/area/security/processing)
+"imc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "imP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"inc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
-"inm" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "inO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
@@ -19018,6 +19171,15 @@
 	dir = 8
 	},
 /area/science/research)
+"ioT" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "ipg" = (
 /turf/open/floor/iron/dark,
 /area/command/gateway)
@@ -19027,6 +19189,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/transit_tube)
+"ipt" = (
+/obj/machinery/modular_computer/console/preset/id,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
 "ipB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -19037,15 +19203,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"ipC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "ipM" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -19065,6 +19222,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"iqi" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "iqr" = (
 /turf/closed/wall/r_wall,
 /area/commons/storage/mining)
@@ -19093,6 +19255,15 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"irj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "irN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19160,11 +19331,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"itl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "ity" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -19231,17 +19397,6 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
-"ivi" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Equipment Room"
-	},
-/turf/open/floor/glass/reinforced,
-/area/security/lockers)
-"ivr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/meter/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "ivR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -19293,16 +19448,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
-"ixn" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "ixx" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -19412,6 +19557,19 @@
 /obj/item/clothing/under/color/rainbow,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"izc" = (
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "2";
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "izd" = (
 /obj/item/assembly/signaler{
 	pixel_y = 8
@@ -19450,6 +19608,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"izs" = (
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "izt" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -19511,13 +19672,26 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
+"iAv" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Security Checkpoint"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "iAE" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/wood,
 /area/command/meeting_room)
-"iAK" = (
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "iAN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/atmos{
@@ -19543,15 +19717,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
-"iBf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "iBh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Quartermaster Office Maintenance";
@@ -19561,6 +19726,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"iBt" = (
+/obj/structure/flora/grass/green,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"iBC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "iBJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -19677,15 +19857,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/medical/central)
-"iDv" = (
-/obj/machinery/disposal/bin,
-/obj/item/radio/intercom/prison/directional/north,
-/obj/machinery/camera/autoname/directional/north{
-	c_tag = "Security - Warden's Office"
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "iDw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -19942,6 +20113,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
+"iKP" = (
+/turf/open/floor/glass/reinforced,
+/area/security/office)
 "iKS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -19980,6 +20154,18 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"iLa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "iLd" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -20007,13 +20193,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"iLs" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "iLK" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -20038,14 +20217,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/pumproom)
-"iMy" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "iMR" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -20103,19 +20274,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
-"iOq" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/storage/tools)
 "iOs" = (
 /obj/item/food/grown/carrot,
 /turf/open/misc/asteroid/snow/standard_air,
@@ -20124,9 +20282,25 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/commons/storage/mining)
-"iOM" = (
-/turf/closed/wall,
-/area/security/warden)
+"iOG" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Secure Walkway"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/checkpoint/auxiliary)
+"iPC" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "riot";
+	name = "security shutters"
+	},
+/turf/open/floor/glass/reinforced,
+/area/hallway/primary/fore)
 "iPG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20185,9 +20359,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"iRm" = (
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/processing)
 "iRr" = (
 /obj/structure/table,
 /obj/machinery/button/ignition{
@@ -20205,6 +20376,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/misc_lab)
+"iSl" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Lockers";
+	location = "EVA"
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "iSn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -20226,6 +20413,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"iSG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/item/restraints/handcuffs,
+/obj/item/radio/off,
+/obj/structure/cable,
+/obj/machinery/door/window/brigdoor/left/directional/west{
+	req_one_access_txt = "1";
+	name = "Brig Reception"
+	},
+/obj/machinery/door/window/right/directional/east{
+	name = "Brig Reception"
+	},
+/turf/open/floor/iron/dark,
+/area/security/checkpoint/auxiliary)
 "iSQ" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -20262,6 +20467,13 @@
 /obj/item/camera_film,
 /turf/open/floor/wood,
 /area/service/library)
+"iUy" = (
+/obj/structure/table,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "iUA" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
@@ -20321,12 +20533,6 @@
 /obj/effect/spawner/random/techstorage/rnd_secure_all,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
-"iVe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "iVf" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 1
@@ -20378,6 +20584,16 @@
 /obj/item/grenade/chem_grenade,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"iVG" = (
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "iVO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20444,15 +20660,6 @@
 "iWV" = (
 /turf/closed/wall,
 /area/command/heads_quarters/hop)
-"iXu" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "iXF" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -20471,6 +20678,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"iXK" = (
+/obj/structure/table/wood,
+/obj/item/phone{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/radio/off{
+	pixel_y = 7;
+	pixel_x = -3
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/command/heads_quarters/hos)
 "iYj" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/chair/stool/directional/south,
@@ -20480,6 +20702,13 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"iYx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "iYA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -20490,28 +20719,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"iYF" = (
-/obj/structure/sign/directions/security{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = 40
-	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/structure/sign/directions/evac{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "iYP" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -20533,39 +20740,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing/chamber)
-"iYZ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/button/door/directional/west{
-	id = "briggate";
-	name = "Brig Shutters";
-	pixel_y = -2;
-	pixel_x = -6
-	},
-/obj/machinery/button/flasher{
-	id = "brigentry";
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/machinery/button/door/directional/west{
-	id = "innerbrig";
-	name = "Brig Interior Doors Control";
-	normaldoorcontrol = 1;
-	req_access_txt = "63";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/machinery/button/door/directional/west{
-	id = "outerbrig";
-	name = "Brig Exterior Doors Control";
-	normaldoorcontrol = 1;
-	pixel_y = -2;
-	req_access_txt = "63";
-	pixel_x = 6
-	},
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/checkpoint/auxiliary)
 "iZj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20593,19 +20767,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"iZI" = (
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "iZN" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -20624,18 +20785,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
-"jav" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/processing)
 "jay" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
@@ -20744,6 +20893,27 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall,
 /area/medical/cryo)
+"jcH" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Vestibule"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/processing)
+"jcP" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "jdv" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
@@ -20784,6 +20954,14 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
+"jex" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/checkpoint/auxiliary)
 "jeB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20798,6 +20976,9 @@
 	},
 /turf/open/openspace,
 /area/commons/storage/mining)
+"jfb" = (
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "jfc" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -20810,13 +20991,6 @@
 "jff" = (
 /turf/open/openspace,
 /area/hallway/secondary/service)
-"jfk" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "jfN" = (
 /obj/machinery/computer/operating,
 /obj/effect/turf_decal/tile/blue/full,
@@ -20941,17 +21115,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"jik" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "jiO" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21021,26 +21184,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"jkq" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/restraints/handcuffs{
-	pixel_y = 5
-	},
-/obj/item/restraints/handcuffs{
-	pixel_y = 1
-	},
-/obj/item/restraints/handcuffs{
-	pixel_x = 1;
-	pixel_y = -4
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - Holding Cells"
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
+"jkt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/command/heads_quarters/hos)
 "jkC" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics Waste Tank"
@@ -21063,13 +21212,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
-"jld" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "jlr" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -21087,13 +21229,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage)
-"jlN" = (
-/mob/living/simple_animal/hostile/asteroid/polarbear{
-	name = "Louie";
-	move_force = 999
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "jlO" = (
 /obj/structure/reflector/single/anchored{
 	dir = 9
@@ -21198,12 +21333,22 @@
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"jnZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+"jnR" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	req_access_txt = "1"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/security/checkpoint/customs/auxiliary)
+"jnY" = (
+/obj/structure/bed/dogbed/mcgriff,
+/mob/living/simple_animal/pet/dog/pug/mcgriff,
+/obj/item/food/beef_wellington_slice,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "jok" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "cmoprivacy";
@@ -21218,6 +21363,13 @@
 /obj/item/hand_tele,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"joM" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "joR" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -21259,6 +21411,17 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
+"jpm" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "jpE" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -21267,6 +21430,13 @@
 "jpF" = (
 /turf/closed/wall,
 /area/command/heads_quarters/rd)
+"jpP" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "jpR" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/carpet,
@@ -21366,6 +21536,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/central/lesser)
+"jrH" = (
+/obj/effect/turf_decal/tile/red/full,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/checkpoint/auxiliary)
 "jrQ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -21392,6 +21569,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jsz" = (
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "jsC" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
@@ -21410,17 +21594,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/cryo)
-"jtj" = (
-/obj/effect/turf_decal/tile/red/anticorner,
-/obj/machinery/requests_console/directional/north{
-	department = "Security";
-	departmentType = 3;
-	name = "Security Requests Console"
-	},
-/turf/open/floor/iron/dark/textured_corner{
-	dir = 1
-	},
-/area/security/office)
 "jtG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21458,15 +21631,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"juB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "juK" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 4
@@ -21531,6 +21695,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jwI" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore/lesser)
+"jwT" = (
+/turf/closed/wall,
+/area/security/checkpoint/customs/auxiliary)
 "jxf" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -21626,6 +21799,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
+"jzi" = (
+/obj/effect/turf_decal/tile/red/anticorner{
+	dir = 8
+	},
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
+/area/security/office)
 "jzz" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -21642,13 +21824,14 @@
 	dir = 8
 	},
 /area/science/research)
-"jAf" = (
+"jAe" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=EVA";
-	location = "Security"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "jAn" = (
@@ -21675,6 +21858,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/medical/central)
+"jAH" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "jAK" = (
 /obj/machinery/rnd/server,
 /obj/structure/lattice/catwalk,
@@ -21692,6 +21879,13 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
+"jBU" = (
+/obj/item/radio/intercom/directional/north,
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "jBV" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
@@ -21786,21 +21980,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"jDP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
-"jEs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
-"jEx" = (
-/mob/living/simple_animal/bot/secbot/beepsky,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/fore/lesser)
 "jEF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21812,11 +21991,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"jEM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/lockers)
 "jET" = (
 /obj/machinery/air_sensor/mix_tank,
 /turf/open/floor/engine/vacuum,
@@ -21845,20 +22019,15 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"jFh" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/light/directional/south,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
+"jFt" = (
+/obj/structure/railing{
+	dir = 4
 	},
-/area/security/lockers)
-"jFw" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/security/brig/upper)
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "jFG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21879,6 +22048,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"jGf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "jGq" = (
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/firealarm/directional/south,
@@ -22057,11 +22235,6 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"jKh" = (
-/obj/structure/table,
-/obj/item/storage/box/prisoner,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "jKu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -22205,15 +22378,6 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"jPk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "jPn" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -22260,6 +22424,17 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"jPR" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "jPY" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -22295,11 +22470,33 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/maint)
+"jRh" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch/directional/south,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "jRi" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"jRj" = (
+/obj/item/radio/off,
+/obj/item/crowbar,
+/obj/item/assembly/flash/handheld,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "jRs" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -22327,6 +22524,9 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/checkpoint/engineering)
+"jRM" = (
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "jRO" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table/glass,
@@ -22410,22 +22610,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
-"jTS" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Checkpoint";
-	id_tag = "outerbrig"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigoutpost"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "jTV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -22446,19 +22630,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"jUl" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
-/obj/machinery/button/door{
-	id = "BrigLock";
-	name = "Cell Shutters";
-	pixel_y = 9;
-	pixel_x = 7
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+"jUn" = (
+/obj/vehicle/ridden/secway,
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "jUs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -22469,16 +22646,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"jVe" = (
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/iron/smooth_edge,
-/area/security/lockers)
-"jVn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/large,
-/area/command/heads_quarters/hos)
+"jUY" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/potato{
+	name = "\improper Beepsky's emergency battery"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "jVr" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
@@ -22543,13 +22719,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"jWD" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "jWH" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -22557,27 +22726,24 @@
 /obj/item/cultivator/rake,
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
-"jWV" = (
-/obj/machinery/computer/prisoner/gulag_teleporter_computer{
-	dir = 4
+"jWM" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/computer/secure_data{
+	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/security/processing)
+/area/security/warden)
+"jXk" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "jXp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"jXq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "jXr" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -22586,30 +22752,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jXz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "2";
-	dir = 1
+"jXD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
-"jXG" = (
-/obj/machinery/computer/department_orders/security{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "jXT" = (
 /obj/structure/table/glass,
 /obj/machinery/light/directional/west,
@@ -22647,13 +22796,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"kae" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/structure/sign/nanotrasen,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "kaq" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall,
@@ -22673,6 +22815,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/commons/locker)
+"kaw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "kaC" = (
 /obj/structure/chair,
 /obj/structure/disposalpipe/segment{
@@ -22783,13 +22932,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/upper)
-"kbY" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "kcl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -22816,6 +22958,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"kcG" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "kcH" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/tile/brown,
@@ -22825,13 +22974,6 @@
 /obj/structure/noticeboard/directional/east,
 /turf/open/floor/wood,
 /area/command/meeting_room)
-"kdc" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "kdq" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/heater,
 /obj/structure/sign/poster/official/science{
@@ -22863,13 +23005,6 @@
 /obj/item/folder/yellow,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"kdI" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "kdK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -22883,39 +23018,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/locker)
-"kdY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/security/lockers)
 "kdZ" = (
 /obj/machinery/computer/camera_advanced/xenobio,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"kem" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_y = 9;
-	pixel_x = 7
-	},
-/obj/machinery/button/door{
-	id = "Prison Gate";
-	name = "Prison Wing Lockdown";
-	req_access_txt = "2";
-	pixel_x = 7
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "keL" = (
 /obj/machinery/light/directional/south,
 /obj/structure/closet/firecloset,
@@ -22951,6 +23057,14 @@
 "kfT" = (
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"kgc" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "MiniSat External NorthEast";
+	network = list("minisat");
+	start_active = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/ai_monitored/turret_protected/aisat/maint)
 "kge" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/blue,
@@ -22982,6 +23096,18 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"kgI" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
+"kgP" = (
+/turf/closed/wall/r_wall,
+/area/icemoon/surface/outdoors/nospawn)
 "kgQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/side{
@@ -23030,14 +23156,6 @@
 "kiC" = (
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/maint)
-"kiD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "kjd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -23112,11 +23230,12 @@
 /obj/item/trash/waffles,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"kkP" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
+"kkY" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
 	},
-/area/maintenance/fore/lesser)
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "kla" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23177,14 +23296,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"kms" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "MiniSat External NorthWest";
-	network = list("minisat");
-	start_active = 1
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/ai_monitored/turret_protected/aisat/maint)
 "kmA" = (
 /obj/structure/railing{
 	dir = 5
@@ -23247,19 +23358,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
-"knU" = (
-/obj/structure/rack,
-/obj/item/electropack,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
-"kok" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "armory";
-	name = "Armoury Shutter"
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/security/armory/upper)
 "koo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23311,9 +23409,6 @@
 /obj/machinery/navbeacon/wayfinding/dockesc,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"kpT" = (
-/turf/closed/wall,
-/area/security/brig/upper)
 "kpX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -23324,6 +23419,14 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"kqE" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "krh" = (
 /obj/item/wrench,
 /obj/item/weldingtool,
@@ -23361,12 +23464,6 @@
 "krt" = (
 /turf/open/floor/carpet,
 /area/maintenance/space_hut/cabin)
-"krv" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "krI" = (
 /obj/effect/turf_decal/siding/yellow/end{
 	dir = 8
@@ -23387,6 +23484,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
+"krU" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"kse" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Interrogation";
+	network = list("interrogation")
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "ksg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -23399,18 +23518,16 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"ksI" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "ksN" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
+"ksV" = (
+/obj/structure/table,
+/obj/item/storage/box/prisoner,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "ktb" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -23426,6 +23543,19 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"kuc" = (
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "kuy" = (
 /obj/structure/table,
 /obj/item/electronics/apc,
@@ -23433,16 +23563,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"kuM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "kuR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 1
@@ -23470,15 +23590,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/central)
-"kvF" = (
-/obj/machinery/flasher/directional/east{
-	id = "brigentry"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "kwf" = (
 /turf/open/floor/iron,
 /area/command/gateway)
@@ -23515,13 +23626,6 @@
 "kwP" = (
 /turf/open/floor/iron/dark,
 /area/engineering/lobby)
-"kwS" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/security/lockers)
 "kwZ" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/seven,
@@ -23567,15 +23671,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/maintenance/department/medical/central)
-"kyA" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "kyN" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -23593,6 +23688,23 @@
 /obj/item/stack/pipe_cleaner_coil/random,
 /turf/open/floor/iron,
 /area/commons/storage/art)
+"kzl" = (
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/flasher/directional/west{
+	id = "Cell 3"
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "kzp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/chair{
@@ -23667,6 +23779,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"kAS" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "kAZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23699,6 +23815,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
+"kBy" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/security/warden)
 "kBH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23795,27 +23915,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"kCO" = (
-/obj/item/book/manual/wiki/tcomms{
-	pixel_x = 10;
-	pixel_y = -1
-	},
-/obj/item/book/manual/wiki/ordnance{
-	pixel_y = 3;
-	pixel_x = 10
-	},
-/obj/item/book/manual/wiki/experimentor{
-	pixel_x = 10;
-	pixel_y = 8
-	},
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/processing)
 "kCZ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -23826,6 +23925,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
+"kDh" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Walkway";
+	id_tag = "innerbrig"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigoutpost"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "kDt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -23932,6 +24047,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"kGb" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/processing)
 "kGc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -23986,15 +24110,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"kHc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+"kGZ" = (
+/obj/machinery/suit_storage_unit/hos,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "kHq" = (
 /obj/machinery/cell_charger{
 	pixel_y = 5
@@ -24068,22 +24188,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/engineering/storage_shared)
-"kJu" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "EVA2"
+"kJo" = (
+/obj/machinery/keycard_auth/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "kJC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24097,6 +24208,16 @@
 "kJV" = (
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
+"kJW" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "kJX" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -24110,16 +24231,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/meeting_room)
-"kKo" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "kKQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -24171,25 +24282,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"kLL" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Head of Security"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/hos,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth_large,
-/area/command/heads_quarters/hos)
-"kLN" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	shuttledocked = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/processing)
 "kLO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -24200,24 +24292,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"kLU" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "MiniSat External NorthEast";
-	network = list("minisat");
-	start_active = 1
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/ai_monitored/turret_protected/aisat/maint)
 "kMd" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/mixing)
 "kMf" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+/obj/machinery/space_heater,
+/obj/machinery/camera/directional/south{
+	c_tag = "Auxiliary Tool Storage"
+	},
+/turf/open/floor/iron,
+/area/commons/storage/tools)
 "kMm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -24251,6 +24340,9 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/service/kitchen/coldroom)
+"kNB" = (
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "kNM" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -24310,10 +24402,24 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/heads_quarters/cmo)
+"kOM" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "kOP" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"kPm" = (
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "kPp" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -24325,15 +24431,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/research)
-"kPx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/camera/directional/north,
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "kPE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output{
 	dir = 1
@@ -24403,10 +24500,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
-"kRr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/security/armory/upper)
 "kRG" = (
 /obj/structure/grille,
 /obj/structure/window{
@@ -24429,14 +24522,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"kSr" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "kSy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -24451,6 +24536,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"kSJ" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
+"kSQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "kTP" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -24590,13 +24689,6 @@
 /obj/item/dest_tagger,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"kXQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/radio/intercom/prison/directional/south,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "kXV" = (
 /obj/structure/table,
 /obj/item/storage/box,
@@ -24643,9 +24735,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"kYD" = (
-/turf/open/openspace,
-/area/ai_monitored/security/armory/upper)
 "kZc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24687,29 +24776,6 @@
 	dir = 8
 	},
 /area/science/misc_lab)
-"kZv" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
-	pixel_y = 20;
-	pixel_x = 7
-	},
-/obj/item/taperecorder{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6
-	},
-/obj/item/storage/secure/safe/hos{
-	pixel_x = 35
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
 "kZL" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/service_all,
@@ -24729,15 +24795,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/mixing/launch)
-"lak" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/corner{
-	dir = 8
-	},
-/area/security/processing)
 "laq" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/camera/directional/south{
@@ -24871,13 +24928,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"lev" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
 "lez" = (
 /obj/structure/bed,
 /obj/machinery/airalarm/directional/north,
@@ -24891,6 +24941,13 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"leS" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "leY" = (
 /obj/machinery/computer/atmos_control/plasma_tank{
 	dir = 8
@@ -24955,6 +25012,14 @@
 /obj/effect/spawner/random/techstorage/tcomms_all,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
+"lgW" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/auxiliary)
 "lhw" = (
 /obj/structure/ladder{
 	name = "upper dispenser access"
@@ -24977,10 +25042,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"lit" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+"lin" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/obj/item/toy/cards/deck{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 14;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -18;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -10;
+	pixel_y = 2
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/maintenance/fore/lesser)
 "liN" = (
 /obj/machinery/light/small/broken/directional/south,
 /obj/item/trash/energybar,
@@ -25011,13 +25094,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"lla" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+"lkx" = (
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
+"lkR" = (
+/obj/item/bedsheet/red,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "llw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -25052,11 +25143,24 @@
 /obj/item/camera,
 /turf/open/floor/iron,
 /area/commons/storage/art)
+"lmb" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "Armory - Internal - Upper"
+	},
+/turf/open/openspace,
+/area/ai_monitored/security/armory/upper)
 "lmd" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
 /area/engineering/atmos/storage/gas)
+"lmi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/processing)
 "lmj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -25081,6 +25185,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"lmF" = (
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/fore/lesser)
 "lmK" = (
 /obj/machinery/iv_drip,
 /obj/structure/mirror/directional/north{
@@ -25092,6 +25202,15 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/service/hydroponics)
+"lno" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/rack,
+/obj/item/storage/crayons,
+/turf/open/floor/iron,
+/area/security/processing)
 "lnv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25242,37 +25361,12 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"lsm" = (
-/obj/machinery/computer/security{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/computer/security/telescreen/prison{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
-"lsn" = (
-/obj/structure/cable,
-/turf/open/floor/wood{
-	icon_state = "wood-broken2"
-	},
-/area/maintenance/fore/lesser)
 "lsq" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/open/floor/engine/cult,
 /area/service/library)
-"lsD" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom/prison/directional/east,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "lsV" = (
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
@@ -25319,35 +25413,6 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/iron/freezer,
 /area/maintenance/starboard/fore)
-"luH" = (
-/obj/structure/flora/bush,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"lvb" = (
-/obj/structure/table,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -8;
-	pixel_y = 11
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/hand_labeler{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "lvq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25362,15 +25427,21 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
-"lvO" = (
-/turf/closed/wall/r_wall,
-/area/security/checkpoint/auxiliary)
 "lvU" = (
 /obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/fore/lesser)
+"lvW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/checkpoint/auxiliary)
 "lvZ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -25455,22 +25526,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"lxm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
-"lxu" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/inspector,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "lxL" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 4
@@ -25513,6 +25568,9 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lyi" = (
+/turf/closed/wall/r_wall,
+/area/security/brig/upper)
 "lyj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
@@ -25557,6 +25615,15 @@
 /obj/structure/closet/wardrobe/grey,
 /turf/open/floor/iron,
 /area/commons/locker)
+"lzk" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "lzw" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
@@ -25570,10 +25637,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lzZ" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/glass/reinforced,
-/area/ai_monitored/security/armory/upper)
+"lzS" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Walkway"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigentrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "lAq" = (
 /obj/structure/grille,
 /obj/structure/window{
@@ -25613,12 +25689,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
-"lAX" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "lBf" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -25637,6 +25707,23 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/starboard/fore)
+"lBh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"lBj" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Infirmary"
+	},
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "lBD" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
@@ -25706,11 +25793,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
-"lEk" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/light/small/directional/west,
+"lDS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"lEb" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
+/area/security/office)
 "lEo" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -25737,11 +25833,6 @@
 "lEv" = (
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/pumproom)
-"lEI" = (
-/obj/structure/window/reinforced,
-/obj/machinery/holopad,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "lEL" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -25783,13 +25874,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"lFX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+"lFN" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/fore/lesser)
 "lGE" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -25804,6 +25894,10 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/pumproom)
+"lGS" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/glass/reinforced,
+/area/ai_monitored/security/armory/upper)
 "lGT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25828,6 +25922,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"lHu" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "lHY" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -25886,6 +25987,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"lJK" = (
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/structure/cable,
+/obj/structure/noticeboard/directional/east,
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "lJL" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=AIE";
@@ -25897,12 +26006,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"lJW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "lKi" = (
 /obj/machinery/computer/security,
 /obj/effect/turf_decal/tile/red,
@@ -25911,16 +26014,14 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"lKk" = (
-/obj/machinery/computer/security/labor{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "lKm" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"lKI" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/ice,
+/area/icemoon/surface/outdoors/nospawn)
 "lKJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -25930,6 +26031,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"lKN" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/closet/emcloset,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/processing)
 "lKO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/siding/yellow{
@@ -26063,17 +26173,19 @@
 	dir = 1
 	},
 /area/service/hydroponics)
-"lNI" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/twenty,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "lNM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"lNR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "lOp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/east,
@@ -26126,6 +26238,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
+"lQo" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "lQz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26196,19 +26312,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
-"lTd" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Entrance"
+"lSN" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigentrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "lTy" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -26264,26 +26373,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"lUS" = (
-/mob/living/simple_animal/hostile/asteroid/polarbear{
-	name = "Dewey";
-	move_force = 999
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"lUV" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Vestibule"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/security/detective,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/turf/open/floor/iron/smooth,
-/area/security/processing)
 "lUZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26444,20 +26533,41 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"lZz" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Office"
+"lZo" = (
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
 	},
-/turf/open/floor/iron/dark/textured_half,
-/area/security/office)
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "lZT" = (
 /obj/structure/chair/sofa/left,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
+"mad" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/restraints/handcuffs{
+	pixel_y = 5
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 1
+	},
+/obj/item/restraints/handcuffs{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Holding Cells"
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "mas" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -26477,10 +26587,6 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics)
-"maD" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/grass,
-/area/security/warden)
 "maG" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -26516,18 +26622,15 @@
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"mbw" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "mbC" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"mbF" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/structure/closet/emcloset,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security Entrance"
-	},
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "mbW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -26540,15 +26643,19 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/engineering/lobby)
-"mcz" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/item/inspector,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
+"mcr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Transport Parlor"
 	},
-/area/security/office)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron,
+/area/security/processing)
 "mcB" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -26561,6 +26668,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"mcS" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/grass,
+/area/security/warden)
 "mdh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26645,6 +26759,13 @@
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"mgj" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "mgp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26666,6 +26787,21 @@
 /obj/structure/cable,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
+"mhe" = (
+/obj/structure/closet/secure_closet/security,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "mhg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -26719,6 +26855,9 @@
 	},
 /turf/open/floor/iron,
 /area/science/storage)
+"miI" = (
+/turf/open/openspace,
+/area/ai_monitored/security/armory/upper)
 "miP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
@@ -26810,6 +26949,18 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/medical/cryo)
+"mkw" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Upper Brig South"
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "mkH" = (
 /obj/structure/closet/secure_closet/security/med,
 /obj/machinery/firealarm/directional/south,
@@ -26875,14 +27026,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"mmO" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L9"
-	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "mni" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26926,12 +27069,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
-"mot" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet,
-/area/command/heads_quarters/captain)
 "moz" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
@@ -27030,11 +27167,6 @@
 "mpV" = (
 /turf/open/floor/iron,
 /area/cargo/lobby)
-"mpZ" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "mqc" = (
 /obj/machinery/requests_console/directional/west{
 	department = "Science";
@@ -27067,15 +27199,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/storage_shared)
-"mqQ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/ai_monitored/security/armory/upper)
 "mqW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27158,6 +27281,11 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
+"muv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "muM" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -27233,19 +27361,6 @@
 	dir = 4
 	},
 /area/science/xenobiology)
-"mxL" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/structure/table,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "mxZ" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 8
@@ -27314,11 +27429,30 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"mzK" = (
-/obj/machinery/vending/security,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth_edge,
-/area/security/lockers)
+"mzM" = (
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/bedsheet/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "mzO" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -27452,18 +27586,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"mDz" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/processing)
 "mDG" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -27483,15 +27605,6 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"mFq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "mFE" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
@@ -27594,27 +27707,6 @@
 	dir = 1
 	},
 /area/engineering/engine_smes)
-"mIg" = (
-/obj/effect/landmark/start/head_of_security,
-/obj/machinery/holopad,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
-"mIs" = (
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "2";
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "mIB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27624,15 +27716,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"mIF" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "mIM" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -27684,11 +27767,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/medical/treatment_center)
-"mJH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "mJP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -27724,13 +27802,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/pumproom)
-"mKH" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "mKO" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/chair/stool/directional/south,
@@ -27849,12 +27920,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"mOf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "mOn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27875,21 +27940,16 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/pumproom)
+"mOK" = (
+/obj/machinery/computer/prisoner/gulag_teleporter_computer{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "mOR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"mOW" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"mOY" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/fore/lesser)
 "mPc" = (
 /obj/machinery/requests_console/directional/west{
 	department = "Cargo Bay";
@@ -27927,23 +27987,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"mPB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron,
-/area/security/brig/upper)
-"mPI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
 "mPL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27968,15 +28011,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/lobby)
-"mQb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "mQd" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -28005,15 +28039,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/red,
 /area/commons/vacant_room/office)
-"mQF" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "mQP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -28028,29 +28053,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"mRO" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
-"mRQ" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "mRX" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/red/half{
@@ -28125,6 +28127,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/misc/asteroid/snow/standard_air,
 /area/hallway/secondary/exit/departure_lounge)
+"mTN" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "mTO" = (
 /turf/closed/wall/r_wall,
 /area/commons/storage/primary)
@@ -28134,16 +28144,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"mVq" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/iron,
-/area/security/warden)
 "mWg" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
@@ -28175,10 +28175,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"mWF" = (
-/obj/machinery/modular_computer/console/preset/id,
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
 "mWJ" = (
 /obj/machinery/door/window/right/directional/east{
 	base_state = "left";
@@ -28275,6 +28271,11 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"mZr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "mZD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28293,18 +28294,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/meeting_room)
-"nai" = (
-/obj/machinery/door/airlock/external{
-	name = "Security Yard";
-	space_dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "naj" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -28315,6 +28304,13 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"nau" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "naL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -28330,9 +28326,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half,
 /area/maintenance/department/medical/central)
-"nbj" = (
-/turf/open/floor/glass,
-/area/security/lockers)
+"nbb" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "nbs" = (
 /obj/machinery/door/window/right/directional/east{
 	base_state = "left";
@@ -28345,6 +28343,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
+"nbv" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron/dark/textured_half,
+/area/security/office)
 "nbH" = (
 /obj/structure/chair,
 /turf/open/floor/iron/white/smooth_large,
@@ -28444,6 +28448,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/aft)
+"nea" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/fore/lesser)
 "nec" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -28471,10 +28480,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"nfD" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
 "nfU" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -28547,6 +28552,12 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
+"ngU" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "nhe" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Medical Officer";
@@ -28575,6 +28586,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage)
+"nhP" = (
+/mob/living/simple_animal/mouse/white{
+	name = "Mik";
+	desc = "This mouse smells faintly of alcohol."
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/maintenance/fore/lesser)
 "nhQ" = (
 /turf/open/floor/carpet,
 /area/service/library)
@@ -28628,12 +28648,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
-"njA" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "njE" = (
 /obj/structure/table/wood,
 /obj/item/pen/red{
@@ -28684,24 +28698,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"nlp" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/drinks/bottle/amaretto{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/food/drinks/bottle/fernet{
-	pixel_x = 7;
-	pixel_y = 16
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/sol_dry,
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 10
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/fore/lesser)
 "nlQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -28714,13 +28710,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"nmg" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+"nme" = (
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "nmi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -28738,15 +28734,44 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/aft)
-"nmu" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/disposalpipe/segment,
+"nmr" = (
+/obj/machinery/vending/cigarette,
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_x = -22
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
+"nmt" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Fore - Courtroom Hallway"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"nmv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "nmw" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nmE" = (
+/obj/structure/disposalpipe/trunk/multiz/down,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "nmJ" = (
 /obj/item/stamp{
 	pixel_x = -3;
@@ -28805,10 +28830,6 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"nog" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "noi" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -28909,6 +28930,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"nrh" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Transport"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "nrA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28985,10 +29013,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/cargo/lobby)
-"nsD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint/customs/auxiliary)
 "nsK" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -29067,6 +29091,13 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"ntU" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear{
+	name = "Dewey";
+	move_force = 999
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "nuf" = (
 /turf/closed/wall,
 /area/command/meeting_room)
@@ -29086,10 +29117,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"nvF" = (
-/obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "nvH" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -29097,16 +29124,20 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"nvY" = (
-/obj/structure/plasticflaps,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "nwq" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"nwr" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "nwI" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -29147,6 +29178,9 @@
 "nxB" = (
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"nxE" = (
+/turf/closed/wall,
+/area/security/brig/upper)
 "nxI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29175,6 +29209,19 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"nyg" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -6
+	},
+/obj/machinery/button/door{
+	id = "BrigLock";
+	name = "Cell Shutters";
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "nyq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -29201,15 +29248,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
-"nyP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "nyY" = (
 /obj/machinery/computer/crew,
 /obj/effect/turf_decal/tile/green,
@@ -29228,16 +29266,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"nzl" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "nzu" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -29277,25 +29305,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
-"nAv" = (
-/obj/item/radio/off,
-/obj/item/crowbar,
-/obj/item/assembly/flash/handheld,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
-"nAA" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/start/warden,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "nAQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -29309,6 +29318,15 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"nAY" = (
+/turf/closed/wall,
+/area/security/lockers)
+"nBk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "nBq" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/turf_decal/stripes/corner{
@@ -29384,6 +29402,13 @@
 /obj/item/kirbyplants/potty,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"nEd" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "nEf" = (
 /obj/item/storage/fancy/donut_box,
 /obj/structure/table,
@@ -29398,6 +29423,15 @@
 	dir = 4
 	},
 /area/hallway/primary/starboard)
+"nEI" = (
+/obj/machinery/disposal/bin,
+/obj/item/radio/intercom/prison/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Security - Warden's Office"
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "nFn" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -29508,6 +29542,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"nIg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "nIo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -29535,9 +29578,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"nIv" = (
-/turf/open/floor/carpet,
-/area/security/processing)
 "nIz" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -29626,28 +29666,6 @@
 	dir = 4
 	},
 /area/engineering/lobby)
-"nKB" = (
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 24
-	},
-/turf/open/floor/carpet,
-/area/security/processing)
-"nKQ" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/requests_console/directional/north{
-	department = "Security";
-	departmentType = 3;
-	name = "Security Requests Console"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "nLM" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/grimy,
@@ -29668,6 +29686,10 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
+"nMC" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "nMM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29685,19 +29707,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
-"nNt" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Upper Hallway North"
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "nNy" = (
 /obj/structure/railing{
 	dir = 4
@@ -29853,14 +29862,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"nQs" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch/directional/south,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
 "nQt" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/sign/poster/contraband/random/directional/north,
@@ -29881,22 +29882,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
-"nQE" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Walkway";
-	id_tag = "innerbrig"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigoutpost"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "nQQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/plating,
@@ -29941,14 +29926,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"nRs" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "nRt" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
@@ -29979,25 +29956,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"nRM" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
-"nRQ" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/potato{
-	name = "\improper Beepsky's emergency battery"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "nRY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30220,18 +30178,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"nVr" = (
-/obj/machinery/computer/security,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "nVS" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -30342,28 +30288,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nZb" = (
-/obj/machinery/computer/security/hos,
-/obj/machinery/requests_console/directional/north{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security Requests Console"
-	},
-/obj/machinery/button/door/directional/north{
-	id = "hosspace";
-	name = "Icemoon Shutters Control";
-	pixel_x = -24
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
-"nZE" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "nZK" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
@@ -30399,14 +30323,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/pumproom)
-"oaR" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/timer,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "oaV" = (
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
@@ -30476,6 +30392,15 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
+"ocb" = (
+/obj/machinery/button/flasher{
+	id = "cell4";
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "ocw" = (
 /obj/structure/chair/office,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -30535,6 +30460,16 @@
 /obj/structure/industrial_lift,
 /turf/open/openspace,
 /area/commons/storage/mining)
+"odJ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"oeo" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "oep" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/effect/turf_decal/siding/white{
@@ -30543,23 +30478,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
-"oeA" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/restraints/handcuffs{
-	pixel_y = 5
-	},
-/obj/item/restraints/handcuffs{
-	pixel_y = 1
-	},
-/obj/item/restraints/handcuffs{
-	pixel_x = 1;
-	pixel_y = -4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "oeC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -30616,10 +30534,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"ofc" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "ofj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30651,15 +30565,19 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"oga" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"ogQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/camera/directional/west{
+	c_tag = "Dormitory South"
+	},
 /turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
+/area/commons/dorms)
 "ogY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -30740,6 +30658,10 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"oiY" = (
+/obj/machinery/computer/warrant,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "ojc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -30778,15 +30700,6 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ojQ" = (
-/obj/machinery/button/flasher{
-	id = "cell4";
-	pixel_y = -22
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "oka" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/light/directional/east,
@@ -30913,6 +30826,13 @@
 /obj/item/ai_module/supplied/protect_station,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"omh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "omi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -30936,6 +30856,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"omG" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "omH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -30966,6 +30893,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"onI" = (
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "onV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -31071,27 +31002,21 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"oqh" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
 "oqz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
 /area/science/research)
-"oqS" = (
+"oqR" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "orl" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -31125,6 +31050,15 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"orV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "orZ" = (
 /obj/machinery/camera/autoname/directional/south{
 	c_tag = "Gas Storage";
@@ -31149,10 +31083,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"osw" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "osN" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
@@ -31179,6 +31109,49 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/cargo/qm)
+"otv" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
+	pixel_y = 20;
+	pixel_x = 7
+	},
+/obj/item/taperecorder{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6
+	},
+/obj/item/storage/secure/safe/hos{
+	pixel_x = 35
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
+"otW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	name = "Warden Desk";
+	req_access_txt = "3"
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/window/left/directional/north{
+	name = "Warden Desk"
+	},
+/turf/open/floor/iron,
+/area/security/warden)
 "oug" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31189,6 +31162,13 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"ouv" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "ouM" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable,
@@ -31292,6 +31272,16 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/aft)
+"oxY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "oyk" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
@@ -31398,15 +31388,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"oAq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "oAu" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -31503,12 +31484,11 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"oDB" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
+"oDY" = (
+/obj/structure/plasticflaps,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "oEe" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/radiation,
@@ -31538,6 +31518,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"oEC" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "oEU" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -31551,14 +31535,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/recharge_floor,
 /area/science/robotics/mechbay)
-"oFu" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "oFG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31587,30 +31563,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/maintenance/aft/greater)
-"oGC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
-"oGS" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Secure Walkway"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "oHR" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -31630,12 +31582,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"oHV" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "oIf" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -31652,13 +31598,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter)
-"oIp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "oIC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31714,12 +31653,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
-"oJc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "oJd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31730,11 +31663,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"oJp" = (
-/obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/security/processing)
 "oJH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot{
@@ -31826,20 +31754,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
-"oLn" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used to access the various cameras on the station.";
-	layer = 3.1;
-	name = "Security Camera Monitor";
-	network = list("ss13");
-	pixel_y = 2;
-	dir = 1
-	},
-/obj/structure/table,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "oLq" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
@@ -32056,27 +31970,6 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/iron,
 /area/engineering/main)
-"oPD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
-"oPM" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "oPR" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
@@ -32125,25 +32018,21 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"oQJ" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "oQS" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Port"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"oQY" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment,
+"oRa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/security/brig/upper)
 "oRm" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -32157,17 +32046,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"oRN" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security EVA"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth,
-/area/security/processing)
 "oRT" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -32181,6 +32059,12 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/central)
+"oSg" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "oSt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm/directional/south,
@@ -32240,14 +32124,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"oTK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "oTL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32333,6 +32209,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"oVW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "oWb" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/blue,
@@ -32344,6 +32225,17 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"oWj" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "EVA Maintenance";
+	req_access_txt = "18"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "oWr" = (
 /obj/machinery/computer/monitor{
 	name = "bridge power monitoring console"
@@ -32358,6 +32250,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
+"oWu" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "armory";
+	name = "Armoury Shutter"
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/security/armory/upper)
 "oWy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32387,10 +32286,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"oWT" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
+"oWZ" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
+/area/icemoon/surface/outdoors/nospawn)
 "oXa" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/disposalpipe/segment,
@@ -32425,6 +32324,9 @@
 "oYz" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/starboard)
+"oYI" = (
+/turf/open/floor/iron/dark/textured,
+/area/security/processing)
 "oYL" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -32445,18 +32347,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
-"oZa" = (
-/obj/structure/table/wood,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/storage/box/deputy,
-/turf/open/floor/wood/large,
-/area/command/heads_quarters/hos)
 "oZl" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"oZC" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
+/area/security/warden)
+"oZH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "oZI" = (
 /turf/closed/wall,
 /area/commons/storage/tools)
@@ -32485,20 +32387,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"pbr" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
-"pbx" = (
-/obj/structure/rack,
-/obj/machinery/syndicatebomb/training,
-/obj/structure/cable,
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "pby" = (
 /obj/structure/rack,
 /obj/item/integrated_circuit/loaded/speech_relay,
@@ -32516,13 +32404,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/construction)
-"pcc" = (
-/obj/effect/turf_decal/tile/red/half{
+"pbX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "2";
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth_half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/security/brig/upper)
 "pcf" = (
 /obj/structure/railing,
@@ -32577,6 +32471,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"peY" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "pfS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32611,19 +32511,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"pgY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/item/radio/intercom/prison/directional/east{
-	frequency = 1359
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "pgZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -32683,6 +32570,26 @@
 /obj/structure/closet/secure_closet/quartermaster,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"phP" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -6
+	},
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	req_access_txt = "2";
+	pixel_x = 7
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "phQ" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -32699,16 +32606,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"pii" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "pij" = (
 /obj/structure/frame/computer,
 /obj/structure/sign/poster/official/help_others{
@@ -32734,19 +32631,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"piO" = (
-/obj/machinery/modular_computer/console/preset/cargochat/security{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
-"pji" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/security/processing)
 "pjx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/south{
@@ -32761,6 +32645,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/science/genetics)
+"pjK" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom/prison/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "pjN" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32802,13 +32695,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
-"plz" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/camera/motion/directional/south{
-	c_tag = "Armory - Internal - Upper"
-	},
-/turf/open/openspace,
-/area/ai_monitored/security/armory/upper)
 "pmn" = (
 /obj/structure/table,
 /obj/machinery/newscaster/directional/north,
@@ -32846,15 +32732,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"pmA" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/closet/emcloset,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/processing)
 "pmJ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -32863,6 +32740,10 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
+"pmQ" = (
+/obj/effect/turf_decal/tile/red/full,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/checkpoint/auxiliary)
 "pmR" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera{
@@ -32940,15 +32821,6 @@
 /obj/item/clipboard,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"pnQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "pnR" = (
 /obj/structure/sink{
 	dir = 8;
@@ -33051,12 +32923,6 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"pqa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "pqc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33086,10 +32952,6 @@
 /obj/item/shovel/spade,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"pqD" = (
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "pqO" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 4
@@ -33103,6 +32965,11 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
+"pqV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig/upper)
 "prj" = (
 /obj/machinery/computer/atmos_control/mix_tank{
 	dir = 8
@@ -33141,27 +33008,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
-"pry" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "prA" = (
 /obj/structure/reflector/single/anchored{
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
-"prI" = (
-/obj/machinery/keycard_auth/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
 "prX" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -33214,6 +33066,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"ptf" = (
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/iron/smooth_edge,
+/area/security/lockers)
 "ptr" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -33294,6 +33150,13 @@
 /obj/item/taperecorder,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"pvg" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "pvn" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/green{
@@ -33388,6 +33251,15 @@
 /obj/effect/spawner/random/clothing/wardrobe_closet_colored,
 /turf/open/floor/iron,
 /area/commons/locker)
+"pwJ" = (
+/obj/structure/rack,
+/obj/machinery/syndicatebomb/training,
+/obj/structure/cable,
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "pwP" = (
 /obj/machinery/door/airlock{
 	name = "Hydroponics Backroom";
@@ -33415,9 +33287,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"pxl" = (
-/turf/closed/wall,
-/area/security/checkpoint/customs/auxiliary)
 "pxs" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/iron/dark,
@@ -33473,13 +33342,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"pxW" = (
-/obj/machinery/space_heater,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "pyd" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -33510,22 +33372,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"pyM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "pyS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"pyT" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "pAk" = (
 /obj/machinery/chem_heater/withbuffer,
 /obj/structure/window/reinforced{
@@ -33566,6 +33428,16 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
+"pBI" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "pBR" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -33724,19 +33596,15 @@
 "pFQ" = (
 /turf/open/floor/iron,
 /area/engineering/main)
-"pGf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+"pGm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig/upper)
-"pGj" = (
-/obj/machinery/computer/warrant,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "pGo" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood/parquet,
@@ -33897,15 +33765,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"pKm" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
 "pKI" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port Mix to West Ports"
@@ -33991,18 +33850,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"pMk" = (
-/obj/item/storage/box/bodybags,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/item/reagent_containers/syringe{
-	name = "steel point"
-	},
-/obj/item/reagent_containers/glass/bottle/multiver,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/structure/table/glass,
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "pMp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34037,11 +33884,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/aft/greater)
-"pNt" = (
-/obj/machinery/suit_storage_unit/hos,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
 "pNC" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/landmark/start/hangover,
@@ -34089,9 +33931,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/meeting_room)
-"pOx" = (
-/turf/closed/wall/r_wall,
-/area/security/brig/upper)
 "pOE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -34116,6 +33955,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"pPc" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "pPh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -34157,19 +34003,6 @@
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/pharmacy)
-"pQi" = (
-/obj/effect/landmark/observer_start,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L8"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "pQk" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -34194,16 +34027,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"pQV" = (
-/obj/structure/railing,
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
+"pRf" = (
+/obj/structure/closet/bombcloset/security,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "pRo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -34220,10 +34047,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/storage)
-"pRG" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "pRW" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
@@ -34232,17 +34055,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/service/janitor)
-"pSd" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "pSk" = (
 /turf/closed/wall,
 /area/medical/medbay/aft)
@@ -34259,6 +34071,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"pSE" = (
+/obj/structure/cable,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/maintenance/fore/lesser)
 "pSG" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer/on/coldroom{
 	dir = 1
@@ -34292,6 +34110,11 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
+"pSW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/checkpoint/auxiliary)
 "pTk" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -34400,22 +34223,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"pUN" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Lockers";
-	location = "EVA"
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "pUU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -34460,6 +34267,18 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/engineering/supermatter)
+"pWK" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "pXv" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -34649,6 +34468,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/storage/gas)
+"qcV" = (
+/turf/closed/wall,
+/area/security/interrogation)
 "qcZ" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -34671,6 +34493,16 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
+"qdr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/security/processing)
 "qdy" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
@@ -34701,6 +34533,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/service/library)
+"qdO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory/upper)
 "qdX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -34720,6 +34557,13 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
+"qeq" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/warden,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "qer" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/turf_decal/trimline/green/filled,
@@ -34790,18 +34634,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/large,
 /area/engineering/atmos)
-"qgp" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/security/processing)
 "qgG" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -34824,6 +34656,14 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"qhe" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "qhq" = (
 /obj/machinery/computer/atmos_control/nitrogen_tank{
 	dir = 1
@@ -34863,14 +34703,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"qhP" = (
-/obj/structure/disposalpipe/trunk/multiz/down,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "qin" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -34959,6 +34791,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"qkv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "qkC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -35026,6 +34867,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"qlj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "qll" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=AftH";
@@ -35036,21 +34886,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"qlq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
-"qlH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "qlI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35059,22 +34894,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"qlP" = (
-/obj/structure/table,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
-/obj/item/key/security,
-/obj/machinery/light/directional/east,
-/obj/item/radio/intercom/prison/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
-"qmc" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
 "qme" = (
 /obj/structure/table,
 /obj/item/multitool/circuit{
@@ -35127,16 +34946,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"qmU" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Infirmary"
-	},
-/obj/machinery/light_switch/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "qne" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35158,6 +34967,9 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"qnZ" = (
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "qod" = (
 /obj/structure/rack,
 /obj/machinery/status_display/evac/directional/south,
@@ -35165,17 +34977,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"qoq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "EVA Maintenance";
-	req_access_txt = "18"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "qoA" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/wood{
@@ -35222,15 +35023,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qpD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "qpL" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -35238,6 +35030,9 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"qpO" = (
+/turf/closed/wall,
+/area/security/warden)
 "qpQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35263,19 +35058,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/engine/cult,
 /area/service/library)
-"qqu" = (
-/obj/machinery/modular_computer/console/preset/id,
-/obj/machinery/light/directional/north,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "qqA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35338,6 +35120,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
+"qrI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/camera/directional/south,
+/turf/open/floor/iron/white/corner,
+/area/hallway/secondary/entry)
 "qsi" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
@@ -35377,6 +35166,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"qtg" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/security/processing)
 "qtk" = (
 /obj/structure/table,
 /obj/item/hemostat,
@@ -35386,13 +35187,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
-"qtJ" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "qtW" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/meter/monitored/waste_loop,
@@ -35467,9 +35261,27 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
+"qye" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "qyf" = (
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"qyB" = (
+/obj/machinery/door/window/brigdoor/right/directional/north{
+	name = "Flash Storage";
+	req_access_txt = "3"
+	},
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "qyD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35479,6 +35291,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"qyE" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "qyN" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
@@ -35496,15 +35314,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"qzk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "Interrogation";
-	name = "Interrogation Shutters"
-	},
-/turf/open/floor/plating,
-/area/security/interrogation)
 "qzA" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
@@ -35569,14 +35378,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"qBw" = (
-/obj/item/storage/box/seccarts{
-	pixel_x = 9;
-	pixel_y = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood/large,
-/area/command/heads_quarters/hos)
 "qBL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 8
@@ -35660,15 +35461,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"qEp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "qEr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35684,24 +35476,29 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
-"qEO" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "qEX" = (
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
+"qEZ" = (
+/obj/machinery/computer/security/hos,
+/obj/machinery/requests_console/directional/north{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	name = "Head of Security Requests Console"
+	},
+/obj/machinery/button/door/directional/north{
+	id = "hosspace";
+	name = "Icemoon Shutters Control";
+	pixel_x = -24
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
 "qFe" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"qFl" = (
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/glass/reinforced,
-/area/security/office)
 "qFw" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -35713,13 +35510,6 @@
 /obj/item/crowbar/red,
 /turf/open/floor/glass/reinforced,
 /area/science/xenobiology)
-"qFY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/security/lockers)
 "qGg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35733,19 +35523,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"qHn" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/mask/muzzle,
-/obj/machinery/flasher/directional/east{
-	id = "cell4"
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "qHv" = (
 /obj/structure/sink{
 	dir = 8;
@@ -35783,6 +35560,15 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/medical/treatment_center)
+"qHQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "qIe" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35830,6 +35616,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"qJD" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "qJQ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/grimy,
@@ -35855,6 +35645,24 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"qKh" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"qKk" = (
+/obj/item/gun/energy/laser/practice{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice{
+	pixel_y = -5
+	},
+/obj/structure/rack,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "qKn" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port Mix to East Ports"
@@ -35866,17 +35674,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"qKT" = (
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "qKV" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -35902,6 +35699,16 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
+"qLO" = (
+/turf/closed/mineral/random/snow,
+/area/icemoon/surface/outdoors/nospawn)
+"qMb" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "qMc" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -35946,20 +35753,18 @@
 "qNy" = (
 /turf/closed/wall,
 /area/engineering/atmos/storage/gas)
-"qNG" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "qNL" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"qNU" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "qNV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -35969,16 +35774,24 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"qOd" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "qOf" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Service-Hallway Top 2"
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"qOp" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/closet/secure_closet/contraband/armory,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/spawner/random/contraband/armory,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "qOO" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -36003,6 +35816,9 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/pharmacy)
+"qPC" = (
+/turf/open/openspace,
+/area/hallway/primary/fore)
 "qQb" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -36013,6 +35829,14 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
+"qQe" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "qQx" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -36035,11 +35859,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"qQS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "qQV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -36064,14 +35883,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"qRL" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/processing)
 "qRO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
@@ -36106,16 +35917,6 @@
 /obj/machinery/portable_atmospherics/canister/tier_1,
 /turf/open/floor/iron,
 /area/science/mixing)
-"qSr" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "qSv" = (
 /obj/structure/sign/departments/chemistry{
 	pixel_y = -32
@@ -36128,19 +35929,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"qSB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/processing)
-"qSJ" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "qSW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -36231,30 +36019,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"qUB" = (
-/obj/structure/table,
-/obj/item/folder/red{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/item/folder/red{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/storage/box/evidence{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
-"qVz" = (
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "qVH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36277,28 +36041,11 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"qWu" = (
-/obj/structure/cable,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "qWC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"qWF" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/corner,
-/area/security/processing)
 "qWH" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -36346,20 +36093,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"qYM" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/rag,
-/obj/item/clothing/head/collectable/tophat{
-	pixel_y = 5;
-	pixel_x = 6
-	},
-/obj/effect/spawner/random/entertainment/gambling{
-	pixel_x = -13
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/maintenance/fore/lesser)
 "qYQ" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
@@ -36378,6 +36111,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
+"qZH" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "qZK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
@@ -36424,20 +36163,21 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/maintenance/aft/greater)
+"raB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "raT" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/bluespace_vendor/directional/north,
 /obj/effect/mapping_helpers/trapdoor_placer,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"rbu" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "rbC" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/red{
@@ -36565,6 +36305,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/mining)
+"rfs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "rfy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -36581,6 +36330,18 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
+"rgX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/lockers)
+"rhu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "rhJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36674,27 +36435,12 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"rjk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "rjq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"rjs" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security EVA"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "rjC" = (
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/openspace,
@@ -36747,10 +36493,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"rlc" = (
-/obj/item/bedsheet/red,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
+"rld" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "rln" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
@@ -36777,12 +36529,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"rlH" = (
-/obj/structure/cable,
-/turf/open/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/maintenance/fore/lesser)
 "rlN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -36799,10 +36545,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"rmd" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
 "rmg" = (
 /obj/structure/chair/plastic{
 	dir = 0
@@ -36830,6 +36572,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"rms" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "rmv" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -36923,9 +36670,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"roS" = (
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
 "roZ" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -36944,6 +36688,15 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"rpD" = (
+/obj/structure/bed/dogbed/lia,
+/mob/living/simple_animal/hostile/carp/lia,
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - HoS Office"
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
 "rpH" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/three,
@@ -37062,18 +36815,27 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "rss" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Walkway"
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 40
 	},
-/obj/structure/cable,
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigentrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron,
-/area/security/brig/upper)
+/area/hallway/primary/central)
 "rsK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37090,6 +36852,10 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"rtp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "rtx" = (
 /turf/closed/wall,
 /area/commons/storage/art)
@@ -37120,6 +36886,13 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"rum" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/interrogation)
 "ruo" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -37217,6 +36990,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/engineering/atmos/storage/gas)
+"rvz" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "rvA" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -37346,6 +37128,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"ryV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "ryW" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -37430,11 +37218,23 @@
 /obj/item/hand_tele,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"rAY" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark/textured,
+/area/security/processing)
 "rBh" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"rBB" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "rBK" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -37543,6 +37343,10 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron/grimy,
 /area/service/bar/atrium)
+"rEa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/customs/auxiliary)
 "rEs" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -37721,6 +37525,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+"rHe" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "rHB" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
@@ -37763,6 +37572,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/mining)
+"rHT" = (
+/obj/item/radio/intercom/prison/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "rIq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37773,6 +37589,19 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"rIB" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Entrance"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigentrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "rJa" = (
 /obj/machinery/vending/modularpc,
 /turf/open/floor/iron,
@@ -37849,12 +37678,33 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"rKN" = (
+/obj/machinery/modular_computer/console/preset/id,
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "rKT" = (
 /obj/machinery/computer/teleporter{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/command/teleporter)
+"rKX" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "rLf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -37904,26 +37754,6 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"rLL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	name = "Warden Desk";
-	req_access_txt = "3"
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/window/left/directional/north{
-	name = "Warden Desk"
-	},
-/turf/open/floor/iron,
-/area/security/warden)
 "rLS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37936,9 +37766,10 @@
 "rLU" = (
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"rLW" = (
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
+"rLV" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "rLX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -37991,21 +37822,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"rNv" = (
-/obj/machinery/button/door/directional/west{
-	id = "riot";
-	name = "Anti-Riot Shutters";
-	pixel_x = -7;
-	pixel_y = 32;
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+"rNx" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "rND" = (
 /obj/structure/displaycase/labcage,
 /obj/effect/turf_decal/stripes/end{
@@ -38035,11 +37855,6 @@
 	icon_state = "damaged3"
 	},
 /area/icemoon/surface/outdoors/nospawn)
-"rPf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "rPh" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/item/radio/intercom/directional/north,
@@ -38064,26 +37879,16 @@
 	dir = 9
 	},
 /area/science/research)
+"rPX" = (
+/obj/structure/rack,
+/obj/item/electropack,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "rPZ" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
-"rQo" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Walkway";
-	id_tag = "innerbrig"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigoutpost"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "rQs" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -38092,13 +37897,6 @@
 	dir = 5
 	},
 /area/science/lab)
-"rQt" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "rQA" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
@@ -38106,18 +37904,19 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"rQC" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light/directional/east,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "rQD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"rQO" = (
+/obj/machinery/computer/shuttle/labor{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "rRf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -38137,15 +37936,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"rRm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Fore - Courtroom Hallway"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "rRH" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/vending/wardrobe/curator_wardrobe,
@@ -38282,17 +38072,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"rUD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "rUM" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/machinery/light/directional/north,
@@ -38389,13 +38168,6 @@
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
-"rXp" = (
-/obj/docking_port/stationary/random/icemoon{
-	id = "pod_3_lavaland";
-	name = "lavaland"
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "rXs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -38415,23 +38187,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"rXK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "rXL" = (
 /obj/machinery/research/anomaly_refinery,
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/science/mixing/launch)
-"rXR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/lockers)
 "rYd" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -38518,6 +38279,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
+"rZw" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "rZB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38597,20 +38364,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"sbV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
-"sch" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "scm" = (
 /obj/machinery/door/window/right/directional/east{
 	dir = 1;
@@ -38644,6 +38397,13 @@
 	dir = 1
 	},
 /area/hallway/secondary/service)
+"scK" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "scP" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/rack,
@@ -38747,16 +38507,6 @@
 	dir = 6
 	},
 /area/science/research)
-"sfE" = (
-/obj/machinery/computer/security{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "sgf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
@@ -38895,6 +38645,13 @@
 "siL" = (
 /turf/open/floor/wood,
 /area/service/library)
+"siN" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/obj/effect/gibspawner/human,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "sjb" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -39059,6 +38816,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"slk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/lockers)
 "slC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
 	dir = 8
@@ -39082,6 +38844,10 @@
 	dir = 1
 	},
 /area/engineering/engine_smes)
+"slM" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "smd" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 8
@@ -39094,6 +38860,10 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"smp" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/security/processing)
 "smE" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
@@ -39167,6 +38937,12 @@
 /obj/structure/railing/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"sog" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "sol" = (
 /obj/structure/rack,
 /obj/item/pickaxe{
@@ -39199,6 +38975,12 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/port/aft)
+"soS" = (
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "soT" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -39255,9 +39037,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/mixing)
-"sqx" = (
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/hos)
 "sqJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -39385,14 +39164,13 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
-"stx" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+"stw" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/landmark/start/hangover,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/security/brig/upper)
+/area/hallway/primary/fore)
 "stA" = (
 /obj/structure/chair{
 	dir = 8
@@ -39405,6 +39183,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
+"stF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "stJ" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/spawner,
@@ -39457,10 +39241,6 @@
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"suE" = (
-/obj/effect/turf_decal/tile/red/full,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/checkpoint/auxiliary)
 "suH" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
@@ -39501,16 +39281,24 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
-"swq" = (
-/obj/machinery/door/airlock/external{
-	name = "Security Yard";
-	space_dir = 8
+"swo" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_x = -8
 	},
-/turf/open/floor/iron/smooth_half,
+/obj/item/clothing/shoes/winterboots/ice_boots{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/clothing/shoes/winterboots/ice_boots{
+	pixel_x = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/security/brig/upper)
 "sww" = (
 /obj/structure/table,
@@ -39528,10 +39316,6 @@
 	dir = 10
 	},
 /area/science/lab)
-"swy" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/icemoon/surface/outdoors/nospawn)
 "swA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -39566,6 +39350,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"sxj" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/muzzle,
+/obj/machinery/flasher/directional/east{
+	id = "cell4"
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "sxo" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39609,12 +39406,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/upper)
-"szI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "szM" = (
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
@@ -39830,6 +39621,13 @@
 "sEf" = (
 /turf/closed/wall,
 /area/service/kitchen/coldroom)
+"sEl" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "sEn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -39851,15 +39649,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"sEB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "sEI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39913,6 +39702,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"sFS" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/processing)
 "sFY" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/red{
@@ -39933,13 +39728,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"sGx" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "EVA Maintenance"
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "sGO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40002,9 +39790,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"sIX" = (
-/turf/open/floor/iron/dark/textured,
-/area/security/processing)
 "sIZ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -40015,6 +39800,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"sJt" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "sKx" = (
@@ -40049,6 +39844,14 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"sKU" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "sLc" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -40073,6 +39876,12 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"sLP" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "sLX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -40082,6 +39891,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"sMa" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "sMe" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/shoes/jackboots,
@@ -40168,11 +39984,6 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/glass/reinforced,
 /area/medical/treatment_center)
-"sMX" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "sMZ" = (
 /obj/structure/kitchenspike,
 /obj/item/stack/sheet/leather,
@@ -40228,13 +40039,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"sOE" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "sON" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
@@ -40256,6 +40060,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/fore)
+"sOS" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "sPg" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/newscaster/directional/east,
@@ -40306,6 +40118,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"sRL" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "sRN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -40321,6 +40137,15 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"sSh" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "sSi" = (
 /turf/open/floor/plating,
 /area/commons/storage/emergency/port)
@@ -40361,14 +40186,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"sTV" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/camera/directional/south,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "sUc" = (
 /obj/machinery/shower{
 	dir = 8
@@ -40384,6 +40201,16 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"sUl" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "sUA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -40458,6 +40285,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
+"sWP" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"sWQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "sWX" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -40517,15 +40356,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"sXR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 23
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "sXX" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Security Post - Science";
@@ -40542,16 +40372,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
-"sXY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Interrogation";
-	network = list("interrogation")
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "sYe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -40614,13 +40434,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"sYP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/camera/directional/south,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "sZi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/broken/directional/north,
@@ -40637,10 +40450,6 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
-"sZP" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "sZW" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
@@ -40654,11 +40463,6 @@
 "tbf" = (
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
-"tbl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "tbx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/light_construct/directional/west,
@@ -40749,14 +40553,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"tdp" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Central Hallway North-West"
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "tdJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -40776,6 +40572,17 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
+"teJ" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/machinery/light/directional/south,
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/security/lockers)
 "teS" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -40814,6 +40621,15 @@
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
+"tfO" = (
+/obj/machinery/button/flasher{
+	id = "cell4";
+	pixel_y = -22
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "tfP" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -40865,6 +40681,11 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"tgM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/meter/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "the" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/light/small/directional/west,
@@ -40880,11 +40701,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/project)
-"thm" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/maintenance/fore/lesser)
 "tih" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -40923,17 +40739,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"tjj" = (
-/obj/machinery/flasher/directional/east{
-	id = "brigentry"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "tjm" = (
 /obj/item/stack/sheet/plasteel{
 	amount = 10
@@ -40959,6 +40764,13 @@
 /obj/item/newspaper,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"tjH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "tjI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
@@ -41102,6 +40914,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"tmE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
+"tmV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/office)
 "tmX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemical Storage";
@@ -41179,13 +41002,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"toN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"toX" = (
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "2";
+	dir = 1;
+	name = "Security Delivery"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/turf/open/floor/plating,
+/area/security/processing)
 "toY" = (
 /obj/structure/table,
 /obj/item/tank/internals/emergency_oxygen{
@@ -41227,11 +41051,27 @@
 "tpQ" = (
 /turf/closed/wall,
 /area/service/hydroponics/garden)
+"tpZ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Walkway"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigentrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "tqd" = (
 /obj/item/trash/cheesie,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"tql" = (
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/hos)
 "tqm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41262,6 +41102,15 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/port)
+"trs" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "tru" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
@@ -41279,16 +41128,6 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/medical/treatment_center)
-"tsj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "tsk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -41407,6 +41246,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"tuM" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "EVA2"
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "tvk" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -41468,6 +41323,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"twh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "twF" = (
 /obj/effect/landmark/start/chemist,
 /obj/structure/chair/office/light{
@@ -41539,6 +41400,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"tyd" = (
+/obj/structure/railing,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "tyA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -41622,6 +41487,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"tAm" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "tAn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -41674,27 +41543,22 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"tBH" = (
-/obj/machinery/camera/motion/directional/north{
-	c_tag = "Armory - External"
-	},
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "tBZ" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
 /area/maintenance/port/aft)
-"tCe" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
+"tCd" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron,
+/area/security/warden)
 "tCh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41715,6 +41579,13 @@
 	},
 /turf/open/floor/plating,
 /area/medical/pharmacy)
+"tCV" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/security/lockers)
 "tDy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41925,6 +41796,10 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"tHr" = (
+/obj/structure/sign/warning/coldtemp,
+/turf/closed/wall,
+/area/maintenance/fore/greater)
 "tHJ" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/bookmanagement,
@@ -41943,6 +41818,19 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"tHU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/item/radio/intercom/prison/directional/east{
+	frequency = 1359
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "tHZ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/rack,
@@ -42005,6 +41893,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
+"tJu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "tJH" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42020,6 +41919,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/checker,
 /area/engineering/atmos)
+"tJY" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "tKa" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -42088,15 +41999,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood,
 /area/service/library)
-"tMJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "tMN" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -42152,6 +42054,38 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
+"tOf" = (
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/timer,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
+"tOn" = (
+/obj/structure/table/glass,
+/obj/structure/sign/barsign{
+	pixel_y = 32;
+	icon_state = "thecavern";
+	chosen_sign = "thecavern"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vermouth{
+	pixel_x = 10;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/food/drinks/bottle/pineapplejuice{
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/bottle/orangejuice{
+	pixel_x = 15
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/tonic,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "tOu" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -42168,13 +42102,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"tOL" = (
-/obj/machinery/computer/prisoner/management{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "tOT" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -42186,6 +42113,37 @@
 "tPd" = (
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"tPi" = (
+/obj/structure/table,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/hand_labeler{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
+"tPl" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "tPo" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
@@ -42205,13 +42163,6 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
-"tPU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "tQg" = (
 /obj/structure/table/glass,
 /obj/item/hemostat,
@@ -42222,6 +42173,15 @@
 "tQo" = (
 /turf/closed/wall,
 /area/engineering/atmos/project)
+"tQv" = (
+/obj/structure/table,
+/obj/item/folder/red,
+/obj/item/pen,
+/obj/item/inspector,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "tQx" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/portable_atmospherics/pump,
@@ -42238,15 +42198,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"tQF" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/ice,
-/area/icemoon/surface/outdoors/nospawn)
-"tRg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
+"tQE" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9"
+	},
+/obj/effect/landmark/start/hangover,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "tRl" = (
 /obj/structure/sign/painting/library_secure{
 	pixel_x = 32
@@ -42305,13 +42264,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"tSw" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "tSF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/closed/wall/r_wall,
@@ -42320,13 +42272,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
-"tTi" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "tTq" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -42478,6 +42423,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/storage)
+"tXQ" = (
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/glass/reinforced,
+/area/security/office)
 "tYc" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
@@ -42532,11 +42481,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"tYG" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "tYN" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
@@ -42548,6 +42492,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tYR" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Office"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/security/office)
 "tYS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42647,9 +42600,6 @@
 	dir = 4
 	},
 /area/medical/medbay/central)
-"uaZ" = (
-/turf/closed/wall,
-/area/security/lockers)
 "ube" = (
 /obj/structure/chair{
 	dir = 1
@@ -42662,21 +42612,25 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"ubH" = (
-/mob/living/simple_animal/mouse/white{
-	name = "Mik";
-	desc = "This mouse smells faintly of alcohol."
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/fore/lesser)
 "ubI" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	name = "mix to port"
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"ubM" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "ubR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -42690,6 +42644,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"ubV" = (
+/obj/structure/cable,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/maintenance/fore/lesser)
 "ubX" = (
 /obj/structure/chair,
 /obj/item/radio/intercom/directional/north,
@@ -42716,17 +42676,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"ucj" = (
-/obj/structure/closet/bombcloset/security,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
-"ucu" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "udc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -42737,6 +42686,50 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"udg" = (
+/obj/machinery/button/door/directional/east{
+	id = "armory";
+	name = "Armory Shutters";
+	req_access_txt = "3";
+	pixel_x = -9;
+	pixel_y = 30
+	},
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
+"udh" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/machinery/door/window/brigdoor/right/directional/west{
+	name = "Brig Reception";
+	req_one_access_txt = "1"
+	},
+/obj/machinery/door/window/left/directional/east{
+	name = "Brig Reception"
+	},
+/turf/open/floor/iron/dark,
+/area/security/checkpoint/auxiliary)
 "udj" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 8
@@ -42759,6 +42752,15 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"udS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "udZ" = (
 /obj/structure/chair{
 	dir = 1;
@@ -42795,6 +42797,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"ueB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/smooth_edge,
+/area/security/lockers)
 "ueK" = (
 /obj/structure/window/reinforced/fulltile/ice{
 	name = "frozen window"
@@ -42825,6 +42834,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"ufC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "ufF" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/transmitter,
@@ -42834,31 +42850,12 @@
 /obj/item/stock_parts/subspace/treatment,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"ufH" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Secure Walkway"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/checkpoint/auxiliary)
 "ufP" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"ufT" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/space_heater,
-/obj/machinery/camera/directional/south{
-	c_tag = "Auxiliary Tool Storage"
-	},
-/turf/open/floor/iron,
-/area/commons/storage/tools)
 "ufX" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -42885,6 +42882,13 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"ugZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "uhi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -42924,6 +42928,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"uhW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "uhY" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -42947,6 +42957,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/lobby)
+"uiD" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "uiO" = (
 /obj/structure/table,
 /obj/item/toy/plush/beeplushie{
@@ -43058,6 +43078,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"ukN" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Secure Walkway"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "ukP" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -43124,13 +43156,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"umE" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+"umH" = (
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "umQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -43144,6 +43173,11 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"umR" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "umY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/vending/wardrobe/science_wardrobe,
@@ -43207,10 +43241,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"uom" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "uoB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43248,6 +43278,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"uoT" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "upb" = (
 /obj/structure/cable,
 /obj/structure/railing,
@@ -43306,6 +43340,11 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/engineering/atmos/storage/gas)
+"uqd" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/fore/lesser)
 "uqM" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -43330,13 +43369,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"uqU" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "urc" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
@@ -43390,6 +43422,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"usa" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "usb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -43420,13 +43458,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
-"utc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "uts" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -43448,6 +43479,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"utQ" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/table,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "uub" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43572,14 +43616,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"uwh" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/checkpoint/auxiliary)
 "uwi" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -43639,12 +43675,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/surgery/fore)
-"uyd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "uyf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -43778,6 +43808,18 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"uBf" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/processing)
 "uBg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43798,16 +43840,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness)
-"uBp" = (
-/obj/structure/closet/l3closet/security,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
-"uBr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
+"uBX" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/security/processing)
 "uBY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -43864,6 +43905,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
+"uCX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "uDd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43949,10 +43999,12 @@
 	dir = 5
 	},
 /area/science/lab)
-"uEk" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+"uEt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "uEI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43988,6 +44040,9 @@
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
+"uFe" = (
+/turf/closed/wall/r_wall,
+/area/security/medical)
 "uFn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43998,6 +44053,21 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"uFC" = (
+/obj/machinery/button/door/directional/west{
+	id = "riot";
+	name = "Anti-Riot Shutters";
+	pixel_x = -7;
+	pixel_y = 32;
+	req_one_access_txt = "1;4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "uFV" = (
 /obj/machinery/shower{
 	dir = 4
@@ -44139,6 +44209,10 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
+"uIc" = (
+/obj/structure/sign/warning/xeno_mining,
+/turf/closed/wall/ice,
+/area/icemoon/surface/outdoors/nospawn)
 "uId" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -44197,11 +44271,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"uJF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig/upper)
 "uKl" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
@@ -44224,13 +44293,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"uLu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "uLK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -44329,6 +44391,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/misc_lab)
+"uOk" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "uOl" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/directional/east,
@@ -44337,18 +44406,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"uOx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor{
-	name = "Armory Desk";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/left/directional/north{
-	name = "Armory Desk"
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/security/armory/upper)
 "uOC" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood{
@@ -44401,26 +44458,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"uQc" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/machinery/door/window/brigdoor/right/directional/west{
-	name = "Brig Reception";
-	req_one_access_txt = "1"
-	},
-/obj/machinery/door/window/left/directional/east{
-	name = "Brig Reception"
-	},
-/turf/open/floor/iron/dark,
-/area/security/checkpoint/auxiliary)
 "uQl" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/smooth_large,
@@ -44439,14 +44476,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/misc_lab)
-"uQC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "uQH" = (
 /obj/structure/railing{
 	dir = 1
@@ -44463,6 +44492,10 @@
 /obj/structure/closet/secure_closet/captains,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"uRd" = (
+/obj/structure/flora/bush,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "uRj" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -44587,25 +44620,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"uUu" = (
-/obj/machinery/computer/shuttle/labor{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "uUz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"uUS" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "uVb" = (
 /obj/structure/table,
 /obj/item/razor{
@@ -44626,6 +44646,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uVG" = (
+/obj/structure/flora/rock/icy,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "uVZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -44671,15 +44695,6 @@
 	dir = 4
 	},
 /area/science/misc_lab)
-"uWM" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Security Medpost"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "uXt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44704,23 +44719,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"uYB" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark/textured,
-/area/security/processing)
-"uYO" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Entrance"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigentrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "uYT" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/maintenance{
@@ -44736,13 +44734,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"uZj" = (
-/obj/structure/table,
-/obj/item/assembly/flash/handheld,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "uZy" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -44921,6 +44912,13 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
+"veN" = (
+/obj/structure/table/wood,
+/obj/item/paicard,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/maintenance/fore/lesser)
 "veR" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -44936,6 +44934,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"vfP" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Checkpoint";
+	id_tag = "outerbrig"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigoutpost"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "vfT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/ignition{
@@ -44949,6 +44963,12 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"vga" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "vgc" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/siding/white{
@@ -44956,28 +44976,24 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+"vgi" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/security/interrogation)
 "vgj" = (
 /obj/structure/ladder,
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/textured_large,
 /area/maintenance/department/medical/central)
-"vgD" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "vhk" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"vhl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "vho" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
@@ -45017,12 +45033,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"viw" = (
-/obj/vehicle/ridden/secway,
-/obj/effect/turf_decal/tile/red/half,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "viy" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/landmark/event_spawn,
@@ -45060,27 +45070,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"vjo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "vjE" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/full,
 /obj/item/clothing/head/fedora,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
-"vjH" = (
-/obj/structure/table/wood,
-/obj/item/phone{
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/item/radio/off{
-	pixel_y = 7;
-	pixel_x = -3
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/large,
-/area/command/heads_quarters/hos)
 "vjL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -45105,15 +45109,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"vkj" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "vkx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/landmark/start/chief_medical_officer,
@@ -45142,6 +45137,17 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
+"vkD" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "vkT" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
@@ -45205,10 +45211,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"vmi" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "vmE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45236,6 +45238,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"vnG" = (
+/obj/item/paper/fluff/jobs/security/beepsky_mom,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "vnL" = (
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/keycard_auth/directional/south,
@@ -45263,6 +45269,19 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"voz" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/glass,
+/area/security/lockers)
+"vpq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "vpz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -45285,19 +45304,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"vpK" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
-"vpM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "vqr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45306,9 +45312,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
-"vqt" = (
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "vqw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45346,15 +45349,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
-"vqK" = (
-/turf/open/openspace,
-/area/security/brig/upper)
 "vqO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
+"vrk" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "vrn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45371,6 +45378,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"vry" = (
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 24
+	},
+/turf/open/floor/carpet,
+/area/security/processing)
 "vrD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/north,
@@ -45386,12 +45399,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/maint)
-"vrY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "vsx" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/disposalpipe/segment,
@@ -45416,11 +45423,33 @@
 "vtF" = (
 /turf/closed/wall,
 /area/command/heads_quarters/captain)
+"vua" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
+"vue" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "vui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"vvs" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - EVA"
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "vvt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -45443,6 +45472,30 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"vwb" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
+"vwd" = (
+/obj/effect/turf_decal/tile/red/anticorner,
+/obj/machinery/requests_console/directional/north{
+	department = "Security";
+	departmentType = 3;
+	name = "Security Requests Console"
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
+/area/security/office)
+"vwf" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "vwl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
@@ -45463,6 +45516,15 @@
 	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
+"vwV" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "vxk" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron/smooth,
@@ -45485,6 +45547,17 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"vxn" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"vxr" = (
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "vxA" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
@@ -45532,15 +45605,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
+"vyp" = (
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "vyt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"vyw" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/fore)
 "vyY" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/bottle/lithium{
@@ -45559,6 +45636,15 @@
 	dir = 8
 	},
 /area/medical/medbay/central)
+"vzu" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_large,
+/area/command/heads_quarters/hos)
 "vzx" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/blue{
@@ -45588,15 +45674,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"vAx" = (
+"vAf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/turf/open/floor/iron,
+/area/security/processing)
 "vAz" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -28
@@ -45631,6 +45717,26 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"vAQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "vAX" = (
 /obj/item/chair/wood,
 /turf/open/floor/wood{
@@ -45647,13 +45753,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/command/meeting_room)
-"vBI" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Transport"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "vCg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -45703,6 +45802,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"vDt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "vDN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -45723,25 +45827,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"vEk" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_x = -8
-	},
-/obj/item/clothing/shoes/winterboots/ice_boots{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/clothing/shoes/winterboots/ice_boots{
-	pixel_x = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "vEl" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/light/directional/north,
@@ -45823,15 +45908,6 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"vFK" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "vFP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45941,10 +46017,22 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
-"vHY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/security/lockers)
+"vHI" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/requests_console/directional/north{
+	department = "Security";
+	departmentType = 3;
+	name = "Security Requests Console"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "vIv" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -46093,6 +46181,15 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery/fore)
+"vLx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "vLA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46134,6 +46231,19 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"vLW" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Vestibule"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/turf/open/floor/iron/smooth,
+/area/security/processing)
 "vMh" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxToilet1";
@@ -46205,18 +46315,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
-"vOc" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Upper Brig South"
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "vOf" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -46274,18 +46372,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/command/storage/eva)
-"vPg" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/closet/secure_closet/contraband/armory,
-/obj/machinery/firealarm/directional/north,
-/obj/effect/spawner/random/maintenance/three,
-/obj/effect/spawner/random/contraband/armory,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "vPE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46325,6 +46411,12 @@
 /obj/item/stock_parts/cell/high/empty,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"vQz" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "vQC" = (
 /obj/structure/sign/departments/psychology{
 	pixel_y = -32
@@ -46401,15 +46493,6 @@
 	},
 /turf/open/floor/iron,
 /area/medical/pharmacy)
-"vRC" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "vRS" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 1
@@ -46458,11 +46541,16 @@
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/large,
 /area/medical/pharmacy)
-"vTh" = (
-/obj/effect/turf_decal/tile/red/half,
+"vTT" = (
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "vTY" = (
 /obj/item/toy/snowball{
 	pixel_x = -6;
@@ -46589,6 +46677,9 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"vWu" = (
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "vWA" = (
 /obj/machinery/vending/modularpc,
 /turf/open/floor/iron,
@@ -46629,18 +46720,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
-"vXi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "vXm" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -46684,6 +46763,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/maintenance/starboard/fore)
+"vYQ" = (
+/obj/structure/railing,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_y = 4
+	},
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "vYW" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46699,6 +46792,14 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"vZg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "vZk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -46719,6 +46820,14 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"vZw" = (
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/security/processing)
 "vZH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
@@ -46765,6 +46874,13 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/freezer,
 /area/command/heads_quarters/captain)
+"wbn" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "wbB" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Cargo Receiving Dock"
@@ -46791,6 +46907,18 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"wbG" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/processing)
 "wca" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/wood{
@@ -46804,14 +46932,18 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
-"wcF" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "wcH" = (
 /obj/machinery/vending/games,
 /turf/open/floor/wood,
 /area/service/library)
+"wcJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "wcO" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate/maint,
@@ -46825,19 +46957,25 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/openspace,
 /area/service/chapel)
+"wdb" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/security/processing)
 "wdi" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
-"wdq" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "wdt" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -46903,9 +47041,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
-"wfl" = (
-/turf/closed/mineral/random/snow,
-/area/icemoon/surface/outdoors/nospawn)
 "wfC" = (
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
@@ -46964,14 +47099,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
-"whX" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "wit" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -47099,13 +47226,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"wmi" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "wmm" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
@@ -47231,17 +47351,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
-"wol" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "woA" = (
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
 /area/service/chapel)
+"woC" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "woD" = (
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/circuit,
@@ -47303,10 +47422,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
-"wqi" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "wql" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47367,13 +47482,9 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/science/mixing/launch)
-"wrt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/smooth_edge,
-/area/security/lockers)
+"wrP" = (
+/turf/closed/wall/r_wall,
+/area/hallway/primary/fore)
 "wrW" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/iron,
@@ -47418,6 +47529,12 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"wsN" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "wsW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -47531,6 +47648,27 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"wuW" = (
+/obj/item/book/manual/wiki/tcomms{
+	pixel_x = 10;
+	pixel_y = -1
+	},
+/obj/item/book/manual/wiki/ordnance{
+	pixel_y = 3;
+	pixel_x = 10
+	},
+/obj/item/book/manual/wiki/experimentor{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/processing)
 "wvl" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -47560,6 +47698,11 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"wvy" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "wvC" = (
 /obj/structure/table,
 /obj/item/cartridge/signal/ordnance{
@@ -47580,6 +47723,15 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
+"wwh" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "wwu" = (
 /obj/structure/rack,
 /obj/item/crowbar/red,
@@ -47620,10 +47772,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
-"wxL" = (
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "wxV" = (
 /turf/closed/wall/r_wall,
 /area/command/gateway)
@@ -47745,28 +47893,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"wBU" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/matches,
-/obj/item/toy/cards/deck{
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 14;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = -18;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = -10;
-	pixel_y = 2
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/maintenance/fore/lesser)
 "wCa" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -47809,18 +47935,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"wCZ" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "wDd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47868,6 +47982,9 @@
 /obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"wET" = (
+/turf/open/floor/glass/reinforced,
+/area/security/checkpoint/auxiliary)
 "wEX" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Arrivals Bay 3 & 4"
@@ -47943,12 +48060,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"wIi" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "wIk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -47991,6 +48102,15 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"wJE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "wJF" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -48001,6 +48121,12 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/cargo/office)
+"wJL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "wJV" = (
 /obj/structure/railing/corner,
 /obj/machinery/door/firedoor/border_only,
@@ -48026,8 +48152,9 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood,
 /area/service/library)
-"wKv" = (
-/turf/open/openspace/icemoon/keep_below,
+"wKq" = (
+/obj/structure/flora/tree/dead,
+/turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "wKz" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -48058,6 +48185,18 @@
 /obj/item/trash/cheesie,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
+"wLx" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "wLE" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -48065,6 +48204,23 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"wLO" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/restraints/handcuffs{
+	pixel_y = 5
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 1
+	},
+/obj/item/restraints/handcuffs{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "wLS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -48166,15 +48322,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"wOn" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L14"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "wOt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48206,15 +48353,6 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"wOX" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "N2O Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "wPj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48240,22 +48378,6 @@
 	dir = 9
 	},
 /area/science/research)
-"wQh" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Desk"
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/checkpoint/auxiliary)
 "wQp" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/line,
@@ -48315,8 +48437,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "wSi" = (
-/turf/open/openspace,
-/area/hallway/primary/fore)
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/lockers)
 "wSv" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/modular_computer/console/preset/cargochat/cargo{
@@ -48352,6 +48482,14 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"wTq" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "wTv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -48376,11 +48514,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"wTW" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/checkpoint/auxiliary)
 "wTY" = (
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
@@ -48476,16 +48609,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/misc_lab)
-"wWP" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "wWY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48503,15 +48626,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"wXq" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "wXx" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment{
@@ -48564,13 +48678,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"wYg" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "wYI" = (
 /obj/machinery/power/solar{
 	id = "starboardsolar";
@@ -48642,14 +48749,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/engineering/storage)
-"wZR" = (
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/table/glass,
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "wZS" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -48659,15 +48758,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/maintenance/department/medical/central)
-"xae" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "xal" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -48701,14 +48791,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"xbq" = (
-/obj/structure/cable,
-/obj/item/radio/intercom/prison/directional/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "xbC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -48727,6 +48809,15 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
+"xcl" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/ai_monitored/security/armory/upper)
 "xcv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line{
@@ -48749,13 +48840,6 @@
 "xdi" = (
 /turf/closed/wall,
 /area/medical/treatment_center)
-"xdr" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Three";
-	space_dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/processing)
 "xdv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/iron,
@@ -48860,6 +48944,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
+"xfZ" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/closet/secure_closet/hos,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "xgb" = (
 /obj/item/storage/secure/safe/directional/south,
 /obj/machinery/light/directional/south,
@@ -48940,6 +49030,9 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/central/lesser)
+"xhV" = (
+/turf/open/floor/glass,
+/area/security/lockers)
 "xib" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -49108,12 +49201,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
+"xkz" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "xkD" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"xkJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=EVA";
+	location = "Security"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "xkN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -49145,12 +49251,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"xlK" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "xlQ" = (
 /obj/item/airlock_painter,
 /obj/structure/closet,
@@ -49224,6 +49324,13 @@
 "xnR" = (
 /turf/closed/wall/r_wall,
 /area/science/breakroom)
+"xoh" = (
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/carpet,
+/area/security/processing)
 "xon" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/camera/directional/south{
@@ -49293,13 +49400,12 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xpH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+"xpK" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Equipment Room"
+	},
+/turf/open/floor/glass/reinforced,
+/area/security/lockers)
 "xpS" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
@@ -49330,6 +49436,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xqD" = (
+/obj/structure/bookcase,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet,
+/area/security/processing)
 "xqE" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -49387,10 +49498,6 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/medical/treatment_center)
-"xsm" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/security/warden)
 "xst" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -49414,9 +49521,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"xsO" = (
-/turf/open/floor/glass/reinforced,
-/area/security/office)
 "xtn" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -49438,22 +49542,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/meeting_room)
-"xtK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/office)
 "xuf" = (
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
 /area/science/research)
-"xui" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+"xuk" = (
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "xuD" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -49542,6 +49639,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"xwF" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "xwV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -49689,6 +49792,20 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/mining)
+"xzJ" = (
+/obj/item/grenade/barrier{
+	pixel_x = 4
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = -4
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "xzP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -49696,6 +49813,28 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"xAe" = (
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -6;
+	pixel_y = 16
+	},
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/stamp/hos{
+	pixel_y = 6;
+	pixel_x = 10
+	},
+/obj/machinery/recharger{
+	pixel_y = -1;
+	pixel_x = -4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood/large,
+/area/command/heads_quarters/hos)
 "xAh" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -49715,12 +49854,17 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"xBf" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+"xBj" = (
+/obj/machinery/flasher/directional/east{
+	id = "brigentry"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
+/area/security/checkpoint/auxiliary)
 "xBn" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -49747,10 +49891,6 @@
 /obj/item/trash/raisins,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xCz" = (
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/glass,
-/area/security/lockers)
 "xCC" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49831,20 +49971,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"xDH" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "xDK" = (
 /obj/structure/rack,
 /obj/machinery/light/small/directional/north,
@@ -49882,6 +50008,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
+"xEs" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/security/lockers)
+"xEA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 23
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "xFn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49941,13 +50083,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"xGL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "xGS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/west,
@@ -49965,15 +50100,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service)
-"xHa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "xHg" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -49985,6 +50111,14 @@
 /obj/item/stamp/captain,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"xHz" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/processing)
 "xHC" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -50017,12 +50151,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"xIg" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "xIk" = (
 /obj/effect/turf_decal/arrows,
 /obj/effect/turf_decal/stripes/line{
@@ -50048,6 +50176,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"xJy" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_edge,
+/area/security/lockers)
 "xJD" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -50126,13 +50260,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/meeting_room)
-"xLH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "xMh" = (
 /obj/structure/railing{
 	dir = 4
@@ -50144,17 +50271,6 @@
 	dir = 8
 	},
 /area/service/chapel)
-"xMl" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "xMm" = (
 /obj/structure/table,
 /obj/item/t_scanner,
@@ -50201,6 +50317,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"xNO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "xNR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -50238,16 +50361,9 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
-"xOn" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
+"xOo" = (
+/turf/open/floor/glass/reinforced,
+/area/security/lockers)
 "xOt" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -50338,30 +50454,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"xQO" = (
-/obj/structure/table/glass,
-/obj/structure/sign/barsign{
-	pixel_y = 32;
-	icon_state = "thecavern";
-	chosen_sign = "thecavern"
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vermouth{
-	pixel_x = 10;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/food/drinks/bottle/pineapplejuice{
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/bottle/orangejuice{
-	pixel_x = 15
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka{
-	pixel_x = -11;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/tonic,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "xQR" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/wood,
@@ -50391,13 +50483,24 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
-"xSW" = (
-/mob/living/simple_animal/hostile/asteroid/polarbear{
-	name = "Huey";
-	move_force = 999
+"xSt" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/bluespace_vendor/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Fore Primary Hallway"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"xTd" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/head_of_security,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
 "xTA" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
@@ -50418,6 +50521,16 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"xUk" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "xUM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
@@ -50455,6 +50568,10 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
+"xWl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory/upper)
 "xWu" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -50491,6 +50608,13 @@
 "xXp" = (
 /turf/closed/wall,
 /area/medical/break_room)
+"xXx" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/corner,
+/area/security/processing)
 "xXG" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -50584,6 +50708,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"yaA" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "yaE" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/stripes/line{
@@ -50612,12 +50743,11 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plating,
 /area/service/hydroponics)
-"ybU" = (
+"ybT" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
+	dir = 6
 	},
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/plating/snowed/icemoon,
+/turf/open/floor/glass/reinforced/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "ybV" = (
 /obj/effect/turf_decal/stripes/line{
@@ -50662,6 +50792,14 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"ycK" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/closet/emcloset,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security Entrance"
+	},
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "ycO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -50670,13 +50808,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
-"ycQ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "ycR" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
@@ -50700,6 +50831,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ydd" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor{
+	name = "Armory Desk";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/window/left/directional/north{
+	name = "Armory Desk"
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/security/armory/upper)
 "ydg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/south,
@@ -50729,12 +50872,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"ydZ" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/dark/textured_half,
-/area/security/office)
+"ydK" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "yeC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
@@ -50742,6 +50885,10 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"yeS" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "yfb" = (
 /turf/open/floor/glass,
 /area/maintenance/department/medical/central)
@@ -50808,12 +50955,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"yhk" = (
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/lockers)
 "yhl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -50857,9 +50998,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"yik" = (
-/turf/open/floor/glass/reinforced,
-/area/security/lockers)
 "yir" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -50894,18 +51032,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"yiW" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "yjG" = (
 /obj/structure/table,
 /obj/item/paper_bin/construction,
@@ -50914,15 +51040,6 @@
 /obj/item/stack/pipe_cleaner_coil/random,
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"yjL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "yjS" = (
 /obj/structure/sink{
 	dir = 4;
@@ -60411,7 +60528,7 @@ awW
 awW
 awW
 aQG
-sTV
+hRM
 arB
 jnk
 jnk
@@ -61436,7 +61553,7 @@ jnk
 jnk
 jnk
 awW
-bij
+ilh
 ayl
 ayl
 aRY
@@ -61680,7 +61797,7 @@ apN
 apN
 apN
 apJ
-kPx
+emI
 aDD
 ayl
 ayk
@@ -62981,7 +63098,7 @@ jnk
 awW
 aPt
 aym
-sYP
+qrI
 arB
 awW
 awW
@@ -63998,10 +64115,10 @@ alU
 alU
 alU
 alU
-pxl
-pxl
-pxl
-pxl
+jwT
+jwT
+jwT
+jwT
 ssG
 aKj
 aLw
@@ -64255,10 +64372,10 @@ aol
 aol
 aol
 alU
-bDC
-pii
-ikn
-pxl
+mhe
+hOK
+iAv
+jwT
 aIJ
 aKk
 aLy
@@ -64512,10 +64629,10 @@ alU
 alU
 aol
 alU
-jik
-hjU
-oga
-xae
+jPR
+oZH
+kgI
+jnR
 aIJ
 aKk
 aLj
@@ -64769,10 +64886,10 @@ ays
 alU
 aol
 alU
-nVr
-gyh
-iZI
-nsD
+gpw
+vWu
+kuc
+rEa
 aIJ
 aKk
 aLz
@@ -65026,9 +65143,9 @@ gaz
 alU
 aol
 alU
-qqu
-gyh
-vkj
+rKN
+vWu
+fpf
 qmP
 aIJ
 aKk
@@ -65283,10 +65400,10 @@ kaJ
 alU
 aol
 alU
-nKQ
-gyh
-qKT
-nsD
+vHI
+vWu
+dyt
+rEa
 sIF
 auq
 aLA
@@ -65540,10 +65657,10 @@ tQg
 alU
 aol
 gYm
-dlI
-hiT
-nAv
-pxl
+tJu
+uOk
+jRj
+jwT
 fkT
 aKk
 asE
@@ -69364,7 +69481,7 @@ dUi
 dUi
 dUi
 dUi
-swy
+oWZ
 cul
 dUi
 dUi
@@ -69621,7 +69738,7 @@ jnk
 jnk
 jnk
 jnk
-ePl
+tyd
 jnk
 jnk
 jnk
@@ -69878,7 +69995,7 @@ jnk
 jnk
 jnk
 jnk
-ePl
+tyd
 jnk
 jnk
 jnk
@@ -70135,7 +70252,7 @@ jnk
 jnk
 jnk
 jnk
-ePl
+tyd
 jnk
 jnk
 jnk
@@ -70392,7 +70509,7 @@ jnk
 jnk
 jnk
 jnk
-ePl
+tyd
 jnk
 jnk
 jnk
@@ -70649,7 +70766,7 @@ jnk
 jnk
 jnk
 jnk
-ePl
+tyd
 jnk
 jnk
 jnk
@@ -70687,7 +70804,7 @@ mTO
 mTO
 mTO
 fUJ
-kdc
+vxn
 gzQ
 cPo
 xoM
@@ -70906,7 +71023,7 @@ jnk
 jnk
 jnk
 jnk
-ePl
+tyd
 jnk
 jnk
 jnk
@@ -70944,8 +71061,8 @@ jnk
 jnk
 aJd
 aLM
-eCP
-cWc
+qQe
+oEC
 rtx
 rtx
 rtx
@@ -71154,17 +71271,17 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-tQF
-kyA
-kyA
-kyA
-kyA
-bfE
-wfl
-swy
-wKv
+qLO
+qLO
+lKI
+ept
+ept
+ept
+ept
+uIc
+qLO
+oWZ
+eGS
 jnk
 jnk
 jnk
@@ -71201,7 +71318,7 @@ xpS
 jnk
 aJd
 aLL
-nRs
+rKX
 aLE
 etw
 kzk
@@ -71410,21 +71527,21 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
-cOi
+qLO
+qLO
+qLO
+qLO
+lSN
 src
 src
 cwi
-wfl
-wfl
-wfl
-wKv
-wKv
-wKv
-wKv
+qLO
+qLO
+qLO
+eGS
+eGS
+eGS
+eGS
 jnk
 jnk
 jnk
@@ -71458,7 +71575,7 @@ xpS
 jnk
 aJd
 aLN
-hZc
+qKh
 aNl
 hKn
 rzb
@@ -71666,29 +71783,29 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
+qLO
 jnk
-fZG
-bKD
-wfl
-wfl
-wfl
-wIi
+siN
+onI
+qLO
+qLO
+qLO
+jcP
 jnk
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
 ali
 dad
 amG
@@ -71715,7 +71832,7 @@ qYV
 aJd
 aJd
 aLN
-hZc
+qKh
 aLE
 etw
 ixQ
@@ -71922,30 +72039,30 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
+qLO
 jnk
 jnk
 jnk
 jnk
-wfl
-wfl
-pRG
+qLO
+qLO
+fOS
 cwi
 jnk
 jnk
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
 ali
 aKY
 amC
@@ -71972,8 +72089,8 @@ rdy
 qHB
 cxB
 aLP
-pnQ
-bKM
+qlj
+dIK
 jhN
 jhN
 jhN
@@ -72177,32 +72294,32 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
+qLO
+gtA
 jnk
 jnk
+mzM
+vxr
 jnk
-pqD
-jnk
-wfl
-wfl
+qLO
+qLO
 jnk
 src
-ckU
+uVG
 jnk
 jnk
 jnk
-pRG
+fOS
 jnk
-wKv
-wKv
-wKv
-wKv
-wKv
+eGS
+eGS
+eGS
+eGS
+eGS
 ali
 alW
 lPM
@@ -72229,7 +72346,7 @@ qYV
 aJd
 aJd
 aLN
-pnQ
+qlj
 ssk
 hfl
 tmD
@@ -72434,32 +72551,32 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
 jnk
-xSW
-jnk
-jnk
-pRG
-gme
-jnk
-wfl
-wfl
-jnk
-cOi
+hIK
 jnk
 jnk
+fOS
+kkY
+jnk
+qLO
+qLO
+jnk
+lSN
 jnk
 jnk
 jnk
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
+jnk
+jnk
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
 ali
 ali
 alU
@@ -72486,7 +72603,7 @@ xpS
 jnk
 aJd
 aLN
-tMJ
+lDS
 jDm
 jhN
 jhN
@@ -72691,36 +72808,36 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
 jnk
-ckU
-jnk
-jnk
+uVG
 jnk
 jnk
 jnk
-wfl
-wfl
+jnk
+jnk
+qLO
+qLO
 jnk
 src
-pRG
+fOS
 jnk
 jnk
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
 jnk
 jnk
 jnk
@@ -72743,7 +72860,7 @@ xpS
 jnk
 aJd
 aLN
-tMJ
+lDS
 aLE
 tsw
 ldi
@@ -72947,47 +73064,47 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
 jnk
 jnk
 jnk
 jnk
 jnk
 jnk
-wIi
+jcP
 jnk
-wfl
-wfl
+qLO
+qLO
 jnk
-nmg
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
+fcv
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
 src
-lit
+qJD
 src
 src
 jnk
 jnk
-pRG
+fOS
 jnk
 jnk
 jnk
-hIx
-osw
-egY
+tHr
+tAm
+fBz
 wCC
 rdl
 jnk
@@ -73000,7 +73117,7 @@ jnk
 jnk
 aJd
 aLN
-tMJ
+lDS
 aNl
 aNl
 lrm
@@ -73204,42 +73321,42 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
-cOi
+qLO
+qLO
+qLO
+qLO
+lSN
 jnk
 jnk
-pqD
-gme
+vxr
+kkY
 jnk
 src
 jnk
-wfl
-wfl
+qLO
+qLO
 jnk
 jnk
-wKv
-wKv
-wKv
-wKv
-wKv
-wfl
-wfl
-wfl
-wfl
+eGS
+eGS
+eGS
+eGS
+eGS
+qLO
+qLO
+qLO
+qLO
 src
 jnk
-hJm
+qZH
 jnk
 jnk
 jnk
-gme
+kkY
 src
 jnk
 jnk
-ckU
+uVG
 jnk
 bkS
 bkS
@@ -73257,7 +73374,7 @@ uhx
 uhx
 uhx
 aLl
-tMJ
+lDS
 aLE
 aPL
 ldi
@@ -73461,60 +73578,60 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
 src
-bKD
+onI
 jnk
-hJm
+qZH
 jnk
-gJA
-wol
+acz
+tPl
 jnk
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
 src
-wKv
-wKv
-wKv
+eGS
+eGS
+eGS
 jnk
-wfl
-wfl
-wfl
-wfl
-wfl
-wIi
+qLO
+qLO
+qLO
+qLO
+qLO
+jcP
 jnk
 src
 jnk
 jnk
 jnk
 jnk
-gme
+kkY
 jnk
-luH
+uRd
 jnk
 jnk
 bkS
-nvF
-fRL
-nRM
-oAq
-eRl
-eRl
-eRl
-eRl
-eRl
-eRl
-eRl
-eRl
-eRl
-wdq
-tYG
-ftp
+gsa
+tmE
+sUl
+raB
+wvy
+wvy
+wvy
+wvy
+wvy
+wvy
+wvy
+wvy
+wvy
+sOS
+odJ
+rfs
 aLE
 rBh
 ldi
@@ -73718,36 +73835,36 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
-cOi
+qLO
+qLO
+qLO
+qLO
+lSN
 jnk
 jnk
 jnk
 jnk
 jnk
 jnk
-wfl
-wfl
-wfl
-wfl
-gme
+qLO
+qLO
+qLO
+qLO
+kkY
 jnk
 jnk
 jnk
 jnk
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
 jnk
-gme
+kkY
 jnk
-lit
+qJD
 jnk
-luH
+uRd
 jnk
 jnk
 src
@@ -73756,10 +73873,10 @@ pQy
 jnk
 jnk
 bkS
-mpZ
-tRg
+jXk
+rms
 bkS
-eaa
+aJF
 uhx
 uhx
 uhx
@@ -73975,29 +74092,29 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
-pRG
-lUS
+qLO
+qLO
+qLO
+qLO
+fOS
+ntU
 jnk
 jnk
 jnk
-pRG
+fOS
 jnk
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
 jnk
 jnk
 jnk
@@ -74015,8 +74132,8 @@ jnk
 bkS
 lEr
 qkr
-qhP
-jPk
+nmE
+vjo
 uhx
 pMA
 ipg
@@ -74232,39 +74349,39 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
 jnk
-gme
+kkY
 src
 cwi
 jnk
 jnk
-jlN
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
-wfl
+hoT
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
+qLO
 jnk
-ckU
+uVG
 jnk
-wol
+tPl
 jnk
-wol
-jnk
-jnk
+tPl
 jnk
 jnk
-gme
+jnk
+jnk
+kkY
 jnk
 jnk
 jnk
@@ -74272,8 +74389,8 @@ jnk
 bkS
 puA
 wLd
-qhP
-mFq
+nmE
+pGm
 uhx
 oNp
 eLE
@@ -74489,48 +74606,48 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
-hJm
-bKD
+qLO
+qLO
+qLO
+qLO
+qZH
+onI
 jnk
 jnk
 jnk
 jnk
 jnk
-bKD
-tQF
-wfl
-wfl
+onI
+lKI
+qLO
+qLO
 src
 jnk
-ckU
+uVG
 jnk
 jnk
-hOT
+kgP
 jnk
 jnk
 jnk
 jnk
 jnk
-wIi
+jcP
 src
-wIi
-src
-jnk
-hJm
+jcP
 src
 jnk
+qZH
+src
 jnk
 jnk
+jnk
 bkS
 bkS
 bkS
 bkS
 bkS
-eaa
+aJF
 uhx
 eLE
 tto
@@ -74746,10 +74863,10 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
 src
 jnk
 jnk
@@ -74758,17 +74875,17 @@ jnk
 jnk
 jnk
 jnk
-mOW
+rZw
 cwi
 src
 cwi
 jnk
-gme
+kkY
 src
-gme
-hOT
+kkY
+kgP
 jnk
-pRG
+fOS
 jnk
 pQy
 jnk
@@ -74787,7 +74904,7 @@ ihv
 pSJ
 bkS
 cOH
-eaa
+aJF
 uhx
 sYt
 eLE
@@ -74802,9 +74919,9 @@ aLN
 kGQ
 aLE
 oMA
-iOq
+hGg
 fNY
-ufT
+kMf
 qEX
 tju
 tXN
@@ -75003,48 +75120,48 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
 jnk
-wIi
-pqD
-wIi
+jcP
+vxr
+jcP
 jnk
-ckU
+uVG
 jnk
 jnk
-kae
+fTx
 jnk
 jnk
 jnk
 src
 jnk
 jnk
-dUf
-hOT
+iBt
+kgP
 jnk
 jnk
 jnk
-luH
+uRd
 jnk
 jnk
 jnk
 jnk
 jnk
-pRG
+fOS
 jnk
 jnk
 jnk
-awX
+wKq
 jnk
 bkS
 aXv
 pSJ
 tmX
 qkr
-eaa
+aJF
 uhx
 het
 ipg
@@ -75260,27 +75377,27 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
-gme
-kMf
-gJA
+qLO
+qLO
+qLO
+qLO
+kkY
+fgj
+acz
 jnk
 jnk
-wfl
-wfl
+qLO
+qLO
 jnk
-mOW
-dUf
-jnk
-jnk
-hJm
+rZw
+iBt
 jnk
 jnk
-pRG
-hOT
+qZH
+jnk
+jnk
+fOS
+kgP
 jnk
 jnk
 jnk
@@ -75301,7 +75418,7 @@ dlp
 bkS
 bkS
 wOy
-eaa
+aJF
 uhx
 uhx
 uhx
@@ -75518,56 +75635,56 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
 jnk
 jnk
 src
-wfl
-wfl
-wfl
-wfl
-tQF
+qLO
+qLO
+qLO
+qLO
+lKI
 jnk
 jnk
 jnk
-wol
-dUf
-ckU
+tPl
+iBt
+uVG
 jnk
-swy
-hOT
-hOT
-hOT
-hOT
-hOT
-hOT
-hOT
-hOT
-swy
-gPn
-gPn
-gPn
-swy
-ckU
+oWZ
+kgP
+kgP
+kgP
+kgP
+kgP
+kgP
+kgP
+kgP
+oWZ
+jFt
+jFt
+jFt
+oWZ
+uVG
 jnk
 bkS
 bkS
 bkS
 hPN
 qkr
-jXq
-jld
-jld
-jld
-uyd
-uyd
-uyd
-qlq
-uyd
-uQC
+orV
+jpP
+jpP
+jpP
+fWt
+fWt
+fWt
+fWL
+fWt
+dnD
 bkS
 nRt
 lUZ
@@ -75775,10 +75892,10 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
+qLO
 heo
 heo
 heo
@@ -75786,8 +75903,8 @@ heo
 heo
 heo
 heo
-hOT
-hOT
+kgP
+kgP
 jnk
 jnk
 src
@@ -75795,19 +75912,19 @@ jnk
 jnk
 jnk
 src
-cIX
-gVc
+sLP
+xwF
 src
-cIX
-gVc
+sLP
+xwF
 src
-cIX
-gVc
-uqU
-wKv
-wKv
-wKv
-hOT
+sLP
+xwF
+bFH
+eGS
+eGS
+eGS
+kgP
 jnk
 jnk
 jnk
@@ -75816,18 +75933,18 @@ bkS
 bkS
 bkS
 bkS
-oHV
+soS
 wCC
-sGx
+dvN
 qkr
 ksN
 cBy
 kCj
 xXi
-oqS
-cNz
-mOf
-qpD
+vZg
+ioT
+twh
+gPM
 izp
 cpE
 bBi
@@ -76033,48 +76150,48 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
-wfl
+qLO
+qLO
+qLO
 heo
-mzK
-ivi
-xCz
-fHK
-jFh
+cKO
+xpK
+voz
+gmu
+dux
 heo
-tBH
-cIX
-hFb
-hFb
-qEO
-hFb
-hFb
-gVc
-yiW
-lAX
-eEH
+gbH
+sLP
+kOM
+kOM
+bZT
+kOM
+kOM
+xwF
+wLx
+sWP
+yeS
 src
-lAX
-eEH
+sWP
+yeS
 src
-lAX
-eEH
-uqU
-wKv
-wKv
-wKv
-hOT
+sWP
+yeS
+bFH
+eGS
+eGS
+eGS
+kgP
 jnk
 jnk
 jnk
 jnk
-hPu
-wSi
-wSi
+bFd
+qPC
+qPC
 suH
 suH
-qoq
+oWj
 suH
 suH
 suH
@@ -76083,8 +76200,8 @@ sgN
 sgN
 sgN
 sgN
-tdp
-rUD
+eCt
+iBC
 aJq
 aLX
 aLX
@@ -76291,44 +76408,44 @@ gQb
 gQb
 gQb
 gQb
-wfl
-wfl
+qLO
+qLO
 heo
-jVe
-yik
-nbj
-yik
-kwS
-jEM
+ptf
+xOo
+xhV
+xOo
+xEs
+slk
 jnk
-fYn
-oQJ
-oQJ
-hzI
-oQJ
-oQJ
-xui
-pqD
-lAX
-eEH
+qyE
+oSg
+oSg
+hqi
+oSg
+oSg
+ybT
+vxr
+sWP
+yeS
 src
-lAX
-eEH
+sWP
+yeS
 src
-lAX
-eEH
-uqU
-wKv
-wKv
-wKv
-vyw
-vyw
-vyw
-vyw
-vyw
-vyw
-aHi
-wSi
+sWP
+yeS
+bFH
+eGS
+eGS
+eGS
+wrP
+wrP
+wrP
+wrP
+wrP
+wrP
+chn
+qPC
 suH
 gJM
 uDP
@@ -76340,8 +76457,8 @@ jFb
 pvH
 lUB
 sgN
-xIg
-fLH
+wsN
+oqR
 oQH
 aJn
 aJn
@@ -76549,43 +76666,43 @@ gQb
 gQb
 gQb
 gQb
-wfl
+qLO
 heo
-dcz
-yik
-nbj
-yik
-kwS
-dqQ
-dqQ
-dBS
-dBS
-dBS
-dqQ
-dqQ
+tCV
+xOo
+xhV
+xOo
+xEs
+gAN
+gAN
+qdO
+qdO
+qdO
+gAN
+gAN
 aIF
 aIF
-xsm
-fYn
-xui
-pqD
-fYn
-xui
-pqD
-fYn
-xui
-uqU
-wKv
-wKv
-wKv
-vyw
-wSi
-wSi
-wSi
-wSi
-bCn
-kHc
-gAb
+oZC
+qyE
+ybT
+vxr
+qyE
+ybT
+vxr
+qyE
+ybT
+bFH
+eGS
+eGS
+eGS
+wrP
+qPC
+qPC
+qPC
+qPC
+iPC
+cdX
+fqh
 suH
 dhx
 uDP
@@ -76598,7 +76715,7 @@ mkd
 mkd
 sgN
 aLX
-fLH
+oqR
 aOE
 aJn
 jnk
@@ -76806,23 +76923,23 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 heo
-jVe
-yik
-nbj
-yik
-kdY
-uOx
-vqt
-sMX
-hCj
-pQV
-plz
-dqQ
-oWT
-maD
-iOM
+ptf
+xOo
+xhV
+xOo
+cIP
+ydd
+eRb
+iqi
+hyK
+aIz
+lmb
+gAN
+cXS
+kBy
+qpO
 aIF
 aIF
 aIF
@@ -76831,18 +76948,18 @@ agn
 jnk
 jnk
 jnk
-uqU
-iAK
-iAK
-iAK
-vyw
-wSi
-wSi
-wSi
-wSi
-bCn
+bFH
+jRM
+jRM
+jRM
+wrP
+qPC
+qPC
+qPC
+qPC
+iPC
 anw
-tPU
+jXD
 suH
 lTy
 uDP
@@ -76855,7 +76972,7 @@ fah
 txw
 dxt
 aJs
-fLH
+oqR
 aOE
 aJn
 jnk
@@ -77063,43 +77180,43 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 heo
-wrt
-yik
-nbj
-yik
-qFY
-kok
-vqt
-wxL
-hCj
-bSB
-kYD
-dqQ
-tTi
-auA
-iOM
-lvb
-kem
-jUl
-dCG
+ueB
+xOo
+xhV
+xOo
+biU
+oWu
+eRb
+xuk
+hyK
+vYQ
+miI
+gAN
+gwy
+mcS
+qpO
+tPi
+phP
+nyg
+jWM
 agn
 jnk
 jnk
 jnk
-uqU
-wKv
-wKv
-wKv
-vyw
-wSi
-wSi
-wSi
-wSi
-bCn
-oIp
-qEp
+bFH
+eGS
+eGS
+eGS
+wrP
+qPC
+qPC
+qPC
+qPC
+iPC
+lNR
+wJE
 suH
 nJf
 uDP
@@ -77112,7 +77229,7 @@ dRN
 txw
 iGT
 aJs
-fLH
+oqR
 bJx
 aJn
 jnk
@@ -77320,43 +77437,43 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 heo
-bKc
-vHY
-rXR
-yhk
-eLK
-dqQ
-brN
-vmi
-hCj
-sch
-mRQ
-wWP
-mJH
-mJH
-xOn
-qQS
-qQS
-nAA
-tOL
+xJy
+ahV
+rgX
+ifd
+teJ
+gAN
+udg
+ejE
+hyK
+qhe
+jpm
+uiD
+dGq
+dGq
+rld
+epx
+epx
+eSo
+fbC
 agn
-swq
-jFw
-gPn
-swy
-wKv
-wKv
-wKv
-bvz
-wSi
-wSi
-wSi
-wSi
-bCn
-oIp
-rRm
+hvk
+gzw
+hLk
+oWZ
+eGS
+eGS
+eGS
+cER
+qPC
+qPC
+qPC
+qPC
+iPC
+lNR
+nmt
 suH
 tHi
 uDP
@@ -77369,7 +77486,7 @@ dXm
 txw
 dxt
 nmW
-fLH
+oqR
 oQH
 aJn
 jnk
@@ -77577,43 +77694,43 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 heo
-uaZ
+nAY
 rkj
-cCN
+wSi
 rkj
-uaZ
-dqQ
-lzZ
-hCj
-hCj
-hCj
-hCj
-oFu
-rLW
-rLW
-whX
+nAY
+gAN
+lGS
+hyK
+hyK
+hyK
+hyK
+eQh
+jfb
+jfb
+gpK
 agt
-qQS
-xGL
-fyd
+epx
+ugZ
+jnY
 aIF
-bcO
-uJF
-wKv
-wKv
-wKv
-wKv
-wKv
-bvz
-wSi
-wSi
-wSi
-wSi
-bCn
-oIp
-tPU
+kNB
+pqV
+eGS
+eGS
+eGS
+eGS
+eGS
+cER
+qPC
+qPC
+qPC
+qPC
+iPC
+lNR
+jXD
 suH
 dJT
 uDP
@@ -77626,7 +77743,7 @@ mkd
 rYh
 sgN
 aJr
-fLH
+oqR
 aOE
 aJn
 jnk
@@ -77834,43 +77951,43 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 lLe
-piO
-jXG
-inm
-inm
-pbx
-dqQ
-vPg
-ksI
-hCj
-wXq
-dcr
-dqQ
-pxW
-rQt
+fEY
+hTu
+nwr
+nwr
+pwJ
+gAN
+qOp
+vrk
+hyK
+rvz
+xzJ
+gAN
+gXp
+sMa
 agn
-qUB
-qQS
-gtB
-dyS
+dWQ
+epx
+uoT
+eRS
 aIF
-uom
-uJF
-wKv
-wKv
-wKv
-wKv
-wKv
-bvz
-wSi
-wSi
-wSi
-wSi
-bCn
-oIp
-kXQ
+rLV
+pqV
+eGS
+eGS
+eGS
+eGS
+eGS
+cER
+qPC
+qPC
+qPC
+qPC
+iPC
+lNR
+elf
 suH
 sjb
 uDP
@@ -77883,7 +78000,7 @@ xcv
 bLy
 sgN
 aGk
-fLH
+oqR
 aOE
 aJn
 jnk
@@ -78093,41 +78210,41 @@ gQb
 gQb
 lLe
 lLe
-jtj
-xsO
-xsO
-qFl
-pyT
-dqQ
-dqQ
-viw
-nog
-csk
-qlP
-dqQ
-vqK
-vqK
+vwd
+iKP
+iKP
+tXQ
+kJW
+gAN
+gAN
+jUn
+lQo
+ehp
+ekU
+gAN
+cnx
+cnx
 agn
-iDv
-aKO
-bnZ
+nEI
+vAQ
+geQ
 agn
 agn
-nai
-pOx
-wKv
-wKv
-wKv
-wKv
-wKv
-bvz
-wSi
-wSi
-wSi
-wSi
-bCn
-oTK
-juB
+djN
+lyi
+eGS
+eGS
+eGS
+eGS
+eGS
+cER
+qPC
+qPC
+qPC
+qPC
+iPC
+nmv
+nIg
 suH
 iFo
 xCJ
@@ -78140,7 +78257,7 @@ sgN
 sgN
 sgN
 aJq
-fLH
+oqR
 aOE
 aJn
 jnk
@@ -78349,42 +78466,42 @@ gQb
 gQb
 gQb
 lLe
-ydZ
-qFl
-oaR
-uZj
-pry
-inc
-aET
-dqQ
-dqQ
-mqQ
-kRr
-dqQ
-dqQ
-vqK
-vqK
+nbv
+tXQ
+tOf
+iUy
+rBB
+stF
+qKk
+gAN
+gAN
+xcl
+xWl
+gAN
+gAN
+cnx
+cnx
 agn
-lsm
-vAx
-gld
+fQc
+vLx
+ryV
 aIF
-mxL
-qSJ
-uJF
-wKv
-wKv
-wKv
-wKv
-wKv
-lvO
-lvO
-lvO
-lvO
-lvO
-vyw
-rNv
-gjq
+utQ
+gmK
+pqV
+dNz
+eGS
+eGS
+eGS
+eGS
+eey
+eey
+eey
+eey
+eey
+wrP
+uFC
+kSQ
 sgN
 oJX
 fmJ
@@ -78397,7 +78514,7 @@ dxt
 jnk
 aJn
 aLY
-nzl
+hlW
 awd
 rup
 rup
@@ -78606,42 +78723,42 @@ gQb
 gQb
 gQb
 lLe
-lZz
-xsO
-hgS
-gzz
-mIg
-cPS
-oJc
-ehN
-xBf
-wcF
-qNG
-xBf
-nNt
-qlH
-bhS
-rLL
-hjg
-vAx
+tYR
+iKP
+pBI
+pPc
+hbp
+irj
+aLH
+cNy
+usa
+nMC
+fof
+usa
+bHz
+jGf
+fQW
+otW
+qeq
+vLx
 agQ
-mVq
-vTh
-qSJ
-oGS
-cBH
-cBH
-cBH
-cBH
-cBH
-ufH
-krv
-xMl
-cfT
-mPI
-uEk
-oTK
-tPU
+tCd
+nbb
+gmK
+ukN
+hQb
+hQb
+hQb
+hQb
+hQb
+iOG
+dPm
+ePT
+aPb
+lvW
+slM
+nmv
+jXD
 sgN
 bWc
 xkN
@@ -78654,7 +78771,7 @@ dxt
 jnk
 aJn
 aJq
-qSr
+vTT
 aOE
 gri
 eWw
@@ -78863,42 +78980,42 @@ gQb
 gQb
 gQb
 lLe
-ydZ
-qFl
-lxu
-mcz
-wmi
-mQb
-xLH
-mRO
-lFX
-lFX
-lFX
-lFX
-lFX
-mPB
-kKo
+nbv
+tXQ
+bfL
+tQv
+jsz
+qHQ
+kaw
+pWK
+gcj
+gcj
+gcj
+gcj
+gcj
+dcI
+qye
 aIF
 ahX
-vAx
-kSr
+vLx
+aJi
 aIF
-asR
-bQe
-uJF
-wKv
-wKv
-wKv
-wKv
-wKv
-lvO
-iYZ
-dTm
-dTm
-wQh
-eCF
-tsj
-kiD
+vwf
+wwh
+pqV
+eGS
+eGS
+eGS
+eGS
+eGS
+eey
+fNg
+jrH
+jrH
+blq
+hxA
+jAe
+fab
 sgN
 mkd
 kmh
@@ -78911,7 +79028,7 @@ sgN
 aJn
 aJn
 aJq
-fLH
+oqR
 aOE
 eCl
 nXI
@@ -79121,40 +79238,40 @@ gQb
 gQb
 lLe
 lLe
-ahp
-qFl
-xsO
-qFl
-diX
-hco
-ehN
-jfk
-vpK
-umE
-mQF
-vpK
-eSC
-cEI
+jzi
+tXQ
+iKP
+tXQ
+fPD
+lEb
+cNy
+cEM
+vQz
+joM
+hvW
+vQz
+bpQ
+xUk
 agn
 aIF
-xDH
+cZP
 aIF
 agn
-mbF
-pcc
-pOx
-wKv
-wKv
-wKv
-wKv
-wKv
-lvO
-mKH
-cSN
-oLn
-mPI
-pGj
-xHa
+ycK
+vwb
+lyi
+eGS
+eGS
+eGS
+eGS
+eGS
+eey
+omG
+ubM
+eNk
+lvW
+oiY
+qkv
 aov
 sgN
 hDo
@@ -79168,7 +79285,7 @@ vCj
 aJp
 aKE
 aMa
-wCZ
+tJY
 aOE
 eCl
 dWK
@@ -79376,42 +79493,42 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 lLe
-rQC
-bMs
-sfE
-hiB
-gmq
-sqx
-sqx
-sqx
-sqx
-sqx
-sqx
-sqx
-tSw
-oGC
-xBf
-hBb
-beS
-mIF
-pOx
-aHI
-iMy
-pOx
-wKv
-wKv
-wKv
-wKv
-wKv
-lvO
-uQc
-ijJ
-mPI
-lvO
-hPu
-qWu
+bYg
+lHu
+ebC
+gBE
+lJK
+tql
+tql
+tql
+tql
+tql
+tql
+tql
+scK
+iLa
+usa
+bmT
+vua
+sSh
+lyi
+fQy
+gDY
+lyi
+kzl
+eGS
+eGS
+eGS
+eGS
+eey
+udh
+iSG
+lvW
+eey
+bFd
+iVG
 aov
 sgN
 sgN
@@ -79425,7 +79542,7 @@ sgN
 fBl
 fGw
 aLZ
-eIH
+gvf
 oQH
 eCl
 oWr
@@ -79633,45 +79750,45 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 lLe
 lLe
-xtK
-xtK
-xtK
+tmV
+tmV
+tmV
 lLe
-sqx
-nZb
-bVP
-ccL
-gSS
-pNt
+tql
+qEZ
+rpD
+xAe
+xfZ
+kGZ
 gLf
-xlK
-iBf
-hen
-oPD
-xpH
-sXR
-lTd
-nZE
-hcn
-cge
-uwh
-uwh
-uwh
-uwh
-uwh
-nQE
-eMI
-eMI
-eMI
-jTS
-exB
-xHa
-uLu
-toN
-hgG
+vga
+uCX
+omh
+ahv
+iYx
+xEA
+eFz
+cyh
+kqE
+tpZ
+lgW
+lgW
+lgW
+lgW
+lgW
+enZ
+xNO
+xNO
+xNO
+gAP
+wcJ
+qkv
+lBh
+hYb
+xSt
 azZ
 azZ
 azZ
@@ -79682,7 +79799,7 @@ aHQ
 aJr
 aJq
 aMc
-pUN
+iSl
 aOE
 eCl
 dKW
@@ -79890,56 +80007,56 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 jnk
 jnk
 jnk
-cgW
+edW
 jnk
 src
 gLf
-nfD
-fyT
-oZa
-aek
-gPD
-kLL
-xpH
-gWW
-stx
-awp
-xpH
-eSG
-uJF
-pbr
-sOE
-uJF
-cEs
-cEs
-cEs
-cEs
-cEs
-lxm
-suE
-wTW
-suE
-lxm
+fhK
+xTd
+aCs
+vzu
+cMK
+dHx
+iYx
+gCa
+wTq
+pyM
+iYx
+bCg
+pqV
+diK
+azr
+pqV
+wET
+wET
+wET
+wET
+wET
+pSW
+pmQ
+dYF
+pmQ
+pSW
 anz
-jAf
-aZA
-duE
+xkJ
+gdC
+imc
 rUv
-eCF
-qtJ
-eCF
-qtJ
-eCF
-eCF
-kuM
+hxA
+yaA
+hxA
+yaA
+hxA
+hxA
+oxY
 ppw
 ppw
-vRC
-pQi
+vwV
+gFp
 aOE
 eCl
 igw
@@ -80147,56 +80264,56 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 jnk
 jnk
 jnk
-cgW
+edW
 jnk
 jnk
 gLf
-mWF
-roS
-vjH
-rmd
-nQs
-sqx
+ipt
+eeC
+iXK
+gkn
+jRh
+tql
 tGb
 tGb
 tGb
-vOc
-bpj
-jWD
-uYO
-dwD
-tCe
+mkw
+hzb
+goR
+rIB
+gxY
+mTN
+lzS
+jex
+jex
+jex
+jex
+jex
+kDh
+diA
+xBj
+eUW
+vfP
+cXv
+sEl
+aHw
+ngU
+pjK
+oeo
+stw
+oeo
+oeo
+oeo
+oeo
+krU
 rss
-cZW
-cZW
-cZW
-cZW
-cZW
-rQo
-kbY
-tjj
-xbq
-byI
-kvF
-dYa
-njA
-uUS
-lsD
-nmu
-oQY
-nmu
-nmu
-nmu
-nmu
-vXi
-iYF
 bmE
-mmO
-kJu
+tQE
+tuM
 aOE
 eCl
 uzQ
@@ -80404,35 +80521,35 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 jnk
 jnk
 jnk
-cOi
-vFK
-vFK
+lSN
+trs
+trs
 gLf
 gLf
-qBw
-jVn
-prI
-kZv
-sqx
-bwq
-qmU
-pMk
-ycQ
-feP
-lJW
-pOx
-pOx
-pOx
-pOx
-wKv
-wKv
-wKv
-wKv
-wKv
+fwi
+jkt
+kJo
+otv
+tql
+qNU
+lBj
+hCI
+nEd
+dbB
+fwJ
+lyi
+lyi
+lyi
+lyi
+eGS
+eGS
+eGS
+eGS
+eGS
 eMl
 eMl
 eMl
@@ -80453,7 +80570,7 @@ eMl
 nmW
 aJq
 aMd
-ixn
+sJt
 aOE
 eCl
 uvo
@@ -80661,36 +80778,36 @@ gQb
 gQb
 gQb
 gQb
-ybU
+nau
 jnk
 jnk
 jnk
-cgW
+edW
 jnk
 jnk
 jnk
 gLf
 gLf
 gLf
-sqx
-sqx
-sqx
-wYg
-cik
-lEI
-xlK
-feP
-wqi
-pSd
-oPM
-rbu
-uJF
-wKv
-wKv
-wKv
-wKv
-wKv
-dYd
+tql
+tql
+tql
+kSJ
+eXS
+cgm
+vga
+dbB
+sRL
+vkD
+lkx
+sKU
+pqV
+eGS
+eGS
+eGS
+eGS
+eGS
+muv
 nim
 nim
 nim
@@ -80710,7 +80827,7 @@ vKP
 aJu
 aKF
 aMf
-wOn
+lzk
 aOE
 eCl
 nyY
@@ -80918,11 +81035,11 @@ gQb
 gQb
 gQb
 gQb
-gme
-vFK
-vFK
-vFK
-wol
+kkY
+trs
+trs
+trs
+tPl
 jnk
 jnk
 jnk
@@ -80931,23 +81048,23 @@ jnk
 jnk
 gQb
 gQb
-hIX
-cSp
-rXK
-uWM
-eGQ
-feP
-cCI
-jXz
-rjk
-vrY
-uJF
-wKv
-wKv
-wKv
-wKv
-wKv
-dYd
+uFe
+nme
+gaF
+fmk
+avh
+dbB
+eET
+pbX
+cLn
+rhu
+pqV
+eGS
+eGS
+eGS
+eGS
+eGS
+muv
 nim
 eMl
 eMl
@@ -81188,23 +81305,23 @@ gQb
 gQb
 gQb
 gQb
-hIX
-hNd
-rXK
-wZR
-xlK
-ipC
-iLs
-iXu
-uBr
-kdI
-uJF
-wKv
-wKv
-wKv
-wKv
-wKv
-dYd
+uFe
+jBU
+gaF
+kPm
+vga
+bOA
+bHm
+dGy
+hFd
+qMb
+pqV
+eGS
+eGS
+eGS
+eGS
+eGS
+muv
 nim
 eMl
 buo
@@ -81224,7 +81341,7 @@ jnk
 jnk
 aJn
 aJq
-ucu
+leS
 aOE
 eCl
 uTV
@@ -81445,22 +81562,22 @@ gQb
 gQb
 gQb
 gQb
-hIX
-qVz
-itl
-cwO
-xlK
-ipC
-wqi
-qHn
-pgY
-jkq
-pOx
-wKv
-wKv
-wKv
-wKv
-wKv
+uFe
+vyp
+fzG
+ewM
+vga
+bOA
+sRL
+sxj
+tHU
+mad
+lyi
+eGS
+eGS
+eGS
+eGS
+eGS
 eMl
 nim
 eMl
@@ -81481,7 +81598,7 @@ jnk
 jnk
 aJn
 aLY
-hrR
+pvg
 oak
 rup
 rup
@@ -81702,22 +81819,22 @@ gQb
 gQb
 gQb
 gQb
-hIX
-hIX
-hIX
-hIX
-xlK
-bWL
-ojQ
-pOx
-pOx
-pOx
-pOx
-wKv
-wKv
-wKv
-wKv
-wKv
+uFe
+uFe
+uFe
+uFe
+vga
+oRa
+tfO
+lyi
+lyi
+lyi
+lyi
+eGS
+eGS
+eGS
+eGS
+eGS
 eMl
 nim
 eMl
@@ -81738,7 +81855,7 @@ aJw
 aJw
 aJw
 beX
-jnZ
+nBk
 aOE
 aJn
 jnk
@@ -81758,7 +81875,7 @@ jdv
 vnL
 olj
 jOT
-mot
+ezx
 uRa
 cUa
 mvr
@@ -81954,27 +82071,27 @@ jnk
 jnk
 jnk
 jnk
-hOT
+kgP
 uXB
 uXB
 uXB
 aiV
 aiV
-qWF
-eoh
-lUV
-lFX
-pGf
-ehD
-uJF
+xXx
+wdb
+vLW
+gcj
+udS
+umR
+pqV
 jnk
 jnk
 jnk
-wKv
-wKv
-wKv
-wKv
-wKv
+eGS
+eGS
+eGS
+eGS
+eGS
 eMl
 nim
 eMl
@@ -81995,7 +82112,7 @@ hTM
 lRr
 hhm
 aMg
-dKO
+kcG
 aOE
 aJn
 jnk
@@ -82216,22 +82333,22 @@ jnk
 jnk
 cwi
 aiV
-uYB
-lev
-jav
+rAY
+aWu
+uBf
 aiT
-dvd
-dnj
-fVq
-uJF
+wbn
+izs
+ocb
+pqV
 jnk
 jnk
 jnk
-wKv
-wKv
-wKv
-wKv
-wKv
+eGS
+eGS
+eGS
+eGS
+eGS
 eMl
 nim
 saX
@@ -82246,13 +82363,13 @@ cRN
 tHq
 pSI
 rVS
-aQO
+ogQ
 xdS
 opq
 aJy
 aJy
 aMj
-jnZ
+nBk
 oQH
 aJn
 jnk
@@ -82467,28 +82584,28 @@ jnk
 jnk
 jnk
 jnk
-rXp
+dTw
 jnk
 jnk
 jnk
-cPL
-xdr
-sIX
-hqi
-biM
+lZo
+fyy
+oYI
+peY
+aya
 aiV
-pOx
-rjs
-pOx
-pOx
-ckU
+lyi
+eOA
+lyi
+lyi
+uVG
 jnk
-wKv
-wKv
-wKv
-wKv
-wKv
-wKv
+eGS
+eGS
+eGS
+eGS
+eGS
+eGS
 eMl
 nim
 eMl
@@ -82730,21 +82847,21 @@ jnk
 jnk
 cwi
 aiV
-oJp
-hqi
-biM
+das
+peY
+aya
 aiV
-flg
-utc
-vEk
-uJF
+mbw
+tjH
+swo
+pqV
 jnk
 jnk
-wKv
-wKv
-wKv
-wKv
-wKv
+eGS
+eGS
+eGS
+eGS
+eGS
 eMl
 eMl
 wCm
@@ -82987,23 +83104,23 @@ iDc
 iDc
 iDc
 iDc
-brC
-lla
-gRV
+qcV
+ouv
+jcH
 aiV
-eHc
-sbV
-kpT
-pOx
+vvs
+eCP
+nxE
+lyi
 jnk
-wKv
-wKv
-wKv
-wKv
-dYd
-dYd
+eGS
+eGS
+eGS
+eGS
+muv
+muv
 eMl
-grm
+lFN
 nim
 eMl
 oZl
@@ -83239,28 +83356,28 @@ jnk
 jnk
 jnk
 jnk
-qzk
-cNy
-lEk
-vgD
-pqa
-brC
-fwp
-biM
-oRN
-bXv
-rPf
-dQT
-uJF
+cGX
+nmr
+woC
+iiu
+uhW
+qcV
+mgj
+aya
+fqP
+wJL
+mZr
+adQ
+pqV
 jnk
-wKv
-wKv
-wKv
-wKv
-dYd
-cnP
-rlH
-lsn
+eGS
+eGS
+eGS
+eGS
+muv
+ubV
+pSE
+boQ
 nim
 eMl
 xHC
@@ -83496,28 +83613,28 @@ jnk
 jnk
 jnk
 jnk
-qzk
-oqh
-oqh
-tbl
-ejL
-gJd
-pKm
-biM
+cGX
+rum
+rum
+oVW
+dHv
+dDv
+bdT
+aya
 aiV
-gIs
-hUF
-dBV
-uJF
-wKv
-wKv
+rHT
+giV
+qyB
+pqV
+eGS
+eGS
 eMl
 eMl
 eMl
 eMl
-xQO
-kkP
-fYM
+tOn
+hzR
+veN
 nim
 eMl
 qpL
@@ -83753,28 +83870,28 @@ jnk
 jnk
 jnk
 jnk
-qzk
+cGX
 goK
 pvf
-jDP
-knU
-brC
-qmc
-ckv
+rtp
+rPX
+qcV
+idE
+gQu
 aiV
-uBp
-ucj
-uJF
-uJF
-wKv
-wKv
+cfx
+pRf
+pqV
+pqV
+eGS
+eGS
 eMl
-gOT
+jwI
 bTn
 eMl
-nlp
-ubH
-wBU
+ggs
+nhP
+lin
 nim
 eMl
 hTM
@@ -84010,28 +84127,28 @@ jnk
 jnk
 jnk
 jnk
-qzk
+cGX
 xzg
-cYS
-sXY
-lNI
-brC
-lak
-qgp
+vgi
+kse
+rHe
+qcV
+uBX
+qtg
 aiV
-uJF
-uJF
-uJF
+pqV
+pqV
+pqV
 jnk
-wKv
+eGS
 jnk
 tpE
-bMa
+jAH
 rpv
 eMl
-aQT
-thm
-qYM
+cVZ
+uqd
+asl
 nim
 eMl
 vFB
@@ -84268,13 +84385,13 @@ jnk
 jnk
 aiV
 iDc
-brC
-brC
-brC
-brC
-brC
+qcV
+qcV
+qcV
+qcV
+qcV
 aiT
-mDz
+wbG
 aiV
 jnk
 jnk
@@ -84283,13 +84400,13 @@ jnk
 jnk
 jnk
 tpE
-dYd
-wOX
+muv
+dQV
 eMl
 eMl
 eMl
 eMl
-gGe
+lmF
 eMl
 svI
 bHH
@@ -84524,26 +84641,26 @@ gQb
 gQb
 gQb
 aiV
-jKh
-aHD
-jWV
-lKk
+ksV
+aIX
+mOK
+dqM
 aiT
-hQT
-imM
-fKc
+xqD
+xoh
+qdr
 aiV
 tpE
 tpE
 tpE
 jnk
 jnk
-pRG
+fOS
 tpE
-nRQ
+jUY
 nim
 wCm
-gGe
+lmF
 eMl
 iZN
 nim
@@ -84781,26 +84898,26 @@ gQb
 gQb
 gQb
 aiV
-ofc
-avJ
-oDB
-szI
+rNx
+qnZ
+sog
+vue
 aiT
-nKB
-nIv
-nyP
-eZf
-flc
+vry
+dKH
+vAf
+toX
+aSV
 bTn
 tpE
 tpE
 tpE
 tpE
 tpE
-fIi
-rlc
-jEx
-gGe
+vnG
+lkR
+fUb
+lmF
 eMl
 buZ
 lvU
@@ -85038,30 +85155,30 @@ gQb
 gQb
 gQb
 aiV
-vBI
-avJ
-avJ
-hRD
-gnF
-pji
+nrh
+qnZ
+qnZ
+dZy
+lno
+smp
 amb
-hVX
+mcr
 aiV
 eMl
 bTn
 vWE
 eMl
-qOd
+kAS
 dFE
 eMl
 eMl
 eMl
 eMl
-nvY
+oDY
 eMl
-sZP
+xkz
 kHG
-aDu
+dpT
 ycs
 gQI
 uBj
@@ -85295,19 +85412,19 @@ gQb
 gQb
 gQb
 aiV
-dsH
-jEs
-jEs
-cEL
-mIs
-qSB
-qSB
-sEB
-aJU
-vpM
+ydK
+vDt
+vDt
+sWQ
+izc
+lmi
+lmi
+vpq
+fbb
+ufC
 jkL
 jkL
-cQi
+dmF
 jkL
 jkL
 jkL
@@ -85317,7 +85434,7 @@ jkL
 jkL
 jkL
 agR
-yjL
+fFH
 eMl
 gsx
 fOZ
@@ -85552,14 +85669,14 @@ gQb
 gQb
 gQb
 aiV
-oeA
-vhl
-aSc
-uUu
-pmA
-iVe
-kCO
-hdl
+wLO
+uEt
+umH
+rQO
+lKN
+ame
+wuW
+vZw
 aiV
 bTn
 bTn
@@ -85567,14 +85684,14 @@ bTn
 bTn
 dRx
 bTn
-brJ
+eho
 bTn
 rpv
-mOY
-sZP
-ivr
+nea
+xkz
+tgM
 rpv
-cPB
+fHG
 eMl
 lXa
 gmP
@@ -85809,13 +85926,13 @@ gQb
 gQb
 gQb
 aiV
-dMQ
-gVs
-dMQ
+bTa
+kGb
+bTa
 aiV
-dMQ
-cDS
-dMQ
+bTa
+sFS
+bTa
 aiV
 aiV
 tSM
@@ -86066,13 +86183,13 @@ gQb
 gQb
 gQb
 gQb
-dMQ
-iRm
-dMQ
+bTa
+bEn
+bTa
 jnk
-dMQ
-iRm
-dMQ
+bTa
+bEn
+bTa
 gQb
 gQb
 gQb
@@ -86323,13 +86440,13 @@ gQb
 gQb
 gQb
 gQb
-dMQ
-qRL
-dMQ
+bTa
+xHz
+bTa
 jnk
-dMQ
-kLN
-dMQ
+bTa
+aEM
+bTa
 gQb
 gQb
 gQb
@@ -87613,7 +87730,7 @@ jnk
 jnk
 jnk
 jnk
-buw
+bYT
 jnk
 jnk
 jnk
@@ -87744,7 +87861,7 @@ ctZ
 jnk
 jnk
 jnk
-kms
+bbO
 jnk
 gQb
 gQb
@@ -91342,7 +91459,7 @@ cuf
 jnk
 jnk
 jnk
-kLU
+kgc
 jnk
 gQb
 gQb

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -6,6 +6,9 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"aal" = (
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/hos)
 "aaD" = (
 /obj/structure/table,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -43,20 +46,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"acz" = (
-/obj/effect/gibspawner/human,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"adQ" = (
-/obj/machinery/flasher/portable,
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "2";
-	dir = 1;
-	name = "Flash Storage"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "adY" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -143,16 +132,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
-"ahv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "ahx" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -182,10 +161,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
-"ahV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/security/lockers)
 "ahX" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -259,6 +234,22 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"alo" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "EVA2"
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "als" = (
 /obj/structure/mineral_door/wood{
 	name = "Maintenance Bar"
@@ -320,12 +311,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
-"ame" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+"amq" = (
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/processing)
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "amu" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
@@ -709,6 +701,17 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"arF" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/lockers)
 "arI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -720,20 +723,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/fore)
-"asl" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/rag,
-/obj/item/clothing/head/collectable/tophat{
-	pixel_y = 5;
-	pixel_x = 6
-	},
-/obj/effect/spawner/random/entertainment/gambling{
-	pixel_x = -13
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/maintenance/fore/lesser)
 "asn" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -971,11 +960,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"avh" = (
+"auY" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/security/processing)
 "avi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1019,6 +1017,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"avu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "avC" = (
 /turf/closed/wall,
 /area/cargo/lobby)
@@ -1185,6 +1192,10 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"axh" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "axC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1218,17 +1229,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
-"aya" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"ayc" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2"
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/processing)
 "ayd" = (
 /obj/machinery/door/firedoor,
@@ -1310,13 +1317,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"azr" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "azs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -1474,6 +1474,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"aBt" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
+"aBu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "aBF" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -1526,14 +1540,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
-"aCs" = (
-/obj/structure/table/wood,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/storage/box/deputy,
-/turf/open/floor/wood/large,
-/area/command/heads_quarters/hos)
 "aCt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -1544,6 +1550,12 @@
 /obj/item/toy/gun,
 /turf/open/floor/iron,
 /area/commons/locker)
+"aCD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "aCN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -1595,13 +1607,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aEM" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	shuttledocked = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/processing)
 "aES" = (
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
@@ -1672,6 +1677,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aGY" = (
+/obj/machinery/vending/security,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth_edge,
+/area/security/lockers)
 "aHd" = (
 /obj/machinery/duct,
 /obj/machinery/door/poddoor/preopen{
@@ -1699,12 +1709,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"aHw" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "aHM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1731,16 +1735,6 @@
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
-"aIz" = (
-/obj/structure/railing,
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "aIF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -1765,23 +1759,23 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aIX" = (
-/obj/machinery/gulag_teleporter,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "aJd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"aJi" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "aJn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1839,15 +1833,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"aJF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "aJV" = (
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -1974,12 +1959,6 @@
 "aLE" = (
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"aLH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "aLK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -2248,18 +2227,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
-"aPb" = (
-/obj/machinery/computer/warrant{
-	dir = 4
-	},
-/obj/machinery/camera/motion/directional/west{
-	c_tag = "Security - Checkpoint"
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "aPp" = (
 /turf/open/openspace,
 /area/service/bar/atrium)
@@ -2309,6 +2276,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"aQu" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light/directional/east,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "aQz" = (
 /obj/machinery/power/smes/engineering,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -2392,16 +2365,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"aSV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 1;
-	freq = 1400;
-	location = "Security"
-	},
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "aTg" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2431,12 +2394,28 @@
 "aTJ" = (
 /turf/open/floor/iron/dark/smooth_edge,
 /area/service/chapel)
+"aTO" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "aTS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/aft/greater)
+"aUp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "aUx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
@@ -2468,6 +2447,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"aUP" = (
+/obj/structure/table/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/storage/box/deputy,
+/turf/open/floor/wood/large,
+/area/command/heads_quarters/hos)
 "aVb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -2560,13 +2547,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
-"aWu" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
 "aWH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue,
@@ -2812,14 +2792,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/lobby)
-"bbO" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "MiniSat External NorthWest";
-	network = list("minisat");
-	start_active = 1
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/ai_monitored/turret_protected/aisat/maint)
 "bbS" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
@@ -2920,15 +2892,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/service/library)
-"bdT" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
 "bed" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -3039,16 +3002,12 @@
 /turf/closed/wall,
 /area/security/checkpoint/medical)
 "bfL" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/inspector,
-/turf/open/floor/iron/dark/textured_half{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/area/security/office)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "bfT" = (
 /turf/closed/wall,
 /area/science/robotics/mechbay)
@@ -3143,6 +3102,11 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"bhv" = (
+/obj/structure/window/reinforced,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "bhy" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
@@ -3171,6 +3135,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
+"bhP" = (
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "bhY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -3254,13 +3222,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"biU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/security/lockers)
 "biW" = (
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -3365,22 +3326,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"blq" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Desk"
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/checkpoint/auxiliary)
 "blv" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -3453,15 +3398,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/large,
 /area/engineering/atmos)
-"bmT" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "bnb" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -3603,12 +3539,6 @@
 "boM" = (
 /turf/open/floor/iron/white/corner,
 /area/science/research)
-"boQ" = (
-/obj/structure/cable,
-/turf/open/floor/wood{
-	icon_state = "wood-broken2"
-	},
-/area/maintenance/fore/lesser)
 "boV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -3636,12 +3566,6 @@
 "bpI" = (
 /turf/closed/wall,
 /area/medical/psychology)
-"bpQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "bpR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -4186,6 +4110,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/sepia,
 /area/service/library)
+"bzb" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"bzf" = (
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "bzr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/nosmoking{
@@ -4228,6 +4161,15 @@
 	dir = 5
 	},
 /area/science/research)
+"bzO" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "bzW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -4353,14 +4295,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"bCg" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "bCq" = (
 /turf/closed/wall,
 /area/maintenance/port/aft)
@@ -4372,6 +4306,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bCt" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "bCA" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
@@ -4496,8 +4438,16 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"bEn" = (
-/turf/open/floor/iron/dark/smooth_large,
+"bEa" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"bEi" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/side,
 /area/security/processing)
 "bEo" = (
 /obj/effect/spawner/random/trash/mess,
@@ -4561,9 +4511,14 @@
 /obj/machinery/atmospherics/pipe/color_adapter,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
-"bFd" = (
-/turf/closed/wall,
-/area/hallway/primary/fore)
+"bFe" = (
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/security/processing)
 "bFf" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -4582,13 +4537,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/plating/icemoon,
 /area/science/test_area)
-"bFH" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "bFU" = (
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -4690,13 +4638,6 @@
 /obj/machinery/microwave,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
-"bHm" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "bHw" = (
 /obj/item/target,
 /obj/structure/window/reinforced,
@@ -4705,19 +4646,6 @@
 	},
 /turf/open/floor/plating/icemoon,
 /area/science/test_area)
-"bHz" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Upper Hallway North"
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "bHB" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
@@ -4865,6 +4793,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"bJy" = (
+/obj/structure/closet/bombcloset/security,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "bJB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
@@ -4984,6 +4916,15 @@
 "bLU" = (
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
+"bLV" = (
+/obj/machinery/flasher/directional/east{
+	id = "brigentry"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "bMi" = (
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -5085,15 +5026,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"bOA" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "bOJ" = (
 /obj/item/target,
 /obj/structure/window/reinforced{
@@ -5179,6 +5111,12 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"bQV" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "bQZ" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
@@ -5195,6 +5133,13 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/port/aft)
+"bRE" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/obj/effect/gibspawner/human,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "bRK" = (
 /obj/structure/sink{
 	dir = 4;
@@ -5291,11 +5236,6 @@
 /obj/structure/noticeboard/directional/west,
 /turf/open/floor/engine/cult,
 /area/service/library)
-"bTa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/processing)
 "bTc" = (
 /obj/machinery/conveyor{
 	dir = 6;
@@ -5344,6 +5284,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
+"bUb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bUd" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -5370,6 +5321,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"bUW" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "bUZ" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -5381,6 +5342,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"bVb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "bVk" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -5430,6 +5398,14 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"bVI" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "bVJ" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
@@ -5561,12 +5537,13 @@
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"bYg" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light/directional/east,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
+"bXQ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "bYi" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -5662,18 +5639,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"bYT" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
-	width = 9
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "bZa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5727,13 +5692,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"bZT" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "cad" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -5875,6 +5833,10 @@
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"ccj" = (
+/obj/structure/closet/secure_closet/warden,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "ccm" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -5882,6 +5844,9 @@
 "ccp" = (
 /turf/closed/wall,
 /area/science/mixing/hallway)
+"ccr" = (
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "ccP" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -6021,15 +5986,6 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cdX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "cdZ" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/iron/dark/telecomms,
@@ -6098,11 +6054,12 @@
 "cfw" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
-"cfx" = (
-/obj/structure/closet/l3closet/security,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
+"cfJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "cfV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -6112,11 +6069,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"cgm" = (
-/obj/structure/window/reinforced,
-/obj/machinery/holopad,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "cgp" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating,
@@ -6141,6 +6093,11 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/port/aft)
+"cgL" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/fore/lesser)
 "cgM" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Fore Starboard Solar Access"
@@ -6154,12 +6111,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"chn" = (
-/obj/structure/sign/departments/court{
-	pixel_y = 32
-	},
-/turf/open/openspace,
-/area/hallway/primary/fore)
+"chd" = (
+/turf/closed/wall/r_wall,
+/area/icemoon/surface/outdoors/nospawn)
 "chw" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -6181,6 +6135,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"cim" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "ciB" = (
 /obj/structure/railing/corner,
 /obj/machinery/firealarm/directional/west,
@@ -6222,6 +6180,9 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"cjp" = (
+/turf/open/floor/glass/reinforced,
+/area/security/lockers)
 "cjr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -6329,6 +6290,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"clZ" = (
+/turf/closed/wall,
+/area/security/interrogation)
 "cmd" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -6390,9 +6354,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"cnx" = (
-/turf/open/openspace,
-/area/security/brig/upper)
 "cnF" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -6442,6 +6403,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"coC" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/processing)
 "coT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6653,6 +6626,16 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"csW" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/captain{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet,
+/area/command/heads_quarters/captain)
 "csX" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -6672,6 +6655,15 @@
 	},
 /turf/open/floor/iron/checker,
 /area/science/lab)
+"ctf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "ctg" = (
 /obj/structure/closet/emcloset{
 	anchored = 1
@@ -7132,6 +7124,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/construction)
+"cxh" = (
+/obj/structure/closet/l3closet/security,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
+"cxm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "cxB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -7145,12 +7149,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
 /area/commons/vacant_room/commissary)
-"cyh" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "cyl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -7219,6 +7217,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"cyQ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigentrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "cyR" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -7263,6 +7274,19 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"czZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Transport Parlor"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron,
+/area/security/processing)
 "cAa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7334,6 +7358,10 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"cAV" = (
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/glass/reinforced,
+/area/security/office)
 "cAY" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -7468,6 +7496,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"cEm" = (
+/obj/item/storage/box/bodybags,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/reagent_containers/syringe{
+	name = "steel point"
+	},
+/obj/item/reagent_containers/glass/bottle/multiver,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "cEt" = (
 /obj/machinery/computer/upload/ai{
 	dir = 1
@@ -7484,21 +7524,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"cEM" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/security/brig/upper)
-"cER" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Courtroom";
-	name = "security shutters"
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/fore)
 "cFA" = (
 /obj/structure/table/optable,
 /obj/machinery/light/directional/east,
@@ -7600,15 +7625,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage)
-"cGX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "Interrogation";
-	name = "Interrogation Shutters"
-	},
-/turf/open/floor/plating,
-/area/security/interrogation)
 "cHo" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/light/small/directional/north,
@@ -7617,6 +7633,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"cHy" = (
+/obj/machinery/space_heater,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/maintenance/fore/lesser)
 "cHK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass{
@@ -7760,15 +7783,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/upper)
-"cIP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/security/lockers)
 "cJg" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "pharmacy_shutters";
@@ -7782,6 +7796,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"cJQ" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "MiniSat External NorthWest";
+	network = list("minisat");
+	start_active = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/ai_monitored/turret_protected/aisat/maint)
 "cJT" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/drinks/waterbottle{
@@ -7803,6 +7825,11 @@
 /mob/living/simple_animal/mouse/white,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"cJZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "cKn" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -7839,17 +7866,18 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"cKO" = (
-/obj/machinery/vending/security,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth_edge,
-/area/security/lockers)
 "cKW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
+"cKX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "cKY" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/engine/plasma,
@@ -7861,6 +7889,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"cLf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "cLl" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -7869,12 +7906,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/heads_quarters/cmo)
 "cLn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Office"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/security/office)
 "cLo" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -7910,15 +7949,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
-"cMK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/smooth_large,
-/area/command/heads_quarters/hos)
 "cMO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7978,11 +8008,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"cNy" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/office)
 "cNW" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
@@ -8059,6 +8084,19 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/cargo/storage)
+"cQc" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
+"cQi" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "cQo" = (
 /obj/machinery/door/airlock/external{
 	name = "Common Mining Shuttle Bay";
@@ -8074,6 +8112,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central/greater)
+"cQw" = (
+/obj/machinery/camera/motion/directional/north{
+	c_tag = "Armory - External"
+	},
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"cQA" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "cQJ" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -8149,6 +8204,28 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"cUl" = (
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 40
+	},
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "cUm" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
@@ -8157,6 +8234,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"cUo" = (
+/obj/structure/chair/office,
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "cUv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
@@ -8236,16 +8322,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cVZ" = (
-/obj/machinery/space_heater,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/wood{
-	icon_state = "wood-broken2"
-	},
-/area/maintenance/fore/lesser)
 "cWt" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"cWw" = (
+/obj/machinery/modular_computer/console/preset/id,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
 "cWA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -8289,19 +8372,6 @@
 /obj/item/lipstick/random,
 /turf/open/floor/iron,
 /area/commons/locker)
-"cXv" = (
-/obj/machinery/flasher/directional/east{
-	id = "brigentry"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"cXS" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "cXW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8349,6 +8419,12 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"cZn" = (
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/lockers)
 "cZv" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/cable,
@@ -8394,20 +8470,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/commons/vacant_room/office)
-"cZP" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "cZR" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/tile/red{
@@ -8450,11 +8512,6 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/textured,
 /area/medical/medbay/central)
-"das" = (
-/obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/security/processing)
 "daz" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -8469,6 +8526,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"dbd" = (
+/turf/closed/wall/r_wall,
+/area/security/brig/upper)
 "dbe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -8500,15 +8560,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
-"dbB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"dbC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "dbF" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -8576,14 +8633,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
-"dcI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "dcQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -8618,6 +8667,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"ddd" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/commons/storage/tools)
 "ddn" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -8661,6 +8723,9 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"dfr" = (
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
 "dfs" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -8788,13 +8853,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
-"diA" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "diC" = (
 /obj/machinery/light/directional/east,
 /obj/structure/closet/secure_closet/exile,
@@ -8803,11 +8861,14 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
-"diK" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
+"diH" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/auxiliary)
 "diN" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -8848,18 +8909,13 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
-"djN" = (
-/obj/machinery/door/airlock/external{
-	name = "Security Yard";
-	space_dir = 8
+"djZ" = (
+/obj/structure/fence{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "dki" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/matches,
@@ -8903,6 +8959,11 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"dli" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "dlj" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -8967,6 +9028,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
+"dmh" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Secure Walkway"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/checkpoint/auxiliary)
 "dmn" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -8982,13 +9051,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/textured_large,
 /area/science/storage)
-"dmF" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+"dmO" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/rag,
+/obj/item/clothing/head/collectable/tophat{
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/obj/effect/spawner/random/entertainment/gambling{
+	pixel_x = -13
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/fore/lesser)
 "dnf" = (
@@ -9018,14 +9092,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
-"dnD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "dnI" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/line{
@@ -9130,18 +9196,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"dpT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fitness Maintenance"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "dpX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -9187,12 +9241,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"dqM" = (
-/obj/machinery/computer/security/labor{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "drD" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9258,6 +9306,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+"dtm" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear{
+	name = "Huey";
+	move_force = 999
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "dtp" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light/small/directional/west,
@@ -9270,16 +9325,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"dux" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/light/directional/south,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/security/lockers)
 "duF" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -9306,6 +9351,12 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"duK" = (
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/fore/lesser)
 "duP" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
@@ -9340,13 +9391,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"dvN" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "EVA Maintenance"
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "dvV" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -9418,17 +9462,6 @@
 "dyq" = (
 /turf/closed/wall,
 /area/cargo/office)
-"dyt" = (
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "dyC" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -9449,6 +9482,22 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/engineering/main)
+"dzi" = (
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/flasher/directional/west{
+	id = "Cell 2"
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "dzl" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -9489,6 +9538,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
+"dzK" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "dzP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -9631,16 +9688,15 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"dDv" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/security/detective,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
+"dDr" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "dEh" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/igniter{
@@ -9755,20 +9811,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"dGq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
-"dGy" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "dGF" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
@@ -9787,24 +9829,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"dHv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
-"dHx" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Head of Security"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/hos,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth_large,
-/area/command/heads_quarters/hos)
 "dHD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -9851,15 +9875,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"dIK" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Port Hallway"
+"dIS" = (
+/turf/open/floor/iron/dark/textured,
+/area/security/processing)
+"dIY" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/central)
 "dJA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9920,9 +9950,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/maintenance/starboard/fore)
-"dKH" = (
-/turf/open/floor/carpet,
-/area/security/processing)
 "dKK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -9950,6 +9977,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"dLx" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "N2O Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "dLG" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -9967,6 +10003,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/pumproom)
+"dLM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "dLZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -10082,12 +10127,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/genetics)
-"dPm" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "dPx" = (
 /obj/structure/table/glass,
 /obj/item/storage/medkit/fire{
@@ -10164,15 +10203,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"dQV" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "N2O Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "dRb" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -10251,13 +10281,6 @@
 /obj/item/pen,
 /turf/open/floor/wood,
 /area/service/library)
-"dTw" = (
-/obj/docking_port/stationary/random/icemoon{
-	id = "pod_3_lavaland";
-	name = "lavaland"
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "dTz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -10290,10 +10313,29 @@
 /obj/item/paicard,
 /turf/open/floor/iron,
 /area/commons/locker)
+"dVH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "dVN" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"dVP" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	freq = 1400;
+	location = "Security"
+	},
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "dVS" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -10319,23 +10361,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/command/bridge)
-"dWQ" = (
-/obj/structure/table,
-/obj/item/folder/red{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/item/folder/red{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/storage/box/evidence{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "dXd" = (
 /obj/structure/chair{
 	dir = 1
@@ -10380,6 +10405,15 @@
 /obj/machinery/computer/security/qm,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"dXj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "dXm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -10423,16 +10457,15 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"dYF" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/checkpoint/auxiliary)
 "dYL" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
+"dZt" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "dZu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -10443,15 +10476,18 @@
 /obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"dZy" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "dZH" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/maint)
+"eai" = (
+/turf/open/openspace,
+/area/hallway/primary/fore)
+"eam" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/lockers)
 "eay" = (
 /obj/structure/railing{
 	dir = 1
@@ -10503,16 +10539,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
-"ebC" = (
-/obj/machinery/computer/security{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
+"eco" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
+"ecq" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
-/area/security/office)
+/area/ai_monitored/security/armory/upper)
 "ecr" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -10553,13 +10592,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"edW" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "eeh" = (
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
@@ -10578,9 +10610,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
-"eey" = (
-/turf/closed/wall/r_wall,
-/area/security/checkpoint/auxiliary)
 "eeA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -10588,9 +10617,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/mixing)
-"eeC" = (
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
 "eeI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -10695,27 +10721,6 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
-"eho" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/fore/lesser)
-"ehp" = (
-/obj/structure/table,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "ehA" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -10788,6 +10793,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/smooth_large,
 /area/science/genetics)
+"eiT" = (
+/obj/docking_port/stationary/random/icemoon{
+	id = "pod_3_lavaland";
+	name = "lavaland"
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "eiU" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Robotics Lab - South";
@@ -10807,6 +10819,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/aft/greater)
+"ejf" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear{
+	name = "Louie";
+	move_force = 999
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"ejk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "ejr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -10821,10 +10846,6 @@
 /obj/machinery/seed_extractor,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"ejE" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "ejY" = (
 /obj/effect/decal/cleanable/insectguts,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -10866,28 +10887,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central/greater)
+"ekC" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/ai_monitored/security/armory/upper)
 "ekK" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
-"ekU" = (
-/obj/structure/table,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
-/obj/item/key/security,
-/obj/machinery/light/directional/east,
-/obj/item/radio/intercom/prison/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
-"elf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/radio/intercom/prison/directional/south,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "elr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -10958,15 +10972,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"emI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/camera/directional/north,
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "emL" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -11058,22 +11063,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
-"enZ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Walkway";
-	id_tag = "innerbrig"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigoutpost"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "eoo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11097,20 +11086,6 @@
 /obj/item/reagent_containers/food/drinks/waterbottle,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ept" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"epx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "epN" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
@@ -11139,6 +11114,13 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"epY" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "eqo" = (
 /obj/structure/railing,
 /turf/open/floor/iron,
@@ -11190,6 +11172,20 @@
 	dir = 4
 	},
 /area/engineering/transit_tube)
+"erf" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "ert" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/decal/cleanable/dirt,
@@ -11284,6 +11280,16 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"eum" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "euu" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -11391,17 +11397,6 @@
 /obj/item/flashlight,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"ewM" = (
-/obj/item/storage/medkit/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/medkit/regular,
-/obj/structure/table/glass,
-/obj/structure/window/reinforced,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "ewN" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/shower{
@@ -11419,6 +11414,26 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"eyj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/machinery/door/window/brigdoor/right/directional/west{
+	name = "Brig Reception";
+	req_one_access_txt = "1"
+	},
+/obj/machinery/door/window/left/directional/east{
+	name = "Brig Reception"
+	},
+/turf/open/floor/iron/dark,
+/area/security/checkpoint/auxiliary)
 "eyy" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -11467,16 +11482,9 @@
 	dir = 8
 	},
 /area/service/chapel)
-"ezx" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/captain{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet,
-/area/command/heads_quarters/captain)
+"ezr" = (
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "ezB" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "MiniSat External South";
@@ -11594,14 +11602,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
-"eCt" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Central Hallway North-West"
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "eCu" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/tile/red,
@@ -11612,15 +11612,29 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"eCP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
+"eCx" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/corner,
+/area/security/processing)
 "eDq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"eDv" = (
+/obj/effect/landmark/observer_start,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L8"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "eDN" = (
@@ -11665,31 +11679,12 @@
 	},
 /turf/open/floor/iron,
 /area/service/janitor)
-"eET" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "eFk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/cargo/qm)
-"eFz" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Entrance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigentrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "eFN" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/siding/yellow{
@@ -11722,9 +11717,16 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"eGS" = (
-/turf/open/openspace/icemoon/keep_below,
-/area/icemoon/surface/outdoors/nospawn)
+"eGP" = (
+/obj/machinery/flasher/portable,
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "2";
+	dir = 1;
+	name = "Flash Storage"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "eGW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11908,20 +11910,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
-"eNk" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used to access the various cameras on the station.";
-	layer = 3.1;
-	name = "Security Camera Monitor";
-	network = list("ss13");
-	pixel_y = 2;
-	dir = 1
-	},
-/obj/structure/table,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "eNs" = (
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
@@ -11939,6 +11927,24 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/commons/fitness)
+"eNZ" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "riot";
+	name = "security shutters"
+	},
+/turf/open/floor/glass/reinforced,
+/area/hallway/primary/fore)
+"eOb" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "eOd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -11956,14 +11962,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/science/misc_lab)
-"eOA" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security EVA"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "eOE" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -12006,29 +12004,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
-"ePT" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "eQf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/pumproom)
-"eQh" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "eQN" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -12047,14 +12026,18 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
 /area/science/storage)
-"eRb" = (
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "eRv" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/aft)
+"eRB" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "eRG" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "8;12"
@@ -12082,21 +12065,12 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/medical/treatment_center)
-"eRS" = (
-/obj/structure/closet/secure_closet/warden,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "eSj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"eSo" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/start/warden,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "eSD" = (
 /obj/machinery/computer/med_data,
 /obj/effect/turf_decal/tile/green,
@@ -12155,6 +12129,20 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"eUw" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"eUD" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "Armory - Internal - Upper"
+	},
+/turf/open/openspace,
+/area/ai_monitored/security/armory/upper)
 "eUL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12165,14 +12153,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"eUW" = (
-/obj/structure/cable,
-/obj/item/radio/intercom/prison/directional/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "eVj" = (
 /obj/structure/filingcabinet,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -12220,6 +12200,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/commons/storage/mining)
+"eWs" = (
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory/upper)
 "eWw" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/secure/briefcase,
@@ -12281,10 +12264,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"eXS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "eYz" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -12322,6 +12301,10 @@
 /obj/item/circuitboard/aicore,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
+"eYS" = (
+/obj/item/bedsheet/red,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "eYY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -12351,14 +12334,14 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engineering/storage/tech)
-"fab" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"faa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "faf" = (
 /obj/structure/window/reinforced,
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -12409,17 +12392,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
-"fbb" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Transport Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/plating,
-/area/security/processing)
 "fbf" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Captain's Office Maintenance";
@@ -12434,6 +12406,13 @@
 "fbm" = (
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
+"fbo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "fbx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12443,13 +12422,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
-"fbC" = (
-/obj/machinery/computer/prisoner/management{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "fbK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12477,13 +12449,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"fcv" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "fcL" = (
 /obj/structure/railing{
 	dir = 4
@@ -12562,10 +12527,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"few" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "fex" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
+"fey" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory/upper)
 "feG" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -12642,12 +12619,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/pumproom)
-"fgj" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "fgA" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
@@ -12704,10 +12675,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
-"fhK" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
 "fhM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -12779,6 +12746,15 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
+"fjw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/office)
+"fjH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/security/lockers)
 "fjZ" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/mutadone{
@@ -12830,6 +12806,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
+"flV" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "flW" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/tile/yellow,
@@ -12838,15 +12827,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"fmk" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Security Medpost"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "fmm" = (
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 1
@@ -12913,14 +12893,11 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"fof" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+"fob" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "fok" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
@@ -12949,15 +12926,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"fpf" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"fpi" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/machinery/light/directional/south,
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
+/area/security/lockers)
 "fpu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12972,15 +12951,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/storage/gas)
-"fqh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "fql" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -13007,17 +12977,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"fqP" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security EVA"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth,
-/area/security/processing)
 "fqX" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
@@ -13141,14 +13100,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"fwi" = (
-/obj/item/storage/box/seccarts{
-	pixel_x = 9;
-	pixel_y = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood/large,
-/area/command/heads_quarters/hos)
 "fwq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -13169,12 +13120,6 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"fwJ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "fwM" = (
 /obj/structure/chair,
 /turf/open/floor/iron/cafeteria,
@@ -13292,13 +13237,6 @@
 "fym" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/upper)
-"fyy" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Three";
-	space_dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/processing)
 "fyM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13356,11 +13294,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"fzG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "fzJ" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm2";
@@ -13383,6 +13316,10 @@
 /obj/item/storage/medkit/toxin,
 /turf/open/floor/iron,
 /area/science/mixing)
+"fAA" = (
+/obj/structure/sign/warning/gasmask,
+/turf/closed/wall,
+/area/maintenance/fore/greater)
 "fAD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13428,10 +13365,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"fBz" = (
-/obj/structure/sign/warning/gasmask,
-/turf/closed/wall,
-/area/maintenance/fore/greater)
+"fBt" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "fBL" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13478,6 +13420,18 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
+"fDI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
+"fEb" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "fEo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13514,15 +13468,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"fEY" = (
-/obj/machinery/modular_computer/console/preset/cargochat/security{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "fFg" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13558,15 +13503,6 @@
 	dir = 8
 	},
 /area/science/research)
-"fFH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "fFO" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 4;
@@ -13584,6 +13520,11 @@
 "fGe" = (
 /turf/open/openspace,
 /area/cargo/storage)
+"fGm" = (
+/obj/structure/chair/office,
+/obj/effect/landmark/start/warden,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "fGw" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -13641,11 +13582,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/engineering/main)
-"fHG" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "fHZ" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon,
@@ -13656,6 +13592,15 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
+"fIs" = (
+/obj/machinery/modular_computer/console/preset/cargochat/security{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "fIE" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -13736,6 +13681,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"fKm" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/camera/directional/south,
+/turf/open/floor/iron/white/corner,
+/area/hallway/secondary/entry)
 "fKn" = (
 /obj/structure/ladder,
 /turf/open/floor/wood,
@@ -13751,6 +13703,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
+"fKT" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used to access the various cameras on the station.";
+	layer = 3.1;
+	name = "Security Camera Monitor";
+	network = list("ss13");
+	pixel_y = 2;
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "fLl" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -13789,6 +13755,30 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"fMr" = (
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/bedsheet/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "fMz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13819,39 +13809,6 @@
 "fMZ" = (
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"fNg" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/button/door/directional/west{
-	id = "briggate";
-	name = "Brig Shutters";
-	pixel_y = -2;
-	pixel_x = -6
-	},
-/obj/machinery/button/flasher{
-	id = "brigentry";
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/machinery/button/door/directional/west{
-	id = "innerbrig";
-	name = "Brig Interior Doors Control";
-	normaldoorcontrol = 1;
-	req_access_txt = "63";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/machinery/button/door/directional/west{
-	id = "outerbrig";
-	name = "Brig Exterior Doors Control";
-	normaldoorcontrol = 1;
-	pixel_y = -2;
-	req_access_txt = "63";
-	pixel_x = 6
-	},
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/checkpoint/auxiliary)
 "fNY" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -13875,6 +13832,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/storage/gas)
+"fOg" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "fOy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -13886,24 +13848,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/cargo/lobby)
-"fOS" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "fOZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
-"fPD" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "fPJ" = (
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/east,
@@ -13916,16 +13866,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/locker)
-"fQc" = (
-/obj/machinery/computer/security{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/computer/security/telescreen/prison{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "fQk" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -13967,16 +13907,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"fQy" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/structure/closet/firecloset,
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "fQD" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"fQO" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "fQS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -13992,13 +13930,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery/aft)
-"fQW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "fQX" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -14120,24 +14051,20 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos/storage/gas)
-"fTx" = (
-/obj/structure/fence{
-	dir = 4
+"fTf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/structure/sign/nanotrasen,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "fTI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"fUb" = (
-/mob/living/simple_animal/bot/secbot/beepsky,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/fore/lesser)
 "fUu" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -14223,6 +14150,27 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"fVT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
+"fWd" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Security Checkpoint"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "fWj" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel"
@@ -14231,12 +14179,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/sepia,
 /area/service/library)
-"fWt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "fWx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -14266,11 +14208,9 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
 "fWL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
+/obj/effect/gibspawner/human,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "fWQ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -14421,6 +14361,12 @@
 /obj/item/trash/semki,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
+"gaA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "gaD" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/high,
@@ -14435,11 +14381,12 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/engineering/storage_shared)
-"gaF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
+"gaK" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "gaT" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -14502,13 +14449,6 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"gbH" = (
-/obj/machinery/camera/motion/directional/north{
-	c_tag = "Armory - External"
-	},
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "gbZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -14528,13 +14468,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/storage)
-"gcj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "gcq" = (
 /turf/closed/wall/r_wall,
 /area/medical/treatment_center)
@@ -14575,6 +14508,13 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"gdf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/smooth_edge,
+/area/security/lockers)
 "gdp" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/reagent_dispensers/plumbed{
@@ -14591,12 +14531,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
-"gdC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "gdK" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -14637,6 +14571,39 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
+"geA" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/button/door/directional/west{
+	id = "briggate";
+	name = "Brig Shutters";
+	pixel_y = -2;
+	pixel_x = -6
+	},
+/obj/machinery/button/flasher{
+	id = "brigentry";
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/machinery/button/door/directional/west{
+	id = "innerbrig";
+	name = "Brig Interior Doors Control";
+	normaldoorcontrol = 1;
+	req_access_txt = "63";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/machinery/button/door/directional/west{
+	id = "outerbrig";
+	name = "Brig Exterior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_y = -2;
+	req_access_txt = "63";
+	pixel_x = 6
+	},
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/checkpoint/auxiliary)
 "geG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14646,12 +14613,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"geQ" = (
-/obj/machinery/power/apc/auto_name/directional/south,
+"gfd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
 /obj/structure/cable,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "gfi" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
@@ -14699,24 +14666,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"ggs" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/drinks/bottle/amaretto{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/food/drinks/bottle/fernet{
-	pixel_x = 7;
-	pixel_y = 16
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/sol_dry,
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 10
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/fore/lesser)
 "ggA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -14796,6 +14745,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
+"ghD" = (
+/obj/machinery/door/airlock/external{
+	name = "Security Yard";
+	space_dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "ghJ" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
@@ -14803,20 +14764,29 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"ghR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "gid" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"giB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "giE" = (
 /obj/machinery/power/shieldwallgen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"giV" = (
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "giZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -14869,6 +14839,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"gjD" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "gjH" = (
 /obj/structure/sign/warning/docking,
 /obj/effect/spawner/structure/window/reinforced,
@@ -14897,10 +14875,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"gkn" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
 "gkS" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -14916,6 +14890,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
+"gll" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "glo" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -14945,6 +14927,10 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/snowed/icemoon,
 /area/cargo/miningdock)
+"glR" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "glW" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -14978,10 +14964,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
-"gmu" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/glass/reinforced,
-/area/security/lockers)
 "gmx" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -14992,6 +14974,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"gmG" = (
+/obj/effect/landmark/start/head_of_security,
+/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "gmH" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/clothing/costume,
@@ -15002,13 +14992,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
-"gmK" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "gmL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/securearea{
@@ -15088,13 +15071,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"goR" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "goU" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -15125,31 +15101,11 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
-"gpw" = (
-/obj/machinery/computer/security,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "gpI" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/mixing/launch)
-"gpK" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "gpU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -15165,6 +15121,11 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"gqx" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "gri" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -15196,10 +15157,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/department/medical/central)
-"gsa" = (
-/obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "gsx" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -15227,6 +15184,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"gsV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "gtk" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -15307,18 +15272,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/locker)
-"gvf" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "gvi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -15355,13 +15308,6 @@
 	icon_state = "damaged2"
 	},
 /area/icemoon/surface/outdoors/nospawn)
-"gwy" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "gwW" = (
 /obj/machinery/meter/monitored/distro_loop,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
@@ -15390,6 +15336,13 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"gxG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "gxJ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Control Room";
@@ -15401,13 +15354,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
-"gxY" = (
-/obj/effect/turf_decal/tile/red/half,
+"gxM" = (
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "gye" = (
 /obj/machinery/computer/atmos_control/oxygen_tank{
 	dir = 1
@@ -15442,10 +15393,6 @@
 /obj/item/stack/sheet/iron/five,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"gzw" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/security/brig/upper)
 "gzD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15488,25 +15435,6 @@
 "gAK" = (
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
-"gAN" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/security/armory/upper)
-"gAP" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Checkpoint";
-	id_tag = "outerbrig"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigoutpost"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "gAQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15532,17 +15460,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"gBE" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "gBO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Stbd";
@@ -15563,17 +15480,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"gCa" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "gCg" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -15690,24 +15596,33 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"gDY" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "gEi" = (
 /obj/structure/cable,
 /turf/open/floor/iron/corner{
 	dir = 8
 	},
 /area/engineering/lobby)
+"gEn" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "gEw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"gER" = (
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "2";
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "gEX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -15725,19 +15640,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
-"gFp" = (
-/obj/effect/landmark/observer_start,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L8"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "gFq" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
@@ -15886,6 +15788,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/storage)
+"gJt" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "gJM" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "EVA Motion Sensor"
@@ -16067,6 +15975,13 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/command/heads_quarters/captain)
+"gNu" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "gNv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/secure_closet/personal{
@@ -16094,6 +16009,15 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"gOh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "gOr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -16136,6 +16060,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/commons/storage/mining)
+"gPb" = (
+/obj/machinery/computer/warrant{
+	dir = 4
+	},
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "Security - Checkpoint"
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "gPg" = (
 /obj/machinery/keycard_auth/directional/west,
 /obj/machinery/computer/cargo{
@@ -16159,15 +16095,6 @@
 /obj/effect/spawner/random/clothing/costume,
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
-"gPM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "gPW" = (
 /obj/effect/turf_decal/siding/yellow/corner,
 /obj/structure/cable,
@@ -16198,18 +16125,12 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "gQu" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/bodycontainer/morgue{
+	dir = 2
 	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/processing)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "gQv" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -16222,6 +16143,22 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/science/lab)
+"gQG" = (
+/obj/machinery/computer/security/hos,
+/obj/machinery/requests_console/directional/north{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	name = "Head of Security Requests Console"
+	},
+/obj/machinery/button/door/directional/north{
+	id = "hosspace";
+	name = "Icemoon Shutters Control";
+	pixel_x = -24
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
 "gQI" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -16281,6 +16218,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"gSz" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_edge,
+/area/security/lockers)
 "gSA" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -16398,6 +16341,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
+"gUF" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "gVp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -16489,13 +16443,6 @@
 /obj/structure/barricade/wooden/crude/snow,
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
-"gXp" = (
-/obj/machinery/space_heater,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "gXv" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16631,6 +16578,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"gZx" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "gZC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -16673,14 +16629,19 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"hbp" = (
-/obj/effect/landmark/start/head_of_security,
-/obj/machinery/holopad,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
+"hay" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/area/security/office)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/bluespace_vendor/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Fore Primary Hallway"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "hbB" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
@@ -16691,6 +16652,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"hbP" = (
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "hcb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16743,6 +16712,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"hdc" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "hde" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Mining Dock External"
@@ -16811,6 +16785,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"heR" = (
+/obj/machinery/computer/shuttle/labor{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "heT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -16917,6 +16898,13 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"hgr" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "hgx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -16997,6 +16985,17 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"hjb" = (
+/obj/effect/turf_decal/tile/red/anticorner,
+/obj/machinery/requests_console/directional/north{
+	department = "Security";
+	departmentType = 3;
+	name = "Security Requests Console"
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
+/area/security/office)
 "hjf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -17038,16 +17037,13 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"hlW" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"hlF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/item/radio/intercom/prison/directional/south,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "hlZ" = (
 /obj/machinery/meter,
 /obj/effect/turf_decal/delivery,
@@ -17180,13 +17176,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"hoT" = (
-/mob/living/simple_animal/hostile/asteroid/polarbear{
-	name = "Louie";
-	move_force = 999
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "hoX" = (
 /obj/structure/table,
 /obj/item/grenade/chem_grenade/cleaner,
@@ -17246,12 +17235,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"hqi" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "hqr" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/poster/contraband/random/directional/east,
@@ -17261,6 +17244,13 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"hqI" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "hqO" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/holopad,
@@ -17309,6 +17299,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"hrO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "hsa" = (
 /obj/item/chair/plastic{
 	pixel_y = 10
@@ -17342,6 +17341,21 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"hsr" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Vestibule"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/processing)
 "hsw" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -17441,17 +17455,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/treatment_center)
-"hvk" = (
-/obj/machinery/door/airlock/external{
-	name = "Security Yard";
-	space_dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "hvI" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/wood,
@@ -17462,15 +17465,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"hvW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "hwc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17521,12 +17515,6 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hxA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "hxE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17576,9 +17564,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
-"hyK" = (
-/turf/open/floor/glass/reinforced,
-/area/ai_monitored/security/armory/upper)
 "hyP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17593,15 +17578,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"hzb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "hzd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -17645,11 +17621,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"hzR" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/maintenance/fore/lesser)
 "hzW" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/west,
@@ -17684,6 +17655,13 @@
 /obj/structure/disposalpipe/trunk/multiz/down,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"hAC" = (
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "hAU" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
@@ -17704,6 +17682,12 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hBt" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "hBx" = (
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
@@ -17742,18 +17726,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
-"hCI" = (
-/obj/item/storage/box/bodybags,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/item/reagent_containers/syringe{
-	name = "steel point"
+"hCV" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Checkpoint";
+	id_tag = "outerbrig"
 	},
-/obj/item/reagent_containers/glass/bottle/multiver,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/structure/table/glass,
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigoutpost"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "hDe" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -17786,6 +17774,12 @@
 	},
 /turf/open/openspace,
 /area/commons/storage/mining)
+"hDH" = (
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 24
+	},
+/turf/open/floor/carpet,
+/area/security/processing)
 "hDQ" = (
 /obj/structure/transit_tube_pod,
 /obj/structure/transit_tube/station/reverse/flipped{
@@ -17812,11 +17806,6 @@
 	dir = 4
 	},
 /area/science/genetics)
-"hFd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "hFj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/closed/wall,
@@ -17869,19 +17858,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"hGg" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+"hGp" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/commons/storage/tools)
+/area/hallway/primary/fore)
 "hGz" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
@@ -17936,6 +17921,13 @@
 	dir = 5
 	},
 /area/maintenance/port/aft)
+"hHG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "hIf" = (
 /obj/machinery/dna_scannernew,
 /obj/machinery/light/directional/west,
@@ -17982,13 +17974,6 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/heads_quarters/ce)
-"hIK" = (
-/mob/living/simple_animal/hostile/asteroid/polarbear{
-	name = "Huey";
-	move_force = 999
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "hIO" = (
 /obj/structure/railing{
 	dir = 1
@@ -17997,6 +17982,9 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"hIX" = (
+/turf/closed/wall,
+/area/security/brig/upper)
 "hJo" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
@@ -18039,6 +18027,9 @@
 	},
 /turf/open/floor/plating,
 /area/science/breakroom)
+"hKb" = (
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/processing)
 "hKf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/official/fruit_bowl{
@@ -18194,6 +18185,13 @@
 /obj/effect/turf_decal/siding/wideplating,
 /turf/open/floor/iron,
 /area/engineering/atmos/pumproom)
+"hOg" = (
+/obj/item/beacon,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "hOj" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/four,
@@ -18201,36 +18199,41 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating,
 /area/construction)
+"hOl" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "hOt" = (
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"hOK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "hPg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"hPv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
+"hPK" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "hPN" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
-"hQb" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/glass/reinforced,
-/area/security/checkpoint/auxiliary)
 "hQd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -18297,14 +18300,6 @@
 "hRG" = (
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"hRM" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/camera/directional/south,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "hRT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18351,6 +18346,18 @@
 "hSM" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/ce)
+"hSV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/command/heads_quarters/hos)
+"hSY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "hTn" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -18359,15 +18366,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"hTu" = (
-/obj/machinery/computer/department_orders/security{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
+"hTp" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron/dark/textured_half,
 /area/security/office)
 "hTB" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18412,6 +18415,10 @@
 "hVo" = (
 /turf/open/floor/glass/reinforced,
 /area/medical/treatment_center)
+"hVq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "hVW" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Xenobiology Pens Observation - Port Fore";
@@ -18523,13 +18530,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"hYb" = (
-/obj/effect/turf_decal/tile/blue{
+"hYg" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/security/checkpoint/auxiliary)
 "hYi" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -18702,6 +18709,26 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"ibT" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"ice" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "icl" = (
 /obj/item/chair/wood,
 /obj/structure/sign/poster/contraband/random/directional/east,
@@ -18764,13 +18791,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"idE" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
 "idW" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -18808,12 +18828,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"ifd" = (
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/lockers)
 "ifh" = (
 /obj/machinery/power/emitter/welded{
 	dir = 8
@@ -18947,11 +18961,6 @@
 "iim" = (
 /turf/open/openspace,
 /area/service/chapel)
-"iiu" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "iiD" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -18962,6 +18971,18 @@
 	dir = 10
 	},
 /area/science/research)
+"iiF" = (
+/obj/effect/turf_decal/tile/red/full,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/checkpoint/auxiliary)
+"iiU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Courtroom";
+	name = "security shutters"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/fore)
 "ijD" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -19021,13 +19042,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"ilh" = (
-/obj/item/beacon,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "iln" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -19086,13 +19100,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"imc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+"ime" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "imP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -19111,15 +19122,6 @@
 	dir = 8
 	},
 /area/science/research)
-"ioT" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "ipg" = (
 /turf/open/floor/iron/dark,
 /area/command/gateway)
@@ -19129,10 +19131,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/transit_tube)
-"ipt" = (
-/obj/machinery/modular_computer/console/preset/id,
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
 "ipB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -19162,11 +19160,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"iqi" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "iqr" = (
 /turf/closed/wall/r_wall,
 /area/commons/storage/mining)
@@ -19195,15 +19188,15 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"irj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+"iqU" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom/prison/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "irN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19212,6 +19205,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"irT" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "irX" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/chair,
@@ -19337,6 +19338,16 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
+"iuW" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "ivR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -19384,6 +19395,31 @@
 /obj/item/ai_module/reset,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
+"iwY" = (
+/obj/machinery/door/airlock/external{
+	name = "Security Yard";
+	space_dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
+"ixb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "2";
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "ixm" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
@@ -19443,6 +19479,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"iye" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/machinery/light/directional/south,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/security/lockers)
 "iyk" = (
 /obj/machinery/status_display/supply{
 	pixel_y = 2
@@ -19497,19 +19543,6 @@
 /obj/item/clothing/under/color/rainbow,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"izc" = (
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "2";
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "izd" = (
 /obj/item/assembly/signaler{
 	pixel_y = 8
@@ -19548,9 +19581,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"izs" = (
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "izt" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -19612,22 +19642,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
-"iAv" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Security Checkpoint"
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/light_switch/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "iAE" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/wood,
@@ -19646,6 +19660,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"iAV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "iAX" = (
 /obj/structure/railing{
 	dir = 1
@@ -19666,21 +19691,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"iBt" = (
-/obj/structure/flora/grass/green,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"iBC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "iBJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -20053,9 +20063,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
-"iKP" = (
-/turf/open/floor/glass/reinforced,
-/area/security/office)
 "iKS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -20094,18 +20101,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"iLa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "iLd" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -20222,25 +20217,6 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/commons/storage/mining)
-"iOG" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Secure Walkway"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/checkpoint/auxiliary)
-"iPC" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "riot";
-	name = "security shutters"
-	},
-/turf/open/floor/glass/reinforced,
-/area/hallway/primary/fore)
 "iPG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20263,6 +20239,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"iQx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "iQC" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/entertainment/drugs,
@@ -20299,6 +20280,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"iQN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "iRr" = (
 /obj/structure/table,
 /obj/machinery/button/ignition{
@@ -20316,22 +20307,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/misc_lab)
-"iSl" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Lockers";
-	location = "EVA"
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "iSn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -20353,24 +20328,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"iSG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/item/restraints/handcuffs,
-/obj/item/radio/off,
-/obj/structure/cable,
-/obj/machinery/door/window/brigdoor/left/directional/west{
-	req_one_access_txt = "1";
-	name = "Brig Reception"
-	},
-/obj/machinery/door/window/right/directional/east{
-	name = "Brig Reception"
-	},
-/turf/open/floor/iron/dark,
-/area/security/checkpoint/auxiliary)
 "iSQ" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -20384,6 +20341,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
 /area/science/storage)
+"iTa" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "iTk" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/stripes/corner,
@@ -20407,13 +20371,6 @@
 /obj/item/camera_film,
 /turf/open/floor/wood,
 /area/service/library)
-"iUy" = (
-/obj/structure/table,
-/obj/item/assembly/flash/handheld,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "iUA" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
@@ -20524,16 +20481,6 @@
 /obj/item/grenade/chem_grenade,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"iVG" = (
-/obj/structure/cable,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "iVO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20597,6 +20544,14 @@
 /obj/machinery/rnd/server/master,
 /turf/open/openspace/icemoon,
 /area/science/server)
+"iWv" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "iWV" = (
 /turf/closed/wall,
 /area/command/heads_quarters/hop)
@@ -20618,21 +20573,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"iXK" = (
-/obj/structure/table/wood,
-/obj/item/phone{
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/item/radio/off{
-	pixel_y = 7;
-	pixel_x = -3
+"iXS" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/large,
-/area/command/heads_quarters/hos)
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "iYj" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/chair/stool/directional/south,
@@ -20642,13 +20589,6 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"iYx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "iYA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -20731,6 +20671,9 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"jaC" = (
+/turf/closed/wall/r_wall,
+/area/security/medical)
 "jaD" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/ai_upload";
@@ -20833,27 +20776,15 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall,
 /area/medical/cryo)
-"jcH" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
+"jcG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - Vestibule"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/processing)
-"jcP" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "jdv" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
@@ -20894,14 +20825,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
-"jex" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/checkpoint/auxiliary)
 "jeB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20916,9 +20839,6 @@
 	},
 /turf/open/openspace,
 /area/commons/storage/mining)
-"jfb" = (
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "jfc" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -20981,6 +20901,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
+"jgT" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "jgX" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot{
@@ -21055,6 +20982,14 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"jiM" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "jiO" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21124,12 +21059,26 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"jkt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/large,
-/area/command/heads_quarters/hos)
+"jks" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	name = "Warden Desk";
+	req_access_txt = "3"
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/window/left/directional/north{
+	name = "Warden Desk"
+	},
+/turf/open/floor/iron,
+/area/security/warden)
 "jkC" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics Waste Tank"
@@ -21273,22 +21222,6 @@
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"jnR" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
-"jnY" = (
-/obj/structure/bed/dogbed/mcgriff,
-/mob/living/simple_animal/pet/dog/pug/mcgriff,
-/obj/item/food/beef_wellington_slice,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "jok" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "cmoprivacy";
@@ -21303,13 +21236,6 @@
 /obj/item/hand_tele,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"joM" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "joR" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -21351,17 +21277,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
-"jpm" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "jpE" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -21370,13 +21285,6 @@
 "jpF" = (
 /turf/closed/wall,
 /area/command/heads_quarters/rd)
-"jpP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "jpR" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/carpet,
@@ -21476,13 +21384,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/central/lesser)
-"jrH" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/checkpoint/auxiliary)
 "jrQ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -21509,13 +21410,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jsz" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "jsC" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
@@ -21621,6 +21515,24 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"jww" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/bottle/amaretto{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/fernet{
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/sol_dry,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 10
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/fore/lesser)
 "jwA" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/turretid{
@@ -21635,15 +21547,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"jwI" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/fore/lesser)
-"jwT" = (
-/turf/closed/wall,
-/area/security/checkpoint/customs/auxiliary)
+"jxc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "jxf" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -21675,6 +21584,14 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"jxU" = (
+/obj/item/storage/box/seccarts{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/large,
+/area/command/heads_quarters/hos)
 "jxW" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/structure/table,
@@ -21735,19 +21652,17 @@
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"jyG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "jyP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"jzi" = (
-/obj/effect/turf_decal/tile/red/anticorner{
-	dir = 8
-	},
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/dark/textured_corner{
-	dir = 4
-	},
-/area/security/office)
 "jzz" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -21764,16 +21679,6 @@
 	dir = 8
 	},
 /area/science/research)
-"jAe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "jAn" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/bot,
@@ -21798,10 +21703,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/medical/central)
-"jAH" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "jAK" = (
 /obj/machinery/rnd/server,
 /obj/structure/lattice/catwalk,
@@ -21819,13 +21720,12 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
-"jBU" = (
-/obj/item/radio/intercom/directional/north,
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
+"jBv" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "jBV" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
@@ -21920,6 +21820,16 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"jEf" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "jEF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21959,15 +21869,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"jFt" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "jFG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21988,15 +21889,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"jGf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "jGq" = (
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/firealarm/directional/south,
@@ -22020,6 +21912,28 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage)
+"jGU" = (
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/closed/mineral/random/snow,
+/area/icemoon/surface/outdoors/nospawn)
 "jGV" = (
 /obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
@@ -22042,6 +21956,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"jHX" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/office)
 "jIc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22318,6 +22237,13 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"jOU" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "jPn" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -22364,17 +22290,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"jPR" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "jPY" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -22411,32 +22326,16 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/maint)
 "jRh" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch/directional/south,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "jRi" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"jRj" = (
-/obj/item/radio/off,
-/obj/item/crowbar,
-/obj/item/assembly/flash/handheld,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "jRs" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -22464,9 +22363,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/checkpoint/engineering)
-"jRM" = (
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "jRO" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table/glass,
@@ -22503,6 +22399,14 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"jSC" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/checkpoint/auxiliary)
 "jSE" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -22536,6 +22440,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
+"jTk" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "jTw" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -22570,12 +22482,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"jUn" = (
-/obj/vehicle/ridden/secway,
-/obj/effect/turf_decal/tile/red/half,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "jUs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -22586,15 +22492,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"jUY" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/potato{
-	name = "\improper Beepsky's emergency battery"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "jVr" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
@@ -22666,18 +22563,6 @@
 /obj/item/cultivator/rake,
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
-"jWM" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
-"jXk" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "jXp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -22692,13 +22577,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jXD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "jXT" = (
 /obj/structure/table/glass,
 /obj/machinery/light/directional/west,
@@ -22722,6 +22600,19 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"jZE" = (
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
+"jZI" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
+"jZV" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "jZW" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -22755,13 +22646,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/commons/locker)
-"kaw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "kaC" = (
 /obj/structure/chair,
 /obj/structure/disposalpipe/segment{
@@ -22878,6 +22762,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/mining)
+"kcn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/lockers)
 "kcq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -22898,13 +22788,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"kcG" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "kcH" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/tile/brown,
@@ -22962,6 +22845,13 @@
 /obj/machinery/computer/camera_advanced/xenobio,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"kea" = (
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "keL" = (
 /obj/machinery/light/directional/south,
 /obj/structure/closet/firecloset,
@@ -22997,14 +22887,6 @@
 "kfT" = (
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"kgc" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "MiniSat External NorthEast";
-	network = list("minisat");
-	start_active = 1
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/ai_monitored/turret_protected/aisat/maint)
 "kge" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/blue,
@@ -23029,6 +22911,23 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/smooth,
 /area/maintenance/starboard/fore)
+"kgz" = (
+/obj/structure/table,
+/obj/item/folder/red{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/folder/red{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "kgB" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
@@ -23036,18 +22935,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"kgI" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
-"kgP" = (
-/turf/closed/wall/r_wall,
-/area/icemoon/surface/outdoors/nospawn)
 "kgQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/side{
@@ -23096,6 +22983,26 @@
 "kiC" = (
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/maint)
+"kja" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -6
+	},
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	req_access_txt = "2";
+	pixel_x = 7
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "kjd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -23145,6 +23052,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"kkn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "kkp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23170,12 +23083,6 @@
 /obj/item/trash/waffles,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"kkY" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "kla" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23328,6 +23235,9 @@
 "koB" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"koK" = (
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "kpa" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/tile/brown{
@@ -23359,13 +23269,18 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"kqE" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
+"kqy" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Walkway"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigentrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron,
 /area/security/brig/upper)
 "krh" = (
 /obj/item/wrench,
@@ -23424,28 +23339,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
-"krU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
-"kse" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Interrogation";
-	network = list("interrogation")
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "ksg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -23458,16 +23351,36 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"ksL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "ksN" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
-"ksV" = (
-/obj/structure/table,
-/obj/item/storage/box/prisoner,
+"ksP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/security/processing)
+/area/security/warden)
 "ktb" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -23483,19 +23396,6 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"kuc" = (
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "kuy" = (
 /obj/structure/table,
 /obj/item/electronics/apc,
@@ -23503,6 +23403,16 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
+"kuN" = (
+/obj/structure/railing,
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "kuR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 1
@@ -23520,6 +23430,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"kvl" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "kvq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -23530,6 +23446,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/central)
+"kvU" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "kwf" = (
 /turf/open/floor/iron,
 /area/command/gateway)
@@ -23563,9 +23486,34 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"kwM" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "kwP" = (
 /turf/open/floor/iron/dark,
 /area/engineering/lobby)
+"kwX" = (
+/obj/machinery/button/door/directional/west{
+	id = "riot";
+	name = "Anti-Riot Shutters";
+	pixel_x = -7;
+	pixel_y = 32;
+	req_one_access_txt = "1;4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "kwZ" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/seven,
@@ -23681,6 +23629,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"kAf" = (
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "kAh" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23702,10 +23654,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"kAS" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "kAZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23738,10 +23686,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
-"kBy" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/grass,
-/area/security/warden)
 "kBH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23765,6 +23709,22 @@
 	c_tag = "Central Hallway South-East"
 	},
 /obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"kCb" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Lockers";
+	location = "EVA"
+	},
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "kCi" = (
@@ -23848,22 +23808,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
-"kDh" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Walkway";
-	id_tag = "innerbrig"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigoutpost"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "kDt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -23888,6 +23832,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"kEv" = (
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/timer,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "kEF" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -23900,6 +23852,15 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/breakroom)
+"kEO" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/potato{
+	name = "\improper Beepsky's emergency battery"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "kER" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 1
@@ -23970,15 +23931,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"kGb" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/processing)
 "kGc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -24004,6 +23956,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"kGr" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "kGv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24033,11 +23993,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"kGZ" = (
-/obj/machinery/suit_storage_unit/hos,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
 "kHq" = (
 /obj/machinery/cell_charger{
 	pixel_y = 5
@@ -24111,13 +24066,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/engineering/storage_shared)
-"kJo" = (
-/obj/machinery/keycard_auth/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
 "kJC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24131,16 +24079,6 @@
 "kJV" = (
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
-"kJW" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "kJX" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -24215,21 +24153,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"kLW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "kMd" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/mixing)
-"kMf" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/space_heater,
-/obj/machinery/camera/directional/south{
-	c_tag = "Auxiliary Tool Storage"
-	},
-/turf/open/floor/iron,
-/area/commons/storage/tools)
 "kMm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -24263,9 +24196,6 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/service/kitchen/coldroom)
-"kNB" = (
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "kNM" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -24325,24 +24255,10 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/heads_quarters/cmo)
-"kOM" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "kOP" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"kPm" = (
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/table/glass,
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "kPp" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -24354,6 +24270,22 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/research)
+"kPu" = (
+/obj/effect/turf_decal/tile/red/full,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/checkpoint/auxiliary)
+"kPA" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "kPE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output{
 	dir = 1
@@ -24423,6 +24355,22 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+"kRB" = (
+/obj/structure/table,
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/storage/lockbox/loyalty,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "kRG" = (
 /obj/structure/grille,
 /obj/structure/window{
@@ -24459,20 +24407,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"kSJ" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
-"kSQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "kTP" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -24534,6 +24468,15 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"kVy" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Checkpoint";
+	req_access_txt = "1"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "kVS" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Gateway"
@@ -24588,6 +24531,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"kXJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "kXN" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -24612,6 +24564,14 @@
 /obj/item/dest_tagger,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"kXP" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/closet/emcloset,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security Entrance"
+	},
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "kXV" = (
 /obj/structure/table,
 /obj/item/storage/box,
@@ -24658,6 +24618,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"kYT" = (
+/obj/structure/flora/rock/icy,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "kZc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24822,6 +24786,13 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/pumproom)
+"ldu" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "ldP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24864,13 +24835,6 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"leS" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "leY" = (
 /obj/machinery/computer/atmos_control/plasma_tank{
 	dir = 8
@@ -24909,6 +24873,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"lfj" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "lft" = (
 /obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment,
@@ -24935,14 +24904,23 @@
 /obj/effect/spawner/random/techstorage/tcomms_all,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"lgW" = (
-/obj/structure/window/reinforced{
-	dir = 8
+"lhi" = (
+/obj/item/storage/medkit/regular{
+	pixel_x = 3;
+	pixel_y = 3
 	},
+/obj/item/storage/medkit/regular,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
+"lhq" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/checkpoint/auxiliary)
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "lhw" = (
 /obj/structure/ladder{
 	name = "upper dispenser access"
@@ -24965,28 +24943,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"lin" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/matches,
-/obj/item/toy/cards/deck{
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 14;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = -18;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = -10;
-	pixel_y = 2
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/maintenance/fore/lesser)
 "liN" = (
 /obj/machinery/light/small/broken/directional/south,
 /obj/item/trash/energybar,
@@ -25012,26 +24968,31 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"ljY" = (
+/turf/open/openspace,
+/area/ai_monitored/security/armory/upper)
+"lku" = (
+/obj/effect/turf_decal/tile/red/anticorner{
+	dir = 8
+	},
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
+/area/security/office)
 "lkw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"lkx" = (
-/obj/structure/chair{
-	dir = 4
+"llp" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security EVA"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth,
 /area/security/brig/upper)
-"lkR" = (
-/obj/item/bedsheet/red,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "llw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -25060,30 +25021,24 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"llR" = (
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/carpet,
+/area/security/processing)
 "llU" = (
 /obj/structure/table,
 /obj/item/camera_film,
 /obj/item/camera,
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"lmb" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/camera/motion/directional/south{
-	c_tag = "Armory - Internal - Upper"
-	},
-/turf/open/openspace,
-/area/ai_monitored/security/armory/upper)
 "lmd" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
 /area/engineering/atmos/storage/gas)
-"lmi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/processing)
 "lmj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -25108,12 +25063,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"lmF" = (
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/fore/lesser)
 "lmK" = (
 /obj/machinery/iv_drip,
 /obj/structure/mirror/directional/north{
@@ -25125,15 +25074,6 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/service/hydroponics)
-"lno" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/rack,
-/obj/item/storage/crayons,
-/turf/open/floor/iron,
-/area/security/processing)
 "lnv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25200,6 +25140,21 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"lqh" = (
+/obj/structure/table/wood,
+/obj/item/phone{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/radio/off{
+	pixel_y = 7;
+	pixel_x = -3
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/command/heads_quarters/hos)
 "lqk" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -25217,6 +25172,10 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
+"lqu" = (
+/obj/structure/railing,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "lqw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -25310,12 +25269,27 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"ltF" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "ltI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"ltL" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "ltP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -25323,6 +25297,9 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"luo" = (
+/turf/closed/wall,
+/area/hallway/primary/fore)
 "luq" = (
 /obj/machinery/shower{
 	dir = 1
@@ -25356,15 +25333,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/fore/lesser)
-"lvW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
 "lvZ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -25375,6 +25343,17 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
+"lwe" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "lwf" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -25454,6 +25433,13 @@
 	dir = 4
 	},
 /area/engineering/lobby)
+"lxM" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/security/lockers)
 "lxN" = (
 /obj/machinery/light_switch/directional/south,
 /obj/structure/closet/secure_closet/security/cargo,
@@ -25491,9 +25477,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"lyi" = (
-/turf/closed/wall/r_wall,
-/area/security/brig/upper)
 "lyj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
@@ -25538,15 +25521,6 @@
 /obj/structure/closet/wardrobe/grey,
 /turf/open/floor/iron,
 /area/commons/locker)
-"lzk" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L14"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "lzw" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
@@ -25560,19 +25534,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lzS" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Walkway"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigentrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+"lzZ" = (
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "lAq" = (
 /obj/structure/grille,
 /obj/structure/window{
@@ -25602,6 +25567,20 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"lAT" = (
+/obj/structure/railing,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_y = 4
+	},
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "lAV" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -25630,23 +25609,6 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/starboard/fore)
-"lBh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"lBj" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Infirmary"
-	},
-/obj/machinery/light_switch/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "lBD" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
@@ -25656,6 +25618,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"lBO" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_x = -8
+	},
+/obj/item/clothing/shoes/winterboots/ice_boots{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/clothing/shoes/winterboots/ice_boots{
+	pixel_x = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "lBY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -25681,6 +25662,12 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
+"lCH" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "lCJ" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/recharge_floor,
@@ -25716,20 +25703,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
-"lDS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"lEb" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "lEo" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -25763,6 +25736,14 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
+"lEY" = (
+/obj/structure/disposalpipe/trunk/multiz/down,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "lFt" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -25797,12 +25778,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"lFN" = (
-/obj/effect/spawner/random/trash/moisture_trap,
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
+"lFT" = (
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/area/maintenance/fore/lesser)
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "lGE" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -25817,10 +25802,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/pumproom)
-"lGS" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/glass/reinforced,
-/area/ai_monitored/security/armory/upper)
 "lGT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25845,13 +25826,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"lHu" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "lHY" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -25910,14 +25884,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"lJK" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/structure/cable,
-/obj/structure/noticeboard/directional/east,
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "lJL" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=AIE";
@@ -25941,10 +25907,6 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"lKI" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/ice,
-/area/icemoon/surface/outdoors/nospawn)
 "lKJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -25954,15 +25916,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"lKN" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/closet/emcloset,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/processing)
 "lKO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/siding/yellow{
@@ -26068,6 +26021,27 @@
 "lMk" = (
 /turf/open/floor/plating,
 /area/cargo/miningdock)
+"lMz" = (
+/obj/item/book/manual/wiki/tcomms{
+	pixel_x = 10;
+	pixel_y = -1
+	},
+/obj/item/book/manual/wiki/ordnance{
+	pixel_y = 3;
+	pixel_x = 10
+	},
+/obj/item/book/manual/wiki/experimentor{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/processing)
 "lNf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26102,13 +26076,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"lNR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "lOp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/east,
@@ -26161,10 +26128,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
-"lQo" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "lQz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26220,6 +26183,19 @@
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"lRQ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Walkway"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigentrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "lRV" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrous_input{
 	dir = 8
@@ -26235,9 +26211,25 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
-"lSN" = (
+"lSS" = (
+/obj/structure/railing{
+	dir = 4
+	},
 /obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
+	dir = 8
+	},
+/obj{
+	name = "---Merge conflict marker---"
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/flasher/directional/west{
+	id = "Cell 1"
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
@@ -26302,6 +26294,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"lVf" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/head_of_security,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
+"lVl" = (
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "lVG" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/cable,
@@ -26413,6 +26417,11 @@
 "lYu" = (
 /turf/open/floor/iron,
 /area/commons/locker)
+"lYH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "lYU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -26456,41 +26465,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"lZo" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "lZT" = (
 /obj/structure/chair/sofa/left,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
-"mad" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/restraints/handcuffs{
-	pixel_y = 5
-	},
-/obj/item/restraints/handcuffs{
-	pixel_y = 1
-	},
-/obj/item/restraints/handcuffs{
-	pixel_x = 1;
-	pixel_y = -4
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - Holding Cells"
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "mas" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -26545,11 +26524,6 @@
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"mbw" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "mbC" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron,
@@ -26566,19 +26540,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/engineering/lobby)
-"mcr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - Transport Parlor"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
-/area/security/processing)
 "mcB" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -26591,13 +26552,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"mcS" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/sunnybush,
-/turf/open/floor/grass,
-/area/security/warden)
 "mdh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26605,6 +26559,12 @@
 /obj/structure/rack,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"mdp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "mdr" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -26621,6 +26581,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/commons/locker)
+"mdU" = (
+/obj/structure/bed/dogbed/mcgriff,
+/mob/living/simple_animal/pet/dog/pug/mcgriff,
+/obj/item/food/beef_wellington_slice,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "mee" = (
 /obj/machinery/processor,
 /turf/open/floor/plating,
@@ -26633,6 +26600,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"mep" = (
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "2";
+	dir = 1;
+	name = "Security Delivery"
+	},
+/turf/open/floor/plating,
+/area/security/processing)
+"meL" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/security/processing)
 "meS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26682,13 +26661,15 @@
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"mgj" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+"mfV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
+/area/security/lockers)
 "mgp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26710,21 +26691,6 @@
 /obj/structure/cable,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
-"mhe" = (
-/obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "mhg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -26765,6 +26731,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/pumproom)
+"miB" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fitness Maintenance"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "miE" = (
 /obj/machinery/door/airlock/research{
 	name = "Gas Storage";
@@ -26778,9 +26756,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/storage)
-"miI" = (
-/turf/open/openspace,
-/area/ai_monitored/security/armory/upper)
 "miP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
@@ -26872,18 +26847,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/medical/cryo)
-"mkw" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Upper Brig South"
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "mkH" = (
 /obj/structure/closet/secure_closet/security/med,
 /obj/machinery/firealarm/directional/south,
@@ -27141,6 +27104,9 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"mrB" = (
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "msa" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -27204,11 +27170,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
-"muv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "muM" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -27234,6 +27195,19 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"mvL" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/table,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "mvU" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
@@ -27284,6 +27258,15 @@
 	dir = 4
 	},
 /area/science/xenobiology)
+"mxC" = (
+/obj/machinery/button/flasher{
+	id = "cell4";
+	pixel_y = -22
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "mxZ" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 8
@@ -27368,6 +27351,13 @@
 /obj/item/stock_parts/cell/high/empty,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
+"mzV" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "EVA Maintenance"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "mAy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -27485,6 +27475,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"mDb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "mDG" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -27500,10 +27496,25 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"mEY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "mFl" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"mFs" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "mFE" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
@@ -27706,6 +27717,11 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"mKU" = (
+/obj/structure/table,
+/obj/item/storage/box/prisoner,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "mLd" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -27819,6 +27835,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"mOm" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "mOn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27839,12 +27862,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/pumproom)
-"mOK" = (
-/obj/machinery/computer/prisoner/gulag_teleporter_computer{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "mOR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -27966,6 +27983,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/server)
+"mSB" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "mSI" = (
 /obj/structure/sink{
 	dir = 8;
@@ -28026,14 +28049,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/misc/asteroid/snow/standard_air,
 /area/hallway/secondary/exit/departure_lounge)
-"mTN" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "mTO" = (
 /turf/closed/wall/r_wall,
 /area/commons/storage/primary)
@@ -28043,6 +28058,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"mVP" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - EVA"
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
+"mVW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
+"mVX" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "mWg" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
@@ -28099,6 +28134,17 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"mXs" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security EVA"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth,
+/area/security/processing)
 "mXC" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -28170,9 +28216,15 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"mZr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"mZt" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/security/brig/upper)
 "mZD" = (
@@ -28193,6 +28245,28 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/meeting_room)
+"mZM" = (
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -6;
+	pixel_y = 16
+	},
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/stamp/hos{
+	pixel_y = 6;
+	pixel_x = 10
+	},
+/obj/machinery/recharger{
+	pixel_y = -1;
+	pixel_x = -4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood/large,
+/area/command/heads_quarters/hos)
 "naj" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -28203,13 +28277,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"nau" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "naL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -28225,11 +28292,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half,
 /area/maintenance/department/medical/central)
-"nbb" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "nbs" = (
 /obj/machinery/door/window/right/directional/east{
 	base_state = "left";
@@ -28242,12 +28304,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
-"nbv" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/dark/textured_half,
-/area/security/office)
 "nbH" = (
 /obj/structure/chair,
 /turf/open/floor/iron/white/smooth_large,
@@ -28287,6 +28343,11 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
+"ncR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/meter/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "ncX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -28347,11 +28408,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/aft)
-"nea" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/fore/lesser)
 "nec" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -28417,6 +28473,12 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"ngG" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "ngI" = (
 /obj/machinery/button/flasher{
 	id = "hopflash";
@@ -28451,12 +28513,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
-"ngU" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "nhe" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Medical Officer";
@@ -28485,18 +28541,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage)
-"nhP" = (
-/mob/living/simple_animal/mouse/white{
-	name = "Mik";
-	desc = "This mouse smells faintly of alcohol."
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/fore/lesser)
 "nhQ" = (
 /turf/open/floor/carpet,
 /area/service/library)
+"nhR" = (
+/obj/structure/table,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "nhX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28528,6 +28582,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"niQ" = (
+/obj/structure/cable,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/maintenance/fore/lesser)
+"niU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "njb" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -28547,6 +28616,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"njs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/processing)
 "njE" = (
 /obj/structure/table/wood,
 /obj/item/pen/red{
@@ -28579,6 +28654,10 @@
 "nka" = (
 /turf/open/openspace,
 /area/science/xenobiology)
+"nkl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "nkG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/closed/wall,
@@ -28597,6 +28676,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"nly" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "nlQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -28609,13 +28697,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"nme" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "nmi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -28633,44 +28714,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/aft)
-"nmr" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_x = -22
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
-"nmt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Fore - Courtroom Hallway"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"nmv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "nmw" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"nmE" = (
-/obj/structure/disposalpipe/trunk/multiz/down,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "nmJ" = (
 /obj/item/stamp{
 	pixel_x = -3;
@@ -28729,6 +28776,14 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"nnW" = (
+/obj/machinery/door/window/brigdoor/right/directional/north{
+	name = "Flash Storage";
+	req_access_txt = "3"
+	},
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "noi" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -28799,6 +28854,30 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"nqe" = (
+/obj/machinery/button/door/directional/east{
+	id = "armory";
+	name = "Armory Shutters";
+	req_access_txt = "3";
+	pixel_x = -9;
+	pixel_y = 30
+	},
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "nqk" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
@@ -28829,13 +28908,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
-"nrh" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Transport"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "nrA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28990,13 +29062,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"ntU" = (
-/mob/living/simple_animal/hostile/asteroid/polarbear{
-	name = "Dewey";
-	move_force = 999
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "nuf" = (
 /turf/closed/wall,
 /area/command/meeting_room)
@@ -29028,15 +29093,10 @@
 /obj/item/paicard,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"nwr" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
+"nwB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "nwI" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -29077,9 +29137,6 @@
 "nxB" = (
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"nxE" = (
-/turf/closed/wall,
-/area/security/brig/upper)
 "nxI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29108,18 +29165,8 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"nyg" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
-/obj/machinery/button/door{
-	id = "BrigLock";
-	name = "Cell Shutters";
-	pixel_y = 9;
-	pixel_x = 7
-	},
-/turf/open/floor/iron/showroomfloor,
+"nye" = (
+/turf/closed/wall,
 /area/security/warden)
 "nyq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -29165,6 +29212,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"nzk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "nzu" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -29220,12 +29273,6 @@
 "nAY" = (
 /turf/closed/wall,
 /area/security/lockers)
-"nBk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "nBq" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/turf_decal/stripes/corner{
@@ -29239,6 +29286,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/openspace,
 /area/science/xenobiology)
+"nBY" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/processing)
 "nCf" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/stripes/line,
@@ -29301,13 +29357,6 @@
 /obj/item/kirbyplants/potty,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"nEd" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "nEf" = (
 /obj/item/storage/fancy/donut_box,
 /obj/structure/table,
@@ -29322,15 +29371,15 @@
 	dir = 4
 	},
 /area/hallway/primary/starboard)
-"nEI" = (
-/obj/machinery/disposal/bin,
-/obj/item/radio/intercom/prison/directional/north,
-/obj/machinery/camera/autoname/directional/north{
-	c_tag = "Security - Warden's Office"
+"nEu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "nFn" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -29441,15 +29490,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"nIg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "nIo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -29487,6 +29527,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"nIH" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/rack,
+/obj/item/storage/crayons,
+/turf/open/floor/iron,
+/area/security/processing)
 "nII" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/blobstart,
@@ -29565,6 +29614,10 @@
 	dir = 4
 	},
 /area/engineering/lobby)
+"nLe" = (
+/obj/item/paper/fluff/jobs/security/beepsky_mom,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "nLM" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/grimy,
@@ -29585,10 +29638,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
-"nMC" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "nMM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29846,6 +29895,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"nRG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory/upper)
 "nRH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -30005,6 +30058,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
+"nUU" = (
+/obj/structure/bookcase,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet,
+/area/security/processing)
 "nVb" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
@@ -30085,6 +30143,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"nVT" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "nWc" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology Pens Observation - Starboard Fore";
@@ -30111,6 +30176,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"nWD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "nWN" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/random,
@@ -30156,6 +30230,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nYy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "nYA" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/purple,
@@ -30201,6 +30282,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"oat" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "oau" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30264,6 +30351,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"obH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "obJ" = (
 /obj/structure/sign/directions/engineering{
 	pixel_x = -32;
@@ -30291,15 +30388,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
-"ocb" = (
-/obj/machinery/button/flasher{
-	id = "cell4";
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "ocw" = (
 /obj/structure/chair/office,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -30359,16 +30447,6 @@
 /obj/structure/industrial_lift,
 /turf/open/openspace,
 /area/commons/storage/mining)
-"odJ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"oeo" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "oep" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/effect/turf_decal/siding/white{
@@ -30399,6 +30477,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"oeM" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "MiniSat External NorthEast";
+	network = list("minisat");
+	start_active = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/ai_monitored/turret_protected/aisat/maint)
 "oeQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30464,19 +30550,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"ogQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/camera/directional/west{
-	c_tag = "Dormitory South"
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "ogY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -30496,6 +30569,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"ohm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/camera/directional/west{
+	c_tag = "Dormitory South"
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "ohp" = (
 /obj/machinery/meter{
 	name = "Mixed Air Tank In"
@@ -30538,6 +30624,14 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/service/hydroponics)
+"oiN" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "oiP" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -30557,10 +30651,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"oiY" = (
-/obj/machinery/computer/warrant,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "ojc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -30669,6 +30759,10 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"olc" = (
+/obj/structure/sign/warning/coldtemp,
+/turf/closed/wall,
+/area/maintenance/fore/greater)
 "old" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -30725,13 +30819,6 @@
 /obj/item/ai_module/supplied/protect_station,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"omh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "omi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -30755,13 +30842,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"omG" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "omH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -30783,6 +30863,13 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/starboard/fore)
+"omW" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "ont" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 4
@@ -30792,10 +30879,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"onI" = (
-/obj/effect/gibspawner/human/bodypartless,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "onV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -30837,6 +30920,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"opn" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "opp" = (
 /obj/machinery/holopad,
 /obj/machinery/duct,
@@ -30863,6 +30952,28 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"opB" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/obj/item/toy/cards/deck{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 14;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -18;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -10;
+	pixel_y = 2
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/maintenance/fore/lesser)
 "opG" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -30907,15 +31018,6 @@
 	dir = 9
 	},
 /area/science/research)
-"oqR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "orl" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -30949,15 +31051,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"orV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "orZ" = (
 /obj/machinery/camera/autoname/directional/south{
 	c_tag = "Gas Storage";
@@ -30982,6 +31075,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"osp" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Three";
+	space_dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/processing)
 "osN" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
@@ -31008,49 +31108,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/cargo/qm)
-"otv" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
-	pixel_y = 20;
-	pixel_x = 7
-	},
-/obj/item/taperecorder{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6
-	},
-/obj/item/storage/secure/safe/hos{
-	pixel_x = 35
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
-"otW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	name = "Warden Desk";
-	req_access_txt = "3"
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/window/left/directional/north{
-	name = "Warden Desk"
-	},
-/turf/open/floor/iron,
-/area/security/warden)
 "oug" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31061,13 +31118,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"ouv" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
 "ouM" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable,
@@ -31075,6 +31125,12 @@
 	dir = 9
 	},
 /area/science/research)
+"ouX" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/fore/lesser)
 "ovm" = (
 /obj/machinery/camera/motion/directional/west{
 	c_tag = "MiniSat Core Hallway";
@@ -31089,6 +31145,21 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ovA" = (
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
+"ovR" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark/textured,
+/area/security/processing)
 "owa" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -31117,6 +31188,18 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"owt" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
+"oww" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
+/area/security/warden)
 "owD" = (
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
@@ -31137,6 +31220,12 @@
 	},
 /turf/open/floor/plating,
 /area/medical/pharmacy)
+"oxn" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "oxy" = (
 /obj/structure/table/glass,
 /obj/item/food/grown/harebell{
@@ -31156,6 +31245,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"oxD" = (
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "oxH" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -31171,16 +31266,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/aft)
-"oxY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "oyk" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
@@ -31339,6 +31424,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/locker)
+"oBZ" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/closet/emcloset,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/processing)
 "oCr" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -31346,6 +31440,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"oCu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "oCz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -31364,6 +31465,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
+"oCH" = (
+/obj/structure/flora/bush,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "oDq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail{
@@ -31383,11 +31488,25 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"oDY" = (
-/obj/structure/plasticflaps,
+"oDU" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/processing)
+"oEc" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "oEe" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/radiation,
@@ -31417,10 +31536,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"oEC" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+"oEx" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "oEU" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -31458,10 +31577,23 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"oFR" = (
+/obj/structure/cable,
+/obj/item/radio/intercom/prison/directional/east,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "oFS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/maintenance/aft/greater)
+"oHl" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "oHR" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -31558,10 +31690,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"oJe" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "oJk" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"oJz" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore/lesser)
+"oJB" = (
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "oJH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot{
@@ -31780,6 +31929,16 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"oNv" = (
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "oNJ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -31820,6 +31979,13 @@
 "oOH" = (
 /turf/closed/wall,
 /area/cargo/miningdock)
+"oPc" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear{
+	name = "Dewey";
+	move_force = 999
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "oPd" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -31923,15 +32089,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"oRa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "oRm" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -31958,12 +32115,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/central)
-"oSg" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "oSt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm/directional/south,
@@ -32070,6 +32221,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
+"oUR" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "oVi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32108,11 +32263,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"oVW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "oWb" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/blue,
@@ -32124,17 +32274,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"oWj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "EVA Maintenance";
-	req_access_txt = "18"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "oWr" = (
 /obj/machinery/computer/monitor{
 	name = "bridge power monitoring console"
@@ -32149,13 +32288,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
-"oWu" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "armory";
-	name = "Armoury Shutter"
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/security/armory/upper)
 "oWy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32185,15 +32317,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"oWZ" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/icemoon/surface/outdoors/nospawn)
 "oXa" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
+"oXj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/checkpoint/auxiliary)
 "oXL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -32223,9 +32360,6 @@
 "oYz" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/starboard)
-"oYI" = (
-/turf/open/floor/iron/dark/textured,
-/area/security/processing)
 "oYL" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -32250,14 +32384,6 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/wood,
 /area/commons/dorms)
-"oZC" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/security/warden)
-"oZH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "oZI" = (
 /turf/closed/wall,
 /area/commons/storage/tools)
@@ -32303,20 +32429,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/construction)
-"pbX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "2";
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "pcf" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
@@ -32370,12 +32482,20 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"peY" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+"pfi" = (
+/obj/item/radio/off,
+/obj/item/crowbar,
+/obj/item/assembly/flash/handheld,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/side,
-/area/security/processing)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "pfS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32410,6 +32530,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"pgX" = (
+/obj/vehicle/ridden/secway,
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "pgZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -32469,26 +32595,6 @@
 /obj/structure/closet/secure_closet/quartermaster,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"phP" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_y = 9;
-	pixel_x = 7
-	},
-/obj/machinery/button/door{
-	id = "Prison Gate";
-	name = "Prison Wing Lockdown";
-	req_access_txt = "2";
-	pixel_x = 7
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "phQ" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -32512,6 +32618,16 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
+"pik" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "pio" = (
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
@@ -32544,15 +32660,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/science/genetics)
-"pjK" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom/prison/directional/east,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "pjN" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32561,10 +32668,23 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"pkc" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "pkn" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"pkx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "pkz" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/medkit/regular,
@@ -32639,10 +32759,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
-"pmQ" = (
-/obj/effect/turf_decal/tile/red/full,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/checkpoint/auxiliary)
+"pmO" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "pmR" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera{
@@ -32661,6 +32783,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/commons/locker)
+"pne" = (
+/obj/structure/table/wood,
+/obj/item/paicard,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/maintenance/fore/lesser)
 "pnA" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/stripes/line{
@@ -32777,6 +32906,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"ppi" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "ppl" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable,
@@ -32864,11 +32997,6 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
-"pqV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig/upper)
 "prj" = (
 /obj/machinery/computer/atmos_control/mix_tank{
 	dir = 8
@@ -32921,6 +33049,15 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/space_hut/cabin)
+"prZ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Fore - Courtroom Hallway"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "psc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot{
@@ -32965,10 +33102,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"ptf" = (
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/iron/smooth_edge,
-/area/security/lockers)
 "ptr" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -33049,13 +33182,6 @@
 /obj/item/taperecorder,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"pvg" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "pvn" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/green{
@@ -33150,15 +33276,6 @@
 /obj/effect/spawner/random/clothing/wardrobe_closet_colored,
 /turf/open/floor/iron,
 /area/commons/locker)
-"pwJ" = (
-/obj/structure/rack,
-/obj/machinery/syndicatebomb/training,
-/obj/structure/cable,
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "pwP" = (
 /obj/machinery/door/airlock{
 	name = "Hydroponics Backroom";
@@ -33271,16 +33388,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"pyM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"pyL" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+/area/maintenance/fore/lesser)
 "pyS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -33316,6 +33429,18 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"pBo" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "pBs" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow,
@@ -33327,16 +33452,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"pBI" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "pBR" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -33437,6 +33552,18 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"pDu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "pDx" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "maint1"
@@ -33495,12 +33622,12 @@
 "pFQ" = (
 /turf/open/floor/iron,
 /area/engineering/main)
-"pGm" = (
+"pGa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
@@ -33566,6 +33693,12 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
+"pIp" = (
+/obj/structure/rack,
+/obj/item/electropack,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "pIu" = (
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/rnd/destructive_analyzer,
@@ -33594,6 +33727,17 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"pIS" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "pIY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -33655,6 +33799,11 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"pJM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/checkpoint/auxiliary)
 "pJN" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment,
@@ -33724,6 +33873,9 @@
 /obj/effect/spawner/random/techstorage/ai_all,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
+"pLu" = (
+/turf/open/openspace,
+/area/security/brig/upper)
 "pLE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -33814,6 +33966,15 @@
 	dir = 1
 	},
 /area/science/research)
+"pNZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "pOe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/navbeacon/wayfinding,
@@ -33824,12 +33985,26 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/medical/central)
+"pOl" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "pOt" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/command/meeting_room)
+"pOu" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/grass,
+/area/security/warden)
 "pOE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -33854,13 +34029,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"pPc" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "pPh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -33884,6 +34052,13 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"pPy" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "pPA" = (
 /obj/machinery/door/airlock/command{
 	name = "MiniSat Access";
@@ -33909,6 +34084,18 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/service/library)
+"pQq" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/processing)
 "pQx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33920,16 +34107,30 @@
 /obj/structure/flora/tree/pine,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"pQF" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/muzzle,
+/obj/machinery/flasher/directional/east{
+	id = "cell4"
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
+"pQI" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "pQM" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 5
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"pRf" = (
-/obj/structure/closet/bombcloset/security,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "pRo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -33950,6 +34151,17 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/service/bar/atrium)
+"pSa" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "pSc" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
@@ -33970,12 +34182,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"pSE" = (
-/obj/structure/cable,
-/turf/open/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/maintenance/fore/lesser)
 "pSG" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer/on/coldroom{
 	dir = 1
@@ -34009,11 +34215,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
-"pSW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
 "pTk" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -34122,6 +34323,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"pUO" = (
+/mob/living/simple_animal/bot/secbot/beepsky,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore/lesser)
 "pUU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -34166,18 +34373,13 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/engineering/supermatter)
-"pWK" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Office"
+"pWH" = (
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/security/interrogation)
 "pXv" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -34193,6 +34395,36 @@
 "pXx" = (
 /turf/closed/wall,
 /area/service/library)
+"pXA" = (
+/obj/structure/table/glass,
+/obj/structure/sign/barsign{
+	pixel_y = 32;
+	icon_state = "thecavern";
+	chosen_sign = "thecavern"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vermouth{
+	pixel_x = 10;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/food/drinks/bottle/pineapplejuice{
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/bottle/orangejuice{
+	pixel_x = 15
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/tonic,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
+"pXJ" = (
+/obj/structure/cable,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/maintenance/fore/lesser)
 "pXL" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -34213,6 +34445,10 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"pYA" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "pYI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 4
@@ -34283,6 +34519,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/mining)
+"qaJ" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Infirmary"
+	},
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "qaK" = (
 /obj/machinery/shower{
 	dir = 8
@@ -34330,6 +34576,18 @@
 	},
 /turf/open/floor/carpet,
 /area/command/meeting_room)
+"qco" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/security/processing)
 "qcs" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
@@ -34367,9 +34625,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/storage/gas)
-"qcV" = (
-/turf/closed/wall,
-/area/security/interrogation)
 "qcZ" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -34392,16 +34647,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
-"qdr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/security/processing)
 "qdy" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
@@ -34432,11 +34677,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/service/library)
-"qdO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory/upper)
 "qdX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -34456,13 +34696,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
-"qeq" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/warden,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "qer" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/turf_decal/trimline/green/filled,
@@ -34555,14 +34788,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"qhe" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "qhq" = (
 /obj/machinery/computer/atmos_control/nitrogen_tank{
 	dir = 1
@@ -34615,6 +34840,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/engineering/storage)
+"qix" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/glass/reinforced,
+/area/security/lockers)
 "qiE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34690,15 +34919,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"qkv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "qkC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -34766,15 +34986,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"qlj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "qll" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=AftH";
@@ -34785,6 +34996,27 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"qlo" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
+"qlG" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "qlI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34793,6 +35025,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"qlM" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "qme" = (
 /obj/structure/table,
 /obj/item/multitool/circuit{
@@ -34824,6 +35065,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qmn" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Desk"
+	},
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/checkpoint/auxiliary)
 "qmx" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -34866,9 +35123,6 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
-"qnZ" = (
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "qod" = (
 /obj/structure/rack,
 /obj/machinery/status_display/evac/directional/south,
@@ -34929,9 +35183,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/wood,
 /area/commons/dorms)
-"qpO" = (
-/turf/closed/wall,
-/area/security/warden)
 "qpQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34939,6 +35190,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"qqb" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/ice,
+/area/icemoon/surface/outdoors/nospawn)
 "qqe" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -35019,13 +35274,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"qrI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/camera/directional/south,
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "qsi" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
@@ -35065,18 +35313,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"qtg" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/security/processing)
 "qtk" = (
 /obj/structure/table,
 /obj/item/hemostat,
@@ -35086,6 +35322,9 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"qtK" = (
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "qtW" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/meter/monitored/waste_loop,
@@ -35160,27 +35399,9 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
-"qye" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "qyf" = (
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"qyB" = (
-/obj/machinery/door/window/brigdoor/right/directional/north{
-	name = "Flash Storage";
-	req_access_txt = "3"
-	},
-/obj/machinery/recharge_station,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "qyD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35190,12 +35411,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"qyE" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "qyN" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
@@ -35329,6 +35544,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"qDa" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "qDf" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -35378,22 +35600,10 @@
 "qEX" = (
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
-"qEZ" = (
-/obj/machinery/computer/security/hos,
-/obj/machinery/requests_console/directional/north{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security Requests Console"
-	},
-/obj/machinery/button/door/directional/north{
-	id = "hosspace";
-	name = "Icemoon Shutters Control";
-	pixel_x = -24
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
+"qFb" = (
+/obj/structure/flora/tree/dead,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "qFe" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -35459,15 +35669,6 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/medical/treatment_center)
-"qHQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "qIe" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35477,6 +35678,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/service/library)
+"qIB" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "qIQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35515,10 +35726,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"qJD" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "qJQ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/grimy,
@@ -35544,24 +35751,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"qKh" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"qKk" = (
-/obj/item/gun/energy/laser/practice{
-	pixel_y = 5
-	},
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice{
-	pixel_y = -5
-	},
-/obj/structure/rack,
-/turf/open/floor/iron/dark/textured,
-/area/security/office)
 "qKn" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port Mix to East Ports"
@@ -35598,16 +35787,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
-"qLO" = (
-/turf/closed/mineral/random/snow,
-/area/icemoon/surface/outdoors/nospawn)
-"qMb" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "qMc" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -35649,6 +35828,13 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"qNd" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "qNy" = (
 /turf/closed/wall,
 /area/engineering/atmos/storage/gas)
@@ -35658,12 +35844,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"qNU" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "qNV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -35679,18 +35859,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"qOp" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/closet/secure_closet/contraband/armory,
-/obj/machinery/firealarm/directional/north,
-/obj/effect/spawner/random/maintenance/three,
-/obj/effect/spawner/random/contraband/armory,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
+"qOB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Security Medpost"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "qOO" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -35715,9 +35892,15 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/pharmacy)
-"qPC" = (
-/turf/open/openspace,
-/area/hallway/primary/fore)
+"qPA" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "qQb" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -35728,14 +35911,6 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
-"qQe" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "qQx" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -35774,6 +35949,15 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
+"qQY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 23
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "qRz" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/stripes/line{
@@ -35925,6 +36109,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"qVY" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "qWh" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/freezer,
@@ -35992,6 +36182,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"qYK" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "qYQ" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
@@ -36010,12 +36210,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"qZH" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "qZK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
@@ -36062,21 +36256,24 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/maintenance/aft/greater)
-"raB" = (
+"raP" = (
+/obj/structure/rack,
+/obj/machinery/syndicatebomb/training,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "raT" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/bluespace_vendor/directional/north,
 /obj/effect/mapping_helpers/trapdoor_placer,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"rbb" = (
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "rbC" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/red{
@@ -36204,15 +36401,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/mining)
-"rfs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "rfy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -36229,18 +36417,42 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
-"rgX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"rgs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/lockers)
-"rhu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
 /area/security/brig/upper)
+"rgQ" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"rgY" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Secure Walkway"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
+"rhb" = (
+/obj/item/gun/energy/laser/practice{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice{
+	pixel_y = -5
+	},
+/obj/structure/rack,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "rhJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36255,6 +36467,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"rhV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "ria" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36295,6 +36516,13 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating/icemoon,
 /area/engineering/atmos)
+"riQ" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/interrogation)
 "riS" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -36303,6 +36531,12 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
+"riX" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/closet/secure_closet/hos,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "rjc" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -36334,6 +36568,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"rjk" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "rjq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -36358,6 +36599,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"rkH" = (
+/obj/machinery/modular_computer/console/preset/id,
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "rkI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -36392,16 +36646,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"rld" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "rln" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
@@ -36471,11 +36715,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"rms" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "rmv" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -36587,15 +36826,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"rpD" = (
-/obj/structure/bed/dogbed/lia,
-/mob/living/simple_animal/hostile/carp/lia,
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - HoS Office"
-	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
 "rpH" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/three,
@@ -36681,6 +36911,19 @@
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/pharmacy)
+"rrN" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Vestibule"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/turf/open/floor/iron/smooth,
+/area/security/processing)
 "rrP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -36713,28 +36956,19 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"rss" = (
-/obj/structure/sign/directions/security{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = 40
+"rsI" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -6
 	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = 32
+/obj/machinery/button/door{
+	id = "BrigLock";
+	name = "Cell Shutters";
+	pixel_y = 9;
+	pixel_x = 7
 	},
-/obj/structure/sign/directions/evac{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "rsK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36751,10 +36985,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
-"rtp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "rtx" = (
 /turf/closed/wall,
 /area/commons/storage/art)
@@ -36785,13 +37015,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/atmos)
-"rum" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
 "ruo" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -36848,6 +37071,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"ruG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/processing)
 "ruI" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/airalarm/directional/north,
@@ -36889,15 +37118,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/engineering/atmos/storage/gas)
-"rvz" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "rvA" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -36945,12 +37165,24 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/science/storage)
+"rvX" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_large,
+/area/command/heads_quarters/hos)
 "rwo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
+"rwA" = (
+/turf/open/floor/glass/reinforced,
+/area/ai_monitored/security/armory/upper)
 "rxm" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -36987,6 +37219,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"rxE" = (
+/obj/structure/sign/warning/xeno_mining,
+/turf/closed/wall/ice,
+/area/icemoon/surface/outdoors/nospawn)
 "rxR" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -37007,6 +37243,12 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
+"rym" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "ryo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -37027,12 +37269,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"ryV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "ryW" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -37117,23 +37353,11 @@
 /obj/item/hand_tele,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"rAY" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark/textured,
-/area/security/processing)
 "rBh" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"rBB" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "rBK" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -37242,10 +37466,10 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron/grimy,
 /area/service/bar/atrium)
-"rEa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint/customs/auxiliary)
+"rEr" = (
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/iron/smooth_edge,
+/area/security/lockers)
 "rEs" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -37376,6 +37600,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"rGK" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/camera/directional/north,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "rGN" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -37424,11 +37657,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
-"rHe" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/twenty,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "rHB" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
@@ -37471,13 +37699,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/mining)
-"rHT" = (
-/obj/item/radio/intercom/prison/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+"rIg" = (
+/obj/structure/cable,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
 	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
+/area/maintenance/fore/lesser)
 "rIq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37488,29 +37715,30 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"rIB" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Entrance"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigentrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "rJa" = (
 /obj/machinery/vending/modularpc,
 /turf/open/floor/iron,
 /area/commons/locker)
+"rJw" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron,
+/area/security/warden)
 "rJD" = (
 /obj/structure/chair/stool/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"rJI" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/glass,
+/area/security/lockers)
 "rJN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37577,33 +37805,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"rKN" = (
-/obj/machinery/modular_computer/console/preset/id,
-/obj/machinery/light/directional/north,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "rKT" = (
 /obj/machinery/computer/teleporter{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/command/teleporter)
-"rKX" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "rLf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -37653,6 +37860,12 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"rLH" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Equipment Room"
+	},
+/turf/open/floor/glass/reinforced,
+/area/security/lockers)
 "rLS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37665,10 +37878,6 @@
 "rLU" = (
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"rLV" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "rLX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -37721,10 +37930,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"rNx" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "rND" = (
 /obj/structure/displaycase/labcage,
 /obj/effect/turf_decal/stripes/end{
@@ -37778,12 +37983,6 @@
 	dir = 9
 	},
 /area/science/research)
-"rPX" = (
-/obj/structure/rack,
-/obj/item/electropack,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "rPZ" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -37809,13 +38008,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/lab)
-"rQO" = (
-/obj/machinery/computer/shuttle/labor{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "rRf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -37835,6 +38027,13 @@
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"rRh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "rRH" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/vending/wardrobe/curator_wardrobe,
@@ -37860,6 +38059,11 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"rSp" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "rSr" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/chair{
@@ -37977,6 +38181,15 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"rUN" = (
+/obj/structure/table,
+/obj/item/folder/red,
+/obj/item/pen,
+/obj/item/inspector,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "rUR" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38114,6 +38327,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+"rYq" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "rYG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38178,12 +38399,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
-"rZw" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "rZB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38220,6 +38435,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"saG" = (
+/obj/structure/table,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/obj/item/key/security,
+/obj/machinery/light/directional/east,
+/obj/item/radio/intercom/prison/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "saU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
@@ -38296,19 +38520,20 @@
 	dir = 1
 	},
 /area/hallway/secondary/service)
-"scK" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "scP" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"scQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "scZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -38371,6 +38596,12 @@
 /obj/item/plant_analyzer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"sem" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "seu" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat{
@@ -38445,6 +38676,15 @@
 "sgN" = (
 /turf/closed/wall,
 /area/ai_monitored/command/storage/eva)
+"sgU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore/lesser)
 "shd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38544,13 +38784,6 @@
 "siL" = (
 /turf/open/floor/wood,
 /area/service/library)
-"siN" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/obj/effect/gibspawner/human,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "sjb" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -38715,11 +38948,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"slk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/lockers)
 "slC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/carbon_input{
 	dir = 8
@@ -38743,26 +38971,22 @@
 	dir = 1
 	},
 /area/engineering/engine_smes)
-"slM" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "smd" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard/upper)
+"smg" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "smm" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"smp" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/security/processing)
 "smE" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
@@ -38836,12 +39060,6 @@
 /obj/structure/railing/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"sog" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "sol" = (
 /obj/structure/rack,
 /obj/item/pickaxe{
@@ -38874,12 +39092,14 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/port/aft)
-"soS" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
+"soJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "soT" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -38936,6 +39156,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/mixing)
+"sqz" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "sqJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -39016,6 +39243,11 @@
 /obj/item/radio/headset/headset_med,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"ssh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "ssk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39032,6 +39264,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"ssJ" = (
+/turf/closed/wall,
+/area/security/checkpoint/customs/auxiliary)
 "ssV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -39063,13 +39298,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
-"stw" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "stA" = (
 /obj/structure/chair{
 	dir = 8
@@ -39082,12 +39310,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
-"stF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/office)
 "stJ" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/spawner,
@@ -39157,6 +39379,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"svn" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "svy" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -39180,25 +39412,6 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
-"swo" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_x = -8
-	},
-/obj/item/clothing/shoes/winterboots/ice_boots{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/clothing/shoes/winterboots/ice_boots{
-	pixel_x = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "sww" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass,
@@ -39249,19 +39462,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"sxj" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/mask/muzzle,
-/obj/machinery/flasher/directional/east{
-	id = "cell4"
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "sxo" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39359,6 +39559,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"sAM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=EVA";
+	location = "Security"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "sAO" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral,
@@ -39382,6 +39591,14 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"sBs" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "sBv" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/blue{
@@ -39422,6 +39639,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"sCg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "sCC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -39520,13 +39747,6 @@
 "sEf" = (
 /turf/closed/wall,
 /area/service/kitchen/coldroom)
-"sEl" = (
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "sEn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -39568,6 +39788,13 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"sEX" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "sFg" = (
 /obj/machinery/oven,
 /turf/open/floor/plating,
@@ -39601,12 +39828,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"sFS" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/processing)
 "sFY" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/red{
@@ -39671,6 +39892,31 @@
 /obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"sHG" = (
+/obj/structure/table,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/hand_labeler{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "sHT" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -39684,6 +39930,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"sID" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "EVA Maintenance";
+	req_access_txt = "18"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "sIF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39699,16 +39956,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
-"sJt" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "sKx" = (
@@ -39744,13 +39991,13 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "sKU" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
+/obj/machinery/camera/directional/south,
+/turf/open/floor/iron/white/corner,
+/area/hallway/secondary/entry)
 "sLc" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -39775,12 +40022,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
-"sLP" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "sLX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -39790,13 +40031,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"sMa" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark/textured,
-/area/security/warden)
 "sMe" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/shoes/jackboots,
@@ -39812,6 +40046,11 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
+"sMf" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "sMg" = (
 /obj/machinery/door/window/right/directional/east{
 	base_state = "left";
@@ -39867,6 +40106,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"sMD" = (
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "sMI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -39883,6 +40126,33 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/glass/reinforced,
 /area/medical/treatment_center)
+"sMQ" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/restraints/handcuffs{
+	pixel_y = 5
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 1
+	},
+/obj/item/restraints/handcuffs{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Holding Cells"
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
+"sMW" = (
+/obj/item/radio/intercom/prison/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "sMZ" = (
 /obj/structure/kitchenspike,
 /obj/item/stack/sheet/leather,
@@ -39960,13 +40230,17 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/fore)
 "sOS" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp_home";
+	name = "fore bay 1";
+	roundstart_template = /datum/map_template/shuttle/labour/box;
+	width = 9
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "sPg" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/newscaster/directional/east,
@@ -40017,14 +40291,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"sRL" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "sRN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/kitchen/diner)
+"sSc" = (
+/turf/open/floor/glass,
+/area/security/lockers)
 "sSd" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot{
@@ -40036,15 +40309,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"sSh" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "sSi" = (
 /turf/open/floor/plating,
 /area/commons/storage/emergency/port)
@@ -40059,6 +40323,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"sTd" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/closet/firecloset,
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "sTp" = (
 /obj/machinery/photocopier,
 /obj/item/radio/intercom/directional/north,
@@ -40100,16 +40370,13 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"sUl" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable,
+"sUo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/security/lockers)
 "sUA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -40173,6 +40440,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"sWk" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "sWD" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage";
@@ -40184,18 +40461,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"sWP" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"sWQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "sWX" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -40353,6 +40618,25 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"tat" = (
+/obj/machinery/computer/department_orders/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
+"taK" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Port Hallway"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "taX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
@@ -40380,6 +40664,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
+"tbT" = (
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/structure/cable,
+/obj/structure/noticeboard/directional/east,
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "tca" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -40471,17 +40763,6 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
-"teJ" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/light/directional/south,
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/security/lockers)
 "teS" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -40492,6 +40773,33 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"tfe" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/requests_console/directional/north{
+	department = "Security";
+	departmentType = 3;
+	name = "Security Requests Console"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
+"tff" = (
+/obj/machinery/flasher/directional/east{
+	id = "brigentry"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "tfj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -40520,15 +40828,6 @@
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
-"tfO" = (
-/obj/machinery/button/flasher{
-	id = "cell4";
-	pixel_y = -22
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "tfP" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -40580,16 +40879,23 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"tgM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/meter/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
+"thd" = (
+/obj/item/kirbyplants/random,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/security/processing)
 "the" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
+"thf" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "thg" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -40627,6 +40933,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"tiw" = (
+/obj/structure/bed/dogbed/lia,
+/mob/living/simple_animal/hostile/carp/lia,
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - HoS Office"
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
+"tiR" = (
+/obj/machinery/gulag_teleporter,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "tja" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
@@ -40663,13 +40983,6 @@
 /obj/item/newspaper,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"tjH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "tjI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
@@ -40768,6 +41081,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
+"tlz" = (
+/turf/open/floor/carpet,
+/area/security/processing)
 "tlE" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -40813,17 +41129,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"tmE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
-"tmV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/office)
 "tmX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemical Storage";
@@ -40901,14 +41206,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"toX" = (
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "2";
-	dir = 1;
-	name = "Security Delivery"
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "toY" = (
 /obj/structure/table,
 /obj/item/tank/internals/emergency_oxygen{
@@ -40944,33 +41241,25 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"tpk" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig/upper)
+"tpr" = (
+/turf/closed/wall/r_wall,
+/area/hallway/primary/fore)
 "tpE" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/fore/lesser)
 "tpQ" = (
 /turf/closed/wall,
 /area/service/hydroponics/garden)
-"tpZ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Walkway"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigentrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "tqd" = (
 /obj/item/trash/cheesie,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"tql" = (
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/hos)
 "tqm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41001,15 +41290,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/port)
-"trs" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "tru" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
@@ -41074,6 +41354,13 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"ttO" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "tun" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -41145,22 +41432,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"tuM" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "EVA2"
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "tvk" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -41222,12 +41493,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"twh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "twF" = (
 /obj/effect/landmark/start/chemist,
 /obj/structure/chair/office/light{
@@ -41299,10 +41564,11 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"tyd" = (
-/obj/structure/railing,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+"tyl" = (
+/obj/structure/plasticflaps,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "tyA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -41316,6 +41582,16 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
+"tzf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "tzi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41386,10 +41662,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"tAm" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "tAn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -41406,6 +41678,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"tAB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "tBb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot{
@@ -41436,6 +41717,10 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/openspace,
 /area/service/chapel)
+"tBx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/customs/auxiliary)
 "tBz" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41448,16 +41733,6 @@
 	dir = 5
 	},
 /area/maintenance/port/aft)
-"tCd" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/iron,
-/area/security/warden)
 "tCh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41466,6 +41741,16 @@
 	},
 /turf/open/floor/wood,
 /area/command/meeting_room)
+"tCq" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Transport"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
+"tCr" = (
+/turf/closed/mineral/random/snow,
+/area/icemoon/surface/outdoors/nospawn)
 "tCt" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/plating,
@@ -41478,13 +41763,15 @@
 	},
 /turf/open/floor/plating,
 /area/medical/pharmacy)
-"tCV" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
+"tDg" = (
+/obj/machinery/disposal/bin,
+/obj/item/radio/intercom/prison/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Security - Warden's Office"
 	},
-/area/security/lockers)
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "tDy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41629,6 +41916,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"tGI" = (
+/obj/machinery/suit_storage_unit/hos,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "tGJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/command{
@@ -41695,10 +41987,18 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"tHr" = (
-/obj/structure/sign/warning/coldtemp,
-/turf/closed/wall,
-/area/maintenance/fore/greater)
+"tHE" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Head of Security"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/hos,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth_large,
+/area/command/heads_quarters/hos)
 "tHJ" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/bookmanagement,
@@ -41717,19 +42017,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"tHU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/item/radio/intercom/prison/directional/east{
-	frequency = 1359
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "tHZ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/rack,
@@ -41792,17 +42079,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
-"tJu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "tJH" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41818,18 +42094,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/checker,
 /area/engineering/atmos)
-"tJY" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "tKa" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -41872,6 +42136,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
+"tKT" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
+	pixel_y = 20;
+	pixel_x = 7
+	},
+/obj/item/taperecorder{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6
+	},
+/obj/item/storage/secure/safe/hos{
+	pixel_x = 35
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "tKV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -41953,38 +42240,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
-"tOf" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/timer,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
-"tOn" = (
-/obj/structure/table/glass,
-/obj/structure/sign/barsign{
-	pixel_y = 32;
-	icon_state = "thecavern";
-	chosen_sign = "thecavern"
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vermouth{
-	pixel_x = 10;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/food/drinks/bottle/pineapplejuice{
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/bottle/orangejuice{
-	pixel_x = 15
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka{
-	pixel_x = -11;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/tonic,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "tOu" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -42012,37 +42267,6 @@
 "tPd" = (
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
-"tPi" = (
-/obj/structure/table,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -8;
-	pixel_y = 11
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/hand_labeler{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
-"tPl" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "tPo" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
@@ -42062,6 +42286,26 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"tPP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"tPZ" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Upper Hallway North"
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "tQg" = (
 /obj/structure/table/glass,
 /obj/item/hemostat,
@@ -42072,15 +42316,6 @@
 "tQo" = (
 /turf/closed/wall,
 /area/engineering/atmos/project)
-"tQv" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/item/inspector,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/security/office)
 "tQx" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/portable_atmospherics/pump,
@@ -42097,14 +42332,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"tQE" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L9"
-	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "tRl" = (
 /obj/structure/sign/painting/library_secure{
 	pixel_x = 32
@@ -42163,6 +42390,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"tSr" = (
+/obj/machinery/vending/cigarette,
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_x = -22
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "tSF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/closed/wall/r_wall,
@@ -42196,6 +42432,22 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"tUj" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Checkpoint";
+	id_tag = "outerbrig"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigoutpost"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "tUs" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/preopen{
@@ -42322,10 +42574,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/storage)
-"tXQ" = (
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/glass/reinforced,
-/area/security/office)
 "tYc" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
@@ -42339,6 +42587,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
+"tYi" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "tYk" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -42391,15 +42644,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tYR" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Office"
-	},
-/turf/open/floor/iron/dark/textured_half,
-/area/security/office)
 "tYS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42430,6 +42674,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"tZo" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "tZP" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -42499,6 +42749,18 @@
 	dir = 4
 	},
 /area/medical/medbay/central)
+"uaY" = (
+/obj/machinery/computer/security,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "ube" = (
 /obj/structure/chair{
 	dir = 1
@@ -42517,19 +42779,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"ubM" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "ubR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -42543,12 +42792,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"ubV" = (
-/obj/structure/cable,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/maintenance/fore/lesser)
 "ubX" = (
 /obj/structure/chair,
 /obj/item/radio/intercom/directional/north,
@@ -42568,6 +42811,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"ucc" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "uce" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -42585,50 +42834,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"udg" = (
-/obj/machinery/button/door/directional/east{
-	id = "armory";
-	name = "Armory Shutters";
-	req_access_txt = "3";
-	pixel_x = -9;
-	pixel_y = 30
-	},
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
-"udh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/machinery/door/window/brigdoor/right/directional/west{
-	name = "Brig Reception";
-	req_one_access_txt = "1"
-	},
-/obj/machinery/door/window/left/directional/east{
-	name = "Brig Reception"
-	},
-/turf/open/floor/iron/dark,
-/area/security/checkpoint/auxiliary)
 "udj" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 8
@@ -42651,15 +42856,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"udS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "udZ" = (
 /obj/structure/chair{
 	dir = 1;
@@ -42696,13 +42892,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"ueB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/smooth_edge,
-/area/security/lockers)
 "ueK" = (
 /obj/structure/window/reinforced/fulltile/ice{
 	name = "frozen window"
@@ -42733,13 +42922,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
-"ufC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "ufF" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/transmitter,
@@ -42781,13 +42963,6 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"ugZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "uhi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -42827,12 +43002,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"uhW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "uhY" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -42856,16 +43025,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/lobby)
-"uiD" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "uiO" = (
 /obj/structure/table,
 /obj/item/toy/plush/beeplushie{
@@ -42881,6 +43040,10 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"uiZ" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "uja" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -42977,18 +43140,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"ukN" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Secure Walkway"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "ukP" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -42998,6 +43149,15 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
+"ule" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "ulg" = (
 /obj/structure/closet/firecloset,
 /obj/effect/landmark/start/hangover/closet,
@@ -43013,6 +43173,9 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/medical/central)
+"ulw" = (
+/turf/closed/wall/r_wall,
+/area/security/checkpoint/auxiliary)
 "uly" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Teleporter"
@@ -43027,6 +43190,18 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
+"ulY" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "umh" = (
 /obj/effect/turf_decal/tile/purple/half,
 /obj/effect/turf_decal/arrows/red{
@@ -43055,10 +43230,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"umH" = (
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "umQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -43072,11 +43243,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"umR" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "umY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/vending/wardrobe/science_wardrobe,
@@ -43123,6 +43289,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"unF" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/security/lockers)
 "unT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -43177,10 +43350,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"uoT" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "upb" = (
 /obj/structure/cable,
 /obj/structure/railing,
@@ -43196,6 +43365,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/commons/storage/emergency/port)
+"upq" = (
+/obj/machinery/computer/prisoner/management{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "upt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light/directional/south,
@@ -43239,11 +43415,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/engineering/atmos/storage/gas)
-"uqd" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/maintenance/fore/lesser)
 "uqM" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -43321,12 +43492,14 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"usa" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+"urU" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch/directional/south,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "usb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -43378,19 +43551,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"utQ" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/structure/table,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "uub" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43538,6 +43698,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"uxf" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/warden,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "uxn" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
@@ -43574,6 +43741,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/surgery/fore)
+"uxX" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side,
+/area/security/processing)
 "uyf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -43620,6 +43796,12 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"uyX" = (
+/obj/machinery/computer/security/labor{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "uzf" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CHE";
@@ -43685,6 +43867,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
+"uzT" = (
+/obj/machinery/computer/prisoner/gulag_teleporter_computer{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
+"uAg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "uAz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
@@ -43707,18 +43901,6 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"uBf" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/processing)
 "uBg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43739,15 +43921,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness)
-"uBX" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/corner{
-	dir = 8
-	},
-/area/security/processing)
+"uBr" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hos)
+"uBV" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "uBY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -43804,15 +43988,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
-"uCX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "uDd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43851,6 +44026,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
+"uDI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Interrogation";
+	network = list("interrogation")
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/interrogation)
 "uDP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43898,12 +44083,6 @@
 	dir = 5
 	},
 /area/science/lab)
-"uEt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "uEI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43939,9 +44118,6 @@
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
-"uFe" = (
-/turf/closed/wall/r_wall,
-/area/security/medical)
 "uFn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43952,21 +44128,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"uFC" = (
-/obj/machinery/button/door/directional/west{
-	id = "riot";
-	name = "Anti-Riot Shutters";
-	pixel_x = -7;
-	pixel_y = 32;
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "uFV" = (
 /obj/machinery/shower{
 	dir = 4
@@ -44070,6 +44231,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uHw" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "uHD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -44108,14 +44276,14 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
-"uIc" = (
-/obj/structure/sign/warning/xeno_mining,
-/turf/closed/wall/ice,
-/area/icemoon/surface/outdoors/nospawn)
 "uId" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"uIv" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/glass/reinforced,
+/area/ai_monitored/security/armory/upper)
 "uIw" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -44185,6 +44353,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"uKY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor{
+	name = "Armory Desk";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/window/left/directional/north{
+	name = "Armory Desk"
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/security/armory/upper)
 "uLr" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -44290,13 +44470,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/misc_lab)
-"uOk" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "uOl" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/directional/east,
@@ -44391,10 +44564,6 @@
 /obj/structure/closet/secure_closet/captains,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"uRd" = (
-/obj/structure/flora/bush,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "uRj" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -44439,6 +44608,10 @@
 /obj/item/food/canned/peaches/maint,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uRR" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/security/warden)
 "uRV" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -44545,10 +44718,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"uVG" = (
-/obj/structure/flora/rock/icy,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "uVZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -44778,6 +44947,17 @@
 	dir = 8
 	},
 /area/science/misc_lab)
+"vdH" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/space_heater,
+/obj/machinery/camera/directional/south{
+	c_tag = "Auxiliary Tool Storage"
+	},
+/turf/open/floor/iron,
+/area/commons/storage/tools)
 "vdO" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -44801,6 +44981,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/science/storage)
+"vea" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	shuttledocked = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/processing)
 "vex" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -44811,18 +44998,15 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"veN" = (
-/obj/structure/table/wood,
-/obj/item/paicard,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/fore/lesser)
 "veR" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/aft/greater)
+"vfp" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "vft" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/closed/wall/r_wall,
@@ -44833,22 +45017,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/lab)
-"vfP" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Checkpoint";
-	id_tag = "outerbrig"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	id_tag = "brigoutpost"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "vfT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/ignition{
@@ -44862,12 +45030,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"vga" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "vgc" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/siding/white{
@@ -44875,19 +45037,21 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
-"vgi" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
 "vgj" = (
 /obj/structure/ladder,
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/textured_large,
 /area/maintenance/department/medical/central)
+"vgB" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "vhk" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -44897,6 +45061,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"vhP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/security/processing)
 "vhT" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior{
@@ -44969,15 +45143,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"vjo" = (
+"viY" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/plating,
-/area/maintenance/fore/greater)
+/area/security/processing)
 "vjE" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/full,
@@ -45036,17 +45206,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"vkD" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "vkT" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
@@ -45100,6 +45259,15 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"vlW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "vlY" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/hallway)
@@ -45110,6 +45278,20 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"vmf" = (
+/obj/item/grenade/barrier{
+	pixel_x = 4
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = -4
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "vmE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45137,15 +45319,31 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"vnG" = (
-/obj/item/paper/fluff/jobs/security/beepsky_mom,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
 "vnL" = (
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/keycard_auth/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"vnV" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Transport Maintenance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/plating,
+/area/security/processing)
+"vog" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/security/processing)
 "vov" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
@@ -45168,16 +45366,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"voz" = (
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/glass,
-/area/security/lockers)
-"vpq" = (
+"voI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/processing)
@@ -45254,13 +45448,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
-"vrk" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "vrn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45277,12 +45464,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"vry" = (
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 24
-	},
-/turf/open/floor/carpet,
-/area/security/processing)
 "vrD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/north,
@@ -45303,6 +45484,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vsP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig/upper)
 "vsR" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/landmark/start/hangover,
@@ -45322,33 +45508,16 @@
 "vtF" = (
 /turf/closed/wall,
 /area/command/heads_quarters/captain)
-"vua" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
-"vue" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "vui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"vvs" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - EVA"
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
+"vvl" = (
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore/lesser)
 "vvt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -45365,36 +45534,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"vvE" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "vvQ" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/science/genetics)
-"vwb" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
-"vwd" = (
-/obj/effect/turf_decal/tile/red/anticorner,
-/obj/machinery/requests_console/directional/north{
-	department = "Security";
-	departmentType = 3;
-	name = "Security Requests Console"
-	},
-/turf/open/floor/iron/dark/textured_corner{
-	dir = 1
-	},
-/area/security/office)
-"vwf" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "vwl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
@@ -45415,15 +45565,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
-"vwV" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "vxk" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron/smooth,
@@ -45446,17 +45587,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"vxn" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"vxr" = (
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "vxA" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
@@ -45504,13 +45634,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
-"vyp" = (
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white/textured,
-/area/security/medical)
 "vyt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -45535,15 +45658,23 @@
 	dir = 8
 	},
 /area/medical/medbay/central)
-"vzu" = (
-/obj/structure/chair{
-	dir = 1
+"vzw" = (
+/obj{
+	name = "---Merge conflict marker---"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_large,
-/area/command/heads_quarters/hos)
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/flasher/directional/west{
+	id = "Cell 3"
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/surface/outdoors/nospawn)
 "vzx" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/blue{
@@ -45573,15 +45704,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"vAf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/processing)
 "vAz" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -28
@@ -45616,14 +45738,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"vAQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "vAX" = (
 /obj/item/chair/wood,
 /turf/open/floor/wood{
@@ -45680,6 +45794,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"vDe" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
+/area/security/brig/upper)
 "vDn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
@@ -45689,11 +45807,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"vDt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "vDN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -45852,6 +45965,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"vGC" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "vGD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45904,22 +46026,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
-"vHI" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/requests_console/directional/north{
-	department = "Security";
-	departmentType = 3;
-	name = "Security Requests Console"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "vIv" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -46068,15 +46174,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery/fore)
-"vLx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "vLA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46118,19 +46215,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"vLW" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Vestibule"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/security/detective,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/turf/open/floor/iron/smooth,
-/area/security/processing)
 "vMh" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxToilet1";
@@ -46187,6 +46271,14 @@
 /obj/item/poster/random_contraband,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"vNN" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9"
+	},
+/obj/effect/landmark/start/hangover,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "vNR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46239,6 +46331,12 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"vOt" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "vOu" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
@@ -46298,12 +46396,6 @@
 /obj/item/stock_parts/cell/high/empty,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"vQz" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "vQC" = (
 /obj/structure/sign/departments/psychology{
 	pixel_y = -32
@@ -46428,16 +46520,15 @@
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/large,
 /area/medical/pharmacy)
-"vTT" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
+"vTC" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "vTY" = (
 /obj/item/toy/snowball{
 	pixel_x = -6;
@@ -46564,9 +46655,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"vWu" = (
-/turf/open/floor/iron,
-/area/security/checkpoint/customs/auxiliary)
 "vWA" = (
 /obj/machinery/vending/modularpc,
 /turf/open/floor/iron,
@@ -46630,6 +46718,12 @@
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"vXB" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "vXP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -46650,20 +46744,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/maintenance/starboard/fore)
-"vYQ" = (
-/obj/structure/railing,
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = 4
-	},
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "vYW" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46679,14 +46759,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"vZg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "vZk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -46707,14 +46779,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"vZw" = (
-/obj/structure/chair/comfy{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
-/area/security/processing)
 "vZH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
@@ -46743,10 +46807,29 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port/greater)
+"waD" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Entrance"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigentrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "waM" = (
 /obj/machinery/computer/cargo/request,
 /turf/open/floor/iron,
 /area/cargo/lobby)
+"waX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "wbd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -46761,11 +46844,11 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/freezer,
 /area/command/heads_quarters/captain)
-"wbn" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+"wbw" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "wbB" = (
@@ -46794,18 +46877,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"wbG" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/processing)
 "wca" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/wood{
@@ -46823,14 +46894,6 @@
 /obj/machinery/vending/games,
 /turf/open/floor/wood,
 /area/service/library)
-"wcJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "wcO" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate/maint,
@@ -46844,25 +46907,22 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/openspace,
 /area/service/chapel)
-"wdb" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner{
-	dir = 4
-	},
-/area/security/processing)
 "wdi" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
+"wdp" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/inspector,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/security/office)
 "wdt" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -46986,6 +47046,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
+"wil" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Walkway";
+	id_tag = "innerbrig"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigoutpost"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "wit" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -47243,11 +47319,6 @@
 	dir = 4
 	},
 /area/service/chapel)
-"woC" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark/textured,
-/area/security/interrogation)
 "woD" = (
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/circuit,
@@ -47298,6 +47369,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"wqf" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "armory";
+	name = "Armoury Shutter"
+	},
+/turf/open/floor/iron,
+/area/ai_monitored/security/armory/upper)
 "wqg" = (
 /obj/structure/railing{
 	dir = 1
@@ -47369,9 +47447,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/science/mixing/launch)
-"wrP" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/fore)
 "wrW" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/iron,
@@ -47412,16 +47487,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"wsA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "wsD" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
-"wsN" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "wsW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -47434,6 +47508,10 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"wtc" = (
+/obj/machinery/computer/warrant,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "wtr" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -47535,27 +47613,6 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
-"wuW" = (
-/obj/item/book/manual/wiki/tcomms{
-	pixel_x = 10;
-	pixel_y = -1
-	},
-/obj/item/book/manual/wiki/ordnance{
-	pixel_y = 3;
-	pixel_x = 10
-	},
-/obj/item/book/manual/wiki/experimentor{
-	pixel_x = 10;
-	pixel_y = 8
-	},
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/processing)
 "wvl" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -47585,11 +47642,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"wvy" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
 "wvC" = (
 /obj/structure/table,
 /obj/item/cartridge/signal/ordnance{
@@ -47610,15 +47662,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
-"wwh" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
+"wvW" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Central Hallway North-West"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "wwu" = (
 /obj/structure/rack,
 /obj/item/crowbar/red,
@@ -47659,6 +47710,10 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
+"wxR" = (
+/obj/structure/flora/grass/green,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "wxV" = (
 /turf/closed/wall/r_wall,
 /area/command/gateway)
@@ -47724,6 +47779,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"wAy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "Interrogation";
+	name = "Interrogation Shutters"
+	},
+/turf/open/floor/plating,
+/area/security/interrogation)
 "wAz" = (
 /turf/closed/wall,
 /area/maintenance/starboard/upper)
@@ -47827,10 +47891,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"wDg" = (
+/obj/item/radio/intercom/directional/north,
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "wDk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall,
 /area/maintenance/port/aft)
+"wDG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "wDN" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -47869,9 +47949,6 @@
 /obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"wET" = (
-/turf/open/floor/glass/reinforced,
-/area/security/checkpoint/auxiliary)
 "wEX" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Arrivals Bay 3 & 4"
@@ -47935,6 +48012,15 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/heads_quarters/cmo)
+"wHk" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/glass/reinforced,
+/area/security/checkpoint/auxiliary)
 "wHz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 8
@@ -47983,21 +48069,27 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/pumproom)
+"wIN" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
+"wJi" = (
+/mob/living/simple_animal/mouse/white{
+	name = "Mik";
+	desc = "This mouse smells faintly of alcohol."
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/maintenance/fore/lesser)
 "wJt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"wJE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "wJF" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -48008,12 +48100,6 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/cargo/office)
-"wJL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth,
-/area/security/brig/upper)
 "wJV" = (
 /obj/structure/railing/corner,
 /obj/machinery/door/firedoor/border_only,
@@ -48039,10 +48125,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood,
 /area/service/library)
-"wKq" = (
-/obj/structure/flora/tree/dead,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "wKz" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -48072,18 +48154,6 @@
 /obj/item/trash/cheesie,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
-"wLx" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "wLE" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -48091,23 +48161,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
-"wLO" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/restraints/handcuffs{
-	pixel_y = 5
-	},
-/obj/item/restraints/handcuffs{
-	pixel_y = 1
-	},
-/obj/item/restraints/handcuffs{
-	pixel_x = 1;
-	pixel_y = -4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "wLS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -48133,6 +48186,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"wNm" = (
+/obj/machinery/keycard_auth/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/command/heads_quarters/hos)
 "wNq" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -48323,17 +48383,10 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"wSi" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Equipment Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/security/lockers)
+"wSh" = (
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "wSv" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/modular_computer/console/preset/cargochat/cargo{
@@ -48369,14 +48422,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"wTq" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "wTv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -48405,6 +48450,12 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wUp" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "wUK" = (
 /obj/structure/chair/stool/directional/west,
 /obj/effect/landmark/start/assistant,
@@ -48520,6 +48571,22 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"wXD" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Walkway";
+	id_tag = "innerbrig"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	id_tag = "brigoutpost"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/security/checkpoint/auxiliary)
 "wXI" = (
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -48613,6 +48680,23 @@
 /obj/item/wirecutters,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"wZx" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/restraints/handcuffs{
+	pixel_y = 5
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 1
+	},
+/obj/item/restraints/handcuffs{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/processing)
 "wZI" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -48641,6 +48725,18 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/aft)
+"wZV" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/closet/secure_closet/contraband/armory,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/spawner/random/contraband/armory,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "xaa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -48651,6 +48747,13 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/hallway/primary/starboard)
+"xaR" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/security/office)
 "xaY" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/east,
@@ -48696,15 +48799,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
-"xcl" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/ai_monitored/security/armory/upper)
 "xcv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line{
@@ -48745,6 +48839,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"xdW" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/security/checkpoint/auxiliary)
 "xei" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
@@ -48831,12 +48936,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
-"xfZ" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/closet/secure_closet/hos,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/command/heads_quarters/hos)
 "xgb" = (
 /obj/item/storage/secure/safe/directional/south,
 /obj/machinery/light/directional/south,
@@ -48876,6 +48975,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"xgJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "xgR" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
@@ -48890,6 +48998,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
+"xhe" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "xhj" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Testing Chamber";
@@ -48917,9 +49032,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/central/lesser)
-"xhV" = (
-/turf/open/floor/glass,
-/area/security/lockers)
 "xib" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -48988,6 +49100,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"xjp" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
+/area/icemoon/surface/outdoors/nospawn)
 "xju" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -49088,25 +49204,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"xkz" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/fore/lesser)
+"xkm" = (
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/checkpoint/auxiliary)
 "xkD" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"xkJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=EVA";
-	location = "Security"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "xkN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -49168,6 +49276,13 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"xmq" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/landmark/start/hangover,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "xmL" = (
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/freezer,
@@ -49211,13 +49326,6 @@
 "xnR" = (
 /turf/closed/wall/r_wall,
 /area/science/breakroom)
-"xoh" = (
-/obj/structure/chair/comfy{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/carpet,
-/area/security/processing)
 "xon" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/camera/directional/south{
@@ -49263,6 +49371,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"xoX" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "xpl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -49287,12 +49403,6 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xpK" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Equipment Room"
-	},
-/turf/open/floor/glass/reinforced,
-/area/security/lockers)
 "xpS" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
@@ -49323,11 +49433,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xqD" = (
-/obj/structure/bookcase,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet,
-/area/security/processing)
 "xqE" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -49412,6 +49517,12 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"xtq" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/processing)
 "xtu" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -49429,15 +49540,23 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/meeting_room)
+"xtF" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Upper Brig South"
+	},
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "xuf" = (
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
 /area/science/research)
-"xuk" = (
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "xuD" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -49526,12 +49645,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"xwF" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "xwV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -49675,24 +49788,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"xzE" = (
+/obj/structure/closet/secure_closet/security,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs/auxiliary)
 "xzI" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/mining)
-"xzJ" = (
-/obj/item/grenade/barrier{
-	pixel_x = 4
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory/upper)
 "xzP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -49700,28 +49814,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"xAe" = (
-/obj/item/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -6;
-	pixel_y = 16
-	},
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/stamp/hos{
-	pixel_y = 6;
-	pixel_x = 10
-	},
-/obj/machinery/recharger{
-	pixel_y = -1;
-	pixel_x = -4
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/wood/large,
-/area/command/heads_quarters/hos)
 "xAh" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -49741,17 +49833,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"xBj" = (
-/obj/machinery/flasher/directional/east{
-	id = "brigentry"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 8
-	},
-/area/security/checkpoint/auxiliary)
 "xBn" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -49770,6 +49851,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
+"xBI" = (
+/obj/machinery/button/flasher{
+	id = "cell4";
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/security/brig/upper)
 "xCc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -49790,6 +49880,13 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
+"xCG" = (
+/obj/machinery/space_heater,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "xCJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -49863,6 +49960,18 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"xDL" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "xEh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -49895,22 +50004,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"xEs" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/security/lockers)
-"xEA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 23
-	},
-/turf/open/floor/iron,
-/area/security/brig/upper)
 "xFn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49998,14 +50091,6 @@
 /obj/item/stamp/captain,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"xHz" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/processing)
 "xHC" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -50063,12 +50148,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"xJy" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_edge,
-/area/security/lockers)
 "xJD" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -50112,6 +50191,9 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"xLd" = (
+/turf/open/floor/glass/reinforced,
+/area/security/office)
 "xLh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -50204,13 +50286,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"xNO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/security/checkpoint/auxiliary)
 "xNR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -50248,9 +50323,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
-"xOo" = (
-/turf/open/floor/glass/reinforced,
-/area/security/lockers)
 "xOt" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -50370,24 +50442,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
-"xSt" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/bluespace_vendor/directional/west,
-/obj/machinery/camera/directional/west{
-	c_tag = "Fore Primary Hallway"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"xTd" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/landmark/start/head_of_security,
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hos)
 "xTA" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
@@ -50408,15 +50462,10 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"xUk" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"xUA" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth,
 /area/security/brig/upper)
 "xUM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -50437,6 +50486,9 @@
 "xUW" = (
 /turf/open/floor/wood,
 /area/maintenance/space_hut/cabin)
+"xVg" = (
+/turf/open/floor/glass/reinforced,
+/area/security/checkpoint/auxiliary)
 "xVt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -50455,10 +50507,24 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
-"xWl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/security/armory/upper)
+"xWa" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/item/restraints/handcuffs,
+/obj/item/radio/off,
+/obj/structure/cable,
+/obj/machinery/door/window/brigdoor/left/directional/west{
+	req_one_access_txt = "1";
+	name = "Brig Reception"
+	},
+/obj/machinery/door/window/right/directional/east{
+	name = "Brig Reception"
+	},
+/turf/open/floor/iron/dark,
+/area/security/checkpoint/auxiliary)
 "xWu" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -50466,6 +50532,15 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/heads_quarters/cmo)
+"xWz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/smooth_large,
+/area/command/heads_quarters/hos)
 "xWA" = (
 /obj/machinery/space_heater,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -50495,13 +50570,6 @@
 "xXp" = (
 /turf/closed/wall,
 /area/medical/break_room)
-"xXx" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/corner,
-/area/security/processing)
 "xXG" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -50595,13 +50663,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"yaA" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "yaE" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/stripes/line{
@@ -50625,17 +50686,33 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"ybm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
+"ybo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/item/radio/intercom/prison/directional/east{
+	frequency = 1359
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig/upper)
 "ybD" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plating,
 /area/service/hydroponics)
-"ybT" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "ybV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -50679,14 +50756,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"ycK" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/structure/closet/emcloset,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security Entrance"
-	},
-/turf/open/floor/iron/smooth_half,
-/area/security/brig/upper)
 "ycO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -50718,18 +50787,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ydd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor{
-	name = "Armory Desk";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/left/directional/north{
-	name = "Armory Desk"
-	},
-/turf/open/floor/iron,
-/area/ai_monitored/security/armory/upper)
 "ydg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/south,
@@ -50748,6 +50805,14 @@
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/pharmacy)
+"ydH" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory/upper)
 "ydJ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -50759,12 +50824,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"ydK" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/security/processing)
 "yeC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
@@ -50772,10 +50831,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"yeS" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/glass/reinforced/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "yfb" = (
 /turf/open/floor/glass,
 /area/maintenance/department/medical/central)
@@ -50790,6 +50845,18 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
+"yft" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "yfB" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -50797,6 +50864,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/gateway)
+"yfL" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "yfP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50822,6 +50895,11 @@
 	dir = 8
 	},
 /area/science/research)
+"ygi" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/maintenance/fore/lesser)
 "ygn" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light/directional/south,
@@ -50835,6 +50913,12 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"ygw" = (
+/obj/structure/sign/departments/court{
+	pixel_y = 32
+	},
+/turf/open/openspace,
+/area/hallway/primary/fore)
 "yhe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -50919,6 +51003,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"yjj" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/fore/lesser)
 "yjG" = (
 /obj/structure/table,
 /obj/item/paper_bin/construction,
@@ -50927,6 +51016,11 @@
 /obj/item/stack/pipe_cleaner_coil/random,
 /turf/open/floor/iron,
 /area/commons/storage/art)
+"yjN" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half,
+/area/security/brig/upper)
 "yjS" = (
 /obj/structure/sink{
 	dir = 4;
@@ -50964,6 +51058,19 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos/pumproom)
+"ykG" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/processing)
 "ykU" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -51004,6 +51111,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"ylr" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "ylt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -60415,7 +60528,7 @@ awW
 awW
 awW
 aQG
-hRM
+sKU
 arB
 jnk
 jnk
@@ -61440,7 +61553,7 @@ jnk
 jnk
 jnk
 awW
-ilh
+hOg
 ayl
 ayl
 aRY
@@ -61684,7 +61797,7 @@ apN
 apN
 apN
 apJ
-emI
+rGK
 aDD
 ayl
 ayk
@@ -62985,7 +63098,7 @@ jnk
 awW
 aPt
 aym
-qrI
+fKm
 arB
 awW
 awW
@@ -64002,10 +64115,10 @@ alU
 alU
 alU
 alU
-jwT
-jwT
-jwT
-jwT
+ssJ
+ssJ
+ssJ
+ssJ
 ssG
 aKj
 aLw
@@ -64259,10 +64372,10 @@ aol
 aol
 aol
 alU
-mhe
-hOK
-iAv
-jwT
+xzE
+sCg
+fWd
+ssJ
 aIJ
 aKk
 aLy
@@ -64516,10 +64629,10 @@ alU
 alU
 aol
 alU
-jPR
-oZH
-kgI
-jnR
+pIS
+nwB
+nly
+kVy
 aIJ
 aKk
 aLj
@@ -64773,10 +64886,10 @@ ays
 alU
 aol
 alU
-gpw
-vWu
-kuc
-rEa
+uaY
+bzf
+aIX
+tBx
 aIJ
 aKk
 aLz
@@ -65030,9 +65143,9 @@ gaz
 alU
 aol
 alU
-rKN
-vWu
-fpf
+rkH
+bzf
+cUo
 qmP
 aIJ
 aKk
@@ -65287,10 +65400,10 @@ kaJ
 alU
 aol
 alU
-vHI
-vWu
-dyt
-rEa
+tfe
+bzf
+ovA
+tBx
 sIF
 auq
 aLA
@@ -65544,10 +65657,10 @@ tQg
 alU
 aol
 gYm
-tJu
-uOk
-jRj
-jwT
+iAV
+pkc
+pfi
+ssJ
 fkT
 aKk
 asE
@@ -69368,7 +69481,7 @@ dUi
 dUi
 dUi
 dUi
-oWZ
+xjp
 cul
 dUi
 dUi
@@ -69625,7 +69738,7 @@ jnk
 jnk
 jnk
 jnk
-tyd
+lqu
 jnk
 jnk
 jnk
@@ -69882,7 +69995,7 @@ jnk
 jnk
 jnk
 jnk
-tyd
+lqu
 jnk
 jnk
 jnk
@@ -70139,7 +70252,7 @@ jnk
 jnk
 jnk
 jnk
-tyd
+lqu
 jnk
 jnk
 jnk
@@ -70396,7 +70509,7 @@ jnk
 jnk
 jnk
 jnk
-tyd
+lqu
 jnk
 jnk
 jnk
@@ -70653,7 +70766,7 @@ jnk
 jnk
 jnk
 jnk
-tyd
+lqu
 jnk
 jnk
 jnk
@@ -70691,7 +70804,7 @@ mTO
 mTO
 mTO
 fUJ
-vxn
+bXQ
 gzQ
 cPo
 xoM
@@ -70910,7 +71023,7 @@ jnk
 jnk
 jnk
 jnk
-tyd
+lqu
 jnk
 jnk
 jnk
@@ -70948,8 +71061,8 @@ jnk
 jnk
 aJd
 aLM
-qQe
-oEC
+irT
+oUR
 rtx
 rtx
 rtx
@@ -71158,17 +71271,17 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-lKI
-ept
-ept
-ept
-ept
-uIc
-qLO
-oWZ
-eGS
+tCr
+tCr
+qqb
+dDr
+dDr
+dDr
+dDr
+rxE
+tCr
+xjp
+ccr
 jnk
 jnk
 jnk
@@ -71205,7 +71318,7 @@ xpS
 jnk
 aJd
 aLL
-rKX
+jTk
 aLE
 etw
 kzk
@@ -71414,21 +71527,21 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
-lSN
+tCr
+tCr
+tCr
+tCr
+mSB
 src
 src
 cwi
-qLO
-qLO
-qLO
-eGS
-eGS
-eGS
-eGS
+tCr
+tCr
+tCr
+ccr
+ccr
+ccr
+ccr
 jnk
 jnk
 jnk
@@ -71462,7 +71575,7 @@ xpS
 jnk
 aJd
 aLN
-qKh
+eUw
 aNl
 hKn
 rzb
@@ -71670,29 +71783,29 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
+tCr
 jnk
-siN
-onI
-qLO
-qLO
-qLO
-jcP
+bRE
+wSh
+tCr
+tCr
+tCr
+vOt
 jnk
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
 ali
 dad
 amG
@@ -71719,7 +71832,7 @@ qYV
 aJd
 aJd
 aLN
-qKh
+eUw
 aLE
 etw
 ixQ
@@ -71926,30 +72039,30 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
+tCr
 jnk
 jnk
 jnk
 jnk
-qLO
-qLO
-fOS
+tCr
+tCr
+lzZ
 cwi
 jnk
 jnk
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
 ali
 aKY
 amC
@@ -71976,8 +72089,8 @@ rdy
 qHB
 cxB
 aLP
-qlj
-dIK
+nWD
+taK
 jhN
 jhN
 jhN
@@ -72181,32 +72294,32 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
+tCr
+jGU
 jnk
 jnk
+fMr
+kAf
 jnk
-vxr
-jnk
-qLO
-qLO
+tCr
+tCr
 jnk
 src
-uVG
+kYT
 jnk
 jnk
 jnk
-fOS
+lzZ
 jnk
-eGS
-eGS
-eGS
-eGS
-eGS
+ccr
+ccr
+ccr
+ccr
+ccr
 ali
 alW
 lPM
@@ -72233,7 +72346,7 @@ qYV
 aJd
 aJd
 aLN
-qlj
+nWD
 ssk
 hfl
 tmD
@@ -72438,32 +72551,32 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
 jnk
-hIK
-jnk
-jnk
-fOS
-kkY
-jnk
-qLO
-qLO
-jnk
-lSN
+dtm
 jnk
 jnk
+lzZ
+sem
+jnk
+tCr
+tCr
+jnk
+mSB
 jnk
 jnk
 jnk
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
+jnk
+jnk
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
 ali
 ali
 alU
@@ -72490,7 +72603,7 @@ xpS
 jnk
 aJd
 aLN
-lDS
+tAB
 jDm
 jhN
 jhN
@@ -72695,36 +72808,36 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
 jnk
-uVG
-jnk
-jnk
+kYT
 jnk
 jnk
 jnk
-qLO
-qLO
+jnk
+jnk
+tCr
+tCr
 jnk
 src
-fOS
+lzZ
 jnk
 jnk
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
 jnk
 jnk
 jnk
@@ -72747,7 +72860,7 @@ xpS
 jnk
 aJd
 aLN
-lDS
+tAB
 aLE
 tsw
 ldi
@@ -72951,47 +73064,47 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
 jnk
 jnk
 jnk
 jnk
 jnk
 jnk
-jcP
+vOt
 jnk
-qLO
-qLO
+tCr
+tCr
 jnk
-fcv
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
+uHw
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
 src
-qJD
+uiZ
 src
 src
 jnk
 jnk
-fOS
+lzZ
 jnk
 jnk
 jnk
-tHr
-tAm
-fBz
+olc
+ime
+fAA
 wCC
 rdl
 jnk
@@ -73004,7 +73117,7 @@ jnk
 jnk
 aJd
 aLN
-lDS
+tAB
 aNl
 aNl
 lrm
@@ -73208,42 +73321,42 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
-lSN
+tCr
+tCr
+tCr
+tCr
+mSB
 jnk
 jnk
-vxr
-kkY
+kAf
+sem
 jnk
 src
 jnk
-qLO
-qLO
+tCr
+tCr
 jnk
 jnk
-eGS
-eGS
-eGS
-eGS
-eGS
-qLO
-qLO
-qLO
-qLO
+ccr
+ccr
+ccr
+ccr
+ccr
+tCr
+tCr
+tCr
+tCr
 src
 jnk
-qZH
+jRh
 jnk
 jnk
 jnk
-kkY
+sem
 src
 jnk
 jnk
-uVG
+kYT
 jnk
 bkS
 bkS
@@ -73261,7 +73374,7 @@ uhx
 uhx
 uhx
 aLl
-lDS
+tAB
 aLE
 aPL
 ldi
@@ -73465,60 +73578,60 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
 src
-onI
+wSh
 jnk
-qZH
+jRh
 jnk
-acz
-tPl
+fWL
+gaK
 jnk
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
 src
-eGS
-eGS
-eGS
+ccr
+ccr
+ccr
 jnk
-qLO
-qLO
-qLO
-qLO
-qLO
-jcP
+tCr
+tCr
+tCr
+tCr
+tCr
+vOt
 jnk
 src
 jnk
 jnk
 jnk
 jnk
-kkY
+sem
 jnk
-uRd
+oCH
 jnk
 jnk
 bkS
-gsa
-tmE
-sUl
-raB
-wvy
-wvy
-wvy
-wvy
-wvy
-wvy
-wvy
-wvy
-wvy
-sOS
-odJ
-rfs
+pYA
+gaA
+ice
+pGa
+fob
+fob
+fob
+fob
+fob
+fob
+fob
+fob
+fob
+xoX
+hdc
+fTf
 aLE
 rBh
 ldi
@@ -73722,36 +73835,36 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
-lSN
+tCr
+tCr
+tCr
+tCr
+mSB
 jnk
 jnk
 jnk
 jnk
 jnk
 jnk
-qLO
-qLO
-qLO
-qLO
-kkY
+tCr
+tCr
+tCr
+tCr
+sem
 jnk
 jnk
 jnk
 jnk
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
 jnk
-kkY
+sem
 jnk
-qJD
+uiZ
 jnk
-uRd
+oCH
 jnk
 jnk
 src
@@ -73760,10 +73873,10 @@ pQy
 jnk
 jnk
 bkS
-jXk
-rms
+pQI
+fVT
 bkS
-aJF
+aBu
 uhx
 uhx
 uhx
@@ -73979,29 +74092,29 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
-fOS
-ntU
+tCr
+tCr
+tCr
+tCr
+lzZ
+oPc
 jnk
 jnk
 jnk
-fOS
+lzZ
 jnk
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
 jnk
 jnk
 jnk
@@ -74019,8 +74132,8 @@ jnk
 bkS
 lEr
 qkr
-nmE
-vjo
+lEY
+gOh
 uhx
 pMA
 ipg
@@ -74236,39 +74349,39 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
 jnk
-kkY
+sem
 src
 cwi
 jnk
 jnk
-hoT
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
-qLO
+ejf
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
+tCr
 jnk
-uVG
+kYT
 jnk
-tPl
+gaK
 jnk
-tPl
-jnk
-jnk
+gaK
 jnk
 jnk
-kkY
+jnk
+jnk
+sem
 jnk
 jnk
 jnk
@@ -74276,8 +74389,8 @@ jnk
 bkS
 puA
 wLd
-nmE
-pGm
+lEY
+dVH
 uhx
 oNp
 eLE
@@ -74493,48 +74606,48 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
-qZH
-onI
+tCr
+tCr
+tCr
+tCr
+jRh
+wSh
 jnk
 jnk
 jnk
 jnk
 jnk
-onI
-lKI
-qLO
-qLO
+wSh
+qqb
+tCr
+tCr
 src
 jnk
-uVG
+kYT
 jnk
 jnk
-kgP
+chd
 jnk
 jnk
 jnk
 jnk
 jnk
-jcP
+vOt
 src
-jcP
-src
-jnk
-qZH
+vOt
 src
 jnk
+jRh
+src
 jnk
 jnk
+jnk
 bkS
 bkS
 bkS
 bkS
 bkS
-aJF
+aBu
 uhx
 eLE
 tto
@@ -74750,10 +74863,10 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
 src
 jnk
 jnk
@@ -74762,17 +74875,17 @@ jnk
 jnk
 jnk
 jnk
-rZw
+bzb
 cwi
 src
 cwi
 jnk
-kkY
+sem
 src
-kkY
-kgP
+sem
+chd
 jnk
-fOS
+lzZ
 jnk
 pQy
 jnk
@@ -74791,7 +74904,7 @@ ihv
 pSJ
 bkS
 cOH
-aJF
+aBu
 uhx
 sYt
 eLE
@@ -74806,9 +74919,9 @@ aLN
 kGQ
 aLE
 oMA
-hGg
+ddd
 fNY
-kMf
+vdH
 qEX
 tju
 tXN
@@ -75007,48 +75120,48 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
 jnk
-jcP
-vxr
-jcP
+vOt
+kAf
+vOt
 jnk
-uVG
+kYT
 jnk
 jnk
-fTx
+djZ
 jnk
 jnk
 jnk
 src
 jnk
 jnk
-iBt
-kgP
+wxR
+chd
 jnk
 jnk
 jnk
-uRd
+oCH
 jnk
 jnk
 jnk
 jnk
 jnk
-fOS
+lzZ
 jnk
 jnk
 jnk
-wKq
+qFb
 jnk
 bkS
 aXv
 pSJ
 tmX
 qkr
-aJF
+aBu
 uhx
 het
 ipg
@@ -75264,27 +75377,27 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
-kkY
-fgj
-acz
+tCr
+tCr
+tCr
+tCr
+sem
+ylr
+fWL
 jnk
 jnk
-qLO
-qLO
+tCr
+tCr
 jnk
-rZw
-iBt
-jnk
-jnk
-qZH
+bzb
+wxR
 jnk
 jnk
-fOS
-kgP
+jRh
+jnk
+jnk
+lzZ
+chd
 jnk
 jnk
 jnk
@@ -75305,7 +75418,7 @@ dlp
 bkS
 bkS
 wOy
-aJF
+aBu
 uhx
 uhx
 uhx
@@ -75522,56 +75635,56 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
 jnk
 jnk
 src
-qLO
-qLO
-qLO
-qLO
-lKI
+tCr
+tCr
+tCr
+tCr
+qqb
 jnk
 jnk
 jnk
-tPl
-iBt
-uVG
+gaK
+wxR
+kYT
 jnk
-oWZ
-kgP
-kgP
-kgP
-kgP
-kgP
-kgP
-kgP
-kgP
-oWZ
-jFt
-jFt
-jFt
-oWZ
-uVG
+xjp
+chd
+chd
+chd
+chd
+chd
+chd
+chd
+chd
+xjp
+hPK
+hPK
+hPK
+xjp
+kYT
 jnk
 bkS
 bkS
 bkS
 hPN
 qkr
-orV
-jpP
-jpP
-jpP
-fWt
-fWt
-fWt
-fWL
-fWt
-dnD
+niU
+hPv
+hPv
+hPv
+dbC
+dbC
+dbC
+nzk
+dbC
+faa
 bkS
 nRt
 lUZ
@@ -75779,10 +75892,10 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
+tCr
 heo
 heo
 heo
@@ -75790,8 +75903,8 @@ heo
 heo
 heo
 heo
-kgP
-kgP
+chd
+chd
 jnk
 jnk
 src
@@ -75799,19 +75912,19 @@ jnk
 jnk
 jnk
 src
-sLP
-xwF
+ucc
+bQV
 src
-sLP
-xwF
+ucc
+bQV
 src
-sLP
-xwF
-bFH
-eGS
-eGS
-eGS
-kgP
+ucc
+bQV
+hgr
+ccr
+ccr
+ccr
+chd
 jnk
 jnk
 jnk
@@ -75820,18 +75933,18 @@ bkS
 bkS
 bkS
 bkS
-soS
+oxD
 wCC
-dvN
+mzV
 qkr
 ksN
 cBy
 kCj
 xXi
-vZg
-ioT
-twh
-gPM
+mVW
+vTC
+ghR
+nEu
 izp
 cpE
 bBi
@@ -76037,48 +76150,48 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
-qLO
+tCr
+tCr
+tCr
 heo
-cKO
-xpK
-voz
-gmu
-dux
+aGY
+rLH
+rJI
+qix
+iye
 heo
-gbH
-sLP
-kOM
-kOM
-bZT
-kOM
-kOM
-xwF
-wLx
-sWP
-yeS
+cQw
+ucc
+yfL
+yfL
+iTa
+yfL
+yfL
+bQV
+ulY
+wUp
+bEa
 src
-sWP
-yeS
+wUp
+bEa
 src
-sWP
-yeS
-bFH
-eGS
-eGS
-eGS
-kgP
+wUp
+bEa
+hgr
+ccr
+ccr
+ccr
+chd
 jnk
 jnk
 jnk
 jnk
-bFd
-qPC
-qPC
+luo
+eai
+eai
 suH
 suH
-oWj
+sID
 suH
 suH
 suH
@@ -76087,8 +76200,8 @@ sgN
 sgN
 sgN
 sgN
-eCt
-iBC
+wvW
+bUb
 aJq
 aLX
 aLX
@@ -76295,44 +76408,44 @@ gQb
 gQb
 gQb
 gQb
-qLO
-qLO
+tCr
+tCr
 heo
-ptf
-xOo
-xhV
-xOo
-xEs
-slk
+rEr
+cjp
+sSc
+cjp
+unF
+eam
 jnk
-qyE
-oSg
-oSg
-hqi
-oSg
-oSg
-ybT
-vxr
-sWP
-yeS
+ngG
+opn
+opn
+rym
+opn
+opn
+lCH
+kAf
+wUp
+bEa
 src
-sWP
-yeS
+wUp
+bEa
 src
-sWP
-yeS
-bFH
-eGS
-eGS
-eGS
-wrP
-wrP
-wrP
-wrP
-wrP
-wrP
-chn
-qPC
+wUp
+bEa
+hgr
+ccr
+ccr
+ccr
+tpr
+tpr
+tpr
+tpr
+tpr
+tpr
+ygw
+eai
 suH
 gJM
 uDP
@@ -76344,8 +76457,8 @@ jFb
 pvH
 lUB
 sgN
-wsN
-oqR
+vXB
+jcG
 oQH
 aJn
 aJn
@@ -76553,43 +76666,43 @@ gQb
 gQb
 gQb
 gQb
-qLO
+tCr
 heo
-tCV
-xOo
-xhV
-xOo
-xEs
-gAN
-gAN
-qdO
-qdO
-qdO
-gAN
-gAN
+lxM
+cjp
+sSc
+cjp
+unF
+eWs
+eWs
+fey
+fey
+fey
+eWs
+eWs
 aIF
 aIF
-oZC
-qyE
-ybT
-vxr
-qyE
-ybT
-vxr
-qyE
-ybT
-bFH
-eGS
-eGS
-eGS
-wrP
-qPC
-qPC
-qPC
-qPC
-iPC
-cdX
-fqh
+oww
+ngG
+lCH
+kAf
+ngG
+lCH
+kAf
+ngG
+lCH
+hgr
+ccr
+ccr
+ccr
+tpr
+eai
+eai
+eai
+eai
+eNZ
+avu
+hrO
 suH
 dhx
 uDP
@@ -76602,7 +76715,7 @@ mkd
 mkd
 sgN
 aLX
-oqR
+jcG
 aOE
 aJn
 jnk
@@ -76810,23 +76923,23 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 heo
-ptf
-xOo
-xhV
-xOo
-cIP
-ydd
-eRb
-iqi
-hyK
-aIz
-lmb
-gAN
-cXS
-kBy
-qpO
+rEr
+cjp
+sSc
+cjp
+mfV
+uKY
+koK
+vvE
+rwA
+kuN
+eUD
+eWs
+fQO
+uRR
+nye
 aIF
 aIF
 aIF
@@ -76835,18 +76948,18 @@ agn
 jnk
 jnk
 jnk
-bFH
-jRM
-jRM
-jRM
-wrP
-qPC
-qPC
-qPC
-qPC
-iPC
+hgr
+ezr
+ezr
+ezr
+tpr
+eai
+eai
+eai
+eai
+eNZ
 anw
-jXD
+xhe
 suH
 lTy
 uDP
@@ -76859,7 +76972,7 @@ fah
 txw
 dxt
 aJs
-oqR
+jcG
 aOE
 aJn
 jnk
@@ -77067,43 +77180,43 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 heo
-ueB
-xOo
-xhV
-xOo
-biU
-oWu
-eRb
-xuk
-hyK
-vYQ
-miI
-gAN
-gwy
-mcS
-qpO
-tPi
-phP
-nyg
-jWM
+gdf
+cjp
+sSc
+cjp
+sUo
+wqf
+koK
+sMD
+rwA
+lAT
+ljY
+eWs
+amq
+pOu
+nye
+sHG
+kja
+rsI
+nVT
 agn
 jnk
 jnk
 jnk
-bFH
-eGS
-eGS
-eGS
-wrP
-qPC
-qPC
-qPC
-qPC
-iPC
-lNR
-wJE
+hgr
+ccr
+ccr
+ccr
+tpr
+eai
+eai
+eai
+eai
+eNZ
+eOb
+hGp
 suH
 nJf
 uDP
@@ -77116,7 +77229,7 @@ dRN
 txw
 iGT
 aJs
-oqR
+jcG
 bJx
 aJn
 jnk
@@ -77324,43 +77437,43 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 heo
-xJy
-ahV
-rgX
-ifd
-teJ
-gAN
-udg
-ejE
-hyK
-qhe
-jpm
-uiD
-dGq
-dGq
-rld
-epx
-epx
-eSo
-fbC
+gSz
+fjH
+kcn
+cZn
+fpi
+eWs
+nqe
+gEn
+rwA
+ydH
+qlo
+pik
+ksL
+ksL
+iuW
+gxM
+gxM
+fGm
+upq
 agn
-hvk
-gzw
-jFt
-oWZ
-eGS
-eGS
-eGS
-cER
-qPC
-qPC
-qPC
-qPC
-iPC
-lNR
-nmt
+iwY
+vDe
+lSS
+xjp
+ccr
+ccr
+ccr
+iiU
+eai
+eai
+eai
+eai
+eNZ
+eOb
+prZ
 suH
 tHi
 uDP
@@ -77373,7 +77486,7 @@ dXm
 txw
 dxt
 nmW
-oqR
+jcG
 oQH
 aJn
 jnk
@@ -77581,43 +77694,43 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 heo
 nAY
 rkj
-wSi
+arF
 rkj
 nAY
-gAN
-lGS
-hyK
-hyK
-hyK
-hyK
-eQh
-jfb
-jfb
-gpK
+eWs
+uIv
+rwA
+rwA
+rwA
+rwA
+owt
+rbb
+rbb
+ltF
 agt
-epx
-ugZ
-jnY
+gxM
+jyG
+mdU
 aIF
-kNB
-pqV
-eGS
-eGS
-eGS
-eGS
-eGS
-cER
-qPC
-qPC
-qPC
-qPC
-iPC
-lNR
-jXD
+jZE
+vsP
+ccr
+ccr
+ccr
+ccr
+ccr
+iiU
+eai
+eai
+eai
+eai
+eNZ
+eOb
+xhe
 suH
 dJT
 uDP
@@ -77630,7 +77743,7 @@ mkd
 rYh
 sgN
 aJr
-oqR
+jcG
 aOE
 aJn
 jnk
@@ -77838,43 +77951,43 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 lLe
-fEY
-hTu
-nwr
-nwr
-pwJ
-gAN
-qOp
-vrk
-hyK
-rvz
-xzJ
-gAN
-gXp
-sMa
+fIs
+tat
+qPA
+qPA
+raP
+eWs
+wZV
+epY
+rwA
+bzO
+vmf
+eWs
+xCG
+pPy
 agn
-dWQ
-epx
-uoT
-eRS
+kgz
+gxM
+ppi
+ccj
 aIF
-rLV
-pqV
-eGS
-eGS
-eGS
-eGS
-eGS
-cER
-qPC
-qPC
-qPC
-qPC
-iPC
-lNR
-elf
+vfp
+vsP
+ccr
+ccr
+ccr
+ccr
+ccr
+iiU
+eai
+eai
+eai
+eai
+eNZ
+eOb
+hlF
 suH
 sjb
 uDP
@@ -77887,7 +78000,7 @@ xcv
 bLy
 sgN
 aGk
-oqR
+jcG
 aOE
 aJn
 jnk
@@ -78097,41 +78210,41 @@ gQb
 gQb
 lLe
 lLe
-vwd
-iKP
-iKP
-tXQ
-kJW
-gAN
-gAN
-jUn
-lQo
-ehp
-ekU
-gAN
-cnx
-cnx
+hjb
+xLd
+xLd
+cAV
+cQA
+eWs
+eWs
+pgX
+ecq
+kRB
+saG
+eWs
+pLu
+pLu
 agn
-nEI
-vAQ
-geQ
+tDg
+ksP
+wIN
 agn
 agn
-djN
-lyi
-eGS
-eGS
-eGS
-eGS
-eGS
-cER
-qPC
-qPC
-qPC
-qPC
-iPC
-nmv
-nIg
+ghD
+dbd
+ccr
+ccr
+ccr
+ccr
+ccr
+iiU
+eai
+eai
+eai
+eai
+eNZ
+soJ
+rhV
 suH
 iFo
 xCJ
@@ -78144,7 +78257,7 @@ sgN
 sgN
 sgN
 aJq
-oqR
+jcG
 aOE
 aJn
 jnk
@@ -78353,42 +78466,42 @@ gQb
 gQb
 gQb
 lLe
-nbv
-tXQ
-tOf
-iUy
-rBB
-stF
-qKk
-gAN
-gAN
-xcl
-xWl
-gAN
-gAN
-cnx
-cnx
+hTp
+cAV
+kEv
+nhR
+dzK
+lhq
+rhb
+eWs
+eWs
+ekC
+nRG
+eWs
+eWs
+pLu
+pLu
 agn
-fQc
-vLx
-ryV
+sWk
+ybm
+hSY
 aIF
-utQ
-gmK
-pqV
-eGS
-eGS
-eGS
-eGS
-eGS
-eey
-eey
-eey
-eey
-eey
-wrP
-uFC
-kSQ
+mvL
+iXS
+vsP
+dzi
+ccr
+ccr
+ccr
+ccr
+ulw
+ulw
+ulw
+ulw
+ulw
+tpr
+kwX
+rRh
 sgN
 oJX
 fmJ
@@ -78401,7 +78514,7 @@ dxt
 jnk
 aJn
 aLY
-hlW
+jEf
 awd
 rup
 rup
@@ -78610,42 +78723,42 @@ gQb
 gQb
 gQb
 lLe
-tYR
-iKP
-pBI
-pPc
-hbp
-irj
-aLH
-cNy
-usa
-nMC
-fof
-usa
-bHz
-jGf
-fQW
-otW
-qeq
-vLx
+cLn
+xLd
+qIB
+ttO
+gmG
+mEY
+ejk
+jHX
+gJt
+glR
+jiM
+gJt
+tPZ
+ctf
+ltL
+jks
+uxf
+ybm
 agQ
-tCd
-nbb
-gmK
-ukN
-hQb
-hQb
-hQb
-hQb
-hQb
-iOG
-dPm
-ePT
-aPb
-lvW
-slM
-nmv
-jXD
+rJw
+yjN
+iXS
+rgY
+wHk
+wHk
+wHk
+wHk
+wHk
+dmh
+kvl
+xdW
+gPb
+oXj
+cQi
+soJ
+xhe
 sgN
 bWc
 xkN
@@ -78658,7 +78771,7 @@ dxt
 jnk
 aJn
 aJq
-vTT
+ibT
 aOE
 gri
 eWw
@@ -78867,42 +78980,42 @@ gQb
 gQb
 gQb
 lLe
-nbv
-tXQ
-bfL
-tQv
-jsz
-qHQ
-kaw
-pWK
-gcj
-gcj
-gcj
-gcj
-gcj
-dcI
-qye
+hTp
+cAV
+wdp
+rUN
+kea
+dLM
+hHG
+pBo
+cxm
+cxm
+cxm
+cxm
+cxm
+gsV
+bUW
 aIF
 ahX
-vLx
-aJi
+ybm
+kGr
 aIF
-vwf
-wwh
-pqV
-eGS
-eGS
-eGS
-eGS
-eGS
-eey
-fNg
-jrH
-jrH
-blq
-hxA
-jAe
-fab
+rSp
+oJe
+vsP
+ccr
+ccr
+ccr
+ccr
+ccr
+ulw
+geA
+kPu
+kPu
+qmn
+mDb
+iQN
+scQ
 sgN
 mkd
 kmh
@@ -78915,7 +79028,7 @@ sgN
 aJn
 aJn
 aJq
-oqR
+jcG
 aOE
 eCl
 nXI
@@ -79125,40 +79238,40 @@ gQb
 gQb
 lLe
 lLe
-jzi
-tXQ
-iKP
-tXQ
-fPD
-lEb
-cNy
-cEM
-vQz
-joM
-hvW
-vQz
-bpQ
-xUk
+lku
+cAV
+xLd
+cAV
+oiN
+gqx
+jHX
+jgT
+jZV
+wbw
+cQc
+jZV
+waX
+svn
 agn
 aIF
-cZP
+erf
 aIF
 agn
-ycK
-vwb
-lyi
-eGS
-eGS
-eGS
-eGS
-eGS
-eey
-omG
-ubM
-eNk
-lvW
-oiY
-qkv
+kXP
+bCt
+dbd
+ccr
+ccr
+ccr
+ccr
+ccr
+ulw
+hYg
+flV
+fKT
+oXj
+wtc
+vlW
 aov
 sgN
 hDo
@@ -79172,7 +79285,7 @@ vCj
 aJp
 aKE
 aMa
-tJY
+dIY
 aOE
 eCl
 dWK
@@ -79380,42 +79493,42 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 lLe
-bYg
-lHu
-ebC
-gBE
-lJK
-tql
-tql
-tql
-tql
-tql
-tql
-tql
-scK
-iLa
-usa
-bmT
-vua
-sSh
-lyi
-fQy
-gDY
-lyi
-eGS
-eGS
-eGS
-eGS
-eGS
-eey
-udh
-iSG
-lvW
-eey
-bFd
-iVG
+aQu
+xaR
+qYK
+gUF
+tbT
+aal
+aal
+aal
+aal
+aal
+aal
+aal
+eRB
+pDu
+gJt
+gZx
+kXJ
+vgB
+dbd
+sTd
+bVI
+dbd
+vzw
+ccr
+ccr
+ccr
+ccr
+ulw
+eyj
+xWa
+oXj
+ulw
+luo
+lFT
 aov
 sgN
 sgN
@@ -79429,7 +79542,7 @@ sgN
 fBl
 fGw
 aLZ
-gvf
+yft
 oQH
 eCl
 oWr
@@ -79637,45 +79750,45 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 lLe
 lLe
-tmV
-tmV
-tmV
+fjw
+fjw
+fjw
 lLe
-tql
-qEZ
-rpD
-xAe
-xfZ
-kGZ
+aal
+gQG
+tiw
+mZM
+riX
+tGI
 gLf
-vga
-uCX
-omh
-ahv
-iYx
-xEA
-eFz
-cyh
-kqE
-tpZ
-lgW
-lgW
-lgW
-lgW
-lgW
-enZ
-xNO
-xNO
-xNO
-gAP
-wcJ
-qkv
-lBh
-hYb
-xSt
+tZo
+aUp
+rgs
+obH
+nYy
+qQY
+cyQ
+qVY
+hOl
+kqy
+diH
+diH
+diH
+diH
+diH
+wil
+few
+few
+few
+hCV
+gll
+vlW
+tPP
+mOm
+hay
 azZ
 azZ
 azZ
@@ -79686,7 +79799,7 @@ aHQ
 aJr
 aJq
 aMc
-iSl
+kCb
 aOE
 eCl
 dKW
@@ -79894,56 +80007,56 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 jnk
 jnk
 jnk
-edW
+ldu
 jnk
 src
 gLf
-fhK
-xTd
-aCs
-vzu
-cMK
-dHx
-iYx
-gCa
-wTq
-pyM
-iYx
-bCg
-pqV
-diK
-azr
-pqV
-wET
-wET
-wET
-wET
-wET
-pSW
-pmQ
-dYF
-pmQ
-pSW
+uBr
+lVf
+aUP
+rvX
+xWz
+tHE
+nYy
+pSa
+iWv
+tzf
+nYy
+sBs
+vsP
+oHl
+kvU
+vsP
+xVg
+xVg
+xVg
+xVg
+xVg
+pJM
+iiF
+xkm
+iiF
+pJM
 anz
-xkJ
-gdC
-imc
+sAM
+jxc
+bVb
 rUv
-hxA
-yaA
-hxA
-yaA
-hxA
-hxA
-oxY
+mDb
+fEb
+mDb
+fEb
+mDb
+mDb
+eum
 ppw
 ppw
-vwV
-gFp
+ule
+eDv
 aOE
 eCl
 igw
@@ -80151,56 +80264,56 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 jnk
 jnk
 jnk
-edW
+ldu
 jnk
 jnk
 gLf
-ipt
-eeC
-iXK
-gkn
-jRh
-tql
+cWw
+dfr
+lqh
+dZt
+urU
+aal
 tGb
 tGb
 tGb
-mkw
-hzb
-goR
-rIB
-gxY
-mTN
-lzS
-jex
-jex
-jex
-jex
-jex
-kDh
-diA
-xBj
-eUW
-vfP
-cXv
-sEl
-aHw
-ngU
-pjK
-oeo
-stw
-oeo
-oeo
-oeo
-oeo
-krU
-rss
+xtF
+eco
+omW
+waD
+gNu
+gjD
+lRQ
+jSC
+jSC
+jSC
+jSC
+jSC
+wXD
+pOl
+tff
+oFR
+tUj
+bLV
+sqz
+pmO
+rgQ
+iqU
+tYi
+xmq
+tYi
+tYi
+tYi
+tYi
+xDL
+cUl
 bmE
-tQE
-tuM
+vNN
+alo
 aOE
 eCl
 uzQ
@@ -80408,35 +80521,35 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 jnk
 jnk
 jnk
-lSN
-trs
-trs
+mSB
+qlM
+qlM
 gLf
 gLf
-fwi
-jkt
-kJo
-otv
-tql
-qNU
-lBj
-hCI
-nEd
-dbB
-fwJ
-lyi
-lyi
-lyi
-lyi
-eGS
-eGS
-eGS
-eGS
-eGS
+jxU
+hSV
+wNm
+tKT
+aal
+oxn
+qaJ
+cEm
+hqI
+xgJ
+oat
+dbd
+dbd
+dbd
+dbd
+ccr
+ccr
+ccr
+ccr
+ccr
 eMl
 eMl
 eMl
@@ -80457,7 +80570,7 @@ eMl
 nmW
 aJq
 aMd
-sJt
+qlG
 aOE
 eCl
 uvo
@@ -80665,36 +80778,36 @@ gQb
 gQb
 gQb
 gQb
-nau
+rjk
 jnk
 jnk
 jnk
-edW
+ldu
 jnk
 jnk
 jnk
 gLf
 gLf
 gLf
-tql
-tql
-tql
-kSJ
-eXS
-cgm
-vga
-dbB
-sRL
-vkD
-lkx
-sKU
-pqV
-eGS
-eGS
-eGS
-eGS
-eGS
-muv
+aal
+aal
+aal
+gQu
+hVq
+bhv
+tZo
+xgJ
+smg
+mZt
+lwe
+rYq
+vsP
+ccr
+ccr
+ccr
+ccr
+ccr
+lYH
 nim
 nim
 nim
@@ -80714,7 +80827,7 @@ vKP
 aJu
 aKF
 aMf
-lzk
+fBt
 aOE
 eCl
 nyY
@@ -80922,11 +81035,11 @@ gQb
 gQb
 gQb
 gQb
-kkY
-trs
-trs
-trs
-tPl
+sem
+qlM
+qlM
+qlM
+gaK
 jnk
 jnk
 jnk
@@ -80935,23 +81048,23 @@ jnk
 jnk
 gQb
 gQb
-uFe
-nme
-gaF
-fmk
-avh
-dbB
-eET
-pbX
-cLn
-rhu
-pqV
-eGS
-eGS
-eGS
-eGS
-eGS
-muv
+jaC
+lVl
+wsA
+qOB
+iQx
+xgJ
+cKX
+ixb
+oCu
+gfd
+vsP
+ccr
+ccr
+ccr
+ccr
+ccr
+lYH
 nim
 eMl
 eMl
@@ -81192,23 +81305,23 @@ gQb
 gQb
 gQb
 gQb
-uFe
-jBU
-gaF
-kPm
-vga
-bOA
-bHm
-dGy
-hFd
-qMb
-pqV
-eGS
-eGS
-eGS
-eGS
-eGS
-muv
+jaC
+wDg
+wsA
+hbP
+tZo
+kPA
+qDa
+vGC
+xUA
+jOU
+vsP
+ccr
+ccr
+ccr
+ccr
+ccr
+lYH
 nim
 eMl
 buo
@@ -81228,7 +81341,7 @@ jnk
 jnk
 aJn
 aJq
-leS
+sEX
 aOE
 eCl
 uTV
@@ -81449,22 +81562,22 @@ gQb
 gQb
 gQb
 gQb
-uFe
-vyp
-fzG
-ewM
-vga
-bOA
-sRL
-sxj
-tHU
-mad
-lyi
-eGS
-eGS
-eGS
-eGS
-eGS
+jaC
+hAC
+fDI
+lhi
+tZo
+kPA
+smg
+pQF
+ybo
+sMQ
+dbd
+ccr
+ccr
+ccr
+ccr
+ccr
 eMl
 nim
 eMl
@@ -81485,7 +81598,7 @@ jnk
 jnk
 aJn
 aLY
-pvg
+qNd
 oak
 rup
 rup
@@ -81706,22 +81819,22 @@ gQb
 gQb
 gQb
 gQb
-uFe
-uFe
-uFe
-uFe
-vga
-oRa
-tfO
-lyi
-lyi
-lyi
-lyi
-eGS
-eGS
-eGS
-eGS
-eGS
+jaC
+jaC
+jaC
+jaC
+tZo
+pNZ
+mxC
+dbd
+dbd
+dbd
+dbd
+ccr
+ccr
+ccr
+ccr
+ccr
 eMl
 nim
 eMl
@@ -81742,7 +81855,7 @@ aJw
 aJw
 aJw
 beX
-nBk
+giB
 aOE
 aJn
 jnk
@@ -81762,7 +81875,7 @@ jdv
 vnL
 olj
 jOT
-ezx
+csW
 uRa
 cUa
 mvr
@@ -81958,27 +82071,27 @@ jnk
 jnk
 jnk
 jnk
-kgP
+chd
 uXB
 uXB
 uXB
 aiV
 aiV
-xXx
-wdb
-vLW
-gcj
-udS
-umR
-pqV
+eCx
+auY
+rrN
+cxm
+wDG
+tpk
+vsP
 jnk
 jnk
 jnk
-eGS
-eGS
-eGS
-eGS
-eGS
+ccr
+ccr
+ccr
+ccr
+ccr
 eMl
 nim
 eMl
@@ -81999,7 +82112,7 @@ hTM
 lRr
 hhm
 aMg
-kcG
+uBV
 aOE
 aJn
 jnk
@@ -82220,22 +82333,22 @@ jnk
 jnk
 cwi
 aiV
-rAY
-aWu
-uBf
+ovR
+aTO
+pQq
 aiT
-wbn
-izs
-ocb
-pqV
+oEc
+mrB
+xBI
+vsP
 jnk
 jnk
 jnk
-eGS
-eGS
-eGS
-eGS
-eGS
+ccr
+ccr
+ccr
+ccr
+ccr
 eMl
 nim
 saX
@@ -82250,13 +82363,13 @@ cRN
 tHq
 pSI
 rVS
-ogQ
+ohm
 xdS
 opq
 aJy
 aJy
 aMj
-nBk
+giB
 oQH
 aJn
 jnk
@@ -82471,28 +82584,28 @@ jnk
 jnk
 jnk
 jnk
-dTw
+eiT
 jnk
 jnk
 jnk
-lZo
-fyy
-oYI
-peY
-aya
+oNv
+osp
+dIS
+mFs
+coC
 aiV
-lyi
-eOA
-lyi
-lyi
-uVG
+dbd
+llp
+dbd
+dbd
+kYT
 jnk
-eGS
-eGS
-eGS
-eGS
-eGS
-eGS
+ccr
+ccr
+ccr
+ccr
+ccr
+ccr
 eMl
 nim
 eMl
@@ -82734,21 +82847,21 @@ jnk
 jnk
 cwi
 aiV
-das
-peY
-aya
+thd
+mFs
+coC
 aiV
-mbw
-tjH
-swo
-pqV
+fOg
+gxG
+lBO
+vsP
 jnk
 jnk
-eGS
-eGS
-eGS
-eGS
-eGS
+ccr
+ccr
+ccr
+ccr
+ccr
 eMl
 eMl
 wCm
@@ -82991,23 +83104,23 @@ iDc
 iDc
 iDc
 iDc
-qcV
-ouv
-jcH
+clZ
+bEi
+hsr
 aiV
-vvs
-eCP
-nxE
-lyi
+mVP
+kkn
+hIX
+dbd
 jnk
-eGS
-eGS
-eGS
-eGS
-muv
-muv
+ccr
+ccr
+ccr
+ccr
+lYH
+lYH
 eMl
-lFN
+ouX
 nim
 eMl
 oZl
@@ -83243,28 +83356,28 @@ jnk
 jnk
 jnk
 jnk
-cGX
-nmr
-woC
-iiu
-uhW
-qcV
-mgj
-aya
-fqP
-wJL
-mZr
-adQ
-pqV
+wAy
+tSr
+mVX
+lfj
+pkx
+clZ
+bfL
+coC
+mXs
+kLW
+dli
+eGP
+vsP
 jnk
-eGS
-eGS
-eGS
-eGS
-muv
-ubV
-pSE
-boQ
+ccr
+ccr
+ccr
+ccr
+lYH
+rIg
+pXJ
+niQ
 nim
 eMl
 xHC
@@ -83500,28 +83613,28 @@ jnk
 jnk
 jnk
 jnk
-cGX
-rum
-rum
-oVW
-dHv
-dDv
-bdT
-aya
+wAy
+riQ
+riQ
+ssh
+cfJ
+kwM
+uxX
+coC
 aiV
-rHT
-giV
-qyB
-pqV
-eGS
-eGS
+sMW
+oJB
+nnW
+vsP
+ccr
+ccr
 eMl
 eMl
 eMl
 eMl
-tOn
-hzR
-veN
+pXA
+ygi
+pne
 nim
 eMl
 qpL
@@ -83757,28 +83870,28 @@ jnk
 jnk
 jnk
 jnk
-cGX
+wAy
 goK
 pvf
-rtp
-rPX
-qcV
-idE
-gQu
+nkl
+pIp
+clZ
+thf
+ykG
 aiV
-cfx
-pRf
-pqV
-pqV
-eGS
-eGS
+cxh
+bJy
+vsP
+vsP
+ccr
+ccr
 eMl
-jwI
+pyL
 bTn
 eMl
-ggs
-nhP
-lin
+jww
+wJi
+opB
 nim
 eMl
 hTM
@@ -84014,28 +84127,28 @@ jnk
 jnk
 jnk
 jnk
-cGX
+wAy
 xzg
-vgi
-kse
-rHe
-qcV
-uBX
-qtg
+pWH
+uDI
+sMf
+clZ
+vog
+qco
 aiV
-pqV
-pqV
-pqV
+vsP
+vsP
+vsP
 jnk
-eGS
+ccr
 jnk
 tpE
-jAH
+cim
 rpv
 eMl
-cVZ
-uqd
-asl
+cHy
+yjj
+dmO
 nim
 eMl
 vFB
@@ -84272,13 +84385,13 @@ jnk
 jnk
 aiV
 iDc
-qcV
-qcV
-qcV
-qcV
-qcV
+clZ
+clZ
+clZ
+clZ
+clZ
 aiT
-wbG
+oDU
 aiV
 jnk
 jnk
@@ -84287,13 +84400,13 @@ jnk
 jnk
 jnk
 tpE
-muv
-dQV
+lYH
+dLx
 eMl
 eMl
 eMl
 eMl
-lmF
+duK
 eMl
 svI
 bHH
@@ -84528,26 +84641,26 @@ gQb
 gQb
 gQb
 aiV
-ksV
-aIX
-mOK
-dqM
+mKU
+tiR
+uzT
+uyX
 aiT
-xqD
-xoh
-qdr
+nUU
+llR
+vhP
 aiV
 tpE
 tpE
 tpE
 jnk
 jnk
-fOS
+lzZ
 tpE
-jUY
+kEO
 nim
 wCm
-lmF
+duK
 eMl
 iZN
 nim
@@ -84785,26 +84898,26 @@ gQb
 gQb
 gQb
 aiV
-rNx
-qnZ
-sog
-vue
+jZI
+qtK
+jBv
+uAg
 aiT
-vry
-dKH
-vAf
-toX
-aSV
+hDH
+tlz
+voI
+mep
+dVP
 bTn
 tpE
 tpE
 tpE
 tpE
 tpE
-vnG
-lkR
-fUb
-lmF
+nLe
+eYS
+pUO
+duK
 eMl
 buZ
 lvU
@@ -85042,30 +85155,30 @@ gQb
 gQb
 gQb
 aiV
-nrh
-qnZ
-qnZ
-dZy
-lno
-smp
+tCq
+qtK
+qtK
+aBt
+nIH
+meL
 amb
-mcr
+czZ
 aiV
 eMl
 bTn
 vWE
 eMl
-kAS
+oEx
 dFE
 eMl
 eMl
 eMl
 eMl
-oDY
+tyl
 eMl
-xkz
+axh
 kHG
-dpT
+miB
 ycs
 gQI
 uBj
@@ -85299,19 +85412,19 @@ gQb
 gQb
 gQb
 aiV
-ydK
-vDt
-vDt
-sWQ
-izc
-lmi
-lmi
-vpq
-fbb
-ufC
+hBt
+cJZ
+cJZ
+mdp
+gER
+ruG
+ruG
+cLf
+vnV
+fbo
 jkL
 jkL
-dmF
+sgU
 jkL
 jkL
 jkL
@@ -85321,7 +85434,7 @@ jkL
 jkL
 jkL
 agR
-fFH
+dXj
 eMl
 gsx
 fOZ
@@ -85556,14 +85669,14 @@ gQb
 gQb
 gQb
 aiV
-wLO
-uEt
-umH
-rQO
-lKN
-ame
-wuW
-vZw
+wZx
+aCD
+bhP
+heR
+oBZ
+njs
+lMz
+bFe
 aiV
 bTn
 bTn
@@ -85571,14 +85684,14 @@ bTn
 bTn
 dRx
 bTn
-eho
+oJz
 bTn
 rpv
-nea
-xkz
-tgM
+cgL
+axh
+ncR
 rpv
-fHG
+vvl
 eMl
 lXa
 gmP
@@ -85813,13 +85926,13 @@ gQb
 gQb
 gQb
 aiV
-bTa
-kGb
-bTa
+viY
+nBY
+viY
 aiV
-bTa
-sFS
-bTa
+viY
+xtq
+viY
 aiV
 aiV
 tSM
@@ -86070,13 +86183,13 @@ gQb
 gQb
 gQb
 gQb
-bTa
-bEn
-bTa
+viY
+hKb
+viY
 jnk
-bTa
-bEn
-bTa
+viY
+hKb
+viY
 gQb
 gQb
 gQb
@@ -86327,13 +86440,13 @@ gQb
 gQb
 gQb
 gQb
-bTa
-xHz
-bTa
+viY
+ayc
+viY
 jnk
-bTa
-aEM
-bTa
+viY
+vea
+viY
 gQb
 gQb
 gQb
@@ -87617,7 +87730,7 @@ jnk
 jnk
 jnk
 jnk
-bYT
+sOS
 jnk
 jnk
 jnk
@@ -87748,7 +87861,7 @@ ctZ
 jnk
 jnk
 jnk
-bbO
+cJQ
 jnk
 gQb
 gQb
@@ -91346,7 +91459,7 @@ cuf
 jnk
 jnk
 jnk
-kgc
+oeM
 jnk
 gQb
 gQb

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -46,6 +46,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/medical/morgue)
+"ah" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "ai" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 1
@@ -94,19 +100,29 @@
 /turf/open/floor/plating,
 /area/cargo/drone_bay)
 "ar" = (
-/obj/structure/table/wood,
-/obj/item/trapdoor_remote/preloaded{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/gavelblock{
-	pixel_x = 5
-	},
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/structure/table/reinforced,
+/obj/structure/reagent_dispensers/servingdish,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "as" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
+/obj/machinery/button/door/directional/north{
+	id = "permainner";
+	name = "Inner Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	req_access_txt = "2";
+	specialfunctions = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "permaouter";
+	name = "Outer Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	req_access_txt = "2";
+	specialfunctions = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "at" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
@@ -133,8 +149,10 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "aw" = (
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/security/prison)
 "ax" = (
 /obj/structure/sign/poster/random/directional/north,
@@ -241,15 +259,19 @@
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
 "aP" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/rack,
+/obj/item/gun/energy/disabler{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Lower Hallway South"
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "aQ" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
@@ -367,24 +389,41 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"bo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "bq" = (
 /turf/closed/wall,
 /area/mine/production)
 "br" = (
-/obj/structure/table,
-/obj/item/electropack,
-/obj/item/screwdriver,
-/obj/item/wrench,
-/obj/item/clothing/head/helmet,
-/obj/item/assembly/signaler,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
 /obj/structure/cable,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
+/turf/open/floor/plating,
+/area/security/brig)
 "bs" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/structure/toilet/greyscale{
+	dir = 4;
+	cistern = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "bt" = (
 /obj/structure/sign/poster/official/here_for_your_safety{
 	pixel_x = 32
@@ -426,19 +465,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "bB" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/item/storage/box/evidence{
+	pixel_x = -10;
+	pixel_y = 12
 	},
-/obj/machinery/door/airlock/external{
-	name = "External Access"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "bC" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/brig)
 "bD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -487,15 +527,18 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"bL" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/camera/directional/south{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Cells"
-	},
-/turf/open/floor/iron/dark/side{
+"bK" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/edge,
+/area/security/prison)
+"bL" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/security/prison)
 "bN" = (
 /obj/structure/cable,
@@ -516,11 +559,21 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "bQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"bR" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/security/prison)
 "bS" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -551,9 +604,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "bX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "bY" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -590,18 +643,16 @@
 /turf/open/floor/iron/dark,
 /area/medical/chemistry)
 "cf" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"cg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/security/prison/safe)
+"cg" = (
+/obj/machinery/door/airlock{
+	name = "Cleaning Closet"
+	},
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "ch" = (
 /obj/structure/chair{
 	dir = 1
@@ -643,10 +694,16 @@
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
 "cm" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "cn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -664,13 +721,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/medical/morgue)
-"cp" = (
-/obj/structure/closet{
-	name = "Evidence Closet 2"
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/textured_edge,
-/area/security/brig)
 "cq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -704,18 +754,12 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cu" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/obj/item/cartridge/lawyer,
-/obj/machinery/computer/security/telescreen/prison{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "cv" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance";
@@ -738,11 +782,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"cx" = (
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "cy" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/cargo)
@@ -767,38 +806,32 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/chapel)
-"cE" = (
-/obj/machinery/flasher/directional/north{
-	id = "Cell 2"
-	},
-/obj/structure/bed{
-	dir = 1;
-	pixel_x = -2
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig)
 "cF" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Cafeteria"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/hallway/primary/central/fore)
 "cG" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/side,
-/area/security/prison)
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "cH" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 4"
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 3";
+	name = "Cell 3";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/security/brig)
 "cI" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -894,6 +927,14 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"cW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
 "cX" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -912,26 +953,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
-"cZ" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/brown{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/north{
-	id = "miningdorm_A";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -24;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/donk,
-/area/mine/production)
 "da" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -983,21 +1004,14 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "dh" = (
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"di" = (
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "dj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1058,23 +1072,24 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dp" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom";
-	req_access_txt = "42"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
 	},
-/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/prison)
+"dq" = (
+/obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/court,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"dq" = (
-/obj/machinery/vending/sustenance,
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
+"dr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/courtroom)
 "dt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -1111,22 +1126,15 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/wood/tile,
 /area/service/theater)
+"dz" = (
+/turf/closed/wall,
+/area/security/brig)
 "dA" = (
-/obj/structure/rack,
-/obj/item/storage/box/teargas{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "dB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -1244,9 +1252,11 @@
 /turf/closed/wall/r_wall,
 /area/mine/eva)
 "dQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Lower Brig Hallway"
+	},
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "dR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1277,8 +1287,15 @@
 /turf/open/floor/plating,
 /area/mine/production)
 "dW" = (
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/obj/machinery/camera/directional/north{
+	c_tag = "Courtroom North"
+	},
+/obj/item/radio/intercom/directional/north,
+/obj/structure/chair{
+	name = "Defense"
+	},
+/turf/open/floor/wood,
+/area/security/courtroom)
 "dX" = (
 /obj/structure/stairs/south,
 /obj/structure/railing{
@@ -1287,9 +1304,11 @@
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
 "dY" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "ea" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -1299,13 +1318,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/cargo/drone_bay)
-"eb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "ec" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/north,
@@ -1436,6 +1448,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"er" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/security/courtroom)
 "es" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -1444,22 +1460,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark/side,
 /area/service/chapel)
-"et" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/medical{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/virology)
 "eu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -1470,11 +1470,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "ev" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/carpet,
+/obj/structure/table/wood,
+/obj/machinery/computer/security/wooden_tv,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "ew" = (
 /obj/effect/turf_decal/siding/white{
@@ -1533,13 +1533,11 @@
 /turf/open/floor/plating,
 /area/service/chapel)
 "eA" = (
-/obj/structure/chair{
-	name = "Judge";
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plating,
+/area/hallway/primary/central/fore)
 "eB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -1565,20 +1563,17 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/service/chapel)
 "eE" = (
-/obj/machinery/holopad,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
+"eH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
-"eG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
-"eH" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/openspace/icemoon/keep_below,
-/area/security/execution/education)
 "eI" = (
 /obj/machinery/smartfridge/organ,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -1588,16 +1583,9 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
-"eK" = (
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
 "eL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "eM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -1608,20 +1596,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "eN" = (
-/turf/closed/wall,
-/area/service/lawoffice)
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "eO" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light/directional/east,
 /turf/open/floor/grass,
 /area/service/hydroponics)
-"eP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "eQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1648,8 +1631,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "eU" = (
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "eW" = (
 /obj/item/clothing/suit/hooded/wintercoat/science,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -1667,12 +1654,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
-"eZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
 "fa" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -1698,20 +1679,23 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"fd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "fe" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/effect/landmark/start/lawyer,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/hand_labeler{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "ff" = (
 /obj/structure/stairs/south,
 /obj/structure/disposalpipe/segment,
@@ -1755,11 +1739,12 @@
 /turf/open/floor/iron/dark,
 /area/cargo/drone_bay)
 "fk" = (
-/obj/machinery/computer/bookmanagement,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/hallway/primary/central/fore)
 "fl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1849,23 +1834,17 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "fy" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "fz" = (
-/obj/structure/closet{
-	name = "Evidence Closet 5"
-	},
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 1
-	},
-/area/security/brig)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "fA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -1874,11 +1853,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"fB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/execution/education)
 "fC" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
@@ -1901,16 +1875,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"fG" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
-"fH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
+"fF" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/prison)
+"fG" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "fI" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -1938,11 +1912,12 @@
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
 "fM" = (
-/obj/structure/chair/stool/directional/north,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plating,
+/area/security/courtroom)
 "fN" = (
 /obj/machinery/vending/dinnerware,
 /obj/structure/sign/poster/random/directional/east,
@@ -2002,10 +1977,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "fU" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/side{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permaouter";
+	name = "Permabrig Transfer"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-entrance"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/textured,
 /area/security/prison)
 "fV" = (
 /obj/structure/chair/comfy/brown{
@@ -2040,12 +2021,17 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/mine/storage)
 "fZ" = (
-/obj/structure/grille,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/obj/structure/closet{
+	name = "Evidence Closet 4"
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/security/brig)
 "ga" = (
-/turf/closed/wall,
-/area/security/courtroom)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
 "gb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -2123,14 +2109,16 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "gj" = (
-/turf/closed/wall,
-/area/ai_monitored/security/armory)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "gk" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/security/prison)
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "gl" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -2150,29 +2138,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"gn" = (
-/obj/structure/window/reinforced{
-	dir = 8
+"go" = (
+/turf/open/floor/plating,
+/area/security/prison/safe)
+"gp" = (
+/obj/machinery/button/door/directional/north{
+	id = "visitation";
+	name = "Visitation Shutters";
+	pixel_x = 6;
+	req_access_txt = "2";
+	pixel_y = -24
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/button/flasher{
+	id = "visitorflash";
+	pixel_x = -6;
+	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
-"go" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
-"gp" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/plating,
-/area/security/courtroom)
+/area/security/prison/visit)
 "gq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -2191,9 +2176,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/science/xenobiology)
-"gu" = (
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "gv" = (
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/misc/dirt{
@@ -2211,9 +2193,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/mine/mechbay)
-"gy" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/security/armory)
 "gz" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 1
@@ -2258,16 +2237,11 @@
 /turf/open/floor/stone,
 /area/service/bar)
 "gD" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/space_heater,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/maintenance/fore)
 "gE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -2280,14 +2254,20 @@
 /obj/item/storage/crayons,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
-"gG" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"gF" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/item/pen,
+/obj/machinery/camera/directional/south{
+	network = list("ss13","prison");
+	c_tag = "Security - Permabrig Recreation"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison)
 "gH" = (
 /obj/structure/sink{
 	dir = 4;
@@ -2393,21 +2373,23 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "gU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/small/directional/south,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "gV" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/hydroponics/soil,
+/obj/item/cultivator,
+/obj/machinery/camera/directional/west{
+	c_tag = "Prison Forestry";
+	network = list("ss13","prison")
 	},
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/turf/open/floor/grass,
+/area/security/prison)
 "gW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -2447,8 +2429,19 @@
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
 "ha" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "hb" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -2537,12 +2530,28 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "hl" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/stamp/law,
+/obj/machinery/camera/directional/south{
+	c_tag = "Service - Law Office"
 	},
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 17
+	},
+/obj/machinery/requests_console/directional/south{
+	department = "Law Office";
+	name = "Law Office Requests Console"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "hm" = (
 /obj/machinery/button/elevator{
 	id = "publicElevator";
@@ -2559,17 +2568,8 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"ho" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "hp" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/textured,
 /area/security/prison)
 "hq" = (
 /obj/machinery/duct,
@@ -2580,13 +2580,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "hr" = (
-/obj/structure/closet{
-	name = "Evidence Closet 4"
-	},
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 1
-	},
-/area/security/brig)
+/turf/closed/wall/r_wall,
+/area/icemoon/underground/unexplored/rivers)
 "hs" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -2625,31 +2620,22 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "hy" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/prison)
 "hz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permainner";
+	name = "Permabrig Transfer"
 	},
-/obj/machinery/door/airlock{
-	name = "Law Office"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-entrance"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
 "hA" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -2720,9 +2706,15 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "hI" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
-/area/security/prison/safe)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "hJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2845,15 +2837,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/hallway/secondary/service)
 "hX" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Courtroom North"
-	},
-/obj/item/radio/intercom/directional/north,
-/obj/structure/chair{
-	name = "Defense"
-	},
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "hY" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -2885,6 +2872,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/mine/storage)
+"id" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/visit)
 "if" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -2916,19 +2908,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "ii" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/security/prison)
 "ij" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison)
 "ik" = (
 /obj/machinery/light/dim/directional/east,
 /obj/structure/table,
@@ -2989,10 +2976,12 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "iq" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/railing/corner,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "ir" = (
 /obj/structure/cable,
 /obj/structure/closet,
@@ -3016,19 +3005,22 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "it" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "lawyer_blast";
-	name = "privacy door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/service/lawoffice)
+/area/security/prison/safe)
 "iu" = (
-/obj/machinery/shower{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	name = "External Access"
 	},
-/turf/open/floor/iron/freezer,
-/area/security/prison)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "iv" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/grille,
@@ -3077,17 +3069,11 @@
 	},
 /area/service/hydroponics)
 "iE" = (
-/obj/structure/rack,
-/obj/item/clothing/glasses/sunglasses/big{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/clothing/glasses/sunglasses/big{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "iF" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -3099,16 +3085,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "iG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
-"iH" = (
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/obj/item/soap/nanotrasen,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron,
 /area/security/prison)
 "iI" = (
 /obj/structure/marker_beacon/burgundy{
@@ -3171,13 +3148,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/medical/morgue)
-"iQ" = (
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
 "iR" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -3212,6 +3182,16 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"iV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
+"iW" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "iX" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -3220,15 +3200,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/mine/storage)
-"iY" = (
-/obj/structure/closet{
-	name = "Evidence Closet 3"
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Lower Brig Evidence"
-	},
-/turf/open/floor/iron/dark/textured_edge,
-/area/security/brig)
 "iZ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -3291,24 +3262,14 @@
 	},
 /area/maintenance/aft/lesser)
 "jf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/stool/directional/west,
 /obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
-"jg" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/security/prison)
+"jg" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/openspace/icemoon/keep_below,
+/area/security/execution/education)
 "jh" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
@@ -3326,10 +3287,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "jj" = (
-/obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/door/airlock/security{
+	name = "Cell Block"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "jl" = (
 /obj/machinery/iv_drip,
@@ -3339,18 +3304,14 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "jm" = (
-/obj/structure/railing,
+/obj/machinery/vending/cigarette,
+/obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "jn" = (
 /turf/closed/wall/r_wall,
 /area/cargo/drone_bay)
-"jp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/beach_ball/holoball,
-/turf/open/floor/iron,
-/area/security/prison)
 "jq" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white/side{
@@ -3373,6 +3334,12 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/cargo/warehouse)
+"ju" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "jv" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -3387,13 +3354,15 @@
 /turf/closed/wall/ice,
 /area/mine/storage)
 "jy" = (
-/obj/structure/chair{
-	name = "Judge";
-	dir = 8
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/security/prison)
 "jz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -3415,13 +3384,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "jB" = (
-/obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/hooded/ablative,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/ai_monitored/security/armory)
 "jC" = (
@@ -3451,12 +3414,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"jH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
 "jJ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -3482,11 +3439,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "jN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/turf/open/floor/iron,
+/area/security/prison)
 "jO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -3494,10 +3451,8 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "jP" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 29
-	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -3521,27 +3476,17 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "jS" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/corner,
+/obj/machinery/hydroponics/soil,
+/obj/item/cultivator,
+/turf/open/floor/grass,
 /area/security/prison)
 "jT" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
-"jV" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/machinery/camera/directional/south{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Recreation"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
 /area/security/prison)
+"jV" = (
+/turf/open/floor/iron,
+/area/security/courtroom)
 "jW" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -3573,29 +3518,22 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
+"jZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ka" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
+/obj/machinery/flasher/directional/north{
+	id = "Cell 1"
 	},
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
-"kc" = (
-/obj/machinery/button/flasher{
-	id = "executionflash";
-	pixel_x = -24;
-	pixel_y = 5
+/obj/structure/bed{
+	dir = 1;
+	pixel_x = -2
 	},
-/obj/machinery/button/door/directional/west{
-	id = "executionfireblast";
-	name = "Transfer Area Lockdown";
-	pixel_y = -6;
-	req_access_txt = "2"
-	},
-/obj/structure/railing,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "kd" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet,
@@ -3648,11 +3586,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "kk" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "kl" = (
@@ -3675,14 +3612,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "kn" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/item/radio/intercom/prison/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/computer/warrant{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "kp" = (
 /obj/structure/bonfire,
 /obj/item/melee/roastingstick,
@@ -3695,28 +3631,16 @@
 	},
 /area/maintenance/aft/lesser)
 "kr" = (
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "ks" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Brig Lower Hallway North";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/light/small/directional/west,
+/mob/living/simple_animal/mouse/brown/tom,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "kt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -3756,12 +3680,12 @@
 	},
 /area/maintenance/department/medical/morgue)
 "kx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "ky" = (
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -3780,6 +3704,12 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"kB" = (
+/obj/structure/chair/stool/directional/north,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "kC" = (
 /obj/structure/marker_beacon/burgundy,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -3808,6 +3738,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"kG" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Courtroom";
+	req_access_txt = "42"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/court,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "kH" = (
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plating,
@@ -3848,13 +3790,24 @@
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
 "kN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "kO" = (
-/turf/closed/wall/r_wall,
-/area/security/prison/safe)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "kP" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/carpet,
@@ -3872,6 +3825,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"kS" = (
+/turf/open/floor/iron/white,
+/area/security/prison)
 "kT" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -3907,12 +3863,15 @@
 	},
 /area/mine/eva)
 "kW" = (
-/obj/structure/chair{
-	name = "Defense"
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
 	},
-/obj/effect/landmark/start/lawyer,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Permabrig Forestry"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "kX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3947,11 +3906,12 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "la" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/visit)
 "lb" = (
 /obj/structure/fluff/tram_rail{
 	pixel_y = 17
@@ -3961,35 +3921,18 @@
 /area/icemoon/underground/explored)
 "lc" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
+/obj/item/gun/energy/laser{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
 	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/ai_monitored/security/armory)
 "ld" = (
@@ -3998,10 +3941,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "le" = (
-/obj/machinery/light/small/directional/east,
 /obj/structure/cable,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "lf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4015,15 +3959,10 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "lh" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "li" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -4037,10 +3976,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "lj" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "ll" = (
 /obj/structure/railing{
@@ -4063,6 +4004,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/eva)
+"lo" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "lp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4147,16 +4106,23 @@
 /turf/open/floor/iron,
 /area/mine/eva)
 "lz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "lA" = (
 /obj/structure/closet/decay,
 /turf/open/floor/plating,
@@ -4191,19 +4157,19 @@
 	},
 /area/maintenance/aft/lesser)
 "lF" = (
-/obj/structure/sign/poster/official/safety_report{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison/visit)
-"lG" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/side,
 /area/security/prison)
+"lG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "lH" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -4220,14 +4186,9 @@
 	},
 /area/maintenance/department/chapel)
 "lJ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/prison)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "lK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/light/small/directional/south,
@@ -4249,6 +4210,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"lM" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "lN" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -4259,8 +4226,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "lO" = (
-/obj/structure/filingcabinet/employment,
-/turf/open/floor/wood,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plating,
 /area/service/lawoffice)
 "lP" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -4292,13 +4261,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"lT" = (
-/obj/item/radio/intercom/prison/directional/north,
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "lU" = (
 /obj/item/stack/sheet/animalhide/lizard{
 	desc = "Landssslidessss, the landssslidesss...";
@@ -4336,12 +4298,13 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "lZ" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Detective's Office"
+	},
+/obj/machinery/computer/secure_data,
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "ma" = (
 /turf/open/floor/circuit,
 /area/mine/living_quarters)
@@ -4351,12 +4314,27 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"mc" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "md" = (
 /obj/structure/ladder,
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
 /area/maintenance/aft/lesser)
+"me" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "mf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -4380,11 +4358,11 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/aft/lesser)
 "mk" = (
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "ml" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -4400,23 +4378,19 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "mo" = (
-/obj/machinery/door/poddoor{
-	id = "executionfireblast"
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
+/obj/machinery/light/directional/north,
+/obj/structure/bed{
 	dir = 4
 	},
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
-"mp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/item/bedsheet/medical{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "mq" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4462,24 +4436,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "mx" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
-"my" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "mz" = (
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "mA" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -4506,9 +4473,12 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "mD" = (
-/obj/item/food/fried_chicken,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/maintenance/fore)
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/execution/education)
 "mE" = (
 /obj/structure/stairs/west,
 /obj/effect/turf_decal/siding/white{
@@ -4536,11 +4506,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/mine/storage)
-"mI" = (
-/obj/machinery/vending/cola/red,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "mJ" = (
 /obj/structure/cable,
 /turf/open/floor/iron/chapel{
@@ -4742,8 +4707,9 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "nm" = (
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "nn" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -4876,23 +4842,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "nE" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	dir = 8;
-	name = "old sink";
-	pixel_x = 12
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/security/prison)
 "nF" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "nG" = (
 /obj/structure/sign/warning{
 	pixel_y = 32
@@ -4905,16 +4863,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/hallway/secondary/service)
 "nH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/chair/office{
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/open/floor/iron/dark/textured_large,
+/area/security/brig)
 "nI" = (
 /obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/plating,
@@ -4923,14 +4877,12 @@
 /turf/closed/wall,
 /area/service/hydroponics)
 "nK" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/machinery/camera/directional/west{
-	c_tag = "Prison Forestry";
-	network = list("ss13","prison")
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/grass,
-/area/security/prison)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "nL" = (
 /obj/machinery/telecomms/relay/preset/mining,
 /turf/open/floor/circuit,
@@ -4939,9 +4891,12 @@
 /turf/closed/wall,
 /area/mine/mechbay)
 "nN" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/security/prison)
 "nO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner,
@@ -4961,12 +4916,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/grimy,
 /area/commons/lounge)
-"nQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "nS" = (
 /obj/structure/closet/crate/secure/freezer/pizza,
 /obj/effect/decal/cleanable/dirt,
@@ -4983,13 +4932,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"nW" = (
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "nX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
@@ -4998,14 +4940,14 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "nZ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/security/brig,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "oa" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 4
@@ -5042,9 +4984,8 @@
 	},
 /area/mine/eva)
 "od" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/textured,
-/area/security/prison)
+/turf/open/floor/wood,
+/area/security/courtroom)
 "oe" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -5104,6 +5045,11 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plating,
 /area/mine/eva)
+"ol" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/execution/education)
 "om" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -5151,12 +5097,9 @@
 /turf/open/floor/plating,
 /area/mine/eva)
 "os" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -5200,12 +5143,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "oz" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/plating,
-/area/security/courtroom)
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "oA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5220,13 +5160,8 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "oB" = (
-/obj/structure/rack,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
-/obj/machinery/light/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/turf/closed/wall/r_wall,
+/area/security/courtroom)
 "oC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5257,19 +5192,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "oG" = (
-/obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
-/obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/turf/open/floor/iron/edge,
+/area/security/prison)
 "oH" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -5281,9 +5208,8 @@
 /area/service/theater)
 "oI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "oJ" = (
 /obj/structure/sign/poster/official/report_crimes,
 /turf/closed/wall/ice,
@@ -5297,6 +5223,11 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/stone,
 /area/commons/lounge)
+"oL" = (
+/obj/structure/railing,
+/obj/structure/cable,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "oN" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 5
@@ -5315,14 +5246,10 @@
 	},
 /area/mine/living_quarters)
 "oO" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Forestry"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/secure_closet/detective,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "oP" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -5331,9 +5258,32 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "oQ" = (
-/obj/structure/chair/stool/directional/south,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_y = 8;
+	req_access_txt = "2";
+	pixel_x = 5
+	},
+/obj/machinery/button/door{
+	id = "Trial Transfer";
+	name = "Trial Transfer Lockdown";
+	pixel_y = 8;
+	req_access_txt = "2";
+	pixel_x = -7
+	},
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_y = -3;
+	pixel_x = -7
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "oR" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -5430,14 +5380,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"pe" = (
+/obj/machinery/firealarm/directional/south,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "pg" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/computer/warrant{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory)
 "ph" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
@@ -5515,14 +5466,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"po" = (
-/turf/open/openspace/icemoon/keep_below,
-/area/security/execution/education)
 "pp" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/dice,
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
+"pq" = (
+/turf/closed/wall,
+/area/security/courtroom)
 "pr" = (
 /turf/closed/wall,
 /area/maintenance/fore)
@@ -5546,10 +5497,21 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
+"pv" = (
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "pw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "px" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
@@ -5569,10 +5531,7 @@
 /turf/open/floor/iron/smooth_edge,
 /area/medical/chemistry)
 "pB" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/structure/cable,
-/obj/item/instrument/harmonica,
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "pC" = (
@@ -5583,13 +5542,16 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "pD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/brig)
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "pE" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/glass{
@@ -5604,16 +5566,16 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/edge,
+/area/security/prison)
+"pH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/fore)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "pI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/engine,
@@ -5632,11 +5594,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "pL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/brig)
+/turf/closed/wall,
+/area/security/prison)
 "pM" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/camera{
@@ -5661,16 +5620,16 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "pQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
-"pR" = (
-/obj/structure/table,
-/obj/item/storage/dice,
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_y = 32
+	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/visit)
+"pR" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "pT" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -5718,16 +5677,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "pZ" = (
-/obj/structure/closet/secure_closet/courtroom,
-/obj/item/gavelhammer,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron,
-/area/security/courtroom)
-"qa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "qb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -5767,7 +5721,7 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/mine/storage)
 "qg" = (
-/obj/structure/cable/multilayer/multiz,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "qh" = (
@@ -5829,6 +5783,9 @@
 /obj/effect/landmark/start/mime,
 /turf/open/floor/wood/tile,
 /area/service/theater)
+"qn" = (
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "qo" = (
 /obj/machinery/button/crematorium{
 	id = "crematoriumChapel";
@@ -5856,11 +5813,10 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "qr" = (
-/obj/structure/closet/secure_closet/evidence,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 1
-	},
-/area/security/brig)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "qs" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy{
@@ -5880,6 +5836,16 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"qv" = (
+/obj/machinery/flasher/directional/north{
+	id = "transferflash"
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
 "qw" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -5917,11 +5883,9 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "qA" = (
-/obj/machinery/door/airlock{
-	name = "Cleaning Closet"
-	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "qB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5959,13 +5923,19 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"qF" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/textured,
+/area/security/prison)
 "qG" = (
-/obj/structure/closet/secure_closet/detective,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Lower Brig Cells";
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
-"qH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured,
 /area/security/brig)
 "qJ" = (
@@ -5983,12 +5953,12 @@
 /turf/open/floor/carpet,
 /area/service/chapel)
 "qM" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/detectives_office)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "qN" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -5998,38 +5968,22 @@
 /turf/open/floor/iron/smooth_large,
 /area/cargo/warehouse)
 "qO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/plating,
-/area/service/lawoffice)
+/area/maintenance/fore)
 "qP" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/item/radio/intercom/prison/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "qQ" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 1
@@ -6120,10 +6074,15 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "qZ" = (
+/obj/machinery/light_switch/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/courtroom)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "rb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -6144,6 +6103,10 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics)
+"re" = (
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "rf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -6154,9 +6117,14 @@
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "rg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/structure/closet{
+	name = "Evidence Closet 3"
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Lower Brig Evidence"
+	},
+/turf/open/floor/iron/dark/textured_edge,
+/area/security/brig)
 "rh" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -6237,16 +6205,21 @@
 /turf/open/floor/iron/dark/corner,
 /area/mine/eva)
 "rq" = (
-/obj/machinery/flasher/directional/east{
-	id = "executionflash"
-	},
-/turf/open/openspace/icemoon/keep_below,
-/area/security/execution/education)
+/obj/machinery/light/directional/south,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "rr" = (
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
 /area/service/chapel)
+"rs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
 "rt" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/blue{
@@ -6264,10 +6237,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"ru" = (
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron,
-/area/security/prison/visit)
 "rv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/light/directional/south,
@@ -6281,9 +6250,9 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
 "rx" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/shovel/spade,
-/turf/open/floor/grass,
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "ry" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -6381,39 +6350,6 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"rI" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Courtroom Audience"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
-"rJ" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/stamp/law,
-/obj/machinery/camera/directional/south{
-	c_tag = "Service - Law Office"
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 17
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Law Office";
-	name = "Law Office Requests Console"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "rK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/plating,
@@ -6506,11 +6442,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "rW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
+/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/courtroom)
 "rX" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -6526,25 +6462,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"rZ" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "sa" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -6610,10 +6527,13 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "sj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/machinery/door/poddoor/preopen{
+	id = "lawyer_blast";
+	name = "privacy door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/service/lawoffice)
 "sk" = (
 /obj/structure/fireplace,
 /turf/open/floor/plating,
@@ -6635,16 +6555,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "sn" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/left/directional/north,
-/obj/machinery/door/window/left/directional/south,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/machinery/light/small/directional/east,
+/turf/open/openspace/icemoon/keep_below,
+/area/security/execution/education)
 "so" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
@@ -6658,20 +6571,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
-"sq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/fore)
-"sr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron/corner{
-	dir = 1
-	},
-/area/security/prison)
 "ss" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -6679,21 +6578,31 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/chemistry)
 "su" = (
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison)
-"sv" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/pen/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Lower Hallway South"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
+"sv" = (
+/obj/structure/bed/maint,
+/obj/item/toy/plush/rouny{
+	name = "Therapy Dog";
+	desc = "What is this? Is this a dog?"
+	},
+/obj/structure/cable,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Isolation Cell";
+	network = list("ss13","prison","Isolation");
+	view_range = 5
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/security/prison/safe)
 "sx" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6705,10 +6614,15 @@
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "sy" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/turf/open/floor/grass,
-/area/security/prison)
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "sz" = (
 /obj/structure/railing{
 	dir = 9
@@ -6750,13 +6664,6 @@
 	dir = 4
 	},
 /area/mine/production)
-"sD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "sE" = (
 /obj/machinery/space_heater,
 /obj/structure/disposalpipe/segment{
@@ -6785,9 +6692,10 @@
 /turf/open/floor/plating,
 /area/commons/dorms/laundry)
 "sK" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/firealarm/directional/east,
-/obj/structure/cable,
+/obj/structure/sign/poster/official/here_for_your_safety{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "sL" = (
@@ -6857,6 +6765,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"sW" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "sX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -6954,15 +6867,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "ti" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
+/obj/machinery/button/door/directional/east{
+	id = "lawyer_blast";
+	name = "Privacy Shutters"
 	},
-/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "tk" = (
 /obj/machinery/duct,
 /obj/machinery/holopad,
@@ -6979,12 +6892,23 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "tm" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/camera/emp_proof/directional/south,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms/laundry)
+"tn" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "to" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
@@ -7027,14 +6951,12 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "tu" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light/directional/east,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/turf/open/floor/plating,
+/area/security/prison)
 "tv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -7042,24 +6964,29 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "tw" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permaouter";
-	name = "Permabrig Transfer"
+/obj/structure/bed{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "perma-entrance"
+/obj/item/bedsheet/brown{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
+/obj/machinery/button/door/directional/north{
+	id = "miningdorm_B";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = 23;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/stellar,
+/area/mine/production)
 "tx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/execution/education)
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron,
+/area/security/prison)
 "ty" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
@@ -7094,6 +7021,9 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"tE" = (
+/turf/closed/wall,
+/area/ai_monitored/security/armory)
 "tF" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 1
@@ -7106,11 +7036,6 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
-"tH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
 "tJ" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/closet{
@@ -7129,12 +7054,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "tM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/structure/rack,
+/obj/item/clothing/glasses/sunglasses/big{
+	pixel_x = 4;
+	pixel_y = 8
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/item/clothing/glasses/sunglasses/big{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "tN" = (
 /obj/structure/chair{
 	dir = 8
@@ -7197,28 +7127,20 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"tU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/corner{
-	dir = 8
-	},
-/area/security/prison)
 "tV" = (
-/obj/machinery/button/door/directional/east{
-	name = "Privacy Shutters"s;
-	id = "kanyewest"
-	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "tW" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/fore)
 "tX" = (
 /obj/machinery/light/dim/directional/north,
@@ -7230,22 +7152,42 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "tY" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2";
+/obj/structure/rack,
+/obj/item/storage/box/teargas{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half{
-	dir = 1
-	},
-/area/security/brig)
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "tZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/obj/structure/table,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/clothing/suit/hooded/wintercoat{
+	pixel_x = -5
+	},
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_x = 5
+	},
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_x = 5
+	},
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_x = 5
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "ua" = (
 /obj/effect/landmark/start/chaplain,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7286,23 +7228,14 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"ug" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "uh" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "ui" = (
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/dark/textured_edge,
-/area/security/brig)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "uj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -7339,43 +7272,50 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
-"un" = (
-/obj/structure/grille/broken,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"up" = (
-/obj/item/radio/intercom/prison/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig)
-"uq" = (
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/photo_album/prison,
-/obj/item/camera,
+"uo" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
+/area/security/courtroom)
+"up" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/camera/directional/south{
+	network = list("ss13","prison");
+	c_tag = "Security - Permabrig Cells"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
+"uq" = (
+/obj/structure/chair{
+	name = "Judge";
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "ur" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/iron/freezer,
 /area/science/xenobiology)
-"ut" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Permabrig Workshop";
-	network = list("ss13","prison")
+"us" = (
+/obj/machinery/flasher/directional/north{
+	id = "Cell 2"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/structure/bed{
+	dir = 1;
+	pixel_x = -2
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig)
+"ut" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "uu" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -7442,20 +7382,21 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "uB" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "uC" = (
-/obj/machinery/shower{
-	dir = 1
+/obj/structure/closet{
+	name = "Evidence Closet 2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured_edge,
+/area/security/brig)
 "uD" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -7494,11 +7435,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
-"uH" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "uI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7506,12 +7442,21 @@
 /turf/open/floor/iron,
 /area/mine/eva)
 "uJ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/edge,
-/area/security/prison)
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "uK" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -7534,6 +7479,16 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
+"uM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
+"uN" = (
+/turf/closed/wall,
+/area/security/execution/education)
 "uO" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /obj/effect/decal/cleanable/dirt,
@@ -7562,12 +7517,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "uR" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/plating,
-/area/security/courtroom)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
 "uS" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/tile/brown,
@@ -7610,16 +7564,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "va" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Wing"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/obj/structure/grille/broken,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "vb" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/table/wood,
@@ -7647,6 +7594,12 @@
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"ve" = (
+/obj/item/storage/briefcase,
+/obj/structure/rack,
+/obj/item/camera/detective,
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "vf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/gambling,
@@ -7655,9 +7608,9 @@
 /turf/open/floor/iron/grimy,
 /area/commons/lounge)
 "vg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "vh" = (
 /obj/structure/sign/departments/cargo,
 /turf/closed/wall/r_wall,
@@ -7686,23 +7639,9 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "vn" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/landmark/start/prisoner,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "vo" = (
 /obj/item/flashlight/lantern{
 	light_on = 1
@@ -7710,28 +7649,19 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "vp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/closed/wall,
+/area/security/prison/safe)
 "vq" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/shower{
+	pixel_y = 12
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "vr" = (
-/obj/machinery/vending/cola/sodie,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "vs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -7794,13 +7724,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "vB" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Sec - Permabrig Exercise";
-	network = ssssssssssssss
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/security/prison)
 "vC" = (
 /turf/closed/wall/r_wall,
@@ -7824,34 +7751,32 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"vG" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/security/prison)
 "vH" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
-"vI" = (
-/obj/machinery/flasher/directional/north{
-	id = "Cell 1"
-	},
-/obj/structure/bed{
-	dir = 1;
-	pixel_x = -2
-	},
+/obj/structure/table,
+/obj/item/clothing/gloves/color/orange,
+/obj/item/restraints/handcuffs,
+/obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/iron/smooth,
-/area/security/brig)
+/area/security/prison)
+"vI" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "vJ" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Cafeteria"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron,
 /area/security/prison)
 "vK" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -7859,19 +7784,8 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "vL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/detective,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "vN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -7893,12 +7807,11 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
 "vR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/turf/open/floor/iron,
 /area/security/prison)
 "vS" = (
 /obj/item/radio/intercom/directional/south,
@@ -7922,8 +7835,11 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "vU" = (
-/turf/closed/wall/r_wall,
-/area/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "vW" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -7979,12 +7895,11 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "wd" = (
-/obj/machinery/recharger,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red/half,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/item/razor,
+/obj/item/storage/backpack/duffelbag/sec/surgery,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "we" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -8048,7 +7963,12 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wn" = (
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "wo" = (
 /obj/structure/chair/wood{
@@ -8074,16 +7994,12 @@
 /turf/closed/wall/ice,
 /area/mine/living_quarters)
 "wr" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Lower Brig Cells";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/item/radio/intercom/prison/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "ws" = (
 /obj/machinery/mineral/processing_unit{
 	dir = 1
@@ -8147,12 +8063,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "wD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/corner,
 /area/security/prison)
 "wE" = (
 /obj/effect/turf_decal/tile/bar{
@@ -8174,6 +8086,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"wG" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "wI" = (
 /obj/structure/railing,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -8218,13 +8135,28 @@
 /turf/open/floor/iron,
 /area/service/chapel)
 "wO" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/turf/open/floor/wood,
-/area/security/courtroom)
-"wP" = (
-/turf/closed/wall/r_wall,
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	dir = 8;
+	name = "old sink";
+	pixel_x = 12
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/security/prison)
+"wP" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 2";
+	name = "Cell 2";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/security/brig)
 "wQ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/xeno_mining{
@@ -8255,20 +8187,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "wV" = (
-/obj/machinery/door/airlock/security{
-	name = "Permabrig Visitation"
+/turf/open/floor/iron/dark/side{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison/visit)
+/area/security/prison)
 "wW" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/light_switch/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/table,
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "wX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -8300,11 +8227,9 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "xb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
-/area/security/prison/visit)
+/area/security/prison)
 "xc" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -8343,13 +8268,10 @@
 	},
 /area/mine/living_quarters)
 "xi" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron/textured,
 /area/security/brig)
 "xj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8369,14 +8291,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plating,
 /area/medical/virology)
-"xm" = (
-/obj/structure/toilet/greyscale,
-/obj/machinery/airalarm/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half{
-	dir = 1
-	},
-/area/security/prison/safe)
 "xn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -8384,16 +8298,10 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "xo" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/fore)
-"xp" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "xq" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -8416,16 +8324,13 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "xs" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Evidence Storage";
-	req_one_access_txt = "1;4"
+/obj/machinery/door/airlock/maintenance{
+	name = "Permabrig Maintenance"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "xt" = (
 /obj/structure/table,
 /obj/item/scalpel{
@@ -8455,8 +8360,17 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "xx" = (
-/turf/closed/wall/r_wall,
-/area/service/lawoffice)
+/obj/machinery/door/poddoor{
+	id = "executionfireblast"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "xy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -8482,6 +8396,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"xD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/visit)
 "xE" = (
 /obj/machinery/food_cart,
 /obj/machinery/light/directional/south,
@@ -8491,11 +8412,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "xF" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "xG" = (
 /obj/machinery/door/airlock/external{
@@ -8513,6 +8433,11 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/aft/lesser)
+"xI" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "xJ" = (
 /obj/structure/table,
 /obj/item/stock_parts/scanning_module{
@@ -8535,13 +8460,15 @@
 /turf/open/floor/iron/dark,
 /area/cargo/drone_bay)
 "xL" = (
-/obj/item/radio/intercom/prison/directional/south,
+/obj/machinery/door/airlock/security{
+	name = "Permanent Cell 5"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
-"xN" = (
+/turf/open/floor/iron,
+/area/security/prison/safe)
+"xM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -8550,6 +8477,11 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/security/prison)
+"xO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
 /area/security/prison)
 "xP" = (
@@ -8571,15 +8503,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"xS" = (
+"xT" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
+/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/wood,
-/area/service/lawoffice)
+/area/security/courtroom)
 "xW" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -8621,14 +8549,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "yc" = (
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "yd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/iron,
+/area/security/prison)
 "ye" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8648,32 +8579,20 @@
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "yg" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "Prison Gate";
-	name = "Prison Wing Lockdown";
-	pixel_y = 8;
-	req_access_txt = "2";
-	pixel_x = 5
+/obj/machinery/button/flasher{
+	id = "executionflash";
+	pixel_x = -24;
+	pixel_y = 5
 	},
-/obj/machinery/button/door{
-	id = "Trial Transfer";
-	name = "Trial Transfer Lockdown";
-	pixel_y = 8;
-	req_access_txt = "2";
-	pixel_x = -7
+/obj/machinery/button/door/directional/west{
+	id = "executionfireblast";
+	name = "Transfer Area Lockdown";
+	pixel_y = -6;
+	req_access_txt = "2"
 	},
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_y = -3;
-	pixel_x = -7
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/structure/railing,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "yh" = (
 /obj/structure/sign/warning/gasmask{
 	pixel_y = -32
@@ -8682,25 +8601,35 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "yi" = (
-/obj/structure/chair/stool/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "yj" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "yk" = (
-/obj/item/storage/briefcase,
-/obj/structure/rack,
-/obj/item/camera/detective,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Wing"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "yl" = (
-/obj/machinery/light/small/directional/west,
-/mob/living/simple_animal/mouse/brown/tom,
+/obj/machinery/plate_press,
 /turf/open/floor/plating,
-/area/security/prison/safe)
+/area/security/prison)
 "ym" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -8713,6 +8642,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"yn" = (
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/right/directional/north,
+/obj/machinery/door/window/right/directional/south,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "yo" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/blue{
@@ -8725,20 +8665,17 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "yp" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "yq" = (
-/obj/structure/stairs/east,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ys" = (
 /obj/structure/railing{
 	dir = 10
@@ -8763,22 +8700,11 @@
 	},
 /area/service/chapel)
 "yu" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin/carbon{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/shower{
+	dir = 1
 	},
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_x = 9;
-	pixel_y = 7
-	},
-/obj/item/hand_labeler{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "yw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/north,
@@ -8800,24 +8726,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/greater)
-"yA" = (
-/obj/structure/table,
-/obj/item/storage/box/prisoner{
-	pixel_y = 8
-	},
-/obj/item/storage/box/prisoner,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
-"yB" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permainner";
-	name = "Permabrig Transfer"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "perma-entrance"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
 "yC" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -8846,16 +8754,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/lobby)
-"yI" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"yG" = (
+/obj/structure/chair/stool/directional/east,
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison)
+"yH" = (
+/obj/structure/toilet/greyscale,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/security/prison/safe)
 "yJ" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -8884,20 +8795,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "yN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/prison/safe)
 "yO" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/engineering/lobby)
-"yP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "yQ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -8936,6 +8841,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
+"yW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "yX" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -8947,8 +8856,10 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "yY" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/textured,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/brig)
 "yZ" = (
 /obj/structure/window/reinforced{
@@ -9000,15 +8911,10 @@
 	dir = 1
 	},
 /area/service/hydroponics)
-"zh" = (
-/obj/machinery/light_switch/directional/south,
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/landmark/start/detective,
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+"zg" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/icemoon/underground/explored)
 "zi" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9019,12 +8925,13 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "zk" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/security/prison/visit)
+"zl" = (
+/obj/structure/closet/secure_closet/evidence,
+/turf/open/floor/iron/dark/textured_edge,
+/area/security/brig)
 "zm" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm_A";
@@ -9036,9 +8943,13 @@
 	},
 /area/mine/production)
 "zn" = (
-/obj/effect/spawner/random/entertainment/arcade,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/door/airlock/public/glass{
+	name = "Courtroom"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "zo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/event_spawn,
@@ -9056,12 +8967,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/medical/virology)
-"zq" = (
-/obj/item/instrument/harmonica,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/grass,
-/area/security/prison/safe)
 "zs" = (
 /obj/structure/window/reinforced,
 /obj/machinery/light/directional/west,
@@ -9150,44 +9055,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "zC" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/knife/plastic,
-/obj/item/knife/plastic,
-/obj/item/knife/plastic,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Sec - Permabrig Cafe";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
-"zD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "zE" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/box,
@@ -9276,15 +9147,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "zQ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Trial Transfer"
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 30
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/textured,
-/area/security/courtroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "zR" = (
 /obj/effect/decal/cleanable/oil,
 /obj/item/stack/ore/glass,
@@ -9304,20 +9178,15 @@
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
-"zV" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/trapdoor_placer,
-/turf/open/floor/glass/reinforced,
-/area/security/courtroom)
 "zW" = (
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "zY" = (
 /obj/effect/turf_decal/siding/wood/end,
 /obj/structure/bookcase/random/fiction,
@@ -9349,13 +9218,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"Ae" = (
-/turf/open/floor/iron,
-/area/security/prison)
 "Af" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"Ag" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "Ah" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
@@ -9370,9 +9240,10 @@
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
 "Aj" = (
+/obj/machinery/vending/cola/sodie,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "Ak" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -9443,13 +9314,12 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "Au" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Permabrig Maintenance"
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "Av" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -9510,22 +9380,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plating,
 /area/cargo/warehouse)
-"AC" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
 "AD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -9533,10 +9387,15 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "AE" = (
-/turf/open/floor/iron/dark/side{
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/area/security/prison)
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "AF" = (
 /turf/closed/wall,
 /area/mine/storage)
@@ -9545,12 +9404,11 @@
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "AH" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "AI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -9563,13 +9421,25 @@
 /turf/closed/wall,
 /area/service/chapel)
 "AK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 1
+/obj/structure/table,
+/obj/item/taperecorder{
+	pixel_x = -3
 	},
-/area/security/prison)
+/obj/item/folder/red{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/assembly/flash,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
+"AL" = (
+/obj/structure/chair{
+	name = "Judge";
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "AN" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -9582,24 +9452,12 @@
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
 "AP" = (
-/obj/structure/toilet/greyscale{
-	dir = 4;
-	cistern = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "AQ" = (
 /turf/open/floor/iron/dark,
 /area/service/chapel)
@@ -9611,10 +9469,9 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "AS" = (
-/obj/machinery/light/directional/south,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/security/courtroom)
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/security/prison/safe)
 "AT" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/tile/blue{
@@ -9689,15 +9546,16 @@
 /turf/closed/wall,
 /area/maintenance/department/cargo)
 "Be" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
 	},
-/obj/structure/cable,
-/obj/machinery/door/window/brigdoor/right/directional/east{
-	req_access_txt = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/left/directional/north,
+/obj/machinery/door/window/left/directional/south,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "Bf" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
@@ -9812,11 +9670,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "By" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "Bz" = (
 /obj/structure/chair/pew{
@@ -9866,15 +9721,19 @@
 /turf/open/floor/iron/dark/side,
 /area/mine/eva)
 "BF" = (
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	name = "Cell 1";
+	pixel_x = -32
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "prison blast door"
+	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
-"BG" = (
-/turf/closed/wall/r_wall,
-/area/icemoon/underground/unexplored/rivers)
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "BH" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -9887,12 +9746,13 @@
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "BK" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/chair/office{
+	dir = 8
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/effect/landmark/start/lawyer,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "BM" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -9936,23 +9796,26 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "BS" = (
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
-/area/security/prison/visit)
+/area/hallway/primary/central/fore)
 "BT" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/visit)
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "BU" = (
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "BV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "BW" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -9961,12 +9824,25 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "BX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
+/obj/structure/rack,
+/obj/item/storage/box/rubbershot{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "BY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -10020,26 +9896,16 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "Cf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/structure/sign/poster/official/obey,
+/turf/closed/wall/r_wall,
+/area/security/prison/visit)
 "Cg" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plating,
+/area/security/courtroom)
 "Ch" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
@@ -10076,25 +9942,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"Cm" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
 "Cn" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -10110,13 +9957,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"Cp" = (
-/obj/structure/sign/poster/official/here_for_your_safety{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison/visit)
 "Cq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -10124,9 +9964,24 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/maintenance/department/chapel)
 "Cr" = (
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating,
+/area/service/lawoffice)
+"Cs" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Brig Lower Hallway North";
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Ct" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10208,13 +10063,32 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"CE" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+"CD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/side,
-/area/security/prison)
+/turf/open/floor/wood,
+/area/service/lawoffice)
+"CE" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "CF" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -10224,10 +10098,14 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "CI" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/machinery/light_switch/directional/south,
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/landmark/start/detective,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "CJ" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -10252,6 +10130,17 @@
 	dir = 8
 	},
 /area/mine/living_quarters)
+"CM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "CN" = (
 /obj/structure/table,
 /obj/effect/landmark/event_spawn,
@@ -10358,22 +10247,39 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "CY" = (
-/turf/closed/wall,
-/area/hallway/primary/central/fore)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "Da" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "Db" = (
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Common Room"
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "Dc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -10390,6 +10296,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"De" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "Dg" = (
 /turf/closed/wall,
 /area/service/bar)
@@ -10458,8 +10368,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "Dp" = (
-/obj/machinery/plate_press,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/security/prison)
 "Dq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10469,18 +10380,20 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "Dr" = (
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "Ds" = (
-/turf/open/floor/iron/dark/side{
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 1";
+	name = "Cell 1";
 	dir = 8
 	},
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/security/brig)
 "Dt" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 4;
@@ -10494,11 +10407,10 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "Du" = (
-/obj/structure/table,
-/obj/item/razor,
-/obj/item/storage/backpack/duffelbag/sec/surgery,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore)
 "Dv" = (
 /obj/structure/railing{
 	dir = 9
@@ -10506,12 +10418,14 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "Dw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/machinery/light/small/directional/south,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "Dx" = (
 /obj/structure/railing{
 	dir = 10
@@ -10532,16 +10446,22 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "DA" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 7;
+	pixel_y = 12
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/item/taperecorder{
+	pixel_x = -5
 	},
-/obj/structure/chair/stool/directional/west,
-/obj/machinery/camera/emp_proof/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/commons/dorms/laundry)
+/obj/item/lighter{
+	pixel_x = 8;
+	pixel_y = -9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "DB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/newscaster/directional/south,
@@ -10613,18 +10533,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"DJ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half,
+/area/security/prison)
 "DK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_x = -32
 	},
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
-"DN" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/edge,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured,
+/area/security/brig)
+"DM" = (
+/obj/structure/stairs/east,
+/turf/open/floor/plating,
+/area/security/brig)
 "DO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -10645,10 +10571,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/department/medical/morgue)
 "DQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "DR" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -10685,6 +10611,14 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"DX" = (
+/obj/structure/closet{
+	name = "Evidence Closet 5"
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/security/brig)
 "Ea" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -10776,9 +10710,13 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "En" = (
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/machinery/door/airlock/security{
+	id_tag = "IsolationCell";
+	name = "Isolation Cell"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/smooth,
+/area/security/prison/safe)
 "Eo" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -10795,40 +10733,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"Eq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig)
 "Er" = (
-/obj/structure/toilet/greyscale{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
-"Es" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Armory - Internal - Lower"
+/obj/machinery/door/window/brigdoor/right/directional/east{
+	req_access_txt = "3"
 	},
-/obj/structure/rack,
-/obj/item/storage/toolbox/drone,
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
+"Es" = (
+/obj/structure/closet{
+	name = "Evidence Closet 6"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/security/brig)
 "Et" = (
 /turf/closed/mineral/random/snow,
 /area/icemoon/underground/explored)
@@ -10850,11 +10773,12 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "Ex" = (
-/obj/machinery/firealarm/directional/south,
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/iron,
-/area/security/courtroom)
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "Ez" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -10873,17 +10797,16 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "EC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "ED" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/plant_analyzer,
-/turf/open/floor/grass,
-/area/security/prison)
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/unexplored)
 "EE" = (
 /obj/machinery/icecream_vat,
 /obj/structure/sign/poster/random/directional/east,
@@ -10916,21 +10839,25 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "EI" = (
-/turf/closed/wall/r_wall,
-/area/security/detectives_office)
+/obj/structure/table,
+/obj/item/food/energybar,
+/turf/open/floor/iron,
+/area/security/prison)
 "EJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "EK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"EL" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/security/prison/visit)
 "EM" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -10962,11 +10889,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"EQ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "ER" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -10985,17 +10907,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/storage)
-"ES" = (
-/obj/structure/closet/secure_closet/evidence,
-/turf/open/floor/iron/dark/textured_edge,
-/area/security/brig)
 "ET" = (
 /turf/closed/wall,
 /area/cargo/storage)
 "EU" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "EX" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
@@ -11073,6 +10993,12 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
+"Ff" = (
+/obj/item/instrument/harmonica,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "Fg" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -11087,49 +11013,47 @@
 	},
 /area/mine/eva)
 "Fh" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
+/obj/machinery/door/airlock/security{
+	name = "Permanent Cell 2"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig)
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "Fi" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Fj" = (
-/obj/machinery/door/airlock/security{
-	name = "Cell Block"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/crate,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/onion,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "Fk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "Fl" = (
-/obj/structure/bed,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/bed{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/item/bedsheet/medical{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/obj/item/storage/secure/safe/directional/south,
+/obj/effect/turf_decal/tile/green/full,
+/turf/open/floor/iron/dark/smooth_large,
+/area/medical/virology)
 "Fm" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -11137,15 +11061,6 @@
 "Fo" = (
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
-"Fp" = (
-/obj/machinery/flasher/directional/north{
-	id = "visitorflash"
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Visitation North"
-	},
-/turf/open/floor/iron,
-/area/security/prison/visit)
 "Fq" = (
 /turf/closed/wall/mineral/wood,
 /area/maintenance/aft/lesser)
@@ -11168,23 +11083,23 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
 "Ft" = (
-/obj/machinery/button/door/directional/north{
-	id = "permainner";
-	name = "Inner Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -6;
-	req_access_txt = "2";
-	specialfunctions = 4
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/machinery/button/door/directional/north{
-	id = "permaouter";
-	name = "Outer Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 6;
-	req_access_txt = "2";
-	specialfunctions = 4
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
 	},
-/turf/open/floor/iron/smooth,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "Fu" = (
 /obj/structure/fence,
@@ -11197,16 +11112,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Fw" = (
-/obj/effect/spawner/random/contraband/prison,
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/structure/window/reinforced{
+/obj/structure/rack,
+/obj/item/gun/energy/ionrifle,
+/obj/item/gun/energy/temperature/security,
+/obj/item/clothing/suit/hooded/ablative,
+/obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/security/prison)
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "Fx" = (
 /obj/structure/cable,
 /obj/item/wrench,
@@ -11224,13 +11138,17 @@
 /obj/structure/flora/grass/green,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"FB" = (
-/obj/machinery/door/airlock{
-	name = "Permabrig Showers"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"FA" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
+"FC" = (
+/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron,
 /area/security/prison)
 "FD" = (
 /obj/structure/chair/plastic{
@@ -11280,44 +11198,44 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "FH" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "FJ" = (
-/obj/machinery/newscaster/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/seeds/onion,
+/obj/item/seeds/garlic,
+/obj/item/seeds/potato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/carrot,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/effect/spawner/random/contraband/prison,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "FK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "FL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/mine/production)
 "FM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "FN" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 8
@@ -11325,25 +11243,25 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "FO" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"FP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"FQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/area/security/courtroom)
+"FP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
+"FQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "FR" = (
 /turf/closed/mineral/random/snow/high_chance,
 /area/icemoon/underground/explored)
@@ -11360,13 +11278,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"FW" = (
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "FX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"FY" = (
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "FZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -11381,16 +11303,9 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "Gb" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bottle/ammonia,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/security/prison)
 "Gc" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -11577,18 +11492,14 @@
 /turf/open/openspace/icemoon/keep_below,
 /area/maintenance/department/medical/morgue)
 "Gw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/obj/machinery/light/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "Gx" = (
 /turf/closed/wall,
-/area/security/execution/education)
-"Gy" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
-/area/security/prison)
+/area/hallway/primary/central/fore)
 "Gz" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -11647,15 +11558,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "GG" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Permabrig Forestry"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/visit)
 "GH" = (
 /obj/structure/stairs/east,
 /obj/structure/railing{
@@ -11664,8 +11570,11 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "GI" = (
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "GJ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -11695,21 +11604,14 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "GP" = (
-/obj/structure/bed/maint,
-/obj/item/toy/plush/rouny{
-	name = "Therapy Dog";
-	desc = "What is this? Is this a dog?"
+/obj/structure/chair{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Isolation Cell";
-	network = list("ss13","prison","Isolation");
-	view_range = 5
-	},
-/turf/open/floor/iron/smooth_half{
-	dir = 1
-	},
-/area/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "GR" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -11765,6 +11667,19 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"GX" = (
+/obj/structure/table,
+/obj/item/storage/box/hug{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/razor{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "GZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/north,
@@ -11801,10 +11716,9 @@
 /turf/open/floor/iron/textured,
 /area/mine/mechbay)
 "Hh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/brig)
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Hi" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -11849,11 +11763,12 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "Hm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/item/radio/intercom/prison/directional/north,
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "Hn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11927,19 +11842,15 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "Ht" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_half,
 /area/security/prison)
 "Hu" = (
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_y = 32
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "Hv" = (
 /turf/closed/wall/r_wall,
 /area/mine/storage)
@@ -11982,18 +11893,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"HB" = (
-/obj/structure/table,
-/obj/item/taperecorder{
-	pixel_x = -3
-	},
-/obj/item/folder/red{
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/spray/pepper,
-/obj/item/assembly/flash,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
 "HC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/corner{
@@ -12042,20 +11941,10 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"HI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/visit)
 "HJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/detectives_office)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "HK" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/xeno_mining{
@@ -12091,29 +11980,17 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "HN" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/unexplored)
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "HO" = (
-/obj/structure/rack,
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "HP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12192,13 +12069,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"HZ" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/orange,
-/obj/item/restraints/handcuffs,
-/obj/item/reagent_containers/spray/pepper,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
 "Ib" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/tank/air{
@@ -12234,14 +12104,14 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "Ie" = (
-/obj/machinery/button/flasher{
-	id = "transferflash";
-	pixel_x = 23;
-	pixel_y = 9
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Permabrig Workshop";
+	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/smooth,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "If" = (
 /obj/machinery/duct,
@@ -12262,11 +12132,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"Ij" = (
-/obj/item/storage/bag/trash,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "Ik" = (
 /obj/structure/chair{
 	dir = 4
@@ -12284,6 +12149,39 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/mine/eva)
+"Im" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/red/half,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "In" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -12316,6 +12214,27 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"Iq" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/pen/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/lawoffice)
+"Ir" = (
+/obj/structure/closet/secure_closet/evidence,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/security/brig)
+"Is" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "It" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -12353,9 +12272,19 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "Iy" = (
-/obj/structure/flora/grass/green,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/unexplored)
+/obj/machinery/door/airlock/security{
+	name = "Permabrig Visitation"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison/visit)
+"Iz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "IA" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -12404,6 +12333,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"IH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron/corner{
+	dir = 8
+	},
+/area/security/prison)
 "II" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -12421,16 +12358,13 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "IK" = (
-/obj/structure/bed{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/item/bedsheet/medical{
-	dir = 4
-	},
-/obj/item/storage/secure/safe/directional/south,
-/obj/effect/turf_decal/tile/green/full,
-/turf/open/floor/iron/dark/smooth_large,
-/area/medical/virology)
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/brig)
 "IL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -12466,13 +12400,8 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "IP" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Detective's Office"
-	},
-/obj/machinery/computer/secure_data,
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/turf/open/openspace/icemoon/keep_below,
+/area/security/execution/education)
 "IQ" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Base";
@@ -12501,8 +12430,14 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "IT" = (
-/turf/closed/wall,
-/area/security/prison/safe)
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "IU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12523,8 +12458,9 @@
 /turf/open/floor/iron,
 /area/mine/eva)
 "IX" = (
-/turf/closed/wall,
-/area/security/prison/visit)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "IY" = (
 /obj/structure/ladder{
 	name = "upper dispenser access"
@@ -12588,14 +12524,32 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"Jf" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 29
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Jg" = (
 /obj/effect/turf_decal/siding/brown,
 /obj/structure/chair/office,
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "Jh" = (
-/turf/closed/wall/r_wall,
-/area/icemoon/underground/explored)
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/trash/sosjerky,
+/obj/item/trash/boritos,
+/obj/item/trash/can,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "Ji" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
@@ -12615,8 +12569,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Jm" = (
-/turf/open/floor/iron,
-/area/security/courtroom)
+/turf/closed/wall/r_wall,
+/area/hallway/primary/central/fore)
 "Jn" = (
 /obj/structure/table,
 /obj/item/radio/intercom/directional/east,
@@ -12634,18 +12588,12 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"Jp" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
 "Jq" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
+/obj/machinery/newscaster/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison)
 "Jr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -12673,6 +12621,9 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
+"Jv" = (
+/turf/closed/wall/r_wall,
+/area/security/detectives_office)
 "Jw" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 4;
@@ -12721,12 +12672,12 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "JD" = (
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/trash/chips,
+/obj/item/trash/candy,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "JE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12780,12 +12731,16 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "JK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
+/obj/machinery/door/airlock/security/glass{
+	name = "Evidence Storage";
+	req_one_access_txt = "1;4"
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/brig)
 "JL" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -12801,14 +12756,12 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "JO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/table,
+/obj/item/storage/box/prisoner{
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
+/obj/item/storage/box/prisoner,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "JP" = (
 /obj/structure/window/reinforced,
@@ -12844,12 +12797,6 @@
 	},
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
-"JV" = (
-/obj/structure/disposalpipe/trunk/multiz{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "JW" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -12866,12 +12813,12 @@
 	},
 /area/mine/living_quarters)
 "JY" = (
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "JZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12916,11 +12863,19 @@
 	},
 /area/maintenance/department/medical/morgue)
 "Kg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/detective,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "Kh" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
@@ -12930,21 +12885,26 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "Ki" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/rack,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/machinery/button/door{
+	id = "Trial Transfer";
+	name = "Trial Transfer Lockdown";
+	pixel_y = -23;
+	req_access_txt = "2";
+	pixel_x = -7
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/security/brig)
 "Kk" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/plating,
-/area/service/lawoffice)
-"Kl" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/directional/south,
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison/visit)
 "Km" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12963,16 +12923,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"Ko" = (
-/obj/machinery/flasher/directional/north{
-	id = "Cell 3"
-	},
-/obj/structure/bed{
-	dir = 1;
-	pixel_x = -2
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig)
 "Kp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east,
@@ -12983,25 +12933,21 @@
 /turf/closed/wall/r_wall,
 /area/mine/eva)
 "Kr" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/right/directional/north,
-/obj/machinery/door/window/right/directional/south,
-/turf/open/floor/iron,
-/area/security/prison/visit)
-"Ks" = (
-/obj/structure/closet{
-	name = "Evidence Closet 6"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured_edge{
+/obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/area/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
+"Ks" = (
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "Ku" = (
 /obj/effect/turf_decal/siding/brown/corner,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -13059,15 +13005,14 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/medical/morgue)
 "KC" = (
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_x = -32
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "KD" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
@@ -13108,25 +13053,8 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "KJ" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/turf/closed/wall/r_wall,
+/area/security/prison/safe)
 "KL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13138,22 +13066,11 @@
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "KM" = (
-/obj/machinery/button/door/directional/north{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = 6;
-	req_access_txt = "2";
-	pixel_y = -24
-	},
-/obj/machinery/button/flasher{
-	id = "visitorflash";
-	pixel_x = -6;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "KN" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -13184,17 +13101,16 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "KQ" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Prisoner Transfer Centre"
+/obj/structure/chair{
+	name = "Judge";
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/obj/machinery/camera/directional/east{
+	c_tag = "Courtroom"
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "KR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13261,18 +13177,14 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "KY" = (
-/obj/structure/table,
-/obj/item/storage/box/hug{
-	pixel_x = 4;
-	pixel_y = 3
+/obj/machinery/camera/directional/north{
+	c_tag = "Armory - Internal - Lower"
 	},
-/obj/item/razor{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/obj/structure/rack,
+/obj/item/storage/toolbox/drone,
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "KZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13315,9 +13227,8 @@
 	},
 /area/mine/living_quarters)
 "Lf" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/icemoon/underground/explored)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "Lg" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -13402,21 +13313,23 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Lo" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "prison blast door"
 	},
-/area/maintenance/fore)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "Lp" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "Lq" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/courtroom)
+/area/security/prison)
 "Lr" = (
 /obj/structure/chair/pew{
 	dir = 1
@@ -13437,8 +13350,21 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "Lu" = (
-/turf/open/floor/iron/smooth_half,
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/obj/item/soap/nanotrasen,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
+"Lv" = (
+/obj/machinery/door/airlock/security{
+	name = "Permanent Cell 3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "Lw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -13449,20 +13375,21 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Lx" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/trash/sosjerky,
-/obj/item/trash/boritos,
-/obj/item/trash/can,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/hallway/primary/central/fore)
 "Ly" = (
-/obj/structure/sign/poster/official/obey,
-/turf/closed/wall/r_wall,
-/area/security/prison/visit)
+/obj/machinery/hydroponics/soil,
+/obj/item/shovel/spade,
+/turf/open/floor/grass,
+/area/security/prison)
 "Lz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -13517,15 +13444,10 @@
 /turf/closed/wall,
 /area/mine/storage)
 "LI" = (
-/obj/machinery/button/door/directional/east{
-	id = "lawyer_blast";
-	name = "Privacy Shutters"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "LK" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -13540,16 +13462,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
 "LL" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3";
-	dir = 8
+/obj/machinery/flasher/directional/north{
+	id = "visitorflash"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half{
-	dir = 1
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Visitation North"
 	},
-/area/security/brig)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "LM" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -13621,16 +13541,14 @@
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "LX" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/light/small/directional/south,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "LY" = (
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13658,23 +13576,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"Mb" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 7;
-	pixel_y = 12
-	},
-/obj/item/taperecorder{
-	pixel_x = -5
-	},
-/obj/item/lighter{
-	pixel_x = 8;
-	pixel_y = -9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
 "Md" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13698,16 +13599,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Mh" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/freezer,
+/obj/machinery/hydroponics/soil,
+/obj/item/plant_analyzer,
+/turf/open/floor/grass,
 /area/security/prison)
 "Mi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "Mj" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -13771,8 +13670,13 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "Mr" = (
-/turf/closed/wall,
-/area/security/brig)
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "Ms" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
@@ -13894,6 +13798,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"ML" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "MM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -13909,7 +13820,14 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "MO" = (
-/turf/closed/wall/r_wall,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Visitation South";
+	network = list("ss13","prison")
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/security/prison/visit)
 "MP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13925,10 +13843,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"MR" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/security/prison)
 "MS" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -13967,19 +13881,13 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "MX" = (
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_x = -32
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/security/prison)
 "MY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -14000,15 +13908,32 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"Nb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "Nc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "Nd" = (
-/obj/machinery/vending/wardrobe/det_wardrobe,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/turf/closed/wall/r_wall,
+/area/security/prison/visit)
+"Ne" = (
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "Ng" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/glass{
@@ -14020,12 +13945,14 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "Nh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/airlock/security{
+	name = "Prison Forestry"
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "Ni" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
@@ -14043,11 +13970,6 @@
 	dir = 4
 	},
 /area/mine/eva)
-"Nk" = (
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "Nl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -14072,10 +13994,6 @@
 "No" = (
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"Np" = (
-/obj/structure/stairs/east,
-/turf/open/floor/plating,
-/area/security/brig)
 "Nq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -14094,10 +14012,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/service/chapel)
-"Nt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
 "Nu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -14143,8 +14057,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "NB" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/item/pen,
+/obj/structure/cable,
+/obj/item/instrument/harmonica,
+/turf/open/floor/iron,
 /area/security/prison)
 "NC" = (
 /obj/item/organ/tail/monkey,
@@ -14152,23 +14069,31 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "NF" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/door/airlock/security{
+	name = "Permanent Cell 1"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "NG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plating,
 /area/mine/production)
+"NH" = (
+/obj/effect/spawner/random/contraband/prison,
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "NJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/l3closet/scientist,
@@ -14194,10 +14119,20 @@
 /turf/open/floor/stone,
 /area/commons/lounge)
 "NM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/iron/textured,
+/area/security/brig)
+"NN" = (
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/photo_album/prison,
+/obj/item/camera,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "NO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -14253,28 +14188,30 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "NX" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "NZ" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/obj/machinery/light/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
-"Ob" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kanyewest";
-	name = "privacy shutters"
+/turf/open/floor/iron/textured,
+/area/security/brig)
+"Oa" = (
+/obj/machinery/flasher/directional/north{
+	id = "Cell 3"
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/detectives_office)
+/obj/structure/bed{
+	dir = 1;
+	pixel_x = -2
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig)
+"Ob" = (
+/obj/item/food/fried_chicken,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/maintenance/fore)
 "Oc" = (
 /obj/structure/railing/corner,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -14325,9 +14262,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "Ol" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "Om" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -14399,18 +14336,11 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/textured,
 /area/mine/mechbay)
-"Ou" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "Ov" = (
-/obj/structure/disposalpipe/trunk/multiz{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/brig)
 "Ox" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
@@ -14438,12 +14368,18 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "OC" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/chair{
+	dir = 1;
+	name = "Prosecution"
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/security/courtroom)
+"OD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "OE" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -14470,12 +14406,19 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "OH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/door/airlock{
+	name = "Law Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "OI" = (
 /obj/structure/marker_beacon/burgundy{
 	name = "landing marker"
@@ -14596,8 +14539,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "OX" = (
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
+/obj/machinery/flasher/directional/east{
+	id = "executionflash"
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/security/execution/education)
 "OY" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -14643,12 +14589,32 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"Pe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"Pd" = (
+/obj/structure/table,
+/obj/machinery/microwave,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/turf/open/floor/iron/white,
+/area/security/prison)
+"Pe" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "miningdorm_A";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/donk,
+/area/mine/production)
 "Pf" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -14706,6 +14672,11 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
+"Pm" = (
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "Pn" = (
 /obj/machinery/requests_console/directional/north{
 	name = "Kitchen Requests Console"
@@ -14713,12 +14684,14 @@
 /obj/machinery/oven,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"Pr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
+"Po" = (
+/turf/open/floor/iron,
+/area/security/prison/visit)
+"Pq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "Pt" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -14728,11 +14701,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "Pv" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/closed/wall/r_wall,
 /area/security/brig)
 "Pw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -14758,11 +14727,12 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "Py" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Lower Brig Hallway"
-	},
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "Pz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -14800,17 +14770,11 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "PD" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/structure/table,
-/obj/item/rcl/pre_loaded,
-/turf/open/floor/iron/cafeteria,
-/area/commons/dorms/laundry)
+/turf/closed/wall,
+/area/maintenance/fore)
 "PF" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -14825,12 +14789,10 @@
 "PG" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"PH" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/edge,
+"PI" = (
+/obj/structure/table,
+/obj/item/storage/dice,
+/turf/open/floor/iron,
 /area/security/prison)
 "PJ" = (
 /obj/structure/disposalpipe/segment{
@@ -14843,15 +14805,15 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "PK" = (
-/obj/machinery/light_switch/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/electropack,
+/obj/item/screwdriver,
+/obj/item/wrench,
+/obj/item/clothing/head/helmet,
+/obj/item/assembly/signaler,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "PL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14859,21 +14821,15 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "PM" = (
-/obj/item/storage/box/evidence{
-	pixel_x = -10;
-	pixel_y = 12
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "PN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/prison)
 "PO" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14886,26 +14842,45 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
-"PQ" = (
-/obj/structure/table,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/machinery/light/directional/east,
+"PR" = (
+/obj/machinery/vending/sustenance,
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
+"PS" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/knife/plastic,
+/obj/item/knife/plastic,
+/obj/item/knife/plastic,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/box/drinkingglasses,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Sec - Permabrig Cafe";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron/white,
 /area/security/prison)
-"PR" = (
-/obj/machinery/light/directional/north,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
-"PS" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
 "PT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -14918,13 +14893,9 @@
 	},
 /area/service/hydroponics)
 "PU" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/fore)
+/obj/structure/filingcabinet/employment,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "PV" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -14932,12 +14903,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "PW" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/brig)
 "PY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15026,11 +14996,22 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
-"Qi" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+"Qh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/security/prison)
+"Qi" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Visitation"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "Qj" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/food_or_drink/cups,
@@ -15116,19 +15097,12 @@
 /turf/open/floor/iron/smooth,
 /area/medical/chemistry)
 "Qt" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/medical{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/iron/dark,
-/area/medical/virology)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "Qu" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -15136,13 +15110,6 @@
 "Qv" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"Qw" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/edge,
-/area/security/prison)
 "Qy" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -15199,6 +15166,15 @@
 /obj/machinery/plumbing/sender,
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"QG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kanyewest";
+	name = "privacy shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "QH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -15251,11 +15227,9 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "QK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/grille,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "QL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15296,13 +15270,6 @@
 "QP" = (
 /turf/open/floor/iron/dark,
 /area/mine/storage)
-"QQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
 "QR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -15313,14 +15280,15 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "QT" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 5"
+/obj/machinery/camera/directional/west{
+	c_tag = "Courtroom Audience"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "QU" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/iron/dark/smooth_half,
@@ -15369,14 +15337,11 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "Ra" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/computer/bookmanagement,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison)
 "Rb" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -15393,6 +15358,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"Rd" = (
+/obj/structure/toilet/greyscale{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "Re" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -15530,8 +15513,16 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "Rz" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/central/fore)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "RA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -15641,8 +15632,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
 "RS" = (
-/turf/closed/wall,
-/area/security/prison)
+/obj/machinery/vending/wardrobe/det_wardrobe,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "RT" = (
 /obj/structure/fence{
 	dir = 4
@@ -15675,12 +15668,12 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "RX" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Prosecution"
-	},
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "RY" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -15748,11 +15741,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"Si" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "Sj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -15798,26 +15786,12 @@
 /turf/open/floor/iron/smooth,
 /area/cargo/warehouse)
 "Sp" = (
-/obj/structure/table,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/obj/item/clothing/suit/hooded/wintercoat{
-	pixel_x = -5
-	},
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_x = 5
-	},
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_x = 5
-	},
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_x = 5
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/turf/open/floor/iron,
+/area/security/prison)
 "Sr" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 4
@@ -15829,20 +15803,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
+"Ss" = (
+/turf/closed/wall/r_wall,
+/area/service/lawoffice)
 "St" = (
-/obj/structure/rack,
-/obj/item/storage/box/evidence,
-/obj/item/storage/box/evidence,
-/obj/machinery/button/door{
-	id = "Trial Transfer";
-	name = "Trial Transfer Lockdown";
-	pixel_y = -23;
-	req_access_txt = "2";
-	pixel_x = -7
+/obj/structure/chair{
+	dir = 1;
+	name = "Prosecution"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/turf/open/floor/wood,
+/area/security/courtroom)
 "Su" = (
 /turf/closed/wall,
 /area/maintenance/department/medical/morgue)
@@ -15852,11 +15822,12 @@
 /turf/open/floor/iron,
 /area/service/chapel)
 "Sw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
-/area/security/courtroom)
+/area/hallway/primary/central/fore)
 "Sx" = (
 /obj/machinery/door/airlock{
 	name = "Bar";
@@ -15892,12 +15863,13 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "SB" = (
-/obj/structure/railing/corner,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
+/obj/structure/rack,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "SC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -15981,10 +15953,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"SQ" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "SR" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
@@ -16006,15 +15974,9 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "SY" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - Visitation South";
-	network = list("ss13","prison")
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron,
-/area/security/prison/visit)
+/area/security/prison)
 "SZ" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
@@ -16050,18 +16012,15 @@
 	},
 /area/service/hydroponics)
 "Td" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 30
+/obj/machinery/button/flasher{
+	id = "transferflash";
+	pixel_x = 23;
+	pixel_y = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "Te" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen";
@@ -16076,15 +16035,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "Tg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "Th" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Ti" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -16146,10 +16108,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "Tp" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/trash/chips,
-/obj/item/trash/candy,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "Tq" = (
@@ -16167,9 +16127,9 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "Ts" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/security/prison/safe)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Tt" = (
 /obj/structure/flora/rock/pile/icy,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -16294,16 +16254,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "TG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/closet{
+	name = "Evidence Closet 1"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/dark/textured_edge,
+/area/security/brig)
 "TH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16346,26 +16302,16 @@
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"TL" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "TM" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/trapdoor_placer,
+/turf/open/floor/glass/reinforced,
 /area/security/courtroom)
 "TN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -16401,6 +16347,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"TR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "TS" = (
 /turf/open/floor/iron/dark,
 /area/mine/eva)
@@ -16459,35 +16409,50 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "Ub" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/wood,
-/area/security/courtroom)
-"Uc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/item/radio/intercom/prison/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
+"Uc" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/detectives_office)
 "Ud" = (
-/obj/structure/chair/stool/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "Ue" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/obj/structure/stairs/east,
+/turf/open/floor/plating,
+/area/hallway/primary/central/fore)
 "Uf" = (
-/obj/structure/cable,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
-"Ug" = (
-/obj/structure/table,
-/obj/item/food/energybar,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
+/area/security/prison/visit)
+"Ug" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "Uh" = (
 /obj/effect/turf_decal/tile/blue{
@@ -16539,11 +16504,16 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Uo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/button/door/directional/east{
+	name = "Privacy Shutters"s;
+	id = "kanyewest"
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "Up" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -16560,13 +16530,10 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/medical/virology)
 "Ur" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Prosecution"
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/wood,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating,
 /area/security/courtroom)
 "Ut" = (
 /obj/effect/turf_decal/loading_area{
@@ -16579,18 +16546,20 @@
 /turf/open/floor/iron/smooth_large,
 /area/cargo/warehouse)
 "Uu" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
-"Uv" = (
-/obj/structure/table,
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/security/prison)
+"Uv" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore)
 "Uw" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/plasma,
@@ -16639,20 +16608,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/stone,
 /area/commons/lounge)
-"UB" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Trial Transfer";
-	name = "Transfer Blast Door"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Trial Transfer"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/textured,
-/area/security/brig)
 "UD" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/machinery/light/directional/west,
@@ -16661,13 +16616,12 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "UE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/wood,
+/area/security/courtroom)
 "UF" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -16680,17 +16634,8 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "UG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
-"UI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron,
 /area/security/prison/visit)
 "UK" = (
 /turf/closed/wall,
@@ -16732,9 +16677,24 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "UQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/interrogation{
+	name = "isolation room monitor";
+	network = list("isolation");
+	pixel_y = -32;
+	dir = 1
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket{
+	pixel_x = 6
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Permabrig Prep";
+	network = list("ss13","prison");
+	view_range = 5
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "UR" = (
 /obj/machinery/door/airlock{
@@ -16748,18 +16708,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "US" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/cable,
+/obj/item/storage/bag/trash,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/prison/safe)
 "UT" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/chapel)
+"UU" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison/safe)
 "UV" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -16778,6 +16740,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"UX" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "UY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -16801,9 +16770,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "Vb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "Vc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16854,6 +16823,15 @@
 "Vj" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/morgue)
+"Vk" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Sec - Permabrig Exercise";
+	network = ssssssssssssss
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "Vl" = (
 /obj/structure/fence{
 	dir = 4
@@ -16873,12 +16851,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Vn" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/door/airlock/security{
+	name = "Permanent Cell 4"
 	},
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "Vo" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -16892,9 +16872,23 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/service/bar)
+"Vp" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/structure/table,
+/obj/item/rcl/pre_loaded,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms/laundry)
 "Vq" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/iron,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/security/prison)
 "Vr" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
@@ -16960,26 +16954,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"Vy" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/brown{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/north{
-	id = "miningdorm_B";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = 23;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/stellar,
-/area/mine/production)
 "Vz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -17001,12 +16975,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "VC" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "VD" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -17033,14 +17006,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"VF" = (
-/obj/machinery/door/airlock/security{
-	id_tag = "IsolationCell";
-	name = "Isolation Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/smooth,
-/area/security/prison/safe)
 "VG" = (
 /obj/machinery/shower{
 	dir = 4
@@ -17113,8 +17078,9 @@
 /turf/open/floor/carpet/lone,
 /area/service/chapel)
 "VQ" = (
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/stairs/east,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "VR" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Warehouse";
@@ -17127,9 +17093,13 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/cargo/warehouse)
 "VS" = (
-/obj/machinery/light/directional/west,
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
-/area/security/prison/visit)
+/area/security/prison)
 "VT" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_lower_shutters";
@@ -17141,18 +17111,17 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"VV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/iron,
-/area/security/prison)
+"VU" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "VW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/security/prison)
 "VX" = (
 /obj/structure/stairs/north,
 /obj/structure/railing{
@@ -17161,10 +17130,8 @@
 /turf/open/floor/iron,
 /area/service/chapel)
 "VY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/turf/closed/wall,
+/area/security/prison/visit)
 "VZ" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -17179,14 +17146,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "Wc" = (
-/obj/machinery/flasher/directional/north{
-	id = "transferflash"
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark/textured,
+/obj/machinery/vending/cola/red,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/security/prison)
 "Wd" = (
 /obj/machinery/disposal/bin{
@@ -17205,13 +17167,6 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/virology)
-"We" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "Wf" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -17223,14 +17178,11 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "Wi" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig)
+/obj/structure/closet/secure_closet/courtroom,
+/obj/item/gavelhammer,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "Wj" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/sign/warning/coldtemp{
@@ -17287,6 +17239,9 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"Wp" = (
+/turf/closed/wall/r_wall,
+/area/icemoon/underground/explored)
 "Wq" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -17320,9 +17275,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "Wu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/chair{
+	name = "Defense"
+	},
+/obj/effect/landmark/start/lawyer,
+/turf/open/floor/wood,
 /area/security/courtroom)
 "Wv" = (
 /obj/machinery/space_heater,
@@ -17378,17 +17335,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
-"WE" = (
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "WF" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/security/prison/safe)
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/obj/item/cartridge/lawyer,
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "WG" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -17406,9 +17365,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "WI" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/turf/closed/wall,
+/area/service/lawoffice)
 "WJ" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 20
@@ -17424,12 +17382,8 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "WL" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/security/wooden_tv,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "WN" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -17489,13 +17443,12 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/drone_bay)
-"WS" = (
-/obj/structure/stairs/east,
-/turf/open/floor/plating,
-/area/hallway/primary/central/fore)
 "WT" = (
-/turf/closed/wall/r_wall,
-/area/security/execution/education)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "WU" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/landmark/start/hangover,
@@ -17521,6 +17474,10 @@
 "WY" = (
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"WZ" = (
+/obj/structure/flora/grass/green,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/unexplored)
 "Xa" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -17530,11 +17487,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Xb" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Trial Transfer";
+	name = "Transfer Blast Door"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Trial Transfer"
+	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "Xc" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/line{
@@ -17559,10 +17524,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"Xe" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "Xf" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/security/prison/safe)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/iron,
+/area/security/prison)
 "Xg" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -17640,9 +17613,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "Xs" = (
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/door/airlock/public/glass{
+	name = "Trial Transfer"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/textured,
-/area/security/brig)
+/area/security/courtroom)
 "Xt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -17651,18 +17630,8 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "Xu" = (
-/obj/structure/closet/crate,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/security/execution/education)
 "Xv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -17690,9 +17659,12 @@
 	},
 /area/mine/eva)
 "Xx" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/openspace/icemoon/keep_below,
-/area/security/execution/education)
+/obj/machinery/recharger,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red/half,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "Xy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/south,
@@ -17706,15 +17678,39 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "XA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "XC" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/servingdish,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "XD" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
@@ -17742,14 +17738,14 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "XI" = (
-/obj/structure/chair{
-	dir = 4
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "XK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -17813,19 +17809,12 @@
 /turf/closed/wall/r_wall,
 /area/mine/mechbay)
 "XU" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
-"XV" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 1"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
+"XV" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
 /area/security/prison/safe)
 "XW" = (
 /obj/machinery/door/window/left/directional/north{
@@ -17951,36 +17940,15 @@
 /obj/structure/sign/warning/electricshock,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"Yl" = (
-/obj/structure/chair{
-	name = "Judge";
+"Ym" = (
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Courtroom"
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/wood,
-/area/security/courtroom)
-"Ym" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen/interrogation{
-	name = "isolation room monitor";
-	network = list("isolation");
-	pixel_y = -32;
-	dir = 1
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket{
-	pixel_x = 6
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Permabrig Prep";
-	network = list("ss13","prison");
-	view_range = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/security/prison)
 "Yn" = (
 /obj/effect/turf_decal/tile/bar{
@@ -18000,31 +17968,26 @@
 /area/service/chapel)
 "Yq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/security/prison)
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "Yr" = (
 /obj/effect/decal/cleanable/ants,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "Ys" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
-"Yt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/shower{
+	pixel_y = 12
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
+"Yt" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/edge,
+/area/security/prison)
 "Yu" = (
 /obj/structure/fence{
 	dir = 4
@@ -18039,6 +18002,13 @@
 /obj/structure/sign/nanotrasen,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"Yw" = (
+/obj/structure/sign/poster/official/safety_report{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "Yx" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18094,10 +18064,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
-"YD" = (
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/textured,
-/area/security/brig)
 "YE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table/reinforced,
@@ -18113,25 +18079,34 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "YF" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "YG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/recharge_floor,
 /area/mine/mechbay)
 "YH" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half{
+/obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/area/security/brig)
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
+"YJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
+/area/security/prison)
 "YK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
@@ -18160,13 +18135,25 @@
 /obj/structure/railing,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"YO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+"YN" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"YO" = (
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	name = "Prisoner Transfer Centre"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "YP" = (
 /obj/structure/cable,
 /obj/structure/grille,
@@ -18205,9 +18192,28 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "YV" = (
-/obj/effect/spawner/structure/window,
+/obj/structure/bed,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/bedsheet/red,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
+"YW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/courtroom)
+/area/security/prison)
 "YX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18282,31 +18288,26 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "Zj" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/door/airlock{
+	name = "Permabrig Showers"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "Zk" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Common Room"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/turf/open/floor/iron/textured,
+/area/security/brig)
+"Zl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "Zm" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner,
@@ -18335,10 +18336,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"Zp" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "Zq" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/conveyor_switch/oneway{
@@ -18449,14 +18446,16 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "ZG" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 2"
+/obj/structure/table/wood,
+/obj/item/trapdoor_remote/preloaded{
+	pixel_x = -5;
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/obj/item/gavelblock{
+	pixel_x = 5
+	},
+/turf/open/floor/wood,
+/area/security/courtroom)
 "ZH" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/south,
@@ -18604,8 +18603,9 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "ZW" = (
-/turf/closed/wall/r_wall,
-/area/security/courtroom)
+/obj/structure/bookcase/random,
+/turf/open/floor/iron,
+/area/security/prison)
 "ZX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -36228,7 +36228,7 @@ iK
 dj
 To
 cP
-DA
+tm
 iK
 kK
 kK
@@ -36742,7 +36742,7 @@ cs
 fn
 cP
 vc
-PD
+Vp
 GK
 kK
 kK
@@ -37281,9 +37281,9 @@ wl
 sh
 bf
 cL
-cZ
+Pe
 bq
-Vy
+tw
 SG
 bq
 oP
@@ -38735,20 +38735,20 @@ ak
 ak
 ak
 ak
-Lf
+zg
 Et
 Et
 Et
 Et
 Et
-Lf
-fZ
-fZ
-un
-fZ
-fZ
-fZ
-Lf
+zg
+QK
+QK
+va
+QK
+QK
+QK
+zg
 ak
 ak
 ak
@@ -39251,18 +39251,18 @@ ak
 ak
 Et
 kK
-Jh
-FQ
-hp
-hp
-MR
-wP
-wP
-wP
-wP
-wP
-wP
-MR
+Wp
+gk
+YW
+YW
+qA
+qn
+qn
+qn
+qn
+qn
+qn
+qA
 mO
 mO
 mO
@@ -39508,18 +39508,18 @@ ak
 ak
 Et
 kK
-cg
-uq
-eK
-SQ
-SQ
-SQ
-RS
-Lx
-la
-sy
-nK
-We
+FA
+NN
+pB
+Lq
+Lq
+Lq
+pL
+Jh
+FH
+jS
+gV
+UX
 mO
 mO
 mO
@@ -39765,18 +39765,18 @@ ak
 ak
 Et
 kK
-We
-zn
-eK
-mp
-ha
-Ud
-RS
-kk
-Nk
-Lu
-Lu
-We
+UX
+SY
+pB
+jN
+tx
+yG
+pL
+me
+Dp
+Ht
+Ht
+UX
 mO
 mO
 mO
@@ -40022,18 +40022,18 @@ ak
 ak
 Et
 kK
-We
-fk
-eK
-eG
-pR
-NZ
-RS
-Cm
-Nk
-rx
-as
-We
+UX
+Ra
+pB
+De
+PI
+HN
+pL
+FJ
+Dp
+Ly
+VW
+UX
 mO
 mO
 mO
@@ -40054,9 +40054,9 @@ mO
 mO
 mO
 pr
-rW
-rW
-rW
+jZ
+jZ
+jZ
 pr
 mO
 mO
@@ -40277,20 +40277,20 @@ ak
 ak
 ak
 ak
-Lf
+zg
 kK
-MR
-Vq
-Ae
-iq
-pB
-jV
-RS
-PW
-Nk
-Lu
-Lu
-We
+qA
+ZW
+iG
+FC
+NB
+gF
+pL
+vR
+Dp
+Ht
+Ht
+UX
 mO
 mO
 mO
@@ -40310,11 +40310,11 @@ mO
 mO
 mO
 mO
-PN
+AH
 Ix
 XZ
 mw
-PN
+AH
 mO
 mO
 mO
@@ -40536,18 +40536,18 @@ ak
 ak
 Et
 kK
-wP
-FM
-TL
-eG
-aw
-yi
-RS
-GG
-Nk
-Lu
-Lu
-We
+qn
+lz
+ha
+De
+xb
+jf
+pL
+kW
+Dp
+Ht
+Ht
+UX
 mO
 mO
 mO
@@ -40560,21 +40560,21 @@ mO
 mO
 mO
 mO
-EI
-HJ
-HJ
-EI
+Jv
+ML
+ML
+Jv
 mO
 mO
 kK
-cf
+KM
 PV
-PU
+Uv
 XM
 pr
-rW
-rW
-rW
+jZ
+jZ
+jZ
 pr
 wS
 wS
@@ -40793,45 +40793,45 @@ ak
 ak
 Et
 kK
-wP
-LX
-yp
-lj
-FJ
-fH
-RS
-di
-mk
-ED
-as
-We
+qn
+CM
+yi
+VC
+Jq
+WT
+pL
+Kr
+Ks
+Mh
+VW
+UX
 mO
 mO
 mO
 mO
 mO
-eN
-qO
-qO
-eN
-eN
+WI
+lO
+lO
+WI
+WI
 mO
-EI
-EI
-hl
-qG
-EI
-EI
+Jv
+Jv
+Hu
+oO
+Jv
+Jv
 kK
 kK
 pr
-xo
+gD
 BO
 mU
-NM
+qr
 mU
 mU
-Lo
+Du
 pr
 wS
 wS
@@ -41050,45 +41050,45 @@ ak
 ak
 Et
 kK
-wP
-NF
-gD
-RS
-RS
-Zk
-RS
-ka
-JD
-Gy
-Gy
-We
+qn
+kN
+Ud
+pL
+pL
+Db
+pL
+YH
+Ne
+DJ
+DJ
+UX
 mO
 mO
 mO
 mO
-eN
-eN
-lO
-xS
-pg
-eN
+WI
+WI
+PU
+YF
+kn
+WI
 mO
-EI
-WL
-PM
+Jv
 ev
-yk
-qM
+bB
+AP
+ve
+Uc
 kK
 kK
 pr
 pr
 pr
-qg
-Zp
+vg
+yq
 mU
 pr
-fy
+iu
 pr
 wS
 wS
@@ -41307,46 +41307,46 @@ ak
 ak
 Et
 kK
-kO
+KJ
+vp
+vp
+vp
+oG
+iE
+pL
 IT
-IT
-IT
-DN
-Ou
-RS
-mx
-XU
-as
-as
-We
+vB
+VW
+VW
+UX
 mO
 mO
 mO
 kK
-Kk
+Cr
 ME
-Pr
-FW
-fe
-eN
+CD
+cG
+BK
+WI
 mO
-EI
-PS
-tm
-oI
-zh
-EI
+Jv
+dY
+kx
+vr
+CI
+Jv
 kK
 kK
 pr
-mD
+Ob
 pr
-Th
-fd
-tW
-PN
+nF
+dA
+qg
+AH
 mU
-PN
+AH
 Kb
 ak
 ak
@@ -41564,52 +41564,52 @@ ak
 ak
 Et
 kK
-EC
-Er
-Zj
-QT
-Ou
-Ou
-RS
-oO
-IT
-IT
-IT
-WF
+lG
+Rd
+CY
+xL
+iE
+iE
+pL
+Nh
+vp
+vp
+vp
+UU
 mO
 mO
 kK
 dJ
-eN
-AH
-yd
-sv
-rJ
-eN
+WI
+Tg
+ju
+Iq
+hl
+WI
 mO
-EI
-IP
-jH
-Mb
-yu
-EI
+Jv
+lZ
+mx
+DA
+fe
+Jv
 kK
 rm
 pr
 pr
 pr
 kJ
-pG
-Ov
+tW
+FM
 pr
-bB
+qO
 pr
-Iy
+WZ
 ak
 Kb
 Kb
 Kb
-HN
+ED
 Kb
 Kb
 Kb
@@ -41821,43 +41821,43 @@ ak
 ak
 Et
 kK
-EC
-Fl
-vn
-IT
-uJ
-Ou
-ut
-Ou
-qA
-yl
-Tp
-kO
+lG
+YV
+lo
+vp
+bK
+iE
+Ie
+iE
+cg
+ks
+JD
+KJ
 dJ
 kK
 kK
 kK
-eN
-iE
-FW
-ho
-nH
-eN
+WI
+tM
+cG
+DQ
+cm
+WI
 mO
-EI
-Nd
-QQ
-Uc
-tV
-EI
+Jv
+RS
+Zl
+KC
+Uo
+Jv
 kK
 kK
 kK
 kK
 pr
 yU
-Yt
-JV
+FQ
+pZ
 pr
 Kb
 Kb
@@ -42076,52 +42076,52 @@ ak
 ak
 ak
 ak
-Lf
+zg
 kK
-WF
-IT
-IT
-IT
-PH
-Ou
-vq
-BK
-IT
-Ij
-Gb
-kO
+UU
+vp
+vp
+vp
+pG
+iE
+nZ
+Xe
+vp
+US
+vI
+KJ
 kK
 kK
 rm
 dJ
-eN
-cu
-yP
-LI
-PK
-eN
-CY
-EI
-EI
-Ob
-vL
-EI
-EI
-CY
-CY
-bQ
-bQ
+WI
+WF
+HJ
+ti
+qZ
+WI
+Gx
+Jv
+Jv
+QG
+Kg
+Jv
+Jv
+Gx
+Gx
+eA
+eA
 pr
 pr
-hy
-sq
+Nb
+PD
 pr
 Kb
 Kb
-HN
+ED
 Kb
 Kb
-Iy
+WZ
 ak
 ak
 ak
@@ -42335,44 +42335,44 @@ ak
 ak
 Et
 kK
-EC
-AP
-Zj
-cH
-Ou
-Ou
-od
-Dp
-IT
-IT
-IT
-kO
-MO
-MO
-UI
-UI
-xx
-it
-it
-eN
-hz
-eN
-Nh
-go
-lz
-go
-os
-OC
-OC
-gG
-OC
-OC
-OC
-Cg
-aP
-Td
-gU
+lG
+bs
 CY
+Vn
+iE
+iE
+qF
+yl
+vp
+vp
+vp
+KJ
+Nd
+Nd
+xD
+xD
+Ss
+sj
+sj
+WI
+OH
+WI
+Sw
+Iz
+Lx
+Iz
+cF
+kO
+kO
+yp
+kO
+kO
+kO
+pw
+su
+zQ
+bQ
+Gx
 Kb
 ak
 ak
@@ -42592,44 +42592,44 @@ ak
 ak
 Et
 kK
-EC
-Fl
-vn
-IT
-DN
-Ou
-od
-wn
-IX
-BS
-VS
-oQ
-sn
-fM
-dY
-Kg
-Ly
-Nh
-go
-go
-os
-OC
-OC
-Ol
-sD
-sD
-sD
-sD
-Jq
-yI
-kn
-Jq
-Jq
-Jq
-tu
+lG
+YV
+lo
+vp
+oG
+iE
+qF
+ii
+VY
+UG
+zk
+pR
+Be
+kB
+pH
+bo
+Cf
+Sw
+Iz
+Iz
+cF
+kO
+kO
+ut
+eU
+eU
+eU
+eU
 jP
-ij
-CY
+hI
+Ub
+jP
+jP
+jP
+os
+Jf
+fk
+Gx
 ak
 ak
 ak
@@ -42849,44 +42849,44 @@ ak
 ak
 Et
 kK
-kO
-IT
-IT
-IT
-Qw
-Ou
-od
-Dp
-IX
-lF
-xb
-oQ
-Kr
-ru
-dY
-DQ
-nZ
-jT
-jT
-jT
-Pe
-jT
-kx
-jT
-VW
-Kl
-fG
-fG
-EQ
-ga
-ga
-YV
-TM
-ga
-ga
-TG
-Cf
-CY
+KJ
+vp
+vp
+vp
+Yt
+iE
+qF
+yl
+VY
+Yw
+vU
+pR
+yn
+pv
+pH
+lh
+Qi
+Hh
+Hh
+Hh
+Th
+Hh
+XA
+Hh
+YN
+xI
+Ts
+Ts
+BS
+pq
+pq
+er
+rW
+pq
+pq
+pD
+AE
+Gx
 ak
 ak
 ak
@@ -43106,44 +43106,44 @@ ak
 ak
 Et
 kK
-EC
-AP
-Zj
-Ra
-Ou
-Ou
-jg
-Fw
-IX
-Cp
-VQ
-VQ
-BT
-vr
-CI
-qa
-HI
-Uo
-Uo
-ti
-Uo
-Uo
-ks
-Uo
-Uo
-Rz
-bQ
-bQ
-bQ
-ga
-NX
-gV
-XI
-rI
-Uu
-YO
-fG
+lG
+bs
 CY
+Lv
+iE
+iE
+Ym
+NH
+VY
+sK
+Po
+Po
+id
+Aj
+LI
+GG
+la
+EU
+EU
+sy
+EU
+EU
+Cs
+EU
+EU
+Jm
+eA
+eA
+eA
+pq
+tn
+mz
+GP
+QT
+zn
+nK
+Ts
+Gx
 ak
 ak
 ak
@@ -43363,44 +43363,44 @@ ak
 ak
 Et
 kK
-EC
-Fl
-vn
-IT
-jS
-Ou
-JO
-VY
-wV
-qa
-eL
-oQ
-sn
-ru
-dY
-SY
+lG
+YV
+lo
+vp
+wD
+iE
+jy
+Pq
+Iy
+GG
+Uf
+pR
+Be
+pv
+pH
 MO
-vp
-vp
-vU
-vp
-vp
-vU
-vp
-vp
-vU
+Nd
+uB
+uB
+Pv
+uB
+uB
+Pv
+uB
+uB
+Pv
 mO
 mO
 mO
-ga
-PR
-Ue
-UG
-iG
-ga
-go
-fG
-CY
+pq
+Gw
+yW
+kr
+Is
+pq
+Iz
+Ts
+Gx
 ak
 ak
 ak
@@ -43618,46 +43618,46 @@ ak
 ak
 ak
 ak
-Lf
+zg
 kK
-kO
-IT
-IT
-IT
-lG
-JY
-lJ
-bC
-IX
-Fp
-VQ
-oQ
-Kr
-ru
-kN
-wW
-MO
-vI
-Fh
+KJ
+vp
+vp
+vp
+qM
 Mr
-cE
-Wi
-Mr
-Ko
-xi
-vU
+XI
+By
+VY
+LL
+Po
+pR
+yn
+pv
+zC
+Kk
+Nd
+ka
+Dw
+dz
+us
+LX
+dz
+Oa
+gU
+Pv
 mO
 mO
 mO
-gp
-gV
-gV
-UG
-gV
-ga
-go
-fG
-CY
+Ur
+mz
+mz
+kr
+mz
+pq
+Iz
+Ts
+Gx
 ak
 ak
 ak
@@ -43877,44 +43877,44 @@ ak
 ak
 Et
 kK
-EC
-Er
-Zj
-ZG
-Ou
-Ou
-gu
-gu
-IX
-Hu
-EL
-VQ
-BT
-sK
-dY
-KM
-MO
-up
-Eq
-Mr
-up
-Eq
-Mr
-up
-Eq
-vU
-mO
-mO
-mO
-ZW
-Wu
-Wu
-dp
-Wu
-ga
-WS
-WS
+lG
+Rd
 CY
+Fh
+iE
+iE
+Lf
+Lf
+VY
+pQ
+FK
+Po
+id
+jm
+pH
+gp
+Nd
+qP
+EC
+dz
+qP
+EC
+dz
+qP
+EC
+Pv
+mO
+mO
+mO
+oB
+FO
+FO
+kG
+FO
+pq
+Ue
+Ue
+Gx
 ak
 ak
 ak
@@ -44134,44 +44134,44 @@ ak
 ak
 Et
 kK
-EC
-Fl
-vn
-IT
-CE
-JY
-bL
-gy
-gy
-gy
-gy
-gy
-gy
-gy
-BT
-HI
-MO
-YH
-pQ
+lG
+YV
+lo
+vp
+lF
 Mr
-tY
-pQ
-Mr
-LL
-pQ
-vU
+up
+pg
+pg
+pg
+pg
+pg
+pg
+pg
+id
+la
+Nd
+Ds
+yY
+dz
+wP
+yY
+dz
+cH
+yY
+Pv
 mO
 mO
 mO
-ZW
-pZ
-Jm
-Sw
-Ex
-ga
-ga
-CY
-CY
+oB
+Wi
+jV
+GI
+pe
+pq
+pq
+Gx
+Gx
 ak
 ak
 ak
@@ -44391,42 +44391,42 @@ ak
 ak
 Et
 kK
-WF
-IT
-IT
-IT
-tU
-Ou
-sr
-gy
-qP
-Nt
-VC
-Hm
-Hm
+UU
+vp
+vp
+vp
+IH
+iE
+YJ
+pg
+XC
+tV
+NX
+BT
+BT
+cu
+oQ
+Zk
 BF
-yg
-Ys
-MX
-qH
-Ys
-KC
-Da
-Ys
-kr
-Da
-Ys
-UB
-gn
-gn
-gn
-zQ
-qZ
-qZ
-Lq
-Jm
-AS
-ga
+IX
+Zk
+DK
+HO
+Zk
+EJ
+HO
+Zk
+Xb
+Rz
+Rz
+Rz
+Xs
+dr
+dr
+dq
+jV
+rq
+pq
 ak
 ak
 ak
@@ -44648,42 +44648,42 @@ ak
 ak
 Et
 kK
-EC
-AP
-Zj
-XV
-Ou
-Ou
-gk
-gy
-lc
-eU
-Vb
-gj
-yq
-gy
-vH
-Ys
-lh
-tH
-Ys
-wr
-mz
-Ys
-OH
+lG
+bs
+CY
+NF
+iE
+iE
+bR
+pg
+Im
+vL
+oI
+tE
+VQ
+pg
+wG
+Zk
+Lo
+NM
+Zk
+qG
+NZ
+Zk
+uM
+SB
+Ki
+Pv
+mO
+mO
+mO
 oB
+dW
+lJ
+kr
+lJ
 St
-vU
-mO
-mO
-mO
-ZW
-hX
-WI
-UG
-WI
-RX
-ga
+pq
 ak
 ak
 ak
@@ -44905,42 +44905,42 @@ ak
 ak
 Et
 kK
-EC
-Fl
-vn
-IT
-DN
-Ou
-gk
-gy
-wd
-eU
-Vb
-gj
-gj
-gy
-Py
-FH
-RS
-UQ
-va
-RS
-FK
-xs
-FK
-vU
-yN
-vU
+lG
+YV
+lo
+vp
+oG
+iE
+bR
+pg
+Xx
+vL
+oI
+tE
+tE
+pg
+dQ
+xi
+pL
+PN
+yk
+pL
+Ov
+JK
+Ov
+Pv
+Ex
+Pv
 mO
 mO
 mO
-uR
-kW
-wO
-UG
-my
-Ur
-ga
+fM
+Wu
+PM
+kr
+uo
+OC
+pq
 ak
 ak
 ak
@@ -45160,44 +45160,44 @@ ak
 ak
 ak
 ak
-Lf
+zg
 kK
-kO
-IT
-IT
-IT
-zD
-Fj
-zD
-gy
-oG
-eU
-Vb
 KJ
-AC
-gy
-Ki
-bX
-RS
-HZ
-tZ
-RS
-ui
+vp
+vp
+vp
+iV
+jj
+iV
+pg
+aP
+vL
+oI
+CE
+lc
+pg
+eN
+Yq
 pL
-hr
-vU
+vH
+FP
+pL
+TG
+PW
+fZ
+Pv
 mO
 mO
 mO
 mO
 mO
-zV
-EJ
-XA
-uB
-rg
-Vn
-ga
+TM
+Ag
+TR
+fy
+OD
+UE
+pq
 ak
 ak
 ak
@@ -45417,44 +45417,44 @@ ak
 ak
 ak
 ak
-fZ
+QK
 kK
-wP
-BX
-xN
-JK
-AE
-fH
-Ae
-gy
-Es
-En
-jN
-eU
-nN
-gy
-yY
-Xs
-RS
-Jp
-tZ
-RS
-cp
-pD
-fz
-US
-mO
-mO
-mO
-mO
-mO
+qn
+Uu
+xM
+Qh
+Pm
+WT
+iG
+pg
+KY
+re
+mk
+vL
+jB
+pg
+gj
+Mi
+pL
 oz
-yc
-WI
-ar
-bs
-Ub
-ga
+FP
+pL
+uC
+IK
+DX
+br
+mO
+mO
+mO
+mO
+mO
+Cg
+od
+lJ
+ZG
+xT
+fG
+pq
 ak
 ak
 ak
@@ -45674,44 +45674,44 @@ mO
 mO
 mO
 mO
-fZ
+QK
 kK
-wP
-Dw
-jp
-VV
-AE
-fH
-nQ
-gy
-gy
-dA
-iQ
-HO
-jB
-gy
-YD
-nm
-RS
-cm
-Mi
-RS
-iY
-Hh
-Ks
-US
+qn
+kk
+Xf
+xO
+Pm
+WT
+ij
+pg
+pg
+tY
+Au
+BX
+Fw
+pg
+Dr
+WL
+pL
+rx
+eH
+pL
+rg
+bC
+Es
+br
 mO
 mO
 mO
 mO
 mO
-gp
-yc
-jy
-eA
-Yl
-Cr
-ga
+Ur
+od
+AL
+uq
+KQ
+Ol
+pq
 ak
 ak
 ak
@@ -45931,44 +45931,44 @@ mO
 mO
 mO
 mO
-Lf
+zg
 kK
-wP
-UE
-dQ
-VV
-AE
-xF
-Ds
-NB
-gy
-gy
-gy
-gy
-gy
-gy
-Np
-Np
-RS
-Jp
-xL
-RS
-ES
-Pv
-qr
-US
+qn
+MX
+Gb
+xO
+Pm
+mc
+eE
+Vb
+pg
+pg
+pg
+pg
+pg
+pg
+DM
+DM
+pL
+oz
+wr
+pL
+zl
+nH
+Ir
+br
 mO
 mO
 mO
 mO
 mO
-ZW
-ga
-ga
-ga
-ga
-ga
-ga
+oB
+pq
+pq
+pq
+pq
+pq
+pq
 ak
 ak
 ak
@@ -46190,30 +46190,30 @@ mO
 mO
 mO
 mO
-MR
-Dw
-dQ
-VV
-AE
-AK
-gu
-cG
-RS
-Dr
-Qi
-vG
-dQ
-wP
-wP
-wP
-wP
-KY
-vJ
-RS
-kO
-kO
-kO
-kO
+qA
+kk
+Gb
+xO
+Pm
+Da
+Lf
+ui
+pL
+VS
+yd
+nN
+Gb
+qn
+qn
+qn
+qn
+GX
+BV
+pL
+KJ
+KJ
+KJ
+KJ
 mO
 mO
 mO
@@ -46447,30 +46447,30 @@ mO
 mO
 mO
 mO
-We
-Ht
-tM
+UX
+yc
+Sp
+dp
+Pm
+mc
+wV
+Vb
+pL
+Hm
+EI
+bL
+ah
+qn
+qv
+Vq
+qn
+as
 FP
-AE
 xF
-cx
-NB
-RS
-lT
-Ug
-FO
-QK
-wP
-Wc
-nF
-wP
-Ft
-tZ
-Gw
-VF
-Ts
-zq
-lZ
+En
+iW
+Ff
+it
 mO
 mO
 mO
@@ -46704,30 +46704,30 @@ mO
 mO
 mO
 mO
-We
-BV
-Yq
-Yq
-wD
-fH
-fH
-fH
-cF
-eP
-fH
-eE
-fH
-yB
-DK
-OX
-tw
-dW
-tZ
-yA
-YF
-hI
-Ts
-lZ
+UX
+lM
+JY
+JY
+cW
+WT
+WT
+WT
+vJ
+Py
+WT
+Qt
+WT
+hz
+aw
+hp
+fU
+eL
+FP
+JO
+Tp
+XV
+iW
+it
 mO
 mO
 mO
@@ -46961,30 +46961,30 @@ mO
 mO
 mO
 mO
-We
-cx
-eb
-vB
-fU
-ug
-vR
-cx
-RS
-dq
-Tg
-dQ
-eP
-By
-Xb
-Xb
-By
-tZ
-tZ
-Ym
-Xf
-xm
-GP
-lZ
+UX
+wV
+hy
+Vk
+fF
+le
+wn
+wV
+pL
+PR
+nE
+Gb
+Py
+tu
+rs
+rs
+tu
+FP
+FP
+UQ
+AS
+yH
+sv
+it
 mO
 mO
 mO
@@ -47218,30 +47218,30 @@ mO
 mO
 mO
 mO
-wP
-RS
-FB
-RS
-IT
-Au
-IT
-IT
-IT
-mI
-eG
-dQ
-Ae
-yB
-EU
-eZ
-tw
-Ie
-ii
-wP
-kO
-kO
-kO
-kO
+qn
+pL
+Zj
+pL
+vp
+xs
+vp
+vp
+vp
+Wc
+De
+Gb
+iG
+hz
+ga
+uR
+fU
+Td
+RX
+qn
+KJ
+KJ
+KJ
+KJ
 mO
 mO
 mO
@@ -47475,26 +47475,26 @@ mO
 mO
 mO
 mO
-wP
-nW
-Si
-iu
-IT
-Aj
-Aj
-zW
-IT
-rZ
-XC
-Uv
-vg
-wP
-wP
-wP
-WT
-Gx
-KQ
-WT
+qn
+FY
+xo
+yu
+vp
+nm
+nm
+go
+vp
+Ft
+ar
+wW
+jT
+qn
+qn
+qn
+Xu
+uN
+YO
+Xu
 ak
 ak
 ak
@@ -47732,26 +47732,26 @@ mO
 mO
 mO
 mO
-wP
-WE
-Si
-iu
-IT
-uH
-xp
-zk
-IT
-jj
-sj
-GI
-vg
-wP
+qn
+Ys
+xo
+yu
+vp
+yN
+cf
+VU
+vp
+Pd
+hX
+kS
+jT
+qn
 ak
 ak
-WT
+Xu
 nj
-jf
-WT
+dh
+Xu
 ak
 ak
 ak
@@ -47989,26 +47989,26 @@ mO
 mO
 mO
 mO
-wP
-su
-pw
-uC
-kO
-kO
-kO
-kO
-kO
+qn
+vq
+vn
+Ug
+KJ
+KJ
+KJ
+KJ
+KJ
+Fj
+wO
+lj
+PS
+qn
+ak
+ak
 Xu
-nE
-PQ
-zC
-wP
-ak
-ak
-WT
-Sp
-dh
-WT
+tZ
+fz
+Xu
 ak
 ak
 ak
@@ -48246,30 +48246,30 @@ mO
 mO
 mO
 mO
-wP
-iH
-Mh
-iu
-wP
+qn
+Lu
+bX
+yu
+qn
 ak
 ak
 ak
-wP
-hp
-wP
-wP
-wP
-wP
+qn
+YW
+qn
+qn
+qn
+qn
 ak
 ak
-WT
-fB
-Be
-WT
-WT
-WT
-WT
-BG
+Xu
+ol
+Er
+Xu
+Xu
+Xu
+Xu
+hr
 mO
 mO
 mO
@@ -48503,11 +48503,11 @@ mO
 mO
 mO
 mO
-wP
-wP
-wP
-wP
-wP
+qn
+qn
+qn
+qn
+qn
 ak
 ak
 ak
@@ -48519,13 +48519,13 @@ ak
 ak
 ak
 ak
-WT
-Du
-Uf
-kc
-po
-po
-Xx
+Xu
+wd
+XU
+yg
+IP
+IP
+jg
 mO
 mO
 mO
@@ -48776,13 +48776,13 @@ ak
 ak
 ak
 ak
-WT
-HB
-Uf
-SB
-mo
-Db
-Db
+Xu
+AK
+XU
+iq
+xx
+zW
+zW
 mO
 mO
 mO
@@ -49033,13 +49033,13 @@ ak
 ak
 ak
 ak
-WT
-br
-le
-jm
-po
-rq
-eH
+Xu
+PK
+sW
+oL
+IP
+OX
+sn
 mO
 mO
 mO
@@ -49290,14 +49290,14 @@ ak
 ak
 ak
 ak
-WT
-tx
-WT
-tx
-WT
-WT
-WT
-BG
+Xu
+mD
+Xu
+mD
+Xu
+Xu
+Xu
+hr
 mO
 mO
 mO
@@ -56291,11 +56291,11 @@ bN
 bN
 qD
 RW
-Qt
+mo
 JN
 np
 Ec
-et
+uJ
 RW
 Et
 kK
@@ -58096,7 +58096,7 @@ UF
 rl
 MH
 qy
-IK
+Fl
 RW
 ak
 ak

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -46,33 +46,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/medical/morgue)
-"ah" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
 "ai" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 1
@@ -121,14 +94,20 @@
 /turf/open/floor/plating,
 /area/cargo/drone_bay)
 "ar" = (
-/obj/structure/closet/secure_closet/injection,
-/obj/machinery/airalarm/directional/north,
-/obj/item/soap/nanotrasen,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/obj/structure/table/wood,
+/obj/item/trapdoor_remote/preloaded{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/gavelblock{
+	pixel_x = 5
+	},
+/turf/open/floor/wood,
+/area/security/courtroom)
 "as" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/security/armory)
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/security/prison)
 "at" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 4
@@ -140,10 +119,6 @@
 	dir = 10
 	},
 /area/mine/living_quarters)
-"au" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/textured,
-/area/security/brig)
 "av" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -158,10 +133,7 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "aw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
+/obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "ax" = (
@@ -269,9 +241,15 @@
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
 "aP" = (
-/obj/structure/filingcabinet/employment,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Lower Hallway South"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "aQ" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
@@ -325,13 +303,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"aY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "aZ" = (
 /obj/structure/flora/grass/both,
 /obj/structure/railing,
@@ -399,20 +370,21 @@
 "bq" = (
 /turf/closed/wall,
 /area/mine/production)
+"br" = (
+/obj/structure/table,
+/obj/item/electropack,
+/obj/item/screwdriver,
+/obj/item/wrench,
+/obj/item/clothing/head/helmet,
+/obj/item/assembly/signaler,
+/obj/structure/cable,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "bs" = (
-/obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "bt" = (
 /obj/structure/sign/poster/official/here_for_your_safety{
 	pixel_x = 32
@@ -454,26 +426,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "bB" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
-"bC" = (
-/obj/machinery/button/door/directional/east{
-	name = "Privacy Shutters"s;
-	id = "kanyewest"
-	},
-/obj/structure/chair/office{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"bC" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "bD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -522,21 +487,15 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"bK" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
 "bL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/smooth,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/camera/directional/south{
+	network = list("ss13","prison");
+	c_tag = "Security - Permabrig Cells"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "bN" = (
 /obj/structure/cable,
@@ -557,16 +516,11 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "bQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
-"bR" = (
-/obj/structure/stairs/east,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/hallway/primary/central/fore)
 "bS" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -596,6 +550,10 @@
 /obj/effect/spawner/random/trash/soap,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"bX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "bY" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -631,16 +589,19 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/chemistry)
+"cf" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "cg" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Common Room"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "ch" = (
 /obj/structure/chair{
 	dir = 1
@@ -681,6 +642,11 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
+"cm" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "cn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -698,6 +664,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/medical/morgue)
+"cp" = (
+/obj/structure/closet{
+	name = "Evidence Closet 2"
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured_edge,
+/area/security/brig)
 "cq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -731,21 +704,18 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cu" = (
-/obj/structure/bed/maint,
-/obj/item/toy/plush/rouny{
-	name = "Therapy Dog";
-	desc = "What is this? Is this a dog?"
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/obj/item/cartridge/lawyer,
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 32
 	},
-/obj/structure/cable,
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Isolation Cell";
-	network = list("ss13","prison","Isolation");
-	view_range = 5
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/turf/open/floor/iron/smooth_half{
-	dir = 1
-	},
-/area/security/prison/safe)
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "cv" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance";
@@ -769,11 +739,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "cx" = (
-/obj/structure/table,
-/obj/item/toy/cards/deck,
-/obj/machinery/light/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "cy" = (
 /turf/closed/wall/r_wall,
@@ -799,22 +767,38 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/chapel)
+"cE" = (
+/obj/machinery/flasher/directional/north{
+	id = "Cell 2"
+	},
+/obj/structure/bed{
+	dir = 1;
+	pixel_x = -2
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "cF" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Cafeteria"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/courtroom)
+/area/security/prison)
+"cG" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "cH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/door/airlock/security{
+	name = "Permanent Cell 4"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison/safe)
 "cI" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -847,11 +831,6 @@
 "cM" = (
 /turf/closed/wall,
 /area/mine/living_quarters)
-"cN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "cO" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -915,17 +894,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"cW" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
 "cX" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -945,11 +913,25 @@
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "cZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "miningdorm_A";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/donk,
+/area/mine/production)
 "da" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -977,19 +959,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"dd" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/security/prison)
-"de" = (
-/obj/machinery/vending/sustenance,
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "df" = (
 /obj/machinery/light_switch/directional/north{
 	pixel_x = -7
@@ -1013,11 +982,22 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
+"dh" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "di" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "dj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1078,18 +1058,23 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dp" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Courtroom";
+	req_access_txt = "42"
+	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/court,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
-"dr" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/area/security/courtroom)
+"dq" = (
+/obj/machinery/vending/sustenance,
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "dt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -1126,21 +1111,22 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/wood/tile,
 /area/service/theater)
-"dz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
 "dA" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/camera/directional/south{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Cells"
+/obj/structure/rack,
+/obj/item/storage/box/teargas{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/area/security/prison)
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "dB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -1258,11 +1244,8 @@
 /turf/closed/wall/r_wall,
 /area/mine/eva)
 "dQ" = (
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/freezer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/security/prison)
 "dR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1294,10 +1277,7 @@
 /turf/open/floor/plating,
 /area/mine/production)
 "dW" = (
-/obj/machinery/newscaster/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "dX" = (
 /obj/structure/stairs/south,
@@ -1307,16 +1287,7 @@
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
 "dY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
-"dZ" = (
-/obj/machinery/flasher/directional/north{
-	id = "visitorflash"
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Visitation North"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "ea" = (
@@ -1329,16 +1300,11 @@
 /turf/open/floor/iron/smooth,
 /area/cargo/drone_bay)
 "eb" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	dir = 8;
-	name = "old sink";
-	pixel_x = 12
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
 /area/security/prison)
 "ec" = (
 /obj/structure/grille,
@@ -1470,15 +1436,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"er" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "es" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -1488,15 +1445,21 @@
 /turf/open/floor/iron/dark/side,
 /area/service/chapel)
 "et" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 29
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "eu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -1507,9 +1470,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "ev" = (
-/obj/item/storage/briefcase,
-/obj/structure/rack,
-/obj/item/camera/detective,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "ew" = (
@@ -1569,12 +1533,13 @@
 /turf/open/floor/plating,
 /area/service/chapel)
 "eA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/chair{
+	name = "Judge";
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig)
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "eB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -1600,21 +1565,19 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/service/chapel)
 "eE" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
+"eG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "eH" = (
-/obj/structure/table,
-/obj/item/taperecorder{
-	pixel_x = -3
-	},
-/obj/item/folder/red{
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/spray/pepper,
-/obj/item/assembly/flash,
-/turf/open/floor/plating/icemoon,
+/obj/machinery/light/small/directional/east,
+/turf/open/openspace/icemoon/keep_below,
 /area/security/execution/education)
 "eI" = (
 /obj/machinery/smartfridge/organ,
@@ -1625,17 +1588,16 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"eK" = (
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/iron,
+/area/security/prison)
 "eL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "eM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -1645,15 +1607,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"eN" = (
+/turf/closed/wall,
+/area/service/lawoffice)
 "eO" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light/directional/east,
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "eP" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
-/area/security/prison/safe)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "eQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1680,13 +1648,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "eU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "eW" = (
 /obj/item/clothing/suit/hooded/wintercoat/science,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -1704,6 +1667,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
+"eZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
 "fa" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -1729,13 +1698,20 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"fe" = (
-/obj/machinery/power/apc/auto_name/directional/west,
+"fd" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"fe" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/lawyer,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "ff" = (
 /obj/structure/stairs/south,
 /obj/structure/disposalpipe/segment,
@@ -1778,6 +1754,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/drone_bay)
+"fk" = (
+/obj/machinery/computer/bookmanagement,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/security/prison)
 "fl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1851,25 +1833,6 @@
 "fu" = (
 /turf/closed/wall,
 /area/icemoon/underground/explored)
-"fv" = (
-/obj/structure/toilet/greyscale{
-	dir = 4;
-	cistern = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "fw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1886,17 +1849,23 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "fy" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "fz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/closet{
+	name = "Evidence Closet 5"
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/security/brig)
 "fA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -1906,15 +1875,10 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "fB" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/execution/education)
 "fC" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
@@ -1938,21 +1902,12 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "fG" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Sec - Permabrig Exercise";
-	network = ssssssssssssss
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/security/prison)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "fH" = (
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/photo_album/prison,
-/obj/item/camera,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -1983,11 +1938,11 @@
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
 "fM" = (
+/obj/structure/chair/stool/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/security/prison)
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "fN" = (
 /obj/machinery/vending/dinnerware,
 /obj/structure/sign/poster/random/directional/east,
@@ -2047,12 +2002,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "fU" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/side{
-	dir = 1
+	dir = 4
 	},
 /area/security/prison)
 "fV" = (
@@ -2087,9 +2039,13 @@
 "fY" = (
 /turf/open/misc/asteroid/snow/icemoon,
 /area/mine/storage)
+"fZ" = (
+/obj/structure/grille,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "ga" = (
 /turf/closed/wall,
-/area/security/execution/education)
+/area/security/courtroom)
 "gb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -2167,15 +2123,12 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "gj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/closed/wall,
+/area/ai_monitored/security/armory)
 "gk" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 4
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron/edge{
+	dir = 1
 	},
 /area/security/prison)
 "gl" = (
@@ -2197,18 +2150,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"go" = (
-/obj/structure/closet{
-	name = "Evidence Closet 4"
+"gn" = (
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_edge{
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured,
+/area/security/brig)
+"go" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/area/security/brig)
-"gp" = (
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/security/prison/visit)
+/area/hallway/primary/central/fore)
+"gp" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating,
+/area/security/courtroom)
 "gq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -2228,10 +2192,8 @@
 /turf/open/floor/iron/freezer,
 /area/science/xenobiology)
 "gu" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "gv" = (
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/misc/dirt{
@@ -2249,6 +2211,9 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/mine/mechbay)
+"gy" = (
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory)
 "gz" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 1
@@ -2293,8 +2258,15 @@
 /turf/open/floor/stone,
 /area/service/bar)
 "gD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "gE" = (
 /obj/effect/turf_decal/tile/blue{
@@ -2308,24 +2280,14 @@
 /obj/item/storage/crayons,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
-"gF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
 "gG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "gH" = (
 /obj/structure/sink{
 	dir = 4;
@@ -2431,19 +2393,21 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "gU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
-"gV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
+"gV" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "gW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -2483,9 +2447,9 @@
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
 "ha" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron,
+/area/security/prison)
 "hb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -2573,18 +2537,12 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "hl" = (
-/obj/structure/closet/crate,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "hm" = (
 /obj/machinery/button/elevator{
 	id = "publicElevator";
@@ -2602,9 +2560,17 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "ho" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/lawoffice)
+"hp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "hq" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2614,12 +2580,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "hr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/closet{
+	name = "Evidence Closet 4"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/security/brig)
 "hs" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -2648,12 +2615,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
-"hv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "hx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -2663,24 +2624,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"hz" = (
-/obj/structure/toilet/greyscale{
+"hy" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"hz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Law Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "hA" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -2715,12 +2684,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"hD" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "hE" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/paper/fluff/jobs/prisoner/letter{
@@ -2756,6 +2719,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"hI" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "hJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2877,6 +2844,16 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/hallway/secondary/service)
+"hX" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Courtroom North"
+	},
+/obj/item/radio/intercom/directional/north,
+/obj/structure/chair{
+	name = "Defense"
+	},
+/turf/open/floor/wood,
+/area/security/courtroom)
 "hY" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -2908,17 +2885,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/mine/storage)
-"id" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/right/directional/north,
-/obj/machinery/door/window/right/directional/south,
-/turf/open/floor/iron,
-/area/security/prison/visit)
 "if" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -2950,22 +2916,19 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "ii" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	id = "visitation";
-	name = "Visitation Shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/left/directional/north,
-/obj/machinery/door/window/left/directional/south,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "ij" = (
-/obj/machinery/light/directional/north,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "ik" = (
 /obj/machinery/light/dim/directional/east,
 /obj/structure/table,
@@ -3025,6 +2988,11 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"iq" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "ir" = (
 /obj/structure/cable,
 /obj/structure/closet,
@@ -3048,38 +3016,19 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "it" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/door/poddoor/preopen{
+	id = "lawyer_blast";
+	name = "privacy door"
 	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/service/lawoffice)
+"iu" = (
+/obj/machinery/shower{
+	dir = 1
 	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "iv" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/grille,
@@ -3128,15 +3077,17 @@
 	},
 /area/service/hydroponics)
 "iE" = (
-/obj/machinery/button/flasher{
-	id = "transferflash";
-	pixel_x = 23;
-	pixel_y = 9
+/obj/structure/rack,
+/obj/item/clothing/glasses/sunglasses/big{
+	pixel_x = 4;
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/obj/item/clothing/glasses/sunglasses/big{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "iF" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -3147,6 +3098,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
+"iG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
+"iH" = (
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/obj/item/soap/nanotrasen,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "iI" = (
 /obj/structure/marker_beacon/burgundy{
 	name = "landing marker"
@@ -3209,12 +3172,12 @@
 	},
 /area/maintenance/department/medical/morgue)
 "iQ" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "iR" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -3249,14 +3212,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"iW" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "iX" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -3266,9 +3221,14 @@
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "iY" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/security/prison/safe)
+/obj/structure/closet{
+	name = "Evidence Closet 3"
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Lower Brig Evidence"
+	},
+/turf/open/floor/iron/dark/textured_edge,
+/area/security/brig)
 "iZ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -3331,20 +3291,24 @@
 	},
 /area/maintenance/aft/lesser)
 "jf" = (
-/obj/machinery/light_switch/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "jg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/security/courtroom)
+/area/security/prison)
 "jh" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
@@ -3361,6 +3325,12 @@
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
+"jj" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "jl" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -3369,15 +3339,18 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "jm" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/structure/railing,
+/obj/structure/cable,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "jn" = (
 /turf/closed/wall/r_wall,
 /area/cargo/drone_bay)
+"jp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/iron,
+/area/security/prison)
 "jq" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white/side{
@@ -3414,14 +3387,13 @@
 /turf/closed/wall/ice,
 /area/mine/storage)
 "jy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kanyewest";
-	name = "privacy shutters"
+/obj/structure/chair{
+	name = "Judge";
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/detectives_office)
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "jz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -3443,12 +3415,15 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "jB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/rack,
+/obj/item/gun/energy/ionrifle,
+/obj/item/gun/energy/temperature/security,
+/obj/item/clothing/suit/hooded/ablative,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "jC" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/dark,
@@ -3477,11 +3452,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "jH" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Lower Brig Hallway"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "jJ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -3506,6 +3481,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"jN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "jO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -3513,13 +3494,15 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "jP" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 29
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/prison)
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "jQ" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -3538,29 +3521,27 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "jS" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
-"jV" = (
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/corner,
+/area/security/prison)
+"jT" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"jV" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/machinery/camera/directional/south{
+	network = list("ss13","prison");
+	c_tag = "Security - Permabrig Recreation"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "jW" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -3592,14 +3573,29 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
-"jZ" = (
-/obj/structure/bookcase/random,
+"ka" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "kc" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/side,
-/area/security/prison)
+/obj/machinery/button/flasher{
+	id = "executionflash";
+	pixel_x = -24;
+	pixel_y = 5
+	},
+/obj/machinery/button/door/directional/west{
+	id = "executionfireblast";
+	name = "Transfer Area Lockdown";
+	pixel_y = -6;
+	req_access_txt = "2"
+	},
+/obj/structure/railing,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "kd" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet,
@@ -3652,15 +3648,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "kk" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Lower Hallway South"
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison)
 "kl" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -3681,29 +3675,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "kn" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/item/radio/intercom/prison/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
-"ko" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin/carbon{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_x = 9;
-	pixel_y = 7
-	},
-/obj/item/hand_labeler{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "kp" = (
 /obj/structure/bonfire,
 /obj/item/melee/roastingstick,
@@ -3717,8 +3696,8 @@
 /area/maintenance/aft/lesser)
 "kr" = (
 /obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
+	id = "Cell 3";
+	name = "Cell 3";
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3726,8 +3705,18 @@
 /turf/open/floor/iron/textured,
 /area/security/brig)
 "ks" = (
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Brig Lower Hallway North";
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "kt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -3767,13 +3756,12 @@
 	},
 /area/maintenance/department/medical/morgue)
 "kx" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/landmark/start/lawyer,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "ky" = (
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -3820,24 +3808,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"kG" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/landmark/start/prisoner,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
 "kH" = (
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plating,
@@ -3878,17 +3848,13 @@
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
 "kN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/execution/education)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "kO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/execution/education)
+/turf/closed/wall/r_wall,
+/area/security/prison/safe)
 "kP" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/carpet,
@@ -3906,10 +3872,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"kS" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "kT" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -3944,6 +3906,13 @@
 	dir = 1
 	},
 /area/mine/eva)
+"kW" = (
+/obj/structure/chair{
+	name = "Defense"
+	},
+/obj/effect/landmark/start/lawyer,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "kX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3977,6 +3946,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/mine/production)
+"la" = (
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "lb" = (
 /obj/structure/fluff/tram_rail{
 	pixel_y = 17
@@ -3985,24 +3960,48 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "lc" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/red/half,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "ld" = (
 /obj/effect/spawner/random/trash/hobo_squat,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "le" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/light/small/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "lf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4016,9 +4015,15 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "lh" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/security/prison)
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "prison blast door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "li" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -4032,10 +4037,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "lj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/security/prison)
 "ll" = (
 /obj/structure/railing{
@@ -4058,14 +4063,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/eva)
-"lo" = (
-/obj/structure/table,
-/obj/item/storage/box/prisoner{
-	pixel_y = 8
-	},
-/obj/item/storage/box/prisoner,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
 "lp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4150,9 +4147,16 @@
 /turf/open/floor/iron,
 /area/mine/eva)
 "lz" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "lA" = (
 /obj/structure/closet/decay,
 /turf/open/floor/plating,
@@ -4187,15 +4191,19 @@
 	},
 /area/maintenance/aft/lesser)
 "lF" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/servingdish,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/structure/sign/poster/official/safety_report{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "lG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "lH" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -4212,10 +4220,14 @@
 	},
 /area/maintenance/department/chapel)
 "lJ" = (
-/obj/machinery/vending/cola/sodie,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "lK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/light/small/directional/south,
@@ -4237,13 +4249,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"lM" = (
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "lN" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -4254,15 +4259,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "lO" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Permabrig Workshop";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/structure/filingcabinet/employment,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "lP" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
@@ -4294,13 +4293,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "lT" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/obj/machinery/camera/directional/west{
-	c_tag = "Prison Forestry";
-	network = list("ss13","prison")
+/obj/item/radio/intercom/prison/directional/north,
+/obj/structure/chair{
+	pixel_y = -2
 	},
-/turf/open/floor/grass,
+/turf/open/floor/iron,
 /area/security/prison)
 "lU" = (
 /obj/item/stack/sheet/animalhide/lizard{
@@ -4339,11 +4336,12 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "lZ" = (
-/obj/structure/disposalpipe/trunk/multiz{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/prison/safe)
 "ma" = (
 /turf/open/floor/circuit,
 /area/mine/living_quarters)
@@ -4359,9 +4357,6 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/aft/lesser)
-"me" = (
-/turf/open/floor/iron/white,
-/area/security/prison)
 "mf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -4384,6 +4379,12 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/aft/lesser)
+"mk" = (
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "ml" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -4399,7 +4400,21 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "mo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/poddoor{
+	id = "executionfireblast"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
+"mp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "mq" = (
@@ -4447,13 +4462,24 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "mx" = (
-/obj/structure/chair{
-	name = "Judge";
-	dir = 8
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
 	},
-/obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
+"my" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"mz" = (
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "mA" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -4480,20 +4506,9 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "mD" = (
-/obj/machinery/button/flasher{
-	id = "executionflash";
-	pixel_x = -24;
-	pixel_y = 5
-	},
-/obj/machinery/button/door/directional/west{
-	id = "executionfireblast";
-	name = "Transfer Area Lockdown";
-	pixel_y = -6;
-	req_access_txt = "2"
-	},
-/obj/structure/railing,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
+/obj/item/food/fried_chicken,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/maintenance/fore)
 "mE" = (
 /obj/structure/stairs/west,
 /obj/effect/turf_decal/siding/white{
@@ -4521,6 +4536,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/mine/storage)
+"mI" = (
+/obj/machinery/vending/cola/red,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "mJ" = (
 /obj/structure/cable,
 /turf/open/floor/iron/chapel{
@@ -4705,6 +4725,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"nj" = (
+/obj/structure/closet/secure_closet/injection,
+/obj/machinery/airalarm/directional/north,
+/obj/item/soap/nanotrasen,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "nk" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/engine,
@@ -4716,15 +4742,8 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "nm" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - Visitation South";
-	network = list("ss13","prison")
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "nn" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -4766,13 +4785,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/virology)
-"nq" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "ns" = (
 /turf/closed/wall/r_wall,
 /area/cargo/storage)
@@ -4864,18 +4876,23 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "nE" = (
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_y = 32
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	dir = 8;
+	name = "old sink";
+	pixel_x = 12
 	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
 "nF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/area/security/prison)
 "nG" = (
 /obj/structure/sign/warning{
 	pixel_y = 32
@@ -4888,12 +4905,16 @@
 /turf/open/floor/iron/dark/textured,
 /area/hallway/secondary/service)
 "nH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "nI" = (
 /obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/plating,
@@ -4901,6 +4922,15 @@
 "nJ" = (
 /turf/closed/wall,
 /area/service/hydroponics)
+"nK" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/cultivator,
+/obj/machinery/camera/directional/west{
+	c_tag = "Prison Forestry";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/grass,
+/area/security/prison)
 "nL" = (
 /obj/machinery/telecomms/relay/preset/mining,
 /turf/open/floor/circuit,
@@ -4909,11 +4939,9 @@
 /turf/closed/wall,
 /area/mine/mechbay)
 "nN" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "nO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner,
@@ -4933,6 +4961,12 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/grimy,
 /area/commons/lounge)
+"nQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "nS" = (
 /obj/structure/closet/crate/secure/freezer/pizza,
 /obj/effect/decal/cleanable/dirt,
@@ -4949,6 +4983,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"nW" = (
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "nX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
@@ -4957,18 +4998,14 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "nZ" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/obj/item/cartridge/lawyer,
-/obj/machinery/computer/security/telescreen/prison{
-	pixel_y = 32
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Visitation"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "oa" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 4
@@ -5005,10 +5042,9 @@
 	},
 /area/mine/eva)
 "od" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/textured,
+/area/security/prison)
 "oe" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -5068,11 +5104,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plating,
 /area/mine/eva)
-"ol" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "om" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -5120,10 +5151,17 @@
 /turf/open/floor/plating,
 /area/mine/eva)
 "os" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/area/maintenance/fore)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "ot" = (
 /obj/structure/stairs/south,
 /obj/structure/railing{
@@ -5145,13 +5183,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
-"ox" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
 "oy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5169,10 +5200,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "oz" = (
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/security/prison)
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plating,
+/area/security/courtroom)
 "oA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5186,6 +5219,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"oB" = (
+/obj/structure/rack,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "oC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5216,19 +5257,19 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "oG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/rack,
+/obj/item/gun/energy/disabler{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office"
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/detective,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "oH" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -5239,10 +5280,10 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "oI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "oJ" = (
 /obj/structure/sign/poster/official/report_crimes,
 /turf/closed/wall/ice,
@@ -5256,9 +5297,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/stone,
 /area/commons/lounge)
-"oM" = (
-/turf/closed/wall/r_wall,
-/area/icemoon/underground/explored)
 "oN" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 5
@@ -5276,6 +5314,15 @@
 	dir = 8
 	},
 /area/mine/living_quarters)
+"oO" = (
+/obj/machinery/door/airlock/security{
+	name = "Prison Forestry"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "oP" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -5284,12 +5331,9 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "oQ" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "oR" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -5386,13 +5430,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"pe" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+"pg" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/computer/warrant{
+	dir = 4
 	},
 /turf/open/floor/wood,
-/area/security/courtroom)
+/area/service/lawoffice)
 "ph" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
@@ -5471,17 +5516,13 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "po" = (
-/turf/open/floor/iron/smooth_half,
-/area/security/prison)
+/turf/open/openspace/icemoon/keep_below,
+/area/security/execution/education)
 "pp" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/dice,
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
-"pq" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
 "pr" = (
 /turf/closed/wall,
 /area/maintenance/fore)
@@ -5506,14 +5547,8 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "pw" = (
-/obj/machinery/door/airlock/security{
-	name = "Cell Block"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "px" = (
 /obj/structure/stairs/north,
@@ -5534,9 +5569,12 @@
 /turf/open/floor/iron/smooth_edge,
 /area/medical/chemistry)
 "pB" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/structure/table,
+/obj/item/pen,
+/obj/structure/cable,
+/obj/item/instrument/harmonica,
+/turf/open/floor/iron,
+/area/security/prison)
 "pC" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -5545,7 +5583,12 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "pD" = (
-/turf/open/floor/iron/textured,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
 /area/security/brig)
 "pE" = (
 /obj/structure/cable,
@@ -5561,13 +5604,16 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/area/security/prison)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/fore)
 "pI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/engine,
@@ -5586,12 +5632,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "pL" = (
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/open/floor/iron/dark/textured_large,
+/area/security/brig)
 "pM" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/camera{
@@ -5616,21 +5661,16 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "pQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison/visit)
-"pR" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/pen/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/open/floor/plating,
+/area/security/brig)
+"pR" = (
+/obj/structure/table,
+/obj/item/storage/dice,
+/turf/open/floor/iron,
+/area/security/prison)
 "pT" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -5677,15 +5717,17 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"pZ" = (
+/obj/structure/closet/secure_closet/courtroom,
+/obj/item/gavelhammer,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "qa" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "qb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -5725,21 +5767,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/mine/storage)
 "qg" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "qh" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -5826,14 +5856,11 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "qr" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
+/obj/structure/closet/secure_closet/evidence,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
+/area/security/brig)
 "qs" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy{
@@ -5853,17 +5880,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"qv" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half{
-	dir = 1
-	},
-/area/security/brig)
 "qw" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -5901,10 +5917,11 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "qA" = (
-/turf/open/floor/iron/dark/side{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Cleaning Closet"
 	},
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "qB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5942,14 +5959,13 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"qF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"qG" = (
+/obj/structure/closet/secure_closet/detective,
 /obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "qH" = (
-/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured,
 /area/security/brig)
 "qJ" = (
@@ -5967,12 +5983,12 @@
 /turf/open/floor/carpet,
 /area/service/chapel)
 "qM" = (
-/obj/item/radio/intercom/prison/directional/north,
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "qN" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -5982,19 +5998,38 @@
 /turf/open/floor/iron/smooth_large,
 /area/cargo/warehouse)
 "qO" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plating,
+/area/service/lawoffice)
 "qP" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/light_switch/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "qQ" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 1
@@ -6085,9 +6120,10 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "qZ" = (
-/obj/structure/grille,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "rb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -6108,9 +6144,6 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics)
-"re" = (
-/turf/closed/wall/r_wall,
-/area/security/detectives_office)
 "rf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -6121,19 +6154,9 @@
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "rg" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/machinery/camera/directional/south{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Recreation"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "rh" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -6214,18 +6237,16 @@
 /turf/open/floor/iron/dark/corner,
 /area/mine/eva)
 "rq" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/flasher/directional/east{
+	id = "executionflash"
+	},
+/turf/open/openspace/icemoon/keep_below,
+/area/security/execution/education)
 "rr" = (
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
 /area/service/chapel)
-"rs" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/security/prison/safe)
 "rt" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/blue{
@@ -6243,6 +6264,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"ru" = (
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "rv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/light/directional/south,
@@ -6256,12 +6281,10 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
 "rx" = (
-/obj/structure/chair{
-	name = "Defense"
-	},
-/obj/effect/landmark/start/lawyer,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/hydroponics/soil,
+/obj/item/shovel/spade,
+/turf/open/floor/grass,
+/area/security/prison)
 "ry" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
@@ -6358,9 +6381,39 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"rI" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Courtroom Audience"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "rJ" = (
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/stamp/law,
+/obj/machinery/camera/directional/south{
+	c_tag = "Service - Law Office"
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 17
+	},
+/obj/machinery/requests_console/directional/south{
+	department = "Law Office";
+	name = "Law Office Requests Console"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "rK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/plating,
@@ -6452,6 +6505,12 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
+"rW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "rX" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -6468,8 +6527,24 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "rZ" = (
-/turf/closed/wall,
-/area/ai_monitored/security/armory)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "sa" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -6534,6 +6609,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"sj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "sk" = (
 /obj/structure/fireplace,
 /turf/open/floor/plating,
@@ -6555,13 +6635,16 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "sn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
 	},
-/turf/open/floor/iron/corner{
-	dir = 1
-	},
-/area/security/prison)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/left/directional/north,
+/obj/machinery/door/window/left/directional/south,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "so" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
@@ -6575,8 +6658,19 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
+"sq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/fore)
 "sr" = (
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
 /area/security/prison)
 "ss" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -6585,14 +6679,21 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/chemistry)
 "su" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Visitation"
+/obj/machinery/shower{
+	pixel_y = 12
 	},
-/obj/machinery/door/firedoor,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
+"sv" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/pen/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/security/brig,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "sx" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6604,12 +6705,10 @@
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "sy" = (
-/obj/structure/closet{
-	name = "Evidence Closet 2"
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/textured_edge,
-/area/security/brig)
+/obj/machinery/hydroponics/soil,
+/obj/item/cultivator,
+/turf/open/floor/grass,
+/area/security/prison)
 "sz" = (
 /obj/structure/railing{
 	dir = 9
@@ -6651,6 +6750,13 @@
 	dir = 4
 	},
 /area/mine/production)
+"sD" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "sE" = (
 /obj/machinery/space_heater,
 /obj/structure/disposalpipe/segment{
@@ -6674,37 +6780,16 @@
 "sG" = (
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"sI" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permainner";
-	name = "Permabrig Transfer"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "perma-entrance"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
 "sJ" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/commons/dorms/laundry)
 "sK" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 7;
-	pixel_y = 12
-	},
-/obj/item/taperecorder{
-	pixel_x = -5
-	},
-/obj/item/lighter{
-	pixel_x = 8;
-	pixel_y = -9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/vending/cigarette,
+/obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "sL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -6736,11 +6821,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/service/theater)
-"sQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "sR" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Service-Hallway Bottom 2"
@@ -6777,25 +6857,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"sW" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "sX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -6893,11 +6954,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "ti" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
 	},
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "tk" = (
 /obj/machinery/duct,
 /obj/machinery/holopad,
@@ -6914,9 +6979,12 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "tm" = (
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "to" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
@@ -6959,8 +7027,14 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "tu" = (
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "tv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -6968,14 +7042,23 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "tw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permaouter";
+	name = "Permabrig Transfer"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-entrance"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
+"tx" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
 /obj/structure/cable,
-/obj/machinery/door/window/brigdoor/right/directional/east{
-	req_access_txt = "3"
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/security/execution/education)
 "ty" = (
 /obj/effect/decal/cleanable/generic,
@@ -7023,17 +7106,11 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
-"tG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/security/prison)
 "tH" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/trash/chips,
-/obj/item/trash/candy,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "tJ" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/closet{
@@ -7052,12 +7129,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "tM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/visit)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "tN" = (
 /obj/structure/chair{
 	dir = 8
@@ -7120,15 +7197,29 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"tU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron/corner{
+	dir = 8
+	},
+/area/security/prison)
 "tV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/plating,
-/area/service/lawoffice)
+/obj/machinery/button/door/directional/east{
+	name = "Privacy Shutters"s;
+	id = "kanyewest"
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "tW" = (
-/turf/closed/wall/r_wall,
-/area/security/execution/education)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tX" = (
 /obj/machinery/light/dim/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7139,27 +7230,22 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "tY" = (
-/obj/machinery/button/door/directional/north{
-	id = "permainner";
-	name = "Inner Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -6;
-	req_access_txt = "2";
-	specialfunctions = 4
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 2";
+	name = "Cell 2";
+	dir = 8
 	},
-/obj/machinery/button/door/directional/north{
-	id = "permaouter";
-	name = "Outer Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 6;
-	req_access_txt = "2";
-	specialfunctions = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
 	},
+/area/security/brig)
+"tZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/security/prison)
-"tZ" = (
-/turf/closed/wall,
-/area/security/courtroom)
 "ua" = (
 /obj/effect/landmark/start/chaplain,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7201,15 +7287,22 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "ug" = (
-/obj/machinery/door/airlock{
-	name = "Cleaning Closet"
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/area/security/prison)
 "uh" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
+"ui" = (
+/obj/structure/closet{
+	name = "Evidence Closet 1"
+	},
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/dark/textured_edge,
+/area/security/brig)
 "uj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -7247,43 +7340,26 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "un" = (
-/obj/structure/table,
-/obj/item/electropack,
-/obj/item/screwdriver,
-/obj/item/wrench,
-/obj/item/clothing/head/helmet,
-/obj/item/assembly/signaler,
-/obj/structure/cable,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
-"uo" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/shovel/spade,
-/turf/open/floor/grass,
-/area/security/prison)
+/obj/structure/grille/broken,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "up" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12
+/obj/item/radio/intercom/prison/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bottle/ammonia,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "uq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/photo_album/prison,
+/obj/item/camera,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison)
 "ur" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -7291,14 +7367,15 @@
 /turf/open/floor/iron/freezer,
 /area/science/xenobiology)
 "ut" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Prosecution"
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Permabrig Workshop";
+	network = list("ss13","prison")
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "uu" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -7365,23 +7442,20 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "uB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
-"uC" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3";
-	dir = 8
-	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half{
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
+"uC" = (
+/obj/machinery/shower{
 	dir = 1
 	},
-/area/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "uD" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -7421,9 +7495,10 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "uH" = (
-/obj/structure/sign/poster/official/obey,
-/turf/closed/wall/r_wall,
-/area/security/prison/visit)
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "uI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7431,9 +7506,11 @@
 /turf/open/floor/iron,
 /area/mine/eva)
 "uJ" = (
-/obj/structure/table,
-/obj/item/storage/dice,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/edge,
 /area/security/prison)
 "uK" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -7457,16 +7534,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
-"uN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
-/area/security/prison)
 "uO" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /obj/effect/decal/cleanable/dirt,
@@ -7495,16 +7562,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "uR" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Wing"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plating,
+/area/security/courtroom)
 "uS" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/tile/brown,
@@ -7547,11 +7610,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "va" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Wing"
 	},
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "vb" = (
 /obj/item/radio/intercom/directional/north,
@@ -7580,12 +7647,6 @@
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"ve" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/brig)
 "vf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/gambling,
@@ -7594,11 +7655,9 @@
 /turf/open/floor/iron/grimy,
 /area/commons/lounge)
 "vg" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/courtroom)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "vh" = (
 /obj/structure/sign/departments/cargo,
 /turf/closed/wall/r_wall,
@@ -7627,15 +7686,23 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "vn" = (
-/obj/machinery/flasher/directional/north{
-	id = "Cell 1"
+/obj/machinery/light/small/directional/east,
+/obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/structure/bed{
-	dir = 1;
-	pixel_x = -2
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/iron/smooth,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "vo" = (
 /obj/item/flashlight/lantern{
 	light_on = 1
@@ -7643,15 +7710,28 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "vp" = (
-/obj/structure/chair/stool/directional/west,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
+"vq" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison)
+"vr" = (
+/obj/machinery/vending/cola/sodie,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
-"vq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/area/security/prison/visit)
 "vs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -7714,8 +7794,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "vB" = (
-/turf/open/floor/iron,
-/area/security/courtroom)
+/obj/machinery/camera/directional/east{
+	c_tag = "Sec - Permabrig Exercise";
+	network = ssssssssssssss
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "vC" = (
 /turf/closed/wall/r_wall,
 /area/mine/production)
@@ -7739,39 +7825,53 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "vG" = (
-/obj/machinery/flasher/directional/north{
-	id = "transferflash"
-	},
 /obj/structure/chair{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark/textured,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
 /area/security/prison)
+"vH" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "vI" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
+/obj/machinery/flasher/directional/north{
+	id = "Cell 1"
 	},
-/obj/structure/cable,
+/obj/structure/bed{
+	dir = 1;
+	pixel_x = -2
+	},
 /turf/open/floor/iron/smooth,
 /area/security/brig)
 "vJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "vK" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "vL" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/plating,
-/area/security/courtroom)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/detective,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "vN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -7793,9 +7893,13 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
 "vR" = (
-/obj/item/food/fried_chicken,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "vS" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -7818,9 +7922,8 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "vU" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/textured,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/security/brig)
 "vW" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -7875,23 +7978,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"wc" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 1"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
 "wd" = (
-/obj/machinery/door/airlock{
-	name = "Permabrig Showers"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
+/obj/machinery/recharger,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red/half,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "we" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -7955,14 +8048,8 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wn" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/open/floor/plating,
+/area/security/prison)
 "wo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -7987,12 +8074,16 @@
 /turf/closed/wall/ice,
 /area/mine/living_quarters)
 "wr" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Lower Brig Cells";
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/detectives_office)
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "ws" = (
 /obj/machinery/mineral/processing_unit{
 	dir = 1
@@ -8006,24 +8097,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/production)
-"wt" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "wu" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -8074,12 +8147,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "wD" = (
-/obj/structure/closet{
-	name = "Evidence Closet 1"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
 	},
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/dark/textured_edge,
-/area/security/brig)
+/area/security/prison)
 "wE" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -8100,32 +8174,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"wG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
-"wH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/structure/holohoop{
-	dir = 4
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/security/prison)
 "wI" = (
 /obj/structure/railing,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -8170,16 +8218,12 @@
 /turf/open/floor/iron,
 /area/service/chapel)
 "wO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "wP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "wQ" = (
 /obj/effect/turf_decal/bot,
@@ -8211,23 +8255,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "wV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/door/airlock/security{
+	name = "Permabrig Visitation"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/chair/stool/directional/west,
-/obj/machinery/camera/emp_proof/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/commons/dorms/laundry)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison/visit)
 "wW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison/visit)
 "wX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -8259,12 +8300,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "xb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/icemoon/underground/explored)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "xc" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -8302,19 +8342,15 @@
 	dir = 1
 	},
 /area/mine/living_quarters)
-"xg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/security/prison)
 "xi" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 5"
+/obj/machinery/light/small/directional/south,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "xj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -8334,9 +8370,13 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "xm" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/openspace/icemoon/keep_below,
-/area/security/execution/education)
+/obj/structure/toilet/greyscale,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/security/prison/safe)
 "xn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -8344,21 +8384,16 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "xo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/space_heater,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/area/maintenance/fore)
 "xp" = (
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/obj/item/soap/nanotrasen,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "xq" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -8381,10 +8416,15 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "xs" = (
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/door/airlock/security/glass{
+	name = "Evidence Storage";
+	req_one_access_txt = "1;4"
+	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/textured,
+/turf/open/floor/iron/dark/textured_large,
 /area/security/brig)
 "xt" = (
 /obj/structure/table,
@@ -8416,7 +8456,7 @@
 /area/mine/eva)
 "xx" = (
 /turf/closed/wall/r_wall,
-/area/security/prison/visit)
+/area/service/lawoffice)
 "xy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -8442,12 +8482,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"xD" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "xE" = (
 /obj/machinery/food_cart,
 /obj/machinery/light/directional/south,
@@ -8456,6 +8490,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"xF" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "xG" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -8493,23 +8534,24 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/cargo/drone_bay)
-"xK" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/iron/dark,
-/area/medical/virology)
 "xL" = (
-/obj/structure/chair/stool/directional/north,
+/obj/item/radio/intercom/prison/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
+"xN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/structure/holohoop{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/security/prison/visit)
-"xO" = (
-/turf/closed/wall,
-/area/hallway/primary/central/fore)
+/area/security/prison)
 "xP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -8530,9 +8572,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "xS" = (
-/obj/structure/grille/broken,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "xW" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -8574,10 +8621,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "yc" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/wood,
+/area/security/courtroom)
+"yd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "ye" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8596,6 +8647,33 @@
 	},
 /turf/open/floor/wood/tile,
 /area/service/theater)
+"yg" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_y = 8;
+	req_access_txt = "2";
+	pixel_x = 5
+	},
+/obj/machinery/button/door{
+	id = "Trial Transfer";
+	name = "Trial Transfer Lockdown";
+	pixel_y = 8;
+	req_access_txt = "2";
+	pixel_x = -7
+	},
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_y = -3;
+	pixel_x = -7
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "yh" = (
 /obj/structure/sign/warning/gasmask{
 	pixel_y = -32
@@ -8603,19 +8681,26 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"yi" = (
+/obj/structure/chair/stool/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "yj" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "yk" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
+/obj/item/storage/briefcase,
+/obj/structure/rack,
+/obj/item/camera/detective,
+/turf/open/floor/carpet,
+/area/security/detectives_office)
+"yl" = (
+/obj/machinery/light/small/directional/west,
+/mob/living/simple_animal/mouse/brown/tom,
 /turf/open/floor/plating,
 /area/security/prison/safe)
-"yl" = (
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron,
-/area/security/prison/visit)
 "ym" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -8628,11 +8713,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"yn" = (
-/obj/item/storage/bag/trash,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "yo" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/blue{
@@ -8645,17 +8725,20 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "yp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/security/courtroom)
-"yq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/cafeteria,
 /area/security/prison)
+"yq" = (
+/obj/structure/stairs/east,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "ys" = (
 /obj/structure/railing{
 	dir = 10
@@ -8680,16 +8763,22 @@
 	},
 /area/service/chapel)
 "yu" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/openspace/icemoon/keep_below,
-/area/security/execution/education)
-"yv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/hand_labeler{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "yw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/north,
@@ -8711,11 +8800,23 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/greater)
-"yB" = (
-/obj/machinery/computer/bookmanagement,
+"yA" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/item/storage/box/prisoner{
+	pixel_y = 8
+	},
+/obj/item/storage/box/prisoner,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
+"yB" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permainner";
+	name = "Permabrig Transfer"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "perma-entrance"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/security/prison)
 "yC" = (
 /obj/structure/chair/pew/left{
@@ -8745,19 +8846,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/lobby)
-"yG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
-"yH" = (
-/obj/structure/chair{
-	dir = 4
-	},
+"yI" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "yJ" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -8786,23 +8884,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "yN" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "yO" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/engineering/lobby)
 "yP" = (
-/obj/structure/chair{
-	dir = 1;
-	name = "Prosecution"
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
-/area/security/courtroom)
+/area/service/lawoffice)
 "yQ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -8841,18 +8936,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
-"yW" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permaouter";
-	name = "Permabrig Transfer"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "perma-entrance"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
 "yX" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -8864,10 +8947,9 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "yY" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/cultivator,
-/turf/open/floor/grass,
-/area/security/prison)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "yZ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8918,20 +9000,15 @@
 	dir = 1
 	},
 /area/service/hydroponics)
-"zg" = (
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_x = -32
+"zh" = (
+/obj/machinery/light_switch/directional/south,
+/obj/structure/chair/comfy/brown{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/effect/landmark/start/detective,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "zi" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8942,15 +9019,12 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "zk" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison)
-"zl" = (
-/obj/structure/flora/grass/green,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/unexplored)
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "zm" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm_A";
@@ -8962,11 +9036,9 @@
 	},
 /area/mine/production)
 "zn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron,
-/area/security/prison/visit)
+/area/security/prison)
 "zo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/event_spawn,
@@ -8985,16 +9057,11 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "zq" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/item/instrument/harmonica,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/grass,
 /area/security/prison/safe)
-"zr" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/plating,
-/area/service/lawoffice)
 "zs" = (
 /obj/structure/window/reinforced,
 /obj/machinery/light/directional/west,
@@ -9082,6 +9149,45 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"zC" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/knife/plastic,
+/obj/item/knife/plastic,
+/obj/item/knife/plastic,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/box/drinkingglasses,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Sec - Permabrig Cafe";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/white,
+/area/security/prison)
+"zD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "zE" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/box,
@@ -9170,15 +9276,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "zQ" = (
-/obj/structure/chair{
-	name = "Judge";
-	dir = 8
+/obj/machinery/door/airlock/public/glass{
+	name = "Trial Transfer"
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Courtroom"
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/wood,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/iron/textured,
 /area/security/courtroom)
 "zR" = (
 /obj/effect/decal/cleanable/oil,
@@ -9200,20 +9305,19 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "zV" = (
-/obj/machinery/shower{
-	pixel_y = 12
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
 	},
-/turf/open/floor/iron/freezer,
-/area/security/prison)
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/trapdoor_placer,
+/turf/open/floor/glass/reinforced,
+/area/security/courtroom)
 "zW" = (
-/obj/machinery/door/airlock/security{
-	name = "Prison Forestry"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "zY" = (
 /obj/effect/turf_decal/siding/wood/end,
 /obj/structure/bookcase/random/fiction,
@@ -9246,20 +9350,12 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "Ae" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/security/courtroom)
+/turf/open/floor/iron,
+/area/security/prison)
 "Af" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"Ag" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "Ah" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
@@ -9274,8 +9370,9 @@
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
 "Aj" = (
-/turf/closed/wall/r_wall,
-/area/security/courtroom)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "Ak" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -9346,10 +9443,13 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "Au" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/door/airlock/maintenance{
+	name = "Permabrig Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "Av" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -9411,11 +9511,21 @@
 /turf/open/floor/plating,
 /area/cargo/warehouse)
 "AC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/plating,
-/area/hallway/primary/central/fore)
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "AD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -9423,10 +9533,10 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "AE" = (
-/obj/structure/closet/secure_closet/detective,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "AF" = (
 /turf/closed/wall,
 /area/mine/storage)
@@ -9435,9 +9545,12 @@
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "AH" = (
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "AI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -9449,6 +9562,14 @@
 /obj/structure/sign/departments/holy,
 /turf/closed/wall,
 /area/service/chapel)
+"AK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "AN" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -9461,9 +9582,24 @@
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
 "AP" = (
+/obj/structure/toilet/greyscale{
+	dir = 4;
+	cistern = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "AQ" = (
 /turf/open/floor/iron/dark,
 /area/service/chapel)
@@ -9475,12 +9611,10 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "AS" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/security/brig)
+/obj/machinery/light/directional/south,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "AT" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/tile/blue{
@@ -9521,10 +9655,6 @@
 	dir = 1
 	},
 /area/service/chapel)
-"AX" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "AY" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -9558,6 +9688,16 @@
 "Bd" = (
 /turf/closed/wall,
 /area/maintenance/department/cargo)
+"Be" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/door/window/brigdoor/right/directional/east{
+	req_access_txt = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "Bf" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
@@ -9672,11 +9812,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "By" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "Bz" = (
 /obj/structure/chair/pew{
 	dir = 1
@@ -9725,11 +9866,15 @@
 /turf/open/floor/iron/dark/side,
 /area/mine/eva)
 "BF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
+"BG" = (
+/turf/closed/wall/r_wall,
+/area/icemoon/underground/unexplored/rivers)
 "BH" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -9742,12 +9887,11 @@
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "BK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "BM" = (
 /obj/structure/cable,
@@ -9792,36 +9936,37 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "BS" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half{
-	dir = 1
-	},
-/area/security/brig)
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "BT" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Courtroom Audience"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/turf/open/floor/plating,
+/area/security/prison/visit)
 "BU" = (
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"BV" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "BW" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"BX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "BY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -9875,12 +10020,26 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "Cf" = (
-/turf/closed/wall/r_wall,
-/area/security/prison)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Cg" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
-/area/security/prison)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Ch" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
@@ -9918,8 +10077,23 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "Cm" = (
-/obj/machinery/plate_press,
-/turf/open/floor/plating,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/seeds/onion,
+/obj/item/seeds/garlic,
+/obj/item/seeds/potato,
+/obj/item/seeds/tomato,
+/obj/item/seeds/carrot,
+/obj/item/seeds/grass,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/effect/spawner/random/contraband/prison,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
 /area/security/prison)
 "Cn" = (
 /obj/effect/turf_decal/tile/bar,
@@ -9937,10 +10111,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "Cp" = (
-/obj/structure/table,
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/structure/sign/poster/official/here_for_your_safety{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "Cq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9948,13 +10124,9 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/maintenance/department/chapel)
 "Cr" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/security/prison)
-"Cs" = (
-/obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "Ct" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10036,20 +10208,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"CD" = (
-/turf/closed/wall/r_wall,
-/area/security/prison/safe)
 "CE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "CF" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -10058,23 +10223,11 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
-"CH" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/plating,
-/area/security/courtroom)
 "CI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison/visit)
 "CJ" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -10099,17 +10252,6 @@
 	dir = 8
 	},
 /area/mine/living_quarters)
-"CM" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/door/window/brigdoor{
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/trapdoor_placer,
-/turf/open/floor/glass/reinforced,
-/area/security/courtroom)
 "CN" = (
 /obj/structure/table,
 /obj/effect/landmark/event_spawn,
@@ -10216,17 +10358,20 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "CY" = (
+/turf/closed/wall,
+/area/hallway/primary/central/fore)
+"Da" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
-"CZ" = (
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "Db" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/plating/icemoon,
 /area/security/execution/education)
 "Dc" = (
@@ -10245,24 +10390,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
-"De" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
-"Df" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	name = "Law Office"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "Dg" = (
 /turf/closed/wall,
 /area/service/bar)
@@ -10331,14 +10458,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "Dp" = (
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/machinery/plate_press,
+/turf/open/floor/plating,
 /area/security/prison)
 "Dq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10347,19 +10468,19 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
-"Ds" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 30
+"Dr" = (
+/obj/structure/chair{
+	pixel_y = -2
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison)
+"Ds" = (
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "Dt" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 4;
@@ -10373,10 +10494,9 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "Du" = (
-/obj/structure/railing/corner,
-/obj/structure/railing/corner{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/razor,
+/obj/item/storage/backpack/duffelbag/sec/surgery,
 /turf/open/floor/plating/icemoon,
 /area/security/execution/education)
 "Dv" = (
@@ -10386,13 +10506,12 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "Dw" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/computer/warrant{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/open/floor/iron,
+/area/security/prison)
 "Dx" = (
 /obj/structure/railing{
 	dir = 10
@@ -10412,6 +10531,17 @@
 /obj/item/clothing/suit/hooded/wintercoat/science,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"DA" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/camera/emp_proof/directional/south,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms/laundry)
 "DB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/newscaster/directional/south,
@@ -10483,34 +10613,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"DJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "DK" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/textured,
 /area/security/prison)
-"DM" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "DN" = (
-/obj/item/instrument/harmonica,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/grass,
-/area/security/prison/safe)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/edge,
+/area/security/prison)
 "DO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -10531,12 +10645,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/department/medical/morgue)
 "DQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "DR" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -10573,33 +10685,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"DX" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/edge,
-/area/security/prison)
-"DY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/brig)
-"DZ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/machinery/button/door/directional/north{
-	id = "miningdorm_A";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -24;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/donk,
-/area/mine/production)
 "Ea" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -10691,12 +10776,9 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "En" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "Eo" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -10714,22 +10796,39 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "Eq" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "Er" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/structure/toilet/greyscale{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/edge,
-/area/security/prison)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "Es" = (
-/obj/structure/chair/stool/directional/south,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/machinery/camera/directional/north{
+	c_tag = "Armory - Internal - Lower"
+	},
+/obj/structure/rack,
+/obj/item/storage/toolbox/drone,
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "Et" = (
 /turf/closed/mineral/random/snow,
 /area/icemoon/underground/explored)
@@ -10751,8 +10850,11 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "Ex" = (
-/turf/closed/wall,
-/area/security/prison/visit)
+/obj/machinery/firealarm/directional/south,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "Ez" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -10771,9 +10873,17 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "EC" = (
-/obj/structure/stairs/east,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central/fore)
+/area/security/prison/safe)
+"ED" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/plant_analyzer,
+/turf/open/floor/grass,
+/area/security/prison)
 "EE" = (
 /obj/machinery/icecream_vat,
 /obj/structure/sign/poster/random/directional/east,
@@ -10805,22 +10915,22 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
-"EJ" = (
-/obj/machinery/vending/wardrobe/det_wardrobe,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/grimy,
+"EI" = (
+/turf/closed/wall/r_wall,
 /area/security/detectives_office)
+"EJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "EK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "EL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/visit)
 "EM" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -10853,28 +10963,10 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "EQ" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/stamp/law,
-/obj/machinery/camera/directional/south{
-	c_tag = "Service - Law Office"
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 17
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Law Office";
-	name = "Law Office Requests Console"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "ER" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -10894,22 +10986,16 @@
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "ES" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/closet/secure_closet/evidence,
+/turf/open/floor/iron/dark/textured_edge,
+/area/security/brig)
 "ET" = (
 /turf/closed/wall,
 /area/cargo/storage)
 "EU" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Permabrig Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
 "EX" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
@@ -11001,52 +11087,65 @@
 	},
 /area/mine/eva)
 "Fh" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Prison Cafeteria"
+/obj/machinery/light/small/directional/south,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "Fi" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Fj" = (
+/obj/machinery/door/airlock/security{
+	name = "Cell Block"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "Fk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "Fl" = (
-/obj/structure/closet/secure_closet/evidence,
-/turf/open/floor/iron/dark/textured_edge,
-/area/security/brig)
+/obj/structure/bed,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/bedsheet/red,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/prison/safe)
 "Fm" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"Fn" = (
-/turf/open/openspace/icemoon/keep_below,
-/area/security/execution/education)
 "Fo" = (
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
 "Fp" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/trash/sosjerky,
-/obj/item/trash/boritos,
-/obj/item/trash/can,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
+/obj/machinery/flasher/directional/north{
+	id = "visitorflash"
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Visitation North"
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/visit)
 "Fq" = (
 /turf/closed/wall/mineral/wood,
 /area/maintenance/aft/lesser)
@@ -11069,7 +11168,23 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
 "Ft" = (
-/turf/open/floor/iron,
+/obj/machinery/button/door/directional/north{
+	id = "permainner";
+	name = "Inner Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	req_access_txt = "2";
+	specialfunctions = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "permaouter";
+	name = "Outer Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	req_access_txt = "2";
+	specialfunctions = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "Fu" = (
 /obj/structure/fence,
@@ -11082,16 +11197,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Fw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/spawner/random/contraband/prison,
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/turf/open/floor/plating,
+/area/security/prison)
 "Fx" = (
 /obj/structure/cable,
 /obj/item/wrench,
@@ -11109,32 +11224,13 @@
 /obj/structure/flora/grass/green,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"FA" = (
-/obj/structure/closet/secure_closet/courtroom,
-/obj/item/gavelhammer,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron,
-/area/security/courtroom)
 "FB" = (
-/obj/structure/bed,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Permabrig Showers"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
-"FC" = (
-/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "FD" = (
 /obj/structure/chair/plastic{
@@ -11184,34 +11280,44 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "FH" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/plant_analyzer,
-/turf/open/floor/grass,
-/area/security/prison)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "FJ" = (
-/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/newscaster/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "FK" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/plating,
+/area/security/brig)
 "FL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/mine/production)
 "FM" = (
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "FN" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 8
@@ -11219,23 +11325,25 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "FO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/turf/open/floor/iron,
 /area/security/prison)
 "FP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "FQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
 /obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/icemoon/underground/explored)
 "FR" = (
 /turf/closed/mineral/random/snow/high_chance,
 /area/icemoon/underground/explored)
@@ -11253,14 +11361,8 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "FW" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "FX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -11278,6 +11380,17 @@
 /obj/structure/stairs/west,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"Gb" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "Gc" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -11464,29 +11577,18 @@
 /turf/open/openspace/icemoon/keep_below,
 /area/maintenance/department/medical/morgue)
 "Gw" = (
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"Gx" = (
-/obj/machinery/flasher/directional/north{
-	id = "Cell 2"
-	},
-/obj/structure/bed{
-	dir = 1;
-	pixel_x = -2
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig)
-"Gy" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/turf/open/floor/iron/smooth,
+/area/security/prison)
+"Gx" = (
+/turf/closed/wall,
+/area/security/execution/education)
+"Gy" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half,
+/area/security/prison)
 "Gz" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -11545,17 +11647,14 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "GG" = (
-/obj/structure/table,
-/obj/item/storage/box/hug{
-	pixel_x = 4;
-	pixel_y = 3
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
 	},
-/obj/item/razor{
-	pixel_x = -8;
-	pixel_y = 3
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Permabrig Forestry"
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron,
 /area/security/prison)
 "GH" = (
 /obj/structure/stairs/east,
@@ -11564,6 +11663,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"GI" = (
+/turf/open/floor/iron/white,
+/area/security/prison)
 "GJ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -11593,8 +11695,21 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "GP" = (
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/structure/bed/maint,
+/obj/item/toy/plush/rouny{
+	name = "Therapy Dog";
+	desc = "What is this? Is this a dog?"
+	},
+/obj/structure/cable,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Isolation Cell";
+	network = list("ss13","prison","Isolation");
+	view_range = 5
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/security/prison/safe)
 "GR" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -11650,9 +11765,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"GX" = (
-/turf/open/floor/iron/smooth,
-/area/security/prison)
 "GZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/north,
@@ -11689,12 +11801,10 @@
 /turf/open/floor/iron/textured,
 /area/mine/mechbay)
 "Hh" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/side,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/security/brig)
 "Hi" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -11739,12 +11849,11 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "Hm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "Hn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11818,19 +11927,19 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "Ht" = (
-/obj/structure/chair{
-	pixel_y = -2
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "Hu" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_y = 32
 	},
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "Hv" = (
 /turf/closed/wall/r_wall,
 /area/mine/storage)
@@ -11874,12 +11983,17 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "HB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/table,
+/obj/item/taperecorder{
+	pixel_x = -3
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/item/folder/red{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/assembly/flash,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "HC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/corner{
@@ -11928,13 +12042,20 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"HJ" = (
+"HI" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/security/prison)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/visit)
+"HJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "HK" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/xeno_mining{
@@ -11970,16 +12091,29 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "HN" = (
-/obj/item/radio/intercom/prison/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig)
+/obj/structure/flora/rock/pile/icy,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/unexplored)
 "HO" = (
-/obj/structure/cable,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
+/obj/structure/rack,
+/obj/item/storage/box/rubbershot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "HP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12100,11 +12234,15 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "Ie" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/obj/machinery/button/flasher{
+	id = "transferflash";
+	pixel_x = 23;
+	pixel_y = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "If" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12125,14 +12263,10 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Ij" = (
-/obj/structure/closet{
-	name = "Evidence Closet 6"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 1
-	},
-/area/security/brig)
+/obj/item/storage/bag/trash,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "Ik" = (
 /obj/structure/chair{
 	dir = 4
@@ -12150,17 +12284,6 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/mine/eva)
-"Im" = (
-/obj/structure/table/wood,
-/obj/item/trapdoor_remote/preloaded{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/gavelblock{
-	pixel_x = 5
-	},
-/turf/open/floor/wood,
-/area/security/courtroom)
 "In" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -12193,33 +12316,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
-"Iq" = (
-/obj/effect/spawner/random/entertainment/arcade,
-/turf/open/floor/iron,
-/area/security/prison)
-"Ir" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"Is" = (
-/obj/machinery/button/door/directional/north{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = 6;
-	req_access_txt = "2";
-	pixel_y = -24
-	},
-/obj/machinery/button/flasher{
-	id = "visitorflash";
-	pixel_x = -6;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/visit)
 "It" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -12248,12 +12344,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/service)
-"Iv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "Iw" = (
 /turf/open/floor/grass,
 /area/service/hydroponics)
@@ -12263,9 +12353,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "Iy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/structure/flora/grass/green,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/unexplored)
 "IA" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -12314,15 +12404,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"IH" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
-/area/security/prison)
 "II" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -12340,16 +12421,16 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "IK" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/bed{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/item/bedsheet/medical{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/obj/item/storage/secure/safe/directional/south,
+/obj/effect/turf_decal/tile/green/full,
+/turf/open/floor/iron/dark/smooth_large,
+/area/medical/virology)
 "IL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -12384,6 +12465,14 @@
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"IP" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Detective's Office"
+	},
+/obj/machinery/computer/secure_data,
+/obj/item/radio/intercom/prison/directional/north,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "IQ" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Base";
@@ -12411,6 +12500,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"IT" = (
+/turf/closed/wall,
+/area/security/prison/safe)
 "IU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12431,11 +12523,8 @@
 /turf/open/floor/iron,
 /area/mine/eva)
 "IX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/closed/wall,
+/area/security/prison/visit)
 "IY" = (
 /obj/structure/ladder{
 	name = "upper dispenser access"
@@ -12499,26 +12588,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"Jf" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/icemoon/underground/explored)
 "Jg" = (
 /obj/effect/turf_decal/siding/brown,
 /obj/structure/chair/office,
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "Jh" = (
-/obj/effect/spawner/random/contraband/prison,
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/icemoon/underground/explored)
 "Ji" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
@@ -12538,12 +12615,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Jm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/smooth,
-/area/security/prison)
+/turf/open/floor/iron,
+/area/security/courtroom)
 "Jn" = (
 /obj/structure/table,
 /obj/item/radio/intercom/directional/east,
@@ -12562,11 +12635,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Jp" = (
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
+"Jq" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Jr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -12594,11 +12673,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
-"Jv" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "Jw" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 4;
@@ -12647,10 +12721,10 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "JD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "JE" = (
@@ -12706,10 +12780,11 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "JK" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/side{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
 	},
+/turf/open/floor/iron,
 /area/security/prison)
 "JL" = (
 /obj/machinery/door/airlock/maintenance{
@@ -12726,14 +12801,15 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "JO" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/security/prison)
 "JP" = (
 /obj/structure/window/reinforced,
 /obj/machinery/camera/directional/east{
@@ -12769,10 +12845,11 @@
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
 "JV" = (
-/obj/effect/turf_decal/tile/red,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "JW" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -12789,8 +12866,13 @@
 	},
 /area/mine/living_quarters)
 "JY" = (
-/turf/closed/wall/r_wall,
-/area/icemoon/underground/unexplored/rivers)
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "JZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -12834,16 +12916,11 @@
 	},
 /area/maintenance/department/medical/morgue)
 "Kg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/prison/visit)
 "Kh" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
@@ -12853,28 +12930,21 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "Ki" = (
-/obj/machinery/light/small/directional/west,
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "Kk" = (
-/obj/machinery/door/poddoor{
-	id = "executionfireblast"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating,
+/area/service/lawoffice)
 "Kl" = (
-/obj/structure/chair/stool/directional/north,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/security/prison/visit)
+/area/hallway/primary/central/fore)
 "Km" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12893,6 +12963,16 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"Ko" = (
+/obj/machinery/flasher/directional/north{
+	id = "Cell 3"
+	},
+/obj/structure/bed{
+	dir = 1;
+	pixel_x = -2
+	},
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "Kp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east,
@@ -12903,12 +12983,21 @@
 /turf/closed/wall/r_wall,
 /area/mine/eva)
 "Kr" = (
-/turf/closed/wall/r_wall,
-/area/security/brig)
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/right/directional/north,
+/obj/machinery/door/window/right/directional/south,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "Ks" = (
 /obj/structure/closet{
-	name = "Evidence Closet 5"
+	name = "Evidence Closet 6"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
@@ -12970,11 +13059,15 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/medical/morgue)
 "KC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_x = -32
 	},
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "KD" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
@@ -13015,59 +13108,25 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "KJ" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/knife/plastic,
-/obj/item/knife/plastic,
-/obj/item/knife/plastic,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/box/drinkingglasses,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Sec - Permabrig Cafe";
-	network = list("ss13","prison")
+/obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/open/floor/iron/white,
-/area/security/prison)
-"KK" = (
-/obj/structure/table,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/obj/item/clothing/suit/hooded/wintercoat{
-	pixel_x = -5
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_x = 5
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
 	},
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_x = 5
-	},
-/obj/item/clothing/suit/hooded/wintercoat/security{
-	pixel_x = 5
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "KL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13079,13 +13138,22 @@
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "KM" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom"
+/obj/machinery/button/door/directional/north{
+	id = "visitation";
+	name = "Visitation Shutters";
+	pixel_x = 6;
+	req_access_txt = "2";
+	pixel_y = -24
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/obj/machinery/button/flasher{
+	id = "visitorflash";
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "KN" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -13115,6 +13183,18 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
+"KQ" = (
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	name = "Prisoner Transfer Centre"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "KR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13181,11 +13261,18 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "KY" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/obj/structure/table,
+/obj/item/storage/box/hug{
+	pixel_x = 4;
+	pixel_y = 3
 	},
-/area/maintenance/fore)
+/obj/item/razor{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "KZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13228,12 +13315,9 @@
 	},
 /area/mine/living_quarters)
 "Lf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/icemoon/underground/explored)
 "Lg" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -13318,25 +13402,20 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Lo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/detectives_office)
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore)
 "Lp" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "Lq" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Courtroom North"
-	},
-/obj/item/radio/intercom/directional/north,
-/obj/structure/chair{
-	name = "Defense"
-	},
-/turf/open/floor/wood,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/security/courtroom)
 "Lr" = (
 /obj/structure/chair/pew{
@@ -13358,22 +13437,8 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "Lu" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
-"Lv" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/item/radio/intercom/prison/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/turf/open/floor/iron/smooth_half,
+/area/security/prison)
 "Lw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -13383,11 +13448,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"Ly" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth,
+"Lx" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/trash/sosjerky,
+/obj/item/trash/boritos,
+/obj/item/trash/can,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/security/prison)
+"Ly" = (
+/obj/structure/sign/poster/official/obey,
+/turf/closed/wall/r_wall,
+/area/security/prison/visit)
 "Lz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -13442,22 +13517,15 @@
 /turf/closed/wall,
 /area/mine/storage)
 "LI" = (
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_x = -32
+/obj/machinery/button/door/directional/east{
+	id = "lawyer_blast";
+	name = "Privacy Shutters"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/security/brig)
-"LJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/item/storage/secure/safe/directional/south,
-/obj/effect/turf_decal/tile/green/full,
-/turf/open/floor/iron/dark/smooth_large,
-/area/medical/virology)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "LK" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -13472,12 +13540,16 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
 "LL" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 3";
+	name = "Cell 3";
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/courtroom)
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/security/brig)
 "LM" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -13548,6 +13620,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/storage)
+"LX" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "LY" = (
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13575,22 +13658,23 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"Mc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"Mb" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 7;
+	pixel_y = 12
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/item/taperecorder{
+	pixel_x = -5
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/item/lighter{
+	pixel_x = 8;
+	pixel_y = -9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/prison/safe)
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "Md" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13614,17 +13698,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Mh" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom";
-	req_access_txt = "42"
-	},
-/obj/machinery/door/firedoor,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
+"Mi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/court,
-/turf/open/floor/iron,
-/area/security/courtroom)
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "Mj" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -13688,16 +13771,8 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "Mr" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/turf/closed/wall,
+/area/security/brig)
 "Ms" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
@@ -13713,18 +13788,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
-"Mu" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/virology)
 "Mv" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
@@ -13788,28 +13851,14 @@
 	},
 /area/maintenance/aft/lesser)
 "ME" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Prisoner Transfer Centre"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "MF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"MG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "MH" = (
 /turf/closed/wall,
 /area/medical/virology)
@@ -13845,11 +13894,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"ML" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/iron,
-/area/security/prison)
 "MM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -13865,12 +13909,8 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "MO" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/edge,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/security/prison/visit)
 "MP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -13886,13 +13926,9 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "MR" = (
-/obj/structure/rack,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
-/obj/machinery/light/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "MS" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -13930,6 +13966,20 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
+"MX" = (
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	name = "Cell 1";
+	pixel_x = -32
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "prison blast door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "MY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -13950,29 +14000,15 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"Nb" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "Nc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "Nd" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/structure/cable,
-/obj/item/instrument/harmonica,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/vending/wardrobe/det_wardrobe,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "Ng" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/glass{
@@ -13984,14 +14020,12 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "Nh" = (
-/obj/machinery/light_switch/directional/south,
-/obj/structure/chair/comfy/brown{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/landmark/start/detective,
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Ni" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
@@ -14010,8 +14044,9 @@
 	},
 /area/mine/eva)
 "Nk" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/iron/smooth,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/security/prison)
 "Nl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -14024,13 +14059,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"Nm" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
 "Nn" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -14045,13 +14073,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "Np" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/stairs/east,
+/turf/open/floor/plating,
+/area/security/brig)
 "Nq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -14070,6 +14094,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/service/chapel)
+"Nt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "Nu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -14115,30 +14143,25 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "NB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "NC" = (
 /obj/item/organ/tail/monkey,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"ND" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/security/courtroom)
-"NE" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/west,
-/turf/open/floor/plating,
-/area/security/courtroom)
 "NF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "NG" = (
 /obj/structure/grille,
@@ -14146,11 +14169,6 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plating,
 /area/mine/production)
-"NH" = (
-/obj/structure/railing,
-/obj/structure/cable,
-/turf/open/floor/plating/icemoon,
-/area/security/execution/education)
 "NJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/l3closet/scientist,
@@ -14176,17 +14194,10 @@
 /turf/open/floor/stone,
 /area/commons/lounge)
 "NM" = (
-/obj/structure/chair{
-	name = "Judge";
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood,
-/area/security/courtroom)
-"NN" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "NO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -14242,19 +14253,28 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "NX" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "lawyer_blast";
-	name = "privacy door"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/service/lawoffice)
-"Ob" = (
-/obj/machinery/firealarm/directional/south,
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/iron,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
+"NZ" = (
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
+"Ob" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kanyewest";
+	name = "privacy shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "Oc" = (
 /obj/structure/railing/corner,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -14305,15 +14325,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "Ol" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Trial Transfer"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/textured,
-/area/security/courtroom)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Om" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -14385,10 +14399,18 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/textured,
 /area/mine/mechbay)
+"Ou" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "Ov" = (
-/obj/structure/flora/rock/pile/icy,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/unexplored)
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "Ox" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
@@ -14415,6 +14437,13 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"OC" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "OE" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -14441,13 +14470,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "OH" = (
-/obj/effect/turf_decal/stripes/red/line{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/fore)
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "OI" = (
 /obj/structure/marker_beacon/burgundy{
 	name = "landing marker"
@@ -14568,15 +14596,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "OX" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
 "OY" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -14622,31 +14643,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"Pd" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Armory - Internal - Lower"
-	},
-/obj/structure/rack,
-/obj/item/storage/toolbox/drone,
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
 "Pe" = (
-/obj/structure/rack,
-/obj/item/storage/box/teargas{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Pf" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -14704,12 +14706,6 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
-"Pm" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "Pn" = (
 /obj/machinery/requests_console/directional/north{
 	name = "Kitchen Requests Console"
@@ -14717,17 +14713,12 @@
 /obj/machinery/oven,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"Po" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/courtroom)
-"Pq" = (
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
+"Pr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "Pt" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -14737,9 +14728,12 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "Pv" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/corner,
-/area/security/prison)
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/security/brig)
 "Pw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14764,8 +14758,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "Py" = (
-/turf/closed/wall,
-/area/security/prison/safe)
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Lower Brig Hallway"
+	},
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "Pz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -14802,11 +14799,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"PC" = (
+"PD" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /obj/structure/table,
-/obj/item/food/energybar,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/table,
+/obj/item/rcl/pre_loaded,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms/laundry)
 "PF" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -14822,24 +14826,11 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "PH" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen/interrogation{
-	name = "isolation room monitor";
-	network = list("isolation");
-	pixel_y = -32;
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket{
-	pixel_x = 6
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Permabrig Prep";
-	network = list("ss13","prison");
-	view_range = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/edge,
 /area/security/prison)
 "PJ" = (
 /obj/structure/disposalpipe/segment{
@@ -14851,6 +14842,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"PK" = (
+/obj/machinery/light_switch/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "PL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14858,27 +14859,21 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "PM" = (
-/obj/structure/closet{
-	name = "Evidence Closet 3"
+/obj/item/storage/box/evidence{
+	pixel_x = -10;
+	pixel_y = 12
 	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Lower Brig Evidence"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/textured_edge,
-/area/security/brig)
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "PN" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Brig Lower Hallway North";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "PO" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14892,21 +14887,25 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "PQ" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/security/courtroom)
-"PR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
 /area/security/prison)
-"PS" = (
-/obj/machinery/light/directional/south,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+"PR" = (
+/obj/machinery/light/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
+"PS" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "PT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -14918,6 +14917,14 @@
 	dir = 1
 	},
 /area/service/hydroponics)
+"PU" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore)
 "PV" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -14925,28 +14932,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "PW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/edge,
+/turf/open/floor/iron,
 /area/security/prison)
-"PX" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/machinery/button/door/directional/north{
-	id = "miningdorm_B";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = 23;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/stellar,
-/area/mine/production)
 "PY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15035,29 +15026,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
-"Qh" = (
-/obj/structure/rack,
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
 "Qi" = (
-/turf/closed/wall,
-/area/security/brig)
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/iron,
+/area/security/prison)
 "Qj" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/food_or_drink/cups,
@@ -15143,13 +15116,19 @@
 /turf/open/floor/iron/smooth,
 /area/medical/chemistry)
 "Qt" = (
-/obj/machinery/door/airlock/security{
-	id_tag = "IsolationCell";
-	name = "Isolation Cell"
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/open/floor/iron/smooth,
-/area/security/prison/safe)
+/obj/machinery/light/directional/north,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "Qu" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -15158,12 +15137,12 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "Qw" = (
-/obj/machinery/recharger,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red/half,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/edge,
+/area/security/prison)
 "Qy" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -15220,16 +15199,6 @@
 /obj/machinery/plumbing/sender,
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"QG" = (
-/obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/hooded/ablative,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
 "QH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -15282,9 +15251,11 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "QK" = (
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "QL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15326,24 +15297,12 @@
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "QQ" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "QR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -15354,11 +15313,14 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "QT" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/door/airlock/security{
+	name = "Permanent Cell 5"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison/visit)
+/area/security/prison/safe)
 "QU" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/iron/dark/smooth_half,
@@ -15407,8 +15369,14 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "Ra" = (
-/turf/open/floor/iron/dark/textured,
-/area/security/prison)
+/obj/machinery/door/airlock/security{
+	name = "Permanent Cell 3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "Rb" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -15425,20 +15393,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"Rd" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Trial Transfer";
-	name = "Transfer Blast Door"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Trial Transfer"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/textured,
-/area/security/brig)
 "Re" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -15576,10 +15530,8 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "Rz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/beach_ball/holoball,
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/hallway/primary/central/fore)
 "RA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -15610,12 +15562,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/mine/eva)
-"RF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "RG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -15695,12 +15641,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
 "RS" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/security/wooden_tv,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/turf/closed/wall,
+/area/security/prison)
 "RT" = (
 /obj/structure/fence{
 	dir = 4
@@ -15733,10 +15675,12 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "RX" = (
-/obj/machinery/vending/cola/red,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
+/obj/structure/chair{
+	dir = 1;
+	name = "Prosecution"
+	},
+/turf/open/floor/wood,
+/area/security/courtroom)
 "RY" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -15805,7 +15749,9 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "Si" = (
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
 /area/security/prison)
 "Sj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -15852,10 +15798,26 @@
 /turf/open/floor/iron/smooth,
 /area/cargo/warehouse)
 "Sp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison/visit)
+/obj/structure/table,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/clothing/suit/hooded/wintercoat{
+	pixel_x = -5
+	},
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_x = 5
+	},
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_x = 5
+	},
+/obj/item/clothing/suit/hooded/wintercoat/security{
+	pixel_x = 5
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "Sr" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 4
@@ -15868,13 +15830,19 @@
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "St" = (
-/obj/structure/toilet/greyscale,
-/obj/machinery/airalarm/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half{
-	dir = 1
+/obj/structure/rack,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/machinery/button/door{
+	id = "Trial Transfer";
+	name = "Trial Transfer Lockdown";
+	pixel_y = -23;
+	req_access_txt = "2";
+	pixel_x = -7
 	},
-/area/security/prison/safe)
+/obj/structure/cable,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "Su" = (
 /turf/closed/wall,
 /area/maintenance/department/medical/morgue)
@@ -15884,13 +15852,11 @@
 /turf/open/floor/iron,
 /area/service/chapel)
 "Sw" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Detective's Office"
-	},
-/obj/machinery/computer/secure_data,
-/obj/item/radio/intercom/prison/directional/north,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "Sx" = (
 /obj/machinery/door/airlock{
 	name = "Bar";
@@ -15926,9 +15892,10 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "SB" = (
-/obj/structure/table,
-/obj/item/razor,
-/obj/item/storage/backpack/duffelbag/sec/surgery,
+/obj/structure/railing/corner,
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/plating/icemoon,
 /area/security/execution/education)
 "SC" = (
@@ -16015,15 +15982,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "SQ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/security/prison)
 "SR" = (
 /obj/structure/sign/warning,
@@ -16046,17 +16006,15 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "SY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Visitation South";
+	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/structure/table,
-/obj/item/rcl/pre_loaded,
-/turf/open/floor/iron/cafeteria,
-/area/commons/dorms/laundry)
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "SZ" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
@@ -16091,6 +16049,19 @@
 	dir = 1
 	},
 /area/service/hydroponics)
+"Td" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 30
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "Te" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen";
@@ -16104,12 +16075,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"Tf" = (
-/obj/machinery/flasher/directional/east{
-	id = "executionflash"
-	},
-/turf/open/openspace/icemoon/keep_below,
-/area/security/execution/education)
+"Tg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
+"Th" = (
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "Ti" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -16171,12 +16146,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
 "Tp" = (
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/trash/chips,
+/obj/item/trash/candy,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "Tq" = (
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
@@ -16192,10 +16167,9 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "Ts" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/security/prison/safe)
 "Tt" = (
 /obj/structure/flora/rock/pile/icy,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -16320,13 +16294,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "TG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/iron/corner{
-	dir = 8
-	},
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "TH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16370,12 +16347,26 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "TL" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
+"TM" = (
+/obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/prison/visit)
+/area/security/courtroom)
 "TN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16410,10 +16401,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
-"TR" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
 "TS" = (
 /turf/open/floor/iron/dark,
 /area/mine/eva)
@@ -16471,70 +16458,37 @@
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"Ub" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "Uc" = (
-/obj/structure/rack,
-/obj/item/storage/box/evidence,
-/obj/item/storage/box/evidence,
-/obj/machinery/button/door{
-	id = "Trial Transfer";
-	name = "Trial Transfer Lockdown";
-	pixel_y = -23;
-	req_access_txt = "2";
-	pixel_x = -7
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
-"Ud" = (
-/obj/item/radio/intercom/prison/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
+"Ud" = (
+/obj/structure/chair/stool/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/security/prison)
 "Ue" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "Uf" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/security/prison)
+/obj/structure/cable,
+/turf/open/floor/plating/icemoon,
+/area/security/execution/education)
 "Ug" = (
 /obj/structure/table,
-/obj/machinery/button/door{
-	id = "Prison Gate";
-	name = "Prison Wing Lockdown";
-	pixel_y = 8;
-	req_access_txt = "2";
-	pixel_x = 5
-	},
-/obj/machinery/button/door{
-	id = "Trial Transfer";
-	name = "Trial Transfer Lockdown";
-	pixel_y = 8;
-	req_access_txt = "2";
-	pixel_x = -7
-	},
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_y = -3;
-	pixel_x = -7
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/obj/item/food/energybar,
+/turf/open/floor/iron,
+/area/security/prison)
 "Uh" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -16585,7 +16539,9 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Uo" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "Up" = (
@@ -16604,14 +16560,14 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/medical/virology)
 "Ur" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 3"
+/obj/structure/chair{
+	dir = 1;
+	name = "Prosecution"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison/safe)
+/turf/open/floor/wood,
+/area/security/courtroom)
 "Ut" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -16623,28 +16579,18 @@
 /turf/open/floor/iron/smooth_large,
 /area/cargo/warehouse)
 "Uu" = (
-/obj/structure/rack,
-/obj/item/clothing/glasses/sunglasses/big{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/clothing/glasses/sunglasses/big{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
-"Uv" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Evidence Storage";
-	req_one_access_txt = "1;4"
+/obj/machinery/door/airlock/public/glass{
+	name = "Courtroom"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/security/brig)
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
+"Uv" = (
+/obj/structure/table,
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "Uw" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/plasma,
@@ -16694,11 +16640,19 @@
 /turf/open/floor/stone,
 /area/commons/lounge)
 "UB" = (
-/obj/structure/disposalpipe/trunk/multiz{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "Trial Transfer";
+	name = "Transfer Blast Door"
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/door/airlock/public/glass{
+	name = "Trial Transfer"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "UD" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/machinery/light/directional/west,
@@ -16706,6 +16660,14 @@
 /obj/structure/displaycase,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
+"UE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/security/prison)
 "UF" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -16717,12 +16679,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"UG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "UI" = (
-/obj/structure/window/reinforced/spawner/north,
 /obj/structure/grille,
-/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/prison/visit)
 "UK" = (
 /turf/closed/wall,
 /area/maintenance/department/chapel)
@@ -16763,14 +16732,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "UQ" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Permabrig Forestry"
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/prison)
 "UR" = (
 /obj/machinery/door/airlock{
@@ -16784,27 +16748,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "US" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
 /obj/structure/cable,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/turf/open/floor/plating,
+/area/security/brig)
 "UT" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/chapel)
-"UU" = (
-/obj/item/storage/box/evidence{
-	pixel_x = -10;
-	pixel_y = 12
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
 "UV" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -16846,11 +16801,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "Vb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
-/area/security/prison)
+/area/ai_monitored/security/armory)
 "Vc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16901,13 +16854,6 @@
 "Vj" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/morgue)
-"Vk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/textured,
-/area/security/brig)
 "Vl" = (
 /obj/structure/fence{
 	dir = 4
@@ -16926,6 +16872,13 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"Vn" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/courtroom)
 "Vo" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -16939,6 +16892,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/service/bar)
+"Vq" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/iron,
+/area/security/prison)
 "Vr" = (
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/structure/displaycase,
@@ -17004,13 +16961,25 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Vy" = (
-/obj/structure/table,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/security/prison)
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "miningdorm_B";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = 23;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/stellar,
+/area/mine/production)
 "Vz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -17032,12 +17001,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "VC" = (
-/obj/structure/sign/poster/official/safety_report{
-	pixel_y = 32
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/ai_monitored/security/armory)
 "VD" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -17065,15 +17034,13 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "VF" = (
-/obj/machinery/button/door/directional/east{
-	id = "lawyer_blast";
-	name = "Privacy Shutters"
+/obj/machinery/door/airlock/security{
+	id_tag = "IsolationCell";
+	name = "Isolation Cell"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/open/floor/iron/smooth,
+/area/security/prison/safe)
 "VG" = (
 /obj/machinery/shower{
 	dir = 4
@@ -17146,11 +17113,8 @@
 /turf/open/floor/carpet/lone,
 /area/service/chapel)
 "VQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/turf/open/floor/iron,
+/area/security/prison/visit)
 "VR" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Warehouse";
@@ -17163,10 +17127,7 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/cargo/warehouse)
 "VS" = (
-/obj/structure/sign/poster/official/here_for_your_safety{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "VT" = (
@@ -17181,17 +17142,17 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "VV" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/iron,
+/area/security/prison)
 "VW" = (
-/obj/structure/closet/secure_closet/evidence,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 1
-	},
-/area/security/brig)
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "VX" = (
 /obj/structure/stairs/north,
 /obj/structure/railing{
@@ -17199,6 +17160,11 @@
 	},
 /turf/open/floor/iron,
 /area/service/chapel)
+"VY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "VZ" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -17213,11 +17179,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "Wc" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+/obj/machinery/flasher/directional/north{
+	id = "transferflash"
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/side,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/textured,
 /area/security/prison)
 "Wd" = (
 /obj/machinery/disposal/bin{
@@ -17237,11 +17206,12 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/virology)
 "We" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/prison)
 "Wf" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -17253,8 +17223,14 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "Wi" = (
-/turf/closed/wall,
-/area/service/lawoffice)
+/obj/machinery/light/small/directional/south,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/brig)
 "Wj" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/sign/warning/coldtemp{
@@ -17311,10 +17287,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"Wp" = (
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron,
-/area/security/prison)
 "Wq" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -17348,9 +17320,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "Wu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/courtroom)
 "Wv" = (
 /obj/machinery/space_heater,
@@ -17407,15 +17379,16 @@
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
 "WE" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"WF" = (
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/shower{
+	pixel_y = 12
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/textured,
-/area/security/brig)
+/turf/open/floor/iron/freezer,
+/area/security/prison)
+"WF" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison/safe)
 "WG" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -17432,6 +17405,10 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"WI" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "WJ" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 20
@@ -17446,6 +17423,13 @@
 /obj/item/crowbar/large/old,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
+"WL" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/security/wooden_tv,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "WN" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -17506,18 +17490,12 @@
 /turf/open/floor/plating,
 /area/cargo/drone_bay)
 "WS" = (
-/turf/open/floor/iron,
-/area/security/prison/visit)
-"WT" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/structure/stairs/east,
+/turf/open/floor/plating,
 /area/hallway/primary/central/fore)
+"WT" = (
+/turf/closed/wall/r_wall,
+/area/security/execution/education)
 "WU" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/landmark/start/hangover,
@@ -17543,10 +17521,6 @@
 "WY" = (
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"WZ" = (
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron,
-/area/security/prison)
 "Xa" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -17555,6 +17529,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"Xb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
 "Xc" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/line{
@@ -17579,17 +17559,9 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"Xe" = (
-/turf/closed/wall/r_wall,
-/area/service/lawoffice)
 "Xf" = (
-/obj/machinery/door/airlock/security{
-	name = "Permanent Cell 4"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/closed/wall/r_wall,
 /area/security/prison/safe)
 "Xg" = (
 /obj/machinery/light/small/directional/west,
@@ -17668,10 +17640,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "Xs" = (
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/security/prison)
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "Xt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -17680,10 +17651,17 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "Xu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
+/obj/structure/closet/crate,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/onion,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "Xv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -17712,16 +17690,9 @@
 	},
 /area/mine/eva)
 "Xx" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/machinery/light/small/directional/west,
+/turf/open/openspace/icemoon/keep_below,
+/area/security/execution/education)
 "Xy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/south,
@@ -17735,20 +17706,15 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "XA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison/visit)
-"XC" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/security/courtroom)
+"XC" = (
+/obj/structure/table/reinforced,
+/obj/structure/reagent_dispensers/servingdish,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/turf/open/floor/iron/white,
+/area/security/prison)
 "XD" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
@@ -17776,8 +17742,14 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "XI" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/central/fore)
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "XK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -17789,11 +17761,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/eva)
-"XL" = (
-/obj/structure/chair/stool/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "XM" = (
 /obj/item/trash/syndi_cakes,
 /obj/effect/turf_decal/stripes/red/line{
@@ -17845,6 +17812,21 @@
 "XT" = (
 /turf/closed/wall/r_wall,
 /area/mine/mechbay)
+"XU" = (
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
+"XV" = (
+/obj/machinery/door/airlock/security{
+	name = "Permanent Cell 1"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "XW" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -17970,14 +17952,36 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "Yl" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/iron/dark,
-/area/security/prison)
+/obj/structure/chair{
+	name = "Judge";
+	dir = 8
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Courtroom"
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/wood,
+/area/security/courtroom)
 "Ym" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison/visit)
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/interrogation{
+	name = "isolation room monitor";
+	network = list("isolation");
+	pixel_y = -32;
+	dir = 1
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket{
+	pixel_x = 6
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Permabrig Prep";
+	network = list("ss13","prison");
+	view_range = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/security/prison)
 "Yn" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -17995,27 +17999,20 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "Yq" = (
-/obj/machinery/flasher/directional/north{
-	id = "Cell 3"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/obj/structure/bed{
-	dir = 1;
-	pixel_x = -2
-	},
-/turf/open/floor/iron/smooth,
-/area/security/brig)
+/area/security/prison)
 "Yr" = (
 /obj/effect/decal/cleanable/ants,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "Ys" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Lower Brig Cells";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/security/brig)
@@ -18023,9 +18020,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "Yu" = (
 /obj/structure/fence{
 	dir = 4
@@ -18095,6 +18094,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"YD" = (
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/textured,
+/area/security/brig)
 "YE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table/reinforced,
@@ -18109,18 +18112,26 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"YF" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "YG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/recharge_floor,
 /area/mine/mechbay)
 "YH" = (
-/obj/machinery/door/airlock/security{
-	name = "Permabrig Visitation"
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 1";
+	name = "Cell 1";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/prison/visit)
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/security/brig)
 "YK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
@@ -18149,15 +18160,10 @@
 /obj/structure/railing,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"YN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "YO" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
@@ -18198,9 +18204,9 @@
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
-"YW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood,
+"YV" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/security/courtroom)
 "YX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18276,13 +18282,30 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "Zj" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron/dark,
 /area/security/prison/safe)
-"Zl" = (
-/obj/machinery/holopad,
+"Zk" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Common Room"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/security/prison)
 "Zm" = (
 /obj/structure/grille,
@@ -18313,9 +18336,9 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "Zp" = (
-/obj/structure/stairs/east,
-/turf/open/floor/iron/dark/textured,
-/area/ai_monitored/security/armory)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "Zq" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/conveyor_switch/oneway{
@@ -18426,14 +18449,14 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "ZG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/door/airlock/security{
+	name = "Permanent Cell 2"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/turf/open/floor/iron,
+/area/security/prison/safe)
 "ZH" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/south,
@@ -18581,11 +18604,8 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "ZW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/fore)
+/turf/closed/wall/r_wall,
+/area/security/courtroom)
 "ZX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -36208,7 +36228,7 @@ iK
 dj
 To
 cP
-wV
+DA
 iK
 kK
 kK
@@ -36722,7 +36742,7 @@ cs
 fn
 cP
 vc
-SY
+PD
 GK
 kK
 kK
@@ -37261,9 +37281,9 @@ wl
 sh
 bf
 cL
-DZ
+cZ
 bq
-PX
+Vy
 SG
 bq
 oP
@@ -38715,20 +38735,20 @@ ak
 ak
 ak
 ak
-Jf
+Lf
 Et
 Et
 Et
 Et
 Et
-Jf
-qZ
-qZ
-xS
-qZ
-qZ
-qZ
-Jf
+Lf
+fZ
+fZ
+un
+fZ
+fZ
+fZ
+Lf
 ak
 ak
 ak
@@ -39231,18 +39251,18 @@ ak
 ak
 Et
 kK
-oM
-xb
+Jh
+FQ
+hp
+hp
+MR
 wP
 wP
-lh
-Cf
-Cf
-Cf
-Cf
-Cf
-Cf
-lh
+wP
+wP
+wP
+wP
+MR
 mO
 mO
 mO
@@ -39488,18 +39508,18 @@ ak
 ak
 Et
 kK
-ox
-fH
-Wp
-Fj
-Fj
-Fj
-Si
-Fp
-Ir
-yY
-lT
-Ag
+cg
+uq
+eK
+SQ
+SQ
+SQ
+RS
+Lx
+la
+sy
+nK
+We
 mO
 mO
 mO
@@ -39745,18 +39765,18 @@ ak
 ak
 Et
 kK
-Ag
-Iq
-Wp
-EL
-NN
-XL
-Si
-iW
-FC
-po
-po
-Ag
+We
+zn
+eK
+mp
+ha
+Ud
+RS
+kk
+Nk
+Lu
+Lu
+We
 mO
 mO
 mO
@@ -40002,18 +40022,18 @@ ak
 ak
 Et
 kK
-Ag
-yB
-Wp
-mo
-uJ
-cx
-Si
-QQ
-FC
-uo
-Cr
-Ag
+We
+fk
+eK
+eG
+pR
+NZ
+RS
+Cm
+Nk
+rx
+as
+We
 mO
 mO
 mO
@@ -40034,9 +40054,9 @@ mO
 mO
 mO
 pr
-hv
-hv
-hv
+rW
+rW
+rW
 pr
 mO
 mO
@@ -40257,20 +40277,20 @@ ak
 ak
 ak
 ak
-Jf
+Lf
 kK
-lh
-jZ
-Ft
-Zl
-Nd
-rg
-Si
-yN
-FC
-po
-po
-Ag
+MR
+Vq
+Ae
+iq
+pB
+jV
+RS
+PW
+Nk
+Lu
+Lu
+We
 mO
 mO
 mO
@@ -40290,11 +40310,11 @@ mO
 mO
 mO
 mO
-RF
+PN
 Ix
 XZ
 mw
-RF
+PN
 mO
 mO
 mO
@@ -40516,18 +40536,18 @@ ak
 ak
 Et
 kK
-Cf
-wt
-wG
-mo
-WZ
-vp
-Si
-UQ
-FC
-po
-po
-Ag
+wP
+FM
+TL
+eG
+aw
+yi
+RS
+GG
+Nk
+Lu
+Lu
+We
 mO
 mO
 mO
@@ -40540,21 +40560,21 @@ mO
 mO
 mO
 mO
-re
-Lo
-Lo
-re
+EI
+HJ
+HJ
+EI
 mO
 mO
 kK
-UI
+cf
 PV
-OH
+PU
 XM
 pr
-hv
-hv
-hv
+rW
+rW
+rW
 pr
 wS
 wS
@@ -40773,45 +40793,45 @@ ak
 ak
 Et
 kK
-Cf
-Mr
-SQ
-Pm
-dW
-FP
-Si
-Dp
-Pq
-FH
-Cr
-Ag
+wP
+LX
+yp
+lj
+FJ
+fH
+RS
+di
+mk
+ED
+as
+We
 mO
 mO
 mO
 mO
 mO
-Wi
-tV
-tV
-Wi
-Wi
+eN
+qO
+qO
+eN
+eN
 mO
-re
-re
-Nm
-AE
-re
-re
+EI
+EI
+hl
+qG
+EI
+EI
 kK
 kK
 pr
-KY
+xo
 BO
 mU
-Jv
+NM
 mU
 mU
-os
+Lo
 pr
 wS
 wS
@@ -41030,45 +41050,45 @@ ak
 ak
 Et
 kK
-Cf
-Nb
-IK
-Si
-Si
-cg
-Si
-Np
-FJ
-Cg
-Cg
-Ag
-mO
-mO
-mO
-mO
-Wi
-Wi
-aP
-wn
-Dw
-Wi
-mO
-re
+wP
+NF
+gD
 RS
-UU
-jB
+RS
+Zk
+RS
+ka
+JD
+Gy
+Gy
+We
+mO
+mO
+mO
+mO
+eN
+eN
+lO
+xS
+pg
+eN
+mO
+EI
+WL
+PM
 ev
-wr
+yk
+qM
 kK
 kK
 pr
 pr
 pr
-Cs
-kS
+qg
+Zp
 mU
 pr
-OX
+fy
 pr
 wS
 wS
@@ -41287,46 +41307,46 @@ ak
 ak
 Et
 kK
-CD
-Py
-Py
-Py
-DX
-BF
-Si
-qr
-lc
-Cr
-Cr
-Ag
-mO
-mO
-mO
-kK
-zr
-eE
-gj
-ks
-kx
-Wi
-mO
-re
-US
-fy
-gU
-Nh
-re
-kK
-kK
-pr
-vR
-pr
-WE
+kO
+IT
+IT
+IT
+DN
+Ou
+RS
+mx
+XU
+as
+as
 We
-AX
-RF
+mO
+mO
+mO
+kK
+Kk
+ME
+Pr
+FW
+fe
+eN
+mO
+EI
+PS
+tm
+oI
+zh
+EI
+kK
+kK
+pr
+mD
+pr
+Th
+fd
+tW
+PN
 mU
-RF
+PN
 Kb
 ak
 ak
@@ -41544,52 +41564,52 @@ ak
 ak
 Et
 kK
-MG
-hz
-Mc
-xi
-BF
-BF
-Si
-zW
-Py
-Py
-Py
-iY
+EC
+Er
+Zj
+QT
+Ou
+Ou
+RS
+oO
+IT
+IT
+IT
+WF
 mO
 mO
 kK
 dJ
-Wi
-pL
-VQ
-pR
-EQ
-Wi
+eN
+AH
+yd
+sv
+rJ
+eN
 mO
-re
-Sw
-KC
-sK
-ko
-re
+EI
+IP
+jH
+Mb
+yu
+EI
 kK
 rm
 pr
 pr
 pr
 kJ
-CE
-UB
+pG
+Ov
 pr
-fB
+bB
 pr
-zl
+Iy
 ak
 Kb
 Kb
 Kb
-Ov
+HN
 Kb
 Kb
 Kb
@@ -41801,43 +41821,43 @@ ak
 ak
 Et
 kK
-MG
-FB
-kG
-Py
-Er
-BF
-lO
-BF
-ug
-Ki
-tH
-CD
+EC
+Fl
+vn
+IT
+uJ
+Ou
+ut
+Ou
+qA
+yl
+Tp
+kO
 dJ
 kK
 kK
 kK
-Wi
-Uu
-ks
-YN
-eL
-Wi
+eN
+iE
+FW
+ho
+nH
+eN
 mO
-re
-EJ
-uB
-xo
-bC
-re
+EI
+Nd
+QQ
+Uc
+tV
+EI
 kK
 kK
 kK
 kK
 pr
 yU
-gV
-lZ
+Yt
+JV
 pr
 Kb
 Kb
@@ -42056,52 +42076,52 @@ ak
 ak
 ak
 ak
-Jf
+Lf
 kK
-iY
-Py
-Py
-Py
-MO
-BF
-FW
-oQ
-Py
-yn
-up
-CD
+WF
+IT
+IT
+IT
+PH
+Ou
+vq
+BK
+IT
+Ij
+Gb
+kO
 kK
 kK
 rm
 dJ
-Wi
-nZ
+eN
+cu
+yP
+LI
+PK
+eN
+CY
+EI
+EI
+Ob
+vL
+EI
+EI
+CY
+CY
+bQ
+bQ
+pr
+pr
+hy
+sq
+pr
+Kb
+Kb
+HN
+Kb
+Kb
 Iy
-VF
-jf
-Wi
-xO
-re
-re
-jy
-oG
-re
-re
-xO
-xO
-AC
-AC
-pr
-pr
-gG
-ZW
-pr
-Kb
-Kb
-Ov
-Kb
-Kb
-zl
 ak
 ak
 ak
@@ -42315,44 +42335,44 @@ ak
 ak
 Et
 kK
-MG
-fv
-Mc
-Xf
-BF
-BF
-vU
-Cm
-Py
-Py
-Py
-CD
+EC
+AP
+Zj
+cH
+Ou
+Ou
+od
+Dp
+IT
+IT
+IT
+kO
+MO
+MO
+UI
+UI
 xx
-xx
-tM
-tM
-Xe
-NX
-NX
-Wi
-Df
-Wi
-HB
-Gy
-Fw
-Gy
-uq
-jm
-jm
-le
-jm
-jm
-jm
-Xx
-kk
-Ds
-CI
-xO
+it
+it
+eN
+hz
+eN
+Nh
+go
+lz
+go
+os
+OC
+OC
+gG
+OC
+OC
+OC
+Cg
+aP
+Td
+gU
+CY
 Kb
 ak
 ak
@@ -42572,44 +42592,44 @@ ak
 ak
 Et
 kK
-MG
-FB
-kG
-Py
-DX
-BF
-vU
+EC
+Fl
+vn
+IT
+DN
+Ou
+od
+wn
+IX
+BS
+VS
+oQ
+sn
+fM
+dY
+Kg
+Ly
+Nh
+go
+go
+os
+OC
+OC
+Ol
+sD
+sD
+sD
+sD
+Jq
+yI
+kn
+Jq
+Jq
+Jq
 tu
-Ex
-yl
-ho
-Es
-ii
-Kl
-AP
-zn
-uH
-HB
-Gy
-Gy
-uq
-jm
-jm
-Uo
-DJ
-DJ
-DJ
-DJ
-Lu
-bB
-Lv
-Lu
-Lu
-Lu
-XC
-et
-Yt
-xO
+jP
+ij
+CY
 ak
 ak
 ak
@@ -42829,44 +42849,44 @@ ak
 ak
 Et
 kK
-CD
-Py
-Py
-Py
-PW
-BF
-vU
-Cm
-Ex
-VC
-pQ
-Es
-id
-xL
-AP
-oI
-su
-jV
-jV
-jV
-dp
-jV
-hr
-jV
-YO
-DM
-rq
-rq
-JV
-tZ
-tZ
-Ae
-vg
-tZ
-tZ
-Kg
-cH
-xO
+kO
+IT
+IT
+IT
+Qw
+Ou
+od
+Dp
+IX
+lF
+xb
+oQ
+Kr
+ru
+dY
+DQ
+nZ
+jT
+jT
+jT
+Pe
+jT
+kx
+jT
+VW
+Kl
+fG
+fG
+EQ
+ga
+ga
+YV
+TM
+ga
+ga
+TG
+Cf
+CY
 ak
 ak
 ak
@@ -43086,44 +43106,44 @@ ak
 ak
 Et
 kK
-MG
-fv
-Mc
-Ur
-BF
-BF
-DK
-Jh
-Ex
-VS
-WS
-WS
-Sp
-lJ
-od
-Ym
-TL
-CY
-CY
-WT
-CY
-CY
-PN
-CY
-CY
-XI
-AC
-AC
-AC
-tZ
-En
-VV
-yH
+EC
+AP
+Zj
+Ra
+Ou
+Ou
+jg
+Fw
+IX
+Cp
+VQ
+VQ
 BT
-KM
-wW
-rq
-xO
+vr
+CI
+qa
+HI
+Uo
+Uo
+ti
+Uo
+Uo
+ks
+Uo
+Uo
+Rz
+bQ
+bQ
+bQ
+ga
+NX
+gV
+XI
+rI
+Uu
+YO
+fG
+CY
 ak
 ak
 ak
@@ -43343,44 +43363,44 @@ ak
 ak
 Et
 kK
-MG
-FB
-kG
-Py
-Pv
-BF
-uN
-cN
-YH
-Ym
-XA
-Es
-ii
-xL
-AP
-nm
-xx
-er
-er
-Kr
-er
-er
-Kr
-er
-er
-Kr
-mO
-mO
-mO
-tZ
-ij
+EC
+Fl
+vn
+IT
+jS
+Ou
+JO
+VY
+wV
+qa
+eL
+oQ
+sn
+ru
 dY
-Jp
-Wu
-tZ
-Gy
-rq
-xO
+SY
+MO
+vp
+vp
+vU
+vp
+vp
+vU
+vp
+vp
+vU
+mO
+mO
+mO
+ga
+PR
+Ue
+UG
+iG
+ga
+go
+fG
+CY
 ak
 ak
 ak
@@ -43598,46 +43618,46 @@ ak
 ak
 ak
 ak
-Jf
+Lf
 kK
-CD
-Py
-Py
-Py
-Wc
-Gw
-fU
-lz
-Ex
-dZ
-WS
-Es
-id
-xL
-wO
-qP
-xx
-vn
-qa
-Qi
-Gx
-JO
-Qi
-Yq
-vI
+kO
+IT
+IT
+IT
+lG
+JY
+lJ
+bC
+IX
+Fp
+VQ
+oQ
 Kr
+ru
+kN
+wW
+MO
+vI
+Fh
+Mr
+cE
+Wi
+Mr
+Ko
+xi
+vU
 mO
 mO
 mO
-vL
-VV
-VV
-Jp
-VV
-tZ
-Gy
-rq
-xO
+gp
+gV
+gV
+UG
+gV
+ga
+go
+fG
+CY
 ak
 ak
 ak
@@ -43857,44 +43877,44 @@ ak
 ak
 Et
 kK
-MG
-hz
-Mc
-FK
-BF
-BF
-sr
-sr
-Ex
-nE
-gp
+EC
+Er
+Zj
+ZG
+Ou
+Ou
+gu
+gu
+IX
+Hu
+EL
+VQ
+BT
+sK
+dY
+KM
+MO
+up
+Eq
+Mr
+up
+Eq
+Mr
+up
+Eq
+vU
+mO
+mO
+mO
+ZW
+Wu
+Wu
+dp
+Wu
+ga
 WS
-Sp
-QT
-AP
-Is
-xx
-HN
-eA
-Qi
-HN
-eA
-Qi
-HN
-eA
-Kr
-mO
-mO
-mO
-Aj
-jg
-jg
-Mh
-jg
-tZ
-EC
-EC
-xO
+WS
+CY
 ak
 ak
 ak
@@ -44114,44 +44134,44 @@ ak
 ak
 Et
 kK
-MG
-FB
-kG
-Py
-Hh
-Gw
-dA
-as
-as
-as
-as
-as
-as
-as
-Sp
-TL
-xx
-qv
-IX
-Qi
-BS
-IX
-Qi
-uC
-IX
-Kr
+EC
+Fl
+vn
+IT
+CE
+JY
+bL
+gy
+gy
+gy
+gy
+gy
+gy
+gy
+BT
+HI
+MO
+YH
+pQ
+Mr
+tY
+pQ
+Mr
+LL
+pQ
+vU
 mO
 mO
 mO
-Aj
-FA
-vB
-cF
-Ob
-tZ
-tZ
-xO
-xO
+ZW
+pZ
+Jm
+Sw
+Ex
+ga
+ga
+CY
+CY
 ak
 ak
 ak
@@ -44371,42 +44391,42 @@ ak
 ak
 Et
 kK
-iY
-Py
-Py
-Py
-TG
+WF
+IT
+IT
+IT
+tU
+Ou
+sr
+gy
+qP
+Nt
+VC
+Hm
+Hm
 BF
-sn
-as
-ah
-ha
-fe
-nF
-nF
-nH
-Ug
-qF
-zg
-lG
-qF
+yg
+Ys
+MX
+qH
+Ys
+KC
+Da
+Ys
 kr
-dz
-qF
-LI
-dz
-qF
-Rd
-cW
-cW
-cW
-Ol
-Po
-Po
-LL
-vB
-PS
-tZ
+Da
+Ys
+UB
+gn
+gn
+gn
+zQ
+qZ
+qZ
+Lq
+Jm
+AS
+ga
 ak
 ak
 ak
@@ -44628,42 +44648,42 @@ ak
 ak
 Et
 kK
-MG
-fv
-Mc
-wc
-BF
-BF
-Uf
-as
-it
-CZ
-yG
-rZ
-Zp
-as
-gu
-qF
-Ue
-vq
-qF
+EC
+AP
+Zj
+XV
+Ou
+Ou
+gk
+gy
+lc
+eU
+Vb
+gj
+yq
+gy
+vH
 Ys
-FQ
-qF
-Vk
-MR
-Uc
-Kr
+lh
+tH
+Ys
+wr
+mz
+Ys
+OH
+oB
+St
+vU
 mO
 mO
 mO
-Aj
-Lq
-PQ
-Jp
-PQ
-yP
-tZ
+ZW
+hX
+WI
+UG
+WI
+RX
+ga
 ak
 ak
 ak
@@ -44885,42 +44905,42 @@ ak
 ak
 Et
 kK
-MG
-FB
-kG
+EC
+Fl
+vn
+IT
+DN
+Ou
+gk
+gy
+wd
+eU
+Vb
+gj
+gj
+gy
 Py
-DX
-BF
-Uf
-as
-Qw
-CZ
-yG
-rZ
-rZ
-as
-jH
+FH
+RS
+UQ
+va
+RS
+FK
 xs
-Si
-NB
+FK
+vU
+yN
+vU
+mO
+mO
+mO
 uR
-Si
-Ts
-Uv
-Ts
-Kr
-aY
-Kr
-mO
-mO
-mO
-CH
-rx
-Au
-Jp
-Eq
-ut
-tZ
+kW
+wO
+UG
+my
+Ur
+ga
 ak
 ak
 ak
@@ -45140,44 +45160,44 @@ ak
 ak
 ak
 ak
-Jf
+Lf
 kK
-CD
-Py
-Py
-Py
-lj
-pw
-lj
-as
-bs
-CZ
-yG
-jS
-qg
-as
-WF
-vJ
-Si
+kO
+IT
+IT
+IT
+zD
+Fj
+zD
+gy
+oG
+eU
+Vb
+KJ
+AC
+gy
+Ki
+bX
+RS
 HZ
-gF
-Si
-wD
-ve
-go
-Kr
-mO
-mO
-mO
-mO
-mO
-CM
-YW
-yp
-Ie
-ND
-pe
 tZ
+RS
+ui
+pL
+hr
+vU
+mO
+mO
+mO
+mO
+mO
+zV
+EJ
+XA
+uB
+rg
+Vn
+ga
 ak
 ak
 ak
@@ -45397,44 +45417,44 @@ ak
 ak
 ak
 ak
-qZ
+fZ
 kK
-Cf
-yv
-wH
-aw
-Xs
-FP
-Ft
-as
-Pd
-tm
-By
-CZ
-TR
-as
-qH
-au
-Si
-Nk
-gF
-Si
-sy
+wP
+BX
+xN
+JK
+AE
+fH
+Ae
+gy
+Es
+En
+jN
 eU
-Ks
-nq
-mO
-mO
-mO
-mO
-mO
-NE
-GP
-PQ
-Im
-di
-pB
+nN
+gy
+yY
+Xs
+RS
+Jp
 tZ
+RS
+cp
+pD
+fz
+US
+mO
+mO
+mO
+mO
+mO
+oz
+yc
+WI
+ar
+bs
+Ub
+ga
 ak
 ak
 ak
@@ -45654,44 +45674,44 @@ mO
 mO
 mO
 mO
-qZ
+fZ
 kK
-Cf
-Lf
-Rz
-ML
-Xs
-FP
-Iv
-as
-as
-Pe
-Tp
-Qh
-QG
-as
-FM
-pD
-Si
-Ly
-bL
-Si
-PM
-DY
-Ij
-nq
+wP
+Dw
+jp
+VV
+AE
+fH
+nQ
+gy
+gy
+dA
+iQ
+HO
+jB
+gy
+YD
+nm
+RS
+cm
+Mi
+RS
+iY
+Hh
+Ks
+US
 mO
 mO
 mO
 mO
 mO
-vL
-GP
-mx
-NM
-zQ
-QK
-tZ
+gp
+yc
+jy
+eA
+Yl
+Cr
+ga
 ak
 ak
 ak
@@ -45911,44 +45931,44 @@ mO
 mO
 mO
 mO
-Jf
+Lf
 kK
-Cf
-BK
-xg
-ML
-Xs
-qO
-oz
-Yl
-as
-as
-as
-as
-as
-as
-bR
-bR
-Si
-Nk
-Ud
-Si
-Fl
-AS
-VW
-nq
+wP
+UE
+dQ
+VV
+AE
+xF
+Ds
+NB
+gy
+gy
+gy
+gy
+gy
+gy
+Np
+Np
+RS
+Jp
+xL
+RS
+ES
+Pv
+qr
+US
 mO
 mO
 mO
 mO
 mO
-Aj
-tZ
-tZ
-tZ
-tZ
-tZ
-tZ
+ZW
+ga
+ga
+ga
+ga
+ga
+ga
 ak
 ak
 ak
@@ -46170,30 +46190,30 @@ mO
 mO
 mO
 mO
-lh
-Lf
-xg
-ML
-Xs
-jP
-sr
-kc
-Si
-Ht
-yc
-dd
-xg
-Cf
-Cf
-Cf
-Cf
-GG
-DQ
-Si
-CD
-CD
-CD
-CD
+MR
+Dw
+dQ
+VV
+AE
+AK
+gu
+cG
+RS
+Dr
+Qi
+vG
+dQ
+wP
+wP
+wP
+wP
+KY
+vJ
+RS
+kO
+kO
+kO
+kO
 mO
 mO
 mO
@@ -46427,30 +46447,30 @@ mO
 mO
 mO
 mO
-Ag
-JD
-va
-PR
-Xs
-qO
-qA
-Yl
-Si
-qM
-PC
-hD
-ES
-Cf
-vG
-Hu
-Cf
-tY
-gF
-ti
-Qt
-rs
-DN
-kn
+We
+Ht
+tM
+FP
+AE
+xF
+cx
+NB
+RS
+lT
+Ug
+FO
+QK
+wP
+Wc
+nF
+wP
+Ft
+tZ
+Gw
+VF
+Ts
+zq
+lZ
 mO
 mO
 mO
@@ -46684,30 +46704,30 @@ mO
 mO
 mO
 mO
-Ag
-fM
-pG
-pG
-yq
-FP
-FP
-FP
-Fh
-bQ
-FP
-iQ
-FP
-sI
-Vb
-Ra
-yW
-GX
-gF
-lo
-zq
+We
+BV
+Yq
+Yq
+wD
+fH
+fH
+fH
+cF
 eP
-rs
-kn
+fH
+eE
+fH
+yB
+DK
+OX
+tw
+dW
+tZ
+yA
+YF
+hI
+Ts
+lZ
 mO
 mO
 mO
@@ -46941,30 +46961,30 @@ mO
 mO
 mO
 mO
-Ag
-qA
-HJ
-fG
-JK
-gk
-FO
-qA
-Si
-de
-fz
-xg
-bQ
-Hm
-cZ
-cZ
-Hm
-gF
-gF
-PH
-Zj
-St
-cu
-kn
+We
+cx
+eb
+vB
+fU
+ug
+vR
+cx
+RS
+dq
+Tg
+dQ
+eP
+By
+Xb
+Xb
+By
+tZ
+tZ
+Ym
+Xf
+xm
+GP
+lZ
 mO
 mO
 mO
@@ -47198,30 +47218,30 @@ mO
 mO
 mO
 mO
-Cf
-Si
-wd
-Si
-Py
+wP
+RS
+FB
+RS
+IT
+Au
+IT
+IT
+IT
+mI
+eG
+dQ
+Ae
+yB
 EU
-Py
-Py
-Py
-RX
-mo
-xg
-Ft
-sI
-pq
-Xu
-yW
-iE
-Jm
-Cf
-CD
-CD
-CD
-CD
+eZ
+tw
+Ie
+ii
+wP
+kO
+kO
+kO
+kO
 mO
 mO
 mO
@@ -47455,26 +47475,26 @@ mO
 mO
 mO
 mO
-Cf
-lM
-NF
-zk
-Py
-AH
-AH
-rJ
-Py
-sW
-lF
-Cp
-tG
-Cf
-Cf
-Cf
-tW
-ga
-ME
-tW
+wP
+nW
+Si
+iu
+IT
+Aj
+Aj
+zW
+IT
+rZ
+XC
+Uv
+vg
+wP
+wP
+wP
+WT
+Gx
+KQ
+WT
 ak
 ak
 ak
@@ -47712,26 +47732,26 @@ mO
 mO
 mO
 mO
-Cf
-dQ
-NF
+wP
+WE
+Si
+iu
+IT
+uH
+xp
 zk
-Py
-ol
-yk
-dr
-Py
-nN
-sQ
-me
-tG
-Cf
+IT
+jj
+sj
+GI
+vg
+wP
 ak
 ak
-tW
-ar
-ZG
-tW
+WT
+nj
+jf
+WT
 ak
 ak
 ak
@@ -47969,26 +47989,26 @@ mO
 mO
 mO
 mO
-Cf
-zV
-gD
-IH
-CD
-CD
-CD
-CD
-CD
-hl
-eb
-Vy
-KJ
-Cf
+wP
+su
+pw
+uC
+kO
+kO
+kO
+kO
+kO
+Xu
+nE
+PQ
+zC
+wP
 ak
 ak
-tW
-KK
-xD
-tW
+WT
+Sp
+dh
+WT
 ak
 ak
 ak
@@ -48226,30 +48246,30 @@ mO
 mO
 mO
 mO
-Cf
-xp
-De
-zk
-Cf
-ak
-ak
-ak
-Cf
 wP
-Cf
-Cf
-Cf
-Cf
+iH
+Mh
+iu
+wP
 ak
 ak
-tW
-kO
-tw
-tW
-tW
-tW
-tW
-JY
+ak
+wP
+hp
+wP
+wP
+wP
+wP
+ak
+ak
+WT
+fB
+Be
+WT
+WT
+WT
+WT
+BG
 mO
 mO
 mO
@@ -48483,11 +48503,11 @@ mO
 mO
 mO
 mO
-Cf
-Cf
-Cf
-Cf
-Cf
+wP
+wP
+wP
+wP
+wP
 ak
 ak
 ak
@@ -48499,13 +48519,13 @@ ak
 ak
 ak
 ak
-tW
-SB
-HO
-mD
-Fn
-Fn
-xm
+WT
+Du
+Uf
+kc
+po
+po
+Xx
 mO
 mO
 mO
@@ -48756,13 +48776,13 @@ ak
 ak
 ak
 ak
-tW
-eH
-HO
-Du
-Kk
-bK
-bK
+WT
+HB
+Uf
+SB
+mo
+Db
+Db
 mO
 mO
 mO
@@ -49013,13 +49033,13 @@ ak
 ak
 ak
 ak
-tW
-un
-Db
-NH
-Fn
-Tf
-yu
+WT
+br
+le
+jm
+po
+rq
+eH
 mO
 mO
 mO
@@ -49270,14 +49290,14 @@ ak
 ak
 ak
 ak
-tW
-kN
-tW
-kN
-tW
-tW
-tW
-JY
+WT
+tx
+WT
+tx
+WT
+WT
+WT
+BG
 mO
 mO
 mO
@@ -56271,11 +56291,11 @@ bN
 bN
 qD
 RW
-xK
+Qt
 JN
 np
 Ec
-Mu
+et
 RW
 Et
 kK
@@ -58076,7 +58096,7 @@ UF
 rl
 MH
 qy
-LJ
+IK
 RW
 ak
 ak

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -4151,7 +4151,9 @@
 	dir = 8
 	},
 /obj/machinery/iv_drip,
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/structure/curtain,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
@@ -24984,10 +24986,14 @@
 /turf/closed/wall/r_wall/rust,
 /area/maintenance/starboard)
 "dNK" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/landmark/start/assistant,
-/obj/item/bedsheet/dorms,
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
 /obj/effect/landmark/start/hangover,
 /obj/machinery/button/door/directional/north{
 	id = "Cabin_3";
@@ -28892,8 +28898,12 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "fcy" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/captain{
+	dir = 4
+	},
 /obj/effect/landmark/start/captain,
 /obj/item/radio/intercom/directional/west{
 	freerange = 1;
@@ -52242,6 +52252,17 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"mPc" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/commons/locker)
 "mPo" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -82466,11 +82487,15 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "wNg" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/obj/item/bedsheet/brown,
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -109862,7 +109887,7 @@ oCh
 hwF
 qqe
 shg
-ppf
+mPc
 nHK
 nHK
 gcs

--- a/_maps/map_files/Mafia/mafia_snow.dmm
+++ b/_maps/map_files/Mafia/mafia_snow.dmm
@@ -46,8 +46,12 @@
 /turf/open/floor/plating,
 /area/mafia)
 "l" = (
-/obj/item/bedsheet/brown,
-/obj/structure/bed,
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/holofloor/wood,
 /area/mafia)
 "m" = (
@@ -60,8 +64,12 @@
 /turf/open/floor/holofloor/wood,
 /area/mafia)
 "o" = (
-/obj/item/bedsheet/blue,
-/obj/structure/bed,
+/obj/item/bedsheet/blue{
+	dir = 4
+	},
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/holofloor/wood,
 /area/mafia)
 "p" = (
@@ -165,8 +173,12 @@
 /turf/open/floor/holofloor/wood,
 /area/mafia)
 "H" = (
-/obj/item/bedsheet/black,
-/obj/structure/bed,
+/obj/item/bedsheet/black{
+	dir = 4
+	},
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/holofloor/wood,
 /area/mafia)
 "I" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -25830,8 +25830,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ifA" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -27145,7 +27149,9 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "iGI" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/mask/muzzle,
@@ -30522,8 +30528,12 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "jTj" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -32157,6 +32167,17 @@
 	},
 /turf/open/floor/iron,
 /area/science/lab)
+"kzP" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/light/directional/south,
+/obj/structure/bed/pod{
+	desc = "An old medical bed, just waiting for replacement with something up to date.";
+	name = "medical bed";
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "kzV" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/treatment,
@@ -88975,7 +88996,7 @@ vTJ
 nUM
 hNP
 fBL
-uxv
+kzP
 bXK
 vTp
 cto

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1144,8 +1144,12 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "fe" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet,
 /area/mine/living_quarters)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2219,8 +2219,12 @@
 	color = "#2e2e2e";
 	dir = 10
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/syndie,
+/obj/item/bedsheet/syndie{
+	dir = 4
+	},
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -8394,6 +8398,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/evacuation)
+"Ch" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evacuation/ship)
 "Ci" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine/cult,
@@ -9946,8 +9956,10 @@
 /turf/open/floor/plating,
 /area/centcom/evacuation/ship)
 "Lx" = (
-/obj/structure/bed,
 /obj/machinery/light/directional/west,
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evacuation/ship)
 "Ly" = (
@@ -39810,11 +39822,11 @@ Lj
 Ln
 Lq
 KH
-Lv
-Lv
+Ch
+Ch
 Lx
-Lv
-Lv
+Ch
+Ch
 KH
 KH
 aa

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7951,7 +7951,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "bxJ" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -9297,7 +9299,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/effect/landmark/start/virologist,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
@@ -28476,7 +28480,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/medical/virology)
@@ -41140,8 +41146,12 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "nvj" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
 "nvp" = (
@@ -55236,8 +55246,12 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/command/nuke_storage)
 "sFC" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/captain{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -62354,7 +62368,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -65734,7 +65750,9 @@
 /area/science/mixing/launch)
 "wCW" = (
 /obj/machinery/light/directional/west,
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /turf/open/floor/iron/textured_large,
 /area/security/execution/education)
 "wDe" = (

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -200,15 +200,11 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/mineral/bananium,
-/area/shuttle/escape)
-"aP" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/random{
+	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
@@ -311,6 +307,15 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
+"An" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
 "RX" = (
 /obj/item/toy/snappop/phoenix,
 /obj/machinery/vending/wallmed/directional/north{
@@ -359,11 +364,11 @@ au
 au
 ab
 aJ
-aM
-aM
-aM
-aM
-aM
+An
+An
+An
+An
+An
 aR
 ab
 aV
@@ -503,7 +508,7 @@ ak
 aE
 aH
 ak
-aP
+aO
 aO
 aO
 aO

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -696,6 +696,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plating,
 /area/shuttle/escape/brig)
+"nl" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
 "xt" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -805,7 +811,7 @@ bw
 bw
 Lu
 ax
-bD
+nl
 bE
 bc
 "}

--- a/_maps/shuttles/pirate_silverscale.dmm
+++ b/_maps/shuttles/pirate_silverscale.dmm
@@ -464,6 +464,15 @@
 /obj/machinery/meter,
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
+"yK" = (
+/obj/structure/bed/pod{
+	dir = 4
+	},
+/obj/item/bedsheet/black{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/pirate)
 "zB" = (
 /obj/structure/table/glass,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -1293,7 +1302,7 @@ Sh
 rB
 fN
 Sv
-uP
+yK
 rB
 "}
 (16,1,1) = {"

--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -449,8 +449,12 @@
 /area/shuttle/caravan/freighter1)
 "xG" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/all_access{
 	dir = 4;

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -78,8 +78,12 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/caravan/pirate)
 "fS" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
 /obj/machinery/airalarm/all_access{
 	dir = 8;
 	pixel_x = -24
@@ -392,8 +396,12 @@
 /turf/open/floor/iron,
 /area/shuttle/caravan/pirate)
 "vq" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/side{
 	dir = 6

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -1766,6 +1766,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/bridge)
+"fy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/built/directional/north,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/item/bedsheet{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned/crew)
 "gL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2258,7 +2276,7 @@ ag
 "}
 (19,1,1) = {"
 ac
-Uq
+fy
 FW
 ax
 aK

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -80,8 +80,12 @@
 "al" = (
 /obj/machinery/light/small/built/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed,
-/obj/item/bedsheet/centcom,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/centcom{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/airalarm/all_access{
 	dir = 4;

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -1012,7 +1012,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned/bar)
 "bX" = (
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/all_access{
 	dir = 8;
@@ -1020,7 +1022,9 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/item/bedsheet/brown,
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/crew)

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -2186,9 +2186,13 @@
 /area/shuttle/abandoned/cargo)
 "Sv" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed,
+/obj/structure/bed{
+	dir = 4
+	},
 /obj/machinery/light/small/built/directional/east,
-/obj/item/bedsheet/brown,
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,

--- a/_maps/templates/holodeck_medicalsim.dmm
+++ b/_maps/templates/holodeck_medicalsim.dmm
@@ -778,7 +778,9 @@
 	},
 /area/template_noop)
 "Tt" = (
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

So back in #64525, I rotated all the sleepers since I noticed we had directional variants for all of those.

![image](https://user-images.githubusercontent.com/34697715/160538306-1a783077-fcec-44ac-8948-7ad7654a22e2.png)

Don't they look so good? However, if you look at the polar opposite of that same room...

![image](https://user-images.githubusercontent.com/34697715/160538320-3c1c58f5-c445-41f6-adf4-c88f89359c9c.png)

FUUUUUUUUUUUUCK......... FUUUUUUUUUUUUUUUUUUUUUUUUUUUUU-

Let's fix that in every map that has a bed, and where applicable. When I couldn't decide what way the bed should face, I defaulted to what was there prior to honor the original artistic intent and what-not.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/160538333-c9442a27-4635-4143-aad0-7921f87ef0a1.png)

Ah, much better, I think. I think a lot of these were mapped before we even had the flipped bed variant, so I just adjusted all of those (and the bedsheets too, when applicable) to make it look better and more cohesive on the overall.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: A conformational change in reality has caused every single bed (when applicable) to be tastefully rotated in the opposite direction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
