### PR TITLE
[NO GBP] (re)move some wall objects that were overlapping large painting frames

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -37861,7 +37861,6 @@
 	c_tag = "Art Gallery";
 	name = "library camera"
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/window/reinforced{
 	dir = 8
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19854,6 +19854,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
+/obj/machinery/newscaster/directional/west,
 /obj/item/pen/invisible,
 /turf/open/floor/engine/cult,
 /area/service/library)
@@ -68533,7 +68534,6 @@
 /obj/item/clothing/under/suit/red,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/book/codex_gigas,
-/obj/machinery/newscaster/directional/west,
 /turf/open/floor/engine/cult,
 /area/service/library)
 "yiv" = (


### PR DESCRIPTION
## About The Pull Request
Removes a fire extinguisher cabinet from delta (There's already a fire extinguisher/tank holder no further than 5 steps away) and moved a newscaster two tiles down.

## Why It's Good For The Game
I was so tired as of remaking the same map edits for the Xth time because of unsolveable map conflicts that I did some mistakes. This should fix them. 

## Changelog

:cl:
fix: Removed a fire extinguisher cabinet that was overlapping a large painting frame on Delta. Moved a newscaster that was also overlapping the large painting frame in the curator's backroom two tiles down on Meta.
/:cl:
