### PR TITLE
Fixes some in-wall obj placement [GLS RUIN]

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
+++ b/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
@@ -397,6 +397,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/thelizardsgas)
 "Mw" = (
@@ -548,10 +551,6 @@
 /turf/open/floor/engine/plasma{
 	initial_gas_mix = "plasma=35000;TEMP=293.15"
 	},
-/area/ruin/space/has_grav/thelizardsgas)
-"XB" = (
-/obj/machinery/power/terminal,
-/turf/closed/wall,
 /area/ruin/space/has_grav/thelizardsgas)
 "Ys" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -988,7 +987,7 @@ CA
 CA
 CA
 Qg
-XB
+mR
 Io
 cm
 Mw


### PR DESCRIPTION
## About The Pull Request
Stashun Lizards Gas Ruin

Fixes a possible oversight with a terminal being stuck in a wall. I don't know if it was causing bad stuff to happen, but I figure this isn't a positive interaction regardless of if it was or not. I talked it over with @san7890 in order to preserve the original intention of the former placement.

## Why It's Good For The Game

Fix es muy bueno.

## Changelog

:cl:
fix: relocates the SMES terminal to not be in a wall in the lizard gas space ruin
/:cl:
