### PR TITLE
[NO GBP] Fix for incorrect shuttles appearing on Meta, Tram, and Runtime stations

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
@@ -34608,7 +34608,7 @@ wk
 wk
 wk
 wk
-ut
+wk
 ut
 zt
 zt

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
@@ -34609,7 +34609,7 @@ wk
 wk
 wk
 ut
-zt
+ut
 zt
 zt
 zt
@@ -34866,7 +34866,7 @@ wk
 wk
 ut
 wk
-zt
+ut
 zt
 zt
 zt
@@ -35121,9 +35121,9 @@ wk
 wk
 wk
 ut
+wk
 ut
-zt
-zt
+ut
 zt
 zt
 zt
@@ -35379,8 +35379,8 @@ wk
 wk
 wk
 ut
-zt
-zt
+wk
+wk
 zt
 zt
 zt
@@ -35636,8 +35636,8 @@ wk
 wk
 wk
 ut
-zt
-zt
+ut
+ut
 zt
 zt
 zt

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3046,7 +3046,7 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
+	roundstart_template = /datum/map_template/shuttle/labour/generic;
 	width = 9
 	},
 /turf/open/space/basic,

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1132,7 +1132,7 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
+	roundstart_template = /datum/map_template/shuttle/labour/generic;
 	width = 9
 	},
 /turf/open/space/basic,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -26648,7 +26648,7 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
+	roundstart_template = /datum/map_template/shuttle/labour/generic;
 	width = 9
 	},
 /turf/open/misc/asteroid/airless,

--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -121,8 +121,7 @@
 /area/shuttle/labor)
 "W" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Labor Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Labor Shuttle Airlock"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)

--- a/_maps/shuttles/labour_generic.dmm
+++ b/_maps/shuttles/labour_generic.dmm
@@ -1,0 +1,180 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/labor)
+"b" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/labor)
+"c" = (
+/obj/machinery/computer/shuttle/labor{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"d" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"e" = (
+/obj/structure/table,
+/obj/item/folder/red,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"f" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"g" = (
+/obj/machinery/button/flasher{
+	id = "gulagshuttleflasher";
+	name = "Flash Control";
+	pixel_y = -26;
+	req_access_txt = "1"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"h" = (
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 2;
+	pixel_x = 30;
+	pixel_y = 30
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"j" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Labor Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"k" = (
+/obj/machinery/mineral/stacking_machine/laborstacker{
+	input_dir = 2;
+	output_dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/labor)
+"l" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/labor)
+"m" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/labor)
+"n" = (
+/obj/machinery/mineral/labor_claim_console{
+	machinedir = 1;
+	pixel_x = 30
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/labor)
+"o" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/flasher/directional/east{
+	id = "gulagshuttleflasher"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/labor)
+"p" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/labor)
+"q" = (
+/obj/docking_port/mobile{
+	dir = 8;
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp";
+	name = "labor camp shuttle";
+	width = 9;
+	port_direction = 4
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Labor Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/labor)
+"r" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/labor)
+"s" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/labor)
+"W" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Labor Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/labor)
+
+(1,1,1) = {"
+a
+a
+b
+a
+a
+b
+b
+a
+a
+"}
+(2,1,1) = {"
+b
+c
+f
+j
+l
+p
+l
+r
+s
+"}
+(3,1,1) = {"
+b
+d
+g
+a
+m
+l
+l
+r
+s
+"}
+(4,1,1) = {"
+b
+e
+h
+k
+n
+o
+l
+r
+s
+"}
+(5,1,1) = {"
+a
+a
+W
+a
+a
+a
+q
+a
+a
+"}

--- a/_maps/shuttles/labour_generic.dmm
+++ b/_maps/shuttles/labour_generic.dmm
@@ -98,8 +98,7 @@
 	port_direction = 4
 	},
 /obj/machinery/door/airlock/titanium{
-	name = "Labor Shuttle Airlock";
-	req_access_txt = "2"
+	name = "Labor Shuttle Airlock"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -572,6 +572,10 @@
 	suffix = "box"
 	name = "labour shuttle (Box)"
 
+/datum/map_template/shuttle/labour/generic
+	suffix = "generic"
+	name = "labour shuttle (Generic)"
+
 /datum/map_template/shuttle/arrival/donut
 	suffix = "donut"
 	name = "arrival shuttle (Donut)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a generic version of the labor shuttle which has its doors in the right side. Right side doors are used on Meta, Tram, and Runtime stations and since the shuttles used are handled in an object instead of the json were not caught when I modified the BoxStation labor shuttle to have its doors on the left.

Meta, Tram, and Runtime now use the generic version, and titling it generic will hopefully avoid confusion in the future.

EDIT: Turns out at some point down the line I also added access reqs to the prisoner side door, so they couldn't even get on the shuttle! Very bad of me. Fixed.

Also, tested on every map effected (Ice, Tram, Meta, Runtime) and the shuttle works on every map.

## Why It's Good For The Game

Meta, Tram, and Runtime stations will be able to use gulag mechanics again.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: Labor shuttle is useable again on Meta, Box, Tram, and Runtime.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
