### PR TITLE
Makes brimdemons delete their beams when deleted

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
@@ -44,6 +44,10 @@
 	/// A list of all the beam parts.
 	var/list/beamparts = list()
 
+/mob/living/simple_animal/hostile/asteroid/brimdemon/Destroy()
+	QDEL_LIST(beamparts)
+	return ..()
+
 /mob/living/simple_animal/hostile/asteroid/brimdemon/Login()
 	ranged = TRUE
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #66062, where brimdemon beams would remain active forever if the demon got deleted as the callback to delete the beam would never happen.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Infinite death laser bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes brimdemon lasers never disappearing if the demon was deleted while firing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
