### PR TITLE
Remaps icebox's ordnance

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -21235,9 +21235,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
-"jtU" = (
-/turf/open/genturf,
-/area/icemoon/surface/outdoors/nospawn)
 "jue" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/west{
@@ -24466,7 +24463,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/science/breakroom)
 "lah" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41494,6 +41491,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/science/mixing/hallway)
 "tIQ" = (
@@ -109580,7 +109578,7 @@ bun
 bOJ
 bgx
 jnk
-jtU
+gQb
 gQb
 gQb
 gQb
@@ -111629,7 +111627,7 @@ gQb
 gQb
 gQb
 gQb
-jtU
+gQb
 gQb
 gQb
 gQb

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -22,14 +22,8 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
 "abJ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/science/mixing/hallway)
+/turf/open/openspace,
+/area/maintenance/starboard/upper)
 "abU" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/blue,
@@ -864,15 +858,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"atS" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/mixing/launch)
 "auc" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -2128,9 +2113,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction{
-	dir = 2
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
 "aMO" = (
@@ -2483,14 +2466,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aVs" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/cafeteria{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "aVu" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -2777,11 +2758,11 @@
 	},
 /area/hallway/secondary/entry)
 "bbg" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "bbk" = (
 /obj/structure/table,
 /obj/item/wallframe/camera,
@@ -3440,15 +3421,6 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"bne" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/icemoon,
-/area/science/test_area)
 "bni" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3586,12 +3558,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bps" = (
-/obj/item/target/alien/anchored,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/camera/preset/ordnance{
 	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/plating/icemoon,
 /area/science/test_area)
@@ -4371,10 +4345,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"bCX" = (
-/obj/structure/chair/stool/directional/south,
-/turf/open/floor/iron,
-/area/science/mixing)
 "bDb" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -4386,18 +4356,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bDf" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "8;12"
+/obj/structure/sign/warning/testchamber{
+	pixel_y = -32
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/iron,
+/area/science/mixing/launch)
 "bDi" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -4490,7 +4453,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "bDW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/sofa/right,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -4511,8 +4473,15 @@
 	},
 /area/maintenance/port/aft)
 "bEs" = (
-/turf/closed/wall,
-/area/science/mixing)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "bEu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2,
@@ -4565,9 +4534,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/plating/icemoon,
 /area/science/test_area)
-"bFU" = (
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "bFW" = (
 /obj/item/soap/deluxe,
 /obj/item/bikehorn/rubberducky,
@@ -4683,20 +4649,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"bId" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	dir = 8;
-	freq = 1400;
-	location = "Research Division"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/iron,
-/area/maintenance/starboard/upper)
 "bIo" = (
 /obj/structure/sign/painting/library_secure{
 	pixel_x = 32
@@ -4943,10 +4895,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/security/office)
-"bMu" = (
-/obj/machinery/door/poddoor/incinerator_ordmix,
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
 "bMB" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -4996,10 +4944,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bNA" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"bNC" = (
-/obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bNI" = (
@@ -5070,9 +5014,12 @@
 /turf/open/floor/plating,
 /area/science/misc_lab)
 "bPP" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/science/mixing)
 "bPS" = (
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
@@ -5508,15 +5455,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"bXy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/kirbyplants/random,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron/dark,
-/area/science/breakroom)
 "bXz" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/iron/dark/telecomms,
@@ -5714,8 +5652,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cas" = (
-/turf/closed/wall/r_wall,
-/area/science/storage)
+/obj/structure/railing,
+/obj/structure/lattice/catwalk,
+/turf/open/openspace,
+/area/science/mixing)
 "cax" = (
 /obj/structure/closet/wardrobe/black,
 /obj/effect/decal/cleanable/cobweb,
@@ -5825,9 +5765,6 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"ccp" = (
-/turf/closed/wall,
-/area/science/mixing/hallway)
 "ccP" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -6074,9 +6011,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cgu" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/mass_driver/ordnance{
+	dir = 4
+	},
+/obj/machinery/door/window/left/directional/north,
+/turf/open/floor/iron,
+/area/science/mixing/launch)
 "cgB" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -6195,16 +6135,18 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
 "cjK" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/fire{
-	pixel_x = 32
+/obj/structure/table,
+/obj/item/book/manual/wiki/ordnance{
+	pixel_x = 5;
+	pixel_y = 1
 	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/camera/directional/east{
+	c_tag = "Ordnance Office";
+	network = list("ss13","rd")
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "cks" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -6279,13 +6221,11 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "cll" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/cafeteria{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "clq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6372,10 +6312,7 @@
 	},
 /area/maintenance/fore/lesser)
 "cnT" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark,
 /area/science/mixing)
 "coa" = (
 /obj/effect/spawner/random/trash/mess,
@@ -7254,14 +7191,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "czO" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped{
-	dir = 4
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 28
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "czY" = (
 /obj/machinery/pdapainter/engineering,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -7583,16 +7516,12 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/cargo/miningdock)
 "cGb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/cafeteria{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "cGj" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/three,
@@ -7902,9 +7831,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/heads_quarters/cmo)
 "cLo" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/item/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
 "cLy" = (
@@ -7923,13 +7854,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"cMf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/mixing/launch)
 "cMi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -8282,17 +8206,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"cUD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/computer/security/telescreen/ordnance{
-	dir = 8;
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/science/mixing/launch)
 "cUE" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -8487,11 +8400,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
 "cZL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "cZM" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -9096,11 +9007,22 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
 "dmE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
+/obj/structure/table,
+/obj/item/assembly/timer{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/assembly/timer{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/assembly/timer{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/assembly/timer,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "dnf" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "MiniSat External SouthEast";
@@ -9424,12 +9346,17 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dvF" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
+/obj/structure/table,
+/obj/item/computer_hardware/hard_drive/portable{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/computer_hardware/hard_drive/portable{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "dvJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -9453,13 +9380,6 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"dwi" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
 "dwp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9542,13 +9462,6 @@
 /obj/structure/closet/secure_closet/warden,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
-"dzl" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
 "dzn" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/red{
@@ -9739,28 +9652,16 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "dEh" = (
-/obj/structure/table/reinforced,
-/obj/item/assembly/igniter{
-	pixel_x = -8;
-	pixel_y = -2
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/item/assembly/igniter{
-	pixel_x = -2;
-	pixel_y = 3
+/obj/structure/railing/corner,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/cafeteria{
+	dir = 8
 	},
-/obj/item/assembly/igniter{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -6
-	},
-/obj/structure/sign/poster/official/safety_report{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "dEj" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -9788,17 +9689,11 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "dER" = (
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron,
-/area/science/mixing)
-"dET" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/mob/living/simple_animal/pet/penguin/emperor{
+	name = "Club"
 	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/misc/asteroid/snow/standard_air,
+/area/science/research)
 "dEW" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -9845,20 +9740,28 @@
 /turf/open/floor/iron,
 /area/cargo/lobby)
 "dFZ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Firefighting Equipment";
+	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/mixing)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "dGb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dGF" = (
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "dHb" = (
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron,
@@ -10698,13 +10601,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
-"eeA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/mixing)
 "eeI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -10780,13 +10676,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "egQ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/light/small/directional/west,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
-/area/science/mixing/hallway)
+/area/science/mixing/launch)
 "egT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow,
@@ -10913,11 +10810,19 @@
 /turf/open/floor/iron/white,
 /area/maintenance/aft/greater)
 "ejr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab";
+	req_access_txt = "8"
+	},
+/turf/open/floor/iron/white/side,
+/area/science/mixing/hallway)
 "ejD" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/iron,
@@ -11026,13 +10931,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
-"emf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/storage)
 "emg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -11260,10 +11158,17 @@
 	},
 /area/engineering/transit_tube)
 "ert" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "erG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -11533,15 +11438,11 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "ezW" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/south{
-	c_tag = "Ordnance Lab South";
-	network = list("ss13","rd")
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/iron/dark/textured,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
 /area/science/mixing)
 "ezY" = (
 /obj/structure/cable,
@@ -11620,12 +11521,6 @@
 "eBR" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/central/greater)
-"eBV" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/air_sensor/ordnance_mixing_tank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
 "eCg" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
@@ -11856,11 +11751,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"eJm" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance/eight,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "eJt" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/oxygen_input{
 	dir = 1
@@ -12103,13 +11993,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"eQR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron,
-/area/science/storage)
 "eRl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -12241,12 +12124,18 @@
 /turf/open/floor/wood,
 /area/service/library)
 "eVu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab";
+	req_access_txt = "8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria{
+	dir = 8
+	},
+/area/science/mixing/hallway)
 "eVN" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
@@ -12622,18 +12511,6 @@
 /obj/structure/tank_holder/oxygen/red,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ffg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/camera/directional/south{
-	c_tag = "Research Break Room";
-	network = list("ss13","rd")
-	},
-/turf/open/floor/iron/dark,
-/area/science/breakroom)
 "ffG" = (
 /obj/structure/table/wood,
 /obj/item/radio{
@@ -13166,12 +13043,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"fvo" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
 "fvu" = (
 /turf/open/openspace,
 /area/medical/medbay/central)
@@ -13406,11 +13277,19 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fAi" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/ordnance,
-/obj/item/storage/medkit/toxin,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Launch Room";
+	req_access_txt = "8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "fAD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13740,10 +13619,9 @@
 /turf/open/openspace,
 /area/medical/medbay/aft)
 "fJg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -13918,7 +13796,9 @@
 /area/commons/fitness)
 "fPJ" = (
 /obj/structure/cable,
-/obj/machinery/status_display/ai/directional/east,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
@@ -14137,10 +14017,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "fTI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria{
+	dir = 8
+	},
+/area/science/mixing/hallway)
 "fUu" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -14310,11 +14191,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"fXx" = (
-/obj/machinery/igniter/incinerator_ordmix,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
 "fXB" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -14463,14 +14339,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"gaV" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/storage)
 "gaY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -14538,12 +14406,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"gci" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/storage)
 "gcq" = (
 /turf/closed/wall/r_wall,
 /area/medical/treatment_center)
@@ -14642,16 +14504,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "gfi" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Lab";
-	req_access_txt = "8"
+/obj/item/target/alien/anchored,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/mixing)
+/turf/open/floor/plating/icemoon,
+/area/science/test_area)
 "gfw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14998,10 +14856,9 @@
 /area/maintenance/starboard/upper)
 "gmM" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "gmP" = (
@@ -15108,10 +14965,12 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "gpI" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/mixing/launch)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/openspace,
+/area/science/mixing)
 "gpU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -15214,27 +15073,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"gtm" = (
-/obj/structure/table/reinforced,
-/obj/item/assembly/timer{
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/item/assembly/timer{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/assembly/timer{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/assembly/timer{
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron,
-/area/science/mixing)
 "gtv" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/grimy,
@@ -15406,15 +15244,18 @@
 	},
 /area/security/office)
 "gzD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron,
-/area/science/storage)
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "gzQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -15444,15 +15285,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/commons/locker)
-"gAG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction{
-	dir = 2
-	},
-/turf/open/floor/iron,
-/area/science/mixing/hallway)
 "gAK" = (
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
@@ -15541,28 +15373,20 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "gCW" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Ordnance Launch Room Access";
-	network = list("ss13","rd")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 2;
+	sortType = 25
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
-/area/science/mixing/hallway)
+/area/science/mixing/launch)
 "gDf" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/structure/sign/warning/fire{
-	pixel_y = -32
-	},
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "gDk" = (
 /obj/docking_port/stationary/random/icemoon{
 	dir = 8;
@@ -15740,11 +15564,9 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "gHC" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_mixing_input{
-	dir = 1
-	},
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "gHJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15827,11 +15649,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/iron/dark/textured,
 /area/security/interrogation)
-"gJg" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/storage)
 "gJA" = (
 /obj/effect/gibspawner/human,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -15945,14 +15762,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/research)
-"gLh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "gLn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/smooth_large,
@@ -16065,9 +15874,18 @@
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "gNX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/obj/structure/table,
+/obj/item/holosign_creator/atmos{
+	pixel_x = -5
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/firealarm/directional/east,
+/obj/item/holosign_creator/atmos{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "gOc" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -16445,18 +16263,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
 "gVZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/machinery/light/directional/east,
+/turf/open/floor/glass/reinforced,
+/area/science/mixing/hallway)
 "gWp" = (
 /obj/machinery/computer/apc_control{
 	dir = 4
@@ -16547,10 +16356,6 @@
 	dir = 9
 	},
 /area/science/research)
-"gXV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "gYm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -16870,17 +16675,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "hfv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Ordnance Test Lab";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron,
-/area/science/mixing/hallway)
+/area/science/mixing/launch)
 "hfx" = (
 /obj/machinery/pdapainter/security,
 /turf/open/floor/wood/large,
@@ -16989,30 +16794,19 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "hgK" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Science Ordnance Launch";
-	network = list("ss13","rd")
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	dir = 8;
+	freq = 1400;
+	location = "Research Division"
 	},
-/obj/structure/table,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/item/computer_hardware/hard_drive/portable{
-	pixel_x = -5;
-	pixel_y = 8
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/computer_hardware/hard_drive/portable{
-	pixel_x = -2
-	},
-/obj/item/computer_hardware/hard_drive/portable{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/item/computer_hardware/hard_drive/portable{
-	pixel_x = -8;
-	pixel_y = -3
-	},
-/turf/open/floor/iron,
-/area/science/mixing/launch)
+/turf/open/floor/plating,
+/area/maintenance/starboard/upper)
 "hgS" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -17169,28 +16963,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"hmW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Research Break Room";
-	req_access_txt = "47"
-	},
-/turf/open/floor/iron/dark,
-/area/science/breakroom)
-"hna" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Research Division South"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/side{
-	dir = 9
-	},
-/area/science/research)
 "hnp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/stool/directional/east,
@@ -17348,12 +17120,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/treatment_center)
 "hqQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/science/mixing/hallway)
+/area/science/mixing/launch)
 "hqZ" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -17422,10 +17190,12 @@
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "hsh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "hsj" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -17475,13 +17245,7 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "hub" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/openspace,
 /area/maintenance/starboard/aft)
 "huw" = (
 /obj/machinery/firealarm/directional/south,
@@ -17511,10 +17275,11 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "hva" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured,
+/obj/machinery/atmospherics/components/binary/tank_compressor{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
 /area/science/mixing)
 "hvb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -17593,16 +17358,6 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hxE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "hxL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17717,12 +17472,11 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "hzW" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/firealarm/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "hAb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -17908,12 +17662,11 @@
 /turf/closed/wall,
 /area/engineering/atmos)
 "hFn" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/binary/tank_compressor{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "hFq" = (
 /obj/item/trash/pistachios,
 /turf/open/floor/plating,
@@ -18085,14 +17838,6 @@
 /obj/item/chair/wood,
 /turf/open/floor/carpet,
 /area/maintenance/space_hut/cabin)
-"hJZ" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd2";
-	name = "research lab shutters"
-	},
-/turf/open/floor/plating,
-/area/science/breakroom)
 "hKd" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2"
@@ -18725,15 +18470,13 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "iaj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/table,
+/obj/item/binoculars,
+/obj/machinery/computer/security/telescreen/ordnance{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/science/mixing/hallway)
+/area/science/mixing/launch)
 "iaE" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -18772,12 +18515,12 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "ibF" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	name = "port to mix"
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "icl" = (
 /obj/item/chair/wood,
 /obj/structure/sign/poster/contraband/random/directional/east,
@@ -19128,23 +18871,8 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "imb" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
-	},
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Launch Room Access";
-	req_access_txt = "8"
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/closed/wall/r_wall,
+/area/science/mixing/launch)
 "imm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -19185,7 +18913,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "inS" = (
-/obj/effect/spawner/random/vending/colavend,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/cafeteria{
 	dir = 8
 	},
@@ -19242,14 +18970,11 @@
 /turf/closed/wall,
 /area/commons/storage/mining)
 "iqv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/warning/fire{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/floor/glass/reinforced,
+/area/science/mixing/hallway)
 "iqA" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -19350,11 +19075,7 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
 "itB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
 "itD" = (
@@ -19587,25 +19308,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "izd" = (
-/obj/item/assembly/signaler{
-	pixel_y = 8
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/openspace,
+/area/science/mixing/hallway)
 "izk" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -19621,9 +19326,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "izq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "izL" = (
 /turf/closed/wall,
 /area/command/bridge)
@@ -19760,20 +19467,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "iCR" = (
-/obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_x = -8;
-	pixel_y = -24
-	},
-/obj/machinery/button/door/incinerator_vent_ordmix{
-	pixel_x = 8;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "iCX" = (
 /obj/structure/sink{
 	dir = 4;
@@ -19787,10 +19484,14 @@
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
 "iDg" = (
-/obj/structure/chair/stool/directional/south,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/upper)
 "iDm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20354,12 +20055,6 @@
 	dir = 9
 	},
 /area/science/research)
-"iSz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "iSQ" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -20367,18 +20062,6 @@
 /obj/item/clothing/under/pants/youngfolksjeans,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"iST" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
-"iTk" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "iTu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
@@ -20432,13 +20115,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"iUS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "iUT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -20668,18 +20344,10 @@
 	},
 /area/engineering/lobby)
 "iYY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/mixingchamber{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing/chamber)
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "iZj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21112,13 +20780,11 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "jiY" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/science/mixing/hallway)
+/area/science/mixing/launch)
 "jjc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -21570,11 +21236,8 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
 "jtU" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/storage)
+/turf/open/genturf,
+/area/icemoon/surface/outdoors/nospawn)
 "jue" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/west{
@@ -21832,20 +21495,17 @@
 /turf/open/floor/wood,
 /area/service/library)
 "jBV" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Launch Room";
+	req_access_txt = "8"
 	},
-/obj/structure/chair/comfy{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/mixing/hallway)
+/turf/open/floor/plating,
+/area/science/mixing/launch)
 "jBY" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -22189,11 +21849,8 @@
 /turf/open/floor/carpet,
 /area/cargo/qm)
 "jJE" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/structure/tank_dispenser,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/floor/glass/reinforced,
+/area/science/mixing/hallway)
 "jJP" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/stripes/line{
@@ -22216,13 +21873,24 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/processing)
 "jKu" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/door/window/right/directional/east{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Research Division Delivery";
+	req_access_txt = "47"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "jKR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22269,12 +21937,8 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "jMz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/side{
-	dir = 10
+/turf/open/floor/iron/cafeteria{
+	dir = 8
 	},
 /area/science/research)
 "jMH" = (
@@ -23041,15 +22705,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
-"kfg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "kfs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 9
@@ -23236,9 +22891,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/engineering/atmos/storage/gas)
 "klw" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/science/mixing/launch)
+/obj/structure/chair/office/light,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "klM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -23636,15 +23291,6 @@
 /mob/living/simple_animal/sloth/paperwork,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"kxt" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/science/research)
 "kxw" = (
 /obj/structure/bed,
 /obj/machinery/airalarm/directional/north,
@@ -23838,15 +23484,9 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "kCs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/starboard/upper)
 "kCu" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/blue,
@@ -24292,9 +23932,14 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/ai_monitored/turret_protected/aisat/maint)
 "kMd" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/mixing/launch)
 "kMf" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -24312,10 +23957,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kMq" = (
-/obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
@@ -24812,19 +24456,18 @@
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "lag" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/research/glass{
+	name = "Research Break Room";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Launch Room";
-	req_access_txt = "8"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/mixing/launch)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/science/breakroom)
 "lah" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -25124,11 +24767,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"lkw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "lla" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -25228,8 +24866,10 @@
 /turf/open/floor/wood,
 /area/command/meeting_room)
 "loi" = (
-/turf/closed/wall,
-/area/science/storage)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "loD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/barsign,
@@ -25338,23 +24978,17 @@
 /turf/open/floor/plating,
 /area/commons/storage/emergency/port)
 "lrw" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/disposalpipe/junction{
+	dir = 2
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/item/cigbutt{
-	pixel_x = -7;
-	pixel_y = 12
-	},
-/obj/item/food/candy_trash,
-/turf/open/floor/iron,
-/area/science/mixing/hallway)
+/turf/open/floor/plating,
+/area/maintenance/starboard/upper)
 "lry" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/filingcabinet/filingcabinet,
@@ -25771,8 +25405,9 @@
 	id = "rnd2";
 	name = "research lab shutters"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "lCi" = (
 /obj/docking_port/stationary/public_mining_dock{
 	dir = 8
@@ -25869,14 +25504,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
 "lFt" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/table,
+/obj/item/computer_hardware/hard_drive/portable{
+	pixel_x = 7;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/item/computer_hardware/hard_drive/portable{
+	pixel_x = -2
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "lFx" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/reinforced,
@@ -26101,14 +25738,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"lLs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/west,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron,
-/area/science/mixing/launch)
 "lLx" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/closet/crate,
@@ -26273,15 +25902,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/cargo/office)
-"lRm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "lRr" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
@@ -26806,9 +26426,17 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/upper)
 "mho" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "mhF" = (
 /turf/open/floor/iron/icemoon{
 	icon_state = "damaged5"
@@ -26840,19 +26468,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/pumproom)
-"miE" = (
-/obj/machinery/door/airlock/research{
-	name = "Gas Storage";
-	req_access_txt = "71"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/storage)
 "miP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
@@ -27148,13 +26763,6 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"mpU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/science/mixing)
 "mpV" = (
 /turf/open/floor/iron,
 /area/cargo/lobby)
@@ -27176,11 +26784,12 @@
 /turf/open/floor/iron/checker,
 /area/science/lab)
 "mqf" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "mqG" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Research Division North";
@@ -27713,24 +27322,10 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "mHw" = (
-/obj/item/transfer_valve{
-	pixel_x = -5
+/turf/open/floor/iron/cafeteria{
+	dir = 8
 	},
-/obj/item/transfer_valve{
-	pixel_x = -5
-	},
-/obj/item/transfer_valve,
-/obj/item/transfer_valve,
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "mHx" = (
 /obj/machinery/door/airlock{
 	name = "Garden"
@@ -27976,13 +27571,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "mOb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/turf/open/openspace,
 /area/science/mixing)
 "mOf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28784,23 +28377,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/commons/vacant_room/office)
-"njW" = (
-/obj/structure/table/reinforced,
-/obj/item/wrench,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/analyzer,
-/obj/item/pipe_dispenser,
-/obj/machinery/light/directional/south,
-/obj/machinery/requests_console/directional/south{
-	department = "Ordnance Lab";
-	departmentType = 2;
-	name = "Ordnance Lab Requests Console";
-	receive_ore_updates = 1
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "nka" = (
 /turf/open/openspace,
 /area/science/xenobiology)
@@ -29039,16 +28615,9 @@
 /turf/open/floor/wood,
 /area/service/library)
 "nqP" = (
-/obj/machinery/airlock_sensor/incinerator_ordmix{
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/components/binary/pump,
-/obj/structure/sign/warning/fire{
-	pixel_y = -32
-	},
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "nrA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29113,11 +28682,6 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"nsu" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/starboard/upper)
 "nsx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -29148,13 +28712,8 @@
 /turf/open/openspace,
 /area/cargo/storage)
 "nta" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/science/mixing)
+/turf/open/floor/plating,
+/area/science/mixing/launch)
 "ntc" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input{
 	dir = 8
@@ -29385,15 +28944,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nzC" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater,
-/obj/structure/sign/poster/official/science{
-	pixel_y = 32
+/obj/machinery/camera/directional/south{
+	c_tag = "Research Break Room";
+	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/structure/sign/poster/official/random/directional/south,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "nzF" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -29419,14 +28977,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nzZ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/item/kirbyplants/random,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "nAb" = (
 /obj/structure/sign/warning/coldtemp,
 /turf/closed/wall,
@@ -29517,14 +29071,10 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "nBq" = (
-/obj/structure/closet/bombcloset,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/east,
-/obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "nBv" = (
 /obj/machinery/light/directional/east,
 /turf/open/openspace,
@@ -29534,12 +29084,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"nCo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/science/storage)
 "nCr" = (
 /obj/item/stack/cable_coil{
 	amount = 5
@@ -29792,13 +29336,13 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "nJt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nJS" = (
@@ -29866,12 +29410,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
-"nMM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "nMN" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/brown{
@@ -30214,12 +29752,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"nTe" = (
-/obj/machinery/mass_driver/ordnance{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/science/mixing/launch)
 "nTp" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
@@ -30477,16 +30009,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"nYG" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
 "nYH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30650,11 +30172,6 @@
 /obj/machinery/atmospherics/components/tank/plasma,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"ocU" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/science/mixing/hallway)
 "odg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30665,11 +30182,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"odq" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/beer,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "ods" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
@@ -30932,7 +30444,6 @@
 /area/security/brig/upper)
 "oka" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
@@ -30970,24 +30481,6 @@
 /obj/effect/decal/cleanable/food/pie_smudge,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"okN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/comfy{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/mixing/hallway)
 "ola" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -31150,16 +30643,6 @@
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"opQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "opU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31224,15 +30707,22 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "orZ" = (
-/obj/machinery/camera/autoname/directional/south{
-	c_tag = "Gas Storage";
-	network = list("ss13","rd")
+/obj/structure/table,
+/obj/item/transfer_valve{
+	pixel_x = -5
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "osc" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
@@ -31297,13 +30787,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"ouM" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/white/side{
-	dir = 9
-	},
-/area/science/research)
 "ovm" = (
 /obj/machinery/camera/motion/directional/west{
 	c_tag = "MiniSat Core Hallway";
@@ -31484,16 +30967,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/commons/locker)
-"ozO" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/white/side{
-	dir = 9
-	},
-/area/science/research)
 "ozZ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -31604,15 +31077,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"oCz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/science/mixing/launch)
 "oCF" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -32432,9 +31896,6 @@
 /area/maintenance/starboard/upper)
 "oVG" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
@@ -32654,9 +32115,12 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "pdq" = (
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "pdr" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
@@ -33754,15 +33218,8 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/medical/central)
 "pCU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/openspace,
+/area/science/mixing/hallway)
 "pCV" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -33826,9 +33283,19 @@
 /turf/open/floor/plating,
 /area/commons/storage/emergency/port)
 "pEL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "pFL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -34124,22 +33591,13 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/white/textured,
 /area/security/medical)
-"pMp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/upper)
 "pMA" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "pMZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/gasmask{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/science/mixing/launch)
 "pNi" = (
 /obj/structure/cable,
@@ -34320,21 +33778,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/ai_monitored/security/armory/upper)
 "pRo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/structure/lattice/catwalk,
+/turf/open/openspace,
 /area/science/mixing)
-"pRt" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/science/storage)
 "pRG" = (
 /obj/structure/flora/rock/pile/icy,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -34596,10 +34045,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"pYw" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "pYI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 4
@@ -35835,15 +35280,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"qEr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "qEs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36042,11 +35478,9 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "qKZ" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
+/obj/machinery/research/anomaly_refinery,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "qLA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -36293,15 +35727,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/service/library)
-"qTI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron,
-/area/science/storage)
 "qTN" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/plating,
@@ -36711,14 +36136,9 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "rhJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 25
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
-/area/science/mixing/hallway)
+/area/science/mixing/launch)
 "rhU" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -37096,15 +36516,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"rpC" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "rpH" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/three,
@@ -37282,13 +36693,9 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "ruo" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "rup" = (
 /turf/closed/wall/r_wall,
 /area/command/bridge)
@@ -37421,11 +36828,12 @@
 /turf/open/floor/iron,
 /area/medical/pharmacy)
 "rvI" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/delivery,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/red,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "rwo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -37674,14 +37082,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
-"rDJ" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "rDU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -37829,36 +37229,12 @@
 /turf/open/floor/plating,
 /area/maintenance/central/greater)
 "rGT" = (
-/obj/structure/table/reinforced,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -4;
-	pixel_y = 3
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/cafeteria{
+	dir = 8
 	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = 9;
-	pixel_y = -4
-	},
-/obj/item/raw_anomaly_core/random{
-	pixel_y = 11
-	},
-/obj/item/raw_anomaly_core/random{
-	pixel_y = -2
-	},
-/obj/machinery/light/directional/south,
-/obj/structure/noticeboard/directional/south,
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "rHa" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
@@ -38206,14 +37582,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
-"rPH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron/white/side{
-	dir = 9
-	},
-/area/science/research)
 "rPZ" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -38581,11 +37949,13 @@
 /turf/open/floor/iron/white/textured,
 /area/security/medical)
 "rXL" = (
-/obj/machinery/research/anomaly_refinery,
-/obj/effect/turf_decal/bot,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
-/area/science/mixing/launch)
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd2";
+	name = "research lab shutters"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/science/research)
 "rXR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39265,11 +38635,25 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "snK" = (
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
+/obj/structure/table,
+/obj/item/assembly/signaler{
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "snW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39374,25 +38758,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"sql" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/science/mixing)
 "sqx" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/hos)
 "sqJ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "sqN" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -40068,16 +39442,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
-"sGO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "sGU" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -40354,11 +39718,6 @@
 /obj/item/clothing/gloves/boxing,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"sOs" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "sOE" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
@@ -40388,8 +39747,8 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/fore)
 "sPg" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/machinery/newscaster/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria{
 	dir = 8
 	},
@@ -40570,13 +39929,12 @@
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "sVl" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/science/storage)
+/area/science/mixing/launch)
 "sWi" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer";
@@ -40642,14 +40000,6 @@
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
-"sXN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/south,
-/obj/machinery/computer/atmos_control/nocontrol/ordnancemix{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "sXR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40929,15 +40279,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "tfw" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
-	pixel_x = 24
+/obj/structure/table,
+/obj/item/pipe_dispenser{
+	pixel_x = 3;
+	pixel_y = 7
 	},
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
-	name = "Burn Chamber Interior Airlock"
-	},
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/item/pipe_dispenser,
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "tfN" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Xenobiology Pens Observation - Port Aft";
@@ -41173,12 +40522,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"tlp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/science/breakroom)
 "tlE" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -41221,10 +40564,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"tmu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/mixing)
 "tmD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41450,22 +40789,8 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "ttk" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/window/right/directional/east{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
-	name = "Research Division Delivery";
-	req_access_txt = "47"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron/dark/smooth_half,
 /area/science/breakroom)
 "tto" = (
@@ -41540,11 +40865,11 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "tuH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/openspace,
 /area/science/mixing)
 "tuI" = (
 /obj/structure/disposalpipe/segment{
@@ -41902,9 +41227,11 @@
 /turf/open/floor/wood,
 /area/command/meeting_room)
 "tCt" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "tCL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -41938,12 +41265,8 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/aft/greater)
 "tEi" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
+/turf/open/openspace,
+/area/science/mixing)
 "tEn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -42075,16 +41398,6 @@
 "tHa" = (
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"tHc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/storage)
 "tHe" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -42101,18 +41414,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"tHl" = (
-/obj/machinery/door/window/left/directional/south{
-	name = "Mass Driver Door";
-	req_access_txt = "8"
-	},
-/obj/effect/turf_decal/loading_area,
-/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
-	pixel_x = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/mixing/launch)
 "tHq" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -42183,10 +41484,18 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "tIN" = (
-/obj/structure/closet/bombcloset,
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "tIQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -42195,16 +41504,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tIZ" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/openspace,
 /area/science/mixing)
 "tJa" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -42380,9 +41684,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tOe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab";
+	req_access_txt = "8"
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "tOu" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -42466,12 +41776,15 @@
 /turf/closed/wall,
 /area/engineering/atmos/project)
 "tQx" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured,
-/area/science/mixing)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/starboard/upper)
 "tQC" = (
 /turf/open/floor/iron/textured_half,
 /area/service/hydroponics)
@@ -42727,11 +42040,9 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "tXP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/science/storage)
+/obj/structure/tank_dispenser,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "tYc" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
@@ -42815,14 +42126,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
 "tZf" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/camera/directional/north{
-	c_tag = "Ordnance Lab North";
-	network = list("ss13","rd")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "tZn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42903,12 +42209,14 @@
 	},
 /area/medical/medbay/central)
 "uaT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/coldtemp{
-	pixel_x = -32
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "uaZ" = (
 /turf/closed/wall,
 /area/security/lockers)
@@ -42925,11 +42233,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "ubI" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	name = "mix to port"
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "ubX" = (
 /obj/structure/chair,
 /obj/item/radio/intercom/directional/north,
@@ -43019,13 +42325,6 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
-"uej" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "ueK" = (
 /obj/structure/window/reinforced/fulltile/ice{
 	name = "frozen window"
@@ -43116,15 +42415,6 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"uhi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "uhx" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/fore/greater)
@@ -43260,16 +42550,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "ujX" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "8;12"
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard/upper)
 "ukf" = (
@@ -43396,11 +42683,8 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "umY" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/misc/asteroid/snow/standard_air,
+/area/science/research)
 "unj" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Public Mining Storage";
@@ -43445,13 +42729,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central/greater)
-"uoe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/gasmask{
-	pixel_x = 32
-	},
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
 "uoh" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/landmark/start/assistant,
@@ -43539,15 +42816,14 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/port/aft)
 "upA" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "upC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -43702,7 +42978,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
 "uuz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/light/small/directional/north,
@@ -43739,11 +43014,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"uvi" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/dark,
-/area/science/breakroom)
 "uvo" = (
 /obj/machinery/computer/rdconsole,
 /obj/effect/turf_decal/tile/green{
@@ -44574,12 +43844,12 @@
 /area/engineering/atmos)
 "uNd" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/meter/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/science/mixing/launch)
 "uNm" = (
 /obj/structure/table,
 /obj/item/folder/blue,
@@ -44673,12 +43943,25 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "uPh" = (
-/obj/machinery/light/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
+/obj/structure/table,
+/obj/item/assembly/prox_sensor{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "uPG" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -44926,10 +44209,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uWl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -45195,13 +44474,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
-"vdT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/storage)
 "vex" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -45235,15 +44507,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/textured_large,
 /area/maintenance/department/medical/central)
-"vgu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/sign/warning/coldtemp{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/science/mixing/launch)
 "vgD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -45265,12 +44528,11 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "vhT" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior{
-	name = "Burn Chamber Exterior Airlock"
+/obj/machinery/portable_atmospherics/pump{
+	name = "Lil Pump"
 	},
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "vhX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45480,14 +44742,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vnb" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron,
-/area/science/storage)
 "vnc" = (
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -45564,11 +44818,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/lesser)
 "vqr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
 "vqt" = (
@@ -45637,15 +44887,9 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "vrD" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Ordnance Lab Burn Chamber";
-	network = list("ss13","rd")
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/modular_computer/console/preset/civilian,
+/turf/open/floor/iron/dark,
+/area/science/mixing/hallway)
 "vrW" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -45679,10 +44923,9 @@
 /turf/closed/wall/r_wall,
 /area/security/holding_cell)
 "vui" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/iron/dark,
+/area/science/breakroom)
 "vvt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -46065,13 +45308,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"vFr" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "vFB" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet,
@@ -46526,9 +45762,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"vOU" = (
-/turf/closed/wall,
-/area/science/mixing/launch)
 "vOZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -46753,21 +45986,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"vUl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/research{
-	name = "Gas Storage";
-	req_access_txt = "71"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/storage)
 "vUy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -47235,8 +46453,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "wiI" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/machinery/vending/cigarette,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
 "wiL" = (
@@ -47438,12 +46659,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/command/gateway)
-"wnu" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/dark/textured_large,
-/area/science/storage)
 "wnP" = (
 /obj/machinery/door/window/brigdoor{
 	name = "Research Director Observation";
@@ -47615,13 +46830,20 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wrl" = (
-/obj/machinery/doppler_array{
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/science/mixing/launch)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "wrt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -47630,9 +46852,11 @@
 /turf/open/floor/iron/smooth_edge,
 /area/security/lockers)
 "wrW" = (
-/obj/machinery/vending/assist,
+/obj/machinery/doppler_array{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/science/mixing/hallway)
+/area/science/mixing/launch)
 "wsf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -47745,12 +46969,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "wuy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
 "wuD" = (
@@ -48529,12 +47750,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "wQu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/storage)
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "wQy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/bed/roller,
@@ -48944,7 +48168,6 @@
 /obj/structure/table,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/spawner/random/trash/food_packaging,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
 "xbo" = (
@@ -49122,15 +48345,14 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "xfD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Break Room";
 	req_access_txt = "47"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
 "xfG" = (
@@ -49167,9 +48389,23 @@
 	},
 /area/maintenance/starboard/fore)
 "xgw" = (
-/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/mixing/hallway)
 "xgy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -49472,14 +48708,15 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "xnF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/camera/directional/south{
+	c_tag = "Ordnance Upper Mix Lab";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/dark,
 /area/science/mixing)
 "xnJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -50139,12 +49376,7 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "xEi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/science/breakroom)
 "xEp" = (
@@ -50577,8 +49809,11 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "xPi" = (
-/turf/open/openspace/icemoon,
-/area/science/mixing/chamber)
+/obj/structure/sign/warning/fire{
+	pixel_y = -32
+	},
+/turf/open/floor/glass/reinforced,
+/area/science/mixing/hallway)
 "xPm" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -50960,9 +50195,10 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "ycR" = (
-/obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
-/obj/machinery/light/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Research Division South"
+	},
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
@@ -51060,14 +50296,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ygf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/directional/east,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron/white/side{
-	dir = 8
+	dir = 10
 	},
 /area/science/research)
 "ygn" = (
@@ -97742,17 +96976,17 @@ bBD
 bBD
 oka
 bBD
+fPJ
+bta
 bta
 iSw
-bta
-bta
 jxH
 ycR
 fPJ
-ouM
-hna
-ozO
-kxt
+bta
+bta
+bta
+bta
 oVG
 iiD
 dUo
@@ -97996,24 +97230,24 @@ cdA
 bgc
 bgc
 jiO
+rXL
+jiO
 jiO
 bvx
-fFz
-rPH
 ygf
 jMz
 sPg
 inS
 bvx
-cas
-cas
-cas
-cas
-miE
-cas
-cas
-cas
-cas
+bvx
+bvx
+bvx
+bvx
+bvx
+bvx
+bvx
+bvx
+bvx
 bQZ
 uOi
 oWy
@@ -98254,23 +97488,23 @@ quU
 bgc
 bYp
 vTY
-bEC
-bEC
+umY
+umY
+bvx
+vlY
 lBY
-gfi
+eVu
 lBY
-bEC
-bEC
-bEC
+vlY
 cas
-wnu
-hzW
-tHc
-gaV
-vnb
+tEi
+tEi
+tEi
+tEi
+tIZ
 dvF
 snK
-cas
+bEC
 bXh
 bYj
 uQt
@@ -98511,23 +97745,23 @@ xyr
 bgc
 hZm
 iOs
-bEC
+dER
 umY
-uej
+bvx
 cGb
 cll
 aVs
 mHw
 rGT
-loi
-wnu
-dzl
-vdT
-wQu
-gJg
-dmE
-orZ
 cas
+tEi
+tEi
+tEi
+tEi
+tIZ
+klw
+orZ
+bEC
 kbL
 bYj
 bYm
@@ -98765,26 +97999,26 @@ ekK
 oaV
 vfH
 vQl
-xnR
-hJZ
-hJZ
-bEC
-tIN
-bFU
-uhi
-izq
+bgc
+jiO
+jiO
+jiO
+jiO
+bvx
+mHw
+mHw
 fTI
-iDg
+fTI
 dEh
-loi
-nYG
-wnu
-eQR
-gci
-gJg
+gpI
+tEi
+tEi
+tEi
+tEi
+tIZ
 dmE
 uPh
-cas
+bEC
 duP
 bYj
 bYm
@@ -99025,23 +98259,23 @@ fJg
 xfD
 wuy
 cLo
-bEC
+tCt
 nzZ
-eeA
-dET
-lkw
-eVu
-tmu
+xnR
+pCU
+pCU
+pCU
+pCU
 izd
-loi
-iST
-dwi
-nCo
-emf
-pRt
+tEi
+tEi
+tEi
+tEi
+tEi
+tIZ
 tXP
 qKZ
-cas
+bEC
 wxp
 bcD
 bYm
@@ -99281,24 +98515,24 @@ spl
 uEf
 uXG
 vqr
-uvi
-bEC
+wiI
+tKu
 ruo
-dFZ
-gLh
-izq
-fTI
-bCX
-gtm
-loi
-fvo
+xnR
+pCU
+pCU
+pCU
+pCU
+izd
 tEi
-qTI
-gzD
-sVl
-jtU
+tEi
+tEi
+tEi
+tEi
+tIZ
+cnT
 rvI
-cas
+bEC
 joY
 hdm
 pwU
@@ -99539,23 +98773,23 @@ cdC
 xnR
 xEi
 wiI
-bEC
+tKu
 tZf
-mqf
-lRm
-vui
-gXV
-fAi
-njW
+xnR
+pCU
+pCU
+pCU
+pCU
+izd
+tEi
+tEi
+tEi
+tEi
+tEi
+tIZ
 loi
-loi
-loi
-loi
-vUl
-loi
-loi
-loi
-cas
+xnF
+bEC
 vZH
 bvX
 wWz
@@ -99794,25 +99028,25 @@ qcB
 bon
 bon
 xnR
-hmW
+xnR
+lag
 kEH
-bEC
-dER
-sql
-qEr
-iSz
+xnR
+xnR
 pCU
-xnF
-kfg
-sGO
-opQ
-nta
-hxE
-kCs
+pCU
+pCU
+pCU
+izd
+tEi
+tEi
+tEi
+tEi
+tEi
 tIZ
-tQx
+cnT
 hva
-bQZ
+bEC
 bGk
 bQZ
 bYi
@@ -100052,24 +99286,24 @@ drV
 bon
 uuz
 itB
-ffg
-bEC
+wiI
+tCt
 nzC
-rpC
-upA
-bFU
-iTk
-nMM
-iUS
+xnR
+pCU
+pCU
+pCU
+pCU
+izd
 mOb
 tuH
-vFr
-tmu
+tuH
 pRo
-cnT
+pRo
+bPP
 cnT
 ezW
-bQZ
+bEC
 txm
 bQZ
 bTl
@@ -100308,25 +99542,25 @@ xLp
 dPc
 qcB
 bDW
-tlp
-bXy
-bEC
+vqr
+wiI
+nBq
 sqJ
 ejr
 upA
-sXN
-bEs
-ert
+upA
+wQu
+upA
 ert
 xgw
-dGF
 pEL
+pEL
+pEL
+pEL
+wrl
 dGF
-dGF
-dGF
-dGF
-dGF
-bQZ
+tIN
+vlY
 rvA
 bQZ
 bTl
@@ -100567,23 +99801,23 @@ qcB
 mAy
 jaK
 uWl
-bEC
+tKu
 czO
-mpU
-upA
-rDJ
+xnR
+jJE
+jJE
 bEs
 lFt
 ubI
 iCR
 mho
 gDf
-mho
+cZL
 cZL
 uaT
-bMu
-xPi
-bQZ
+jJE
+jJE
+vlY
 iHF
 mzr
 bTl
@@ -100591,7 +99825,7 @@ bLN
 bTl
 xhj
 mtK
-pdq
+cOe
 cOe
 cOe
 cNW
@@ -100824,9 +100058,9 @@ bon
 lZT
 tKu
 kMq
-bEC
+vui
 hFn
-kMd
+xnR
 iqv
 jJE
 bEs
@@ -100836,11 +100070,11 @@ hsh
 tfw
 bbg
 vhT
-eBV
-fXx
-bMu
+vhT
+uaT
+jJE
 xPi
-bQZ
+vlY
 iHF
 bZc
 bTl
@@ -101081,23 +100315,23 @@ bon
 qwu
 xaY
 ttk
-bEC
+pdq
 jKu
-kMd
+xnR
 gVZ
-nBq
-bEs
+jJE
+gzD
 cjK
 ibF
 iYY
 gNX
 nqP
-gNX
 gHC
-uoe
-bMu
-xPi
-bQZ
+gHC
+uaT
+jJE
+gVZ
+vlY
 bTl
 qcs
 bTl
@@ -101337,21 +100571,21 @@ mGQ
 fym
 wAz
 wAz
-bId
+wAz
+wAz
+hgK
 fym
-vlY
-vlY
 imb
-vlY
-vlY
+imb
+fAi
+imb
+imb
+mtK
 mtK
 mtK
 mtK
 mtK
 tOe
-mtK
-mtK
-mtK
 mtK
 mtK
 mtK
@@ -101594,16 +100828,16 @@ tKv
 fym
 sCI
 rTJ
-pMp
-fym
+dXU
+iDg
 lrw
 jBV
 hfv
 egQ
 gCW
-cNW
-bMB
-bNA
+uNd
+sVl
+jBV
 nJt
 gmM
 nXU
@@ -101851,23 +101085,23 @@ fym
 fym
 wxC
 tYh
-pMp
+dXU
+tQx
+abJ
 fym
-okN
-hqQ
 rhJ
 hqQ
-gAG
+hqQ
 bDf
-uNd
-nXU
+imb
+mtK
 hub
+hzW
 cOe
 cOe
 cOe
 cOe
 cOe
-cOe
 cNW
 cNW
 cNW
@@ -101877,7 +101111,7 @@ cNW
 cNW
 cNW
 cNW
-cOe
+dFZ
 cNW
 cNW
 cNW
@@ -102111,15 +101345,15 @@ knQ
 aMI
 ujX
 abJ
-ocU
+fym
 iaj
 jiY
 wrW
-cNW
+kMd
 cgu
-cOe
-cOe
-cOe
+mtK
+hub
+mqf
 cOe
 rly
 tkC
@@ -102365,17 +101599,17 @@ rTJ
 jyv
 dXU
 ijD
-nsu
+dXU
+kCs
 wAz
-ccp
-ccp
-lag
-ccp
-ccp
+fym
+nSy
+nSy
+nSy
+imb
+nta
+mtK
 cNW
-cNW
-cNW
-sOs
 cNW
 cNW
 cNW
@@ -102625,16 +101859,16 @@ wAz
 eRG
 wAz
 wAz
-rXL
-cMf
-lLs
-tHl
-nTe
-cNW
-bNC
-cOe
-pYw
-cNW
+jnk
+jnk
+jnk
+jnk
+imb
+nta
+mtK
+jnk
+jnk
+jnk
 jnk
 jnk
 jnk
@@ -102882,16 +102116,16 @@ tKG
 mhg
 cqQ
 wAz
-hgK
-atS
-gpI
-klw
+jnk
+jnk
+jnk
+jnk
 pMZ
-cNW
-rly
-tCt
-bPP
-cNW
+hIj
+mtK
+jnk
+jnk
+jnk
 jnk
 jnk
 jnk
@@ -103139,16 +102373,16 @@ rHa
 rHa
 fIh
 wAz
-wrl
-cUD
-oCz
-klw
-vgu
-cNW
-odq
-cdV
-eJm
-cNW
+jnk
+jnk
+jnk
+jnk
+jnk
+jnk
+jnk
+jnk
+jnk
+jnk
 jnk
 jnk
 jnk
@@ -103396,16 +102630,16 @@ fiO
 szB
 xVt
 wAz
-nSy
-nSy
-nSy
-vOU
-hIj
-cNW
-cOT
-cOT
-cOT
-cNW
+jnk
+jnk
+jnk
+jnk
+jnk
+jnk
+jnk
+jnk
+jnk
+jnk
 jnk
 jnk
 jnk
@@ -103656,9 +102890,9 @@ wAz
 jnk
 jnk
 jnk
-dKt
-cwi
-dKt
+jnk
+jnk
+jnk
 jnk
 jnk
 jnk
@@ -104687,7 +103921,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -104944,7 +104178,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -105201,7 +104435,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -105458,7 +104692,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -105715,7 +104949,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -105972,7 +105206,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -106229,7 +105463,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -106486,7 +105720,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -106743,7 +105977,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -107000,7 +106234,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -107257,7 +106491,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -107514,7 +106748,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -107771,7 +107005,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -108028,7 +107262,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -108285,7 +107519,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -108542,7 +107776,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -108799,7 +108033,7 @@ jnk
 jnk
 jnk
 jnk
-gQb
+jnk
 gQb
 gQb
 gQb
@@ -109053,11 +108287,11 @@ jnk
 jnk
 jnk
 jnk
-rdV
 jnk
 rdV
 jnk
-gQb
+rdV
+jnk
 gQb
 gQb
 gQb
@@ -109310,12 +108544,12 @@ jnk
 jnk
 jnk
 jnk
+jnk
 bgx
 boq
 bgx
 jnk
 jnk
-gQb
 gQb
 gQb
 gQb
@@ -109566,6 +108800,7 @@ jnk
 jnk
 jnk
 jnk
+jnk
 bIX
 bgx
 bsF
@@ -109573,7 +108808,6 @@ bgx
 bIX
 jnk
 jnk
-gQb
 gQb
 gQb
 gQb
@@ -109822,6 +109056,7 @@ jnk
 jnk
 jnk
 jnk
+jnk
 bgx
 bgx
 bjJ
@@ -109831,7 +109066,6 @@ bgx
 bgx
 jnk
 jnk
-gQb
 gQb
 gQb
 gQb
@@ -110076,6 +109310,7 @@ gQb
 gQb
 gQb
 gQb
+gQb
 jnk
 jnk
 bGe
@@ -110088,7 +109323,6 @@ bum
 bGe
 bGe
 jnk
-gQb
 gQb
 gQb
 gQb
@@ -110333,6 +109567,7 @@ gQb
 gQb
 gQb
 gQb
+gQb
 jnk
 jnk
 bgx
@@ -110345,8 +109580,7 @@ bun
 bOJ
 bgx
 jnk
-jnk
-jnk
+jtU
 gQb
 gQb
 gQb
@@ -110592,6 +109826,7 @@ gQb
 gQb
 gQb
 jnk
+jnk
 bGe
 bGe
 bjI
@@ -110602,7 +109837,6 @@ buq
 bGe
 bGe
 jnk
-gQb
 gQb
 gQb
 gQb
@@ -110848,18 +110082,18 @@ gQb
 gQb
 gQb
 gQb
+gQb
 jnk
 jnk
 bgx
 bgx
-bne
 bps
+gfi
 btY
 bgx
 bgx
 jnk
 jnk
-gQb
 gQb
 gQb
 gQb
@@ -111106,6 +110340,7 @@ gQb
 gQb
 gQb
 gQb
+gQb
 jnk
 jnk
 bIX
@@ -111115,7 +110350,6 @@ bgx
 bIX
 jnk
 jnk
-gQb
 gQb
 gQb
 gQb
@@ -111364,6 +110598,7 @@ gQb
 gQb
 gQb
 gQb
+gQb
 jnk
 jnk
 bgx
@@ -111371,7 +110606,6 @@ bGe
 bgx
 jnk
 jnk
-gQb
 gQb
 gQb
 gQb
@@ -111622,12 +110856,12 @@ gQb
 gQb
 gQb
 gQb
-jnk
-jnk
-jnk
-jnk
-jnk
 gQb
+jnk
+jnk
+jnk
+jnk
+jnk
 gQb
 gQb
 gQb
@@ -111880,10 +111114,10 @@ gQb
 gQb
 gQb
 gQb
-jnk
-jnk
-jnk
 gQb
+jnk
+jnk
+jnk
 gQb
 gQb
 gQb
@@ -112138,7 +111372,7 @@ gQb
 gQb
 gQb
 gQb
-jnk
+gQb
 gQb
 gQb
 gQb
@@ -112395,7 +111629,7 @@ gQb
 gQb
 gQb
 gQb
-jnk
+jtU
 gQb
 gQb
 gQb

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -27,6 +27,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"ae" = (
+/obj/structure/stairs/west,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "af" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/clown,
@@ -112,6 +116,10 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/drone_bay)
+"ao" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "ap" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
@@ -225,6 +233,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"aG" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/science/mixing)
 "aH" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/status_display/evac/directional/east,
@@ -317,6 +334,11 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/plating,
 /area/service/hydroponics)
+"aS" = (
+/obj/structure/stairs/east,
+/obj/structure/stairs/east,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "aT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -364,6 +386,16 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/mine/living_quarters)
+"bb" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	chamber_id = "ordnancegas2";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "bc" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/blue/corner,
@@ -624,6 +656,13 @@
 "bP" = (
 /turf/open/floor/iron,
 /area/mine/production)
+"bQ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "bR" = (
 /obj/structure/stairs/east,
 /turf/open/floor/plating,
@@ -844,6 +883,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
+"cx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/science/mixing)
 "cy" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/cargo)
@@ -898,6 +941,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"cG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "cH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -1007,6 +1056,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"cY" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	chamber_id = "ordnancegas1"
+	},
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1135,6 +1190,15 @@
 "dq" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/work)
+"dr" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "ds" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -1176,6 +1240,13 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/wood/tile,
 /area/service/theater)
+"dz" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/science/mixing)
 "dA" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -1347,6 +1418,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"dZ" = (
+/obj/machinery/atmospherics/components/tank,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "ea" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -1933,6 +2008,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"fz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "fA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -2097,6 +2179,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/red,
 /area/security/prison/work)
+"fZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/open/floor/iron,
+/area/science/mixing)
 "ga" = (
 /turf/closed/wall,
 /area/security/execution/education)
@@ -2430,6 +2516,10 @@
 	dir = 8
 	},
 /area/mine/eva)
+"gS" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "gT" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck{
@@ -2490,6 +2580,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
+"ha" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/science/mixing)
 "hb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -2592,6 +2687,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"ho" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 8
+	},
+/obj/machinery/air_sensor{
+	chamber_id = "ordnancegas2"
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "hp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -2667,6 +2771,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"hz" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "hA" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -2701,6 +2811,14 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"hD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/research/glass{
+	name = "Ordnance Lab"
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing/chamber)
 "hE" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/paper/fluff/jobs/prisoner/letter{
@@ -3456,6 +3574,12 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/cargo/warehouse)
+"ju" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "jv" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -3869,6 +3993,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"kG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "kH" = (
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plating,
@@ -4066,6 +4196,10 @@
 /obj/item/clothing/under/rank/civilian/lawyer/black/skirt,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
+"lj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "lk" = (
 /obj/machinery/flasher/directional/north{
 	id = "visitorflash"
@@ -4191,6 +4325,15 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/mine/eva)
+"ly" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "lA" = (
 /obj/structure/closet/decay,
 /turf/open/floor/plating,
@@ -4278,6 +4421,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"lO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/science/mixing)
 "lP" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
@@ -4475,6 +4623,15 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"mx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "my" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
@@ -4508,6 +4665,11 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"mD" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "mE" = (
 /obj/structure/stairs/west,
 /obj/effect/turf_decal/siding/white{
@@ -4518,6 +4680,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"mF" = (
+/obj/effect/spawner/random/trash,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "mG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4993,6 +5159,16 @@
 /obj/machinery/plate_press,
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/prison/work)
+"nR" = (
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
+	name = "Burn Chamber Interior Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
+	pixel_x = 24
+	},
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "nS" = (
 /obj/structure/closet/crate/secure/freezer/pizza,
 /obj/effect/decal/cleanable/dirt,
@@ -5424,6 +5600,14 @@
 "oZ" = (
 /turf/closed/wall,
 /area/maintenance/port/greater)
+"pa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
+	},
+/obj/machinery/meter,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/science/mixing)
 "pb" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -5567,6 +5751,14 @@
 /obj/item/storage/dice,
 /turf/open/floor/wood/parquet,
 /area/commons/lounge)
+"pq" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "pr" = (
 /turf/closed/wall,
 /area/maintenance/fore)
@@ -5718,6 +5910,16 @@
 /obj/structure/fence,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
+"pQ" = (
+/obj/machinery/atmospherics/components/binary/pump/off,
+/obj/machinery/airlock_sensor/incinerator_ordmix{
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "pR" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -5926,6 +6128,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/service/theater)
+"qr" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "qs" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy{
@@ -6765,6 +6973,17 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"sB" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/camera/directional/south{
+	c_tag = "Ordnance Lower Mix Lab";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "sC" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/decal/cleanable/dirt,
@@ -7208,6 +7427,10 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"tM" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "tN" = (
 /obj/structure/chair{
 	dir = 8
@@ -7270,6 +7493,16 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"tU" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"tV" = (
+/obj/machinery/air_sensor{
+	chamber_id = "ordnancegas1"
+	},
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "tW" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
@@ -7387,6 +7620,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating/icemoon,
 /area/security/execution/education)
+"uo" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
+"up" = (
+/obj/machinery/space_heater,
+/obj/structure/sign/poster/random/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "uq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -7574,6 +7818,12 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/security/prison/garden)
+"uN" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "uO" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /obj/effect/decal/cleanable/dirt,
@@ -7668,6 +7918,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"va" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "vb" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/table/wood,
@@ -7774,6 +8029,11 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"vq" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/tank/oxygen,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "vs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -7996,6 +8256,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"wc" = (
+/obj/structure/stairs/south,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "we" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -8120,6 +8384,10 @@
 	},
 /turf/open/floor/iron,
 /area/mine/production)
+"wt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "wu" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -8386,6 +8654,18 @@
 	dir = 1
 	},
 /area/mine/living_quarters)
+"xg" = (
+/obj/structure/stairs/east,
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
+"xh" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "xj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -8581,6 +8861,14 @@
 	},
 /turf/open/floor/iron/dark/textured_edge,
 /area/security/prison)
+"xN" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1;
+	piping_layer = 2
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/science/mixing)
 "xO" = (
 /turf/closed/wall,
 /area/hallway/primary/central/fore)
@@ -8613,6 +8901,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/security/prison)
+"xV" = (
+/obj/machinery/door/poddoor/incinerator_ordmix,
+/turf/open/openspace,
+/area/science/mixing/chamber)
 "xW" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -8696,6 +8988,10 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"yk" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ym" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -8766,6 +9062,9 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/openspace/icemoon/keep_below,
 /area/security/execution/education)
+"yv" = (
+/turf/open/floor/iron,
+/area/science/mixing)
 "yw" = (
 /obj/structure/rack,
 /obj/item/storage/box/evidence,
@@ -8903,6 +9202,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"yN" = (
+/obj/machinery/requests_console/directional/north,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "yO" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -8997,6 +9300,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"zc" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "zd" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/icemoon/keep_below,
@@ -9024,6 +9336,13 @@
 	dir = 1
 	},
 /area/service/hydroponics)
+"zg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/science/mixing)
 "zh" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Lower Brig Hallway"
@@ -9042,6 +9361,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/theater)
+"zj" = (
+/obj/structure/stairs/west,
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "zl" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -9198,6 +9523,10 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"zD" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "zE" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/box,
@@ -9317,6 +9646,9 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/security/prison)
+"zW" = (
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
 "zX" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
@@ -9582,6 +9914,12 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/work)
+"AL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/science/mixing)
 "AM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -9694,6 +10032,12 @@
 "Bd" = (
 /turf/closed/wall,
 /area/maintenance/department/cargo)
+"Be" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "Bf" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
@@ -9875,6 +10219,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side,
 /area/mine/eva)
+"BF" = (
+/obj/machinery/door/window/right/directional/south{
+	name = "Ordnance Freezer Chamber Access";
+	req_access_txt = "8"
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "BG" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
@@ -10227,6 +10578,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"CH" = (
+/obj/structure/stairs/north,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "CI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10640,6 +10995,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"DL" = (
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "DM" = (
 /obj/effect/turf_decal/tile/red,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -10864,6 +11222,9 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"Er" = (
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "Es" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
@@ -11046,6 +11407,12 @@
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/iron,
 /area/security/prison/work)
+"EW" = (
+/obj/structure/sign/warning/fire{
+	pixel_x = 32
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "EX" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
@@ -11295,6 +11662,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"FH" = (
+/obj/structure/stairs/east,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "FI" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_lower_shutters";
@@ -11343,6 +11714,10 @@
 	dir = 1
 	},
 /area/security/brig)
+"FW" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "FX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -11376,6 +11751,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"Gd" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "Ge" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11527,6 +11908,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"Gt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/science/mixing)
 "Gu" = (
 /turf/open/openspace/icemoon/keep_below,
 /area/maintenance/department/medical/morgue)
@@ -12024,6 +12411,10 @@
 	},
 /turf/open/floor/iron/dark/textured_edge,
 /area/security/prison)
+"HJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "HK" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/xeno_mining{
@@ -12208,6 +12599,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"Ig" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "Ih" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -12295,6 +12692,10 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"Ir" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "Is" = (
 /obj/machinery/button/door/directional/north{
 	id = "permainner";
@@ -12442,6 +12843,9 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/textured,
 /area/security/brig)
+"IK" = (
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "IL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -12604,6 +13008,15 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
+"Jh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "Ji" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
@@ -12790,6 +13203,10 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"JK" = (
+/obj/machinery/igniter/incinerator_ordmix,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "JL" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -13808,6 +14225,15 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"My" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Ordnance Lab"
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "Mz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemistry Maintenance";
@@ -13906,6 +14332,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"ML" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "MM" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -14011,6 +14441,12 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"Nb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "Nc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -14116,6 +14552,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/service/chapel)
+"Nt" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Ordnance Lab Maintenance";
+	req_one_access_txt = "47"
+	},
+/turf/open/floor/plating,
+/area/science/mixing)
 "Nu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -14186,6 +14634,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"NH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "NI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -14397,6 +14849,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/medical/chemistry)
+"On" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Ordnance Lab Maintenance";
+	req_one_access_txt = "47"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/mixing)
 "Oo" = (
 /obj/effect/turf_decal/siding/wideplating_new/light,
 /obj/item/trash/bee,
@@ -14811,6 +15271,17 @@
 /obj/machinery/oven,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"Po" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/machinery/airalarm/mixingchamber{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing/chamber)
 "Pp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -14846,6 +15317,17 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/textured,
 /area/security/brig)
+"Pv" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/red,
+/obj/machinery/airalarm/mixingchamber{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing/chamber)
 "Pw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14913,6 +15395,10 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/carpet/red,
 /area/security/prison/work)
+"PE" = (
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "PF" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -14947,6 +15433,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"PK" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "PL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14991,6 +15482,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"PR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "PS" = (
 /obj/machinery/light/directional/south,
 /obj/item/kirbyplants/random,
@@ -15091,6 +15588,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/grass,
 /area/medical/virology)
+"Qf" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "Qg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -15473,6 +15976,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"Rd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/tank,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "Re" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -15610,6 +16118,13 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
+"Rw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/tank,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "Rx" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -16130,6 +16645,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"SQ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "SR" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
@@ -16169,6 +16690,12 @@
 /obj/machinery/mineral/processing_unit_console,
 /turf/open/floor/iron,
 /area/mine/production)
+"SV" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "SW" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_y = 32
@@ -16345,6 +16872,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
+"Tp" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "Tq" = (
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
@@ -16568,6 +17099,17 @@
 "TS" = (
 /turf/open/floor/iron/dark,
 /area/mine/eva)
+"TT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "TU" = (
 /obj/structure/table,
 /obj/item/flashlight/lantern,
@@ -16640,6 +17182,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/security/prison)
+"Ue" = (
+/turf/closed/wall/r_wall,
+/area/science/mixing/hallway)
+"Uf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "Ug" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -16877,6 +17428,9 @@
 	dir = 5
 	},
 /area/mine/living_quarters)
+"UM" = (
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "UN" = (
 /obj/machinery/mechpad,
 /obj/effect/turf_decal/stripes/corner,
@@ -16886,6 +17440,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"UP" = (
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "UR" = (
 /obj/machinery/door/airlock{
 	name = "Theater Backstage";
@@ -17025,6 +17582,15 @@
 "Vj" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/morgue)
+"Vk" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "Vl" = (
 /obj/structure/fence{
 	dir = 4
@@ -17136,6 +17702,21 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"Vy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 9
+	},
+/obj/machinery/meter,
+/obj/machinery/button/ignition/incinerator/ordmix{
+	pixel_y = 32;
+	pixel_x = 8
+	},
+/obj/machinery/button/door/incinerator_vent_ordmix{
+	pixel_x = -8;
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "Vz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -17659,6 +18240,10 @@
 "WY" = (
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"WZ" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/science/mixing)
 "Xa" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -17707,6 +18292,18 @@
 "Xe" = (
 /turf/closed/wall/r_wall,
 /area/service/lawoffice)
+"Xf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "Xg" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -17745,6 +18342,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"Xl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "Xm" = (
 /obj/structure/fence/door,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -17886,6 +18490,12 @@
 "XI" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central/fore)
+"XJ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/box/red,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "XK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -17919,6 +18529,10 @@
 /obj/item/food/pie/cream,
 /turf/open/floor/carpet,
 /area/service/theater)
+"XQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "XR" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/dark,
@@ -17933,6 +18547,14 @@
 "XT" = (
 /turf/closed/wall/r_wall,
 /area/mine/mechbay)
+"XU" = (
+/obj/machinery/atmospherics/components/tank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "XV" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -18119,6 +18741,10 @@
 /obj/structure/sign/nanotrasen,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"Yw" = (
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "Yx" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18174,6 +18800,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
+"YD" = (
+/obj/structure/window/reinforced,
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("ordnancegas1" = "Burn Chamber", "ordnancegas2" = "Freezer Chamber");
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/mixing)
 "YE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table/reinforced,
@@ -18188,10 +18822,21 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"YF" = (
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior{
+	name = "Burn Chamber Exterior Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "YG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/recharge_floor,
 /area/mine/mechbay)
+"YH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/maintenance/aft/lesser)
 "YI" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - Visitation South";
@@ -18349,6 +18994,11 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/prison/work)
+"Ze" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/science/mixing)
 "Zf" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -18399,6 +19049,10 @@
 	},
 /turf/open/floor/iron/textured,
 /area/security/brig)
+"Zn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "Zo" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 4;
@@ -63864,7 +64518,7 @@ CR
 CR
 tK
 Qv
-As
+tU
 Qv
 Wb
 Wb
@@ -64121,7 +64775,7 @@ Wn
 CR
 CR
 CR
-hM
+PE
 CR
 CR
 CR
@@ -64889,18 +65543,18 @@ Fa
 ab
 Cx
 TZ
-hM
-hM
-hM
-hM
-hM
-ww
-fi
 Fa
-pY
 Fa
-hM
-hM
+Fa
+Fa
+ju
+Fa
+Fa
+Fa
+Fa
+Fa
+Fa
+Fa
 Fa
 IR
 Fa
@@ -65147,17 +65801,17 @@ hM
 hM
 hM
 hM
-Et
-Et
-Et
+pY
+Fa
+Fa
+ju
+ww
+fi
+Fa
+pY
 hM
 hM
 hM
-hM
-hM
-hM
-ak
-ak
 hM
 hM
 hM
@@ -65396,23 +66050,23 @@ HQ
 kK
 kK
 kK
-Et
-Et
-Et
-Et
-Et
-Et
-Et
-Et
 kK
 kK
-Et
-Et
-ak
-ak
-ak
-ak
-ak
+kK
+kK
+kK
+kK
+kK
+CR
+CR
+CR
+CR
+Nt
+YH
+CR
+CR
+CR
+CR
 ak
 ak
 ak
@@ -65652,24 +66306,24 @@ Et
 Et
 kK
 kK
-Et
-Et
-Et
-Et
-Et
-Et
-Et
-Et
 kK
 kK
 kK
 kK
-ak
-ak
-ak
-ak
-ak
-ak
+kK
+kK
+kK
+kK
+Ue
+dZ
+vq
+pa
+Gt
+pq
+lO
+ML
+ML
+DL
 ak
 ak
 ak
@@ -65910,23 +66564,23 @@ Et
 Et
 kK
 Et
-ak
-ak
-ak
-ak
-ak
-Et
-Et
-ak
+kK
+kK
+EW
 kK
 kK
 kK
-ak
-ak
-ak
-ak
-ak
-ak
+kK
+Ue
+dZ
+Rd
+dz
+aG
+yv
+WZ
+ML
+ML
+DL
 ak
 ak
 ak
@@ -66167,23 +66821,23 @@ ak
 Et
 Et
 Et
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
+Ig
+Fu
+Ue
+Ue
+Ue
+Ue
+Ue
+Ue
+XU
+Rw
+dz
+aG
+yv
+WZ
+Ir
+PK
+DL
 ak
 ak
 ak
@@ -66424,23 +67078,23 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
+AA
+kK
+Ue
+ae
+ae
+ae
+ae
+zj
+mx
+fZ
+zg
+AL
+kG
+WZ
+tM
+tM
+DL
 ak
 ak
 ak
@@ -66681,23 +67335,23 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
+AA
+kK
+Ue
+Yw
+UP
+UP
+UP
+gS
+Vk
+yv
+yv
+Ze
+uN
+WZ
+zD
+zD
+DL
 ak
 ak
 ak
@@ -66938,23 +67592,23 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
+AA
+kK
+Ue
+va
+UP
+UP
+UP
+gS
+Jh
+yv
+cx
+ha
+Nb
+WZ
+bQ
+sB
+DL
 ak
 ak
 ak
@@ -67195,23 +67849,23 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
+AA
+kK
+Ue
+yN
+UP
+UP
+UP
+gS
+Jh
+yv
+yv
+Ze
+Nb
+BF
+Uf
+uo
+DL
 ak
 ak
 ak
@@ -67452,23 +68106,23 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-Et
-ak
+AA
+kK
+Ue
+FH
+FH
+FH
+aS
+xg
+Jh
+Ze
+Ze
+Ze
+Nb
+YD
+PR
+xN
+DL
 ak
 ak
 ak
@@ -67709,23 +68363,23 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-Et
+AA
 kK
-Et
+Er
+Er
+Er
+Er
+NH
+NH
+Xf
+ly
+fz
+fz
+TT
+Er
+My
+Er
+Er
 ak
 ak
 ak
@@ -67966,23 +68620,23 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-Et
+AA
 kK
-oh
-Et
+xV
+ao
+cY
+HJ
+dr
+HJ
+Vy
+Zn
+cG
+UM
+Xl
+hD
+bb
+SQ
+Er
 ak
 ak
 ak
@@ -68223,23 +68877,23 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-Et
-Et
-oh
-Et
+AA
+kK
+xV
+JK
+tV
+YF
+xh
+nR
+UM
+UM
+Qf
+UM
+Gd
+Er
+ho
+Be
+Er
 ak
 ak
 ak
@@ -68480,23 +69134,23 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-Et
-oh
-Et
+AA
+kK
+xV
+Tp
+lj
+XQ
+pQ
+XQ
+Pv
+UM
+hz
+XJ
+Po
+hD
+zc
+SV
+Er
 ak
 ak
 ak
@@ -68737,23 +69391,23 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-Et
-ak
+AA
+kK
+Er
+Er
+Er
+Er
+wt
+Er
+DL
+On
+DL
+DL
+DL
+Er
+Er
+Er
+Er
 ak
 ak
 ak
@@ -68994,17 +69648,17 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
+zW
+zW
+zW
+mD
+IK
+IK
+IK
+IK
+mF
+qr
+zW
 ak
 ak
 ak
@@ -69251,17 +69905,17 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
+zW
+CH
+mF
+IK
+IK
+IK
+IK
+IK
+IK
+wc
+zW
 ak
 ak
 ak
@@ -69508,17 +70162,17 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
+zW
+CH
+IK
+FW
+yk
+up
+IK
+IK
+IK
+wc
+zW
 ak
 ak
 ak
@@ -69765,17 +70419,17 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
+zW
+zW
+zW
+zW
+zW
+zW
+zW
+zW
+zW
+zW
+zW
 ak
 ak
 ak

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -3767,6 +3767,10 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
+"ka" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
 "kb" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - Permabrig Upper Hallway South";
@@ -8387,7 +8391,7 @@
 "wt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/area/maintenance/starboard/aft)
 "wu" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -11318,6 +11322,9 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms/laundry)
+"EI" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/starboard/aft)
 "EJ" = (
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /obj/machinery/light/directional/east,
@@ -66314,7 +66321,7 @@ kK
 kK
 kK
 kK
-Ue
+ka
 dZ
 vq
 pa
@@ -66571,7 +66578,7 @@ kK
 kK
 kK
 kK
-Ue
+ka
 dZ
 Rd
 dz
@@ -69393,15 +69400,15 @@ ak
 ak
 AA
 kK
-Er
-Er
-Er
-Er
+EI
+EI
+EI
+EI
 wt
-Er
-DL
+EI
+EI
 On
-DL
+EI
 DL
 DL
 Er


### PR DESCRIPTION
## About The Pull Request
This one is a bit different than the other toxins, wanted to make it multi z and in that process didn't really make them segmented.

Might even need some code changes to glass floors because currently they can be crowbarred very easily to vent the gas.

A few atmos items on the top floor while they should be at the bottom. I'll find a better place to stick them at later. The current state is the result of trying to make the bottom chamber more spacious than the other maps.

Will probably move on to other maps first. PR-ing for some quick feedback or to see if this is gonna got denied.

## Why It's Good For The Game
Multi z looks pretty good. Also new chambers.

## Changelog
:cl:
expansion: Remapped icebox's toxins
/:cl: