### PR TITLE
[NO GBP] Fixes supply pods not being displayed below their contents when opened.

### DIFF
--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -657,6 +657,7 @@
 /obj/effect/pod_landingzone/proc/endLaunch()
 	pod.tryMakeRubble(drop_location())
 	pod.layer = initial(pod.layer)
+	pod.plane = initial(pod.plane)
 	pod.endGlow()
 	QDEL_NULL(helper)
 	pod.preOpen() //Begin supplypod open procedures. Here effects like explosions, damage, and other dangerous (and potentially admin-caused, if the centcom_podlauncher datum was used) memes will take place


### PR DESCRIPTION
## About The Pull Request
This should resolve one of the few mistakes I made when I PR'd the bugfix to the plane issues brought by FoV.

## Why It's Good For The Game
`// We want this to go right below the layer of supplypods and supplypod_rubble's forground.` - line 517 of the same file.

## Changelog

:cl:
fix: Fixed supply pods not being displayed below their contents when opened or the rubbles effect caused by the impact.
/:cl:
