### PR TITLE
Fixes sec masks not being pepper spray proof

### DIFF
--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -53,8 +53,8 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	w_class = WEIGHT_CLASS_SMALL
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
-	flags_cover = MASKCOVERSMOUTH
-	visor_flags_cover = MASKCOVERSMOUTH
+	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
+	visor_flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
 	tint = 0
 	has_fov = FALSE
 	var/aggressiveness = AGGR_BAD_COP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added PEPPERPROOF to the sechailers. I couldn't for the life of me find where this was changed but I'm fairly certain the intent for the sec masks were to block pepper spray. Without this, sec is unable to use tear gas grenades without gassing themselves and can get hit with their own pepper spray cloud.

## Why It's Good For The Game

Allows security to safely use tear gas and pepper spray, two of their non-lethal tools.

## Changelog

:cl:
fix: sechailers properly block pepper spray and tear gas
/:cl: