### PR TITLE
Assigns the harmful tag to Haloperidol on borg hypos because it is

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1168,6 +1168,7 @@
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
 	ph = 4.3
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	harmful = TRUE
 
 /datum/reagent/medicine/haloperidol/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	for(var/datum/reagent/drug/R in M.reagents.reagent_list)


### PR DESCRIPTION
## About The Pull Request
Flags Haloperidol as harmful so that it shows up as having side effects in the borg hypo selection menu.

## Why It's Good For The Game

Haloperidol is in fact harmful, and while legitimate use of it is covered by assumption of consent to treatment and good faith play by mediborgs (as with C2 chems), using it offensively or aggressively on humans is a law one breach. It's much fairer that mediborg players are more informed about what they're using beforehand so they don't start breaching laws by accident.

## Changelog

:cl:
fix: Haloperidol has been properly labelled in medical cyborg hyposprays after several instances of mediborg induced brain damage were found in human patients.
/:cl:

