### PR TITLE
The screentip context no longer lies about what happens when you left click another carbon mob with combat mode on.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_context.dm
+++ b/code/modules/mob/living/carbon/carbon_context.dm
@@ -21,7 +21,7 @@
 	if (human_user != src)
 		context[SCREENTIP_CONTEXT_RMB] = "Shove"
 
-		if (human_user.combat_mode)
+		if (!human_user.combat_mode)
 			if (body_position == STANDING_UP)
 				if(check_zone(user.zone_selected) == BODY_ZONE_HEAD && get_bodypart(BODY_ZONE_HEAD))
 					context[SCREENTIP_CONTEXT_LMB] = "Headpat"

--- a/code/modules/mob/living/carbon/carbon_context.dm
+++ b/code/modules/mob/living/carbon/carbon_context.dm
@@ -21,16 +21,17 @@
 	if (human_user != src)
 		context[SCREENTIP_CONTEXT_RMB] = "Shove"
 
-		if (body_position == STANDING_UP)
-			if(check_zone(user.zone_selected) == BODY_ZONE_HEAD && get_bodypart(BODY_ZONE_HEAD))
-				context[SCREENTIP_CONTEXT_LMB] = "Headpat"
-			else if(user.zone_selected == BODY_ZONE_PRECISE_GROIN && !isnull(getorgan(/obj/item/organ/tail)))
-				context[SCREENTIP_CONTEXT_LMB] = "Pull tail"
+		if (human_user.combat_mode)
+			if (body_position == STANDING_UP)
+				if(check_zone(user.zone_selected) == BODY_ZONE_HEAD && get_bodypart(BODY_ZONE_HEAD))
+					context[SCREENTIP_CONTEXT_LMB] = "Headpat"
+				else if(user.zone_selected == BODY_ZONE_PRECISE_GROIN && !isnull(getorgan(/obj/item/organ/tail)))
+					context[SCREENTIP_CONTEXT_LMB] = "Pull tail"
+				else
+					context[SCREENTIP_CONTEXT_LMB] = "Hug"
+			else if (health >= 0 && !HAS_TRAIT(src, TRAIT_FAKEDEATH))
+				context[SCREENTIP_CONTEXT_LMB] = "Shake"
 			else
-				context[SCREENTIP_CONTEXT_LMB] = "Hug"
-		else if (health >= 0 && !HAS_TRAIT(src, TRAIT_FAKEDEATH))
-			context[SCREENTIP_CONTEXT_LMB] = "Shake"
-		else
-			context[SCREENTIP_CONTEXT_LMB] = "CPR"
+				context[SCREENTIP_CONTEXT_LMB] = "CPR"
 
 	return CONTEXTUAL_SCREENTIP_SET


### PR DESCRIPTION
## About The Pull Request
Due to a mistake from whoever made them, the lmb content value "Attack" is being overriden by non combat mode stuff for non-user carbons.

## Why It's Good For The Game
Fixes something that surprisingly hasn't been fixed before.

## Changelog

:cl:
fix: The screentip context no longer lies about what happens when you left click another carbon mob with combat mode on.
/:cl:
