### PR TITLE
Fixes large persistent paintings being shown off the wall

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -658,7 +658,8 @@
 	. = ..()
 	// Necessary so that the painting is framed correctly by the frame overlay when flipped.
 	ADD_KEEP_TOGETHER(src, INNATE_TRAIT)
-	finalize_size()
+	if(mapload)
+		finalize_size()
 
 /**
  * This frame is visually put between two wall turfs and it has an icon that's bigger than 32px, and because
@@ -667,11 +668,6 @@
  * that wall turf.
  */
 /obj/structure/sign/painting/large/proc/finalize_size()
-	// Reset the pixel osffsets and bounds.
-	pixel_x = initial(pixel_x)
-	pixel_y = initial(pixel_y)
-	bound_height = initial(bound_height)
-	bound_width = initial(bound_width)
 	switch(dir)
 		if(SOUTH)
 			pixel_y = -32

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -557,10 +557,10 @@
  */
 /obj/structure/sign/painting/proc/load_persistent()
 	if(!persistence_id)
-		return
+		return FALSE
 	var/list/valid_paintings = SSpersistent_paintings.get_paintings_with_tag(persistence_id)
 	if(!length(valid_paintings))
-		return //aborts loading anything this category has no usable paintings
+		return FALSE //aborts loading anything this category has no usable paintings
 	var/datum/painting/painting = pick(valid_paintings)
 	var/png = "data/paintings/images/[painting.md5].png"
 	var/icon/I = new(png)
@@ -585,6 +585,7 @@
 	current_canvas = new_canvas
 	current_canvas.update_appearance()
 	update_appearance()
+	return TRUE
 
 /obj/structure/sign/painting/proc/save_persistent()
 	if(!persistence_id || !current_canvas || current_canvas.no_save || current_canvas.painting_metadata.loaded_from_json)
@@ -657,8 +658,7 @@
 	. = ..()
 	// Necessary so that the painting is framed correctly by the frame overlay when flipped.
 	ADD_KEEP_TOGETHER(src, INNATE_TRAIT)
-	if(mapload)
-		finalize_size()
+	finalize_size()
 
 /**
  * This frame is visually put between two wall turfs and it has an icon that's bigger than 32px, and because
@@ -667,6 +667,11 @@
  * that wall turf.
  */
 /obj/structure/sign/painting/large/proc/finalize_size()
+	// Reset the pixel osffsets and bounds.
+	pixel_x = initial(pixel_x)
+	pixel_y = initial(pixel_y)
+	bound_height = initial(bound_height)
+	bound_width = initial(bound_width)
 	switch(dir)
 		if(SOUTH)
 			pixel_y = -32
@@ -683,8 +688,15 @@
 
 /obj/structure/sign/painting/large/frame_canvas(mob/user, obj/item/canvas/new_canvas)
 	. = ..()
-	if(!.)
-		return
+	if(.)
+		set_painting_offsets()
+
+/obj/structure/sign/painting/large/load_persistent()
+	. = ..()
+	if(.)
+		set_painting_offsets()
+
+/obj/structure/sign/painting/large/proc/set_painting_offsets()
 	switch(dir)
 		if(EAST)
 			transform = transform.Turn(90)


### PR DESCRIPTION
## About The Pull Request
I've come to notice that I've forgotten to add the pixel offsets and rotation behavior to `/obj/structure/sign/painting/large/load_persistent` while observing a few rounds on Manuel, which is why paintings loaded from server data were pretty off.

## Why It's Good For The Game
This should fix that. NO GBP UPDATE.

## Changelog

:cl:
fix: Fixed large persistent paintings being shown off the wall
/:cl:
