### PR TITLE
Adds admin logging to supply orders' rare erroneous manifests mechanic

### DIFF
--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -27,7 +27,7 @@
 		investigate_log("Supply order #[order_id] generated a manifest missing listed contents.", INVESTIGATE_CARGO)
 	if(prob(MANIFEST_ERROR_CHANCE))
 		errors |= MANIFEST_ERROR_ITEM
-		investigate_log("Supply order #[order_id] generated with incorrect contents", INVESTIGATE_CARGO)
+		investigate_log("Supply order #[order_id] generated with incorrect contents shipped.", INVESTIGATE_CARGO)
 
 /obj/item/paper/fluff/jobs/cargo/manifest/proc/is_approved()
 	return stamped?.len && !is_denied()

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -21,7 +21,7 @@
 
 	if(prob(MANIFEST_ERROR_CHANCE))
 		errors |= MANIFEST_ERROR_NAME
-		investigate_log("Supply order #[order_id] generated a manifest with the incorrect station name.", INVESTIGATE_CARGO)
+		investigate_log("Supply order #[order_id] generated a manifest with an incorrect station name.", INVESTIGATE_CARGO)
 	if(prob(MANIFEST_ERROR_CHANCE))
 		errors |= MANIFEST_ERROR_CONTENTS
 		investigate_log("Supply order #[order_id] generated a manifest missing listed contents.", INVESTIGATE_CARGO)

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -21,6 +21,7 @@
 
 	if(prob(MANIFEST_ERROR_CHANCE))
 		errors |= MANIFEST_ERROR_NAME
+		investigate_log("Supply order #[order_id] generated a manifest with the incorrect station name.", INVESTIGATE_CARGO)
 	if(prob(MANIFEST_ERROR_CHANCE))
 		errors |= MANIFEST_ERROR_CONTENTS
 	if(prob(MANIFEST_ERROR_CHANCE))
@@ -94,6 +95,7 @@
 	P.info += "<ul>"
 	for(var/atom/movable/AM in container.contents - P)
 		if((P.errors & MANIFEST_ERROR_CONTENTS))
+			investigate_log("Supply order #[id] generated a manifest missing listed contents.", INVESTIGATE_CARGO)
 			if(prob(50))
 				P.info += "<li>[AM.name]</li>"
 			else
@@ -106,6 +108,7 @@
 		if(istype(container, /obj/structure/closet/crate/secure) || istype(container, /obj/structure/closet/crate/large))
 			P.errors &= ~MANIFEST_ERROR_ITEM
 		else
+			investigate_log("Supply order #[id] generated with missing content.", INVESTIGATE_CARGO)
 			var/lost = max(round(container.contents.len / 10), 1)
 			while(--lost >= 0)
 				qdel(pick(container.contents))

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -27,7 +27,7 @@
 		investigate_log("Supply order #[order_id] generated a manifest missing listed contents.", INVESTIGATE_CARGO)
 	if(prob(MANIFEST_ERROR_CHANCE))
 		errors |= MANIFEST_ERROR_ITEM
-		investigate_log("Supply order #[order_id] generated with missing contents", INVESTIGATE_CARGO)
+		investigate_log("Supply order #[order_id] generated with incorrect contents", INVESTIGATE_CARGO)
 
 /obj/item/paper/fluff/jobs/cargo/manifest/proc/is_approved()
 	return stamped?.len && !is_denied()

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -24,8 +24,10 @@
 		investigate_log("Supply order #[order_id] generated a manifest with the incorrect station name.", INVESTIGATE_CARGO)
 	if(prob(MANIFEST_ERROR_CHANCE))
 		errors |= MANIFEST_ERROR_CONTENTS
+		investigate_log("Supply order #[order_id] generated a manifest missing listed contents.", INVESTIGATE_CARGO)
 	if(prob(MANIFEST_ERROR_CHANCE))
 		errors |= MANIFEST_ERROR_ITEM
+		investigate_log("Supply order #[order_id] generated with missing contents", INVESTIGATE_CARGO)
 
 /obj/item/paper/fluff/jobs/cargo/manifest/proc/is_approved()
 	return stamped?.len && !is_denied()
@@ -95,7 +97,6 @@
 	P.info += "<ul>"
 	for(var/atom/movable/AM in container.contents - P)
 		if((P.errors & MANIFEST_ERROR_CONTENTS))
-			investigate_log("Supply order #[id] generated a manifest missing listed contents.", INVESTIGATE_CARGO)
 			if(prob(50))
 				P.info += "<li>[AM.name]</li>"
 			else
@@ -108,7 +109,6 @@
 		if(istype(container, /obj/structure/closet/crate/secure) || istype(container, /obj/structure/closet/crate/large))
 			P.errors &= ~MANIFEST_ERROR_ITEM
 		else
-			investigate_log("Supply order #[id] generated with missing content.", INVESTIGATE_CARGO)
 			var/lost = max(round(container.contents.len / 10), 1)
 			while(--lost >= 0)
 				qdel(pick(container.contents))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cargo orders currently have a weird undocumented mechanic where there is a small chance for the manifest to generate an incorrect listing for the station name, the order's contents or for the content to go missing altogether. As it isn't a well known feature, plenty of people ahelp it thinking that they have been victims of a bug and as the event isn't logged anywhere, the online staff is inclined to think so if they haven't code dived for it before.
I have never messed with that kind of code so feel free to tell me if I did anything wrong I tried to add the logging to the generateManifest() proc first but ended up going for the manifest's init, the code for that feature is pretty old and full of single letter variables that I wasn't able to fully decipher.

## Why It's Good For The Game

Additional logging for an obscure mechanic, most people think it's a bug when their crates arrive empty, admins will be able to recognize what actually happened.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: added logging for supply orders' rare erroneous manifest mechanic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
