### PR TITLE
Brings stationary tank pressure limit up to canister level and makes them cheaper

### DIFF
--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -1,4 +1,4 @@
-#define TANK_PLATING_SHEETS 20
+#define TANK_PLATING_SHEETS 12
 
 /obj/machinery/atmospherics/components/tank
 	icon = 'icons/obj/atmospherics/stationary_canisters.dmi'
@@ -34,7 +34,7 @@
 	/// The volume of the gas mixture
 	var/volume = 2500 //in liters
 	/// The max pressure of the gas mixture before damaging the tank
-	var/max_pressure = 20000
+	var/max_pressure = 46000
 	/// The typepath of the gas this tank should be filled with.
 	var/gas_type = null
 


### PR DESCRIPTION
## About The Pull Request

It's been a while now to see how the reworked stationary tanks have been used and they're a bit underpowered compared to canisters. This doesn't make them as good as the higher tiered ones because those are ridiculous (and probably need to be nerfed at some point) but the pressure limit has been brought up to at least a base level canister. 

Also this makes the tank itself a bit cheaper to encourage their use a bit more.

:cl:
balance: Stationary gas tanks now cost 12 material for the plating instead of 20
balance: The base level of stationary gas tank pressure limits has been brought up to the base level of canisters. Higher quality materials still increase this further as before.
/:cl:
