### PR TITLE
icon_exists() now screams by default

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1323,7 +1323,7 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 	pixel_y = initialpixely
 
 ///Checks if the given iconstate exists in the given file, caching the result. Setting scream to TRUE will print a stack trace ONCE.
-/proc/icon_exists(file, state, scream)
+/proc/icon_exists(file, state, scream = TRUE)
 	var/static/list/icon_states_cache = list()
 	if(icon_states_cache[file]?[state])
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
icon_exists() now logs failure by default. I don't know why I didn't do this in the first place.