### PR TITLE
Fixes issue #65609 -- Can interact with airlock wires after adding shielding

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -69,7 +69,7 @@
 		var/mob/living/carbon/carbon_user = user
 		if (!istype(carbon_user) || carbon_user.should_electrocute(src))
 			return FALSE
-	if(A.isSecure())
+	if(A.is_secure())
 		return FALSE
 	if(A.panel_open)
 		return TRUE

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -69,7 +69,8 @@
 		var/mob/living/carbon/carbon_user = user
 		if (!istype(carbon_user) || carbon_user.should_electrocute(src))
 			return FALSE
-
+	if(A.isSecure())
+		return FALSE
 	if(A.panel_open)
 		return TRUE
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -475,7 +475,7 @@
 	else
 		return FALSE
 
-/obj/machinery/door/airlock/proc/isSecure()
+/obj/machinery/door/airlock/proc/is_secure()
 	return (security_level > 0)
 
 /obj/machinery/door/airlock/update_icon(updates=ALL, state=0, override=FALSE)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -13,6 +13,7 @@
 	loseBackupPower - handles the effect of backup power going offline.
 	regainBackupPower - handles the effect of main power coming back on.
 	shock - has a chance of electrocuting its target.
+	isSecure - 1 if there some form of shielding in front of the airlock wires.
 */
 
 /// Overlay cache.  Why isn't this just in /obj/machinery/door/airlock?  Because its used just a
@@ -473,6 +474,9 @@
 		return TRUE
 	else
 		return FALSE
+
+/obj/machinery/door/airlock/proc/isSecure()
+	return (security_level > 0)
 
 /obj/machinery/door/airlock/update_icon(updates=ALL, state=0, override=FALSE)
 	if(operating && !override)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #65609

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixing bugs is good for the game, even if its something small like this.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: When an airlock that is being hacked receives plasteel reinforcement, it will no longer keep the hacking UI open and useable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
