### PR TITLE
Human Life Optimization: Citrus Flavored

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -152,7 +152,8 @@
 #define G_FEMALE 2
 #define G_PLURAL 3
 
-///Organ slot processing order for life proc
+/// Defines how a mob's internal_organs_slot is ordered
+/// Exists so Life()'s organ process order is consistent
 GLOBAL_LIST_INIT(organ_process_order, list(
 	ORGAN_SLOT_BRAIN,
 	ORGAN_SLOT_APPENDIX,

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -332,6 +332,8 @@
 ///from [/obj/item/proc/tryEmbed] sent when trying to force an embed (mainly for projectiles and eating glass)
 #define COMSIG_EMBED_TRY_FORCE "item_try_embed"
 	#define COMPONENT_EMBED_SUCCESS (1<<1)
+// FROM [/obj/item/proc/updateEmbedding] sent when an item's embedding properties are changed : ()
+#define COMSIG_ITEM_EMBEDDING_UPDATE "item_embedding_update"
 
 ///sent to targets during the process_hit proc of projectiles
 #define COMSIG_PELLET_CLOUD_INIT "pellet_cloud_init"

--- a/code/__DEFINES/gravity.dm
+++ b/code/__DEFINES/gravity.dm
@@ -3,7 +3,7 @@
 #define STAGE_ONE 1
 /// Singularity is stage 2 (3x3)
 #define STAGE_TWO 3
-/// Singularity is stage 3 (5x5) 
+/// Singularity is stage 3 (5x5)
 #define STAGE_THREE 5
 /// Singularity is stage 4 (7x7)
 #define STAGE_FOUR 7
@@ -11,17 +11,6 @@
 #define STAGE_FIVE 9
 /// Singularity is stage 6 (11x11)
 #define STAGE_SIX 11 //From supermatter shard
-
-///range of values where you suffer from negative gravity
-#define NEGATIVE_GRAVITY_RANGE -INFINITY to NEGATIVE_GRAVITY
-///range of values where you have no gravity
-#define WEIGHTLESS_RANGE NEGATIVE_GRAVITY + 0.01 to 0
-///range of values where you have normal gravity
-#define STANDRARD_GRAVITY_RANGE 0.01 to STANDARD_GRAVITY
-///range of values where you have heavy gravity
-#define HIGH_GRAVITY_RANGE STANDARD_GRAVITY + 0.01 to GRAVITY_DAMAGE_THRESHOLD - 0.01
-///range of values where you suffer from crushing gravity
-#define CRUSHING_GRAVITY_RANGE GRAVITY_DAMAGE_THRESHOLD to INFINITY
 
 /**
  * The point where gravity is negative enough to pull you upwards.

--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -84,7 +84,7 @@
 	START_PROCESSING(SSdcs, src)
 	var/mob/living/carbon/victim = parent
 
-	limb.embedded_objects |= weapon // on the inside... on the inside...
+	limb._embed_object(weapon) // on the inside... on the inside...
 	weapon.forceMove(victim)
 	RegisterSignal(weapon, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING), .proc/weaponDeleted)
 	victim.visible_message(span_danger("[weapon] [harmful ? "embeds" : "sticks"] itself [harmful ? "in" : "to"] [victim]'s [limb.name]!"), span_userdanger("[weapon] [harmful ? "embeds" : "sticks"] itself [harmful ? "in" : "to"] your [limb.name]!"))
@@ -215,7 +215,7 @@
 	SIGNAL_HANDLER
 
 	var/mob/living/carbon/victim = parent
-	limb.embedded_objects -= weapon
+	limb._unembed_object(weapon)
 	UnregisterSignal(weapon, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING)) // have to do it here otherwise we trigger weaponDeleted()
 
 	if(!weapon.unembedded()) // if it hasn't deleted itself due to drop del
@@ -232,7 +232,7 @@
 	SIGNAL_HANDLER
 
 	var/mob/living/carbon/victim = parent
-	limb.embedded_objects -= weapon
+	limb._unembed_object(weapon)
 
 	if(victim)
 		to_chat(victim, span_userdanger("\The [weapon] that was embedded in your [limb.name] disappears!"))

--- a/code/datums/components/surgery_initiator.dm
+++ b/code/datums/components/surgery_initiator.dm
@@ -143,7 +143,7 @@
 		return
 
 	if(the_surgery.operated_bodypart)
-		the_surgery.operated_bodypart.generic_bleedstacks -= 5
+		the_surgery.operated_bodypart.adjustBleedStacks(-5)
 
 	patient.surgeries -= the_surgery
 	REMOVE_TRAIT(patient, TRAIT_ALLOWED_HONORBOUND_ATTACK, ELEMENT_TRAIT(type))

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -58,7 +58,8 @@ Bonus
 			if(power >= 2)
 				if(ears.damage < ears.maxHealth)
 					to_chat(M, span_userdanger("Your ears pop painfully and start bleeding!"))
-					ears.damage = max(ears.damage, ears.maxHealth)
+					// Just absolutely murder me man
+					ears.applyOrganDamage(ears.maxHealth)
 					M.emote("scream")
 			else
 				to_chat(M, span_userdanger("Your ears pop and begin ringing loudly!"))

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -66,7 +66,7 @@ Bonus
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			var/obj/item/bodypart/random_part = pick(H.bodyparts)
-			random_part.generic_bleedstacks += 5 * power
+			random_part.adjustBleedStacks(5 * power)
 	return 1
 
 /*

--- a/code/datums/elements/earhealing.dm
+++ b/code/datums/elements/earhealing.dm
@@ -32,5 +32,5 @@
 		if(!ears || HAS_TRAIT_NOT_FROM(user, TRAIT_DEAF, EAR_DAMAGE))
 			continue
 		ears.deaf = max(ears.deaf - 0.25 * delta_time, (ears.damage < ears.maxHealth ? 0 : 1)) // Do not clear deafness if our ears are too damaged
-		ears.damage = max(ears.damage - 0.025 * delta_time, 0)
+		ears.applyOrganDamage(-0.025 * delta_time, 0)
 		CHECK_TICK

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -199,7 +199,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 /datum/voice_of_god_command/bleed/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	for(var/mob/living/carbon/human/target in listeners)
 		var/obj/item/bodypart/chosen_part = pick(target.bodyparts)
-		chosen_part.generic_bleedstacks += 5
+		chosen_part.adjustBleedStacks(5)
 
 /// This command sets the listeners ablaze.
 /datum/voice_of_god_command/burn

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -364,6 +364,24 @@
 /datum/wound/proc/on_stasis(delta_time, times_fired)
 	return
 
+/// Sets our blood flow
+/datum/wound/proc/set_blood_flow(set_to)
+	adjust_blood_flow(set_to - blood_flow)
+
+/// Use this to modify blood flow. You must use this to change the variable
+/// Takes the amount to adjust by, and the lowest amount we're allowed to have post adjust
+/datum/wound/proc/adjust_blood_flow(adjust_by, minimum = 0)
+	if(!adjust_by)
+		return
+	var/old_flow = blood_flow
+	blood_flow = max(blood_flow + adjust_by, minimum)
+
+	if(old_flow == blood_flow)
+		return
+
+	/// Update our bleed rate
+	limb.refresh_bleed_rate()
+
 /// Used when we're being dragged while bleeding, the value we return is how much bloodloss this wound causes from being dragged. Since it's a proc, you can let bandages soak some of the blood
 /datum/wound/proc/drag_bleed_amount()
 	return

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -24,7 +24,7 @@
 	var/internal_bleeding_coefficient
 
 /datum/wound/pierce/wound_injury(datum/wound/old_wound = null, attack_direction = null)
-	blood_flow = initial_flow
+	set_blood_flow(initial_flow)
 	if(attack_direction && victim.blood_volume > BLOOD_VOLUME_OKAY)
 		victim.spray_blood(attack_direction, severity)
 
@@ -60,18 +60,18 @@
 	return BLOOD_FLOW_STEADY
 
 /datum/wound/pierce/handle_process(delta_time, times_fired)
-	blood_flow = min(blood_flow, WOUND_SLASH_MAX_BLOODFLOW)
+	set_blood_flow(min(blood_flow, WOUND_SLASH_MAX_BLOODFLOW))
 
 	if(victim.bodytemperature < (BODYTEMP_NORMAL - 10))
-		blood_flow -= 0.1 * delta_time
+		adjust_blood_flow(-0.1 * delta_time)
 		if(DT_PROB(2.5, delta_time))
 			to_chat(victim, span_notice("You feel the [lowertext(name)] in your [limb.name] firming up from the cold!"))
 
 	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS))
-		blood_flow += 0.25 * delta_time // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
+		adjust_blood_flow(0.25 * delta_time) // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
 
 	if(limb.current_gauze)
-		blood_flow -= limb.current_gauze.absorption_rate * gauzed_clot_rate * delta_time
+		adjust_blood_flow(-limb.current_gauze.absorption_rate * gauzed_clot_rate * delta_time)
 		limb.current_gauze.absorption_capacity -= limb.current_gauze.absorption_rate * delta_time
 
 	if(blood_flow <= 0)
@@ -94,11 +94,11 @@
 
 /datum/wound/pierce/on_xadone(power)
 	. = ..()
-	blood_flow -= 0.03 * power // i think it's like a minimum of 3 power, so .09 blood_flow reduction per tick is pretty good for 0 effort
+	adjust_blood_flow(-0.03 * power) // i think it's like a minimum of 3 power, so .09 blood_flow reduction per tick is pretty good for 0 effort
 
 /datum/wound/pierce/on_synthflesh(power)
 	. = ..()
-	blood_flow -= 0.025 * power // 20u * 0.05 = -1 blood flow, less than with slashes but still good considering smaller bleed rates
+	adjust_blood_flow(-0.025 * power) // 20u * 0.05 = -1 blood flow, less than with slashes but still good considering smaller bleed rates
 
 /// If someone is using a suture to close this puncture
 /datum/wound/pierce/proc/suture(obj/item/stack/medical/suture/I, mob/user)
@@ -108,7 +108,7 @@
 		return
 	user.visible_message(span_green("[user] stitches up some of the bleeding on [victim]."), span_green("You stitch up some of the bleeding on [user == victim ? "yourself" : "[victim]"]."))
 	var/blood_sutured = I.stop_bleeding / self_penalty_mult
-	blood_flow -= blood_sutured
+	adjust_blood_flow(-blood_sutured)
 	limb.heal_damage(I.heal_brute, I.heal_burn)
 	I.use(1)
 
@@ -131,7 +131,7 @@
 	if(prob(30))
 		victim.emote("scream")
 	var/blood_cauterized = (0.6 / (self_penalty_mult * improv_penalty_mult))
-	blood_flow -= blood_cauterized
+	adjust_blood_flow(-blood_cauterized)
 
 	if(blood_flow > 0)
 		try_treating(I, user)

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -32,12 +32,12 @@
 
 /datum/wound/slash/wound_injury(datum/wound/slash/old_wound = null, attack_direction = null)
 	if(old_wound)
-		blood_flow = max(old_wound.blood_flow, initial_flow)
+		set_blood_flow(max(old_wound.blood_flow, initial_flow))
 		if(old_wound.severity > severity && old_wound.highest_scar)
 			set_highest_scar(old_wound.highest_scar)
 			old_wound.clear_highest_scar()
 	else
-		blood_flow = initial_flow
+		set_blood_flow(initial_flow)
 		if(attack_direction && victim.blood_volume > BLOOD_VOLUME_OKAY)
 			victim.spray_blood(attack_direction, severity)
 
@@ -84,7 +84,7 @@
 
 /datum/wound/slash/receive_damage(wounding_type, wounding_dmg, wound_bonus)
 	if(victim.stat != DEAD && wound_bonus != CANT_WOUND && wounding_type == WOUND_SLASH) // can't stab dead bodies to make it bleed faster this way
-		blood_flow += WOUND_SLASH_DAMAGE_FLOW_COEFF * wounding_dmg
+		adjust_blood_flow(WOUND_SLASH_DAMAGE_FLOW_COEFF * wounding_dmg)
 
 /datum/wound/slash/drag_bleed_amount()
 	// say we have 3 severe cuts with 3 blood flow each, pretty reasonable
@@ -107,7 +107,7 @@
 
 /datum/wound/slash/handle_process(delta_time, times_fired)
 	if(victim.stat == DEAD)
-		blood_flow -= max(clot_rate, WOUND_SLASH_DEAD_CLOT_MIN) * delta_time
+		adjust_blood_flow(-max(clot_rate, WOUND_SLASH_DEAD_CLOT_MIN) * delta_time)
 		if(blood_flow < minimum_flow)
 			if(demotes_to)
 				replace_wound(demotes_to)
@@ -115,18 +115,18 @@
 			qdel(src)
 			return
 
-	blood_flow = min(blood_flow, WOUND_SLASH_MAX_BLOODFLOW)
+	set_blood_flow(min(blood_flow, WOUND_SLASH_MAX_BLOODFLOW))
 
 	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS))
-		blood_flow += 0.25 // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
+		adjust_blood_flow(0.25) // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
 
 	if(limb.current_gauze)
 		if(clot_rate > 0)
-			blood_flow -= clot_rate * delta_time
-		blood_flow -= limb.current_gauze.absorption_rate * delta_time
+			adjust_blood_flow(-clot_rate * delta_time)
+		adjust_blood_flow(-limb.current_gauze.absorption_rate * delta_time)
 		limb.seep_gauze(limb.current_gauze.absorption_rate * delta_time)
 	else
-		blood_flow -= clot_rate * delta_time
+		adjust_blood_flow(-clot_rate * delta_time)
 
 	if(blood_flow > highest_flow)
 		highest_flow = blood_flow
@@ -195,7 +195,7 @@
 
 	user.visible_message(span_notice("[user] licks the wounds on [victim]'s [limb.name]."), span_notice("You lick some of the wounds on [victim]'s [limb.name]"), ignored_mobs=victim)
 	to_chat(victim, span_green("[user] licks the wounds on your [limb.name]!"))
-	blood_flow -= 0.5
+	adjust_blood_flow(-0.5)
 
 	if(blood_flow > minimum_flow)
 		try_handling(user)
@@ -204,11 +204,11 @@
 
 /datum/wound/slash/on_xadone(power)
 	. = ..()
-	blood_flow -= 0.03 * power // i think it's like a minimum of 3 power, so .09 blood_flow reduction per tick is pretty good for 0 effort
+	adjust_blood_flow(-0.03 * power) // i think it's like a minimum of 3 power, so .09 blood_flow reduction per tick is pretty good for 0 effort
 
 /datum/wound/slash/on_synthflesh(power)
 	. = ..()
-	blood_flow -= 0.075 * power // 20u * 0.075 = -1.5 blood flow, pretty good for how little effort it is
+	adjust_blood_flow(-0.075 * power) // 20u * 0.075 = -1.5 blood flow, pretty good for how little effort it is
 
 /// If someone's putting a laser gun up to our cut to cauterize it
 /datum/wound/slash/proc/las_cauterize(obj/item/gun/energy/laser/lasgun, mob/user)
@@ -222,7 +222,7 @@
 	if(!lasgun.process_fire(victim, victim, TRUE, null, limb.body_zone))
 		return
 	victim.emote("scream")
-	blood_flow -= damage / (5 * self_penalty_mult) // 20 / 5 = 4 bloodflow removed, p good
+	adjust_blood_flow(-damage / (5 * self_penalty_mult)) // 20 / 5 = 4 bloodflow removed, p good
 	victim.visible_message(span_warning("The cuts on [victim]'s [limb.name] scar over!"))
 
 /// If someone is using either a cautery tool or something with heat to cauterize this cut
@@ -239,7 +239,7 @@
 	if(prob(30))
 		victim.emote("scream")
 	var/blood_cauterized = (0.6 / (self_penalty_mult * improv_penalty_mult))
-	blood_flow -= blood_cauterized
+	adjust_blood_flow(-blood_cauterized)
 
 	if(blood_flow > minimum_flow)
 		try_treating(I, user)
@@ -256,7 +256,7 @@
 
 	user.visible_message(span_green("[user] stitches up some of the bleeding on [victim]."), span_green("You stitch up some of the bleeding on [user == victim ? "yourself" : "[victim]"]."))
 	var/blood_sutured = I.stop_bleeding / self_penalty_mult
-	blood_flow -= blood_sutured
+	adjust_blood_flow(-blood_sutured)
 	limb.heal_damage(I.heal_brute, I.heal_burn)
 	I.use(1)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1109,6 +1109,9 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 ///For when you want to add/update the embedding on an item. Uses the vars in [/obj/item/var/embedding], and defaults to config values for values that aren't set. Will automatically detach previous embed elements on this item.
 /obj/item/proc/updateEmbedding()
+	SHOULD_CALL_PARENT(TRUE)
+
+	SEND_SIGNAL(src, COMSIG_ITEM_EMBEDDING_UPDATE)
 	if(!LAZYLEN(embedding))
 		disableEmbedding()
 		return

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -426,9 +426,8 @@
 			if(prob(50))
 				step(W, pick(GLOB.alldirs))
 		ADD_TRAIT(H, TRAIT_DISFIGURED, TRAIT_GENERIC)
-		for(var/i in H.bodyparts)
-			var/obj/item/bodypart/BP = i
-			BP.generic_bleedstacks += 5
+		for(var/obj/item/bodypart/part as anything in H.bodyparts)
+			part.adjustBleedStacks(5)
 		H.gib_animation()
 		sleep(3)
 		H.adjustBruteLoss(1000) //to make the body super-bloody

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
@@ -103,4 +103,4 @@
 			bloodiest_wound = iter_wound
 
 	if(bloodiest_wound)
-		bloodiest_wound.blood_flow = max(0, bloodiest_wound.blood_flow - 0.5)
+		bloodiest_wound.set_blood_flow(max(0, bloodiest_wound.blood_flow - 0.5))

--- a/code/modules/clothing/head/tinfoilhat.dm
+++ b/code/modules/clothing/head/tinfoilhat.dm
@@ -90,5 +90,5 @@
 	user.say(pick(conspiracy_line), forced=type)
 	var/obj/item/organ/brain/brain = user.getorganslot(ORGAN_SLOT_BRAIN)
 	if(brain)
-		brain.damage = BRAIN_DAMAGE_DEATH
+		brain.setOrganDamage(BRAIN_DAMAGE_DEATH)
 	return OXYLOSS

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -479,7 +479,6 @@
 				path = /obj/item/bodypart/r_arm
 
 			var/obj/item/bodypart/BP = new path ()
-			BP.owner = src
 			BP.held_index = i
 			add_bodypart(BP)
 			hand_bodyparts[i] = BP

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -66,7 +66,7 @@
 	for(var/obj/item/bodypart/iter_part as anything in bodyparts)
 		var/iter_bleed_rate = iter_part.get_part_bleed_rate()
 		temp_bleed += iter_bleed_rate * delta_time
-		iter_part.generic_bleedstacks = max(0, iter_part.generic_bleedstacks - 1)
+		iter_part.adjustBleedStacks(-1, 0)
 		if(iter_part.update_part_wound_overlay())
 			update_bleed_icons = TRUE
 
@@ -189,7 +189,7 @@
 	blood_volume = BLOOD_VOLUME_NORMAL
 	for(var/i in bodyparts)
 		var/obj/item/bodypart/BP = i
-		BP.generic_bleedstacks = 0
+		BP.setBleedStacks(0)
 
 /****************************************************
 				BLOOD TRANSFERS

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -61,32 +61,22 @@
 				death()
 
 	var/temp_bleed = 0
-	var/update_bleed_icons = FALSE
 	//Bleeding out
 	for(var/obj/item/bodypart/iter_part as anything in bodyparts)
-		var/iter_bleed_rate = iter_part.get_part_bleed_rate()
+		var/iter_bleed_rate = iter_part.get_modified_bleed_rate()
 		temp_bleed += iter_bleed_rate * delta_time
-		iter_part.adjustBleedStacks(-1, 0)
-		if(iter_part.update_part_wound_overlay())
-			update_bleed_icons = TRUE
 
-	if(update_bleed_icons)
-		update_wound_overlays()
+		if(iter_part.generic_bleedstacks) // If you don't have any bleedstacks, don't try and heal them
+			iter_part.adjustBleedStacks(-1, 0)
 
 	if(temp_bleed)
 		bleed(temp_bleed)
 		bleed_warn(temp_bleed)
 
-/// Has each bodypart update its bleed/wound overlay icon states. If any have changed, it has the owner update wound overlays and returns TRUE
+/// Has each bodypart update its bleed/wound overlay icon states
 /mob/living/carbon/proc/update_bodypart_bleed_overlays()
-	var/update_bleed_icons
 	for(var/obj/item/bodypart/iter_part as anything in bodyparts)
-		if(iter_part.update_part_wound_overlay())
-			update_bleed_icons = TRUE
-
-	if(update_bleed_icons)
-		update_wound_overlays()
-	return update_bleed_icons
+		iter_part.update_part_wound_overlay()
 
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/proc/bleed(amt)
@@ -110,7 +100,7 @@
 	var/bleed_amt = 0
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/iter_bodypart = X
-		bleed_amt += iter_bodypart.get_part_bleed_rate()
+		bleed_amt += iter_bodypart.get_modified_bleed_rate()
 	return bleed_amt
 
 /mob/living/carbon/human/get_bleed_rate()

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -20,7 +20,7 @@
 	else if(istype(loc, /obj/item/organ/brain))
 		BR = loc
 	if(BR)
-		BR.damage = BRAIN_DAMAGE_DEATH //beaten to a pulp
+		BR.setOrganDamage(BRAIN_DAMAGE_DEATH) //beaten to a pulp
 
 /mob/living/brain/proc/handle_emp_damage(delta_time, times_fired)
 	if(!emp_damage)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1233,17 +1233,15 @@
 
 /// if any of our bodyparts are bleeding
 /mob/living/carbon/proc/is_bleeding()
-	for(var/i in bodyparts)
-		var/obj/item/bodypart/BP = i
-		if(BP.get_part_bleed_rate())
+	for(var/obj/item/bodypart/part as anything in bodyparts)
+		if(part.get_modified_bleed_rate())
 			return TRUE
 
 /// get our total bleedrate
 /mob/living/carbon/proc/get_total_bleed_rate()
 	var/total_bleed_rate = 0
-	for(var/i in bodyparts)
-		var/obj/item/bodypart/BP = i
-		total_bleed_rate += BP.get_part_bleed_rate()
+	for(var/obj/item/bodypart/part as anything in bodyparts)
+		total_bleed_rate += part.get_modified_bleed_rate()
 
 	return total_bleed_rate
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1036,13 +1036,9 @@
 /mob/living/carbon/proc/slot_in_organ(obj/item/organ/insert, slot)
 	internal_organs |= insert
 	internal_organs_slot[slot] = insert
-	/// internal_organs must ALWAYS be ordered in the same way as organ_process_order
+	/// internal_organs_slot must ALWAYS be ordered in the same way as organ_process_order
 	/// Otherwise life processing breaks down
 	sortTim(internal_organs_slot, /proc/cmp_organ_slot_asc)
-	// Now that internal_organs_slot is sorted, we're gonna use it to also sort internal_organs
-	internal_organs = list()
-	for(var/intenral_slot in internal_organs_slot)
-		internal_organs += internal_organs_slot[intenral_slot]
 
 /proc/cmp_organ_slot_asc(slot_a, slot_b)
 	return GLOB.organ_process_order.Find(slot_a) - GLOB.organ_process_order.Find(slot_b)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -999,7 +999,7 @@
 ///Proc to hook behavior on bodypart additions.
 /mob/living/carbon/proc/add_bodypart(obj/item/bodypart/new_bodypart)
 	bodyparts += new_bodypart
-	new_bodypart.owner = src
+	new_bodypart.set_owner(src)
 
 	switch(new_bodypart.body_part)
 		if(LEG_LEFT, LEG_RIGHT)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1031,6 +1031,17 @@
 		var/obj/item/organ/I = X
 		I.Insert(src)
 
+/// Takes an organ to slot in, and the slot to put it in, and puts in inside our lists properly
+/// To be called once the organ is actually inside us. NOT a helper proc
+/mob/living/carbon/proc/slot_in_organ(obj/item/organ/insert, slot)
+	internal_organs |= insert
+	internal_organs_slot[slot] = insert
+	/// internal_organs_slot must ALWAYS be ordered in the same way as organ_process_order
+	/// Otherwise life processing breaks down
+	sortTim(internal_organs_slot, /proc/cmp_organ_slot_asc)
+
+/proc/cmp_organ_slot_asc(slot_a, slot_b)
+	return GLOB.organ_process_order.Find(slot_a) - GLOB.organ_process_order.Find(slot_b)
 
 /mob/living/carbon/vv_get_dropdown()
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1036,9 +1036,13 @@
 /mob/living/carbon/proc/slot_in_organ(obj/item/organ/insert, slot)
 	internal_organs |= insert
 	internal_organs_slot[slot] = insert
-	/// internal_organs_slot must ALWAYS be ordered in the same way as organ_process_order
+	/// internal_organs must ALWAYS be ordered in the same way as organ_process_order
 	/// Otherwise life processing breaks down
 	sortTim(internal_organs_slot, /proc/cmp_organ_slot_asc)
+	// Now that internal_organs_slot is sorted, we're gonna use it to also sort internal_organs
+	internal_organs = list()
+	for(var/intenral_slot in internal_organs_slot)
+		internal_organs += internal_organs_slot[intenral_slot]
 
 /proc/cmp_organ_slot_asc(slot_a, slot_b)
 	return GLOB.organ_process_order.Find(slot_a) - GLOB.organ_process_order.Find(slot_b)

--- a/code/modules/mob/living/carbon/carbon_context.dm
+++ b/code/modules/mob/living/carbon/carbon_context.dm
@@ -15,7 +15,7 @@
 	else if (human_user == src)
 		context[SCREENTIP_CONTEXT_LMB] = "Check injuries"
 
-		if (get_bodypart(human_user.zone_selected)?.get_part_bleed_rate())
+		if (get_bodypart(human_user.zone_selected)?.get_modified_bleed_rate())
 			context[SCREENTIP_CONTEXT_CTRL_LMB] = "Grab limb"
 
 	if (human_user != src)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -652,7 +652,7 @@
 		return ..()
 
 	var/obj/item/bodypart/grasped_part = get_bodypart(zone_selected)
-	if(!grasped_part?.get_part_bleed_rate())
+	if(!grasped_part?.get_modified_bleed_rate())
 		return
 	var/starting_hand_index = active_hand_index
 	if(starting_hand_index == grasped_part.held_index)
@@ -691,6 +691,7 @@
 	if(grasped_part)
 		UnregisterSignal(grasped_part, list(COMSIG_CARBON_REMOVE_LIMB, COMSIG_PARENT_QDELETING))
 		grasped_part.grasped_by = null
+		grasped_part.refresh_bleed_rate()
 	grasped_part = null
 	user = null
 	return ..()
@@ -710,6 +711,7 @@
 
 	grasped_part = grasping_part
 	grasped_part.grasped_by = src
+	grasped_part.refresh_bleed_rate()
 	RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/qdel_void)
 	RegisterSignal(grasped_part, list(COMSIG_CARBON_REMOVE_LIMB, COMSIG_PARENT_QDELETING), .proc/qdel_void)
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -582,8 +582,9 @@
 				to_chat(src, span_warning("Your ears start to ring badly!"))
 				if(prob(ears.damage - 5))
 					to_chat(src, span_userdanger("You can't hear anything!"))
-					ears.damage = min(ears.damage, ears.maxHealth) // does this actually do anything useful? all this would do is set an upper bound on damage, is this supposed to be a max?
+					// Makes you deaf, enough that you need a proper source of healing, it won't self heal
 					// you need earmuffs, inacusiate, or replacement
+					ears.setOrganDamage(ears.maxHealth)
 			else if(ears.damage >= 5)
 				to_chat(src, span_warning("Your ears start to ring!"))
 			SEND_SOUND(src, sound('sound/weapons/flash_ring.ogg',0,1,0,250))

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -25,7 +25,10 @@
 	///Same as handcuffs but for legs. Bear traps use this.
 	var/obj/item/legcuffed = null
 
+	/// Measure of how disgusted we are. See DISGUST_LEVEL_GROSS and friends
 	var/disgust = 0
+	/// How disgusted we were LAST time we processed disgust. Helps prevent unneeded work
+	var/old_disgust = 0
 
 	//inventory slots
 	var/obj/item/back = null

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -257,9 +257,8 @@
 		var/list/obj/item/bodypart/bleeding_limbs = list()
 		var/list/obj/item/bodypart/grasped_limbs = list()
 
-		for(var/i in bodyparts)
-			var/obj/item/bodypart/body_part = i
-			if(body_part.get_part_bleed_rate())
+		for(var/obj/item/bodypart/body_part as anything in bodyparts)
+			if(body_part.get_modified_bleed_rate())
 				bleeding_limbs += body_part
 			if(body_part.grasped_by)
 				grasped_limbs += body_part

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -807,10 +807,9 @@
 
 	if(is_bleeding())
 		var/list/obj/item/bodypart/bleeding_limbs = list()
-		for(var/i in bodyparts)
-			var/obj/item/bodypart/BP = i
-			if(BP.get_part_bleed_rate())
-				bleeding_limbs += BP
+		for(var/obj/item/bodypart/part as anything in bodyparts)
+			if(part.get_modified_bleed_rate())
+				bleeding_limbs += part
 
 		var/num_bleeds = LAZYLEN(bleeding_limbs)
 		var/bleed_text = "<span class='danger'>You are bleeding from your"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1508,8 +1508,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
  * * humi (required) The mob we will targeting
  */
 /datum/species/proc/body_temperature_alerts(mob/living/carbon/human/humi)
+	var/old_bodytemp = humi.old_bodytemperature
+	var/bodytemp = humi.bodytemperature
 	// Body temperature is too hot, and we do not have resist traits
-	if(humi.bodytemperature > bodytemp_heat_damage_limit && !HAS_TRAIT(humi, TRAIT_RESISTHEAT))
+	if(bodytemp > bodytemp_heat_damage_limit && !HAS_TRAIT(humi, TRAIT_RESISTHEAT))
 		// Clear cold mood and apply hot mood
 		SEND_SIGNAL(humi, COMSIG_CLEAR_MOOD_EVENT, "cold")
 		SEND_SIGNAL(humi, COMSIG_ADD_MOOD_EVENT, "hot", /datum/mood_event/hot)
@@ -1517,7 +1519,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		//Remove any slowdown from the cold.
 		humi.remove_movespeed_modifier(/datum/movespeed_modifier/cold)
 		// display alerts based on how hot it is
-		switch(humi.bodytemperature)
+		switch(bodytemp)
 			if(bodytemp_heat_damage_limit to BODYTEMP_HEAT_WARNING_2)
 				humi.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/hot, 1)
 			if(BODYTEMP_HEAT_WARNING_2 to BODYTEMP_HEAT_WARNING_3)
@@ -1526,14 +1528,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				humi.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/hot, 3)
 
 	// Body temperature is too cold, and we do not have resist traits
-	else if(humi.bodytemperature < bodytemp_cold_damage_limit && !HAS_TRAIT(humi, TRAIT_RESISTCOLD))
+	else if(bodytemp < bodytemp_cold_damage_limit && !HAS_TRAIT(humi, TRAIT_RESISTCOLD))
 		// clear any hot moods and apply cold mood
 		SEND_SIGNAL(humi, COMSIG_CLEAR_MOOD_EVENT, "hot")
 		SEND_SIGNAL(humi, COMSIG_ADD_MOOD_EVENT, "cold", /datum/mood_event/cold)
 		// Apply cold slow down
 		humi.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/cold, multiplicative_slowdown = ((bodytemp_cold_damage_limit - humi.bodytemperature) / COLD_SLOWDOWN_FACTOR))
 		// Display alerts based how cold it is
-		switch(humi.bodytemperature)
+		switch(bodytemp)
 			if(BODYTEMP_COLD_WARNING_2 to bodytemp_cold_damage_limit)
 				humi.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/cold, 1)
 			if(BODYTEMP_COLD_WARNING_3 to BODYTEMP_COLD_WARNING_2)
@@ -1542,11 +1544,16 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				humi.throw_alert(ALERT_TEMPERATURE, /atom/movable/screen/alert/cold, 3)
 
 	// We are not to hot or cold, remove status and moods
-	else
+	// Optimization here, we check these things based off the old temperature to avoid unneeded work
+	// We're not perfect about this, because it'd just add more work to the base case, and resistances are rare
+	else if (old_bodytemp > bodytemp_heat_damage_limit || old_bodytemp < bodytemp_cold_damage_limit)
 		humi.clear_alert(ALERT_TEMPERATURE)
 		humi.remove_movespeed_modifier(/datum/movespeed_modifier/cold)
 		SEND_SIGNAL(humi, COMSIG_CLEAR_MOOD_EVENT, "cold")
 		SEND_SIGNAL(humi, COMSIG_CLEAR_MOOD_EVENT, "hot")
+
+	// Store the old bodytemp for future checking
+	humi.old_bodytemperature = bodytemp
 
 /**
  * Used to apply wounds and damage based on core/body temp

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -331,17 +331,22 @@
 		. |= limb.on_life(delta_time, times_fired)
 
 /mob/living/carbon/proc/handle_organs(delta_time, times_fired)
-	if(stat != DEAD)
-		for(var/organ_slot in GLOB.organ_process_order)
-			var/obj/item/organ/organ = getorganslot(organ_slot)
-			if(organ?.owner) // This exist mostly because reagent metabolization can cause organ reshuffling
-				organ.on_life(delta_time, times_fired)
-	else
+	if(stat == DEAD)
 		if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || reagents.has_reagent(/datum/reagent/cryostylane)) // No organ decay if the body contains formaldehyde.
 			return
 		for(var/V in internal_organs)
 			var/obj/item/organ/organ = V
 			organ.on_death(delta_time, times_fired) //Needed so organs decay while inside the body.
+		return
+
+	// NOTE: internal_organs_slot is sorted by GLOB.organ_process_order on insertion
+	for(var/slot in internal_organs_slot)
+		// We don't use getorganslot here because we know we have the organ we want, since we're iterating the list containing em already
+		// This code is hot enough that it's just not worth the time
+		var/obj/item/organ/organ = internal_organs_slot[slot]
+		if(organ?.owner) // This exist mostly because reagent metabolization can cause organ reshuffling
+			organ.on_life(delta_time, times_fired)
+
 
 /mob/living/carbon/handle_diseases(delta_time, times_fired)
 	for(var/thing in diseases)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -334,14 +334,16 @@
 	if(stat == DEAD)
 		if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || reagents.has_reagent(/datum/reagent/cryostylane)) // No organ decay if the body contains formaldehyde.
 			return
-		for(var/obj/item/organ/organ as anything in internal_organs)
+		for(var/V in internal_organs)
+			var/obj/item/organ/organ = V
 			organ.on_death(delta_time, times_fired) //Needed so organs decay while inside the body.
 		return
 
-	// NOTE: internal_organs is sorted by GLOB.organ_process_order on insertion
-	// It has a defined order, check that list to find it
-	for(var/obj/item/organ/organ as anything in internal_organs)
-		// I could iterate internal_organs_slot here, but this code is hot enough the assoc access actually does barely matter
+	// NOTE: internal_organs_slot is sorted by GLOB.organ_process_order on insertion
+	for(var/slot in internal_organs_slot)
+		// We don't use getorganslot here because we know we have the organ we want, since we're iterating the list containing em already
+		// This code is hot enough that it's just not worth the time
+		var/obj/item/organ/organ = internal_organs_slot[slot]
 		if(organ?.owner) // This exist mostly because reagent metabolization can cause organ reshuffling
 			organ.on_life(delta_time, times_fired)
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -334,16 +334,14 @@
 	if(stat == DEAD)
 		if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || reagents.has_reagent(/datum/reagent/cryostylane)) // No organ decay if the body contains formaldehyde.
 			return
-		for(var/V in internal_organs)
-			var/obj/item/organ/organ = V
+		for(var/obj/item/organ/organ as anything in internal_organs)
 			organ.on_death(delta_time, times_fired) //Needed so organs decay while inside the body.
 		return
 
-	// NOTE: internal_organs_slot is sorted by GLOB.organ_process_order on insertion
-	for(var/slot in internal_organs_slot)
-		// We don't use getorganslot here because we know we have the organ we want, since we're iterating the list containing em already
-		// This code is hot enough that it's just not worth the time
-		var/obj/item/organ/organ = internal_organs_slot[slot]
+	// NOTE: internal_organs is sorted by GLOB.organ_process_order on insertion
+	// It has a defined order, check that list to find it
+	for(var/obj/item/organ/organ as anything in internal_organs)
+		// I could iterate internal_organs_slot here, but this code is hot enough the assoc access actually does barely matter
 		if(organ?.owner) // This exist mostly because reagent metabolization can cause organ reshuffling
 			organ.on_life(delta_time, times_fired)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1071,30 +1071,35 @@
 	. = ..()
 	if(!SSticker.HasRoundStarted())
 		return
-	var/was_weightless = alerts[ALERT_GRAVITY] && istype(alerts[ALERT_GRAVITY], /atom/movable/screen/alert/weightless)
-	var/was_negative = alerts[ALERT_GRAVITY] && istype(alerts[ALERT_GRAVITY], /atom/movable/screen/alert/negative)
+	var/atom/movable/screen/alert/gravity_alert = alerts[ALERT_GRAVITY]
 	switch(gravity)
-		if(NEGATIVE_GRAVITY_RANGE)
-			throw_alert(ALERT_GRAVITY, /atom/movable/screen/alert/negative)
-			if(!was_negative)
+		if(-INFINITY to NEGATIVE_GRAVITY)
+			if(!istype(gravity_alert, /atom/movable/screen/alert/negative))
+				throw_alert(ALERT_GRAVITY, /atom/movable/screen/alert/negative)
 				var/matrix/flipped_matrix = transform
 				flipped_matrix.b = -flipped_matrix.b
 				flipped_matrix.e = -flipped_matrix.e
 				animate(src, transform = flipped_matrix, pixel_y = pixel_y+4, time = 0.5 SECONDS, easing = EASE_OUT)
 				base_pixel_y += 4
-		if(WEIGHTLESS_RANGE)
-			throw_alert(ALERT_GRAVITY, /atom/movable/screen/alert/weightless)
-			if(!was_weightless)
+		if(NEGATIVE_GRAVITY + 0.01 to 0)
+			if(!istype(gravity_alert, /atom/movable/screen/alert/weightless))
+				throw_alert(ALERT_GRAVITY, /atom/movable/screen/alert/weightless)
 				ADD_TRAIT(src, TRAIT_MOVE_FLOATING, NO_GRAVITY_TRAIT)
-		if(STANDRARD_GRAVITY_RANGE)
-			clear_alert(ALERT_GRAVITY)
-		if(HIGH_GRAVITY_RANGE)
+		if(0.01 to STANDARD_GRAVITY)
+			if(gravity_alert)
+				clear_alert(ALERT_GRAVITY)
+		if(STANDARD_GRAVITY + 0.01 to GRAVITY_DAMAGE_THRESHOLD - 0.01)
 			throw_alert(ALERT_GRAVITY, /atom/movable/screen/alert/highgravity)
-		if(CRUSHING_GRAVITY_RANGE)
+		if(GRAVITY_DAMAGE_THRESHOLD to INFINITY)
 			throw_alert(ALERT_GRAVITY, /atom/movable/screen/alert/veryhighgravity)
-	if(!(gravity in WEIGHTLESS_RANGE) && was_weightless)
+
+	// If we had no gravity alert, or the same alert as before, go home
+	if(!gravity_alert || alerts[ALERT_GRAVITY] == gravity_alert)
+		return
+	// By this point we know that we do not have the same alert as we used to
+	if(istype(gravity_alert, /atom/movable/screen/alert/weightless))
 		REMOVE_TRAIT(src, TRAIT_MOVE_FLOATING, NO_GRAVITY_TRAIT)
-	if(!(gravity in NEGATIVE_GRAVITY_RANGE) && was_negative)
+	if(istype(gravity_alert, /atom/movable/screen/alert/negative))
 		var/matrix/flipped_matrix = transform
 		flipped_matrix.b = -flipped_matrix.b
 		flipped_matrix.e = -flipped_matrix.e

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1394,16 +1394,16 @@
 
 //Mobs on Fire
 /mob/living/proc/IgniteMob()
-	if(fire_stacks > 0 && !on_fire)
-		on_fire = TRUE
-		src.visible_message(span_warning("[src] catches fire!"), \
-						span_userdanger("You're set on fire!"))
-		new/obj/effect/dummy/lighting_obj/moblight/fire(src)
-		throw_alert(ALERT_FIRE, /atom/movable/screen/alert/fire)
-		update_fire()
-		SEND_SIGNAL(src, COMSIG_LIVING_IGNITED,src)
-		return TRUE
-	return FALSE
+	if(fire_stacks <= 0 || on_fire)
+		return
+	on_fire = TRUE
+	src.visible_message(span_warning("[src] catches fire!"), \
+					span_userdanger("You're set on fire!"))
+	firelight_ref = WEAKREF(new /obj/effect/dummy/lighting_obj/moblight/fire(src))
+	throw_alert(ALERT_FIRE, /atom/movable/screen/alert/fire)
+	update_fire()
+	SEND_SIGNAL(src, COMSIG_LIVING_IGNITED,src)
+	return TRUE
 
 /**
  * Extinguish all fire on the mob
@@ -1416,8 +1416,7 @@
 		return
 	on_fire = FALSE
 	fire_stacks = min(0, fire_stacks) //Makes sure we don't get rid of negative firestacks.
-	for(var/obj/effect/dummy/lighting_obj/moblight/fire/F in src)
-		qdel(F)
+	QDEL_NULL(firelight_ref)
 	clear_alert(ALERT_FIRE)
 	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "on_fire")
 	SEND_SIGNAL(src, COMSIG_LIVING_EXTINGUISHED, src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1400,7 +1400,7 @@
 //Mobs on Fire
 /mob/living/proc/IgniteMob()
 	if(fire_stacks <= 0 || on_fire)
-		return
+		return FALSE
 	on_fire = TRUE
 	src.visible_message(span_warning("[src] catches fire!"), \
 					span_userdanger("You're set on fire!"))

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -76,6 +76,8 @@
 	var/tod = null
 
 	var/on_fire = FALSE ///The "Are we on fire?" var
+	/// Weak reference to the light our fire is causing, if there is one
+	var/datum/weakref/firelight_ref
 	var/fire_stacks = 0 ///Tracks how many stacks of fire we have on, max is usually 20
 
 	var/limb_destroyer = 0 //1 Sets AI behavior that allows mobs to target and dismember limbs with their basic attack.

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -104,6 +104,8 @@
 
 	/// Default body temperature
 	var/bodytemperature = BODYTEMP_NORMAL //310.15K / 98.6F
+	/// Our body temperatue as of the last process, prevents pointless work when handling alerts
+	var/old_bodytemperature = 0
 	/// Drowsyness level of the mob
 	var/drowsyness = 0//Carbon
 	/// Dizziness level of the mob

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -542,7 +542,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	REMOVE_TRAIT(src, TRAIT_KNOCKEDOUT, CRIT_HEALTH_TRAIT)
 	//Following is for those brought back from the dead only
 	for(var/datum/wound/iter_wound as anything in owner.all_wounds)
-		iter_wound.blood_flow += (1-creation_purity)
+		iter_wound.adjust_blood_flow(1-creation_purity)
 	owner.adjustBruteLoss(5 * (1-creation_purity) * delta_time)
 	owner.adjustOrganLoss(ORGAN_SLOT_HEART, (1 + (1-creation_purity)) * delta_time)
 	if(owner.health < HEALTH_THRESHOLD_CRIT)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1526,7 +1526,7 @@
 		if(!was_working)
 			to_chat(M, span_green("You can feel your flowing blood start thickening!"))
 			was_working = TRUE
-		bloodiest_wound.blood_flow = max(0, bloodiest_wound.blood_flow - (clot_rate * REM * delta_time))
+		bloodiest_wound.adjust_blood_flow(-clot_rate * REM * delta_time)
 	else if(was_working)
 		was_working = FALSE
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -822,6 +822,7 @@
 
 /// Sets our generic bleedstacks
 /obj/item/bodypart/proc/setBleedStacks(set_to)
+	SHOULD_CALL_PARENT(TRUE)
 	adjustBleedStacks(set_to - generic_bleedstacks)
 
 /// Modifies our generic bleedstacks. You must use this to change the variable

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -507,11 +507,10 @@
 
 	if(owner == new_owner)
 		return FALSE //`null` is a valid option, so we need to use a num var to make it clear no change was made.
-	. = owner
+	var/mob/living/carbon/old_owner = owner
 	owner = new_owner
 	var/needs_update_disabled = FALSE //Only really relevant if there's an owner
-	if(.)
-		var/mob/living/carbon/old_owner = .
+	if(old_owner)
 		if(initial(can_be_disabled))
 			if(HAS_TRAIT(old_owner, TRAIT_NOLIMBDISABLE))
 				if(!owner || !HAS_TRAIT(owner, TRAIT_NOLIMBDISABLE))
@@ -530,6 +529,8 @@
 			RegisterSignal(owner, SIGNAL_ADDTRAIT(TRAIT_NOLIMBDISABLE), .proc/on_owner_nolimbdisable_trait_gain)
 		if(needs_update_disabled)
 			update_disabled()
+
+	return old_owner
 
 
 ///Proc to change the value of the `can_be_disabled` variable and react to the event of its change.

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -852,6 +852,9 @@
 
 	var/old_bleed_rate = cached_bleed_rate
 	cached_bleed_rate = 0
+	if(!owner)
+		return
+
 	if(HAS_TRAIT(owner, TRAIT_NOBLEED) || !IS_ORGANIC_LIMB(src))
 		if(cached_bleed_rate != old_bleed_rate)
 			update_part_wound_overlay()

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -108,8 +108,7 @@
 			break
 
 	for(var/obj/item/embedded in embedded_objects)
-		embedded_objects -= embedded
-		embedded.forceMove(src)
+		embedded.forceMove(src) // It'll self remove via signal reaction, just need to move it
 	if(!phantom_owner.has_embedded_objects())
 		phantom_owner.clear_alert(ALERT_EMBEDDED_OBJECT)
 		SEND_SIGNAL(phantom_owner, COMSIG_CLEAR_MOOD_EVENT, "embedded")

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -99,8 +99,7 @@
 		scar.victim = null
 		LAZYREMOVE(owner.all_scars, scar)
 
-	var/mob/living/carbon/phantom_owner = owner // so we can still refer to the guy who lost their limb after said limb forgets 'em
-	owner = null
+	var/mob/living/carbon/phantom_owner = set_owner(null) // so we can still refer to the guy who lost their limb after said limb forgets 'em
 
 	for(var/datum/surgery/surgery as anything in phantom_owner.surgeries) //if we had an ongoing surgery on that limb, we stop it.
 		if(surgery.operated_bodypart == src)

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -207,3 +207,5 @@
 		QDEL_NULL(current_gauze)
 
 	wound_damage_multiplier = dam_mul
+	update_bleed_rate()
+	

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -207,5 +207,4 @@
 		QDEL_NULL(current_gauze)
 
 	wound_damage_multiplier = dam_mul
-	update_bleed_rate()
-	
+	refresh_bleed_rate()

--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -46,7 +46,7 @@
 				span_notice("Blood pools around the incision in [target_human]'s heart."),
 				"")
 			var/obj/item/bodypart/target_bodypart = target_human.get_bodypart(target_zone)
-			target_bodypart.generic_bleedstacks += 10
+			target_bodypart.adjustBleedStacks(10)
 			target_human.adjustBruteLoss(10)
 	return ..()
 
@@ -57,7 +57,7 @@
 			span_warning("[user] screws up, causing blood to spurt out of [target_human]'s chest!"),
 			span_warning("[user] screws up, causing blood to spurt out of [target_human]'s chest!"))
 		var/obj/item/bodypart/target_bodypart = target_human.get_bodypart(target_zone)
-		target_bodypart.generic_bleedstacks += 10
+		target_bodypart.adjustBleedStacks(10)
 		target_human.adjustOrganLoss(ORGAN_SLOT_HEART, 10)
 		target_human.adjustBruteLoss(10)
 
@@ -100,5 +100,5 @@
 		display_pain(target, "Your chest burns; you feel like you're going insane!")
 		target_human.adjustOrganLoss(ORGAN_SLOT_HEART, 20)
 		var/obj/item/bodypart/target_bodypart = target_human.get_bodypart(target_zone)
-		target_bodypart.generic_bleedstacks += 30
+		target_bodypart.adjustBleedStacks(30)
 	return FALSE

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -33,7 +33,7 @@
 				span_notice("Blood pools around the incision in [human_target]'s [parse_zone(target_zone)]."))
 			var/obj/item/bodypart/target_bodypart = target.get_bodypart(target_zone)
 			if(target_bodypart)
-				target_bodypart.generic_bleedstacks += 10
+				target_bodypart.adjustBleedStacks(10)
 	return ..()
 
 /datum/surgery_step/incise/nobleed/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -66,7 +66,7 @@
 		var/mob/living/carbon/human/human_target = target
 		var/obj/item/bodypart/target_bodypart = human_target.get_bodypart(target_zone)
 		if(target_bodypart)
-			target_bodypart.generic_bleedstacks -= 3
+			target_bodypart.adjustBleedStacks(-3)
 	return ..()
 
 //retract skin
@@ -118,7 +118,7 @@
 		var/mob/living/carbon/human/human_target = target
 		var/obj/item/bodypart/target_bodypart = human_target.get_bodypart(target_zone)
 		if(target_bodypart)
-			target_bodypart.generic_bleedstacks -= 3
+			target_bodypart.adjustBleedStacks(-3)
 	return ..()
 
 

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -54,7 +54,7 @@
 /obj/item/organ/ears/proc/adjustEarDamage(ddmg, ddeaf)
 	if(owner.status_flags & GODMODE)
 		return
-	damage = max(damage + (ddmg*damage_multiplier), 0)
+	setOrganDamage(max(damage + (ddmg*damage_multiplier), 0))
 	deaf = max(deaf + (ddeaf*damage_multiplier), 0)
 
 /obj/item/organ/ears/invincible
@@ -121,4 +121,4 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	damage += 40/severity
+	applyOrganDamage(40/severity)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -174,7 +174,7 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	if(prob(10 * severity))
-		damage += 20 * severity
+		applyOrganDamage(20 * severity)
 		to_chat(owner, span_warning("Your eyes start to fizzle in their sockets!"))
 		do_sparks(2, TRUE, owner)
 		owner.emote("scream")

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -103,8 +103,9 @@
 	//metabolize reagents
 	liver_owner.reagents.metabolize(liver_owner, delta_time, times_fired, can_overdose=TRUE)
 
-	applyOrganDamage(damange_to_deal)
-	
+	if(damange_to_deal)
+		applyOrganDamage(damange_to_deal)
+
 	if(provide_pain_message && damage > 10 && DT_PROB(damage/6, delta_time)) //the higher the damage the higher the probability
 		to_chat(liver_owner, span_warning("You feel a dull pain in your abdomen."))
 

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -75,34 +75,39 @@
 
 /obj/item/organ/liver/on_life(delta_time, times_fired)
 	var/mob/living/carbon/liver_owner = owner
-	..() //perform general on_life()
-	if(istype(liver_owner))
-		if(!(organ_flags & ORGAN_FAILING) && !HAS_TRAIT(liver_owner, TRAIT_NOMETABOLISM))//can't process reagents with a failing liver
+	. = ..() //perform general on_life()
 
-			var/provide_pain_message = HAS_NO_TOXIN
-			var/obj/belly = liver_owner.getorganslot(ORGAN_SLOT_STOMACH)
-			if(filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER))
-				//handle liver toxin filtration
-				for(var/datum/reagent/toxin/toxin in liver_owner.reagents.reagent_list)
-					var/thisamount = liver_owner.reagents.get_reagent_amount(toxin.type)
-					if(belly)
-						thisamount += belly.reagents.get_reagent_amount(toxin.type)
-					if (thisamount && thisamount <= toxTolerance * (maxHealth - damage) / maxHealth ) //toxTolerance is effectively multiplied by the % that your liver's health is at
-						liver_owner.reagents.remove_reagent(toxin.type, 0.5 * delta_time)
-					else
-						damage += (thisamount * toxLethality * delta_time)
-						if(provide_pain_message != HAS_PAINFUL_TOXIN)
-							provide_pain_message = toxin.silent_toxin ? HAS_SILENT_TOXIN : HAS_PAINFUL_TOXIN
+	if(!istype(liver_owner))
+		return
+	if(organ_flags & ORGAN_FAILING || HAS_TRAIT(liver_owner, TRAIT_NOMETABOLISM))//can't process reagents with a failing liver
+		return
 
-			//metabolize reagents
-			liver_owner.reagents.metabolize(liver_owner, delta_time, times_fired, can_overdose=TRUE)
+	// How much damage to inflict on our liver
+	var/damange_to_deal = 0
 
-			if(provide_pain_message && damage > 10 && DT_PROB(damage/6, delta_time)) //the higher the damage the higher the probability
-				to_chat(liver_owner, span_warning("You feel a dull pain in your abdomen."))
+	var/provide_pain_message = HAS_NO_TOXIN
+	var/obj/belly = liver_owner.getorganslot(ORGAN_SLOT_STOMACH)
+	if(filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER))
+		//handle liver toxin filtration
+		for(var/datum/reagent/toxin/toxin in liver_owner.reagents.reagent_list)
+			var/thisamount = liver_owner.reagents.get_reagent_amount(toxin.type)
+			if(belly)
+				thisamount += belly.reagents.get_reagent_amount(toxin.type)
+			if (thisamount && thisamount <= toxTolerance * (maxHealth - damage) / maxHealth ) //toxTolerance is effectively multiplied by the % that your liver's health is at
+				liver_owner.reagents.remove_reagent(toxin.type, 0.5 * delta_time)
+			else
+				damange_to_deal += (thisamount * toxLethality * delta_time)
+				if(provide_pain_message != HAS_PAINFUL_TOXIN)
+					provide_pain_message = toxin.silent_toxin ? HAS_SILENT_TOXIN : HAS_PAINFUL_TOXIN
 
+	//metabolize reagents
+	liver_owner.reagents.metabolize(liver_owner, delta_time, times_fired, can_overdose=TRUE)
 
-	if(damage > maxHealth)//cap liver damage
-		damage = maxHealth
+	applyOrganDamage(damange_to_deal)
+	
+	if(provide_pain_message && damage > 10 && DT_PROB(damage/6, delta_time)) //the higher the damage the higher the probability
+		to_chat(liver_owner, span_warning("You feel a dull pain in your abdomen."))
+
 
 /obj/item/organ/liver/handle_failing_organs(delta_time)
 	if(HAS_TRAIT(src, TRAIT_STABLELIVER) || HAS_TRAIT(src, TRAIT_NOMETABOLISM))

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -140,6 +140,9 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		applyOrganDamage(decay_factor * maxHealth * delta_time)
 		return
 
+	if(!damage) // No sense healing if you're not even hurt bro
+		return
+
 	///Damage decrements by a percent of its maxhealth
 	var/healing_amount = healing_factor
 	///Damage decrements again by a percent of its maxhealth, up to a total of 4 extra times depending on the owner's health

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -139,7 +139,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	if(organ_flags & ORGAN_SYNTHETIC_EMP) //Synthetic organ has been emped, is now failing.
 		applyOrganDamage(decay_factor * maxHealth * delta_time)
 		return
-		
+
 	///Damage decrements by a percent of its maxhealth
 	var/healing_amount = healing_factor
 	///Damage decrements again by a percent of its maxhealth, up to a total of 4 extra times depending on the owner's health

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -10,7 +10,7 @@
 	// DO NOT add slots with matching names to different zones - it will break internal_organs_slot list!
 	var/organ_flags = ORGAN_EDIBLE
 	var/maxHealth = STANDARD_ORGAN_THRESHOLD
-	var/damage = 0 //total damage this organ has sustained
+	var/damage = 0
 	///Healing factor and decay factor function on % of maxhealth, and do not work by applying a static number per tick
 	var/healing_factor = 0 //fraction of maxhealth healed per on_life(), set to 0 for generic organs
 	var/decay_factor = 0 //same as above but when without a living owner, set to 0 for generic organs
@@ -74,8 +74,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	SEND_SIGNAL(reciever, COMSIG_CARBON_GAIN_ORGAN, src, special)
 
 	owner = reciever
-	reciever.internal_organs |= src
-	reciever.internal_organs_slot[slot] = src
+	reciever.slot_in_organ(src, slot)
 	moveToNullspace()
 	RegisterSignal(owner, COMSIG_PARENT_EXAMINE, .proc/on_owner_examine)
 	for(var/datum/action/action as anything in actions)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -10,6 +10,8 @@
 	// DO NOT add slots with matching names to different zones - it will break internal_organs_slot list!
 	var/organ_flags = ORGAN_EDIBLE
 	var/maxHealth = STANDARD_ORGAN_THRESHOLD
+	/// Total damage this organ has sustained
+	/// Should only ever be modified by applyOrganDamage
 	var/damage = 0
 	///Healing factor and decay factor function on % of maxhealth, and do not work by applying a static number per tick
 	var/healing_factor = 0 //fraction of maxhealth healed per on_life(), set to 0 for generic organs
@@ -122,8 +124,11 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		return
 	applyOrganDamage(decay_factor * maxHealth * delta_time)
 
+/// Called once every life tick on every organ in a carbon's body
+/// NOTE: THIS IS VERY HOT. Be careful what you put in here
+/// To give you some scale, if there's 100 carbons in the game, they each have maybe 9 organs
+/// So that's 900 calls to this proc every life process. Please don't be dumb
 /obj/item/organ/proc/on_life(delta_time, times_fired) //repair organ damage if the organ is not failing
-	check_failing_thresholds() // Check if an organ should/shouldnt be failing
 	if(organ_flags & ORGAN_FAILING)
 		handle_failing_organs(delta_time)
 		return
@@ -134,6 +139,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	if(organ_flags & ORGAN_SYNTHETIC_EMP) //Synthetic organ has been emped, is now failing.
 		applyOrganDamage(decay_factor * maxHealth * delta_time)
 		return
+		
 	///Damage decrements by a percent of its maxhealth
 	var/healing_amount = healing_factor
 	///Damage decrements again by a percent of its maxhealth, up to a total of 4 extra times depending on the owner's health

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -157,7 +157,8 @@
 		hunger_rate *= human.physiology.hunger_mod
 		human.adjust_nutrition(-hunger_rate * delta_time)
 
-	if(human.nutrition > NUTRITION_LEVEL_FULL)
+	var/nutrition = human.nutrition
+	if(nutrition > NUTRITION_LEVEL_FULL)
 		if(human.overeatduration < 20 MINUTES) //capped so people don't take forever to unfat
 			human.overeatduration = min(human.overeatduration + (1 SECONDS * delta_time), 20 MINUTES)
 	else
@@ -165,13 +166,13 @@
 			human.overeatduration = max(human.overeatduration - (2 SECONDS * delta_time), 0) //doubled the unfat rate
 
 	//metabolism change
-	if(human.nutrition > NUTRITION_LEVEL_FAT)
+	if(nutrition > NUTRITION_LEVEL_FAT)
 		human.metabolism_efficiency = 1
-	else if(human.nutrition > NUTRITION_LEVEL_FED && human.satiety > 80)
+	else if(nutrition > NUTRITION_LEVEL_FED && human.satiety > 80)
 		if(human.metabolism_efficiency != 1.25)
 			to_chat(human, span_notice("You feel vigorous."))
 			human.metabolism_efficiency = 1.25
-	else if(human.nutrition < NUTRITION_LEVEL_STARVING + 50)
+	else if(nutrition < NUTRITION_LEVEL_STARVING + 50)
 		if(human.metabolism_efficiency != 0.8)
 			to_chat(human, span_notice("You feel sluggish."))
 		human.metabolism_efficiency = 0.8
@@ -184,7 +185,9 @@
 	if(CONFIG_GET(flag/disable_human_mood))
 		handle_hunger_slowdown(human)
 
-	switch(human.nutrition)
+	// If we did anything more then just set and throw alerts here I would add bracketing
+	// But well, it is all we do, so there's not much point bothering with it you get me?
+	switch(nutrition)
 		if(NUTRITION_LEVEL_FULL to INFINITY)
 			human.throw_alert(ALERT_NUTRITION, /atom/movable/screen/alert/fat)
 		if(NUTRITION_LEVEL_HUNGRY to NUTRITION_LEVEL_FULL)
@@ -206,27 +209,38 @@
 	return !(NOSTOMACH in owner_species.inherent_traits)
 
 /obj/item/organ/stomach/proc/handle_disgust(mob/living/carbon/human/disgusted, delta_time, times_fired)
-	if(disgusted.disgust)
-		var/pukeprob = 2.5 + (0.025 * disgusted.disgust)
-		if(disgusted.disgust >= DISGUST_LEVEL_GROSS)
+	var/old_disgust = disgusted.old_disgust
+	var/disgust = disgusted.disgust
+
+	if(disgust)
+		var/pukeprob = 2.5 + (0.025 * disgust)
+		if(disgust >= DISGUST_LEVEL_GROSS)
 			if(DT_PROB(5, delta_time))
 				disgusted.stuttering += 1
 				disgusted.add_confusion(2)
 			if(DT_PROB(5, delta_time) && !disgusted.stat)
 				to_chat(disgusted, span_warning("You feel kind of iffy..."))
 			disgusted.jitteriness = max(disgusted.jitteriness - 3, 0)
-		if(disgusted.disgust >= DISGUST_LEVEL_VERYGROSS)
+		if(disgust >= DISGUST_LEVEL_VERYGROSS)
 			if(DT_PROB(pukeprob, delta_time)) //iT hAndLeS mOrE ThaN PukInG
 				disgusted.add_confusion(2.5)
 				disgusted.stuttering += 1
 				disgusted.vomit(10, 0, 1, 0, 1, 0)
 			disgusted.Dizzy(5)
-		if(disgusted.disgust >= DISGUST_LEVEL_DISGUSTED)
+		if(disgust >= DISGUST_LEVEL_DISGUSTED)
 			if(DT_PROB(13, delta_time))
 				disgusted.blur_eyes(3) //We need to add more shit down here
 
 		disgusted.adjust_disgust(-0.25 * disgust_metabolism * delta_time)
-	switch(disgusted.disgust)
+
+	// I would consider breaking this up into steps matching the disgust levels
+	// But disgust is used so rarely it wouldn't save a significant amount of time, and it makes the code just way worse
+	// We're in the same state as the last time we processed, so don't bother
+	if(old_disgust == disgust)
+		return
+
+	disgusted.old_disgust = disgust
+	switch(disgust)
 		if(0 to DISGUST_LEVEL_GROSS)
 			disgusted.clear_alert(ALERT_DISGUST)
 			SEND_SIGNAL(disgusted, COMSIG_CLEAR_MOOD_EVENT, "disgust")

--- a/code/modules/surgery/repair_puncture.dm
+++ b/code/modules/surgery/repair_puncture.dm
@@ -65,7 +65,7 @@
 		span_notice("[user] successfully realigns some of the blood vessels in  [target]'s [parse_zone(target_zone)]!"))
 	log_combat(user, target, "excised infected flesh in", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
 	surgery.operated_bodypart.receive_damage(brute=3, wound_bonus=CANT_WOUND)
-	pierce_wound.blood_flow -= 0.25
+	pierce_wound.adjust_blood_flow(-0.25)
 	return ..()
 
 /datum/surgery_step/repair_innards/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, fail_prob = 0)
@@ -111,7 +111,7 @@
 		span_notice("[user] successfully melds some of the split blood vessels in [target]'s [parse_zone(target_zone)] with [tool]!"),
 		span_notice("[user] successfully melds some of the split blood vessels in [target]'s [parse_zone(target_zone)]!"))
 	log_combat(user, target, "dressed burns in", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
-	pierce_wound.blood_flow -= 0.5
+	pierce_wound.adjust_blood_flow(-0.5)
 	if(pierce_wound.blood_flow > 0)
 		surgery.status = REALIGN_INNARDS
 		to_chat(user, span_notice("<i>There still seems to be misaligned blood vessels to finish...</i>"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Help, what's going on

Me and kyler have made a blood pact to make `Life()` cheaper
He's slow, so here's what I've come up with.

Most of what I've focused on is eliminating unneeded work. I've done a few smaller optimizations, mostly because I was bored. They're not things to replicate I don't think.

Oh and uh, I'm gonna be giving percentages of "`Life()`" as measures for the impact of changes. 
These are not percentages of the total cost of `Life()`, but rather the total cost of the base human Life (It's hard to test say, digestion when you're on a local for instance). 
The upper bound on the impact any changes here would make is roughly 2/3rds their percentage. Just so you know  

I'ma go through change by change.

### Change by Change

`Life()` Optimization Part 1: Organ order (7ffd6fe7f5e0354ca01302057bc736f7214a06b3)
It turns out organ code is really quite dumb. Wastes a lot of time.
I'm going to be doing what I can to optimize it in this branch.

To start with:

If we can ensure organs are sorted according to `organ_process_order` inside `internal_organs_slot`
We can do away with a needless get_organ_slot call in `handle_organs`, and avoid needing to iterate over 30 entries, one per possible organ slot, instead iterating just the ones we have

This saves roughly 5% of life

Organ Optimization Part 2: base on_life()(ff610653390011f38d2474c8beb2e575193005f6)

Organ `on_life`, despite not looking it, is a remarkably hot proc. Called something close to 9 times for each human on the map, it's worth taking care to clean it up.

As things currently stand, we do two dumb things.
The first is manually checking for organ failure each iteration.
We do this because we allow organ damage to be modified outside of the `applyOrganDamage` proc, which also calls `check_failing_thresholds`.

There's no reason to do this, so I've gone through and removed all instances of it

The second is calling `applyOrganDamage` no matter what, to "heal" the organ. Even if it isn't damaged.

The fix for this is simple, just an if check.

This saves roughly 10% of pre changes `Life()` cost

Blood code is slightly more sane, but it calls `get_part_bleed_rate` a lot, and does other checks that are the same so long as the bleed rate never changes. 
This is reasonably expensive

So, I'm going to make it event driven, and cache the bleed rate. 
But to do that, I need to be able to react to limb ownership changes, and well,there's a few that don't use the existing setter. 
This commit (c94b625e59b387d472ee9d0a6abb69627a3b3d1c) fixes that 

Basically, anything that effects bleed rate needs to be setup so it can be reacted to as an event. 
Mostly by setters.
This commit (8f3921c7f309018d4349f5f2d258c2cc0d494d88) makes `NOBLEED` and `generic_bleedstacks` support that
(746db06a43570835ac66bf1fce439bc1c3bd141e) adds the same to embedded items.
(9650c476efe2fb1cdb8fb19507c53a82453e6966) Adds a setter for wound blood flow, and hooks it into `refresh_bleed_rate`

@Ryll-Ryll Yo, can you think of anything in wound code that would benefit from being able to react to blood flow changing?
I noticed some stuff that looked like it might, but I don't trust myself with stuff I'm not that comfortable with


(ca7f52ad0a929df2ddf12690637925c25cbdf44e) fully caches `bleed_rate`. Because I can do this, we only need to call `update_part_wound_overlay` when bleed rate updates
This saves 15%! of human life tick. Get owned

(8f4bb7f2284657398fdd37c01e7a09697a16ee4f) touches some temperature code.

It turns out that clearing alerts and sending signals every process is wasteful. 
There's no reason to do it unless last process was a problem one

The change for that is quite easy, literally just a new var on human.

Saves 2% of human life tick.
Very nice for the amount of time I put into it

BTW, I have a feeling that most of the overhead of bodytemp is caused by human body temperature being higher then room temperature. 
Not sure what to do about this though

(a8f04d293178e6f11954b364d7afe89aedc2ef2a) does something similar to disgust

Basically, don't continuously send signals if you have no disgust
It's rare enough that this is all the caching we really need to do

Saves roughly 1% of life tick. Right on the edge of not worth it

Oh and I cleaned up some of liver, gravity and fire lighting code. Nothing worth writing home about, but it makes things a bit nicer.


### Results 

That brings us to roughly 33% of base human `Life()` saved. So maybe 22% of highpop cost? 
Hard to say for sure. Regardless, I'm quite happy with this

If you're curious, here are all my profiles in order.
[Initial, just humans.txt](https://github.com/tgstation/tgstation/files/8440914/Initial.just.humans.txt)
[Post handle_organ and base on_life.txt](https://github.com/tgstation/tgstation/files/8440922/Post.handle_organ.and.base.on_life.optim.txt)
[Post organs and blood caching.txt](https://github.com/tgstation/tgstation/files/8440916/Post.organs.and.blood.caching.txt)
[Post alert cache.txt](https://github.com/tgstation/tgstation/files/8440915/Post.alert.cache.txt)
[Post stomach.txt](https://github.com/tgstation/tgstation/files/8440917/Post.stomach.txt)
[post gravity.txt](https://github.com/tgstation/tgstation/files/8440921/post.gravity.txt)


Oh. And uh, I found what looked like a bug in soundbanging logic.

If you get soundbangd and see the "You can't hear anything!" message, you will now properly go deaf untill you get healing
Rather then the current behavior of just... doing nothing.

It's technically a balance change, maybe I should atomize it? Thoughts?

## Why It's Good For The Game

[![IMAGE ALT TEXT](http://img.youtube.com/vi/atuFSv2bLa8/0.jpg)](http://www.youtube.com/watch?v=atuFSv2bLa8)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Getting your eardrums blown out will now properly have a low chance to make you go fully deaf, until you find some earmuffs or get a transplant
refactor: Cached some redundant operations in Life(), speeding it up by ~22%. I know that doesn't mean much to you, but cpu time go brrr ok? 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
