### PR TITLE
Refactors janitor cartridge to a tablet app

### DIFF
--- a/code/__DEFINES/devices.dm
+++ b/code/__DEFINES/devices.dm
@@ -6,15 +6,14 @@
 #define CART_MANIFEST (1<<4)
 #define CART_CLOWN (1<<5)
 #define CART_MIME (1<<6)
-#define CART_JANITOR (1<<7)
-#define CART_REAGENT_SCANNER (1<<8)
-#define CART_NEWSCASTER (1<<9)
-#define CART_REMOTE_DOOR (1<<10)
-#define CART_STATUS_DISPLAY (1<<11)
-#define CART_QUARTERMASTER (1<<12)
-#define CART_HYDROPONICS (1<<13)
-#define CART_DRONEPHONE (1<<14)
-#define CART_DRONEACCESS (1<<15)
+#define CART_REAGENT_SCANNER (1<<7)
+#define CART_NEWSCASTER (1<<8)
+#define CART_REMOTE_DOOR (1<<9)
+#define CART_STATUS_DISPLAY (1<<10)
+#define CART_QUARTERMASTER (1<<11)
+#define CART_HYDROPONICS (1<<12)
+#define CART_DRONEPHONE (1<<13)
+#define CART_DRONEACCESS (1<<14)
 
 /// PDA ui menu defines
 #define PDA_UI_HUB 0
@@ -39,11 +38,10 @@
 #define PDA_UI_SUPPLY_RECORDS 46
 #define PDA_UI_SILO_LOGS 47
 #define PDA_UI_BOTS_ACCESS 48
-#define PDA_UI_JANNIE_LOCATOR 49
-#define PDA_UI_EMOJI_GUIDE 50
-#define PDA_UI_SIGNALER 51
-#define PDA_UI_NEWSCASTER 52
-#define PDA_UI_NEWSCASTER_ERROR 53
+#define PDA_UI_EMOJI_GUIDE 49
+#define PDA_UI_SIGNALER 50
+#define PDA_UI_NEWSCASTER 51
+#define PDA_UI_NEWSCASTER_ERROR 52
 
 
 // Used by PDA and cartridge code to reduce repetitiveness of spritesheets

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -36,6 +36,7 @@ GLOBAL_LIST_EMPTY(zombie_infection_list) // A list of all zombie_infection organ
 GLOBAL_LIST_EMPTY(meteor_list) // List of all meteors.
 GLOBAL_LIST_EMPTY(active_jammers)  // List of active radio jammers
 GLOBAL_LIST_EMPTY(ladders)
+GLOBAL_LIST_EMPTY(janitor_devices)
 GLOBAL_LIST_EMPTY(trophy_cases)
 GLOBAL_LIST_EMPTY(experiment_handlers)
 ///This is a global list of all signs you can change an existing sign or new sign backing to, when using a pen on them.

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -342,8 +342,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 				if (cartridge)
 					if(!isnull(cartridge.bot_access))
 						dat += "<li><a href='byond://?src=[REF(src)];choice=[PDA_UI_BOTS_ACCESS]'>[PDAIMG(medbot)]Bots Access</a></li>"
-					if (cartridge.access & CART_JANITOR)
-						dat += "<li><a href='byond://?src=[REF(src)];choice=[PDA_UI_JANNIE_LOCATOR]'>[PDAIMG(bucket)]Custodial Locator</a></li>"
 					if(cartridge.access & CART_MIME)
 						dat += "<li><a href='byond://?src=[REF(src)];choice=[PDA_UI_EMOJI_GUIDE]'>[PDAIMG(emoji)]Emoji Guidebook</a></li>"
 					if (istype(cartridge.radio))

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -105,7 +105,6 @@
 
 /obj/item/pda/janitor
 	name = "janitor PDA"
-	default_cartridge = /obj/item/cartridge/janitor
 	greyscale_colors = "#933ea8#235AB2"
 	ttone = "slip"
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -86,15 +86,6 @@
 		ADVANCED_SEC_BOT,
 	)
 
-/obj/item/cartridge/janitor
-	name = "\improper CustodiPRO cartridge"
-	desc = "The ultimate in clean-room design."
-	icon_state = "cart-j"
-	access = CART_JANITOR | CART_DRONEPHONE
-	bot_access = list(
-		CLEAN_BOT,
-	)
-
 /obj/item/cartridge/lawyer
 	name = "\improper P.R.O.V.E. cartridge"
 	icon_state = "cart-s"
@@ -149,7 +140,7 @@
 /obj/item/cartridge/hop
 	name = "\improper HumanResources9001 cartridge"
 	icon_state = "cart-h"
-	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_JANITOR | CART_SECURITY | CART_NEWSCASTER | CART_QUARTERMASTER | CART_DRONEPHONE
+	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_SECURITY | CART_NEWSCASTER | CART_QUARTERMASTER | CART_DRONEPHONE
 	bot_access = list(
 		MULE_BOT,
 		CLEAN_BOT,
@@ -484,68 +475,6 @@
 			else
 				menu += "<b>No ore silo detected!</b>"
 			menu = jointext(menu, "")
-
-		if (PDA_UI_JANNIE_LOCATOR)
-			menu = "<h4>[PDAIMG(bucket)] Persistent Custodial Object Locator</h4>"
-
-			var/turf/cl = get_turf(src)
-			if (cl)
-				menu += "Current Orbital Location: <b>\[[cl.x],[cl.y]\]</b>"
-
-				menu += "<h4>Located Mops:</h4>"
-
-				var/ldat
-				for (var/obj/item/mop/M in world)
-					var/turf/ml = get_turf(M)
-
-					if(ml)
-						if (ml.z != cl.z)
-							continue
-						var/direction = get_dir(src, M)
-						ldat += "Mop - <b>\[[ml.x],[ml.y] ([uppertext(dir2text(direction))])\]</b> - [M.reagents.total_volume ? "Wet" : "Dry"]<br>"
-
-				if (!ldat)
-					menu += "None"
-				else
-					menu += "[ldat]"
-
-				menu += "<h4>Located Janitorial Cart:</h4>"
-
-				ldat = null
-				for (var/obj/structure/janitorialcart/B in world)
-					var/turf/bl = get_turf(B)
-
-					if(bl)
-						if (bl.z != cl.z)
-							continue
-						var/direction = get_dir(src, B)
-						ldat += "Cart - <b>\[[bl.x],[bl.y] ([uppertext(dir2text(direction))])\]</b> - Water level: [B.reagents.total_volume]/100<br>"
-
-				if (!ldat)
-					menu += "None"
-				else
-					menu += "[ldat]"
-
-				menu += "<h4>Located Cleanbots:</h4>"
-
-				ldat = null
-				for (var/mob/living/simple_animal/bot/cleanbot/B in GLOB.alive_mob_list)
-					var/turf/bl = get_turf(B)
-
-					if(bl)
-						if (bl.z != cl.z)
-							continue
-						var/direction = get_dir(src, B)
-						ldat += "Cleanbot - <b>\[[bl.x],[bl.y] ([uppertext(dir2text(direction))])\]</b> - [B.bot_mode_flags & BOT_MODE_ON ? "Online" : "Offline"]<br>"
-
-				if (!ldat)
-					menu += "None"
-				else
-					menu += "[ldat]"
-
-			else
-				menu += "ERROR: Unable to determine current location."
-			menu += "<br><br><A href='byond://?src=[REF(src)];choice=49'>Refresh GPS Locator</a>"
 
 		if (PDA_UI_NEWSCASTER)
 			menu = "<h4>[PDAIMG(notes)] Newscaster Access</h4>"

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -68,7 +68,7 @@
 
 	var/difficulty = 0
 	if(target.cartridge)
-		difficulty += bit_count(target.cartridge.access&(CART_MEDICAL | CART_SECURITY | CART_ENGINE | CART_CLOWN | CART_JANITOR | CART_MANIFEST))
+		difficulty += bit_count(target.cartridge.access&(CART_MEDICAL | CART_SECURITY | CART_ENGINE | CART_CLOWN | CART_MANIFEST))
 		if(target.cartridge.access & CART_MANIFEST)
 			difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
 	if(SEND_SIGNAL(target, COMSIG_PDA_CHECK_DETONATE) & COMPONENT_PDA_NO_DETONATE || prob(difficulty * 15))

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -26,8 +26,8 @@
 	GLOB.janitor_devices += src
 
 /obj/item/mop/Destroy(force)
-	. = ..()
 	GLOB.janitor_devices -= src
+	return ..()
 
 /obj/item/mop/proc/clean(turf/A, mob/living/cleaner)
 	if(reagents.has_chemical_flag(REAGENT_CLEANS, 1))

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -23,7 +23,11 @@
 /obj/item/mop/Initialize(mapload)
 	. = ..()
 	create_reagents(max_reagent_volume)
+	GLOB.janitor_devices += src
 
+/obj/item/mop/Destroy(force)
+	. = ..()
+	GLOB.janitor_devices -= src
 
 /obj/item/mop/proc/clean(turf/A, mob/living/cleaner)
 	if(reagents.has_chemical_flag(REAGENT_CLEANS, 1))

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -53,7 +53,6 @@
 /obj/structure/closet/jcloset/PopulateContents()
 	..()
 	new /obj/item/clothing/under/rank/civilian/janitor(src)
-	new /obj/item/cartridge/janitor(src)
 	new /obj/item/clothing/gloves/color/black(src)
 	new /obj/item/clothing/head/soft/purple(src)
 	new /obj/item/paint/paint_remover(src)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -19,6 +19,11 @@
 /obj/structure/janitorialcart/Initialize(mapload)
 	. = ..()
 	create_reagents(100, OPENCONTAINER)
+	GLOB.janitor_devices += src
+
+/obj/structure/janitorialcart/Destroy()
+	. = ..()
+	GLOB.janitor_devices -= src
 
 /obj/structure/janitorialcart/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -22,8 +22,8 @@
 	GLOB.janitor_devices += src
 
 /obj/structure/janitorialcart/Destroy()
-	. = ..()
 	GLOB.janitor_devices -= src
+	return ..()
 
 /obj/structure/janitorialcart/examine(mob/user)
 	. = ..()

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -38,7 +38,7 @@
 	id_trim = /datum/id_trim/job/janitor
 	uniform = /obj/item/clothing/under/rank/civilian/janitor
 	backpack_contents = list(
-		/obj/item/modular_computer/tablet/preset/advanced = 1,
+		/obj/item/modular_computer/tablet/preset/advanced/custodial = 1,
 		)
 	belt = /obj/item/pda/janitor
 	ears = /obj/item/radio/headset/headset_srv

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -124,8 +124,10 @@
 		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	GLOB.janitor_devices += src
 
 /mob/living/simple_animal/bot/cleanbot/Destroy()
+	GLOB.janitor_devices -= src
 	if(weapon)
 		var/atom/Tsec = drop_location()
 		weapon.force = weapon_orig_force

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -59,6 +59,11 @@
 	hard_drive.store_file(new /datum/computer_file/program/alarm_monitor)
 	hard_drive.store_file(new /datum/computer_file/program/atmosscan)
 
+/obj/item/modular_computer/tablet/preset/advanced/custodial/Initialize(mapload)
+	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
+	hard_drive.store_file(new /datum/computer_file/program/radar/custodial_locator)
+
 /obj/item/modular_computer/tablet/preset/advanced/engineering/Initialize(mapload)
 	. = ..()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -248,6 +248,38 @@
 				return TRUE
 	return FALSE
 
+///////////////
+// Custodial //
+///////////////
+
+///Tracks all janitor equipment
+/datum/computer_file/program/radar/custodial_locator
+	filename = "custodiallocator"
+	filedesc = "Custodial Locator"
+	extended_desc = "This program allows for tracking of custodial equipment."
+	requires_ntnet = TRUE
+	transfer_access = list(ACCESS_JANITOR)
+	available_on_ntnet = TRUE
+	program_icon = "broom"
+	size = 2
+
+/datum/computer_file/program/radar/custodial_locator/find_atom()
+	return locate(selected) in GLOB.janitor_devices
+
+/datum/computer_file/program/radar/custodial_locator/scan()
+	if(world.time < next_scan)
+		return
+	next_scan = world.time + (2 SECONDS)
+	objects = list()
+	for(var/obj/custodial_tools as anything in GLOB.janitor_devices)
+		if(!trackable(custodial_tools))
+			continue
+		var/list/tool_information = list(
+			ref = REF(custodial_tools),
+			name = custodial_tools.name,
+		)
+		objects += list(tool_information)
+
 ////////////////////////
 //Nuke Disk Finder App//
 ////////////////////////

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -278,7 +278,7 @@
 
 		if(istype(custodial_tools, /obj/structure/janitorialcart))
 			var/obj/structure/janitorialcart/janicart = custodial_tools
-			tool_name = "[janicart.name] - Water level: [janicart.reagents.total_volume] / 100"
+			tool_name = "[janicart.name] - Water level: [janicart.reagents.total_volume] / [janicart.reagents.maximum_volume]"
 
 		if(istype(custodial_tools, /mob/living/simple_animal/bot/cleanbot))
 			var/mob/living/simple_animal/bot/cleanbot/cleanbots = custodial_tools

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -248,10 +248,6 @@
 				return TRUE
 	return FALSE
 
-///////////////
-// Custodial //
-///////////////
-
 ///Tracks all janitor equipment
 /datum/computer_file/program/radar/custodial_locator
 	filename = "custodiallocator"
@@ -274,9 +270,23 @@
 	for(var/obj/custodial_tools as anything in GLOB.janitor_devices)
 		if(!trackable(custodial_tools))
 			continue
+		var/tool_name = custodial_tools.name
+
+		if(istype(custodial_tools, /obj/item/mop))
+			var/obj/item/mop/wet_mop = custodial_tools
+			tool_name = "[wet_mop.reagents.total_volume ? "Wet" : "Dry"] [wet_mop.name]"
+
+		if(istype(custodial_tools, /obj/structure/janitorialcart))
+			var/obj/structure/janitorialcart/janicart = custodial_tools
+			tool_name = "[janicart.name] - Water level: [janicart.reagents.total_volume] / 100"
+
+		if(istype(custodial_tools, /mob/living/simple_animal/bot/cleanbot))
+			var/mob/living/simple_animal/bot/cleanbot/cleanbots = custodial_tools
+			tool_name = "[cleanbots.name] - [cleanbots.bot_mode_flags & BOT_MODE_ON ? "Online" : "Offline"]"
+
 		var/list/tool_information = list(
 			ref = REF(custodial_tools),
-			name = custodial_tools.name,
+			name = tool_name,
 		)
 		objects += list(tool_information)
 

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -16,10 +16,12 @@
 	. = ..()
 	update_appearance()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/janicart)
+	GLOB.janitor_devices += src
 	if (installed_upgrade)
 		installed_upgrade.install(src)
 
 /obj/vehicle/ridden/janicart/Destroy()
+	GLOB.janitor_devices -= src
 	if (trash_bag)
 		QDEL_NULL(trash_bag)
 	if (installed_upgrade)

--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -10,7 +10,6 @@
 		/obj/item/cartridge/medical = 10,
 		/obj/item/cartridge/engineering = 10,
 		/obj/item/cartridge/security = 10,
-		/obj/item/cartridge/janitor = 10,
 		/obj/item/cartridge/signal/ordnance = 10,
 		/obj/item/pda/heads = 10,
 		/obj/item/cartridge/captain = 3,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -315,7 +315,6 @@
 	product_ads = "Come and get your janitorial clothing, now endorsed by lizard janitors everywhere!"
 	vend_reply = "Thank you for using the JaniDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/janitor = 2,
-					/obj/item/cartridge/janitor = 2,
 					/obj/item/clothing/under/rank/civilian/janitor/skirt = 2,
 					/obj/item/clothing/suit/hooded/wintercoat/janitor = 2,
 					/obj/item/clothing/gloves/color/black = 2,


### PR DESCRIPTION
## About The Pull Request

Helps with https://github.com/tgstation/tgstation/pull/65755

Removes old janitor cartridge app and replaces it with a tablet one.
Also adds the pimpin' ride to the list of tracked items, too.
Makes Janitors spawn with said app, too.

![image](https://user-images.githubusercontent.com/53777086/161634057-e033d43d-97af-467c-bc89-a90609cc19db.png)

## Why It's Good For The Game

- Janitor cartridge app checks the WHOLE world for stuff, this is an improvement from that
- Also makes the tablet the janitor spawns with, actually useful (beyond downloading arcade console while I wait to be called somewhere).
- Allows Janitors to more easily track their janitor equipment, since using pure coordinates sucked. This is the last place where sole GPS coordinates were ever given, and it really shows.

## Changelog

:cl:
refactor: Janitor's custodial PDA cartridge has been replaced with a Custodial locator tablet app.
/:cl: