### PR TITLE
Make free golem hazardous area numbers configs

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -460,7 +460,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Used for limbs.
 #define TRAIT_DISABLED_BY_WOUND "disabled-by-wound"
 
-
 //important_recursive_contents traits
 /*
  * Used for movables that need to be updated, via COMSIG_ENTER_AREA and COMSIG_EXIT_AREA, when transitioning areas.
@@ -604,7 +603,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 
 /// trait denoting someone will sometimes recover out of crit
 #define TRAIT_UNBREAKABLE "unbreakable"
-
 
 //Medical Categories for quirks
 #define CAT_QUIRK_ALL 0

--- a/code/controllers/configuration/entries/free_golems.dm
+++ b/code/controllers/configuration/entries/free_golems.dm
@@ -1,0 +1,15 @@
+/// Whether or not free golems should be mechanically disencouraged to visit the station
+/datum/config_entry/flag/free_golems_stay_home
+	default = TRUE
+
+/// How much click delay free golems have on station
+/datum/config_entry/number/free_golem_next_move_modifier
+	default = 4
+
+/// How much action speed should be slowed down for free golems on station
+/datum/config_entry/number/free_golem_action_speed_slowdown
+	default = 4
+
+/// How much a free golem's move speed should be lowered on station
+/datum/config_entry/number/free_golem_move_speed_modifier
+	default = 4

--- a/code/modules/actionspeed/modifiers/status_effects.dm
+++ b/code/modules/actionspeed/modifiers/status_effects.dm
@@ -6,6 +6,3 @@
 
 /datum/actionspeed_modifier/nooartrium
 	multiplicative_slowdown = 0.5
-
-/datum/actionspeed_modifier/status_effect/hazard_area
-	multiplicative_slowdown = 4

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -84,7 +84,8 @@
 		to_chat(user, span_warning("You get a feeling that leaving the station might be a REALLY dumb idea..."))
 		dumb_rev_heads += user.mind
 		return
-	. = ..()
+
+	return ..()
 
 /obj/machinery/computer/shuttle/mining/common
 	name = "lavaland shuttle console"

--- a/code/modules/mob_spawn/ghost_roles/golem_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/golem_roles.dm
@@ -52,10 +52,8 @@
 		if (policy)
 			to_chat(new_spawn, policy)
 		to_chat(new_spawn, "Build golem shells in the autolathe, and feed refined mineral sheets to the shells to bring them to life! You are generally a peaceful group unless provoked.")
-		var/static/list/allowed_areas
-		if(!allowed_areas)
-			allowed_areas = typecacheof(list(/area/icemoon, /area/lavaland, /area/ruin))
-		new_spawn.AddComponent(/datum/component/hazard_area, area_whitelist=allowed_areas)
+
+		try_keep_home(new_spawn)
 	else
 		new_spawn.mind.enslave_mind_to_creator(owner)
 		log_game("[key_name(new_spawn)] possessed a golem shell enslaved to [key_name(owner)].")
@@ -70,6 +68,22 @@
 		new_spawn.mind.set_assigned_role(SSjob.GetJobType(/datum/job/servant_golem))
 	else
 		new_spawn.mind.set_assigned_role(SSjob.GetJobType(/datum/job/free_golem))
+
+/obj/effect/mob_spawn/ghost_role/human/golem/proc/try_keep_home(mob/new_spawn)
+	var/static/list/allowed_areas
+	if (!allowed_areas)
+		allowed_areas = typecacheof(list(/area/icemoon, /area/lavaland, /area/ruin))
+
+	if (!CONFIG_GET(flag/free_golems_stay_home))
+		return
+
+	new_spawn.AddComponent(
+		/datum/component/hazard_area, \
+		area_whitelist = allowed_areas, \
+		next_move_modifier = CONFIG_GET(number/free_golem_next_move_modifier), \
+		action_speed_slowdown = CONFIG_GET(number/free_golem_action_speed_slowdown), \
+		move_speed_modifier = CONFIG_GET(number/free_golem_move_speed_modifier), \
+	)
 
 /obj/effect/mob_spawn/ghost_role/human/golem/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/modules/movespeed/modifiers/status_effects.dm
+++ b/code/modules/movespeed/modifiers/status_effects.dm
@@ -15,7 +15,3 @@
 /datum/movespeed_modifier/status_effect/sepia
 	variable = TRUE
 	blacklisted_movetypes = (FLYING|FLOATING)
-
-/datum/movespeed_modifier/status_effect/hazard_area
-	multiplicative_slowdown = 4
-

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -474,3 +474,20 @@ MAXFINE 2000
 
 ## Whether native FoV is enabled for all people.
 #NATIVE_FOV
+
+### Free golems
+## Whether or not free golems should be mechanically disencouraged to visit the station.
+## All other options will not go into effect if this is off.
+FREE_GOLEMS_STAY_HOME
+
+## How much click delay free golems have on station.
+## Set to 1 for no change.
+FREE_GOLEM_NEXT_MOVE_MODIFIER 4
+
+## How much action speed should be slowed down for free golems on station.
+## Set to 0 for no change.
+FREE_GOLEM_ACTION_SPEED_SLOWDOWN 4
+
+## How much a free golem's move speed should be lowered on station.
+## Set to 0 for no change.
+FREE_GOLEM_MOVE_SPEED_MODIFIER 4

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -425,6 +425,7 @@
 #include "code\controllers\configuration\configuration.dm"
 #include "code\controllers\configuration\entries\comms.dm"
 #include "code\controllers\configuration\entries\dbconfig.dm"
+#include "code\controllers\configuration\entries\free_golems.dm"
 #include "code\controllers\configuration\entries\game_options.dm"
 #include "code\controllers\configuration\entries\general.dm"
 #include "code\controllers\configuration\entries\interview.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the slowdown, movespeed, etc configs, as well as the ability to toggle this on at all.

It's not something I cared about at first, but I figured later down the line that just because this is in the codebase doesn't make it not a policy issue, so head admins might as well have the knobs for this.