### PR TITLE
Moves moffins into the mothic food category

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -496,3 +496,13 @@
 	)
 	result = /obj/item/food/soup/vegetarian_chili
 	subcategory = CAT_MOTH
+
+/datum/crafting_recipe/food/moffin
+	name = "Moffin"
+	reqs = list(
+		/datum/reagent/consumable/milk = 5,
+		/obj/item/food/pastrybase = 1,
+		/obj/item/stack/sheet/cloth = 1,
+	)
+	result = /obj/item/food/muffin/moffin
+	subcategory = CAT_MOTH

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -432,17 +432,6 @@
 	result = /obj/item/food/muffin/booberry
 	subcategory = CAT_PASTRY
 
-
-/datum/crafting_recipe/food/moffin
-	name = "Moffin"
-	reqs = list(
-		/datum/reagent/consumable/milk = 5,
-		/obj/item/food/pastrybase = 1,
-		/obj/item/stack/sheet/cloth = 1,
-	)
-	result = /obj/item/food/muffin/moffin
-	subcategory = CAT_PASTRY
-
 ////////////////////////////////////////////OTHER////////////////////////////////////////////
 
 


### PR DESCRIPTION
## About The Pull Request
It moves the recipe in the crafting menu

## Why It's Good For The Game
It makes sense to put a moth-centric food in the moth food category

## Changelog
:cl:
qol: Moffins are now found in the mothic food category instead of the pastry category. 
/:cl: