### PR TITLE
Creates Linters for (bad) Commented Out Lines in Maps

### DIFF
--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -11,6 +11,10 @@ if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;	then
     echo "ERROR: Non-TGM formatted map detected. Please convert it using Map Merger!"
     st=1
 fi;
+if grep -P '//' _maps/**/*.dmm | grep -v '//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE' | grep -Ev 'name|desc'; then
+	echo "ERROR: Commented out line detected in this map file."
+	st=1
+fi;
 if grep -P 'Merge conflict marker' _maps/**/*.dmm; then
     echo "ERROR: Merge conflict markers detected in map, please resolve all merge failures!"
     st=1

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -12,7 +12,7 @@ if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;	then
     st=1
 fi;
 if grep -P '//' _maps/**/*.dmm | grep -v '//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE' | grep -Ev 'name|desc'; then
-	echo "ERROR: Commented out line detected in this map file."
+	echo "ERROR: Unexpected commented out line detected in this map file. Please remove it."
 	st=1
 fi;
 if grep -P 'Merge conflict marker' _maps/**/*.dmm; then


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

This PR is made because what happened in #65837 was fucking horrible awful shit that I'm still dealing with a few days after I fixed it. This _should hopefully_ add a new linter for commented out lines of code in a .DMM file, and HOPEFULLY doesn't flag the commented line that prevents unwanted TGM > DMM conversion.

As a proof to see if it works, I'll be adding a comment to Line 3 of IcemoonUnderground_Above.dmm. Hopefully, on the first CI check, it'll fail. I'll remove that line so it doesn't make its way into production (it will suck).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/161393946-5dcfc1e9-7daa-491b-90b6-181952dd74ad.png)

Commented-out lines if/when they happen are absolute crap hell to work with because they tend to "float". I'll copy my explanation for this behavior from the aforementioned PR so it's not stuck in hell there:

As people rekey their branches to get rid of merge conflicts, the commented out (when present) line seems to "float" around when parsed through a map editor and comment out something else important (not just the commented line!). This is horrible to fix because sometimes keys can be commented out, and those will be missing if merged into production. However, there's a deeper issue too. Sometimes, you'll get a commented-out map key on the older file that mapmerge2 uses to... merge the maps. This is impossible to fix without starting again from scratch.

It's also very bad if it compiles onto a needed line (like the /turf), and then an entire room (or multiple rooms depending on how that works out) is turned into space. 

Yeesh.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: CI will now lint for commented-out lines of code in map files. This is very good.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
