### PR TITLE
Fixes the bench error overlay when you're buckled

### DIFF
--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -8,7 +8,7 @@
 
 /obj/structure/chair/sofa/Initialize(mapload)
 	. = ..()
-	armrest = mutable_appearance(icon, "[icon_state]_armrest", ABOVE_MOB_LAYER)
+	armrest = mutable_appearance(initial(icon), "[icon_state]_armrest", ABOVE_MOB_LAYER)
 	armrest.plane = GAME_PLANE_UPPER
 	AddElement(/datum/element/soft_landing)
 


### PR DESCRIPTION
## About The Pull Request
Basically, https://github.com/tgstation/tgstation/pull/65918 introduced a bug with anything that used GAGS for subtypes of sofa. Now it won't create the funny error sprite when you're buckled to a bench.

Fixes https://github.com/tgstation/tgstation/issues/66108.

## Why It's Good For The Game
This looks right.
![image](https://user-images.githubusercontent.com/58045821/162644131-458f1434-08ce-4ef6-a170-ec114d2fb2b2.png)

## Changelog

:cl: GoldenAlpharex
fix: Nanotrasen's Furniture Department decided to decommission the faulty hologram projectors from their benches, as they were added by an intern thinking it would be funny to display big red letters above everyone sitting on them.
/:cl: