### PR TITLE
Supermatter CO2 balance, helium and antinoblium gas supermatter interactions (sane this time).

### DIFF
--- a/code/__DEFINES/supermatter.dm
+++ b/code/__DEFINES/supermatter.dm
@@ -65,8 +65,6 @@
 #define HELIUM_CONSUMPTION_PP (ONE_ATMOSPHERE*0.01)
 /// How the amount of helium consumed per tick scales with partial pressure. Higher values decrease the rate helium consumption scales with partial pressure. Should be >0
 #define HELIUM_PRESSURE_SCALING (ONE_ATMOSPHERE*0.125)
-/// How much the amount of helium consumed per tick scales with gasmix power ratio. Higher values means gasmix has a greater effect on the helium consumed.
-#define HELIUM_GASMIX_SCALING (1)
 
 #define POWERLOSS_INHIBITION_GAS_THRESHOLD 0.20         //Higher == Higher percentage of inhibitor gas needed before the charge inertia chain reaction effect starts.
 #define POWERLOSS_INHIBITION_MOLE_THRESHOLD 20        //Higher == More moles of the gas are needed before the charge inertia chain reaction effect starts.        //Scales powerloss inhibition down until this amount of moles is reached

--- a/code/__DEFINES/supermatter.dm
+++ b/code/__DEFINES/supermatter.dm
@@ -2,7 +2,7 @@
 #define OXYGEN_HEAT_PENALTY 1
 #define PLUOXIUM_HEAT_PENALTY -0.5 //Better then co2, worse then n2
 #define TRITIUM_HEAT_PENALTY 10
-#define CO2_HEAT_PENALTY 6
+#define CO2_HEAT_PENALTY 2
 #define NITROGEN_HEAT_PENALTY -1.5
 #define BZ_HEAT_PENALTY 5
 #define H2O_HEAT_PENALTY 12 //This'll get made slowly over time, I want my spice rock spicy god damnit
@@ -11,6 +11,8 @@
 #define HEALIUM_HEAT_PENALTY 4
 #define PROTO_NITRATE_HEAT_PENALTY -3
 #define ZAUKER_HEAT_PENALTY 8
+#define HELIUM_HEAT_PENALTY 6
+#define ANTINOBLIUM_HEAT_PENALTY 23
 
 //All of these get divided by 10-bzcomp * 5 before having 1 added and being multiplied with power to determine rads
 //Keep the negative values here above -10 and we won't get negative rads
@@ -24,6 +26,8 @@
 #define HEALIUM_TRANSMIT_MODIFIER 2.4
 #define PROTO_NITRATE_TRANSMIT_MODIFIER 15
 #define ZAUKER_TRANSMIT_MODIFIER 20
+#define HELIUM_TRANSMIT_MODIFIER 5
+#define ANTINOBLIUM_TRANSMIT_MODIFIER 40
 
 #define BZ_RADIOACTIVITY_MODIFIER 5 //Improves the effect of transmit modifiers
 
@@ -31,7 +35,7 @@
 #define HYDROGEN_HEAT_RESISTANCE 2 // just a bit of heat resistance to spice it up
 #define PROTO_NITRATE_HEAT_RESISTANCE 5
 
-/// The minimum portion of the miasma in the air that will be consumed. Higher values mean more miasma will be consumed be default.
+/// The minimum portion of the miasma in the air that will be consumed. Higher values mean more miasma will be consumed by default.
 #define MIASMA_CONSUMPTION_RATIO_MIN 0
 /// The maximum portion of the miasma in the air that will be consumed. Lower values mean the miasma consumption rate caps earlier.
 #define MIASMA_CONSUMPTION_RATIO_MAX 1
@@ -44,7 +48,7 @@
 /// The amount of matter power generated for every mole of miasma consumed. Higher values mean miasma generates more power.
 #define MIASMA_POWER_GAIN 10
 
-/// The minimum portion of the CO2 in the air that will be consumed. Higher values mean more CO2 will be consumed be default.
+/// The minimum portion of the CO2 in the air that will be consumed. Higher values mean more CO2 will be consumed by default.
 #define CO2_CONSUMPTION_RATIO_MIN 0
 /// The maximum portion of the CO2 in the air that will be consumed. Lower values mean the CO2 consumption rate caps earlier.
 #define CO2_CONSUMPTION_RATIO_MAX 1
@@ -52,8 +56,17 @@
 #define CO2_CONSUMPTION_PP (ONE_ATMOSPHERE*0.01)
 /// How the amount of CO2 consumed per tick scales with partial pressure. Higher values decrease the rate CO2 consumption scales with partial pressure. Should be >0
 #define CO2_PRESSURE_SCALING (ONE_ATMOSPHERE*0.25)
-/// How much the amount of CO2 consumed per tick scales with gasmix power ratio. Higher values means gasmix has a greater effect on the CO2 consumed.
-#define CO2_GASMIX_SCALING (0.1)
+
+/// The minimum portion of the helium in the air that will be consumed. Higher values mean more helium will be consumed by default.
+#define HELIUM_CONSUMPTION_RATIO_MIN 0
+/// The maximum portion of the helium in the air that will be consumed. Lower values mean the helium consumption rate caps earlier.
+#define HELIUM_CONSUMPTION_RATIO_MAX 1
+/// The minimum pressure for a pure helium atmosphere to begin being consumed. Higher values mean it takes more helium pressure to make helium be consumed. Should be >= 0
+#define HELIUM_CONSUMPTION_PP (ONE_ATMOSPHERE*0.01)
+/// How the amount of helium consumed per tick scales with partial pressure. Higher values decrease the rate helium consumption scales with partial pressure. Should be >0
+#define HELIUM_PRESSURE_SCALING (ONE_ATMOSPHERE*0.125)
+/// How much the amount of helium consumed per tick scales with gasmix power ratio. Higher values means gasmix has a greater effect on the helium consumed.
+#define HELIUM_GASMIX_SCALING (1)
 
 #define POWERLOSS_INHIBITION_GAS_THRESHOLD 0.20         //Higher == Higher percentage of inhibitor gas needed before the charge inertia chain reaction effect starts.
 #define POWERLOSS_INHIBITION_MOLE_THRESHOLD 20        //Higher == More moles of the gas are needed before the charge inertia chain reaction effect starts.        //Scales powerloss inhibition down until this amount of moles is reached

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -83,7 +83,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		/datum/gas/healium,
 		/datum/gas/proto_nitrate,
 		/datum/gas/zauker,
-		/datum/gas/miasma
+		/datum/gas/miasma,
+		/datum/gas/helium,
+		/datum/gas/antinoblium,
 	)
 	///The list of gases mapped against their current comp. We use this to calculate different values the supermatter uses, like power or heat resistance. It doesn't perfectly match the air around the sm, instead moving up at a rate determined by gas_change_rate per call. Ranges from 0 to 1
 	var/list/gas_comp = list(
@@ -101,6 +103,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		/datum/gas/healium = 0,
 		/datum/gas/proto_nitrate = 0,
 		/datum/gas/zauker = 0,
+		/datum/gas/helium = 0,
+		/datum/gas/antinoblium = 0,
 	)
 	///The list of gases mapped against their transmit values. We use it to determine the effect different gases have on the zaps
 	var/list/gas_trans = list(
@@ -114,6 +118,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		/datum/gas/healium = HEALIUM_TRANSMIT_MODIFIER,
 		/datum/gas/proto_nitrate = PROTO_NITRATE_TRANSMIT_MODIFIER,
 		/datum/gas/zauker = ZAUKER_TRANSMIT_MODIFIER,
+		/datum/gas/helium = HELIUM_TRANSMIT_MODIFIER,
+		/datum/gas/antinoblium = ANTINOBLIUM_TRANSMIT_MODIFIER,
 	)
 	///The list of gases mapped against their heat penaltys. We use it to determin molar and heat output
 	var/list/gas_heat = list(
@@ -130,6 +136,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		/datum/gas/healium = HEALIUM_HEAT_PENALTY,
 		/datum/gas/proto_nitrate = PROTO_NITRATE_HEAT_PENALTY,
 		/datum/gas/zauker = ZAUKER_HEAT_PENALTY,
+		/datum/gas/helium = HELIUM_HEAT_PENALTY,
+		/datum/gas/antinoblium = ANTINOBLIUM_HEAT_PENALTY,
 	)
 	///The list of gases mapped against their heat resistance. We use it to moderate heat damage.
 	var/list/gas_resist = list(
@@ -153,6 +161,14 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		/datum/gas/proto_nitrate = 1,
 		/datum/gas/zauker = 1,
 		/datum/gas/miasma = 0.5,
+		/datum/gas/helium = 1,
+		/datum/gas/antinoblium = 1,
+	)
+	///The list of gases mapped against their powerloss inhibition. Used to slow down powerloss.
+	var/list/gas_powerloss_inhibitors = list(
+		/datum/gas/carbon_dioxide = 1,
+		/datum/gas/helium = 1,
+		/datum/gas/antinoblium = 1,
 	)
 	///The last air sample's total molar count, will always be above or equal to 0
 	var/combined_gas = 0
@@ -164,8 +180,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/dynamic_heat_resistance = 1
 	///Uses powerloss_dynamic_scaling and combined_gas to lessen the effects of our powerloss functions
 	var/powerloss_inhibitor = 1
-	///Based on co2 percentage, slowly moves between 0 and 1. We use it to calc the powerloss_inhibitor
+	///Based on powerloss_inhibitor gas percentage, slowly moves between 0 and 1. We use it to calc the powerloss_inhibitor
 	var/powerloss_dynamic_scaling= 0
+	///Composition of gases that inhibit powerloss.
+	var/powerloss_inhibitor_comp = 0
 	///Affects the amount of radiation the sm makes. We multiply this with power to find the zap power.
 	var/power_transmission_bonus = 0
 	///Used to increase or lessen the amount of damage the sm takes from heat based on molar counts.

--- a/code/modules/power/supermatter/supermatter_process.dm
+++ b/code/modules/power/supermatter/supermatter_process.dm
@@ -226,7 +226,7 @@
 		consumed_helium = min(consumed_helium * gas_comp[/datum/gas/helium] * combined_gas, removed.gases[/datum/gas/helium][MOLES])
 		if(consumed_helium)
 			removed.gases[/datum/gas/helium][MOLES] -= consumed_helium
-			removed.gases[/datum/gas/tritium][MOLES] += consumed_helium
+			removed.gases[/datum/gas/tritium][MOLES] += consumed_helium * 0.5
 
 	if(prob(gas_comp[/datum/gas/zauker]))
 		playsound(loc, 'sound/weapons/emitter2.ogg', 100, TRUE, extrarange = 10)

--- a/code/modules/power/supermatter/supermatter_process.dm
+++ b/code/modules/power/supermatter/supermatter_process.dm
@@ -280,10 +280,11 @@
 		playsound(src, 'sound/weapons/emitter2.ogg', 70, TRUE)
 		var/power_multiplier = max(0, (1 + (power_transmission_bonus / (10 - (gas_comp[/datum/gas/bz] * BZ_RADIOACTIVITY_MODIFIER)))) * freonbonus)// RadModBZ(500%)
 		var/pressure_multiplier = max((1 / ((env.return_pressure() ** pressure_bonus_curve_angle) + 1) * pressure_bonus_derived_steepness) + pressure_bonus_derived_constant, 1)
+		var/co2_power_increase = max(1 + gas_comp[/datum/gas/carbon_dioxide] * 0.5, 1)
 		supermatter_zap(
 			zapstart = src,
 			range = 3,
-			zap_str = 2.5 * power * power_multiplier * pressure_multiplier,
+			zap_str = 2.5 * power * power_multiplier * pressure_multiplier * co2_power_increase,
 			zap_flags = ZAP_SUPERMATTER_FLAGS,
 			zap_cutoff = 300,
 			power_level = power

--- a/code/modules/power/supermatter/supermatter_process.dm
+++ b/code/modules/power/supermatter/supermatter_process.dm
@@ -222,7 +222,7 @@
 	//Very high energy radiaton will convert helium into tritium.
 	if(gas_comp[/datum/gas/helium] && power > POWER_PENALTY_THRESHOLD)
 		var/helium_pp = env.return_pressure() * gas_comp[/datum/gas/helium]
-		var/consumed_helium = clamp(((helium_pp - HELIUM_CONSUMPTION_PP) / (helium_pp + HELIUM_PRESSURE_SCALING)) * gasmix_power_ratio * HELIUM_GASMIX_SCALING * clamp((power - POWER_PENALTY_THRESHOLD) / POWER_PENALTY_THRESHOLD, 0, 1), HELIUM_CONSUMPTION_RATIO_MIN, HELIUM_CONSUMPTION_RATIO_MAX)
+		var/consumed_helium = clamp(((helium_pp - HELIUM_CONSUMPTION_PP) / (helium_pp + HELIUM_PRESSURE_SCALING)) * gasmix_power_ratio * clamp((power - POWER_PENALTY_THRESHOLD) / POWER_PENALTY_THRESHOLD, 0, 1), HELIUM_CONSUMPTION_RATIO_MIN, HELIUM_CONSUMPTION_RATIO_MAX)
 		consumed_helium = min(consumed_helium * gas_comp[/datum/gas/helium] * combined_gas, removed.gases[/datum/gas/helium][MOLES])
 		if(consumed_helium)
 			removed.gases[/datum/gas/helium][MOLES] -= consumed_helium


### PR DESCRIPTION
CO2 heat penalty reduced to 2 from 6. Reduces bonus power transmission of CO2 to 1.5 from 2.

Powerloss inhibition is now based on the composition of gases in a list of gases mapped with their powerloss inhibition values instead of just co2 composition. The list includes co2, helium, and antinoblium.

Helium interaction with supermatter. Inhibits powerloss, has heat penalty of 6, gasmix power ratio of 1, and power transmission of 5. Gets converted to tritium when the SM's energy is above 5GeV.

Antinoblium interaction with supermatter. Inhibits powerloss, has heat penalty of 23, gasmix power ratio of 1, and power transmission of 40.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces CO2's heat penalty to 2, from 6. CO2's bonus transmission to zaps have been reduced. Adds helium interaction. Helium gets converted to tritium when SM is above 5GeV, and also reduces powerloss like CO2. Adds antinoblium interaction. Antinoblium has a heat penalty of 23, and inhibits powerloss like CO2, but has a power transmission bonus of 40.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
### CO2
CO2 having a heat penalty of 6 means it is much harder to keep it at high composition and low temperature, both being a requirement to achieve high power without delamming, which is what CO2 is about. While it should be challenging to achieve high power levels, the high heat penalty restrained the ranges of power most engines could achieve without delamming, which made CO2's gimmick look a lot more like an ordinary high heat penalty gas than a powerloss inhibitor gas. Lowering the heat penalty should let engineers to have a taste of increasing the SM's power levels with a better setup, but should still be a challenging task if they want to get to the very high power levels.

### Helium
Enabling helium to get converted to tritium under dangerous conditions should give the gas a purpose outside of the HFR. Although a gas's entire purpose outside of the HFR is to get converted to a useful gas is probably not the best or most exciting purpose, at least it gives people something to do with it other than selling it after extracting from HFR.

### Antinoblium
People said they could do tritium engines, so I will introduce antinoblium as the gas probably no engine would be able to maintain at 100% composition.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Reduces CO2 supermatter heat penalty to 2, from 6.
balance: Reduces the additional zap power transmission gain from CO2.
add: Adds helium gas interaction for the supermatter. It inhibits powerloss, and gets converted to tritium when the SM has a power above 5GeV. Heat penalty of 6.
add: Adds antinoblium gas interaction for the supermatter. It will probably destroy your engine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
