### PR TITLE
Standardizes donuts and donks on all stations

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -10297,7 +10297,6 @@
 /area/hallway/secondary/command)
 "cuh" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -23371,7 +23370,6 @@
 /area/security/warden)
 "eyO" = (
 /obj/structure/rack,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/item/holosign_creator/robot_seat/restaurant{
 	pixel_y = -5
 	},
@@ -24752,7 +24750,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/science/breakroom)
 "eUn" = (
@@ -26598,7 +26595,6 @@
 /area/maintenance/disposal)
 "fwR" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "fxb" = (
@@ -27607,7 +27603,6 @@
 /area/service/library)
 "fMQ" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/wood,
 /area/engineering/break_room)
@@ -57232,7 +57227,6 @@
 "otC" = (
 /obj/structure/table,
 /obj/effect/turf_decal/bot,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "otN" = (
@@ -82053,7 +82047,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/item/reagent_containers/food/drinks/britcup,
 /turf/open/floor/iron,
 /area/medical/medbay/lobby)
@@ -84366,9 +84359,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "wFj" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/donkpockets{
-	pixel_x = -6
-	},
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7686,7 +7686,6 @@
 /area/engineering/gravity_generator)
 "bSE" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/donkpockets,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
 "bSF" = (
@@ -21928,7 +21927,6 @@
 /area/security/checkpoint/escape)
 "eeL" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
@@ -22670,7 +22668,6 @@
 /area/commons/toilet/locker)
 "enp" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23942,7 +23939,6 @@
 /area/maintenance/starboard/aft)
 "eHZ" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
@@ -24756,6 +24752,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/science/breakroom)
 "eUn" = (
@@ -27020,7 +27017,6 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/machinery/requests_console/directional/west{
 	department = "Kitchen";
 	departmentType = 2;
@@ -28862,12 +28858,12 @@
 /area/cargo/office)
 "gge" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/medical/break_room)
 "ggt" = (
@@ -36547,8 +36543,6 @@
 "inN" = (
 /obj/item/clothing/neck/stethoscope,
 /obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -41148,7 +41142,6 @@
 /area/hallway/secondary/entry)
 "jFF" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
@@ -42338,7 +42331,6 @@
 /area/service/kitchen)
 "jZj" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
 "jZl" = (
@@ -43717,7 +43709,6 @@
 /area/maintenance/port/greater)
 "ktw" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
@@ -47656,7 +47647,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/requests_console/directional/south{
 	announcementConsole = 1;
 	department = "Bridge";
@@ -55180,7 +55170,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/red,
 /area/hallway/secondary/service)
 "nQR" = (
@@ -57242,8 +57231,8 @@
 /area/security/prison)
 "otC" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "otN" = (
@@ -67656,7 +67645,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/grimy,
 /area/command/meeting_room/council)
 "rDf" = (
@@ -70946,7 +70934,6 @@
 /area/security/brig)
 "syi" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
@@ -78044,7 +78031,6 @@
 /area/security/warden)
 "uDv" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
@@ -81390,11 +81376,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
-"vHf" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/iron/grimy,
-/area/service/library)
 "vHk" = (
 /obj/machinery/rnd/server,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -82071,8 +82052,9 @@
 "vUb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/drinks/britcup,
 /obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/item/reagent_containers/food/drinks/britcup,
 /turf/open/floor/iron,
 /area/medical/medbay/lobby)
 "vUj" = (
@@ -84384,6 +84366,9 @@
 /area/hallway/secondary/exit/departure_lounge)
 "wFj" = (
 /obj/structure/table/reinforced,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -6
+	},
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
@@ -122492,7 +122477,7 @@ lxk
 bzt
 taU
 ybZ
-vHf
+iMC
 kPq
 kBt
 aRL

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -6258,11 +6258,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"chw" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/carpet,
-/area/command/heads_quarters/captain)
 "chH" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -17240,6 +17235,9 @@
 "hsd" = (
 /obj/effect/turf_decal/tile/red/full,
 /obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "hsh" = (
@@ -25205,6 +25203,7 @@
 	pixel_y = 12
 	},
 /obj/item/food/candy_trash,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/science/mixing/hallway)
 "lry" = (
@@ -29036,6 +29035,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "ntF" = (
@@ -29376,7 +29376,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "nEf" = (
-/obj/item/storage/fancy/donut_box,
 /obj/structure/table,
 /turf/open/floor/wood,
 /area/command/meeting_room)
@@ -35176,7 +35175,6 @@
 "qod" = (
 /obj/structure/rack,
 /obj/machinery/status_display/evac/directional/south,
-/obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -42628,6 +42626,10 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/radio/intercom/directional/north,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 9;
+	pixel_x = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "uat" = (
@@ -44308,6 +44310,7 @@
 /obj/structure/table,
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/spawner/random/trash/cigbutt,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "uNS" = (
@@ -50443,7 +50446,6 @@
 	pixel_y = 32
 	},
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "xUM" = (
@@ -82561,7 +82563,7 @@ hcp
 qsj
 olj
 cZv
-chw
+uhQ
 uhQ
 kzW
 jaJ

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -25203,7 +25203,6 @@
 	pixel_y = 12
 	},
 /obj/item/food/candy_trash,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/science/mixing/hallway)
 "lry" = (
@@ -29035,7 +29034,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "ntF" = (
@@ -31844,7 +31842,6 @@
 /area/maintenance/department/medical/central)
 "oMm" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /obj/item/storage/secure/safe/caps_spare/directional/east,
 /turf/open/floor/iron,
 /area/command/bridge)
@@ -44310,7 +44307,6 @@
 /obj/structure/table,
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/spawner/random/trash/cigbutt,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "uNS" = (

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -983,7 +983,6 @@
 /obj/item/food/pie/cream,
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/light/directional/north,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "dd" = (
@@ -5155,7 +5154,6 @@
 	},
 /obj/effect/turf_decal/tile/dark,
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -12458,7 +12456,6 @@
 "Jn" = (
 /obj/structure/table,
 /obj/item/radio/intercom/directional/east,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
@@ -15894,7 +15891,12 @@
 /area/mine/storage)
 "SS" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/random/entertainment/gambling,
+/obj/effect/spawner/random/entertainment/gambling{
+	pixel_y = 9
+	},
+/obj/item/storage/fancy/donut_box{
+	pixel_x = -6
+	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "ST" = (

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
@@ -1132,7 +1132,6 @@
 /area/mine/laborcamp)
 "sP" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/stone,
@@ -1153,6 +1152,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"ti" = (
+/obj/item/storage/box/donkpockets{
+	pixel_y = 5
+	},
+/turf/open/genturf,
+/area/icemoon/underground/unexplored/rivers/deep)
 "tl" = (
 /obj/structure/girder,
 /obj/structure/lattice/catwalk,
@@ -2565,7 +2570,6 @@
 /area/mine/laborcamp)
 "QL" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -4156,7 +4160,7 @@ qI
 qI
 qI
 qI
-qI
+ti
 qI
 qI
 qI

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3190,7 +3190,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "apR" = (
@@ -23192,7 +23191,6 @@
 /area/hallway/primary/fore)
 "ddY" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/wood/tile,
 /area/service/library)
 "deb" = (
@@ -28809,7 +28807,6 @@
 "fbo" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/tray,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchenshutters";
@@ -30226,6 +30223,9 @@
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
 /area/science/lab)
@@ -35295,7 +35295,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/storage/fancy/donut_box,
 /obj/structure/table,
 /obj/machinery/camera/directional/east{
 	c_tag = "Courtroom Jury";
@@ -63174,6 +63173,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/donkpockets{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
 /area/cargo/sorting)
 "quK" = (
@@ -66474,7 +66476,6 @@
 /obj/machinery/microwave{
 	pixel_y = 5
 	},
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "rva" = (
@@ -71086,7 +71087,6 @@
 /turf/open/floor/iron/dark,
 /area/security/lockers)
 "sRX" = (
-/obj/item/storage/fancy/donut_box,
 /obj/structure/table/wood,
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
@@ -77249,6 +77249,9 @@
 	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/lobby)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -41698,9 +41698,6 @@
 /area/security/brig)
 "jrC" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_y = 5
-	},
 /obj/machinery/firealarm/directional/north,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -63173,9 +63170,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/donkpockets{
-	pixel_y = 5
-	},
 /turf/open/floor/iron/dark,
 /area/cargo/sorting)
 "quK" = (
@@ -71752,10 +71746,6 @@
 /obj/structure/mirror/directional/south,
 /obj/item/mod/module/plasma_stabilizer,
 /obj/item/mod/module/thermal_regulator,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 5
-	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "tgh" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -11530,7 +11530,6 @@
 "cXN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen_counter";
 	name = "Kitchen Counter Shutters"
@@ -18573,10 +18572,6 @@
 "ftE" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_x = -14;
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -34255,10 +34250,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
-"lqi" = (
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/turf/open/floor/plating,
-/area/maintenance/starboard/lesser)
 "lqn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -37336,7 +37327,6 @@
 /area/commons/lounge)
 "msj" = (
 /obj/machinery/firealarm/directional/east,
-/obj/item/storage/fancy/donut_box,
 /obj/structure/table/glass,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -104443,7 +104433,7 @@ hCo
 hCo
 tta
 hCo
-lqi
+rah
 vNF
 lpg
 vRa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -180,7 +180,6 @@
 /area/space/nearstation)
 "acn" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -1917,7 +1916,6 @@
 "awd" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "awf" = (
@@ -3914,7 +3912,6 @@
 /area/security/courtroom)
 "aUG" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
@@ -18528,7 +18525,6 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/three,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "fsc" = (
@@ -18576,9 +18572,6 @@
 /area/maintenance/starboard/greater)
 "ftE" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box{
-	pixel_x = 4
-	},
 /obj/structure/cable,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
 	pixel_x = -14;
@@ -18702,7 +18695,6 @@
 /area/medical/surgery/aft)
 "fwO" = (
 /obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
@@ -21798,7 +21790,6 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 5
@@ -25926,7 +25917,6 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ilb" = (
@@ -40062,7 +40052,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "njd" = (
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
@@ -48485,7 +48474,6 @@
 /area/science/xenobiology)
 "qpG" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
@@ -52310,7 +52298,6 @@
 /area/commons/dorms)
 "rRe" = (
 /obj/machinery/light/small/directional/south,
-/obj/item/storage/box/donkpockets,
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
@@ -105221,7 +105208,7 @@ odO
 hrc
 dee
 hCo
-lqi
+rah
 pgH
 hqm
 hCo

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -8824,7 +8824,6 @@
 /area/science/mixing)
 "bOz" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/syndicatebomb/training,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10294,7 +10293,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/radio/intercom/directional/north,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "cun" = (
@@ -13888,7 +13886,6 @@
 "dIJ" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
-/obj/item/storage/fancy/donut_box,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41668,7 +41665,6 @@
 /area/medical/treatment_center)
 "nHp" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "nIu" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -12276,16 +12276,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/dorms)
-"deq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "der" = (
 /turf/closed/wall/r_wall,
 /area/science/research)
@@ -32980,7 +32970,6 @@
 	dir = 8
 	},
 /obj/machinery/recharger,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "kzi" = (
@@ -63917,7 +63906,6 @@
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
 /obj/structure/table/glass,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "vUA" = (
@@ -168720,7 +168708,7 @@ nFh
 cpO
 bsd
 gSy
-deq
+abq
 meK
 gul
 tqq

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -82,8 +82,8 @@
 /datum/bounty/item/assistant/donut
 	name = "Donuts"
 	description = "CentCom's security forces are facing heavy losses against the Syndicate. Ship donuts to raise morale."
-	reward = CARGO_CRATE_VALUE * 6
-	required_count = 10
+	reward = CARGO_CRATE_VALUE * 5
+	required_count = 6
 	wanted_types = list(/obj/item/food/donut = TRUE)
 
 /datum/bounty/item/assistant/donkpocket

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -82,7 +82,7 @@
 /datum/bounty/item/assistant/donut
 	name = "Donuts"
 	description = "CentCom's security forces are facing heavy losses against the Syndicate. Ship donuts to raise morale."
-	reward = CARGO_CRATE_VALUE * 5
+	reward = CARGO_CRATE_VALUE * 6
 	required_count = 6
 	wanted_types = list(/obj/item/food/donut = TRUE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR rebalances donuts and donkpockets to be relatively scarce on all maps based on population size. It endeavors to spread out boxes through different departments and equalize them. Most maps total box count was reduced. Here is the result:

Delta - 16 boxes total
Meta - 12 boxes total
Box - 11 boxes total
Kilo - 8 boxes total
Tram - 8 boxes total

Since I'm reducing the number of donuts, I'm also reducing the requirement and rewards for the assistant donut bounty.

## Why It's Good For The Game

Having all the food you need for the entire round at start is pretty hugbox. Introducing scarcity means the crew will have to actively look for food sources instead of relying on an optimal setup at roundstart. There are many ways to obtain food if you interact with the rest of the crew, and this should encourage that while also taking into account the importance and utility of a quick bite to eat by not removing the boxes entirely.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Brand partners have encouraged Nanotrasen to reduce the availability of syndicate-made donuts and donk pockets aboard all stations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
