### PR TITLE
Breathing plouxium now heal oxygen damage 

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1523,9 +1523,8 @@
 	ADD_TRAIT(L, TRAIT_NOCRITDAMAGE, type)
 
 /datum/reagent/pluoxium/on_mob_end_metabolize(mob/living/L)
-	. = ..()
 	REMOVE_TRAIT(L, TRAIT_NOCRITDAMAGE, type)
-
+	return ..()
 
 /datum/reagent/halon
 	name = "Halon"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1511,7 +1511,7 @@
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5
 	color = "90560B"
-	taste_description = "tasteless"
+	taste_description = "like air but better"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
 /datum/reagent/pluoxium/on_mob_life(mob/living/L, delta_time, times_fired)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1514,9 +1514,9 @@
 	taste_description = "like air but better"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/pluoxium/on_mob_life(mob/living/L, delta_time, times_fired)
+/datum/reagent/pluoxium/on_mob_life(mob/living/Living, delta_time, times_fired)
 	. = ..()
-	L.adjustOxyLoss(-2 * REM * delta_time, FALSE)
+	Living.adjustOxyLoss(-2 * REM * delta_time, FALSE)
 
 /datum/reagent/halon
 	name = "Halon"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1505,6 +1505,28 @@
 	L.adjustToxLoss(-5 * REM * delta_time, FALSE)
 	L.adjustBruteLoss(-2 * REM * delta_time, FALSE)
 
+/datum/reagent/pluoxium
+	name = "Pluoxium"
+	description = "An Oxygen compound that delivers eight times more Oxygen"
+	reagent_state = GAS
+	metabolization_rate = REAGENTS_METABOLISM * 0.5
+	color = "90560B"
+	taste_description = "tasteless"
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+
+/datum/reagent/pluoxium/on_mob_life(mob/living/L, delta_time, times_fired)
+	. = ..()
+	L.adjustOxyLoss(-4 * REM * delta_time, FALSE)
+
+/datum/reagent/pluoxium/on_mob_metabolize(mob/living/L)
+	. = ..()
+	ADD_TRAIT(L, TRAIT_NOCRITDAMAGE, type)
+
+/datum/reagent/pluoxium/on_mob_end_metabolize(mob/living/L)
+	. = ..()
+	REMOVE_TRAIT(L, TRAIT_NOCRITDAMAGE, type)
+	return ..()
+
 /datum/reagent/halon
 	name = "Halon"
 	description = "A fire suppression gas that removes oxygen and cools down the area"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1525,7 +1525,7 @@
 /datum/reagent/pluoxium/on_mob_end_metabolize(mob/living/L)
 	. = ..()
 	REMOVE_TRAIT(L, TRAIT_NOCRITDAMAGE, type)
-	return ..()
+
 
 /datum/reagent/halon
 	name = "Halon"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1516,15 +1516,7 @@
 
 /datum/reagent/pluoxium/on_mob_life(mob/living/L, delta_time, times_fired)
 	. = ..()
-	L.adjustOxyLoss(-4 * REM * delta_time, FALSE)
-
-/datum/reagent/pluoxium/on_mob_metabolize(mob/living/L)
-	. = ..()
-	ADD_TRAIT(L, TRAIT_NOCRITDAMAGE, type)
-
-/datum/reagent/pluoxium/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_NOCRITDAMAGE, type)
-	return ..()
+	L.adjustOxyLoss(-2 * REM * delta_time, FALSE)
 
 /datum/reagent/halon
 	name = "Halon"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1514,9 +1514,9 @@
 	taste_description = "like air but better"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/pluoxium/on_mob_life(mob/living/Living, delta_time, times_fired)
+/datum/reagent/pluoxium/on_mob_life(mob/living/Lmob, delta_time, times_fired)
 	. = ..()
-	Living.adjustOxyLoss(-2 * REM * delta_time, FALSE)
+	Lmob.adjustOxyLoss(-2 * REM * delta_time, FALSE)
 
 /datum/reagent/halon
 	name = "Halon"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1514,9 +1514,9 @@
 	taste_description = "like air but better"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/pluoxium/on_mob_life(mob/living/Lmob, delta_time, times_fired)
+/datum/reagent/pluoxium/on_mob_life(mob/living/pluoxium_huffer, delta_time, times_fired)
 	. = ..()
-	Lmob.adjustOxyLoss(-2 * REM * delta_time, FALSE)
+	pluoxium_huffer.adjustOxyLoss(-2 * REM * delta_time, FALSE)
 
 /datum/reagent/halon
 	name = "Halon"

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -355,6 +355,14 @@
 		gas_breathed = breath_gases[/datum/gas/healium][MOLES]
 		breath_gases[/datum/gas/healium][MOLES]-=gas_breathed
 
+	//Pluoxium
+		var/pluoxium_pp = breath.get_breath_partial_pressure(breath_gases[/datum/gas/pluoxium][MOLES])
+		if(pluoxium_pp > gas_stimulation_min)
+			var/existing = breather.reagents.get_reagent_amount(/datum/reagent/pluoxium)
+			breather.reagents.add_reagent(/datum/reagent/pluoxium, max(0, 10 - existing))
+		gas_breathed = breath_gases[/datum/gas/pluoxium][MOLES]
+		breath_gases[/datum/gas/pluoxium][MOLES]-= gas_breathed
+
 	// Proto Nitrate
 		// Inert
 	// Zauker
@@ -372,7 +380,7 @@
 		if(halon_pp > gas_stimulation_min)
 			breather.adjustOxyLoss(5)
 			var/existing = breather.reagents.get_reagent_amount(/datum/reagent/halon)
-			breather.reagents.add_reagent(/datum/reagent/halon,max(0, 1 - existing))
+			breather.reagents.add_reagent(/datum/reagent/halon,max(0, 10 - existing))
 		gas_breathed = breath_gases[/datum/gas/halon][MOLES]
 		breath_gases[/datum/gas/halon][MOLES]-=gas_breathed
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -359,9 +359,9 @@
 		var/pluoxium_pp = breath.get_breath_partial_pressure(breath_gases[/datum/gas/pluoxium][MOLES])
 		if(pluoxium_pp > gas_stimulation_min)
 			var/existing = breather.reagents.get_reagent_amount(/datum/reagent/pluoxium)
-			breather.reagents.add_reagent(/datum/reagent/pluoxium, max(0, 10 - existing))
+			breather.reagents.add_reagent(/datum/reagent/pluoxium, max(0, 1 - existing))
 		gas_breathed = breath_gases[/datum/gas/pluoxium][MOLES]
-		breath_gases[/datum/gas/pluoxium][MOLES]-= gas_breathed
+		breath_gases[/datum/gas/pluoxium][MOLES] -= gas_breathed
 
 	// Proto Nitrate
 		// Inert
@@ -380,7 +380,7 @@
 		if(halon_pp > gas_stimulation_min)
 			breather.adjustOxyLoss(5)
 			var/existing = breather.reagents.get_reagent_amount(/datum/reagent/halon)
-			breather.reagents.add_reagent(/datum/reagent/halon,max(0, 10 - existing))
+			breather.reagents.add_reagent(/datum/reagent/halon,max(0, 1 - existing))
 		gas_breathed = breath_gases[/datum/gas/halon][MOLES]
 		breath_gases[/datum/gas/halon][MOLES]-=gas_breathed
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently pluoxium is basically oxygen 2 (pun intended) it has no other unique characteristic beside requiring less partial pressure for breathing. This pr aims to expand on its interaction with players. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Expand pluoxium to be more than oxygen +
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Breathing plouxium now prevent oxygen loss in crit and heal oxygen damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
