### PR TITLE
Stabilized extracts work in modsuits

### DIFF
--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -317,13 +317,13 @@ rough example of the "cone" made by the 3 dirs checked
 ///Returns a list of the parents of all storage components that contain the target item
 /proc/get_storage_locs(obj/item/target)
 	. = list()
-	if(!target || !istype(target) || !(target.item_flags & IN_STORAGE))
+	if(!istype(target) || !(target.item_flags & IN_STORAGE))
 		return
 	var/datum/component/storage/concrete/storage_datum = target.loc.GetComponent(/datum/component/storage/concrete)
 	if(!storage_datum)
 		return
 	. += storage_datum.parent
-	for(var/datum/component/storage/slave in storage_datum.slaves)
+	for(var/datum/component/storage/slave as anything in storage_datum.slaves)
 		if(!isatom(slave.parent))
 			continue
 		. += slave.parent

--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -317,9 +317,7 @@ rough example of the "cone" made by the 3 dirs checked
 ///Returns a list of the parents of all storage components that contain the target item
 /proc/get_storage_locs(obj/item/target)
 	. = list()
-	if(!target)
-		return
-	if(!(target.item_flags & IN_STORAGE))
+	if(!target || !istype(target) || !(target.item_flags & IN_STORAGE))
 		return
 	var/datum/component/storage/concrete/storage_datum = target.loc.GetComponent(/datum/component/storage/concrete)
 	if(!storage_datum)

--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -313,3 +313,19 @@ rough example of the "cone" made by the 3 dirs checked
 ///A do nothing proc
 /proc/pass(...)
 	return
+
+///Returns a list of the parents of all storage components that contain the target item
+/proc/get_storage_locs(obj/item/target)
+	. = list()
+	if(!target)
+		return
+	if(!(target.item_flags & IN_STORAGE))
+		return
+	var/datum/component/storage/concrete/storage_datum = target.loc.GetComponent(/datum/component/storage/concrete)
+	if(!storage_datum)
+		return
+	. += storage_datum.parent
+	for(var/datum/component/storage/slave in storage_datum.slaves)
+		if(!isatom(slave.parent))
+			continue
+		. += slave.parent

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -447,15 +447,15 @@
 		return TRUE
 	if(linked_extract.loc.loc == owner)
 		return TRUE
-	for(var/atom/storage_loc in get_storage_locs(linked_extract))
+	for(var/atom/storage_loc as anything in get_storage_locs(linked_extract))
 		if(storage_loc == owner)
 			return TRUE
 		if(storage_loc.loc == owner)
 			return TRUE
-		for(var/atom/storage_loc_storage_loc in get_storage_locs(storage_loc))
+		for(var/atom/storage_loc_storage_loc as anything in get_storage_locs(storage_loc))
 			if(storage_loc_storage_loc == owner)
 				return TRUE
-	for(var/atom/loc_storage_loc in get_storage_locs(linked_extract.loc))
+	for(var/atom/loc_storage_loc as anything in get_storage_locs(linked_extract.loc))
 		if(loc_storage_loc == owner)
 			return TRUE
 	return FALSE

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -442,11 +442,23 @@
 	var/obj/item/slimecross/stabilized/linked_extract
 	var/colour = "null"
 
+/datum/status_effect/stabilized/proc/location_check()
+	if(linked_extract.loc == owner)
+		return TRUE
+	if(linked_extract.loc.loc == owner)
+		return TRUE
+	for(var/atom/storage_loc in get_storage_locs(linked_extract))
+		if(storage_loc == owner)
+			return TRUE
+		if(storage_loc.loc == owner)
+			return TRUE
+	return FALSE
+
 /datum/status_effect/stabilized/tick()
 	if(!linked_extract || !linked_extract.loc) //Sanity checking
 		qdel(src)
 		return
-	if(linked_extract && linked_extract.loc != owner && linked_extract.loc.loc != owner)
+	if(linked_extract && !location_check())
 		linked_extract.linked_effect = null
 		if(!QDELETED(linked_extract))
 			linked_extract.owner = null

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -452,6 +452,9 @@
 			return TRUE
 		if(storage_loc.loc == owner)
 			return TRUE
+		for(var/atom/storage_loc_storage_loc in get_storage_locs(storage_loc))
+			if(storage_loc_storage_loc == owner)
+				return TRUE
 	return FALSE
 
 /datum/status_effect/stabilized/tick()

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -455,6 +455,9 @@
 		for(var/atom/storage_loc_storage_loc in get_storage_locs(storage_loc))
 			if(storage_loc_storage_loc == owner)
 				return TRUE
+	for(var/atom/loc_storage_loc in get_storage_locs(linked_extract.loc))
+		if(loc_storage_loc == owner)
+			return TRUE
 	return FALSE
 
 /datum/status_effect/stabilized/tick()

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -29,18 +29,18 @@ Stabilized extracts:
 		humanfound = loc
 	if(ishuman(loc.loc)) //Check if in backpack.
 		humanfound = (loc.loc)
-	for(var/atom/storage_loc in get_storage_locs(src))
+	for(var/atom/storage_loc as anything in get_storage_locs(src))
 		if(ishuman(storage_loc))
 			humanfound = storage_loc
 			break
 		if(ishuman(storage_loc.loc))
 			humanfound = storage_loc.loc
 			break
-		for(var/atom/storage_loc_storage_loc in get_storage_locs(storage_loc))
+		for(var/atom/storage_loc_storage_loc as anything in get_storage_locs(storage_loc))
 			if(ishuman(storage_loc_storage_loc))
 				humanfound = storage_loc_storage_loc
 				break
-	for(var/atom/loc_storage_loc in get_storage_locs(loc))
+	for(var/atom/loc_storage_loc as anything in get_storage_locs(loc))
 		if(ishuman(loc_storage_loc))
 			humanfound = loc_storage_loc
 			break

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -29,6 +29,13 @@ Stabilized extracts:
 		humanfound = loc
 	if(ishuman(loc.loc)) //Check if in backpack.
 		humanfound = (loc.loc)
+	for(var/atom/storage_loc in get_storage_locs(src))
+		if(ishuman(storage_loc))
+			humanfound = storage_loc
+			break
+		if(ishuman(storage_loc.loc))
+			humanfound = storage_loc.loc
+			break
 	if(!humanfound)
 		return
 	var/mob/living/carbon/human/H = humanfound

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -36,6 +36,10 @@ Stabilized extracts:
 		if(ishuman(storage_loc.loc))
 			humanfound = storage_loc.loc
 			break
+		for(var/atom/storage_loc_storage_loc in get_storage_locs(storage_loc))
+			if(ishuman(storage_loc_storage_loc))
+				humanfound = storage_loc_storage_loc
+				break
 	if(!humanfound)
 		return
 	var/mob/living/carbon/human/H = humanfound

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -40,6 +40,10 @@ Stabilized extracts:
 			if(ishuman(storage_loc_storage_loc))
 				humanfound = storage_loc_storage_loc
 				break
+	for(var/atom/loc_storage_loc in get_storage_locs(loc))
+		if(ishuman(loc_storage_loc))
+			humanfound = loc_storage_loc
+			break
 	if(!humanfound)
 		return
 	var/mob/living/carbon/human/H = humanfound


### PR DESCRIPTION
## About The Pull Request

Stabilized extracts now check the slaves of any storage components that contain them or their location, allowing them to work in indirect storage items like modsuits.

## Why It's Good For The Game

Fixes #63634

## Changelog

:cl:
fix: Stabilized extracts now work when placed inside modsuits
/:cl:
