### PR TITLE
Frozen Treat Quality of Life adjustments..

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -778,7 +778,7 @@
 /datum/crafting_recipe/sillycup
 	name = "Paper Cup"
 	result =  /obj/item/reagent_containers/food/drinks/sillycup
-	time = 10
+	time = 1 SECONDS
 	reqs = list(/obj/item/paper = 2)
 	category = CAT_MISC
 

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -775,6 +775,13 @@
 	result = /obj/item/paper_bin/bundlenatural
 	category = CAT_MISC
 
+/datum/crafting_recipe/sillycup
+	name = "Paper Cup"
+	result =  /obj/item/reagent_containers/food/drinks/sillycup
+	time = 10
+	reqs = list(/obj/item/paper = 2)
+	category = CAT_MISC
+
 /datum/crafting_recipe/toysword
 	name = "Toy Sword"
 	reqs = list(/obj/item/light/bulb = 1, /obj/item/stack/cable_coil = 1, /obj/item/stack/sheet/plastic = 4)

--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
@@ -38,7 +38,7 @@
 			else
 				qdel(cone)
 
-	create_reagents(100, NO_REACT | OPENCONTAINER)
+	create_reagents(300, NO_REACT | OPENCONTAINER)
 	reagents.chem_temp = T0C //So ice doesn't melt
 	for(var/flavour in GLOB.ice_cream_flavours)
 		if(GLOB.ice_cream_flavours[flavour].hidden)


### PR DESCRIPTION

## About The Pull Request

Summer just ended in Australia and being the contrarian that I am, this seemed like the perfect time to make getting ice cream better! This PR makes things easier to make snowcones and ice cream cones for chefs (or whoever feels like stealing the ice cream machine and getting fruit juices for snowcones).

## Why It's Good For The Game

Any excuse to encourage chefs to make something besides a deep-fried cookbook is good. 
In all seriousness,  Currently, the only way of getting paper cups tends to be raiding the HoP office (Not fun) and the content of the ice cream maker is a VERY meagre 100 units. Water coolers were originally common around the station to retrieve cups from, this isn't the case anymore which leaves the recipe being quite reasonable in my opinion. The reason for the ice cream vat change is due to how clunky it is to work with 100 units, it just felt unfun when I tried playing with it due to the juggling and need to purge reagents if you add too much.


## Changelog


:cl:
qol: Adds a recipe to make paper cups and triples ice cream vat capacity. 
/:cl: