### PR TITLE
[s] Removes the Gripper Gloves from the Lavaland Syndicate Base

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_3.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_3.dmm
@@ -32,15 +32,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/ruin/syndicate_lava_base/telecomms)
-"h" = (
-/obj/structure/railing,
-/obj/effect/mapping_helpers/no_lava,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/clothing/gloves/tackler/offbrand{
-	desc = "For a different kind of tackle fishing."
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/template_noop)
 "j" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -289,7 +280,7 @@ o
 b
 w
 K
-h
+v
 "}
 (4,1,1) = {"
 G


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

![image](https://user-images.githubusercontent.com/34697715/161649486-99bbee97-dda0-4913-8147-25fcbe38a7d6.png)

These aren't particularly good. Apparently, with these, you are able to _throw_ someone else out of the balcony, have them crawl the rest of the way to shore, and then extinguisher, and then burn meds, and now the highly deadly Syndicate agent with a sniper rifle is free to have "fun" on Lavaland.

It should be worth mentioning that this is a part of a modular map piece (one of three) of the Lavaland base, so this won't show up _all the time_, but if the stars align... not very good.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This method was discovered quite recently, and it goes against the set policy as well as the design decision made to have the inhabitants of the Lavaland base be able to escape.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Syndicate Operatives positioned on Lavaland are no longer able to violate the ONE THING they were told to not perform (leave the base).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
