### PR TITLE
Trimmeny Cricket: Exposing Gas Flow Meters in Atmospherics

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -10082,7 +10082,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "crK" = (
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
@@ -27237,10 +27236,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "fGc" = (
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "fGi" = (
@@ -45922,10 +45921,10 @@
 /turf/open/floor/carpet/red,
 /area/hallway/secondary/service)
 "leT" = (
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "lfd" = (
@@ -57101,7 +57100,6 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "osk" = (
@@ -64699,7 +64697,6 @@
 /area/medical/surgery/aft)
 "qJT" = (
 /obj/machinery/meter,
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
@@ -79168,7 +79165,6 @@
 /turf/open/floor/iron,
 /area/security/office)
 "uYg" = (
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
@@ -110831,17 +110827,17 @@ uYg
 vFd
 abj
 vFd
-cHo
+fGc
 jEV
-tjL
+leT
 vFd
-cHo
+fGc
 jEV
-tjL
+leT
 vFd
-cHo
+fGc
 jEV
-tjL
+leT
 vFd
 yfC
 vFd

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12012,7 +12012,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/structure/grille,
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "bvG" = (
@@ -49159,7 +49159,7 @@
 /area/maintenance/port/lesser)
 "lRG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/grille,
+/obj/machinery/meter,
 /turf/closed/wall/r_wall/rust,
 /area/engineering/atmos)
 "lSd" = (
@@ -52571,7 +52571,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/structure/grille,
+/obj/machinery/meter,
 /turf/closed/wall/r_wall/rust,
 /area/engineering/atmos)
 "mUW" = (
@@ -53982,13 +53982,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/funeral)
-"nvo" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "nvS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
@@ -54810,7 +54803,7 @@
 /area/engineering/supermatter/room)
 "nLu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/structure/grille,
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "nLK" = (
@@ -56313,7 +56306,7 @@
 /area/service/library)
 "ojE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/structure/grille,
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "ojS" = (
@@ -63283,7 +63276,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/structure/grille,
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "qwL" = (
@@ -85280,7 +85273,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/structure/grille,
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "xIo" = (
@@ -113492,7 +113485,7 @@ xHX
 tmq
 mUT
 idD
-nvo
+bvF
 tmq
 bvF
 idD

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5725,7 +5725,6 @@
 "aPr" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "aPv" = (
@@ -18285,7 +18284,6 @@
 	name = "Mixed Air Tank In"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "fho" = (
@@ -42029,7 +42027,6 @@
 	name = "Mixed Air Tank Out"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "nMn" = (
@@ -47210,7 +47207,6 @@
 "pEV" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "pFt" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

PR #65576 did not go far enough. It turns out that all the maps (except Meta) had gas meters hidden under the grilles. Delta even had a few missing! This PR just finally standardizes it across all five stations.

![image](https://user-images.githubusercontent.com/34697715/161337837-65c925ab-93e0-499d-a686-323def221f8b.png)

That's Tram, right there. All those meters so lovingly placed... yet so hidden...

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/161337875-22550e8c-c1f4-437d-878c-70493417a191.png)

I think those gas flow meters were meant to be seen, and for some reason, they aren't. It's good to have consistency across all five maps, and I'd like to think it's useful information at-a-glance as to how much gas goes in and out of one of those storage tanks.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nanotrasen dug around on TramStation, DeltaStation, and KiloStation and found that grilles were covering a few gas flow meters in each of their atmospherics divisions. This should now be fully rectified.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
