### PR TITLE
How To Kill Your Spiders: Spider Update

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -733,12 +733,16 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	attack_verb_simple = list("swat", "smack")
 	hitsound = 'sound/effects/snap.ogg'
 	w_class = WEIGHT_CLASS_SMALL
-	//Things in this list will be instantly splatted.  Flyman weakness is handled in the flyman species weakness proc.
+	/// Things in this list will be instantly splatted.  Flyman weakness is handled in the flyman species weakness proc.
+	var/list/splattable
+	/// Things in this list which take a lot more damage from the fly swatter, but not be necessarily killed by it.
 	var/list/strong_against
+	/// How much extra damage the fly swatter does against mobs it is strong against
+	var/extra_strength_damage = 29
 
 /obj/item/melee/flyswatter/Initialize(mapload)
 	. = ..()
-	strong_against = typecacheof(list(
+	splattable = typecacheof(list(
 		/mob/living/simple_animal/hostile/bee,
 		/mob/living/simple_animal/butterfly,
 		/mob/living/basic/cockroach,
@@ -747,24 +751,27 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		/mob/living/simple_animal/hostile/ant,
 		/obj/effect/decal/cleanable/ants,
 	))
+	strong_against = typecacheof(list(
+		/mob/living/simple_animal/hostile/giant_spider,
+	))
 
 
 /obj/item/melee/flyswatter/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
-	if(!proximity_flag)
-		return
-	if(!is_type_in_typecache(target, strong_against))
-		return
-	if (HAS_TRAIT(user, TRAIT_PACIFISM))
+	if(!proximity_flag || HAS_TRAIT(user, TRAIT_PACIFISM))
 		return
 
-	new /obj/effect/decal/cleanable/insectguts(target.drop_location())
-	to_chat(user, span_warning("You easily splat [target]."))
-	if(isliving(target))
-		var/mob/living/bug = target
-		bug.gib()
-	else
-		qdel(target)
+	if(is_type_in_typecache(target, splattable))
+		new /obj/effect/decal/cleanable/insectguts(target.drop_location())
+		to_chat(user, span_warning("You easily splat [target]."))
+		if(isliving(target))
+			var/mob/living/bug = target
+			bug.gib()
+		else
+			qdel(target)
+	else if(is_type_in_typecache(target, strong_against) && isliving(target))
+		var/mob/living/living_target = target
+		living_target.adjustBruteLoss(extra_strength_damage)
 
 /obj/item/proc/can_trigger_gun(mob/living/user)
 	if(!user.can_use_guns(src))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -69,6 +69,10 @@
 
 	/// List of weather immunity traits that are then added on Initialize(), see traits.dm.
 	var/list/weather_immunities
+	/// Is this mob flammable?
+	var/flammable = FALSE
+	/// How much burn damage this mob takes from being on fire
+	var/burning_damage = 5
 
 	///Healable by medical stacks? Defaults to yes.
 	var/healable = 1
@@ -184,7 +188,8 @@
 		AddComponent(/datum/component/personal_crafting)
 		ADD_TRAIT(src, TRAIT_ADVANCEDTOOLUSER, ROUNDSTART_TRAIT)
 		ADD_TRAIT(src, TRAIT_CAN_STRIP, ROUNDSTART_TRAIT)
-	ADD_TRAIT(src, TRAIT_NOFIRE_SPREAD, ROUNDSTART_TRAIT)
+	if(!flammable)
+		ADD_TRAIT(src, TRAIT_NOFIRE_SPREAD, ROUNDSTART_TRAIT)
 	for(var/trait in weather_immunities)
 		ADD_TRAIT(src, trait, ROUNDSTART_TRAIT)
 
@@ -491,13 +496,30 @@
 	return TRUE
 
 /mob/living/simple_animal/handle_fire(delta_time, times_fired)
-	return TRUE
+	if(!flammable)
+		return TRUE
+	. = ..()
+	if(fire_stacks > 0)
+		adjustFireLoss(burning_damage)
 
 /mob/living/simple_animal/IgniteMob()
-	return FALSE
+	if(!flammable)
+		return FALSE
+	. = ..()
 
 /mob/living/simple_animal/extinguish_mob()
-	return
+	if(!flammable)
+		return
+	. = ..()
+
+/mob/living/simple_animal/update_fire()
+	if(!flammable)
+		return
+	var/mutable_appearance/fire_overlay = mutable_appearance('icons/mob/onfire.dmi', "Generic_mob_burning")
+	if(on_fire)
+		add_overlay(fire_overlay)
+	else
+		cut_overlay(fire_overlay)
 
 /mob/living/simple_animal/revive(full_heal = FALSE, admin_revive = FALSE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This is an update to spiders to give the average crewmember more ways to handle them.  The changes are as follows:

- You can set spiders on fire now.  They can put themselves out if they can stand still for 6 seconds.  Note that spiders can set each other on fire if they bump into one another, but that also applies to you.
- Using a fly swatter on a spider does vastly increased damage (30 brute)
- Spraying spiders with pesticides does a solid amount of stamina damage to them (along with a little bit of actual damage, which wasn't added with this PR)

There was also some balancing to the spiders themselves:

- Only hunter and viper spiders inject toxin now, and their poison injection per bite has been decreased by 60% (5 to 2)
- Slightly sped up the rate that broodmothers can lay eggs (15 seconds to 12 seconds)
- Broodmother health increased from 40 to 60
- Broodmother damage increased from 5 to 10 to 10 to 15
- Broodmother web laying speed increased from 4 seconds to 2 seconds

Something to note that the flammable spiders change now also allows any simplemob to be flammable if the var is set to TRUE.  Could be something to consider for some of them in the future.

## Why It's Good For The Game

The changes to the spiders give the crew more logical ways to damage spiders, and unlike a lot of weapons, they are relatively safe to give out to crew without it backfiring.  Allowing spiders to be set on fire also allows things like setting fires or using fire grenades on them to be more satisfying and effective.

The number changes to the spiders themselves involving poison was made because its not very fun to deal with poison in most cases.  Poison's now been restricted to the two spider types who specialize it and they deal much less, so while bitten crewmembers will still need to be concerned, it will take a great deal more bites for them to die to spider toxins.

Finally, the broodmother changes were made in order to give them a little bit more resistance during the earlygame when they're most vulnerable, and allow them to place webs effectively once they have a sufficient egg stockpile.  Now that a majority of the crew has access to spider-slaying weaponry, reducing the egg-laying speed a tad shouldn't be too much of an issue.

## Changelog

:cl:
balance: Spiders can now be set on fire
balance: Spiders now take increased damage to fly swatters
balance: Spiders now take significant stamina damage when in contact with pesticide
balance: Only hunter and viper spiders now inject toxins.  Their toxin injection per bite has been nerfed by 60%.
balance: Broodmothers have been buffed in a number of ways, including more health, more damage, and faster web placement
/:cl: