### PR TITLE
you can no longer use spells while in rod form

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -426,6 +426,10 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 // Normally only present in the mind of a Research Director.
 #define TRAIT_ROD_SUPLEX "rod_suplex"
 
+/// If present on a mob, they're currently in rod form
+/// Used to stop soul tapping shenanigans (biddle singularities!)
+#define TRAIT_ROD_FORM "rod_form"
+
 //SKILLS
 #define TRAIT_UNDERWATER_BASKETWEAVING_KNOWLEDGE "underwater_basketweaving"
 #define TRAIT_WINE_TASTER "wine_taster"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -426,8 +426,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 // Normally only present in the mind of a Research Director.
 #define TRAIT_ROD_SUPLEX "rod_suplex"
 
-/// If present on a mob, they're currently in rod form
-/// Used to stop soul tapping shenanigans (biddle singularities!)
+/// This mob is currently in rod form.
 #define TRAIT_ROD_FORM "rod_form"
 
 //SKILLS

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -187,7 +187,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 				to_chat(user, span_warning("Magic seems to flee from you, you can't gather enough power to cast this spell."))
 			return FALSE
 
-	if(!phase_allowed && istype(user.loc, /obj/effect/dummy))
+	if(!phase_allowed && istype(user.loc, /obj/effect/dummy) || HAS_TRAIT(user, TRAIT_ROD_FORM))
 		to_chat(user, span_warning("[name] cannot be cast unless you are completely manifested in the material plane!"))
 		return FALSE
 

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -138,7 +138,6 @@
 	wizard.notransform = FALSE
 	wizard.forceMove(get_turf(src))
 	our_wizard = null
-
 	REMOVE_TRAIT(wizard, TRAIT_ROD_FORM, MAGIC_TRAIT)
 
 #undef BASE_WIZ_ROD_RANGE

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -40,6 +40,7 @@
 			rod_max_distance,
 			rod_damage_bonus,
 		)
+		ADD_TRAIT(caster, TRAIT_ROD_FORM, MAGIC_TRAIT)
 
 /// Wizard Version of the Immovable Rod.
 /obj/effect/immovablerod/wizard
@@ -137,5 +138,7 @@
 	wizard.notransform = FALSE
 	wizard.forceMove(get_turf(src))
 	our_wizard = null
+
+	REMOVE_TRAIT(wizard, TRAIT_ROD_FORM, MAGIC_TRAIT)
 
 #undef BASE_WIZ_ROD_RANGE

--- a/code/modules/spells/spell_types/soultap.dm
+++ b/code/modules/spells/spell_types/soultap.dm
@@ -26,6 +26,10 @@
 		to_chat(user, span_warning("You have no soul to tap into!"))
 		return
 
+	if(HAS_TRAIT(user, TRAIT_ROD_FORM)) // stops caster from being able to rod form while rod forming, and make a singularity
+		to_chat(user, span_warning("Your soul's velocity is far too great to tap into right now!"))
+		return
+
 	to_chat(user, span_danger("Your body feels drained and there is a burning pain in your chest."))
 	user.maxHealth -= HEALTH_LOST_PER_SOUL_TAP
 	user.health = min(user.health, user.maxHealth)

--- a/code/modules/spells/spell_types/soultap.dm
+++ b/code/modules/spells/spell_types/soultap.dm
@@ -26,10 +26,6 @@
 		to_chat(user, span_warning("You have no soul to tap into!"))
 		return
 
-	if(HAS_TRAIT(user, TRAIT_ROD_FORM)) // stops caster from being able to rod form while rod forming, and make a singularity
-		to_chat(user, span_warning("Your soul's velocity is far too great to tap into right now!"))
-		return
-
 	to_chat(user, span_danger("Your body feels drained and there is a burning pain in your chest."))
 	user.maxHealth -= HEALTH_LOST_PER_SOUL_TAP
 	user.health = min(user.health, user.maxHealth)


### PR DESCRIPTION
## About The Pull Request

right now, you can use ANY spell while in rod form. in the best case, this can lead to weird funky shit with jaunts and final rod placement. in the worst case, this can lead to soultapping two rod forms and now you have a singularity.

## Why It's Good For The Game

fixes a glaring issue that i'm surprised wasn't addressed sooner. it's an insignificant amount of time to be locked out of your spells, and just makes sense. also, no 3-click singularities ftw.

fixes #65395

## Changelog
:cl:
fix: you can no longer create singularities by using soultap while in rod form
balance: wizards can no longer cast spells while in rod form
/:cl: