### PR TITLE
Bedsheet Directional Rotational Bigly Large Fix

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1511,7 +1511,9 @@
 /obj/structure/bed{
 	dir = 4
 	},
-/obj/item/bedsheet/dorms,
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/commons/dorms)
 "ame" = (
@@ -20759,10 +20761,10 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "gaG" = (
-/obj/structure/bed/double{
+/obj/item/bedsheet/dorms_double{
 	dir = 4
 	},
-/obj/item/bedsheet/dorms_double{
+/obj/structure/bed/double{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -24032,7 +24034,9 @@
 /obj/structure/bed{
 	dir = 4
 	},
-/obj/item/bedsheet/dorms,
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "hkC" = (
@@ -36428,7 +36432,9 @@
 /obj/structure/bed{
 	dir = 4
 	},
-/obj/item/bedsheet/dorms,
+/obj/item/bedsheet/dorms{
+	dir = 4
+	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/commons/dorms)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -38,7 +38,7 @@ LINEN BINS
 		stack_amount *= 2
 		dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 
-/obj/item/bedsheet/attack_self(mob/user)
+/obj/item/bedsheet/attack_self(mob/living/user)
 	if(!user.CanReach(src)) //No telekenetic grabbing.
 		return
 	if(!user.dropItemToGround(src))
@@ -53,6 +53,13 @@ LINEN BINS
 		layer = initial(layer)
 		plane = initial(plane)
 		to_chat(user, span_notice("You smooth [src] out beneath you."))
+	if(user.body_position == LYING_DOWN)    //The player isn't laying down currently
+		dir = user.dir
+	else
+		if(user.dir |= WEST)    //The player is rotated to the right, lay the sheet left!
+			dir = WEST
+		else    //The player is rotated to the left, lay the sheet right! 
+			dir = EAST
 	add_fingerprint(user)
 	return
 
@@ -312,7 +319,8 @@ LINEN BINS
 				/obj/item/bedsheet/ian,
 				/obj/item/bedsheet/cosmos,
 				/obj/item/bedsheet/nanotrasen))
-	new type(loc)
+	var/obj/item/bedsheet = new type(loc)
+	bedsheet.dir = dir
 	return INITIALIZE_HINT_QDEL
 
 /obj/item/bedsheet/double
@@ -492,7 +500,8 @@ LINEN BINS
 				/obj/item/bedsheet/ian/double,
 				/obj/item/bedsheet/cosmos/double,
 				/obj/item/bedsheet/nanotrasen/double))
-	new type(loc)
+	var/obj/item/bedsheet = new type(loc)
+	bedsheet.dir = dir
 	return INITIALIZE_HINT_QDEL
 
 /obj/structure/bedsheetbin

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -56,9 +56,9 @@ LINEN BINS
 	if(user.body_position == LYING_DOWN)    //The player isn't laying down currently
 		dir = user.dir
 	else
-		if(user.dir |= WEST)    //The player is rotated to the right, lay the sheet left!
+		if(user.dir & WEST)    //The player is rotated to the right, lay the sheet left!
 			dir = WEST
-		else    //The player is rotated to the left, lay the sheet right! 
+		else    //The player is rotated to the left, lay the sheet right!
 			dir = EAST
 	add_fingerprint(user)
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there:

![image](https://user-images.githubusercontent.com/34697715/162873218-d3d1e9d9-8fc8-48eb-947d-2f194e6bbdc7.png)

This is what bedsheets look like now. This is partially my fault with #65789, but it's simply there because the functionality didn't exist yet. Let's add some code to fix that (as well as remap some weird error Tram had). This just adds the functionality for random spawners to honor the dir they were mapped in as, as well as give some functionality to players so they can set the dir of the bedsheet themselves. We only have East/West sprites, so we're running off that assumption I suppose.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/162873063-5929942a-ad9a-4611-9a79-632b099fb1ba.png)

Much better!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You should now be able to rotate bedsheets on yourself as you take restful sleeps.
fix: Nanotrasen will no longer place bedsheets the wrong way on beds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
