### PR TITLE
Fixes Healium not updating health

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1499,11 +1499,12 @@
 	L.SetSleeping(10)
 	return ..()
 
-/datum/reagent/healium/on_mob_life(mob/living/L, delta_time, times_fired)
+/datum/reagent/healium/on_mob_life(mob/living/breather, delta_time, times_fired)
 	. = ..()
-	L.adjustFireLoss(-2 * REM * delta_time, FALSE)
-	L.adjustToxLoss(-5 * REM * delta_time, FALSE)
-	L.adjustBruteLoss(-2 * REM * delta_time, FALSE)
+	breather.adjustFireLoss(-2 * REM * delta_time, FALSE)
+	breather.adjustToxLoss(-5 * REM * delta_time, FALSE)
+	breather.adjustBruteLoss(-2 * REM * delta_time, FALSE)
+	return TRUE
 
 /datum/reagent/halon
 	name = "Halon"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1500,10 +1500,10 @@
 	return ..()
 
 /datum/reagent/healium/on_mob_life(mob/living/breather, delta_time, times_fired)
-	. = ..()
 	breather.adjustFireLoss(-2 * REM * delta_time, FALSE)
 	breather.adjustToxLoss(-5 * REM * delta_time, FALSE)
 	breather.adjustBruteLoss(-2 * REM * delta_time, FALSE)
+	..()
 	return TRUE
 
 /datum/reagent/halon


### PR DESCRIPTION
## About The Pull Request

Healium called all the `adjustXLoss` procs with `updating_health` set to `FALSE`, which means they don't update health
This is fine, for reagents, as you're intended to `return TRUE` at the end of `on_mob_life` runs if they're meant to update the mobs health

Unfortunately, healium did not do this, so it never updated health, which is incorrect and a bug - your health state becomes unsynced with your hud state and it looks weird until someone smacks you or something.

Also updated some var names. 

## Why It's Good For The Game

Healium looks like it's actually healing you now

## Changelog

:cl: Melbert
fix: Healium healing should be a little more responsive, now
/:cl:
