### PR TITLE
Reworks Mech Extinguisher to be utility equipment, related balance changes.

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -188,14 +188,17 @@
 	playsound(chassis, 'sound/effects/extinguish.ogg', 75, TRUE, -3)
 
 /obj/item/mecha_parts/mecha_equipment/extinguisher/proc/attempt_refill(mob/usr)
+	if(reagents.maximum_volume == reagents.total_volume)
+		return
 	var/turf/in_front = get_step(chassis, chassis.dir)
 	var/obj/structure/reagent_dispensers/watertank/refill_source = locate(/obj/structure/reagent_dispensers/watertank) in in_front
 	if(!refill_source)
+		to_chat(usr, span_notice("Refill failed. No compatible tank found."))
 		return
 	if(!refill_source.reagents?.total_volume)
 		return
-	if(reagents.maximum_volume == reagents.total_volume)
-		return
+		to_chat(usr, span_notice("Refill failed. Source tank empty."))
+
 	refill_source.reagents.trans_to(src, reagents.maximum_volume)
 	playsound(chassis, 'sound/effects/refill.ogg', 50, TRUE, -6)
 	return

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -205,7 +205,7 @@
 		"snowflake_id" = MECHA_SNOWFLAKE_ID_EXTINGUISHER,
 		"reagents" = reagents.total_volume,
 		"total_reagents" = reagents.maximum_volume,
-		"minimum_required" = required_amount,
+		"minimum_requ" = required_amount,
 	)
 
 /obj/item/mecha_parts/mecha_equipment/extinguisher/ui_act(action, list/params)

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -158,66 +158,68 @@
 	icon_state = "mecha_exting"
 	equip_cooldown = 5
 	energy_drain = 0
+	equipment_slot = MECHA_UTILITY
 	range = MECHA_MELEE|MECHA_RANGED
 	mech_flags = EXOSUIT_MODULE_WORKING
-	var/sprays_left = 0
+	var/required_amount = 80
 
 /obj/item/mecha_parts/mecha_equipment/extinguisher/Initialize(mapload)
 	. = ..()
-	create_reagents(1000)
-	reagents.add_reagent(/datum/reagent/water, 1000)
+	create_reagents(400)
+	reagents.add_reagent(/datum/reagent/water, 400)
 
-/obj/item/mecha_parts/mecha_equipment/extinguisher/action(mob/source, atom/target, list/modifiers)
-	if(!action_checks(target) || get_dist(chassis, target)>3)
+/obj/item/mecha_parts/mecha_equipment/extinguisher/proc/spray_extinguisher(mob/user)
+	if(reagents.total_volume < required_amount)
 		return
 
-	if(istype(target, /obj/structure/reagent_dispensers/watertank) && get_dist(chassis,target) <= 1)
-		var/obj/structure/reagent_dispensers/watertank/WT = target
-		WT.reagents.trans_to(src, 1000)
-		to_chat(source, "[icon2html(src, source)][span_notice("Extinguisher refilled.")]")
-		playsound(chassis, 'sound/effects/refill.ogg', 50, TRUE, -6)
-		return
+	var/list/turflist = list()
+	for(var/carddir in GLOB.cardinals)
+		turflist += get_step(chassis, carddir)
+		turflist += get_step(get_step(chassis, carddir), turn(carddir, 90))
 
-	if(reagents.total_volume <= 0)
-		return
+	for(var/turf/targetturf in turflist)
+		var/obj/effect/particle_effect/water/extinguisher/water = new /obj/effect/particle_effect/water/extinguisher(targetturf)
+		var/datum/reagents/water_reagents = new /datum/reagents(required_amount/8) //required_amount/8, because the water usage is split between eight sprays. As of this comment, required_amount/8 = 10u each.
+		water.reagents = water_reagents
+		water_reagents.my_atom = water
+		reagents.trans_to(water, required_amount/8)
+		water.move_at(get_step(chassis, get_dir(targetturf, chassis)), 2, 4) //Target is the tile opposite of the mech as the starting turf.
+
 	playsound(chassis, 'sound/effects/extinguish.ogg', 75, TRUE, -3)
 
-	sprays_left += 5
-	add_hiddenprint(source) //log prints so admins can figure out who touched it last.
-	log_combat(source, target, "fired an extinguisher at")
-	spray_extinguisher(target)
-	return ..()
-
-/obj/item/mecha_parts/mecha_equipment/extinguisher/proc/spray_extinguisher(atom/target)
-	var/direction = get_dir(chassis, target)
-	var/turf/T1 = get_turf(target)
-	var/turf/T2 = get_step(T1,turn(direction, 90))
-	var/turf/T3 = get_step(T1,turn(direction, -90))
-	var/list/targets = list(T1,T2,T3)
-
-	var/obj/effect/particle_effect/water/extinguisher/water = new /obj/effect/particle_effect/water/extinguisher(get_turf(chassis))
-	var/datum/reagents/water_reagents = new /datum/reagents(5)
-	water.reagents = water_reagents
-	water_reagents.my_atom = water
-	reagents.trans_to(water, 1)
-
-	var/delay = 2
-	var/datum/move_loop/our_loop = water.move_at(pick(targets), delay, 4)
-	RegisterSignal(our_loop, COMSIG_PARENT_QDELETING, .proc/water_finished_moving)
-
-/obj/item/mecha_parts/mecha_equipment/extinguisher/proc/water_finished_moving(datum/move_loop/has_target/source)
-	SIGNAL_HANDLER
-	sprays_left--
-	if(!sprays_left)
+/obj/item/mecha_parts/mecha_equipment/extinguisher/proc/attempt_refill(mob/usr)
+	var/turf/in_front = get_step(chassis, chassis.dir)
+	var/obj/structure/reagent_dispensers/watertank/refill_source = locate(/obj/structure/reagent_dispensers/watertank) in in_front
+	if(!refill_source)
 		return
-	extinguish(source.target)
+	if(!refill_source.reagents?.total_volume)
+		return
+	if(reagents.maximum_volume == reagents.total_volume)
+		return
+	refill_source.reagents.trans_to(src, reagents.maximum_volume)
+	playsound(chassis, 'sound/effects/refill.ogg', 50, TRUE, -6)
+	return
 
 /obj/item/mecha_parts/mecha_equipment/extinguisher/get_snowflake_data()
 	return list(
 		"snowflake_id" = MECHA_SNOWFLAKE_ID_EXTINGUISHER,
 		"reagents" = reagents.total_volume,
 		"total_reagents" = reagents.maximum_volume,
+		"minimum_required" = required_amount,
 	)
+
+/obj/item/mecha_parts/mecha_equipment/extinguisher/ui_act(action, list/params)
+	. = ..()
+	if(.)
+		return TRUE
+	switch(action)
+		if("activate")
+			spray_extinguisher(usr)
+			return TRUE
+		if("refill")
+			attempt_refill(usr)
+			return TRUE
+
 
 /obj/item/mecha_parts/mecha_equipment/extinguisher/can_attach(obj/vehicle/sealed/mecha/M, attach_right = FALSE)
 	. = ..()

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -196,8 +196,8 @@
 		to_chat(usr, span_notice("Refill failed. No compatible tank found."))
 		return
 	if(!refill_source.reagents?.total_volume)
-		return
 		to_chat(usr, span_notice("Refill failed. Source tank empty."))
+		return
 
 	refill_source.reagents.trans_to(src, reagents.maximum_volume)
 	playsound(chassis, 'sound/effects/refill.ogg', 50, TRUE, -6)

--- a/tgui/packages/tgui/interfaces/Mecha/ArmPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ArmPane.tsx
@@ -117,7 +117,6 @@ const BallisticStats = (props: {weapon: MechWeapon}, context) => {
 const MECHA_SNOWFLAKE_ID_SLEEPER = "sleeper_snowflake";
 const MECHA_SNOWFLAKE_ID_SYRINGE = "syringe_snowflake";
 const MECHA_SNOWFLAKE_ID_MODE = "mode_snowflake";
-const MECHA_SNOWFLAKE_ID_EXTINGUISHER = "extinguisher_snowflake";
 
 // Handles all the snowflake buttons and whatever
 const Snowflake = (props: {weapon: MechWeapon}, context) => {
@@ -129,8 +128,6 @@ const Snowflake = (props: {weapon: MechWeapon}, context) => {
       return <SnowflakeSleeper weapon={props.weapon} />;
     case MECHA_SNOWFLAKE_ID_SYRINGE:
       return <SnowflakeSyringe weapon={props.weapon} />;
-    case MECHA_SNOWFLAKE_ID_EXTINGUISHER:
-      return <SnowflakeExtinguisher weapon={props.weapon} />;
     case MECHA_SNOWFLAKE_ID_MODE:
       return <SnowflakeMode weapon={props.weapon} />;
     default:

--- a/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
@@ -1,5 +1,5 @@
 import { useBackend } from '../../backend';
-import { Button, LabeledList } from '../../components';
+import { Button, Fragment, LabeledList, ProgressBar } from '../../components';
 import { OperatorData, MechaUtility } from './data';
 
 export const UtilityModulesPane = (props, context) => {
@@ -36,6 +36,7 @@ export const UtilityModulesPane = (props, context) => {
 };
 
 const MECHA_SNOWFLAKE_ID_EJECTOR = "ejector_snowflake";
+const MECHA_SNOWFLAKE_ID_EXTINGUISHER = "extinguisher_snowflake";
 
 // Handles all the snowflake buttons and whatever
 const Snowflake = (props: {module: MechaUtility}, context) => {
@@ -45,6 +46,8 @@ const Snowflake = (props: {module: MechaUtility}, context) => {
   switch (snowflake["snowflake_id"]) {
     case MECHA_SNOWFLAKE_ID_EJECTOR:
       return <SnowflakeEjector module={props.module} />;
+    case MECHA_SNOWFLAKE_ID_EXTINGUISHER:
+      return <SnowflakeExtinguisher module={props.module} />;
     default:
       return null;
   }
@@ -70,5 +73,51 @@ const SnowflakeEjector = (props: {module: MechaUtility}, context) => {
         </LabeledList.Item>
       ))}
     </LabeledList>
+  );
+};
+
+const SnowflakeExtinguisher = (props: {module: MechaUtility}, context) => {
+  const { act, data } = useBackend<OperatorData>(context);
+  return (
+    <Fragment>
+    <ProgressBar
+      value={props.module.snowflake.reagents}
+      minValue={0}
+      maxValue={props.module.snowflake.total_reagents}>
+      {props.module.snowflake.reagents}
+    </ProgressBar>
+      <Button
+        tooltip={"ACTIVATE"}
+        color={"red"}
+        disabled={props.module.snowflake.reagents < props.module.snowflake.minimum_required ? 1 : 0}
+        icon={"fire-extinguisher"}
+        onClick={() => act('equip_act', {
+          ref: props.module.ref,
+          gear_action: "activate",
+        })}
+        selected={module.activated} />
+      <Button
+        tooltip={"REFILL"}
+        icon={"fill"}
+        onClick={() => act('equip_act', {
+          ref: props.module.ref,
+          gear_action: "refill",
+        })}
+        selected={module.activated} />
+      <Button
+        tooltip={"REPAIR"}
+        icon={"wrench"}
+        onClick={() => act('equip_act', {
+          ref: props.module.ref,
+          gear_action: "repair",
+        })} />
+      <Button
+        tooltip={"DETACH"}
+        icon={"arrow-down"}
+        onClick={() => act('equip_act', {
+          ref: props.module.ref,
+          gear_action: "detach",
+        })} />
+    </Fragment>
   );
 };

--- a/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
@@ -1,5 +1,6 @@
 import { useBackend } from '../../backend';
-import { Button, Fragment, LabeledList, ProgressBar } from '../../components';
+import { Button, LabeledList, ProgressBar } from '../../components';
+import { Fragment } from 'inferno';
 import { OperatorData, MechaUtility } from './data';
 
 export const UtilityModulesPane = (props, context) => {
@@ -80,30 +81,31 @@ const SnowflakeExtinguisher = (props: {module: MechaUtility}, context) => {
   const { act, data } = useBackend<OperatorData>(context);
   return (
     <Fragment>
-    <ProgressBar
-      value={props.module.snowflake.reagents}
-      minValue={0}
-      maxValue={props.module.snowflake.total_reagents}>
-      {props.module.snowflake.reagents}
-    </ProgressBar>
+      <ProgressBar
+        value={props.module.snowflake.reagents}
+        minValue={0}
+        maxValue={props.module.snowflake.total_reagents}>
+        {props.module.snowflake.reagents}
+      </ProgressBar>
       <Button
         tooltip={"ACTIVATE"}
         color={"red"}
-        disabled={props.module.snowflake.reagents < props.module.snowflake.minimum_required ? 1 : 0}
+        disabled={
+          props.module.snowflake.reagents < props.module.snowflake.minimum_requ
+            ? 1 : 0
+        }
         icon={"fire-extinguisher"}
         onClick={() => act('equip_act', {
           ref: props.module.ref,
           gear_action: "activate",
-        })}
-        selected={module.activated} />
+        })} />
       <Button
         tooltip={"REFILL"}
         icon={"fill"}
         onClick={() => act('equip_act', {
           ref: props.module.ref,
           gear_action: "refill",
-        })}
-        selected={module.activated} />
+        })} />
       <Button
         tooltip={"REPAIR"}
         icon={"wrench"}

--- a/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
@@ -1,6 +1,5 @@
 import { useBackend } from '../../backend';
 import { Button, LabeledList, ProgressBar } from '../../components';
-import { Fragment } from 'inferno';
 import { OperatorData, MechaUtility } from './data';
 
 export const UtilityModulesPane = (props, context) => {
@@ -80,7 +79,7 @@ const SnowflakeEjector = (props: {module: MechaUtility}, context) => {
 const SnowflakeExtinguisher = (props: {module: MechaUtility}, context) => {
   const { act, data } = useBackend<OperatorData>(context);
   return (
-    <Fragment>
+    <>
       <ProgressBar
         value={props.module.snowflake.reagents}
         minValue={0}
@@ -120,6 +119,6 @@ const SnowflakeExtinguisher = (props: {module: MechaUtility}, context) => {
           ref: props.module.ref,
           gear_action: "detach",
         })} />
-    </Fragment>
+    </>
   );
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- The extinguisher is now utility rather than an active equipment mount. This means it no longer takes up one of a mech's limited hardpoint slots.
- Mech extinguishers now extinguish in a 3x3 grid around (and including) themselves.
- Mech extinguishers now use 80u of water, and store a maximum of 400u. This adds up to five uses before needing a refil.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The mech extinguisher was already somewhat of a niche equipment part before the mech rebalance. It's most obvious usage would be on budget/early game mining mechs, where lava can ignite a Ripley. However, as a hardpoint equipment, it occupies one of your two active equipment slots. Ripleys need both slots to fit a mining tool of some sort and also a clamp for storing an ore crate. (Clarke can get by without the clamp, but is also fireproof anyway).

So this PR changes the extinguisher to be a utility equipment item instead. It also somewhat reworks how the extinguisher behaves. Rather than spraying outwards in a direction (like a handheld extinguisher), the mech extinguisher now sprays water from the surrounding tiles towards, which then passes by and will reach out, overall covering a 3x3 grid. This is the mech spraying *itself* with fire suppression, but can reach others if they're nearby as a side effect. The re-balance of water usage and max volume is an attempt to follow this same design idea.

That said, it *can* still extinguish people and objects, but you have to be close:


https://user-images.githubusercontent.com/37497534/162445121-3c5ce69e-21e0-4646-a02c-bb3efdae3af0.mp4


By the by, here's the actual UI. Being a utility equipment, you *have* to use the UI trigger button.
![image](https://user-images.githubusercontent.com/37497534/162443855-2f4caa93-c41e-45d2-bbb1-e443c542071f.png)
Also available are the Refill, Repair, and Detach buttons. Each has a tooltip.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Mecha Extinguisher equipment is now classified as utility.
balance: The Mecha Extinguisher now puts out fires in a 3x3 square (centered on the mech). However, it also only has five uses now. Save it for emergencies!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
