### PR TITLE
Fixes Sloth Ruin note storing its contents in the wrong place.

### DIFF
--- a/code/modules/ruins/lavalandruin_code/sloth.dm
+++ b/code/modules/ruins/lavalandruin_code/sloth.dm
@@ -2,4 +2,4 @@
 
 /obj/item/paper/fluff/stations/lavaland/sloth/note
 	name = "note from sloth"
-	desc = "have not gotten around to finishing my cursed item yet sorry - sloth"
+	info = "have not gotten around to finishing my cursed item yet sorry - sloth"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The note inside of the Sloth ruin had its contents in the item description rather than actually on the paper itself. 

Someday, the orange man in the sloth ruin will finish that cursed item, but today is not that day.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Closes #66025. Also enables players to understand a stale punchline from eight years ago.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The note in the Sloth ruin is fixed! Head on down to Lavaland and reap the rewards!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
