### PR TITLE
Pastry base increased output

### DIFF
--- a/code/game/objects/items/food/dough.dm
+++ b/code/game/objects/items/food/dough.dm
@@ -122,7 +122,7 @@
 	desc = "A base for any self-respecting pastry."
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "pastrybase"
-	food_reagents = list(/datum/reagent/consumable/nutriment = 6)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 3)
 	w_class = WEIGHT_CLASS_SMALL
 	tastes = list("pastry" = 1)
 	foodtypes = GRAIN | DAIRY

--- a/code/game/objects/items/food/dough.dm
+++ b/code/game/objects/items/food/dough.dm
@@ -102,7 +102,7 @@
 	AddComponent(/datum/component/bakeable, /obj/item/food/pie/plain, rand(30 SECONDS, 45 SECONDS), TRUE, TRUE)
 
 /obj/item/food/piedough/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/rawpastrybase, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/rawpastrybase, 6, 30)
 
 /obj/item/food/rawpastrybase
 	name = "raw pastry base"
@@ -122,7 +122,7 @@
 	desc = "A base for any self-respecting pastry."
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "pastrybase"
-	food_reagents = list(/datum/reagent/consumable/nutriment = 3)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 6)
 	w_class = WEIGHT_CLASS_SMALL
 	tastes = list("pastry" = 1)
 	foodtypes = GRAIN | DAIRY


### PR DESCRIPTION
## About The Pull Request

Round start donuts and donk pockets were removed. Instead of having these two ICONIC items be lost forever I figured the best way to go forward would be to make them much more easily accessible to the kitchen. 

![image](https://user-images.githubusercontent.com/16896032/163283731-cbd67db1-67eb-4921-a8e5-6dd66cf5152e.png)
You will now receive 6 pastries per cut pie dough, this doubles the output of what it once was. To accommodate this I have also increased the nutriment of cooked pastries so that there will be no lost nutriment.

As donkpocket and doughnut boxes had 6 of each pastry in them, this means that chefs will be able to make the EXACT required amount from each pie dough they turn into pastries. 

![image](https://user-images.githubusercontent.com/16896032/163284402-6d9e5e3e-3bf6-405a-810b-8d86ddcdabf7.png)


## Why It's Good For The Game

There was too much effort to make pastries before. This will incentivize chefs (or bored crewmembers who want to break into the kitchen) to make the doughnuts and donk pockets that were removed from the station. 

I do selfishly hope that this urges more chefs to make cool artisanal doughnut packs with all of the other flavours. 

## Changelog

:cl:
expansion: Expands pastry output.
/:cl: