### PR TITLE
Adds crafting to crafting logs

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -286,6 +286,7 @@
 			if(O)
 				O.setDir(usr.dir)
 			use(recipe.req_amount * multiplier)
+			usr.investigate_log("[key_name(usr)] crafted [recipe.title]", INVESTIGATE_CRAFTING)
 
 			if(recipe.applies_mats && LAZYLEN(mats_per_unit))
 				if(isstack(O))


### PR DESCRIPTION
## About The Pull Request

Crafting things with the crafting menu via using an item in-hand, is now logged in crafting.

![image](https://user-images.githubusercontent.com/53777086/161655338-cf976e04-0fb9-49ff-88b3-77cc23892f4f.png)

## Why It's Good For The Game

I like being able to 100% accurately tell who crafted something rather than be forced to assume off of tgui logs.

## Changelog

:cl:
admin: Individual material crafting is now logged in crafting.html
/:cl: