### PR TITLE
Fixes Area Slivers on MetaStation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16653,9 +16653,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"eGX" = (
-/turf/closed/wall,
-/area/service/chapel/storage)
 "eGZ" = (
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -37761,12 +37758,6 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
-"mAG" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
 "mAI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -86991,7 +86982,7 @@ gZp
 krK
 osv
 osv
-mAG
+osv
 lox
 oPi
 gZp
@@ -87248,7 +87239,7 @@ gZp
 eTz
 gZp
 far
-kkO
+far
 gZp
 kAa
 eQf
@@ -87505,7 +87496,7 @@ gZp
 rXt
 gZp
 gZp
-wrP
+gZp
 gZp
 ckh
 gZp
@@ -88543,7 +88534,7 @@ gZp
 lMJ
 aaa
 aaa
-eGX
+iRA
 iFJ
 iFJ
 iFJ
@@ -88800,7 +88791,7 @@ gZp
 iRA
 iRA
 iRA
-eGX
+iRA
 pvR
 akT
 aLb
@@ -89057,7 +89048,7 @@ fpF
 jZv
 huj
 fqt
-eGX
+iRA
 mvJ
 wkc
 mvJ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Check out this photograph:

![image](https://user-images.githubusercontent.com/34697715/161810315-dac49272-ae24-42c3-bacc-628687fa1559.png)

I blame mapmerge for this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/161810425-f2903281-08ed-4542-921e-30c0592df28d.png)

Areas work great when they're actually in the right spots.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: After a few mishaps, Nanotrasen fixed a few small area definition errors on MetaStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
