### PR TITLE
General Changes to IceBox's Public Mining Storage and the AI Upload

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12238,6 +12238,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
 /area/commons/storage/mining)
 "eWw" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8305,6 +8305,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "cSK" = (
+/obj/machinery/airalarm/directional/east,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/commons/storage/mining)
@@ -19045,7 +19046,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "iqr" = (
-/turf/closed/wall/r_wall,
+/obj/structure/sign/warning,
+/turf/closed/wall,
 /area/commons/storage/mining)
 "iqv" = (
 /obj/structure/disposalpipe/segment{
@@ -20099,10 +20101,6 @@
 /obj/item/food/grown/carrot,
 /turf/open/misc/asteroid/snow/standard_air,
 /area/science/research)
-"iOA" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/commons/storage/mining)
 "iOM" = (
 /turf/closed/wall,
 /area/security/warden)
@@ -31772,6 +31770,7 @@
 /area/engineering/supermatter/room)
 "oKs" = (
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/commons/storage/mining)
 "oKt" = (
@@ -49683,10 +49682,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"xzI" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/commons/storage/mining)
 "xzP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -78670,7 +78665,7 @@ bfv
 gGl
 gGl
 gGl
-iqr
+jnk
 jnk
 jnk
 jnk
@@ -78924,17 +78919,17 @@ bnn
 xDk
 nVd
 bfv
-iqr
-iqr
-iqr
-iqr
-iqr
-iqr
-xhI
-xhI
-xhI
-xhI
+bfv
 jnk
+xhI
+xhI
+xhI
+xhI
+xhI
+xhI
+xhI
+xhI
+xhI
 jnk
 aJn
 aJq
@@ -79181,8 +79176,9 @@ aZR
 bbm
 toe
 bfv
-iqr
-iqr
+bfv
+jnk
+xhI
 tca
 odB
 hDA
@@ -79191,7 +79187,6 @@ ihd
 mML
 ihd
 xhI
-jnk
 jnk
 aJn
 aJq
@@ -79438,8 +79433,9 @@ aZR
 aZR
 woD
 bfv
-iqr
-iqr
+bfv
+gOQ
+xhI
 jeK
 xKD
 kds
@@ -79447,7 +79443,6 @@ gOQ
 eeM
 eeM
 eeM
-xhI
 xhI
 xhI
 xhI
@@ -79695,18 +79690,18 @@ aCN
 mNc
 cEt
 bfv
+bfv
 uiO
-iqr
-iqr
+xhI
+xhI
 deq
+xhI
 iqr
-iOA
 qpk
 eeM
 rmD
 unj
 oKs
-cSK
 xhI
 gfw
 qll
@@ -79952,6 +79947,7 @@ bcf
 bdg
 bed
 bfv
+bfv
 kbh
 eWg
 nhm
@@ -79960,7 +79956,6 @@ hhJ
 xjO
 cOE
 qaH
-ueT
 ueT
 ueT
 ueT
@@ -80209,17 +80204,17 @@ aCP
 hZQ
 vAG
 bfv
+bfv
 omj
-iqr
-iqr
+xhI
+xhI
 rHS
+xhI
 iqr
-iOA
 toY
 eeM
 fWx
 cNY
-xzI
 cSK
 xhI
 bwh
@@ -80466,8 +80461,9 @@ aZR
 aZR
 oeE
 bfv
-iqr
-iqr
+bfv
+gOQ
+xhI
 kcl
 mwH
 vwl
@@ -80475,7 +80471,6 @@ gOQ
 eeM
 eeM
 eeM
-xhI
 xhI
 xhI
 xhI
@@ -80723,8 +80718,9 @@ aZR
 bbm
 toe
 bfv
-iqr
-iqr
+bfv
+jnk
+xhI
 ftr
 hRf
 rfb
@@ -80733,7 +80729,6 @@ ihd
 qgb
 ihd
 xhI
-jnk
 jnk
 aJn
 fGw
@@ -80980,17 +80975,17 @@ bnt
 aZU
 olN
 bfv
-iqr
-iqr
-iqr
-iqr
-iqr
-iqr
-xhI
-xhI
-xhI
-xhI
+bfv
 jnk
+xhI
+xhI
+xhI
+xhI
+xhI
+xhI
+xhI
+xhI
+xhI
 jnk
 aJn
 aJq
@@ -81240,7 +81235,7 @@ bfv
 olj
 olj
 olj
-iqr
+jnk
 jnk
 jnk
 jnk

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -699,7 +699,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/commons/storage/mining
 	name = "\improper Public Mining Storage"
-	icon_state = "mining"
+	icon_state = "mining_storage"
 
 //Service
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Firstly, what do you notice in this photograph?

![image](https://user-images.githubusercontent.com/34697715/161361832-31103820-0342-4258-be92-18df3adc1c65.png)

There's too many "mining" sprites! We already have a mining_storage area turf, so let's just do some code to fix that up.

Also, there's something else. Look at THIS photograph:

![image](https://user-images.githubusercontent.com/34697715/161361834-f33749f9-4c29-4c7a-b5cc-d1fb9d02398b.png)

You see that? That whole wing was just an expensive usage of reinforced walls. I think this is a carryover from the days where we wanted to restrict the amount of people going lower in the ice moon (why?), and we just... kept the reinforced walls. It's not even good for the AI either, people have a crap-shoot straight into the upload via the maintenance hallway! _IT DIDN'T EVEN HAVE AN APC._

Now, everyone and their mother can get into the lower levels with very little difficulty. Almost none, actually. Let's update this to be more modern. If you were concerned about the AI's upload security, I accommodated for them to retain a decent amount of wall turf security (on par with TramStation).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/161361915-aae8a0de-3994-47ab-b280-eddf210ea4f9.png)

As of the time of this PR, literally everyone with an ID can access every single part of this wing, even the chink in the upload's armor. It makes absolutely no sense for it to all be reinforced and inhibit creativity in a part of the station that everyone can access. Unneeded security, no APC, similar (if not more) AI fortification, and just a nicer looking thing overall.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: IceBoxStation's Public Mining Storage got shuffled around a bit. Nanotrasen realized they were spending too much on reinforced walls, and decided to re-opt for normal walls instead. To accomodate for this downturn in reinforced wallage, another layer of protection was added to the southern wall of the AI's Upload.
fix: The Public Mining Storage now has an APC. Whoopsie.
fix: On the mapping end, it's now easier than ever to tell whatever the fuck "Mining" is (it goes for so many things these days it's ridiculous) from "Mining Storage". Very cool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
