### PR TITLE
Mixing Hyper-Noblium is no longer required for T4 Lasers, and is now a way to get them for free instead.

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -945,8 +945,7 @@
 		"quadultra_micro_laser",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000)
-	required_experiments = list(/datum/experiment/ordnance/gaseous/noblium)
+	discount_experiments = list(/datum/experiment/ordnance/gaseous/noblium = 5000)
 
 /////////////////////////Clown tech/////////////////////////
 /datum/techweb_node/clown


### PR DESCRIPTION
## new info as of 4/4/2022
According to a stat dump from oranges, the Quantum Electromagnetic Technology tech node which requires the 16 moles of hypernob to research has been researched only 84 times since 3/3/2022.

In the previous month, it had been unlocked 973 times.
## About The Pull Request

The Hyper-Noblium Gas Shell experiment is now no longer required for Quad Ultra Micro Lasers, and now provides a 100% discount on the node if you do it.

## Why It's Good For The Game

So, I've been telling players complaining about this for *weeks* to just learn how to mix gases, because toxins hasn't had anything for 20 years other than "make bomb".

I figured I'd put my money where my mouth is and try, as a brand new to atmos player, mix hypernob as a Research Director on a private server.

I failed all three attempts I made.
## Attempt #1: "instructions scribbled on back of napkin"
I was told you mix 3 cans of oxygen and 1 can of plasma and light it on fire to get tritium.
This gave me 2 to 3 moles of it, which isn't enough to mix Hyper-nob; you need 5 moles minimum for 1 mole of hyper-nob.
I forgot to take pictures.
## Attempt #2: Guided by Blase
I was walked through using the ordnance computer, and shown the recipe for hyper-nob that way, walking through the many UI issues with the computer.
I was instructed to make a bunch of alterations to set up a gas mixer and such, and properly pump in a 97:3 ratio of oxygen:plasma for tritium. This made enugh tritium.
When I attempted to put it in the can, the can began making acid noises and then exploded, fucking up my workplace irreparably without an atmos tech coming by and fixing it.
![dreamseeker_uNn9SNKkD0](https://user-images.githubusercontent.com/4081722/161587805-c5e53fac-e2c2-43c7-9a3f-810db9ee508c.png)
Failure. Did as told by an expert, forgot to upgrade the can which isn't communicated to players in any sane way, can exploded from only a few moles of tritium.
## Attempt #3: Guided by Lak
I was walked through the same setup as before, but with additional scrubbers and loading exactly 3 cans in of oxygen and cycling through them, along with how to upgrade my canister through an unintuitive deconstruct/reconstruct method.
After running through the previous setup, after some fiddling with the freezers, we finally produced hyper-nob!
![dreamseeker_yR36o5YlWa](https://user-images.githubusercontent.com/4081722/161587882-ff180e19-b8cb-4e6d-a505-f93b893274ee.png)
An entire 2.6 moles of it.
You need **16 moles** for the research.
We burned through 3 of our 6 cans of oxygen in storage.
![dreamseeker_Jxvl4bVD6q](https://user-images.githubusercontent.com/4081722/161587953-03ec56b6-bfb1-459e-b728-81a4a5354aa8.png)
In order to get all 16 moles, according to my math we'd need about 18-19 cans of oxygen. This would require stealing from atmos/stealing directly from the distro.
I'm deeming it a failure because it would require theft to accomplish, and some advanced thinking which is beyond what we expect from both new players approaching a job and "someone walking in to do station infrastructure support", which Toxins now classifies as since it's required for important parts now.

## The verdict:
This isn't doable by a newbie, and certainly isn't doable for actual brand new players, let alone people who are just expected to do the bare minimum.

The default Supermatter setup on the station will run the engine with no fiddling without blowing up, because people need power to do their job as it sucks to work without power.

The default setup for a map should be the bare minimum needed to do the job for everyone else to benefit. Now that mixing Hyper-Noblium is expected as the bare minimum for scientists/RDs because the better parts are locked behind it, the default setup is no longer enough. Toxins is no longer a job you can fuck around with, it's directly required for station progression now.

This is not good game design. I understand why they wanted there to be interdepartmental interaction on this one, but this just sticks everyone else's enjoyment behind a very specific few science players with the right mentality to actually get this done, and nobody is doing this experiment because it's such a pain in the ass.

Is there a way around this? Maybe. But this isn't great right now, and this absolutely can't be something the station needs for progression, because frankly it's not getting done despite the protests of the atmos players in our community who insist they personally do it so therefore everyone else does it in their mind because they lack the ability to place themselves in someone else's shoes who doesn't understand atmos as well as they do.

I've been telling players for weeks to just learn how to mix hypernob.

I gave it the honest college try three times in a row, from starting off from scratch to multiple attempts with atmos professionals giving me a step-by-step on how to do it successfully, and had absolutely no luck reaching that goal of 16 moles of Hyper-Nob for the research to complete.

This should be done by atmos techs, not scientists. They have the time, the knowhow, and the inclination to do it. Not Science players.

Because everyone wants stock parts upgrades, when this doesn't get done, people get hostile and angry at Scientists and RDs who haven't done it. This makes it really unfun to be a Scientist or RD who can't wrap their head around toxins, that job part you could previously ignore because it was only used for making griefing tools as a non-antag and game winning tools as an antag.

## Problem points I discovered
problem point 1:
toxins players should not have to learn the air alarm interface to do their job
problem point 2:
the pipes going in/out should be red/blue to match our color coding elsewhere, ie. plumbing
problem point 3: 
cant do shit w/o t3 lasers
problem point 5: (i forgot 4)
metastation's toxins is broken, the freezers don't work because there's nothing in waste roundstart, cryogenics has the same problem and so does other maps
problem 7: 
no visual way to tell what layer a pipe is on on machinery pipe inputs
problem point 8: 
make the toxins computer window bigger by default
problem point 9: 
different maps might change the toxins todo list
problem point 10:
the ordnance menu has a search bar instead of buttons or a dropdown to select reactions; it should have both if no reactions are selected
problem point 11:
typing in hypernob doesn't give me the hypernob reaction, add tags to this
problem point 12:
the recipe for making tritium is not listed when you type tritium; it's hidden under "plasma combustion"
problem point 14:
tritium should be 3 oxygen to 1 plasma ratio, 97% is such a weird arbitrary number
problem point 15:
"It's relationship with oxygen also determines reaction speed" on the ordnance computer UI doesn't actually explain what this means, had to ask someone for this
problem point 16:
the default pipe layout on the map has to be adjusted for the required job of making tritium, which is expected of all toxins players now due to the experisci changes
the default map layouts should allow the bare minimum of the job to be done; it can be improved by players looking to improve the setup but the bare minimum should work, ala the default Supermatter piping 
problem point 17:
RPD starts at the wrong color, should start at red/blue/black/brown
problem point 19: 
label what direction node 1/2 are relative to the current facing of the mixer, this is a problem with plumbing machinery too
problem 20:
have to modify the internals of the reaction chamber to do my job to bare minimum as toxins worker
problem 21:
airlock control buttons keep reopening when i walk by them
problem 22:
airlock cycling should be instant if the air between the two are identical
problem 23: 
there's pipe colors that are too similar, i just got punked between brown/pale orange, please make the colors more vibrant
problem 24: 
scrubber needs set to expanded range instead of normal range despite being in a 2x3 room
problem point 26: 
can only throw pipes 1 tile???
problem 27: 
one can of oxygen and 1 can of plasma at a 97:3 ratio only made 4.73 moles of trit; need 5 moles for hypernob
problem point 28: 
the concept of upgrading canisters is not explained anywhere; above suggestion about unfinished can w/ plasteel next to it would teach players how to do it naturally, good environmental teaching
problem point 29: 
nowhere in the atmos guides in game does it tell players that moles increase size the hotter they are/decrease size the colder they are, a player brand new to thermodynamics would be confused by this like I was originally years ago
problem point 30: 
cant upgrade a canister, have to build new one/decon old canister frame to rebuild it, suggest adding a rmb tooltip ala plants w/ welder to show decon for that
problem point 31: 
need to be spaceworthy to do initial job setup; this stuff should be setup roundstart
problem point 32: 
analyzer should pop up auto-updating tgui inputs for pipes so i dont have to spam click
## Changelog
:cl:
balance: Mixing Hyper-Noblium is no longer required for T4 Lasers, and is now a way to get them for free instead.
/:cl:
