### PR TITLE
Middle Mouse Button now toggles equipment safety on mechs.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -20,6 +20,13 @@
 		return
 	next_click = world.time + 1
 
+	var/list/modifiers = params2list(params)
+
+	var/obj/vehicle/sealed/mecha/mech = loc //I know. Shaddup.
+	if(istype(mech) && (!mech.weapons_safety || LAZYACCESS(modifiers, MIDDLE_CLICK))) //mech and (safeties off or middle click)
+		SEND_SIGNAL(src, COMSIG_MOB_CLICKON, A, modifiers) //& COMSIG_MOB_CANCEL_CLICKON
+		return
+
 	if(!can_interact_with(A))
 		return
 
@@ -51,7 +58,6 @@
 			send2tgs_adminless_only("NOCHEAT", message)
 		return
 
-	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK))
 		if(LAZYACCESS(modifiers, CTRL_CLICK))
 			CtrlShiftClickOn(A)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -24,7 +24,7 @@
 
 	var/obj/vehicle/sealed/mecha/mech = loc //I know. Shaddup.
 	if(istype(mech) && (!mech.weapons_safety || LAZYACCESS(modifiers, MIDDLE_CLICK))) //mech and (safeties off or middle click)
-		SEND_SIGNAL(src, COMSIG_MOB_CLICKON, A, modifiers) //& COMSIG_MOB_CANCEL_CLICKON
+		SEND_SIGNAL(src, COMSIG_MOB_CLICKON, A, modifiers)
 		return
 
 	if(!can_interact_with(A))

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -22,9 +22,7 @@
 
 	var/list/modifiers = params2list(params)
 
-	var/obj/vehicle/sealed/mecha/mech = loc //I know. Shaddup.
-	if(istype(mech) && (!mech.weapons_safety || LAZYACCESS(modifiers, MIDDLE_CLICK))) //mech and (safeties off or middle click)
-		SEND_SIGNAL(src, COMSIG_MOB_CLICKON, A, modifiers)
+	if(SEND_SIGNAL(src, COMSIG_MOB_CLICKON, A, modifiers) & COMSIG_MOB_CANCEL_CLICKON)
 		return
 
 	if(!can_interact_with(A))

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -34,6 +34,7 @@
 	light_range = 8
 	generic_canpass = FALSE
 	hud_possible = list(DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD, DIAG_TRACK_HUD)
+	mouse_pointer = 'icons/effects/mouse_pointers/mecha_mouse.dmi'
 	///What direction will the mech face when entered/powered on? Defaults to South.
 	var/dir_in = SOUTH
 	///How much energy the mech will consume each time it moves. This variable is a backup for when leg actuators affect the energy drain.
@@ -147,7 +148,6 @@
 	var/is_currently_ejecting = FALSE
 	///Safety for weapons. Won't fire if enabled, and toggled by middle click.
 	var/weapons_safety = FALSE
-	mouse_pointer = 'icons/effects/mouse_pointers/mecha_mouse.dmi'
 
 	var/datum/effect_system/smoke_spread/smoke_system = new
 
@@ -602,8 +602,6 @@
 		return
 	if(isAI(user)) //For AIs: If safeties are off, use mech functions. If safeties are on, use AI functions.
 		. = COMSIG_MOB_CANCEL_CLICKON
-	if(weapons_safety)
-		return
 	if(modifiers[SHIFT_CLICK]) //Allows things to be examined.
 		return
 	if(!isturf(target) && !isturf(target.loc)) // Prevents inventory from being drilled

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -579,7 +579,12 @@
 		SEND_SOUND(user, sound('sound/machines/beep.ogg', volume=25))
 		balloon_alert(user, "equipment [weapons_safety ? "safe" : "ready"]")
 		set_mouse_pointer()
-		return
+		return COMSIG_MOB_CANCEL_CLICKON
+	if(isAI(user)) //Middle clicks are already handled for AIs via above
+		if(weapons_safety)
+			return //Use AI functions
+		else
+			. = COMSIG_MOB_CANCEL_CLICKON //Use Mech functions
 	if(weapons_safety)
 		return
 	if(modifiers[SHIFT_CLICK]) //Allows things to be examined.

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -587,8 +587,6 @@
 		return
 	if(completely_disabled || is_currently_ejecting || (mecha_flags & CANNOT_INTERACT))
 		return
-//	if(isAI(user) == !LAZYACCESS(modifiers, MIDDLE_CLICK))//BASICALLY if a human uses MMB, or an AI doesn't, then do nothing.
-//		return //DEBUG lmao
 	if(phasing)
 		balloon_alert(user, "not while [phasing]!")
 		return
@@ -652,15 +650,6 @@
 	if(force)
 		target.mech_melee_attack(src, user)
 		TIMER_COOLDOWN_START(src, COOLDOWN_MECHA_MELEE_ATTACK, melee_cooldown)
-
-/obj/vehicle/sealed/mecha/proc/on_middlemouseclick(mob/user, atom/target, params)
-	return
-	SIGNAL_HANDLER
-	weapons_safety = !weapons_safety
-	set_mouse_pointer()
-//	if(isAI(user))
-//		on_mouseclick(user, target, params)
-
 
 //////////////////////////////////
 ////////  Movement procs  ////////
@@ -1183,7 +1172,6 @@
 /obj/vehicle/sealed/mecha/add_occupant(mob/M, control_flags)
 	RegisterSignal(M, COMSIG_LIVING_DEATH, .proc/mob_exit)
 	RegisterSignal(M, COMSIG_MOB_CLICKON, .proc/on_mouseclick)
-//	RegisterSignal(M, COMSIG_MOB_MIDDLECLICKON, .proc/on_mouseclick) //For weapon safety
 	RegisterSignal(M, COMSIG_MOB_SAY, .proc/display_speech_bubble)
 	. = ..()
 	update_appearance()
@@ -1191,7 +1179,6 @@
 /obj/vehicle/sealed/mecha/remove_occupant(mob/M)
 	UnregisterSignal(M, COMSIG_LIVING_DEATH)
 	UnregisterSignal(M, COMSIG_MOB_CLICKON)
-//	UnregisterSignal(M, COMSIG_MOB_MIDDLECLICKON)
 	UnregisterSignal(M, COMSIG_MOB_SAY)
 	M.clear_alert(ALERT_CHARGE)
 	M.clear_alert(ALERT_MECH_DAMAGE)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -576,7 +576,8 @@
 	SIGNAL_HANDLER
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))
 		weapons_safety = !weapons_safety
-		SEND_SOUND(user, sound('sound/machines/beep.ogg', volume=50))
+		SEND_SOUND(user, sound('sound/machines/beep.ogg', volume=25))
+		balloon_alert(user, "equipment [weapons_safety ? "safe" : "ready"]")
 		set_mouse_pointer()
 		return
 	if(weapons_safety)

--- a/code/modules/vehicles/mecha/combat/combat.dm
+++ b/code/modules/vehicles/mecha/combat/combat.dm
@@ -2,7 +2,6 @@
 	force = 30
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
 	armor = list(MELEE = 30, BULLET = 30, LASER = 15, ENERGY = 20, BOMB = 20, BIO = 0, FIRE = 100, ACID = 100)
-	mouse_pointer = 'icons/effects/mouse_pointers/mecha_mouse.dmi'
 	destruction_sleep_duration = 40
 	exit_delay = 40
 

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -181,15 +181,11 @@
 		take_damage(30 / severity, BURN, ENERGY, 1)
 	log_message("EMP detected", LOG_MECHA, color="red")
 
-	if(istype(src, /obj/vehicle/sealed/mecha/combat)) //todo this stupid mouse icon should be a flag
-		mouse_pointer = 'icons/effects/mouse_pointers/mecha_mouse-disable.dmi'
-		for(var/occus in occupants)
-			var/mob/living/occupant = occus
-			occupant.update_mouse_pointer()
 	if(!equipment_disabled && LAZYLEN(occupants)) //prevent spamming this message with back-to-back EMPs
 		to_chat(occupants, span_warning("Error -- Connection to equipment control unit has been lost."))
 	addtimer(CALLBACK(src, /obj/vehicle/sealed/mecha.proc/restore_equipment), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	equipment_disabled = TRUE
+	set_mouse_pointer()
 
 /obj/vehicle/sealed/mecha/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
 	return exposed_temperature > max_temperature

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -270,7 +270,7 @@
 				return
 			name = userinput
 		if("toggle_safety")
-			set_mouse_pointer(usr)
+			set_safety(usr)
 			return
 		if("dna_lock")
 			var/mob/living/carbon/user = usr

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -122,6 +122,7 @@
 	data["cabin_pressure"] = round(return_pressure(), 0.01)
 	data["cabin_temp"] = return_temperature()
 	data["dna_lock"] = dna_lock
+	data["weapons_safety"] = weapons_safety
 	data["mech_view"] = ui_view.assigned_map
 	if(radio)
 		data["mech_electronics"] = list(
@@ -268,6 +269,12 @@
 				tgui_alert(usr, "You cannot set a name that contains a word prohibited in IC chat!")
 				return
 			name = userinput
+		if("toggle_safety")
+			weapons_safety = !weapons_safety
+			SEND_SOUND(usr, sound('sound/machines/beep.ogg', volume=25))
+			balloon_alert(usr, "equipment [weapons_safety ? "safe" : "ready"]")
+			set_mouse_pointer()
+			return
 		if("dna_lock")
 			var/mob/living/carbon/user = usr
 			if(!istype(user) || !user.dna)

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -270,10 +270,7 @@
 				return
 			name = userinput
 		if("toggle_safety")
-			weapons_safety = !weapons_safety
-			SEND_SOUND(usr, sound('sound/machines/beep.ogg', volume=25))
-			balloon_alert(usr, "equipment [weapons_safety ? "safe" : "ready"]")
-			set_mouse_pointer()
+			set_mouse_pointer(usr)
 			return
 		if("dna_lock")
 			var/mob/living/carbon/user = usr

--- a/tgui/packages/tgui/interfaces/Mecha/ArmPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/ArmPane.tsx
@@ -13,11 +13,12 @@ export const ArmPane=(props:{weapon:MechWeapon}, context) => {
   } = props.weapon;
   const {
     power_level,
+    weapons_safety,
   } = data;
   return (
     <Stack fill vertical>
-      <Stack.Item bold>
-        {name}
+      <Stack.Item bold color={weapons_safety ? "red" : ""}>
+        {weapons_safety ? "SAFETY OVERRIDE IN EFFECT" : name}
       </Stack.Item>
       <Stack.Item>
         <Stack>
@@ -62,7 +63,7 @@ export const ArmPane=(props:{weapon:MechWeapon}, context) => {
       <Stack.Item>
         <Snowflake weapon={props.weapon} />
       </Stack.Item>
-      <Stack.Item>
+      <Stack.Item color={weapons_safety ? "red" : ""}>
         {desc}
       </Stack.Item>
     </Stack>

--- a/tgui/packages/tgui/interfaces/Mecha/MechStatPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/MechStatPane.tsx
@@ -8,6 +8,7 @@ export const MechStatPane = (props, context) => {
   const {
     name,
     integrity,
+    weapons_safety,
     air_source,
     cabin_pressure,
     cabin_dangerous_highpressure,
@@ -41,6 +42,11 @@ export const MechStatPane = (props, context) => {
             </LabeledList.Item>
             <LabeledList.Item label="Power">
               <PowerBar />
+            </LabeledList.Item>
+            <LabeledList.Item label="Safety">
+              <Button color={weapons_safety ? "red" : ""} onClick={() => act('toggle_safety')}>
+                {weapons_safety ? "Dis" : "En"}able
+              </Button>
             </LabeledList.Item>
           </LabeledList>
         </Section>

--- a/tgui/packages/tgui/interfaces/Mecha/data.ts
+++ b/tgui/packages/tgui/interfaces/Mecha/data.ts
@@ -81,7 +81,7 @@ export type OperatorData = {
   mech_electronics: MechElectronics;
   right_arm_weapon: MechWeapon | null;
   left_arm_weapon: MechWeapon | null;
-  weapons_safety: BooleanLike;
+  weapons_safety: boolean;
   mech_equipment: string[];
   mech_view: string;
   mineral_material_amount: number;

--- a/tgui/packages/tgui/interfaces/Mecha/data.ts
+++ b/tgui/packages/tgui/interfaces/Mecha/data.ts
@@ -81,6 +81,7 @@ export type OperatorData = {
   mech_electronics: MechElectronics;
   right_arm_weapon: MechWeapon | null;
   left_arm_weapon: MechWeapon | null;
+  weapons_safety: BooleanLike;
   mech_equipment: string[];
   mech_view: string;
   mineral_material_amount: number;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Mechs now have a `weapons_safety` toggle. If set to true, clicking does not use equipment. This is mostly intended to allow users to keep from accidentally firing. Weapon safety defaults to off, but will keep the same state it was in between pilot exit/entry events.
- All mechs now use the green reticle mouse icon. If `weapons_safety` is enabled, the mouse is reverted to normal. The reticle (if shown) still turns red during an EMP-related weapons fault.
- AIs can use mech weapons if the safety is off, and use AI clicks if the safety is on. Fixes #64112. The bigtext message has also been updated.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Before the recent mech rebalance, mechs would cycle between weapons in a list, and could be left on "no equipment selected" for the active equipment. I used to use this to prevent accidental firing when clicking on the viewport (such as when trying to get focus back to the game). Since weapon swapping isn't a thing anymore, I have added a proper safety.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Mechs now have a weapons safety, which can be toggled with the Middle Mouse button. Don't worry, it defaults to off.
expansion: All mechs now use the mouse reticle, and the reticle is disabled when weapons safety is turned on.
fix: AIs can use mech equipment again. With weapons safety off, equipment is used. With weapons safety on, AI clicks are used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
