### PR TITLE
Allow Regal Rats to Pry Airlocks + See Further in Dark

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -180,7 +180,7 @@
 		var/time_to_open = 0.5 SECONDS
 		if(prying_door.hasPower())
 			time_to_open = 5 SECONDS
-			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
+			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, vary = TRUE)
 		if(do_after(src, time_to_open, prying_door))
 			opening_airlock = FALSE
 			if(prying_door.density && !prying_door.open(2))

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -171,23 +171,24 @@
 		return FALSE
 	opening_airlock = TRUE
 	var/obj/machinery/door/airlock/prying_door = target
-	if(prying_door.density && !prying_door.locked && !prying_door.welded && !prying_door.seal)
-		visible_message(
-			span_warning("[src] begins prying open the airlock..."),
-			span_notice("You begin digging your claws into the airlock..."),
-			span_warning("You hear groaning metal..."),
-		)
-		var/time_to_open = 0.5 SECONDS
-		if(prying_door.hasPower())
-			time_to_open = 5 SECONDS
-			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, vary = TRUE)
-		if(do_after(src, time_to_open, prying_door))
-			opening_airlock = FALSE
-			if(prying_door.density && !prying_door.open(2))
-				to_chat(src, span_warning("Despite your efforts, the airlock managed to resist your attempts to open it!"))
-				return FALSE
-			prying_door.open()
+	if(!prying_door.density || prying_door.locked || prying_door.welded || prying_door.seal)
+		return FALSE
+	visible_message(
+		span_warning("[src] begins prying open the airlock..."),
+		span_notice("You begin digging your claws into the airlock..."),
+		span_warning("You hear groaning metal..."),
+	)
+	var/time_to_open = 0.5 SECONDS
+	if(prying_door.hasPower())
+		time_to_open = 5 SECONDS
+		playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, vary = TRUE)
+	if(do_after(src, time_to_open, prying_door))
+		opening_airlock = FALSE
+		if(prying_door.density && !prying_door.open(2))
+			to_chat(src, span_warning("Despite your efforts, the airlock managed to resist your attempts to open it!"))
 			return FALSE
+		prying_door.open()
+		return FALSE
 	opening_airlock = FALSE
 
 /mob/living/simple_animal/hostile/regalrat/controlled/Initialize(mapload)

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -1,3 +1,4 @@
+
 /mob/living/simple_animal/hostile/regalrat
 	name = "feral regal rat"
 	desc = "An evolved rat, created through some strange science. They lead nearby rats with deadly efficiency to protect their kingdom. Not technically a king."
@@ -127,7 +128,7 @@
 		return
 	if (QDELETED(target))
 		return
-	if(istype(target, /obj/machinery/door/airlock))
+	if(istype(target, /obj/machinery/door/airlock) && !opening_airlock)
 		pry_door(target)
 		return
 
@@ -167,12 +168,10 @@
  * accessible doors, something which is common in certain rat king spawn points.
  */
 /mob/living/simple_animal/hostile/regalrat/proc/pry_door(target)
-	if(opening_airlock)
-		return FALSE
-	opening_airlock = TRUE
 	var/obj/machinery/door/airlock/prying_door = target
 	if(!prying_door.density || prying_door.locked || prying_door.welded || prying_door.seal)
 		return FALSE
+	opening_airlock = TRUE
 	visible_message(
 		span_warning("[src] begins prying open the airlock..."),
 		span_notice("You begin digging your claws into the airlock..."),

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -171,7 +171,7 @@
 		return FALSE
 	opening_airlock = TRUE
 	var/obj/machinery/door/airlock/prying_door = target
-	if(prying_door.density && !(prying_door.locked || prying_door.welded || prying_door.seal))
+	if(prying_door.density && !prying_door.locked && !prying_door.welded && !prying_door.seal)
 		visible_message(
 			span_warning("[src] begins prying open the airlock..."),
 			span_notice("You begin digging your claws into the airlock..."),

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -8,7 +8,7 @@
 	turns_per_move = 5
 	maxHealth = 70
 	health = 70
-	see_in_dark = 5
+	see_in_dark = 15
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	obj_damage = 10
 	butcher_results = list(/obj/item/clothing/head/crown = 1,)
@@ -26,6 +26,8 @@
 	attack_vis_effect = ATTACK_EFFECT_CLAW
 	unique_name = TRUE
 	faction = list("rat")
+	///Whether or not the regal rat is already opening an airlock
+	var/opening_airlock = FALSE
 	///The spell that the rat uses to generate miasma
 	var/datum/action/cooldown/domain
 	///The Spell that the rat uses to recruit/convert more rats.
@@ -125,6 +127,9 @@
 		return
 	if (QDELETED(target))
 		return
+	if(istype(target, /obj/machinery/door/airlock))
+		pry_door(target)
+		return
 
 	if (target.reagents && target.is_injectable(src, allowmobs = TRUE) && !istype(target, /obj/item/food/cheese))
 		src.visible_message(span_warning("[src] starts licking [target] passionately!"),span_notice("You start licking [target]..."))
@@ -153,6 +158,35 @@
 		qdel(target)
 	else
 		to_chat(src, span_warning("You feel fine, no need to eat anything!"))
+
+/**
+ * Allows rat king to pry open an airlock if it isn't locked.
+ *
+ * A proc used for letting the rat king pry open airlocks instead of just attacking them.
+ * This allows the rat king to traverse the station when there is a lack of vents or
+ * accessible doors, something which is common in certain rat king spawn points.
+ */
+/mob/living/simple_animal/hostile/regalrat/proc/pry_door(target)
+	if(opening_airlock)
+		return FALSE
+	opening_airlock = TRUE
+	var/obj/machinery/door/airlock/prying_door = target
+	if(prying_door.density && !(prying_door.locked || prying_door.welded || prying_door.seal))
+		visible_message(span_warning("[src] begins prying open the airlock..."),\
+			span_notice("You begin digging your claws into the airlock..."),\
+			span_warning("You hear groaning metal..."))
+		var/time_to_open = 0.5 SECONDS
+		if(prying_door.hasPower())
+			time_to_open = 5 SECONDS
+			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
+		if(do_after(src, time_to_open, prying_door))
+			opening_airlock = FALSE
+			if(prying_door.density && !prying_door.open(2))
+				to_chat(src, span_warning("Despite your efforts, the airlock managed to resist your attempts to open it!"))
+				return FALSE
+			prying_door.open()
+			return FALSE
+	opening_airlock = FALSE
 
 /mob/living/simple_animal/hostile/regalrat/controlled/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -172,9 +172,11 @@
 	opening_airlock = TRUE
 	var/obj/machinery/door/airlock/prying_door = target
 	if(prying_door.density && !(prying_door.locked || prying_door.welded || prying_door.seal))
-		visible_message(span_warning("[src] begins prying open the airlock..."),\
-			span_notice("You begin digging your claws into the airlock..."),\
-			span_warning("You hear groaning metal..."))
+		visible_message(
+			span_warning("[src] begins prying open the airlock..."),
+			span_notice("You begin digging your claws into the airlock..."),
+			span_warning("You hear groaning metal..."),
+		)
 		var/time_to_open = 0.5 SECONDS
 		if(prying_door.hasPower())
 			time_to_open = 5 SECONDS


### PR DESCRIPTION
## About The Pull Request

This PR gives regal rats the ability to pry open airlocks when attacking them.  Prior to this change there were many regal rat spawn locations that were essentially softlocks since regal rats can't break down doors (need obj_damage of 15 or higher, regal rats have an obj_damage of 10), trapping them in obscure areas of maint where chances are nobody will ever find them.

Also buffs the regal rat's dark vision from 5 tiles to 15 tiles.  It's a rat, it should be able to see great in the darkness of maint, right?

## Why It's Good For The Game

Without an open vent in the room the regal rat spawned in or a helpful interloper, the regal rat usually just ended up getting stuck somewhere with no way out, which made accepting the role a massive gamble.  With this change, the regal rat isn't really any stronger than before but less prone to getting stuck in stupid locations.

I'm also just genuinely surprised that nobody noticed this earlier, seeing how often this happens.  A majority of the times I've gotten this role I needed an admin to put me somewhere where I could actually leave.

## Changelog
:cl:
balance: Regal rats can now pry open airlocks.
balance: Regal rats can see further in the dark now.
/:cl: