### PR TITLE
[April Fools] Properly categorizes European speech genes.

### DIFF
--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -71,7 +71,7 @@
 /datum/mutation/human/swedish
 	name = "Swedish"
 	desc = "A horrible mutation originating from the distant past. Thought to be eradicated after the incident in 2037."
-	quality = MINOR_NEGATIVE
+	quality = NEGATIVE
 	text_gain_indication = "<span class='notice'>You feel Swedish, however that works.</span>"
 	text_lose_indication = "<span class='notice'>The feeling of Swedishness passes.</span>"
 
@@ -102,7 +102,7 @@
 /datum/mutation/human/chav
 	name = "Chav"
 	desc = "Unknown"
-	quality = MINOR_NEGATIVE
+	quality = NEGATIVE
 	text_gain_indication = "<span class='notice'>Ye feel like a reet prat like, innit?</span>"
 	text_lose_indication = "<span class='notice'>You no longer feel like being rude and sassy.</span>"
 


### PR DESCRIPTION
## About The Pull Request

There was an issue where these were given improper typing in the mutations/speech.dm.

## Why It's Good For The Game

Proper categorization is always beneficial.