### PR TITLE
Fixes a runtime with bounty cubes on destroy

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -284,8 +284,9 @@
 	RegisterSignal(radio, COMSIG_ITEM_PRE_EXPORT, .proc/on_export)
 
 /obj/item/bounty_cube/Destroy()
-	UnregisterSignal(radio, COMSIG_ITEM_PRE_EXPORT)
-	QDEL_NULL(radio)
+	if(radio)
+		UnregisterSignal(radio, COMSIG_ITEM_PRE_EXPORT)
+		QDEL_NULL(radio)
 	return ..()
 
 /obj/item/bounty_cube/examine()


### PR DESCRIPTION
## About The Pull Request

If the bounty cube's internal radio was destroyed prior to `Destroy()`, _such as when they were exported_, this would runtime due to unregistering a signal from `null`. 

## Why It's Good For The Game

Stops a runtime error

## Changelog

:cl: Melbert
fix: Fixes a runtime with bounty cubes on Destroy
/:cl:
