### PR TITLE
[NO GBP] Fix airlock controller TGUI bugs

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_controller.dm
@@ -216,7 +216,7 @@
 /obj/machinery/embedded_controller/radio/airlock_controller/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "AirlockController")
+		ui = new(user, src, "AirlockController", src)
 		ui.open()
 
 /obj/machinery/embedded_controller/radio/airlock_controller/ui_data(mob/user)
@@ -226,7 +226,7 @@
 	data["exteriorStatus"] = program.memory["exterior_status"] ? program.memory["exterior_status"] : "----"
 	data["interiorStatus"] = program.memory["interior_status"] ? program.memory["interior_status"] : "----"
 	data["pumpStatus"] = program.memory["pump_status"] ? program.memory["pump_status"] : "----"
-	return data		
+	return data
 
 /obj/machinery/embedded_controller/radio/airlock_controller/ui_act(action, params)
 	. = ..()

--- a/code/game/machinery/embedded_controller/airlock_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_controller.dm
@@ -219,6 +219,13 @@
 		ui = new(user, src, "AirlockController", src)
 		ui.open()
 
+/obj/machinery/embedded_controller/radio/airlock_controller/process(delta_time)
+	if(program)
+		program.process(delta_time)
+
+	update_appearance()
+	SStgui.update_uis(src)
+
 /obj/machinery/embedded_controller/radio/airlock_controller/ui_data(mob/user)
 	var/list/data = list()
 	data["airlockState"] = program.state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Similar to #65540 except keeps the base embedded controller in (for the simple vent controllers), and also doesn't refactor GUI into typescript. 
Airlock controller GUI now displays its name at the top.
The GUI now no longer automatically pops back up after you closed it if it updates (and you're still in range).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #65377 also fixes #66130
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Airlock Controllers now display their name in their GUI menu.
fix: Airlock Controllers' GUI menu now doesn't pop back up after being closed if it update while you'll still in range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
