### PR TITLE
The Research Director's locker now contains a spare Rod Suplex skillchip.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -20,6 +20,7 @@
 	new /obj/item/circuitboard/machine/techfab/department/science(src)
 	new /obj/item/storage/photo_album/rd(src)
 	new /obj/item/storage/box/skillchips/science(src)
+	new /obj/item/skillchip/job/research_director(src)
 
 
 


### PR DESCRIPTION
## About The Pull Request

The Research Director's locker now contains a spare Rod Suplex skillchip.

## Why It's Good For The Game

Rods looping endlessly is funny except when no RD signs up and now the crew is just stuck with the rod being a part of the station forever.

We went out of our way to make all the innate job stuff obtainable by people transferred into a job up to and including being able to give someone a security liver to give them the donut healing, so we should absolutely have a spare suplex skill chip on hand.

## Changelog

:cl:
qol: The Research Director's locker now contains a spare Rod Suplex skillchip.
/:cl:
