### PR TITLE
Made screentips appear on a higher layer than action buttons.

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -201,7 +201,7 @@
 
 #define ADMIN_POPUP_LAYER 1
 
-//Layer for screentips
+///Layer for screentips
 #define SCREENTIP_LAYER 4
 
 ///Plane of the "splash" icon used that shows on the lobby screen. Nothing should ever be above this.

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -201,6 +201,8 @@
 
 #define ADMIN_POPUP_LAYER 1
 
+//Layer for screentips
+#define SCREENTIP_LAYER 4
 
 ///Plane of the "splash" icon used that shows on the lobby screen. Nothing should ever be above this.
 #define SPLASHSCREEN_PLANE 9999

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -6,6 +6,7 @@
 	maptext_height = 480
 	maptext_width = 480
 	maptext = ""
+	layer = OBJ_LAYER + 1 //Added to make screentips appear above action buttons
 
 /atom/movable/screen/screentip/Initialize(mapload, _hud)
 	. = ..()

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -6,7 +6,7 @@
 	maptext_height = 480
 	maptext_width = 480
 	maptext = ""
-	layer = OBJ_LAYER + 1 //Added to make screentips appear above action buttons
+	layer = SCREENTIP_LAYER //Added to make screentips appear above action buttons (and other /atom/movable/screen objects)
 
 /atom/movable/screen/screentip/Initialize(mapload, _hud)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pull request makes screentips appear on a higher layer than action buttons so the action buttons don't hide them.
Fixes #64925
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When you acquire too many action buttons (or are on a narrow monitor), longer screentips get hidden by the action buttons. This pull request fixes that and makes it so screentips are always on top.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Made screentips appear on OBJ_LAYER + 1 which is higher than the default layer for action buttons (OBJ_LAYER)
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Screentips are no longer hidden by action buttons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
