### PR TITLE
Adds a new module for Admin modsuits. (+ Chrono, Debug)

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -316,7 +316,7 @@
 /obj/item/mod/control/pre_equipped/debug
 	theme = /datum/mod_theme/debug
 	applied_core = /obj/item/mod/core/infinite
-	initial_modules = list( //one of every type of module, for testing if they all work correctly
+	initial_modules = list(
 		/obj/item/mod/module/storage/bluespace,
 		/obj/item/mod/module/welding,
 		/obj/item/mod/module/flashlight,
@@ -324,6 +324,7 @@
 		/obj/item/mod/module/rad_protection,
 		/obj/item/mod/module/tether,
 		/obj/item/mod/module/injector,
+		/obj/item/mod/module/anomaly_locked/kinesis/plus,
 	)
 
 /obj/item/mod/control/pre_equipped/administrative
@@ -333,6 +334,7 @@
 		/obj/item/mod/module/storage/bluespace,
 		/obj/item/mod/module/welding,
 		/obj/item/mod/module/stealth/ninja,
+		/obj/item/mod/module/anomaly_locked/kinesis/plus,
 		/obj/item/mod/module/quick_carry/advanced,
 		/obj/item/mod/module/magboot/advanced,
 		/obj/item/mod/module/jetpack,

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -309,6 +309,7 @@
 		/obj/item/mod/module/timeline_jumper,
 		/obj/item/mod/module/timestopper,
 		/obj/item/mod/module/rewinder,
+		/obj/item/mod/module/anomaly_locked/kinesis/chrono,
 		/obj/item/mod/module/tem,
 	)
 

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -309,7 +309,7 @@
 		/obj/item/mod/module/timeline_jumper,
 		/obj/item/mod/module/timestopper,
 		/obj/item/mod/module/rewinder,
-		/obj/item/mod/module/anomaly_locked/kinesis/chrono,
+		/obj/item/mod/module/anomaly_locked/kinesis/plus,
 		/obj/item/mod/module/tem,
 	)
 

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -254,8 +254,8 @@
 	given_x = round(icon_x - world.icon_size * our_x)
 	given_y = round(icon_y - world.icon_size * our_y)
 
-/obj/item/mod/module/anomaly_locked/kinesis/chrono
-	name = "MOD kinesis+ module" //Chrono Legionarrie variant. You know why, deep in your heart.
+/obj/item/mod/module/anomaly_locked/kinesis/plus
+	name = "MOD kinesis+ module"
 	desc = "A modular plug-in to the forearm, this module was recently redeveloped in secret. \
 	The bane of all ne'er-do-wells, the kinesis+ module is a powerful tool that allows the user to \
 	manipulate the world around them. Like it's older counterpart, it's capable of manipulating structures, \

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -18,8 +18,10 @@
 	var/grab_range = 5
 	var/hit_cooldown_time = 1 SECONDS
 	var/movement_animation
+	//Are living mobs allowed as targets?
 	var/mobs_allowed = FALSE
-	var/living_stun_length = 100
+	//How long do we want living mobs to be stunned?
+	var/living_stun_length = 5 SECONDS
 	var/atom/movable/grabbed_atom
 	var/datum/beam/kinesis_beam
 	var/mutable_appearance/kinesis_icon

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -259,9 +259,9 @@
 /obj/item/mod/module/anomaly_locked/kinesis/plus
 	name = "MOD kinesis+ module"
 	desc = "A modular plug-in to the forearm, this module was recently redeveloped in secret. \
-	The bane of all ne'er-do-wells, the kinesis+ module is a powerful tool that allows the user to \
-	manipulate the world around them. Like it's older counterpart, it's capable of manipulating structures, \
-	machinery, vehicles, and, thanks to the fruitful efforts of it's creators - living beings. They can, however, \
-	still struggle after an initial burst of inertia."
+	The bane of all ne'er-do-wells, the kinesis+ module is a powerful tool that allows the user \
+	to manipulate the world around them. Like it's older counterpart, it's capable of manipulating \
+	structures, machinery, vehicles, and, thanks to the fruitful efforts of it's creators - living  \
+	beings. They can, however, still struggle after an initial burst of inertia."
 	prebuilt = TRUE
 	mobs_allowed = TRUE

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -259,9 +259,9 @@
 /obj/item/mod/module/anomaly_locked/kinesis/plus
 	name = "MOD kinesis+ module"
 	desc = "A modular plug-in to the forearm, this module was recently redeveloped in secret. \
-	The bane of all ne'er-do-wells, the kinesis+ module is a powerful tool that allows the user \
-	to manipulate the world around them. Like it's older counterpart, it's capable of manipulating \
-	structures, machinery, vehicles, and, thanks to the fruitful efforts of it's creators - living  \
-	beings. They can, however, still struggle after an initial burst of inertia."
+		The bane of all ne'er-do-wells, the kinesis+ module is a powerful tool that allows the user \
+		to manipulate the world around them. Like it's older counterpart, it's capable of manipulating \
+		structures, machinery, vehicles, and, thanks to the fruitful efforts of it's creators - living  \
+		beings. They can, however, still struggle after an initial burst of inertia."
 	prebuilt = TRUE
 	mobs_allowed = TRUE

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -18,6 +18,8 @@
 	var/grab_range = 5
 	var/hit_cooldown_time = 1 SECONDS
 	var/movement_animation
+	var/mobs_allowed = FALSE
+	var/living_stun_length = 100
 	var/atom/movable/grabbed_atom
 	var/datum/beam/kinesis_beam
 	var/mutable_appearance/kinesis_icon
@@ -55,6 +57,9 @@
 		return
 	drain_power(use_power_cost)
 	grabbed_atom = target
+	if(isliving(target))
+		var/mob/living/rdmhobo = target
+		rdmhobo.Stun(living_stun_length) //Be aware they CAN move after this, though they'll be snapped back to your grip unless they leave your range
 	playsound(grabbed_atom, 'sound/effects/contractorbatonhit.ogg', 75, TRUE)
 	START_PROCESSING(SSfastprocess, src)
 	kinesis_icon = mutable_appearance(icon='icons/effects/effects.dmi', icon_state="kinesis", layer=grabbed_atom.layer-0.1)
@@ -142,7 +147,7 @@
 		if(!isliving(movable_target))
 			return FALSE
 		var/mob/living/living_target = movable_target
-		if(living_target.stat != DEAD)
+		if(living_target.stat != DEAD && mobs_allowed == FALSE)
 			return FALSE
 	else if(isitem(movable_target))
 		var/obj/item/item_target = movable_target
@@ -248,3 +253,13 @@
 	given_turf = locate(mob_x+our_x-round(view[1]/2),mob_y+our_y-round(view[2]/2),mob_z)
 	given_x = round(icon_x - world.icon_size * our_x)
 	given_y = round(icon_y - world.icon_size * our_y)
+
+/obj/item/mod/module/anomaly_locked/kinesis/chrono
+	name = "MOD kinesis+ module" //Chrono Legionarrie variant. You know why, deep in your heart.
+	desc = "A modular plug-in to the forearm, this module was recently redeveloped in secret. \
+	The bane of all ne'er-do-wells, the kinesis+ module is a powerful tool that allows the user to \
+	manipulate the world around them. Like it's older counterpart, it's capable of manipulating structures, \
+	machinery, vehicles, and, thanks to the fruitful efforts of it's creators - living beings. They can, however, \
+	still struggle after an initial burst of inertia."
+	prebuilt = TRUE
+	mobs_allowed = TRUE

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -263,5 +263,6 @@
 		to manipulate the world around them. Like it's older counterpart, it's capable of manipulating \
 		structures, machinery, vehicles, and, thanks to the fruitful efforts of it's creators - living  \
 		beings. They can, however, still struggle after an initial burst of inertia."
+	complexity = 0 // As with other admin modules.
 	prebuilt = TRUE
 	mobs_allowed = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/50649185/160939213-d131d145-30a1-4394-93c3-2eee3e7a0529.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As much as Chronos are a reference to a time when even SSBlackbox could be nuked IC, they're still fun adminbus tools. This brings the joke full circle.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: A new Kinesis+ module has rolled out to Chrono Legionaries. Consequently, there's now support for MOD kinesis modules that can handle living mobs, and even variable stun times for it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
