### PR TITLE
Telekinesis improvements/fixes

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -91,8 +91,8 @@
 	* Deletes itself if it is ever not in your hand, or if you should have no access to TK.
 */
 /obj/item/tk_grab
-	name = "Telekinetic Grab"
-	desc = "Magic"
+	name = "telekinetic grab"
+	desc = "i can be the mind controller"
 	icon = 'icons/obj/magic.dmi'//Needs sprites
 	icon_state = "2"
 	item_flags = NOBLUDGEON | ABSTRACT | DROPDEL
@@ -132,11 +132,11 @@
 	qdel(src)
 
 /obj/item/tk_grab/examine(user)
-	if (focus)
-		return focus.examine(user)
-	else
-		return ..()
-
+	. = ..()
+	if(focus)
+		. += span_info("<b>Left-click</b> to primary attack with [focus].")
+		. += span_info("<b>Right-click</b> to secondary attack with [focus].")
+		. += span_info("Use <b>throw mode</b> to throw [focus].")
 
 /obj/item/tk_grab/attack_self(mob/user)
 	if(!focus)
@@ -257,7 +257,7 @@
 	if(!check_if_focusable(target))
 		return
 	focus = target
-	update_appearance()
+	update_appearance(updates=ALL)
 	apply_focus_overlay()
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -99,13 +99,16 @@
 
 /mob/living/carbon/human/can_use_guns(obj/item/G)
 	. = ..()
-	if(G.trigger_guard == TRIGGER_GUARD_NORMAL)
-		if(HAS_TRAIT(src, TRAIT_CHUNKYFINGERS))
-			balloon_alert(src, "fingers are too big!")
-			return FALSE
 	if(HAS_TRAIT(src, TRAIT_NOGUNS))
 		to_chat(src, span_warning("You can't bring yourself to use a ranged weapon!"))
 		return FALSE
+	if(G.trigger_guard == TRIGGER_GUARD_NORMAL)
+		var/obj/item/tk_grab/grabber = is_holding_item_of_type(/obj/item/tk_grab) //can fire with tk even if our fingers are fat
+		if(grabber && grabber.focus == G)
+			return TRUE
+		if(HAS_TRAIT(src, TRAIT_CHUNKYFINGERS))
+			balloon_alert(src, "fingers are too big!")
+			return FALSE
 
 /mob/living/carbon/human/get_policy_keywords()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -102,9 +102,13 @@
 	if(HAS_TRAIT(src, TRAIT_NOGUNS))
 		to_chat(src, span_warning("You can't bring yourself to use a ranged weapon!"))
 		return FALSE
+
 	if(G.trigger_guard == TRIGGER_GUARD_NORMAL)
-		var/obj/item/tk_grab/grabber = is_holding_item_of_type(/obj/item/tk_grab) //can fire with tk even if our fingers are fat
-		if(grabber && grabber.focus == G)
+		var/obj/item/tk_grab/telekinetic_grab = is_holding_item_of_type(/obj/item/tk_grab) //can fire with tk even if our fingers are fat
+		if(telekinetic_grab && telekinetic_grab.focus == G)
+			if(HAS_TRAIT(src, TRAIT_HULK))
+				G.balloon_alert(src, "not allowed!")
+				return FALSE
 			return TRUE
 		if(HAS_TRAIT(src, TRAIT_CHUNKYFINGERS))
 			balloon_alert(src, "fingers are too big!")

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -107,7 +107,7 @@
 		var/obj/item/tk_grab/telekinetic_grab = is_holding_item_of_type(/obj/item/tk_grab) //can fire with tk even if our fingers are fat
 		if(telekinetic_grab && telekinetic_grab.focus == G)
 			if(HAS_TRAIT(src, TRAIT_HULK))
-				G.balloon_alert(src, "not allowed!")
+				G.balloon_alert(src, "too angry to concentrate!")
 				return FALSE
 			return TRUE
 		if(HAS_TRAIT(src, TRAIT_CHUNKYFINGERS))

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -32,8 +32,10 @@
 	if(!ismovable(fired_from))
 		return TRUE
 
+	var/atom/movable/firer = fired_from
+
 	//gun thrown backwards
-	var/throwtarget = get_edge_target_turf(firer, get_dir(target, firer))
+	var/throwtarget = get_edge_target_turf(fired_from, get_dir(target, fired_from))
 	firer.safe_throw_at(throwtarget, tk_recoil, 2)
 	return TRUE
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -164,8 +164,8 @@
 /obj/item/gun/proc/can_shoot()
 	return TRUE
 
-/obj/item/gun/proc/tk_firing(mob/living/user)
-	return loc != user ? TRUE : FALSE
+/obj/item/gun/proc/tk_firing()
+	return !get(src, /mob)
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
 	visible_message(span_warning("*click*"), vision_distance = COMBAT_MESSAGE_RANGE)
@@ -173,7 +173,7 @@
 
 
 /obj/item/gun/proc/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
-	if(recoil && !tk_firing(user))
+	if(recoil && !tk_firing())
 		shake_camera(user, recoil + 1, recoil)
 
 	if(suppressed)
@@ -181,23 +181,29 @@
 	else
 		playsound(src, fire_sound, fire_sound_volume, vary_fire_sound)
 		if(message)
-			if(tk_firing(user))
-				visible_message(span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"), \
-								blind_message = span_hear("You hear a gunshot!"), \
-								vision_distance = COMBAT_MESSAGE_RANGE)
-			else if(pointblank)
-				user.visible_message(span_danger("[user] fires [src] point blank at [pbtarget]!"), \
-								span_danger("You fire [src] point blank at [pbtarget]!"), \
-								span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget)
-				to_chat(pbtarget, span_userdanger("[user] fires [src] point blank at you!"))
+			if(pointblank)
+				if(tk_firing())
+					visible_message(span_danger("[src] fires point blank at [pbtarget]!"), \
+									null, \
+									span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget)
+					to_chat(pbtarget, span_userdanger("[src] fires point blank at you!"))
+				else
+					user.visible_message(span_danger("[user] fires [src] point blank at [pbtarget]!"), \
+										span_danger("You fire [src] point blank at [pbtarget]!"), \
+										span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget)
+					to_chat(pbtarget, span_userdanger("[user] fires [src] point blank at you!"))
 				if(pb_knockback > 0 && ismob(pbtarget))
 					var/mob/PBT = pbtarget
 					var/atom/throw_target = get_edge_target_turf(PBT, user.dir)
 					PBT.throw_at(throw_target, pb_knockback, 2)
-			else if(!tk_firing(user))
-				user.visible_message(span_danger("[user] fires [src]!"), \
-								span_danger("You fire [src]!"), \
+			else if(tk_firing())
+				visible_message(span_danger("[src] fires by itself!"), \
+								null, \
 								span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE)
+			else
+				user.visible_message(span_danger("[user] fires [src]!"), \
+									span_danger("You fire [src]!"), \
+									span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE)
 
 /obj/item/gun/emp_act(severity)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Adds examine messages to the TK grab telling the player how to use the new TK controls (i.e. examining the TK grab no longer examines the focused item)
2. Fixes being unable to fire a gun with TK when wearing insulated gloves (also adds an arbitrary check to prevent hulks firing, because they use the same trait as insulated gloves to prevent them firing guns)
3. Makes it so guns with recoil or whose projectiles do damage are thrown back when firing, based on whichever value is largest (disablers for example are thrown back 3 tiles, based on 30 damage)
4. Improves code a bit for gun throwback when TK firing
5. Makes tk_firing() proc a bit more robust
6. Fixes point blank firing with TK being unable to cause knockbacks like regular firing

Not sure if this should update GBP or not, given these are my bugs but this is also ostensibly a balance change too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

1. Gives players a semi-intuitive way of learning how the new TK controls work for themselves. I don't think being able to examine the focused item through the grab was really used, so I don't think it'll be much of a loss to remove it.
2. This was something I missed while testing the pull that added TK firing. Doesn't make a lot of sense to prevent people from firing a gun when their fingers are too big if they're doing it with TK.
3. Adding more kickback helps balance TK firing a bit more, and just adds a bit of interesting variance and unpredictability to it
4. Early returns
5. Uses get() instead of just checking the gun's location is the user, which recursively checks every location the gun is in to try to find the mob firing it to verify it's not being fired with TK
6. Guns should presumably still knockback if you're firing with TK, this wasn't left out for balance reasons, just my own reluctance to duplicate a visible message
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Examining the TK grab object now tells you the new controls for TK instead of examining the grabbed object
fix: TK firing is no longer blocked by fat fingers
balance: Guns with recoil or projectile damage are now thrown back slightly further when TK firing
code: Minor code improvements to TK firing
fix: Point blank firing with TK can now knockback like regular firing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
