### PR TITLE
Adds load testing macros

### DIFF
--- a/code/__DEFINES/perf_test.dm
+++ b/code/__DEFINES/perf_test.dm
@@ -1,0 +1,9 @@
+/// Macro that takes a tick usage to target, and proceses until we hit it
+/// This lets us simulate generic load as we'd like, to make testing for overtime easier
+#define CONSUME_UNTIL(target_usage) \
+	while(TICK_USAGE < target_usage) {\
+		var/_knockonwood_x = 0;\
+		_knockonwood_x += 20;\
+	}
+
+

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -58,6 +58,20 @@
 /// If this is uncommented, will profile mapload atom initializations
 // #define PROFILE_MAPLOAD_INIT_ATOM
 
+/// If this is uncommented, force our verb processing into just the 2% of a tick
+/// We normally reserve for it
+/// NEVER run this on live, it's for simulating highpop only
+// #define VERB_STRESS_TEST
+
+#ifdef VERB_STRESS_TEST
+/// Uncomment this to force all verbs to run into overtime all of the time
+/// Essentially negating the reserve 2%
+
+// #define FORCE_VERB_OVERTIME
+#warn Hey brother, you're running in LAG MODE.
+#warn IF YOU PUT THIS ON LIVE I WILL FIND YOU AND MAKE YOU WISH YOU WERE NEVE-
+#endif
+
 #ifndef PRELOAD_RSC //set to:
 #define PRELOAD_RSC 2 // 0 to allow using external resources or on-demand behaviour;
 #endif // 1 to use the default behaviour;

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -109,7 +109,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 			for(var/global_var in global.vars)
 				if (istype(global.vars[global_var], /datum/controller/subsystem))
 					existing_subsystems += global.vars[global_var]
-					
+
 			//Either init a new SS or if an existing one was found use that
 			for(var/I in subsystem_types)
 				var/ss_idx = existing_subsystems.Find(I)
@@ -436,6 +436,20 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		if (skip_ticks)
 			skip_ticks--
 		src.sleep_delta = MC_AVERAGE_FAST(src.sleep_delta, sleep_delta)
+
+// Force any verbs into overtime, to test how they perfrom under load
+// For local ONLY
+#ifdef VERB_STRESS_TEST
+		/// Target enough tick usage to only allow time for our maptick estimate and verb processing, and nothing else
+		var/overtime_target = TICK_LIMIT_RUNNING
+// This will leave just enough cpu time for maptick, forcing verbs to run into overtime
+// Use this for testing the worst case scenario, when maptick is spiking and usage is otherwise completely consumed
+#ifdef FORCE_VERB_OVERTIME
+		overtime_target += TICK_BYOND_RESERVE
+#endif
+		CONSUME_UNTIL(overtime_target)
+#endif
+
 		current_ticklimit = TICK_LIMIT_RUNNING
 		if (processing * sleep_delta <= world.tick_lag)
 			current_ticklimit -= (TICK_LIMIT_RUNNING * 0.25) //reserve the tail 1/4 of the next tick for the mc if we plan on running next tick

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -122,6 +122,7 @@
 #include "code\__DEFINES\obj_flags.dm"
 #include "code\__DEFINES\paintings.dm"
 #include "code\__DEFINES\paper.dm"
+#include "code\__DEFINES\perf_test.dm"
 #include "code\__DEFINES\pinpointers.dm"
 #include "code\__DEFINES\pipe_construction.dm"
 #include "code\__DEFINES\plumbing.dm"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a macro that consumes cpu up to some tick limit
Adds a define that uses said macro to leave verb processing just its reserve of the tick
Adds a second subdefine that forces verb processing into total overtime, mimicing the worst case scenario around maptick spikes

Would like @MrStonedOne's opinion on this, since I am "technically" adding this to the mc's main loop

## Why It's Good For The Game

Basically, one of our main bugaboos right now is the overtime that verbs, particularly clicks, cause.
Because verbs run after literally everything else (See #65589), it is useful to have a way to force them into bad and worst case scenarios
Makes testing this stuff easier, plus we can use the macro to simulate load in other ways too. It's good.
