### PR TITLE
Gives traitor logging its own config flag

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -154,7 +154,7 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 		WRITE_LOG(GLOB.world_econ_log, "MONEY: [text]")
 
 /proc/log_traitor(text)
-	if (CONFIG_GET(flag/log_econ))
+	if (CONFIG_GET(flag/log_traitor))
 		WRITE_LOG(GLOB.world_game_log, "TRAITOR: [text]")
 
 /proc/log_manifest(ckey, datum/mind/mind, mob/body, latejoin = FALSE)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -118,6 +118,9 @@
 /// log economy actions
 /datum/config_entry/flag/log_econ
 
+/// log traitor objectives
+/datum/config_entry/flag/log_traitor
+
 /// log admin chat messages
 /datum/config_entry/flag/log_adminchat
 	protection = CONFIG_ENTRY_LOCKED

--- a/config/config.txt
+++ b/config/config.txt
@@ -132,6 +132,9 @@ LOG_SILICON
 ## log economy actions
 LOG_ECON
 
+## log traitor objectives
+LOG_TRAITOR
+
 ## log crew manifest to separate file
 LOG_MANIFEST
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Right now traitor logging uses the same config flag that economy uses to determine whether it should be on or off. This gives traitor logging its own config flag.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Turning on or off economy logging shouldn't also turn traitor logging on and off.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: traitor logging has its own config flag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
