### PR TITLE
Prevents infinite looping of resonator field bursts

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -114,6 +114,8 @@
 
 /obj/effect/temp_visual/resonance/proc/burst()
 	SIGNAL_HANDLER
+	if(rupturing)
+		return
 	rupturing = TRUE
 	var/turf/src_turf = get_turf(src)
 	new /obj/effect/temp_visual/resonance_crush(src_turf)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check to the start of the resonator burst proc to prevent a field from bursting while mid burst which was causing infinite loops.

Best example is with legions, where when the legion got killed with a matrix trap resonator it would forcemove the dead body that it drops onto the tile it died on, activating the trap and making it explode again, causing the legion to die again since it hasn't actually gotten deleted yet, and drop another body triggering the trap again. Repeat until byond gives up and you get left with a huge pile of visible spawner objects, broken humans, and a legion at 0% health walking around.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #66096

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Killing a legion with matrix trap resonators no longer creates body spawner hell.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
