### PR TITLE
Adds missing air alarm to Tram's cargo

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -49106,6 +49106,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/cargo,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/office)
 "qqF" = (
@@ -179698,7 +179699,7 @@ kQm
 tVu
 hRw
 bah
-pXz
+xtb
 qqw
 lrq
 eqy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title

Also replaces one window with a wall because there just weren't enough walls to place the air alarm on
![image](https://user-images.githubusercontent.com/44720187/161674901-6a996eb7-3d5d-4c68-8c73-10cddc3158f7.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Added a missing air alarm in Tramstation's cargo office
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
