### PR TITLE
Adds baseturf helpers to create and destroy ignore list

### DIFF
--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -52,6 +52,8 @@
 	ignore += typesof(/obj/effect/pod_landingzone)
 	//It's a trapdoor to nowhere
 	ignore += typesof(/obj/effect/mapping_helpers/trapdoor_placer)
+	//We have a baseturf limit of 10, adding more than 10 baseturf helpers will kill CI, so here's a future edge case to fix.
+	ignore += typesof(/obj/effect/baseturf_helper)
 	//There's no shapeshift to hold
 	ignore += typesof(/obj/shapeshift_holder)
 	//No tauma to pass in


### PR DESCRIPTION
## About The Pull Request
This simply adds baseturf helpers to the ignore list of create and destroy to prevent future issues. Currently only breaks downstream. If you add more than 10 baseturf helpers, the CI test will fail.

Yes, this is a web edit. I fixed this downstream already.

No, I don't care.

## Why It's Good For The Game
Future proofing.

## Changelog
Not player facing.
