### PR TITLE
Removes Weird Tiling in Closed Turfs on the Ash Walker's Base 

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -613,13 +613,6 @@
 	},
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"cV" = (
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/block{
-	dir = 8
-	},
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "du" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -1418,8 +1411,8 @@ aa
 aa
 ah
 ab
-aF
-cV
+ah
+ah
 ah
 ah
 bi

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -1410,7 +1410,7 @@ aa
 (2,1,1) = {"
 aa
 ah
-ab
+ah
 ah
 ah
 ah


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This one is quite odd. It all started with this screenshot:

![image](https://user-images.githubusercontent.com/34697715/161654488-e19a2125-8f20-4424-96dc-ea7810b76812.png)

Why was there a gen-turf there? Who knows, I did come across this, though:

![image](https://user-images.githubusercontent.com/34697715/161654495-c09115ae-f575-43d6-bcc1-9a87c9f4b54b.png)

Maybe that's the cause of our issue? Regardless, it shouldn't be there (it was hiding under the rock turf surrounding it). It crashed sDMM a few times as I tried to remove it (no clue why), but at least one beast has been exorcised.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Tile decorations shouldn't be placed under closed turfs.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Ash Walker's Base on Lavaland decided to stop putting tiles under solid rock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
