### PR TITLE
washing someone else's mouth out with soap no longer washes YOUR mouth out with soap instead

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -148,11 +148,11 @@
 			decreaseUses(user)
 
 	else if(ishuman(target) && user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
-		var/mob/living/carbon/human/human_user = user
+		var/mob/living/carbon/human/human_target = target
 		user.visible_message(span_warning("\the [user] washes \the [target]'s mouth out with [src.name]!"), span_notice("You wash \the [target]'s mouth out with [src.name]!")) //washes mouth out with soap sounds better than 'the soap' here if(user.zone_selected == "mouth")
-		if(human_user.lip_style)
+		if(human_target.lip_style)
 			user.mind?.adjust_experience(/datum/skill/cleaning, CLEAN_SKILL_GENERIC_WASH_XP)
-			human_user.update_lips(null)
+			human_target.update_lips(null)
 		decreaseUses(user)
 		return
 	else if(istype(target, /obj/structure/window))


### PR DESCRIPTION
## About The Pull Request

See title.

Cobby told me to atomize https://github.com/tgstation/tgstation/pull/55443, so over a year later, I'm finally doing it.

## Why It's Good For The Game

I want to wash someone's mouth out with soap for saying h*ck.

Also, if, say, a janiborg washes someone else's mouth out with soap while this PR isn't merged, the current soap code would try to adjust the lip_style of the janiborg, a non-human mob. That's probably bad.

Interestingly enough, unlike the other uses of soap, washing someone's mouth out with soap doesn't require a do_after(). I'll leave changing that to someone else, as that could be interpreted as a b*lance change if someone is feeling particularly mean.

## Changelog

:cl: ATHATH
fix: Washing someone else's mouth out with soap no longer washes YOUR mouth out with soap instead.
/:cl:
