### PR TITLE
Reworks the jukebox to use the CDN (if available). Please ensure all your jukebox music is .mp3, and that you use a CDN. Looking at you, Skyrat.

### DIFF
--- a/config/jukebox_music/README.txt
+++ b/config/jukebox_music/README.txt
@@ -4,6 +4,8 @@ Using unnecessarily huge sounds can cause client side lag and should be avoided.
 
 You may add as many sounds as you would like.
 
+Sounds MUST be mp3, because of limitations on the sound playback system we use, via embedding an audio tag in a player window.
+
 ---
 
 Naming Conventions:

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -86,6 +86,14 @@ window "mainwindow"
 		anchor2 = -1,-1
 		is-visible = false
 		saved-params = ""
+	elem "music_player"
+		type = BROWSER
+		pos = 0,0
+		size = 200x200
+		anchor1 = none
+		anchor2 = none
+		is-visible = false
+		saved-params = ""
 	elem "tooltip"
 		type = BROWSER
 		pos = 0,0

--- a/tgui/packages/tgui/interfaces/Jukebox.js
+++ b/tgui/packages/tgui/interfaces/Jukebox.js
@@ -58,11 +58,11 @@ export const Jukebox = (props, context) => {
               <Box position="relative">
                 <Knob
                   size={3.2}
-                  color={volume >= 25 ? 'red' : 'green'}
+                  color={volume >= 50 ? 'red' : 'green'}
                   value={volume}
                   unit="%"
                   minValue={0}
-                  maxValue={50}
+                  maxValue={100}
                   step={1}
                   stepPixelSize={1}
                   disabled={active}


### PR DESCRIPTION
## About The Pull Request

Reworks the jukebox to use the CDN (if available). Please ensure all your jukebox music is .mp3.

If you don't have the CDN enabled you're not going to see the lag fix from this. Looking at you, Skyrat. Please setup a CDN already and use the webroot asset transport system.

## Why It's Good For The Game

This fixes a metric fuckton of the lag with the Jukebox, aka the disco ball on Uncle Pete's Rollerdome. It should no longer murder people when it plays Caramelldansen, and now it'll be synced for everyone on the server, even if you walk out of the range of the disco ball and walk back into it.

## Changelog

:cl:
refactor: Uncle Pete's Rollerdome has upgraded it's jukebox software, and now it's more consistent and way, way faster for people with slower computers or internet connections!
/:cl: