### PR TITLE
Fixes the debug lift

### DIFF
--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -432,7 +432,7 @@ GLOBAL_LIST_EMPTY(lifts)
 		"NORTHWEST" = image(icon = 'icons/testing/turf_analysis.dmi', icon_state = "red_arrow", dir = WEST)
 		)
 
-	var/result = show_radial_menu(user, src, tool_list, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE, tooltips = FALSE)
+	var/result = show_radial_menu(user, src, tool_list, custom_check = CALLBACK(src, .proc/check_menu, user, loc), require_near = TRUE, tooltips = FALSE)
 	if (!in_range(src, user))
 		return  // nice try
 


### PR DESCRIPTION
## About The Pull Request

While I was testing my buildables expansion, I found out that the debug lift doesn't work. I fixed that.

## Why It's Good For The Game

Makes testing tram-related stuff easier I guess.

## Changelog

:cl:
fix: The debug industrial lift usable by admins for testing tram behavior has been fixed, and can now be moved again.
/:cl:
