### PR TITLE
Fixes Area Misdefinition on KiloStation Botany

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -59846,7 +59846,7 @@
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/checker,
-/area/maintenance/central)
+/area/service/hydroponics)
 "prC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Check out this photograph:

![image](https://user-images.githubusercontent.com/34697715/161905687-ce52fa7c-cc22-46ea-90a0-7be2fa632194.png)

HRHRRHHGHGHGHHRHRHGHRHGRGH MAP MEEEEEEERGE

Let's fix that area definition to actually be the proper one.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/161905849-4f02ff19-9837-4298-ac64-bd416dab7a57.png)

Much better. Phew. Thought I was going to blow a vein.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: KiloStation's Botany no longer has a bit of it defined as the defunct "Central" Maintenance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
