### PR TITLE
Fixes Newscaster runtime when creating a new channel

### DIFF
--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -655,7 +655,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			existing_authors += GLOB.news_network.redacted_text
 		else
 			existing_authors += iterated_feed_channel.author
-	if((current_user?.account_holder == "Unknown") || (current_user?.account_holder in existing_authors) || isnull(current_user?.account_holder))
+	if(!current_user?.account_holder || current_user.account_holder == "Unknown" || (current_user.account_holder in existing_authors))
 		creating_channel = FALSE
 		tgui_alert(usr, "ERROR: User cannot be found or already has an owned feed channel.", list("Okay"))
 		return TRUE

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -657,7 +657,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			existing_authors += iterated_feed_channel.author
 	if((current_user?.account_holder == "Unknown") || (current_user?.account_holder in existing_authors) || isnull(current_user?.account_holder))
 		creating_channel = FALSE
-		tgui_alert(usr, "ERROR: User cannot be found or already has an owned feed channel.", list("Okay"))
+		tgui_alert(usr, "ERROR: User cannot be found or already has an owned feed channel. Please verify that you are wearing your ID card.", list("Okay"))
+		if(current_user)
+			visible_message("<span_class='danger'>The current_user is:[current_user]</span>")
+		else
+			visible_message("<span_class='danger'>Current user is null.</span>")
+		if(current_user?.account_holder)
+			visible_message("<span_class='danger'>The account_holder is: [current_user.account_holder]</span>")
+		else
+			visible_message("<span_class='danger'>Account holder is null.</span>")
 		return TRUE
 	creating_channel = TRUE
 	return TRUE

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -655,7 +655,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			existing_authors += GLOB.news_network.redacted_text
 		else
 			existing_authors += iterated_feed_channel.author
-	if((current_user?.account_holder == "Unknown") || (current_user.account_holder in existing_authors) || isnull(current_user?.account_holder))
+	if((current_user?.account_holder == "Unknown") || (current_user?.account_holder in existing_authors) || isnull(current_user?.account_holder))
 		creating_channel = FALSE
 		tgui_alert(usr, "ERROR: User cannot be found or already has an owned feed channel.", list("Okay"))
 		return TRUE

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -657,15 +657,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			existing_authors += iterated_feed_channel.author
 	if((current_user?.account_holder == "Unknown") || (current_user?.account_holder in existing_authors) || isnull(current_user?.account_holder))
 		creating_channel = FALSE
-		tgui_alert(usr, "ERROR: User cannot be found or already has an owned feed channel. Please verify that you are wearing your ID card.", list("Okay"))
-		if(current_user)
-			visible_message("<span_class='danger'>The current_user is:[current_user]</span>")
-		else
-			visible_message("<span_class='danger'>Current user is null.</span>")
-		if(current_user?.account_holder)
-			visible_message("<span_class='danger'>The account_holder is: [current_user.account_holder]</span>")
-		else
-			visible_message("<span_class='danger'>Account holder is null.</span>")
+		tgui_alert(usr, "ERROR: User cannot be found or already has an owned feed channel.", list("Okay"))
 		return TRUE
 	creating_channel = TRUE
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a runtime that would happen when creating a channel on the newscaster while not wearing an ID as a carbon or simply by doing so while being a silicon. A `?.` operator was (I presume) mistyped as a `.` operator. High effort PR, I know.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

_Partially_ addresses [#65801](https://github.com/tgstation/tgstation/issues/65801#issue-1185973618) by removing the associated runtime but we still need to do something about silicons not having bank accounts, since they can't use the newscaster and just get the usual error when no bank account is detected. And yes, I'm quite shamelessly saying "Maintainers help, what do" because I've been thinking of possible solutions and they all seem messy in some capacity, so here's the fix for the runtime and the rest can come later.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes runtime caused by a newscaster finding no user bank account when trying to create a channel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
