### PR TITLE
makes grilles grill food, not drinks/condiments

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -141,7 +141,7 @@
 	#define COMPONENT_HANDLED_GRILLING (1<<0)
 ///Called when an object is turned into another item through grilling ontop of a griddle
 #define COMSIG_GRILL_COMPLETED "item_grill_completed"
-///Called when an object is meant to be grilled through a grill
+///Called when an object is meant to be grilled through a grill: (grill_time)
 #define COMSIG_GRILL_FOOD "item_grill_food"
 //Called when an object is in an oven
 #define COMSIG_ITEM_BAKED "item_baked"

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -141,6 +141,8 @@
 	#define COMPONENT_HANDLED_GRILLING (1<<0)
 ///Called when an object is turned into another item through grilling ontop of a griddle
 #define COMSIG_GRILL_COMPLETED "item_grill_completed"
+///Called when an object is meant to be grilled through a grill
+#define COMSIG_GRILL_FOOD "item_grill_food"
 //Called when an object is in an oven
 #define COMSIG_ITEM_BAKED "item_baked"
 	#define COMPONENT_HANDLED_BAKING (1<<0)

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -141,7 +141,7 @@
 	#define COMPONENT_HANDLED_GRILLING (1<<0)
 ///Called when an object is turned into another item through grilling ontop of a griddle
 #define COMSIG_GRILL_COMPLETED "item_grill_completed"
-///Called when an object is meant to be grilled through a grill: (grill_time)
+///Called when an object is meant to be grilled through a grill: (atom/fry_object, grill_time)
 #define COMSIG_GRILL_FOOD "item_grill_food"
 //Called when an object is in an oven
 #define COMSIG_ITEM_BAKED "item_baked"

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -185,9 +185,28 @@ Behavior that's still missing from this component that original food items had t
 	qdel(our_atom)
 	return COMSIG_FRYING_HANDLED
 
-/datum/component/edible/proc/GrillFood(datum/source, atom/fry_object)
+/datum/component/edible/proc/GrillFood(datum/source, atom/fry_object, grill_time)
 	SIGNAL_HANDLER
-	foodtypes |= FRIED
+
+	var/atom/this_food = parent
+
+	switch(grill_time) //no 0-20 to prevent spam
+		if(20 to 30)
+			this_food.name = "lightly-grilled [this_food.name]"
+			this_food.desc = "[this_food.desc] It's been lightly grilled."
+		if(30 to 80)
+			this_food.name = "grilled [this_food.name]"
+			this_food.desc = "[this_food.desc] It's been grilled."
+			foodtypes |= FRIED
+		if(80 to 100)
+			this_food.name = "heavily grilled [this_food.name]"
+			this_food.desc = "[this_food.desc] It's been heavily grilled."
+			foodtypes |= FRIED
+		if(100 to INFINITY) //grill marks reach max alpha
+			this_food.name = "Powerfully Grilled [this_food.name]"
+			this_food.desc = "A [this_food.name]. Reminds you of your wife, wait, no, it's prettier!"
+			foodtypes |= FRIED
+
 
 ///Called when food is created through processing (Usually this means it was sliced). We use this to pass the OG items reagents.
 /datum/component/edible/proc/OnProcessed(datum/source, atom/original_atom, list/chosen_processing_option)

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -83,6 +83,7 @@ Behavior that's still missing from this component that original food items had t
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/UseFromHand)
 		RegisterSignal(parent, COMSIG_ITEM_FRIED, .proc/OnFried)
+		RegisterSignal(parent, COMSIG_GRILL_FOOD, .proc/GrillFood)
 		RegisterSignal(parent, COMSIG_ITEM_MICROWAVE_ACT, .proc/OnMicrowaved)
 		RegisterSignal(parent, COMSIG_ITEM_USED_AS_INGREDIENT, .proc/used_to_customize)
 
@@ -183,6 +184,10 @@ Behavior that's still missing from this component that original food items had t
 	our_atom.reagents.trans_to(fry_object, our_atom.reagents.total_volume)
 	qdel(our_atom)
 	return COMSIG_FRYING_HANDLED
+
+/datum/component/edible/proc/GrillFood(datum/source, atom/fry_object)
+	SIGNAL_HANDLER
+	foodtypes |= FRIED
 
 ///Called when food is created through processing (Usually this means it was sliced). We use this to pass the OG items reagents.
 /datum/component/edible/proc/OnProcessed(datum/source, atom/original_atom, list/chosen_processing_option)

--- a/code/modules/food_and_drinks/kitchen_machinery/grill.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill.dm
@@ -134,7 +134,7 @@
 	return ..()
 
 /obj/machinery/grill/proc/finish_grill()
-	if(grile_time >= 30)
+	if(grill_time >= 30)
 		SEND_SIGNAL(grilled_item, COMSIG_GRILL_FOOD)
 	switch(grill_time) //no 0-20 to prevent spam
 		if(20 to 30)

--- a/code/modules/food_and_drinks/kitchen_machinery/grill.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill.dm
@@ -134,6 +134,7 @@
 	return ..()
 
 /obj/machinery/grill/proc/finish_grill()
+	var/datum/component/edible/food_component = grilled_item.GetComponent(/datum/component/edible)
 	switch(grill_time) //no 0-20 to prevent spam
 		if(20 to 30)
 			grilled_item.name = "lightly-grilled [grilled_item.name]"
@@ -141,15 +142,15 @@
 		if(30 to 80)
 			grilled_item.name = "grilled [grilled_item.name]"
 			grilled_item.desc = "[grilled_item.desc] It's been grilled."
-			grilled_item.foodtype |= FRIED
+			food_component.foodtypes |= FRIED
 		if(80 to 100)
 			grilled_item.name = "heavily grilled [grilled_item.name]"
 			grilled_item.desc = "[grilled_item.desc] It's been heavily grilled."
-			grilled_item.foodtype |= FRIED
+			food_component.foodtypes |= FRIED
 		if(100 to INFINITY) //grill marks reach max alpha
 			grilled_item.name = "Powerfully Grilled [grilled_item.name]"
 			grilled_item.desc = "A [grilled_item.name]. Reminds you of your wife, wait, no, it's prettier!"
-			grilled_item.foodtype |= FRIED
+			food_component.foodtypes |= FRIED
 	grill_time = 0
 	UnregisterSignal(grilled_item, COMSIG_GRILL_COMPLETED)
 	grill_loop.stop()

--- a/code/modules/food_and_drinks/kitchen_machinery/grill.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill.dm
@@ -134,7 +134,6 @@
 	return ..()
 
 /obj/machinery/grill/proc/finish_grill()
-	var/datum/component/edible/food_component = grilled_item.GetComponent(/datum/component/edible)
 	switch(grill_time) //no 0-20 to prevent spam
 		if(20 to 30)
 			grilled_item.name = "lightly-grilled [grilled_item.name]"
@@ -142,15 +141,15 @@
 		if(30 to 80)
 			grilled_item.name = "grilled [grilled_item.name]"
 			grilled_item.desc = "[grilled_item.desc] It's been grilled."
-			food_component.foodtypes |= FRIED
+			SEND_SIGNAL(grilled_item, COMSIG_GRILL_FOOD)
 		if(80 to 100)
 			grilled_item.name = "heavily grilled [grilled_item.name]"
 			grilled_item.desc = "[grilled_item.desc] It's been heavily grilled."
-			food_component.foodtypes |= FRIED
+			SEND_SIGNAL(grilled_item, COMSIG_GRILL_FOOD)
 		if(100 to INFINITY) //grill marks reach max alpha
 			grilled_item.name = "Powerfully Grilled [grilled_item.name]"
 			grilled_item.desc = "A [grilled_item.name]. Reminds you of your wife, wait, no, it's prettier!"
-			food_component.foodtypes |= FRIED
+			SEND_SIGNAL(grilled_item, COMSIG_GRILL_FOOD)
 	grill_time = 0
 	UnregisterSignal(grilled_item, COMSIG_GRILL_COMPLETED)
 	grill_loop.stop()

--- a/code/modules/food_and_drinks/kitchen_machinery/grill.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill.dm
@@ -134,6 +134,8 @@
 	return ..()
 
 /obj/machinery/grill/proc/finish_grill()
+	if(grile_time >= 30)
+		SEND_SIGNAL(grilled_item, COMSIG_GRILL_FOOD)
 	switch(grill_time) //no 0-20 to prevent spam
 		if(20 to 30)
 			grilled_item.name = "lightly-grilled [grilled_item.name]"
@@ -141,15 +143,12 @@
 		if(30 to 80)
 			grilled_item.name = "grilled [grilled_item.name]"
 			grilled_item.desc = "[grilled_item.desc] It's been grilled."
-			SEND_SIGNAL(grilled_item, COMSIG_GRILL_FOOD)
 		if(80 to 100)
 			grilled_item.name = "heavily grilled [grilled_item.name]"
 			grilled_item.desc = "[grilled_item.desc] It's been heavily grilled."
-			SEND_SIGNAL(grilled_item, COMSIG_GRILL_FOOD)
 		if(100 to INFINITY) //grill marks reach max alpha
 			grilled_item.name = "Powerfully Grilled [grilled_item.name]"
 			grilled_item.desc = "A [grilled_item.name]. Reminds you of your wife, wait, no, it's prettier!"
-			SEND_SIGNAL(grilled_item, COMSIG_GRILL_FOOD)
 	grill_time = 0
 	UnregisterSignal(grilled_item, COMSIG_GRILL_COMPLETED)
 	grill_loop.stop()

--- a/code/modules/food_and_drinks/kitchen_machinery/grill.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill.dm
@@ -134,21 +134,7 @@
 	return ..()
 
 /obj/machinery/grill/proc/finish_grill()
-	if(grill_time >= 30)
-		SEND_SIGNAL(grilled_item, COMSIG_GRILL_FOOD)
-	switch(grill_time) //no 0-20 to prevent spam
-		if(20 to 30)
-			grilled_item.name = "lightly-grilled [grilled_item.name]"
-			grilled_item.desc = "[grilled_item.desc] It's been lightly grilled."
-		if(30 to 80)
-			grilled_item.name = "grilled [grilled_item.name]"
-			grilled_item.desc = "[grilled_item.desc] It's been grilled."
-		if(80 to 100)
-			grilled_item.name = "heavily grilled [grilled_item.name]"
-			grilled_item.desc = "[grilled_item.desc] It's been heavily grilled."
-		if(100 to INFINITY) //grill marks reach max alpha
-			grilled_item.name = "Powerfully Grilled [grilled_item.name]"
-			grilled_item.desc = "A [grilled_item.name]. Reminds you of your wife, wait, no, it's prettier!"
+	SEND_SIGNAL(grilled_item, COMSIG_GRILL_FOOD, grilled_item, grill_time)
 	grill_time = 0
 	UnregisterSignal(grilled_item, COMSIG_GRILL_COMPLETED)
 	grill_loop.stop()


### PR DESCRIPTION
## About The Pull Request

When food was moved to newfood (and use an edible component), drinks and condiments were left both as subtypes of a no-longer-existant food. (Even worse, one isn't even a subtype of the other).

Grilles were not updated to make the edible component's foodtypes fried, instead they kept making old food (which again, is just drinks and condiments) get the grilled foodtype instead, so it likely just runtimed and didn't work at all.

This most probably wasn't caught because all the vars for the edible food component were all kept the same when they were created off of old food, even the procs. Edible component is a copy paste of drinks/condiments.

## Why It's Good For The Game

Less runtime errors, more grilling!

## Changelog

:cl:
fix: Grilling food now makes said food, grilled.
/:cl: