### PR TITLE
Fix: Health sensors inside chemical grenades

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -50,6 +50,12 @@
 		var/obj/item/grenade/chem_grenade/grenade = holder
 		grenade.landminemode = sensor
 		sensor.proximity_monitor.set_ignore_if_not_on_turf(FALSE)
+	else if(istype(S,/obj/item/assembly/health))
+		var/obj/item/assembly/health/sensor = S
+		if(!sensor.secured)
+			sensor.toggle_secure()
+		if(!sensor.scanning)
+			sensor.toggle_scan()
 	fingerprint = S.fingerprintslast
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

This will make health sensors inside of chemical grenades work as intended, every time.

## Why It's Good For The Game
Fixes [50673](https://github.com/tgstation/tgstation/issues/50673)

## Explanation of the issue/fix
The health sensor is an assembly part. It contains two vars called 'secured' and 'scanning'. 

In order to attach an assembly part to another assembly part (e.g. a health sensor to a signaller), both have to be attachable (meaning 'secured' = FALSE). After they are attached together, 'secured' will be TRUE. When the assembly is triggered, it checks if 'secured' == TRUE. Problem is, that a grenade is not an assembly part. If you use a screwdriver on the sensor to make it attachable, the chemical grenade won't work. The var 'secured' was simply not intended for usage inside a chemical grenade. Further confusion ensues when the now-attachable part is attached to the chemical grenade via an Attach-/Detach menu, which has nothing to do with the sensor being attachable (secured). This fix always secures the sensor when attaching it.

The other var, 'scanning' determines if the health sensor is currently active or not. A potential pitfall is to not activating it before attaching it to a chemical grenade, assuming that you have to activate the grenade itself to arm it (which in this case will just make the grenade go boom, disregarding the sensor). Since it does not make any sense to create a chemical grenade with an inactive sensor, this fix always enables the sensor when attaching it.

## Changelog
:cl:
fix: Health sensors inside of chemical grenades will now work as intended and the process is almost impossible to screw up.
/:cl: