### PR TITLE
Makes paper logging actually include the text being written

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -414,11 +414,11 @@
 				// the javascript was modified, somehow, outside of
 				// byond.  but right now we are logging it as
 				// the generated html might get beyond this limit
-				log_paper("[key_name(ui.user)] writing to paper [name], and overwrote it by [paper_len-MAX_PAPER_LENGTH]")
+				log_paper("[key_name(ui.user)] wrote to [name], and overwrote it by [paper_len - MAX_PAPER_LENGTH]: \"[in_paper]\"")
 			if(paper_len == 0)
 				to_chat(ui.user, pick("Writing block strikes again!", "You forgot to write anthing!"))
 			else
-				log_paper("[key_name(ui.user)] writing to paper [name]")
+				log_paper("[key_name(ui.user)] wrote to [name]: \"[in_paper]\"")
 				if(info != in_paper)
 					to_chat(ui.user, "You have added to your paper masterpiece!");
 					info = in_paper

--- a/code/modules/wiremod/components/action/printer.dm
+++ b/code/modules/wiremod/components/action/printer.dm
@@ -125,7 +125,7 @@
 	if(!paper)
 		return
 	paper.add_info(print.value, rgb(text_color_red, text_color_green, text_color_blue), typeface.value, signature.value)
-	log_paper("Printer component writing to paper [paper.name]. [parent.get_creator()].")
+	log_paper("Printer component wrote to [paper.name]: \"[print.value]\", authored by [parent.get_creator()].")
 
 /obj/item/circuit_component/printer/proc/eject_paper(datum/port/input/port, list/return_values)
 	var/obj/item/paper/paper = loaded_papers?[1]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since #51534, it would appear that the actual contents of papers wasn't being logged. This is what modern paper logs look like: 
![image](https://user-images.githubusercontent.com/66640614/161458545-a17b7555-f517-42cc-9b54-733b4b2883cb.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Current paper logs are effectively useless. This makes them actually useful again.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: paper logs once again include the paper's contents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
