### PR TITLE
optimizes all lag away for ever and ever and ever: inlines the hottest proc in the codebase.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -1,5 +1,14 @@
 //Microwaving doesn't use recipes, instead it calls the microwave_act of the objects. For food, this creates something based on the food's cooked_type
 
+#define WZHZHZH() \
+	do { \
+		visible_message(span_notice("\The [src] turns on."), null, span_hear("You hear a microwave humming."))\
+		operating = TRUE\
+		set_light(1.5)\
+		soundloop.start()\
+		update_appearance()\
+	} while(FALSE);
+
 /obj/machinery/microwave
 	name = "microwave oven"
 	desc = "Cooks and boils stuff."
@@ -272,14 +281,6 @@
 		break
 	start()
 
-/obj/machinery/microwave/proc/wzhzhzh()
-	visible_message(span_notice("\The [src] turns on."), null, span_hear("You hear a microwave humming."))
-	operating = TRUE
-
-	set_light(1.5)
-	soundloop.start()
-	update_appearance()
-
 /obj/machinery/microwave/proc/spark()
 	visible_message(span_warning("Sparks fly around [src]!"))
 	var/datum/effect_system/spark_spread/s = new
@@ -291,15 +292,15 @@
 #define MICROWAVE_PRE 2
 
 /obj/machinery/microwave/proc/start()
-	wzhzhzh()
+	WZHZHZH()
 	loop(MICROWAVE_NORMAL, 10)
 
 /obj/machinery/microwave/proc/start_can_fail()
-	wzhzhzh()
+	WZHZHZH()
 	loop(MICROWAVE_PRE, 4)
 
 /obj/machinery/microwave/proc/muck()
-	wzhzhzh()
+	WZHZHZH()
 	playsound(src.loc, 'sound/effects/splat.ogg', 50, TRUE)
 	dirty_anim_playing = TRUE
 	update_appearance()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
wzhzhzh() is an extremely hot proc as it involves turning on a microwave. proc call overhead is extremely high in byond, typically reaching at minimum 200 nanoseconds of overhead for a global proc with no arguments. accessing a src to call it on probably costs more. by inlining wzhzhzh() we can save microseconds over the course of a round depending on how diligent the chef is. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes all lag
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
performance: fixes all lag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
