### PR TITLE
Refactors Newscaster cartridge to tablet app

### DIFF
--- a/code/__DEFINES/devices.dm
+++ b/code/__DEFINES/devices.dm
@@ -7,13 +7,12 @@
 #define CART_CLOWN (1<<5)
 #define CART_MIME (1<<6)
 #define CART_REAGENT_SCANNER (1<<7)
-#define CART_NEWSCASTER (1<<8)
-#define CART_REMOTE_DOOR (1<<9)
-#define CART_STATUS_DISPLAY (1<<10)
-#define CART_QUARTERMASTER (1<<11)
-#define CART_HYDROPONICS (1<<12)
-#define CART_DRONEPHONE (1<<13)
-#define CART_DRONEACCESS (1<<14)
+#define CART_REMOTE_DOOR (1<<8)
+#define CART_STATUS_DISPLAY (1<<9)
+#define CART_QUARTERMASTER (1<<10)
+#define CART_HYDROPONICS (1<<11)
+#define CART_DRONEPHONE (1<<12)
+#define CART_DRONEACCESS (1<<13)
 
 /// PDA ui menu defines
 #define PDA_UI_HUB 0
@@ -40,8 +39,6 @@
 #define PDA_UI_BOTS_ACCESS 48
 #define PDA_UI_EMOJI_GUIDE 49
 #define PDA_UI_SIGNALER 50
-#define PDA_UI_NEWSCASTER 51
-#define PDA_UI_NEWSCASTER_ERROR 52
 
 
 // Used by PDA and cartridge code to reduce repetitiveness of spritesheets

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -105,7 +105,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	. = ..()
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "Newscaster", name)
+		ui = new(user, src, "PhysicalNewscaster", name)
 		ui.open()
 	alert = FALSE //We're checking our messages!
 	update_icon()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -346,8 +346,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 						dat += "<li><a href='byond://?src=[REF(src)];choice=[PDA_UI_EMOJI_GUIDE]'>[PDAIMG(emoji)]Emoji Guidebook</a></li>"
 					if (istype(cartridge.radio))
 						dat += "<li><a href='byond://?src=[REF(src)];choice=[PDA_UI_SIGNALER]'>[PDAIMG(signaler)]Signaler System</a></li>"
-					if (cartridge.access & CART_NEWSCASTER)
-						dat += "<li><a href='byond://?src=[REF(src)];choice=[PDA_UI_NEWSCASTER]'>[PDAIMG(notes)]Newscaster Access </a></li>"
 					if (cartridge.access & CART_REAGENT_SCANNER)
 						dat += "<li><a href='byond://?src=[REF(src)];choice=Reagent Scan'>[PDAIMG(reagent)][scanmode == 3 ? "Disable" : "Enable"] Reagent Scanner</a></li>"
 					if (cartridge.access & CART_ATMOS)

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -217,7 +217,6 @@
 	icon_alert = "pda-r-library"
 	icon_pai = "pai_overlay_library"
 	icon_inactive_pai = "pai_off_overlay_library"
-	default_cartridge = /obj/item/cartridge/curator
 	insert_type = /obj/item/pen/fountain
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. This model is a WGW-11 series e-reader."
 	note = "Congratulations, your station has chosen the Thinktronic 5290 WGW-11 Series E-reader and Personal Data Assistant!"

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -92,11 +92,6 @@
 	access = CART_SECURITY
 	spam_enabled = 1
 
-/obj/item/cartridge/curator
-	name = "\improper Lib-Tweet cartridge"
-	icon_state = "cart-s"
-	access = CART_NEWSCASTER
-
 /obj/item/cartridge/roboticist
 	name = "\improper B.O.O.P. Remote Control cartridge"
 	desc = "Packed with heavy duty quad-bot interlink!"
@@ -140,7 +135,7 @@
 /obj/item/cartridge/hop
 	name = "\improper HumanResources9001 cartridge"
 	icon_state = "cart-h"
-	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_SECURITY | CART_NEWSCASTER | CART_QUARTERMASTER | CART_DRONEPHONE
+	access = CART_MANIFEST | CART_STATUS_DISPLAY | CART_SECURITY | CART_QUARTERMASTER | CART_DRONEPHONE
 	bot_access = list(
 		MULE_BOT,
 		CLEAN_BOT,
@@ -476,28 +471,6 @@
 				menu += "<b>No ore silo detected!</b>"
 			menu = jointext(menu, "")
 
-		if (PDA_UI_NEWSCASTER)
-			menu = "<h4>[PDAIMG(notes)] Newscaster Access</h4>"
-			menu += "<br> Current Newsfeed: <A href='byond://?src=[REF(src)];choice=Newscaster Switch Channel'>[current_channel ? current_channel : "None"]</a> <br>"
-			var/datum/feed_channel/current
-			for(var/datum/feed_channel/chan in GLOB.news_network.network_channels)
-				if (chan.channel_name == current_channel)
-					current = chan
-			if(!current)
-				menu += "<h5> ERROR : NO CHANNEL FOUND </h5>"
-				return menu
-			var/i = 1
-			for(var/datum/feed_message/msg in current.messages)
-				menu +="-[msg.return_body(-1)] <BR><FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[msg.return_author(-1)]</FONT>\]</FONT><BR>"
-				menu +="<b><font size=1>[msg.comments.len] comment[msg.comments.len > 1 ? "s" : ""]</font></b><br>"
-				if(msg.img)
-					user << browse_rsc(msg.img, "tmp_photo[i].png")
-					menu +="<img src='tmp_photo[i].png' width = '180'><BR>"
-				i++
-				for(var/datum/feed_comment/comment in msg.comments)
-					menu +="<font size=1><small>[comment.body]</font><br><font size=1><small><small><small>[comment.author] [comment.time_stamp]</small></small></small></small></font><br>"
-			menu += "<br> <A href='byond://?src=[REF(src)];choice=Newscaster Message'>Post Message</a>"
-
 		if (PDA_UI_BOTS_ACCESS)
 			menu = "<h4>[PDAIMG(medbot)] Bots Interlink</h4>"
 			bot_control()
@@ -516,9 +489,6 @@
 
 			menu += "<br> To use an emoji in a pda message, refer to the guide and add \":\" around the emoji. Your PDA supports the following emoji:<br>"
 			menu += emoji_table
-
-		if (PDA_UI_NEWSCASTER_ERROR) //Newscaster message permission error
-			menu = "<h5> ERROR : NOT AUTHORIZED [host_pda.id ? "" : "- ID SLOT EMPTY"] </h5>"
 
 	return menu
 
@@ -581,29 +551,6 @@
 
 		if("Supply Orders")
 			host_pda.ui_mode = PDA_UI_SUPPLY_RECORDS
-
-		if("Newscaster Access")
-			host_pda.ui_mode = PDA_UI_NEWSCASTER
-
-		if("Newscaster Message")
-			var/host_pda_owner_name = host_pda.id ? "[host_pda.id.registered_name] ([host_pda.id.assignment])" : "Unknown"
-			var/message = host_pda.msg_input()
-			var/datum/feed_channel/current
-			for(var/datum/feed_channel/chan in GLOB.news_network.network_channels)
-				if (chan.channel_name == current_channel)
-					current = chan
-			if(current.locked && current.author != host_pda_owner_name)
-				host_pda.ui_mode = PDA_UI_NEWSCASTER_ERROR
-				host_pda.Topic(null,list("choice"="Refresh"))
-				return
-			GLOB.news_network.submit_article(message,host_pda.owner,current_channel)
-			host_pda.Topic(null,list("choice"=num2text(host_pda.ui_mode)))
-			return
-
-		if("Newscaster Switch Channel")
-			current_channel = host_pda.msg_input()
-			host_pda.Topic(null,list("choice"=num2text(host_pda.ui_mode)))
-			return
 
 	//emoji previews
 	if(href_list["emoji"])

--- a/code/modules/admin/verbs/admin_newscaster.dm
+++ b/code/modules/admin/verbs/admin_newscaster.dm
@@ -45,7 +45,7 @@
 /datum/newspanel/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "Newscaster")
+		ui = new(user, src, "PhysicalNewscaster")
 		ui.open()
 
 /datum/newspanel/ui_static_data(mob/user)

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -35,6 +35,7 @@
 	id_trim = /datum/id_trim/job/curator
 	uniform = /obj/item/clothing/under/rank/civilian/curator
 	backpack_contents = list(
+		/obj/item/modular_computer/tablet/preset/advanced/curator = 1,
 		/obj/item/barcodescanner = 1,
 		/obj/item/choice_beacon/hero = 1,
 	)

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -64,6 +64,11 @@
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/radar/custodial_locator)
 
+/obj/item/modular_computer/tablet/preset/advanced/curator/Initialize(mapload)
+	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
+	hard_drive.store_file(new /datum/computer_file/program/newscaster)
+
 /obj/item/modular_computer/tablet/preset/advanced/engineering/Initialize(mapload)
 	. = ..()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")

--- a/code/modules/modular_computers/file_system/programs/newscasterapp.dm
+++ b/code/modules/modular_computers/file_system/programs/newscasterapp.dm
@@ -1,0 +1,37 @@
+/datum/computer_file/program/newscaster
+	filename = "newscasterapp"
+	filedesc = "Newscaster"
+	required_access = list(ACCESS_LIBRARY)
+	category = PROGRAM_CATEGORY_CREW
+	program_icon_state = "computer"
+	extended_desc = "This program allows any user to access the Newscaster network from anywhere."
+	size = 2
+	requires_ntnet = TRUE
+	available_on_ntnet = TRUE
+	tgui_id = "NtosNewscaster"
+	program_icon = "newspaper"
+	///The UI we use for the newscaster
+	var/obj/machinery/newscaster/newscaster_ui
+
+/datum/computer_file/program/newscaster/New()
+	newscaster_ui = new()
+	return ..()
+
+/datum/computer_file/program/newscaster/Destroy()
+	QDEL_NULL(newscaster_ui)
+	return ..()
+
+/datum/computer_file/program/newscaster/ui_data(mob/user)
+	var/list/data = get_header_data()
+	data += newscaster_ui.ui_data(user)
+	return data
+
+/datum/computer_file/program/newscaster/ui_static_data(mob/user)
+	var/list/data = newscaster_ui.ui_static_data(user)
+	return data
+
+/datum/computer_file/program/newscaster/ui_act(action, params, datum/tgui/ui)
+	. = ..()
+	if(.)
+		return
+	return newscaster_ui.ui_act(action, params, ui)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3512,6 +3512,7 @@
 #include "code\modules\modular_computers\file_system\programs\crewmanifest.dm"
 #include "code\modules\modular_computers\file_system\programs\file_browser.dm"
 #include "code\modules\modular_computers\file_system\programs\jobmanagement.dm"
+#include "code\modules\modular_computers\file_system\programs\newscasterapp.dm"
 #include "code\modules\modular_computers\file_system\programs\ntdownloader.dm"
 #include "code\modules\modular_computers\file_system\programs\ntmonitor.dm"
 #include "code\modules\modular_computers\file_system\programs\ntnrc_client.dm"

--- a/tgui/packages/tgui/interfaces/Newscaster.js
+++ b/tgui/packages/tgui/interfaces/Newscaster.js
@@ -10,7 +10,6 @@ import { useBackend, useSharedState, useLocalState } from '../backend';
 import { BountyBoardContent } from './BountyBoard';
 import { UserDetails } from './Vending';
 import { BlockQuote, Box, Button, Divider, LabeledList, Modal, Section, Stack, Tabs, TextArea } from '../components';
-import { Window } from '../layouts';
 import { marked } from 'marked';
 import { sanitizeText } from "../sanitize";
 

--- a/tgui/packages/tgui/interfaces/Newscaster.js
+++ b/tgui/packages/tgui/interfaces/Newscaster.js
@@ -23,41 +23,37 @@ export const Newscaster = (props, context) => {
   const BOUNTYBOARD_SCREEN = 2;
   const [screenmode, setScreenmode] = useSharedState(context, 'tab_main', NEWSCASTER_SCREEN);
   return (
-    <Window
-      width={575}
-      height={560}>
+    <>
       <NewscasterChannelCreation />
       <NewscasterCommentCreation />
-      <NewscasterWantedScreen />
-      <Window.Content scrollable>
-        <Stack fill vertical>
-          <Stack.Item>
-            <Tabs fluid textAlign="center">
-              <Tabs.Tab
-                color="Green"
-                selected={screenmode === NEWSCASTER_SCREEN}
-                onClick={() => setScreenmode(NEWSCASTER_SCREEN)}>
-                Newscaster
-              </Tabs.Tab>
-              <Tabs.Tab
-                Color="Blue"
-                selected={screenmode === BOUNTYBOARD_SCREEN}
-                onClick={() => setScreenmode(BOUNTYBOARD_SCREEN)}>
-                Bounty Board
-              </Tabs.Tab>
-            </Tabs>
-          </Stack.Item>
-          <Stack.Item grow>
-            {screenmode === NEWSCASTER_SCREEN && (
-              <NewscasterContent />
-            )}
-            {screenmode === BOUNTYBOARD_SCREEN && (
-              <BountyBoardContent />
-            )}
-          </Stack.Item>
-        </Stack>
-      </Window.Content>
-    </Window>
+      <Stack fill vertical>
+        <NewscasterWantedScreen />
+        <Stack.Item>
+          <Tabs fluid textAlign="center">
+            <Tabs.Tab
+              color="Green"
+              selected={screenmode === NEWSCASTER_SCREEN}
+              onClick={() => setScreenmode(NEWSCASTER_SCREEN)}>
+              Newscaster
+            </Tabs.Tab>
+            <Tabs.Tab
+              Color="Blue"
+              selected={screenmode === BOUNTYBOARD_SCREEN}
+              onClick={() => setScreenmode(BOUNTYBOARD_SCREEN)}>
+              Bounty Board
+            </Tabs.Tab>
+          </Tabs>
+        </Stack.Item>
+        <Stack.Item grow>
+          {screenmode === NEWSCASTER_SCREEN && (
+            <NewscasterContent />
+          )}
+          {screenmode === BOUNTYBOARD_SCREEN && (
+            <BountyBoardContent />
+          )}
+        </Stack.Item>
+      </Stack>
+    </>
   );
 };
 
@@ -310,7 +306,7 @@ const NewscasterWantedScreen = (props, context) => {
   );
 };
 
-const NewscasterContent = (props, context) => {
+export const NewscasterContent = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     current_channel = {},

--- a/tgui/packages/tgui/interfaces/Newscaster.js
+++ b/tgui/packages/tgui/interfaces/Newscaster.js
@@ -306,7 +306,7 @@ const NewscasterWantedScreen = (props, context) => {
   );
 };
 
-export const NewscasterContent = (props, context) => {
+const NewscasterContent = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     current_channel = {},

--- a/tgui/packages/tgui/interfaces/NtosNewscaster.js
+++ b/tgui/packages/tgui/interfaces/NtosNewscaster.js
@@ -1,0 +1,12 @@
+import { NtosWindow } from '../layouts';
+import { Newscaster } from './Newscaster';
+
+export const NtosNewscaster = (props, context) => {
+  return (
+    <NtosWindow>
+      <NtosWindow.Content scrollable>
+        <Newscaster />
+      </NtosWindow.Content>
+    </NtosWindow>
+  );
+};

--- a/tgui/packages/tgui/interfaces/PhysicalNewscaster.js
+++ b/tgui/packages/tgui/interfaces/PhysicalNewscaster.js
@@ -1,0 +1,14 @@
+import { Newscaster } from "../interfaces/Newscaster";
+import { Window } from "../layouts";
+
+export const PhysicalNewscaster = (props, context) => {
+  return (
+    <Window
+      width={575}
+      height={560}>
+      <Window.Content scrollable>
+        <Newscaster />
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

@ArcaneMusic  pinging since they recently went over a lot of newscaster stuff

Removes the Curator’s PDA cartridge and gives them a roundstart tablet with the newscaster app pre-installed.

Refractors the PDA newscaster cartridge with a tablet TGUI app that takes advantages of the newscaster directly rather than completely snowflake coding it.

## Why It's Good For The Game

Helps us transition away from PDAs to tablets and makes an obscure app more available and easier to use.
I’m thinking of making this app purchasable off a disk (in the future ofc) since it’s locked behind Curator access.

## Changelog

:cl:
refactor: The Curators newscaster PDA app has been moved into a new Newscaster tablet app, with a full new UI.
/:cl:
