### PR TITLE
HARS victims now care for brain suicides

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -928,20 +928,18 @@
 		if (heart.organ_flags & ORGAN_FAILING)
 			return DEFIB_FAIL_FAILING_HEART
 
-	// Carbons with HARS do not need a brain
-	if (!dna?.check_mutation(/datum/mutation/human/headless))
-		var/obj/item/organ/brain/BR = getorgan(/obj/item/organ/brain)
+	var/obj/item/organ/brain/current_brain = getorgan(/obj/item/organ/brain)
 
-		if (QDELETED(BR))
-			return DEFIB_FAIL_NO_BRAIN
+	if (QDELETED(current_brain))
+		return DEFIB_FAIL_NO_BRAIN
 
-		if (BR.organ_flags & ORGAN_FAILING)
-			return DEFIB_FAIL_FAILING_BRAIN
+	if (current_brain.organ_flags & ORGAN_FAILING)
+		return DEFIB_FAIL_FAILING_BRAIN
 
-		if (BR.suicided || BR.brainmob?.suiciding)
-			return DEFIB_FAIL_NO_INTELLIGENCE
+	if (current_brain.suicided || current_brain.brainmob?.suiciding)
+		return DEFIB_FAIL_NO_INTELLIGENCE
 
-	if(key && key[1] == "@") // Adminghosts (#61870)
+	if(key && key[1] == "@") // Adminghosts
 		return DEFIB_NOGRAB_AGHOST
 
 	return DEFIB_POSSIBLE


### PR DESCRIPTION
## About The Pull Request

HARS moves your brain to your chest, so this check is pointless as you DO have a brain.

![image](https://user-images.githubusercontent.com/53777086/162346652-9122ed03-4ca8-41cb-923f-641603f4a655.png)
![image](https://user-images.githubusercontent.com/53777086/162346670-e9e102d2-099f-4e42-a3f2-e9bd64710b09.png)


## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/65010 - a niche potential consistency exploit.

## Changelog

:cl:
fix: Brains from HARS victims in a new HARS body will not be revivable anymore.
/:cl: