### PR TITLE
adds a unique species id unit test + cleans up some golem mischief

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1024,9 +1024,6 @@
 /mob/living/carbon/human/species/golem
 	race = /datum/species/golem
 
-/mob/living/carbon/human/species/golem/random
-	race = /datum/species/golem/random
-
 /mob/living/carbon/human/species/golem/adamantine
 	race = /datum/species/golem/adamantine
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -83,24 +83,6 @@
 
 	return to_add
 
-/datum/species/golem/random
-	name = "Random Golem"
-	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN
-	var/static/list/random_golem_types
-
-/datum/species/golem/random/on_species_gain(mob/living/carbon/C, datum/species/old_species)
-	..()
-	if(!random_golem_types)
-		random_golem_types = subtypesof(/datum/species/golem) - type
-		for(var/V in random_golem_types)
-			var/datum/species/golem/G = V
-			if(!initial(G.random_eligible))
-				random_golem_types -= G
-	var/datum/species/golem/golem_type = pick(random_golem_types)
-	var/mob/living/carbon/human/H = C
-	H.set_species(golem_type)
-	to_chat(H, "[initial(golem_type.info_text)]")
-
 /datum/species/golem/adamantine
 	name = "Adamantine Golem"
 	id = SPECIES_GOLEM_ADAMANTINE

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -653,9 +653,13 @@
 	name = "Golem Mutation Toxin"
 	description = "A crystal toxin."
 	color = "#5EFF3B" //RGB: 94, 255, 59
-	race = /datum/species/golem/random
+	race = /datum/species/golem
 	taste_description = "rocks"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+
+/datum/reagent/mutationtoxin/golem/on_mob_life()
+	race = pick(subtypesof(/datum/species/golem))
+	..()
 
 /datum/reagent/mutationtoxin/abductor
 	name = "Abductor Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -657,7 +657,7 @@
 	taste_description = "rocks"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/mutationtoxin/golem/on_mob_life()
+/datum/reagent/mutationtoxin/golem/on_mob_metabolize()
 	var/static/list/random_golem_types
 	random_golem_types = subtypesof(/datum/species/golem) - type
 	for(var/i in random_golem_types)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -658,7 +658,13 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
 /datum/reagent/mutationtoxin/golem/on_mob_life()
-	race = pick(subtypesof(/datum/species/golem))
+	var/static/list/random_golem_types
+	random_golem_types = subtypesof(/datum/species/golem) - type
+	for(var/i in random_golem_types)
+		var/datum/species/golem/golem = i
+		if(!initial(golem.random_eligible))
+			random_golem_types -= golem
+	race = pick(random_golem_types)
 	..()
 
 /datum/reagent/mutationtoxin/abductor

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -305,8 +305,7 @@ Chilling extracts:
 		var/static/list/random_golem_types
 		random_golem_types = subtypesof(/datum/species/golem) - type
 
-		for(var/i in random_golem_types)
-			var/datum/species/golem/golem = i
+		for(var/datum/species/golem/golem as anything in random_golem_types)
 			if(!initial(golem.random_eligible))
 				random_golem_types -= golem
 		H.set_species(pick(random_golem_types))

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -295,7 +295,7 @@ Chilling extracts:
 
 /obj/item/slimecross/chilling/black
 	colour = "black"
-	effect_desc = "Transforsms the user into a random type of golem."
+	effect_desc = "Transforms the user into a random type of golem."
 
 /obj/item/slimecross/chilling/black/do_effect(mob/user)
 	if(ishuman(user))

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -301,7 +301,15 @@ Chilling extracts:
 	if(ishuman(user))
 		user.visible_message(span_notice("[src] crystallizes along [user]'s skin, turning into metallic scales!"))
 		var/mob/living/carbon/human/H = user
-		H.set_species(pick(subtypesof(/datum/species/golem)))
+
+		var/static/list/random_golem_types
+		random_golem_types = subtypesof(/datum/species/golem) - type
+
+		for(var/i in random_golem_types)
+			var/datum/species/golem/golem = i
+			if(!initial(golem.random_eligible))
+				random_golem_types -= golem
+		H.set_species(pick(random_golem_types))
 	..()
 
 /obj/item/slimecross/chilling/lightpink

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -301,7 +301,7 @@ Chilling extracts:
 	if(ishuman(user))
 		user.visible_message(span_notice("[src] crystallizes along [user]'s skin, turning into metallic scales!"))
 		var/mob/living/carbon/human/H = user
-		H.set_species(/datum/species/golem/random)
+		H.set_species(pick(subtypesof(/datum/species/golem)))
 	..()
 
 /obj/item/slimecross/chilling/lightpink

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -108,6 +108,7 @@
 #include "spawn_humans.dm"
 #include "spawn_mobs.dm"
 #include "species_config_sanity.dm"
+#include "species_unique_id.dm"
 #include "species_whitelists.dm"
 #include "stomach.dm"
 #include "strippable.dm"

--- a/code/modules/unit_tests/species_unique_id.dm
+++ b/code/modules/unit_tests/species_unique_id.dm
@@ -1,10 +1,14 @@
+/**
+ * Every species should use a species ID unique to it and it alone. This test runs through every subtype of /datum/species, and checks for a species ID.
+ * Every ID is written to a list, gathered_species_ids, and if a previously written ID is written again, this test will fail.
+ */
 /datum/unit_test/species_unique_id
 
 /datum/unit_test/species_unique_id/Run()
 	var/list/gathered_species_ids = list()
 	for(var/datum/species/species as anything in subtypesof(/datum/species))
 		var/species_id = initial(species.id)
-		if(!(gathered_species_ids.Find(species_id)))
-			gathered_species_ids += species_id
-		else
+		if(gathered_species_ids.Find(species_id))
 			Fail("Duplicate species ID! [species_id] is not unique to a single species.")
+		else
+			gathered_species_ids += species_id

--- a/code/modules/unit_tests/species_unique_id.dm
+++ b/code/modules/unit_tests/species_unique_id.dm
@@ -8,7 +8,7 @@
 	var/list/gathered_species_ids = list()
 	for(var/datum/species/species as anything in subtypesof(/datum/species))
 		var/species_id = initial(species.id)
-		if(gathered_species_ids.Find(species_id))
+		if(gathered_species_ids[species_id])
 			Fail("Duplicate species ID! [species_id] is not unique to a single species.")
 		else
-			gathered_species_ids += species_id
+			gathered_species_ids[species_id] = TRUE

--- a/code/modules/unit_tests/species_unique_id.dm
+++ b/code/modules/unit_tests/species_unique_id.dm
@@ -1,0 +1,10 @@
+/datum/unit_test/species_unique_id
+
+/datum/unit_test/species_unique_id/Run()
+	var/list/gathered_species_ids = list()
+	for(var/datum/species/species as anything in subtypesof(/datum/species))
+		var/species_id = initial(species.id)
+		if(!(gathered_species_ids.Find(species_id)))
+			gathered_species_ids += species_id
+		else
+			Fail("Duplicate species ID! [species_id] is not unique to a single species.")


### PR DESCRIPTION
## About The Pull Request

adds a unit test, species_unique_id, that verifies that every species has it's own, unique id.
if this test fails, you've done something to make two or more species share the same id, which can lead to the fiasco we had with humans effectively becoming androids.

this also removes a subtype of golem, '/datum/species/golem/random', which existed solely to set you to a different golem species. all instances of this, notably the golem mutation toxin and chilling black extract's effect, have been replaced with a simple pick from all subtypes of 'datum/species/golem'. very cool.

as a bonus, fixes a typo in the chilling black extract's description.

## Why It's Good For The Game

the bug we had was bad. a unit test making sure similar things don't happen in the future is good.

![humanerror](https://user-images.githubusercontent.com/84609863/162362463-c80cfb11-cf88-415e-b803-da0e53278480.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: fixed an error in the chilling black extract's description.
code: the 'random' subtype of golems no longer exists, and is now effectively replaced by picking from all subtypes of the golem species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
