### PR TITLE
Fixes AIize (Player panel Make AI button) killing the client of whoever it was used on

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -720,7 +720,7 @@
 			return
 		message_admins(span_danger("Admin [key_name_admin(usr)] AIized [key_name_admin(our_mob)]!"))
 		log_admin("[key_name(usr)] AIized [key_name(our_mob)].")
-		our_mob.AIize(TRUE, our_mob.client, move)
+		our_mob.AIize(our_mob.client, move)
 
 	else if(href_list["makerobot"])
 		if(!check_rights(R_SPAWN))

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -59,7 +59,7 @@
 	SEND_SIGNAL(src, COMSIG_MONKEY_HUMANIZE)
 	return src
 
-/mob/proc/AIize(transfer_after = TRUE, client/preference_source, move = TRUE)
+/mob/proc/AIize(client/preference_source, move = TRUE)
 	var/list/turf/landmark_loc = list()
 
 	if(!move)
@@ -84,9 +84,6 @@
 
 	if(client)
 		stop_sound_channel(CHANNEL_LOBBYMUSIC)
-
-	if(!transfer_after)
-		mind.active = FALSE
 
 	var/mob/living/silicon/ai/our_AI = new /mob/living/silicon/ai(pick(landmark_loc), null, src)
 	. = our_AI

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -85,6 +85,9 @@
 	if(client)
 		stop_sound_channel(CHANNEL_LOBBYMUSIC)
 
+	if(!transfer_after)
+		mind.active = FALSE
+
 	var/mob/living/silicon/ai/our_AI = new /mob/living/silicon/ai(pick(landmark_loc), null, src)
 	. = our_AI
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -88,13 +88,6 @@
 	var/mob/living/silicon/ai/our_AI = new /mob/living/silicon/ai(pick(landmark_loc), null, src)
 	. = our_AI
 
-	if(mind)
-		if(!transfer_after)
-			mind.active = FALSE
-		mind.transfer_to(our_AI)
-	else if(transfer_after)
-		our_AI.key = key
-
 	if(preference_source)
 		apply_pref_name(/datum/preference/name/ai, preference_source)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes some stuff that was setting the new AIs key to null after it was created which would kill the client. The mind transfer already happens in the AI init proc anyway so the rest of the code there didn't need to exist.

Also what the fuck is `transfer_after` this wasn't false anywhere I could find in the code and when I tried running the proc with it set to false using admin tools it just runtimed? ?? ??? ?? ???? ? ?? ?? ? ?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed the Make AI button in admin player panel killing the client of whoever it was used on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
