### PR TITLE
It is no longer possible to end maint procedures on a mech if the parts panel is still open.

### DIFF
--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -203,7 +203,7 @@
 	if(!(usr in occupants))
 		switch(action)
 			if("stopmaint")
-				if(construction_state >= MECHA_LOCKED)
+				if(construction_state > MECHA_LOCKED)
 					to_chat(usr, span_warning("You must end Maintenance Procedures first!"))
 					return
 				mecha_flags &= ~ADDING_MAINT_ACCESS_POSSIBLE

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -203,6 +203,9 @@
 	if(!(usr in occupants))
 		switch(action)
 			if("stopmaint")
+				if(construction_state >= MECHA_LOCKED)
+					to_chat(usr, span_warning("You must end Maintenance Procedures first!"))
+					return
 				mecha_flags &= ~ADDING_MAINT_ACCESS_POSSIBLE
 				ui.close()
 				return FALSE

--- a/tgui/packages/tgui/interfaces/Mecha/MaintMode.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/MaintMode.tsx
@@ -120,11 +120,11 @@ const StockPartsPanel = (props, context) => {
         <Button
           fluid
           bold
-          content={"Enable part replacement"}
+          content={"Toggle part replacement"}
           textAlign="center"
           fontSize="200%"
           lineHeight={1.25}
-          className="Mecha__Button"
+          className="Mecha__ButtonDanger"
           onClick={() => act('togglemaint')} />
       </Stack.Item>
       <Stack.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Attempting to end maintenance procedures on a mech will now throw an error `You must end Maintenance Procedures first!` if you haven't disabled the parts replacement mode. This would cause the mech to enter a maintenance purgatory where the panel assumed the maintenance procedures was ended but the mech itself thought it was still in progress.

The button to start and end parts replacement mode is now labeled "Toggle part replacement", and has been colored red to signify the importance of the button. Ideally the button would tell you if part replacement is still enabled, but the TGUI window doesn't update, so that's a wash.

Fixes #66004
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Attempting to end maint procedures on a mech with parts replacement mode enabled will now throw an error at the user, rather than silently condemning the mech to lawn ordainment status.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
