### PR TITLE
Swaps Out Useless Lights on TramStation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -28909,11 +28909,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
-"iYu" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "iYG" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -97528,7 +97523,7 @@ jTk
 jTk
 pDT
 aRN
-dDG
+cuX
 dhe
 dhe
 dhe
@@ -98043,12 +98038,12 @@ jTk
 pDT
 sLE
 aRN
-guj
+xFs
 lvw
 lvw
 tRC
 lvw
-dDG
+xFs
 ajc
 ajc
 ajc
@@ -98303,7 +98298,7 @@ aRN
 aRN
 oOe
 aRN
-iYu
+aRN
 lBU
 aRN
 ajc
@@ -98557,12 +98552,12 @@ jTk
 pDT
 sLE
 aRN
-cuX
+xFs
 lvw
 tRC
 lvw
 tRC
-wUS
+xFs
 ajc
 ajc
 ajc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Can _you_ spot the issue in this below photograph?

![image](https://user-images.githubusercontent.com/34697715/161465886-524427d6-1fda-49f2-8d50-226515416ef9.png)

area/mine/explored (or something like that) is an unpowered area, so those directional lights are not useful and don't work. Let's replace them with something that does work, though.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/161465903-8337c790-ad24-49d9-9a41-3b7cb8dddb4a.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: On Tramstation, the external access airlock to the Supermatter's cooling loop uses a different form of lighting that functions in the outside setting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
