### PR TITLE
Remove the span from logging

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -38,7 +38,7 @@
 		if(prob(10))
 			to_chat(target, span_revennotice("You feel as if you are being watched."))
 		return
-	log_combat(span_warning("has started to harvest [key_name(target)]."), LOG_ATTACK)
+	log_combat(src, target, "has started to harvest", LOG_ATTACK)
 	face_atom(target)
 	draining = TRUE
 	essence_drained += rand(15, 20)

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -38,7 +38,7 @@
 		if(prob(10))
 			to_chat(target, span_revennotice("You feel as if you are being watched."))
 		return
-	log_combat(src, target, "has started to harvest")
+	log_combat(src, target, "started to harvest")
 	face_atom(target)
 	draining = TRUE
 	essence_drained += rand(15, 20)

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -38,7 +38,7 @@
 		if(prob(10))
 			to_chat(target, span_revennotice("You feel as if you are being watched."))
 		return
-	log_combat(src, target, "has started to harvest", LOG_ATTACK)
+	log_combat(src, target, "has started to harvest")
 	face_atom(target)
 	draining = TRUE
 	essence_drained += rand(15, 20)


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin. #65715 should have been like this from the start.

## Why It's Good For The Game

Because who in the right mind wants a span in their logs

## Changelog

:cl: Riggle
fix: Revenant logs are no longer wrapped in a span
/:cl:
