### PR TITLE
Slight change to admin messages, ensuring people actually see and read them (take 2)

### DIFF
--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -669,16 +669,7 @@
 		switch(type)
 			if("message")
 				output += "<font color='red' size='3'><b>Admin message left by [span_prefix("[admin_key]")] on [timestamp]</b></font>"
-				output += "<br><font color='red'>[text]</font><br>"
-				var/datum/db_query/query_message_read = SSdbcore.NewQuery(
-					"UPDATE [format_table_name("messages")] SET type = 'message sent' WHERE id = :id",
-					list("id" = message_id)
-				)
-				if(!query_message_read.warn_execute())
-					qdel(query_get_message_output)
-					qdel(query_message_read)
-					return
-				qdel(query_message_read)
+				output += "<br><font color='red'>[text] <A href='?_src_=holder;[HrefToken()];messageread=[message_id]'>(Click here to verify you have read this message)</A></font><br>"
 			if("note")
 				output += "<font color='red' size='3'><b>Note left by [span_prefix("[admin_key]")] on [timestamp]</b></font>"
 				output += "<br><font color='red'>[text]</font><br>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -400,6 +400,19 @@
 		var/target = href_list["showmessageckeylinkless"]
 		browse_messages(target_ckey = target, linkless = 1)
 
+	else if(href_list["messageread"])
+		if(!isnum(href_list["message_id"]))
+			return
+		var/rounded_message_id = round(href_list["message_id"], 1)
+		var/datum/db_query/query_message_read = SSdbcore.NewQuery(
+			"UPDATE [format_table_name("messages")] SET type = 'message sent' WHERE usr.key = :player_key AND id = :id",
+			list("id" = rounded_message_id)
+			)
+		if(!query_message_read.warn_execute())
+			qdel(query_message_read)
+			return
+		qdel(query_message_read)
+
 	else if(href_list["messageedits"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -407,7 +407,7 @@
 		var/datum/db_query/query_message_read = SSdbcore.NewQuery(
 			"UPDATE [format_table_name("messages")] SET type = 'message sent' WHERE usr.key = :player_key AND id = :id",
 			list("id" = rounded_message_id)
-			)
+		)
 		if(!query_message_read.warn_execute())
 			qdel(query_message_read)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Copying from previous: #63846

Admin messages now come with a link attached that you need to click to verify that you have seen the message. Until you do this it will pop up every time you connect.

I think I did the changes mothblocks requested. It compiles but given that it involves the DB I'm not sure it works.

## Why It's Good For The Game

They kinda suck and are easily missed currently. Occasionally I ask players if they saw my message and a good amount say no.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: admin messages now appear every time you connect until you click a link confirming that you read them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
