### PR TITLE
Pride Ruin Remap

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -2,180 +2,295 @@
 "a" = (
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"b" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/mineral/silver,
-/area/ruin/powered/pride)
 "c" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"f" = (
-/obj/structure/mirror/directional/west,
-/turf/open/floor/carpet/red,
-/area/ruin/powered/pride)
-"g" = (
-/turf/open/floor/mineral/silver,
-/area/ruin/powered/pride)
-"i" = (
-/obj/structure/mirror/directional/east,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/mineral/silver,
-/area/ruin/powered/pride)
 "j" = (
 /obj/structure/mirror/magic/pride,
 /turf/closed/wall/mineral/diamond,
 /area/ruin/powered/pride)
 "k" = (
-/obj/structure/table/wood/fancy/red,
 /obj/item/clothing/under/chameleon{
 	armor = null
 	},
-/turf/open/floor/mineral/silver,
+/obj/structure/stone_tile/center,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/powered/pride)
 "l" = (
-/obj/structure/table/wood/fancy/red,
 /obj/item/dyespray,
-/turf/open/floor/mineral/silver,
+/obj/structure/stone_tile/center,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/powered/pride)
-"m" = (
-/obj/structure/mirror/directional/east,
-/turf/open/floor/carpet/red,
+"p" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile,
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/powered/pride)
 "q" = (
 /obj/structure/mirror/directional/east,
-/turf/open/floor/mineral/silver,
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/powered/pride)
 "r" = (
-/turf/open/floor/carpet/red,
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/powered/pride)
+"v" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/powered/pride)
+"w" = (
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/powered/pride)
+"y" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile/burnt,
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 4
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/powered/pride)
+"A" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/center/burnt,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/powered/pride)
+"B" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/powered/pride)
+"D" = (
+/obj/structure/stone_tile/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "G" = (
-/turf/closed/wall/mineral/diamond,
+/turf/closed/wall/mineral/cult,
 /area/ruin/powered/pride)
+"I" = (
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "N" = (
-/obj/machinery/door/airlock/diamond,
-/turf/open/floor/carpet/red,
+/obj/structure/necropolis_gate,
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 4
+	},
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/powered/pride)
-"O" = (
-/obj/structure/mirror/directional/west,
-/turf/open/floor/mineral/silver,
+"R" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile/burnt,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/powered/pride)
+"S" = (
+/obj/structure/stone_tile/block{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/powered/pride)
+"U" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile/burnt,
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile/center/burnt,
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/powered/pride)
 "X" = (
 /obj/structure/mirror/directional/west,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/mineral/silver,
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/powered/pride)
 "Y" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/mineral/silver,
+/turf/closed/indestructible/riveted/boss,
 /area/ruin/powered/pride)
 
 (1,1,1) = {"
 a
 a
+c
 a
 a
 a
 a
 a
-a
-a
-a
+c
+c
 a
 a
 "}
 (2,1,1) = {"
 a
+c
+c
 G
-G
-G
-G
-G
-G
-G
+Y
+Y
+Y
+Y
 G
 G
 c
 a
 "}
 (3,1,1) = {"
-a
-G
-b
-f
-f
-O
+c
+c
+Y
+Y
 X
-O
-O
+X
+X
+X
+X
 G
-G
+D
 a
 "}
 (4,1,1) = {"
-a
-G
+c
+c
 G
 l
 r
+S
 r
-g
-g
-g
+S
+S
 Y
-G
+Y
 a
 "}
 (5,1,1) = {"
-a
-a
+c
+c
 G
 j
-r
-r
-r
-r
-r
-r
+U
+B
+R
+y
+A
+p
 N
 a
 "}
 (6,1,1) = {"
-a
-G
+c
+c
 G
 k
-r
-r
-g
-g
-g
+w
+v
+v
+w
+v
 Y
-G
+Y
 a
 "}
 (7,1,1) = {"
-a
-G
-b
-m
-m
-q
-i
+c
+c
+Y
+Y
 q
 q
+q
+q
+q
 G
-G
+I
 a
 "}
 (8,1,1) = {"
 a
+c
+c
 G
-G
-G
-G
-G
-G
-G
+Y
+Y
+Y
+Y
 G
 G
 c
@@ -184,14 +299,14 @@ a
 (9,1,1) = {"
 a
 a
+c
+c
 a
 a
 a
 a
 a
-a
-a
-a
-a
+c
+c
 a
 "}

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -5,110 +5,59 @@
 "c" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"g" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/turf/open/lava/smooth,
+/area/ruin/powered/pride)
+"i" = (
+/obj/structure/mirror/directional/east,
+/turf/open/lava/smooth,
+/area/ruin/powered/pride)
 "j" = (
 /obj/structure/mirror/magic/pride,
-/turf/closed/wall/mineral/diamond,
+/turf/closed/wall/mineral/silver,
 /area/ruin/powered/pride)
 "k" = (
 /obj/item/clothing/under/chameleon{
 	armor = null
 	},
-/obj/structure/stone_tile/center,
-/obj/structure/table/wood/fancy/royalblack,
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 8
-	},
-/turf/open/lava/smooth/lava_land_surface,
+/obj/structure/table/wood/fancy/royalblue,
+/turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
 "l" = (
 /obj/item/dyespray,
-/obj/structure/stone_tile/center,
-/obj/structure/table/wood/fancy/royalblack,
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 1
-	},
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/powered/pride)
-"p" = (
-/obj/structure/stone_tile/center,
-/obj/structure/stone_tile/center,
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile/surrounding_tile,
-/turf/open/lava/smooth/lava_land_surface,
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/coin/silver,
+/turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
 "q" = (
 /obj/structure/mirror/directional/east,
-/turf/open/lava/smooth/lava_land_surface,
+/obj/structure/stone_tile/surrounding_tile,
+/turf/open/lava/smooth,
 /area/ruin/powered/pride)
 "r" = (
-/obj/structure/stone_tile/block/burnt{
-	dir = 8
-	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
-"v" = (
-/obj/structure/stone_tile/block/burnt{
-	dir = 4
-	},
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/powered/pride)
-"w" = (
-/obj/structure/stone_tile/block{
-	dir = 4
-	},
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/powered/pride)
-"y" = (
+"t" = (
 /obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
 	},
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
-/obj/structure/stone_tile/surrounding_tile/burnt,
-/obj/structure/stone_tile/surrounding_tile/burnt{
+/turf/open/lava/smooth,
+/area/ruin/powered/pride)
+"u" = (
+/obj/structure/stone_tile/block/burnt{
 	dir = 4
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/lava/smooth,
 /area/ruin/powered/pride)
-"A" = (
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile/surrounding_tile,
-/obj/structure/stone_tile/center/burnt,
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/powered/pride)
-"B" = (
-/obj/structure/stone_tile/center,
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile/surrounding_tile,
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/powered/pride)
-"D" = (
+"x" = (
 /obj/structure/stone_tile/burnt{
 	dir = 4
 	},
@@ -117,71 +66,102 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"y" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding,
+/turf/open/lava/smooth,
+/area/ruin/powered/pride)
+"z" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding/burnt,
+/turf/open/lava/smooth,
+/area/ruin/powered/pride)
+"B" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/turf/open/lava/smooth,
+/area/ruin/powered/pride)
 "G" = (
 /turf/closed/wall/mineral/cult,
 /area/ruin/powered/pride)
-"I" = (
+"J" = (
 /obj/structure/stone_tile{
 	dir = 1
 	},
 /obj/structure/stone_tile,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"N" = (
-/obj/structure/necropolis_gate,
+"K" = (
+/obj/structure/mirror/directional/east,
 /obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile/burnt,
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/turf/open/lava/smooth,
+/area/ruin/powered/pride)
+"N" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding/burnt,
+/obj/machinery/door/airlock/cult/unruned,
+/turf/open/lava/smooth,
+/area/ruin/powered/pride)
+"O" = (
+/obj/structure/mirror/directional/west,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/turf/open/lava/smooth,
+/area/ruin/powered/pride)
+"R" = (
+/obj/structure/mirror/directional/west,
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 4
 	},
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
 /obj/structure/stone_tile/surrounding_tile,
-/obj/structure/stone_tile/surrounding_tile/burnt{
+/turf/open/lava/smooth,
+/area/ruin/powered/pride)
+"S" = (
+/obj/structure/stone_tile/block,
+/obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
 	},
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/powered/pride)
-"R" = (
-/obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
 	},
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile/surrounding_tile/burnt,
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/lava/smooth,
 /area/ruin/powered/pride)
-"S" = (
+"U" = (
 /obj/structure/stone_tile/block{
 	dir = 8
 	},
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/powered/pride)
-"U" = (
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/surrounding_tile/burnt,
-/obj/structure/stone_tile/surrounding_tile/burnt{
-	dir = 4
-	},
-/obj/structure/stone_tile/center/burnt,
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/lava/smooth,
 /area/ruin/powered/pride)
 "X" = (
 /obj/structure/mirror/directional/west,
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/lava/smooth,
 /area/ruin/powered/pride)
 "Y" = (
 /turf/closed/indestructible/riveted/boss,
+/area/ruin/powered/pride)
+"Z" = (
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/turf/open/lava/smooth,
 /area/ruin/powered/pride)
 
 (1,1,1) = {"
@@ -206,7 +186,7 @@ G
 Y
 Y
 Y
-Y
+G
 G
 G
 c
@@ -217,13 +197,13 @@ c
 c
 Y
 Y
-X
-X
+R
+O
 X
 X
 X
 G
-D
+x
 a
 "}
 (4,1,1) = {"
@@ -232,10 +212,10 @@ c
 G
 l
 r
-S
-r
-S
-S
+B
+g
+U
+U
 Y
 Y
 a
@@ -245,12 +225,12 @@ c
 c
 G
 j
-U
-B
-R
+r
+S
 y
-A
-p
+z
+y
+z
 N
 a
 "}
@@ -259,11 +239,11 @@ c
 c
 G
 k
-w
-v
-v
-w
-v
+r
+t
+u
+Z
+u
 Y
 Y
 a
@@ -273,13 +253,13 @@ c
 c
 Y
 Y
+K
 q
-q
-q
-q
-q
-G
-I
+i
+i
+i
+Y
+J
 a
 "}
 (8,1,1) = {"
@@ -287,8 +267,8 @@ a
 c
 c
 G
-Y
-Y
+G
+G
 Y
 Y
 G

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -3,58 +3,70 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "b" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
 "c" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"e" = (
-/obj/structure/mirror/directional/west,
-/turf/open/floor/mineral/silver,
-/area/ruin/powered/pride)
 "f" = (
-/obj/structure/mirror/directional/east,
-/turf/open/floor/mineral/silver,
+/obj/structure/mirror/directional/west,
+/turf/open/floor/carpet/red,
 /area/ruin/powered/pride)
 "g" = (
 /turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
-"j" = (
-/obj/structure/mirror/directional/west,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/mineral/silver,
-/area/ruin/powered/pride)
-"k" = (
-/obj/structure/mirror/directional/east,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/mineral/silver,
-/area/ruin/powered/pride)
-"l" = (
-/obj/structure/mirror/directional/west,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/mineral/silver,
-/area/ruin/powered/pride)
-"m" = (
+"i" = (
 /obj/structure/mirror/directional/east,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
-"r" = (
-/obj/machinery/light/small/directional/south,
+"j" = (
+/obj/structure/mirror/magic/pride,
+/turf/closed/wall/mineral/diamond,
+/area/ruin/powered/pride)
+"k" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/clothing/under/chameleon{
+	armor = null
+	},
 /turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
+"l" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/dyespray,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
+"m" = (
+/obj/structure/mirror/directional/east,
+/turf/open/floor/carpet/red,
+/area/ruin/powered/pride)
+"q" = (
+/obj/structure/mirror/directional/east,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
+"r" = (
+/turf/open/floor/carpet/red,
 /area/ruin/powered/pride)
 "G" = (
 /turf/closed/wall/mineral/diamond,
 /area/ruin/powered/pride)
+"N" = (
+/obj/machinery/door/airlock/diamond,
+/turf/open/floor/carpet/red,
+/area/ruin/powered/pride)
 "O" = (
-/obj/structure/mirror/magic/pride,
-/turf/closed/wall/mineral/diamond,
+/obj/structure/mirror/directional/west,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
+"X" = (
+/obj/structure/mirror/directional/west,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
 "Y" = (
-/obj/machinery/door/airlock/diamond,
-/turf/open/floor/mineral/silver{
-	blocks_air = 1
-	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
 
 (1,1,1) = {"
@@ -70,210 +82,116 @@ a
 a
 a
 a
-a
-a
-a
-a
-a
-a
-a
-a
 "}
 (2,1,1) = {"
 a
-a
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
+G
+G
+G
+G
+G
+G
+G
+G
+G
 c
 a
 "}
 (3,1,1) = {"
+a
+G
 b
-c
-c
+f
+f
+O
+X
+O
+O
 G
 G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-c
 a
 "}
 (4,1,1) = {"
-c
-c
-G
-G
-G
-j
-e
-e
-l
-e
-e
-l
-e
-e
-l
-e
-e
-G
-c
 a
-"}
-(5,1,1) = {"
-c
 G
 G
-G
-G
-G
-g
-g
-g
-g
-g
-g
-g
-g
-g
-g
+l
 r
-G
-a
-a
-"}
-(6,1,1) = {"
-c
-G
-G
-G
-G
-G
-O
-g
-g
-g
-g
-g
-g
-g
+r
 g
 g
 g
 Y
-a
+G
 a
 "}
-(7,1,1) = {"
-c
+(5,1,1) = {"
+a
+a
 G
-G
-G
-G
-G
-g
-g
-g
-g
-g
-g
-g
-g
-g
-g
+j
 r
-G
-c
+r
+r
+r
+r
+r
+N
 a
 "}
-(8,1,1) = {"
-c
-c
-G
+(6,1,1) = {"
+a
 G
 G
 k
-f
-f
+r
+r
+g
+g
+g
+Y
+G
+a
+"}
+(7,1,1) = {"
+a
+G
+b
 m
-f
-f
 m
-f
-f
-m
-f
-f
+q
+i
+q
+q
+G
+G
+a
+"}
+(8,1,1) = {"
+a
+G
+G
+G
+G
+G
+G
+G
+G
 G
 c
 a
 "}
 (9,1,1) = {"
-b
-c
-c
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-c
 a
-"}
-(10,1,1) = {"
-b
-b
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
 a
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Honestly this one was pretty fine. I just made it smaller, got rid of the 3x5 block of diamond walls, and added some nice cosmetic loot
- hair dye
- chameleon jumpsuit (no armor, totally ok with removing this if maintainers dislike it)
- lavalandified. begone diamond-and-silver blight

![one2](https://user-images.githubusercontent.com/73589390/162490573-71ec64b9-d436-42c8-a320-3dfe58ab0187.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Smaller ruin, less grating on the eyes with the massive hall of silver floors, remains consistent with theming

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Remapped the Pride's Mirror ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
