### PR TITLE
Fixes diggable turfs being diggable with any item

### DIFF
--- a/code/datums/components/diggable.dm
+++ b/code/datums/components/diggable.dm
@@ -18,7 +18,7 @@
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/handle_attack)
 
 /datum/component/diggable/proc/handle_attack(datum/source, obj/item/hit_by, mob/living/bastard, params)
-	if(!hit_by.tool_behaviour == TOOL_SHOVEL || !params)
+	if(!(hit_by.tool_behaviour == TOOL_SHOVEL) || !params)
 		return
 	var/turf/parent_turf = parent
 	for(var/i in 1 to amount)

--- a/code/datums/components/diggable.dm
+++ b/code/datums/components/diggable.dm
@@ -18,7 +18,7 @@
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/handle_attack)
 
 /datum/component/diggable/proc/handle_attack(datum/source, obj/item/hit_by, mob/living/bastard, params)
-	if(!(hit_by.tool_behaviour == TOOL_SHOVEL) || !params)
+	if(hit_by.tool_behaviour != TOOL_SHOVEL || !params)
 		return
 	var/turf/parent_turf = parent
 	for(var/i in 1 to amount)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a check for if an item behaved as a shovel in the diggable component where it was returning true regardless of the item used.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes https://github.com/tgstation/tgstation/issues/66084

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Diggable turfs no longer get dug up by any item used on them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
