### PR TITLE
Adds eye colour prioritisation

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -12,6 +12,15 @@
 ///how many colour priority levels there are.
 #define COLOUR_PRIORITY_AMOUNT 4
 
+/// Use this for highest priority changes to eye colour, e.g. bloodcult eye.
+#define FIRST_EYE_COLOUR_PRIORITY 1
+/// Use this for medium priority changes to eye colour, e.g. while stoned. Suppressed by oculine.
+#define SECOND_EYE_COLOUR_PRIORITY 2
+/// Use this for lowest priority changes to eye colour, e.g. when a species changes eye colour while it's applied.
+#define THIRD_EYE_COLOUR_PRIORITY 3
+///how many colour priority levels there are.
+#define EYE_COLOUR_PRIORITY_AMOUNT 3
+
 #define COLOR_INPUT_DISABLED "#F0F0F0"
 #define COLOR_INPUT_ENABLED "#D3B5B5"
 

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -133,6 +133,7 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/stock_parts/cell/lead = 1,
 		/obj/item/storage/box/matches = 1,
 		/obj/item/storage/fancy/cigarettes/dromedaryco = 1,
+		/obj/item/reagent_containers/dropper/oculine = 1,
 		) = 1,
 
 	list(//food

--- a/code/datums/elements/cult_eyes.dm
+++ b/code/datums/elements/cult_eyes.dm
@@ -26,9 +26,7 @@
 	ADD_TRAIT(target, TRAIT_UNNATURAL_RED_GLOWY_EYES, CULT_TRAIT)
 	if (ishuman(target))
 		var/mob/living/carbon/human/human_parent = target
-		human_parent.eye_color = BLOODCULT_EYE
-		human_parent.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
-		human_parent.update_body()
+		human_parent.add_temporary_eye_colour(BLOODCULT_EYE, FIRST_EYE_COLOUR_PRIORITY)
 
 /**
  * Detach proc
@@ -39,8 +37,6 @@
 	REMOVE_TRAIT(target, TRAIT_UNNATURAL_RED_GLOWY_EYES, CULT_TRAIT)
 	if (ishuman(target))
 		var/mob/living/carbon/human/human_parent = target
-		human_parent.eye_color = initial(human_parent.eye_color)
-		human_parent.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
-		human_parent.update_body()
+		human_parent.remove_temporary_eye_colour(BLOODCULT_EYE, FIRST_EYE_COLOUR_PRIORITY)
 	UnregisterSignal(target, list(COMSIG_CHANGELING_TRANSFORM, COMSIG_HUMAN_MONKEYIZE, COMSIG_MONKEY_HUMANIZE))
 	return ..()

--- a/code/datums/status_effects/drug_effects.dm
+++ b/code/datums/status_effects/drug_effects.dm
@@ -64,16 +64,13 @@
 	duration = 10 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/stoned
 	status_type = STATUS_EFFECT_REFRESH
-	var/original_eye_color
 
 /datum/status_effect/stoned/on_apply()
 	if(!ishuman(owner))
 		CRASH("[type] status effect added to non-human owner: [owner ? owner.type : "null owner"]")
 	var/mob/living/carbon/human/human_owner = owner
-	original_eye_color = human_owner.eye_color
 	human_owner.add_movespeed_modifier(/datum/movespeed_modifier/reagent/cannabis) //slows you down
-	human_owner.eye_color = BLOODCULT_EYE //makes cult eyes less obvious
-	human_owner.update_body() //updates eye color
+	human_owner.add_temporary_eye_colour(BLOODCULT_EYE, SECOND_EYE_COLOUR_PRIORITY) //makes cult eyes less obvious
 	ADD_TRAIT(human_owner, TRAIT_BLOODSHOT_EYES, type) //dilates blood vessels in eyes
 	ADD_TRAIT(human_owner, TRAIT_CLUMSY, type) //impairs motor coordination
 	SEND_SIGNAL(human_owner, COMSIG_ADD_MOOD_EVENT, "stoned", /datum/mood_event/stoned) //improves mood
@@ -85,8 +82,7 @@
 		stack_trace("[type] status effect being removed from non-human owner: [owner ? owner.type : "null owner"]")
 	var/mob/living/carbon/human/human_owner = owner
 	human_owner.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/cannabis)
-	human_owner.eye_color = original_eye_color
-	human_owner.update_body()
+	human_owner.remove_temporary_eye_colour(BLOODCULT_EYE, SECOND_EYE_COLOUR_PRIORITY)
 	REMOVE_TRAIT(human_owner, TRAIT_BLOODSHOT_EYES, type)
 	REMOVE_TRAIT(human_owner, TRAIT_CLUMSY, type)
 	SEND_SIGNAL(human_owner, COMSIG_CLEAR_MOOD_EVENT, "stoned")

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -259,7 +259,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 			if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 				return TRUE
 			if(new_eye_color)
-				amazed_human.eye_color = sanitize_hexcolor(new_eye_color)
+				amazed_human.set_real_eye_colour(sanitize_hexcolor(new_eye_color))
 				amazed_human.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
 				amazed_human.update_body()
 

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -22,7 +22,7 @@
 	H.facial_hairstyle = random_facial_hairstyle(H.gender)
 	H.hair_color = "#[random_color()]"
 	H.facial_hair_color = H.hair_color
-	H.eye_color = random_eye_color()
+	H.set_real_eye_colour(random_eye_color())
 	H.dna.blood_type = random_blood_type()
 
 	// Mutant randomizing, doesn't affect the mob appearance unless it's the specific mutant.

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -497,8 +497,7 @@
 	r_hand = /obj/item/melee/blood_magic/stun
 
 /datum/outfit/cultist/post_equip(mob/living/carbon/human/H, visualsOnly)
-	H.eye_color = BLOODCULT_EYE
-	H.update_body()
+	H.add_temporary_eye_colour(BLOODCULT_EYE, FIRST_EYE_COLOUR_PRIORITY)
 
 	var/obj/item/clothing/suit/hooded/hooded = locate() in H
 	hooded.MakeHood() // This is usually created on Initialize, but we run before atoms

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -34,7 +34,7 @@
 	if(visualsOnly)
 		return
 	equipped_on.fully_replace_character_name(null,"Waldo")
-	equipped_on.eye_color = "#000000"
+	equipped_on.set_real_eye_colour("#000000")
 	equipped_on.gender = MALE
 	equipped_on.skin_tone = "caucasian3"
 	equipped_on.hairstyle = "Business Hair 3"

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -722,7 +722,7 @@
 		if(1)
 			to_chat(user, span_danger("Your appearance morphs to that of a very small humanoid ash dragon! You get to look like a freak without the cool abilities."))
 			consumer.dna.features = list("mcolor" = "#A02720", "tail_lizard" = "Dark Tiger", "tail_human" = "None", "snout" = "Sharp", "horns" = "Curled", "ears" = "None", "wings" = "None", "frills" = "None", "spines" = "Long", "body_markings" = "Dark Tiger Body", "legs" = "Digitigrade Legs")
-			consumer.eye_color = "#FEE5A3"
+			consumer.set_real_eye_colour("#FEE5A3")
 			consumer.set_species(/datum/species/lizard)
 		if(2)
 			to_chat(user, span_danger("Your flesh begins to melt! Miraculously, you seem fine otherwise."))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -86,7 +86,7 @@
 			. += "[t_He] [t_has] [glasses.get_examine_string(user)] covering [t_his] eyes."
 		else if(HAS_TRAIT(src, TRAIT_UNNATURAL_RED_GLOWY_EYES))
 			. += "<span class='warning'><B>[t_His] eyes are glowing with an unnatural red aura!</B></span>"
-		else if(HAS_TRAIT(src, TRAIT_BLOODSHOT_EYES))
+		else if(HAS_TRAIT(src, TRAIT_BLOODSHOT_EYES) && eye_color == BLOODCULT_EYE)
 			. += "<span class='warning'><B>[t_His] eyes are bloodshot!</B></span>"
 
 	//ears

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -29,6 +29,9 @@
 	//Eye colour
 	var/eye_color = "#000000"
 
+	///Eye colours assigned by things like cannabis or the occult, that do not modify the eye color of the organ itself
+	var/list/temporary_eye_colours
+
 	var/skin_tone = "caucasian1" //Skin tone
 
 	var/lip_style = null //no lipstick by default- arguably misleading, as it could be used for general makeup

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -575,6 +575,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				eye_overlay.pixel_x += add_pixel_x
 				eye_overlay.pixel_y += add_pixel_y
 				if((EYECOLOR in species_traits) && eye_organ)
+					species_human.eye_color = species_human.get_current_eye_colour()
 					eye_overlay.color = species_human.eye_color
 				standing += eye_overlay
 

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -48,7 +48,7 @@
 
 			// We want to give the head some boring old eyes just so it doesn't look too jank on the head sprite.
 			head.eyes = new /obj/item/organ/eyes(head)
-			head.eyes.eye_color = human.eye_color
+			head.eyes.eye_color = human.get_current_eye_colour()
 			head.update_icon_dropped()
 
 	human.set_safe_hunger_level()

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -216,22 +216,19 @@ Lizard subspecies: SILVER SCALED
 	examine_limb_id = SPECIES_LIZARD
 	///stored mutcolor for when we turn back off of a silverscale.
 	var/old_mutcolor
-	///stored eye color for when we turn back off of a silverscale.
-	var/old_eyecolor
 
 /datum/species/lizard/silverscale/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	var/mob/living/carbon/human/new_silverscale = C
 	old_mutcolor = C.dna.features["mcolor"]
-	old_eyecolor = new_silverscale.eye_color
 	new_silverscale.dna.features["mcolor"] = "#eeeeee"
-	new_silverscale.eye_color = "#0000a0"
+	new_silverscale.add_temporary_eye_colour("#0000a0", THIRD_EYE_COLOUR_PRIORITY)
 	..()
 	new_silverscale.add_filter("silver_glint", 2, list("type" = "outline", "color" = "#ffffff63", "size" = 2))
 
 /datum/species/lizard/silverscale/on_species_loss(mob/living/carbon/C)
 	var/mob/living/carbon/human/was_silverscale = C
 	was_silverscale.dna.features["mcolor"] = old_mutcolor
-	was_silverscale.eye_color = old_eyecolor
+	was_silverscale.remove_temporary_eye_colour("#0000a0", THIRD_EYE_COLOUR_PRIORITY)
 
 	was_silverscale.remove_filter("silver_glint")
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -658,6 +658,10 @@
 	if(!eyes)
 		return
 	improve_eyesight(owner, eyes)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/human_owner = owner
+	human_owner.suppress_temporary_eye_colour(SECOND_EYE_COLOUR_PRIORITY) //will affect red eyes from cannabis, but not bloodcult eyes
 
 /datum/reagent/medicine/oculine/proc/improve_eyesight(mob/living/carbon/owner, obj/item/organ/eyes/eyes)
 	delta_light = creation_purity*30
@@ -672,6 +676,10 @@
 	eyes.lighting_alpha += delta_light
 	eyes.see_in_dark -= 3
 	owner.update_sight()
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/human_owner = owner
+	human_owner.unsuppress_temporary_eye_colour(SECOND_EYE_COLOUR_PRIORITY)
 
 /datum/reagent/medicine/oculine/proc/on_gained_organ(mob/owner, obj/item/organ/organ)
 	SIGNAL_HANDLER

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -90,3 +90,11 @@
 	var/mutable_appearance/filling = mutable_appearance('icons/obj/reagentfillings.dmi', "dropper")
 	filling.color = mix_color_from_reagents(reagents.reagent_list)
 	. += filling
+
+/obj/item/reagent_containers/dropper/oculine
+	name = "\improper VISILINE® Single-Use Eye Dropper"
+	desc = "A 5u single-use eye dropper containing vasoconstricting eye drops. These ones are oddly good for your eyes. ACTIVE INGREDIENTS: OCULINE 100%w/v"
+
+/obj/item/reagent_containers/dropper/oculine/Initialize()
+	. = ..()
+	reagents.add_reagent(/datum/reagent/medicine/oculine, 5)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds three priorities of temporary eye colours, which change the colour of a human's eyes without affecting their actual eye colour.

When all temporary eye colours are cleared, the human's eyes revert to their natural eye colour.

Currently, the first priority is used by bloodcult red eyes, the second by cannabis red eyes and the third by silverscale blue eyes. The higher priorities overwrite the lower ones.

It's possible to suppress a certain priority of colour, which means that priority is skipped over.

I've made it so oculine suppresses the second priority colour, to hide the redness caused by cannabis. When you have it in your bloodstream, your eyes will either be the first priority colour, the third priority colour, or their natural colour.

Also adds little droppers of Oculine to the maintenance loot pool.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes it easier for coders to add effects that change a human's eye colour without having to worry about how to get the original colour back or overwriting other changes to eye colour.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Oculine can be used to suppress red eyes from cannabis, but not bloodcult eyes because that shit is magic
add: Added droppers of oculine to the maintenance loot pool
code: Effects that change a human's eye colour are managed with a priority list, similar to changes to an atom's colour
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
