### PR TITLE
Fixes bluespace golem teleportation bug

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -551,7 +551,7 @@
 	icon_icon = 'icons/mob/actions/actions_spells.dmi'
 	var/cooldown = 150
 	var/last_teleport = 0
-	var/is_charging = 0 //Fixes bug 65900 preventing spam activation.
+	var/is_charging = FALSE //Fixes bug 65900 preventing spam activation.
 
 /datum/action/innate/unstable_teleport/IsAvailable()
 	. = ..()
@@ -564,7 +564,7 @@
 /datum/action/innate/unstable_teleport/Activate()
 	var/mob/living/carbon/human/H = owner
 	H.visible_message(span_warning("[H] starts vibrating!"), span_danger("You start charging your bluespace core..."))
-	is_charging = 1
+	is_charging = TRUE
 	UpdateButtonIcon() //action icon looks unavailable
 	playsound(get_turf(H), 'sound/weapons/flash.ogg', 25, TRUE)
 	addtimer(CALLBACK(src, .proc/teleport, H), 15)
@@ -577,7 +577,7 @@
 	spark_system.start()
 	do_teleport(H, get_turf(H), 12, asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
 	last_teleport = world.time
-	is_charging = 0
+	is_charging = FALSE
 	addtimer(CALLBACK(src, .proc/UpdateButtons), cooldown + 5) //action icon looks available again
 
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -551,18 +551,21 @@
 	icon_icon = 'icons/mob/actions/actions_spells.dmi'
 	var/cooldown = 150
 	var/last_teleport = 0
+	var/is_charging = 0 //Fixes bug 65900 preventing spam activation.
 
 /datum/action/innate/unstable_teleport/IsAvailable()
 	. = ..()
 	if(!.)
 		return
-	if(world.time > last_teleport + cooldown)
+	if(world.time > last_teleport + cooldown && !is_charging)
 		return TRUE
 	return FALSE
 
 /datum/action/innate/unstable_teleport/Activate()
 	var/mob/living/carbon/human/H = owner
 	H.visible_message(span_warning("[H] starts vibrating!"), span_danger("You start charging your bluespace core..."))
+	is_charging = 1
+	UpdateButtonIcon() //action icon looks unavailable
 	playsound(get_turf(H), 'sound/weapons/flash.ogg', 25, TRUE)
 	addtimer(CALLBACK(src, .proc/teleport, H), 15)
 
@@ -574,9 +577,8 @@
 	spark_system.start()
 	do_teleport(H, get_turf(H), 12, asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
 	last_teleport = world.time
-	UpdateButtons() //action icon looks unavailable
-	//action icon looks available again
-	addtimer(CALLBACK(src, .proc/UpdateButtons), cooldown + 5)
+	is_charging = 0
+	addtimer(CALLBACK(src, .proc/UpdateButtons), cooldown + 5) //action icon looks available again
 
 
 //honk

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -565,7 +565,6 @@
 	var/mob/living/carbon/human/H = owner
 	H.visible_message(span_warning("[H] starts vibrating!"), span_danger("You start charging your bluespace core..."))
 	is_charging = TRUE
-	UpdateButtonIcon() //action icon looks unavailable
 	playsound(get_turf(H), 'sound/weapons/flash.ogg', 25, TRUE)
 	addtimer(CALLBACK(src, .proc/teleport, H), 15)
 
@@ -578,6 +577,7 @@
 	do_teleport(H, get_turf(H), 12, asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
 	last_teleport = world.time
 	is_charging = FALSE
+	UpdateButtonIcon() //action icon looks unavailable.
 	addtimer(CALLBACK(src, .proc/UpdateButtons), cooldown + 5) //action icon looks available again
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pull request fixes bug #65900 preventing Bluespace Golems from spam teleporting.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bluespace golems were (probably) never intended to spam teleport (as funny as it is). I just saw a bug and wanted to fix it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Added a is_charging variable to track whether the ability was currently in progress. Also moved the UpdateButtonIcon() call to make the button look unavailable as soon as you click it. (The teleport isn't cancellable so may as well make the button look unavailable now).
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Button looks unavailable at the right time.
fix: Fixes the spam teleportation bug.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
