### PR TITLE
Re-adds Athletic shorts and Masks closet(s) to Deltastation's recreational room.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -33679,9 +33679,8 @@
 /turf/open/floor/iron,
 /area/maintenance/port/greater)
 "hxQ" = (
-/obj/structure/table,
-/obj/item/razor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/masks,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -40544,9 +40543,9 @@
 /area/command/gateway)
 "jyk" = (
 /obj/structure/table,
-/obj/item/stack/medical/gauze,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/storage/medkit/regular,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "jym" = (
@@ -79838,8 +79837,7 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "vis" = (
-/obj/structure/table,
-/obj/item/storage/medkit/regular,
+/obj/structure/closet/athletic_mixed,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -33681,6 +33681,7 @@
 "hxQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/closet/masks,
+/obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -39917,6 +39918,7 @@
 /obj/item/cigbutt{
 	pixel_y = 7
 	},
+/obj/item/razor,
 /turf/open/floor/iron/white,
 /area/commons/fitness/recreation)
 "jpd" = (
@@ -79838,6 +79840,7 @@
 /area/security/courtroom)
 "vis" = (
 /obj/structure/closet/athletic_mixed,
+/obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the medkit around, to make space next to the existing Boxing Gloves closet for the other two athletics-adjacent closets present on other maps. Even Kilo has it (in maint).

![image](https://user-images.githubusercontent.com/81882910/162122751-aba155d4-3342-4818-9be7-7d7364318e5c.png)
![image](https://user-images.githubusercontent.com/81882910/162122671-e7f1464f-627c-4a5c-bc25-45b5870c9d99.png)
![image](https://user-images.githubusercontent.com/81882910/162122689-8c2cc2ed-a8fd-4832-8320-6618733ba422.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I like athletic shorts.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Deltastation should once more have wrestling masks and athletic shorts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
