### PR TITLE
Fixes some improper balloon alerts, adds a grep to prevent future bad balloon alert calls

### DIFF
--- a/code/modules/clothing/suits/shirt.dm
+++ b/code/modules/clothing/suits/shirt.dm
@@ -11,10 +11,10 @@
 	. = ..()
 	if(wash_count <= 5)
 		transform *= TRANSFORM_USING_VARIABLE(0.8, 1)
-		washer.balloon_alert_to_viewers("\the [src] appears to have shrunken after being washed.")
+		washer.visible_message("[src] appears to have shrunken after being washed.")
 		wash_count += 1
 	else
-		washer.balloon_alert_to_viewers("\the [src] implodes due to repeated washing.")
+		washer.visible_message("[src] implodes due to repeated washing.")
 		qdel(src)
 
 /obj/item/clothing/suit/nerdshirt
@@ -23,4 +23,3 @@
 	icon_state = "nerdshirt"
 	inhand_icon_state = "nerdshirt"
 	species_exception = list(/datum/species/golem)
-

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -97,7 +97,7 @@
 	banana_rustle.Grant(src)
 	banana_bunch = new()
 	banana_bunch.Grant(src)
-	
+
 /mob/living/simple_animal/hostile/retaliate/clown/banana/Destroy()
 	. = ..()
 	QDEL_NULL(banana_rustle)
@@ -151,7 +151,7 @@
 	if(!bunch_turf)
 		return
 	if(!owner.CanReach(bunch_turf) || !isopenturf(bunch_turf))
-		owner.balloon_alert("can't do that here!")
+		owner.balloon_alert(owner, "can't do that here!")
 		return
 	activating = TRUE
 	if(!do_after(owner, 1 SECONDS))
@@ -513,5 +513,3 @@
 	projected_morsel.throw_at(target, 8, 2, pouch_owner)
 	flick("glutton_mouth", pouch_owner)
 	playsound(pouch_owner, 'sound/misc/soggy.ogg', 75)
-
-

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -76,7 +76,10 @@
 
 /obj/item/autosurgeon/organ/attack(mob/living/target, mob/living/user, params)
 	add_fingerprint(user)
-	user.balloon_alert_to_viewers("Prepares to use [src] on [target].", "You begin to prepare to use [src] on [target].")
+	user.visible_message(
+		"[user] prepares to use [src] on [target].",
+		"You begin to prepare to use [src] on [target]."
+	)
 	if(!do_after(user, (8 SECONDS * surgery_speed), target))
 		return
 	user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You press a button on [src] as it plunges into [target]'s body."))

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -102,7 +102,7 @@ if grep -P '^/[\w/]\S+\(.*(var/|, ?var/.*).*\)' code/**/*.dm; then
     echo "changed files contains proc argument starting with 'var'"
     st=1
 fi;
-if grep -P 'balloon_alert\(".+"\)' code/**/*.dm; then
+if grep 'balloon_alert\(".+"\)' code/**/*.dm; then
 	echo "ERROR: Balloon alert with improper arguments."
 	st=1
 fi;

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -102,7 +102,7 @@ if grep -P '^/[\w/]\S+\(.*(var/|, ?var/.*).*\)' code/**/*.dm; then
     echo "changed files contains proc argument starting with 'var'"
     st=1
 fi;
-if grep -P '\w*\.{0,1}balloon_alert\(".+"\)' code/**/*.dm; then
+if grep -P 'balloon_alert\(".+"\)' code/**/*.dm; then
 	echo "ERROR: Balloon alert with improper arguments."
 	st=1
 fi;

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -102,6 +102,10 @@ if grep -P '^/[\w/]\S+\(.*(var/|, ?var/.*).*\)' code/**/*.dm; then
     echo "changed files contains proc argument starting with 'var'"
     st=1
 fi;
+if grep -P '\w+\.balloon_alert\(".+"\)' code/**/*.dm; then
+	echo "ERROR: Balloon alert with improper arguments."
+	st=1
+fi;
 if grep -i 'centcomm' code/**/*.dm; then
     echo "ERROR: Misspelling(s) of CENTCOM detected in code, please remove the extra M(s)."
     st=1

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -102,7 +102,7 @@ if grep -P '^/[\w/]\S+\(.*(var/|, ?var/.*).*\)' code/**/*.dm; then
     echo "changed files contains proc argument starting with 'var'"
     st=1
 fi;
-if grep -P '\w+\.balloon_alert\(".+"\)' code/**/*.dm; then
+if grep -P '\w*\.{0,1}balloon_alert\(".+"\)' code/**/*.dm; then
 	echo "ERROR: Balloon alert with improper arguments."
 	st=1
 fi;


### PR DESCRIPTION
## About The Pull Request

The first argument of balloon alerts is the person seeing the alert. There is 1 instance of this being incorrect, so this PR fixes that.
This error is very common, so a grep has been added to prevent such a thing from popping up. 

Grep regex:
`balloon_alert\(".+"\)`

Also goes through and reverts some improperly used balloon alerts. 

## Why It's Good For The Game

Fixes a runtime, ensures future balloon alerts don't break, makes more consistent use of balloon alerts

## Changelog

:cl: Melbert
fix: Fixes some improper and bugged balloon alerts. 
code: Adds a grep to prevent malformed balloon alert calls.
/:cl:
