### PR TITLE
Beds, Sofas, Slimes, And Jellypeople now provide a soft landing

### DIFF
--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -20,6 +20,6 @@
 /datum/element/soft_landing/proc/intercept_z_fall(obj/soft_object, falling_movables, levels)
 	SIGNAL_HANDLER
 
-	for(var/mob/living/falling_victim in falling_movables)
+	for (var/mob/living/falling_victim in falling_movables)
 		to_chat(falling_victim, span_notice("[soft_object] provides a soft landing for you!"))
 	return FALL_INTERCEPTED | FALL_NO_MESSAGE

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -22,4 +22,4 @@
 
 	for (var/mob/living/falling_victim in falling_movables)
 		to_chat(falling_victim, span_notice("[soft_object] provides a soft landing for you!"))
-	return FALL_INTERCEPTED + FALL_NO_MESSAGE - FALL_STOP_INTERCEPTING*2 + FALL_RETAIN_PULL
+	return FALL_INTERCEPTED | FALL_NO_MESSAGE

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -1,0 +1,25 @@
+/**
+ * # soft landing element!
+ *
+ * Non bespoke element (1 in existence) that makes objs provide a soft landing when you fall on them!
+ */
+/datum/element/soft_landing
+	element_flags = ELEMENT_DETACH
+
+/datum/element/soft_landing/Attach(datum/target)
+	. = ..()
+	if(!isobj(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_ATOM_INTERCEPT_Z_FALL, .proc/intercept_z_fall)
+
+/datum/element/soft_landing/Detach(datum/target)
+	. = ..()
+	UnregisterSignal(target, COMSIG_ATOM_INTERCEPT_Z_FALL)
+
+///signal called by the stat of the target changing
+/datum/element/soft_landing/proc/intercept_z_fall(obj/soft_object, falling_movables, levels)
+	SIGNAL_HANDLER
+
+	for(var/mob/living/falling_victim in falling_movables)
+		to_chat(falling_victim, span_notice("[soft_object] provides a soft landing for you!"))
+	. |= FALL_INTERCEPTED | FALL_NO_MESSAGE

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -22,4 +22,4 @@
 
 	for (var/mob/living/falling_victim in falling_movables)
 		to_chat(falling_victim, span_notice("[soft_object] provides a soft landing for you!"))
-	return FALL_INTERCEPTED | FALL_NO_MESSAGE
+	return FALL_INTERCEPTED + FALL_NO_MESSAGE - FALL_STOP_INTERCEPTING*2 + FALL_RETAIN_PULL

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -22,4 +22,4 @@
 
 	for(var/mob/living/falling_victim in falling_movables)
 		to_chat(falling_victim, span_notice("[soft_object] provides a soft landing for you!"))
-	. |= FALL_INTERCEPTED | FALL_NO_MESSAGE
+	return (FALL_INTERCEPTED | FALL_NO_MESSAGE)

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -1,5 +1,5 @@
 /**
- * # soft landing element!
+ * ## soft landing element!
  *
  * Non bespoke element (1 in existence) that makes objs provide a soft landing when you fall on them!
  */
@@ -8,7 +8,7 @@
 
 /datum/element/soft_landing/Attach(datum/target)
 	. = ..()
-	if(!isobj(target))
+	if(!isatom(target))
 		return ELEMENT_INCOMPATIBLE
 	RegisterSignal(target, COMSIG_ATOM_INTERCEPT_Z_FALL, .proc/intercept_z_fall)
 

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -22,4 +22,4 @@
 
 	for(var/mob/living/falling_victim in falling_movables)
 		to_chat(falling_victim, span_notice("[soft_object] provides a soft landing for you!"))
-	return (FALL_INTERCEPTED | FALL_NO_MESSAGE)
+	return FALL_INTERCEPTED | FALL_NO_MESSAGE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1770,6 +1770,7 @@
 	filters = null
 
 /atom/proc/intercept_zImpact(list/falling_movables, levels = 1)
+	SHOULD_CALL_PARENT(TRUE)
 	. |= SEND_SIGNAL(src, COMSIG_ATOM_INTERCEPT_Z_FALL, falling_movables, levels)
 
 /// Sets the custom materials for an item.

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -22,6 +22,10 @@
 	var/buildstackamount = 2
 	var/bolts = TRUE
 
+/obj/structure/bed/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/soft_landing)
+
 /obj/structure/bed/examine(mob/user)
 	. = ..()
 	if(bolts)

--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -7,9 +7,9 @@
 	var/mutable_appearance/armrest
 
 /obj/structure/chair/sofa/Initialize(mapload)
+	. = ..()
 	armrest = mutable_appearance(icon, "[icon_state]_armrest", ABOVE_MOB_LAYER)
 	armrest.plane = GAME_PLANE_UPPER
-	. = ..()
 	AddElement(/datum/element/soft_landing)
 
 /obj/structure/chair/sofa/electrify_self(obj/item/assembly/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)

--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -9,7 +9,8 @@
 /obj/structure/chair/sofa/Initialize(mapload)
 	armrest = mutable_appearance(icon, "[icon_state]_armrest", ABOVE_MOB_LAYER)
 	armrest.plane = GAME_PLANE_UPPER
-	return ..()
+	. = ..()
+	AddElement(/datum/element/soft_landing)
 
 /obj/structure/chair/sofa/electrify_self(obj/item/assembly/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)
 	if(!overlays_from_child_procs)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -39,6 +39,7 @@
 /datum/species/jelly/on_species_loss(mob/living/carbon/C)
 	if(regenerate_limbs)
 		regenerate_limbs.Remove(C)
+	RemoveElement(/datum/element/soft_landing)
 	..()
 
 /datum/species/jelly/on_species_gain(mob/living/carbon/C, datum/species/old_species)
@@ -46,6 +47,7 @@
 	if(ishuman(C))
 		regenerate_limbs = new
 		regenerate_limbs.Grant(C)
+	AddElement(/datum/element/soft_landing)
 
 /datum/species/jelly/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
 	if(H.stat == DEAD) //can't farm slime jelly from a dead slime/jelly person indefinitely

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -36,18 +36,18 @@
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/jelly,
 	)
 
-/datum/species/jelly/on_species_loss(mob/living/carbon/C)
+/datum/species/jelly/on_species_loss(mob/living/carbon/old_jellyperson)
 	if(regenerate_limbs)
-		regenerate_limbs.Remove(C)
-	RemoveElement(/datum/element/soft_landing)
+		regenerate_limbs.Remove(old_jellyperson)
+	old_jellyperson.RemoveElement(/datum/element/soft_landing)
 	..()
 
-/datum/species/jelly/on_species_gain(mob/living/carbon/C, datum/species/old_species)
+/datum/species/jelly/on_species_gain(mob/living/carbon/new_jellyperson, datum/species/old_species)
 	..()
-	if(ishuman(C))
+	if(ishuman(new_jellyperson))
 		regenerate_limbs = new
-		regenerate_limbs.Grant(C)
-	AddElement(/datum/element/soft_landing)
+		regenerate_limbs.Grant(new_jellyperson)
+	new_jellyperson.AddElement(/datum/element/soft_landing)
 
 /datum/species/jelly/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
 	if(H.stat == DEAD) //can't farm slime jelly from a dead slime/jelly person indefinitely

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -107,6 +107,7 @@
 	add_cell_sample()
 
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
+	AddElement(/datum/element/soft_landing)
 
 /mob/living/simple_animal/slime/Destroy()
 	for (var/A in actions)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -964,6 +964,7 @@
 #include "code\datums\elements\simple_flying.dm"
 #include "code\datums\elements\skittish.dm"
 #include "code\datums\elements\snail_crawl.dm"
+#include "code\datums\elements\soft_landing.dm"
 #include "code\datums\elements\spooky.dm"
 #include "code\datums\elements\squish.dm"
 #include "code\datums\elements\strippable.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title, those objects/mobs provide a soft landing when you fall on them.

## Why It's Good For The Game

We need more mechanics for the game interacting with multi-z. Simple as.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Beds, Sofas, Slimes, And Jellypeople now provide a soft landing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
