### PR TITLE
Uncle Pete's rollerdome is now an actual rollerdome.

### DIFF
--- a/_maps/shuttles/emergency_rollerdome.dmm
+++ b/_maps/shuttles/emergency_rollerdome.dmm
@@ -47,6 +47,25 @@
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/wood,
 /area/shuttle/escape)
+"jD" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/turf/open/floor/eighties,
+/area/shuttle/escape)
 "ln" = (
 /obj/machinery/vending/games,
 /turf/open/floor/eighties,
@@ -422,7 +441,7 @@ HS
 HS
 pa
 Ry
-Cg
+jD
 Cg
 ce
 uN
@@ -470,7 +489,7 @@ HS
 HS
 pa
 Ry
-Cg
+jD
 Cg
 ce
 Zo


### PR DESCRIPTION


## About The Pull Request

Every time I looked at this shuttle I was baffled by the lack of rollerskates. A roller dome/disco without rollerskates is just a weird disco where everyone dances to caramel dansen. 

## Why It's Good For The Game

A roller dome without rollerskates is bad, this fixes the shuttle in every way imaginable. The crew will now be able to be weirdos and dance on their rollerskates instead of just dancing normally.

## Changelog

:cl:
fix: Uncle Pete remembered to order new rollerskates for his rollerdome. 30 Skates will now be stocked for rent on his shuttle.
/:cl:
