### PR TITLE
Holodeck Photobooth Floor Repainting (with Lacquer)

### DIFF
--- a/_maps/templates/holodeck_photobooth.dmm
+++ b/_maps/templates/holodeck_photobooth.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/open/floor/holofloor/white,
+/turf/open/floor/holofloor/pure_white,
 /area/template_noop)
 "c" = (
 /obj/structure/dresser,

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -45,6 +45,10 @@
 	name = "white floor"
 	icon_state = "white"
 
+/turf/open/floor/holofloor/pure_white
+	name = "white floor"
+	icon_state = "pure_white"
+
 /turf/open/floor/holofloor/plating/burnmix
 	name = "burn-mix floor"
 	initial_gas_mix = BURNMIX_ATMOS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Take a peek at this photograph:

![image](https://user-images.githubusercontent.com/34697715/162636804-01042b4d-23f6-4d36-96a8-df5acc17eb8a.png)

That's... not what it used to be like? I could not find anything to corroborate this, but I think the whole point of the photobooth floor was to have a pure white background. I just think it wasn't set up properly, so I made a new subtype and mapped it in:

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/162636805-00f5d0bf-2689-4308-a956-848fc37ad61d.png)

Much better for taking photographs of your statics. You can get those mangy tiles anywhere, but the versatility of a pure, crisp, white background can not be understated.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Nanotrasen realized that their holodeck simulation of the photobooth was not properly configured, and was showing up with ugly, grouted tiles. This has been rectified to be a pure white backdrop for all your photograph desires.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
