### PR TITLE
Fix typo in filename that cause build fail

### DIFF
--- a/tgui/packages/tgui/styles/main.scss
+++ b/tgui/packages/tgui/styles/main.scss
@@ -54,7 +54,7 @@
 @include meta.load-css('./interfaces/CrewManifest.scss');
 @include meta.load-css('./interfaces/ExperimentConfigure.scss');
 @include meta.load-css('./interfaces/HellishRunes.scss');
-@include meta.load-css('./interfaces/HotkeysHelp.scss');
+@include meta.load-css('./interfaces/HotKeysHelp.scss');
 @include meta.load-css('./interfaces/Hypertorus.scss');
 @include meta.load-css('./interfaces/LibraryComputer.scss');
 @include meta.load-css('./interfaces/NuclearBomb.scss');


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/8555356/161352275-d0d45788-d51c-4cbe-a175-cf37e7a0724e.png)


## Changelog

:cl: azizonkg
fix: fixed typo in filename that cause build fail
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
