### PR TITLE
Allows wizard rod form to travel between z-levels

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -81,7 +81,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/turf/real_destination = get_turf(target_atom)
 	destination_turf = real_destination
 	special_target = specific_target
-	loopy_rod = force_looping
+	loopy_rod ||= force_looping
 
 	SSpoints_of_interest.make_point_of_interest(src)
 

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -45,6 +45,7 @@
 /// Wizard Version of the Immovable Rod.
 /obj/effect/immovablerod/wizard
 	notify = FALSE
+	loopy_rod = TRUE
 	dnd_style_level_up = FALSE
 	/// The wizard who's piloting our rod.
 	var/datum/weakref/our_wizard


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sets loopy_rod to true on the wizard rod form to prevent them being deleted when travelling between zlevels.

Also changes it so that loopy rod will be equal to itself or force_looping instead of just equal to force_looping as it was causing the default value of force_looping to stop rods from looping even if they had loopy_rod set to true.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes https://github.com/tgstation/tgstation/issues/65340
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Wizard immovable rod no longer deletes itself when travelling betwen z-levels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
