### PR TITLE
re-adds food processor upgrades

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -55,7 +55,7 @@
 /obj/machinery/processor/proc/process_food(datum/food_processor_process/recipe, atom/movable/what)
 	if(recipe.output && loc && !QDELETED(src))
 		var/list/cached_mats = recipe.preserve_materials && what.custom_materials
-		var/cached_multiplier = recipe.multiplier
+		var/cached_multiplier = (recipe.food_multiplier + rating_amount)
 		for(var/i in 1 to cached_multiplier)
 			var/atom/processed_food = new recipe.output(drop_location())
 			if(cached_mats)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -55,7 +55,7 @@
 /obj/machinery/processor/proc/process_food(datum/food_processor_process/recipe, atom/movable/what)
 	if(recipe.output && loc && !QDELETED(src))
 		var/list/cached_mats = recipe.preserve_materials && what.custom_materials
-		var/cached_multiplier = (recipe.food_multiplier + rating_amount)
+		var/cached_multiplier = (recipe.food_multiplier * rating_amount)
 		for(var/i in 1 to cached_multiplier)
 			var/atom/processed_food = new recipe.output(drop_location())
 			if(cached_mats)

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -9,8 +9,8 @@
 	var/time = 40
 	/// The machine required to do this recipe
 	var/required_machine = /obj/machinery/processor
-	/// The number of products this recipe creates.
-	var/multiplier = 1 //This multiplies the number of products produced per object processed.
+	/// The additional amount of food made on process.
+	var/food_multiplier = 0
 	/// Whether to copy the materials from the input to the output
 	var/preserve_materials = TRUE
 
@@ -22,7 +22,7 @@
 		/obj/item/food/meat/slab/xeno,
 		/obj/item/food/meat/slab/bear,
 		/obj/item/food/meat/slab/chicken)
-	multiplier = 3
+	food_multiplier = 2
 
 /datum/food_processor_process/cutlet
 	input = /obj/item/food/meat/cutlet/plain
@@ -70,7 +70,7 @@
 /datum/food_processor_process/meat/chicken
 	input = /obj/item/food/meat/slab/chicken
 	output = /obj/item/food/raw_meatball/chicken
-	multiplier = 3
+	food_multiplier = 2
 	blacklist = null
 
 /datum/food_processor_process/cutlet/chicken
@@ -131,5 +131,5 @@
 /datum/food_processor_process/towercap
 	input = /obj/item/grown/log
 	output = /obj/item/popsicle_stick
-	multiplier = 3
+	food_multiplier = 2
 	preserve_materials = FALSE

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -10,7 +10,7 @@
 	/// The machine required to do this recipe
 	var/required_machine = /obj/machinery/processor
 	/// Multiplied additional food made when processed
-	var/food_multiplier = 0
+	var/food_multiplier = 1
 	/// Whether to copy the materials from the input to the output
 	var/preserve_materials = TRUE
 

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -9,7 +9,7 @@
 	var/time = 40
 	/// The machine required to do this recipe
 	var/required_machine = /obj/machinery/processor
-	/// The additional amount of food made on process.
+	/// Multiplied additional food made when processed
 	var/food_multiplier = 0
 	/// Whether to copy the materials from the input to the output
 	var/preserve_materials = TRUE
@@ -22,7 +22,7 @@
 		/obj/item/food/meat/slab/xeno,
 		/obj/item/food/meat/slab/bear,
 		/obj/item/food/meat/slab/chicken)
-	food_multiplier = 2
+	food_multiplier = 3
 
 /datum/food_processor_process/cutlet
 	input = /obj/item/food/meat/cutlet/plain
@@ -70,7 +70,7 @@
 /datum/food_processor_process/meat/chicken
 	input = /obj/item/food/meat/slab/chicken
 	output = /obj/item/food/raw_meatball/chicken
-	food_multiplier = 2
+	food_multiplier = 3
 	blacklist = null
 
 /datum/food_processor_process/cutlet/chicken
@@ -131,5 +131,5 @@
 /datum/food_processor_process/towercap
 	input = /obj/item/grown/log
 	output = /obj/item/popsicle_stick
-	food_multiplier = 2
+	food_multiplier = 3
 	preserve_materials = FALSE


### PR DESCRIPTION
## About The Pull Request

I'm assuming this was accidentally removed when meatballs (?) were added, because the var, upgrades, and examine text are still in the game, but it currently does nothing.
I changed the food_multiplier to fit with the re-addition of the mechanic, which is solely used here, so doesn't affect anything else.

## Why It's Good For The Game

Restoring already-existing mechanics that were accidentally removed.
Closes https://github.com/tgstation/tgstation/issues/65745

## Changelog

:cl:
fix: Food processors now give more processed food, depending on its matter bin.
/:cl: