### PR TITLE
Ling huds persist through bodies + non carbons can sting

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -26,9 +26,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	var/inventory_shown = FALSE //Equipped item inventory
 	var/hotkey_ui_hidden = FALSE //This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
 
-	var/atom/movable/screen/ling/chems/lingchemdisplay
-	var/atom/movable/screen/ling/sting/lingstingdisplay
-
 	var/atom/movable/screen/blobpwrdisplay
 
 	var/atom/movable/screen/alien_plasma_display
@@ -150,8 +147,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	wanted_lvl = null
 	internals = null
 	spacesuit = null
-	lingchemdisplay = null
-	lingstingdisplay = null
 	blobpwrdisplay = null
 	alien_plasma_display = null
 	alien_queen_finder = null

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -35,22 +35,22 @@
 
 /atom/movable/screen/ling
 	icon = 'icons/hud/screen_changeling.dmi'
-	invisibility = INVISIBILITY_ABSTRACT
-
-/atom/movable/screen/ling/sting
-	name = "current sting"
-	screen_loc = ui_lingstingdisplay
-
-/atom/movable/screen/ling/sting/Click()
-	if(isobserver(usr))
-		return
-	var/mob/living/carbon/U = usr
-	U.unset_sting()
 
 /atom/movable/screen/ling/chems
 	name = "chemical storage"
 	icon_state = "power_display"
 	screen_loc = ui_lingchemdisplay
+
+/atom/movable/screen/ling/sting
+	name = "current sting"
+	screen_loc = ui_lingstingdisplay
+	invisibility = INVISIBILITY_ABSTRACT
+
+/atom/movable/screen/ling/sting/Click()
+	if(isobserver(usr))
+		return
+	var/mob/living/carbon/carbon_user = usr
+	carbon_user.unset_sting()
 
 /datum/hud/human/New(mob/living/carbon/human/owner)
 	..()
@@ -301,14 +301,6 @@
 	pull_icon.screen_loc = ui_above_intent
 	pull_icon.hud = src
 	static_inventory += pull_icon
-
-	lingchemdisplay = new /atom/movable/screen/ling/chems()
-	lingchemdisplay.hud = src
-	infodisplay += lingchemdisplay
-
-	lingstingdisplay = new /atom/movable/screen/ling/sting()
-	lingstingdisplay.hud = src
-	infodisplay += lingstingdisplay
 
 	zone_select = new /atom/movable/screen/zone_sel()
 	zone_select.icon = ui_style

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -147,11 +147,8 @@
 	else
 		RegisterSignal(living_mob, COMSIG_MOB_HUD_CREATED, .proc/on_hud_created)
 
-	if(!iscarbon(living_mob))
-		return
-	var/mob/living/carbon/carbon_mob = mob_to_tweak
 	// Brains are optional for lings.
-	var/obj/item/organ/brain/our_ling_brain = carbon_mob.getorganslot(ORGAN_SLOT_BRAIN)
+	var/obj/item/organ/brain/our_ling_brain = living_mob.getorganslot(ORGAN_SLOT_BRAIN)
 	if(our_ling_brain)
 		our_ling_brain.organ_flags &= ~ORGAN_VITAL
 		our_ling_brain.decoy_override = TRUE

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -20,16 +20,16 @@
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	changeling.chosen_sting = src
 
-	user.hud_used.lingstingdisplay.icon_state = button_icon_state
-	user.hud_used.lingstingdisplay.invisibility = 0
+	changeling.lingstingdisplay.icon_state = button_icon_state
+	changeling.lingstingdisplay.invisibility = 0
 
 /datum/action/changeling/sting/proc/unset_sting(mob/user)
 	to_chat(user, span_warning("We retract our sting, we can't sting anyone for now."))
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	changeling.chosen_sting = null
 
-	user.hud_used.lingstingdisplay.icon_state = null
-	user.hud_used.lingstingdisplay.invisibility = INVISIBILITY_ABSTRACT
+	changeling.lingstingdisplay.icon_state = null
+	changeling.lingstingdisplay.invisibility = INVISIBILITY_ABSTRACT
 
 /mob/living/carbon/proc/unset_sting()
 	if(mind)


### PR DESCRIPTION
## About The Pull Request

Changeling HUDs now properly persist through bodies, and their on_life runs while they are non-carbons as well now, since they have the hud.
They can also sting people while a non-carbon, as I'm not sure it was intentional that it *wasn't* allowed, and it seems weird to limit it in that way.

Here's my chem display after I headslug as proof:
![image](https://user-images.githubusercontent.com/53777086/162818851-d9ec6920-3b73-43a4-afa6-c05273cb1a05.png)

## Why It's Good For The Game

Changelings now work better, don't have wacky inconsistency issues, and actually know their ling chems after moving to a new body.
Closes https://github.com/tgstation/tgstation/issues/65981

## Changelog

:cl:
fix: Changeling HUDs now properly carry over through bodies.
code: Non carbon Changelings now respectively regenerate/lose/spend their chems.
/:cl: