### PR TITLE
Fully documents _sound_looping.dm and adds the variables it was missing to allow for full sound customizability

### DIFF
--- a/code/datums/components/area_sound_manager.dm
+++ b/code/datums/components/area_sound_manager.dm
@@ -50,7 +50,7 @@
 	var/time_remaining = 0
 
 	if(our_loop)
-		var/our_id = our_loop.timerid || timerid
+		var/our_id = our_loop.timer_id || timerid
 		if(our_id)
 			time_remaining = timeleft(our_id, SSsound_loops) || 0
 			//Time left will sometimes return negative values, just ignore them and start a new sound loop now

--- a/code/datums/components/geiger_sound.dm
+++ b/code/datums/components/geiger_sound.dm
@@ -80,11 +80,11 @@
 	last_radiation_pulse = null
 	return ..()
 
-/datum/looping_sound/geiger/get_sound(starttime)
+/datum/looping_sound/geiger/get_sound()
 	if (isnull(last_radiation_pulse))
 		return null
 
-	return ..(starttime, mid_sounds[get_perceived_radiation_danger(last_radiation_pulse, last_insulation_to_target)])
+	return ..(mid_sounds[get_perceived_radiation_danger(last_radiation_pulse, last_insulation_to_target)])
 
 /datum/looping_sound/geiger/stop()
 	. = ..()

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -1,41 +1,53 @@
-/*
-	mid_sounds (list or soundfile) Since this can be either a list or a single soundfile you can have random sounds. May contain further lists but must contain a soundfile at the end.
-	mid_length (num) The length to wait between playing mid_sounds
-
-	start_sound (soundfile) Played before starting the mid_sounds loop
-	start_length (num) How long to wait before starting the main loop after playing start_sound
-
-	end_sound (soundfile) The sound played after the main loop has concluded
-
-	chance (num) Chance per loop to play a mid_sound
-	volume (num) Sound output volume
-	max_loops (num) The max amount of loops to run for.
-	direct (bool) If true plays directly to provided atoms instead of from them
-*/
+/**
+ * A datum for sounds that need to loop, with a high amount of configurability.
+ */
 /datum/looping_sound
+	/// The source of the sound, or the recipient of the sound.
 	var/atom/parent
+	/// (list or soundfile) Since this can be either a list or a single soundfile you can have random sounds. May contain further lists but must contain a soundfile at the end.
 	var/mid_sounds
+	/// The length of time to wait between playing mid_sounds.
 	var/mid_length
-	///Override for volume of start sound
+	/// Override for volume of start sound.
 	var/start_volume
+	/// (soundfile) Played before starting the mid_sounds loop.
 	var/start_sound
+	/// How long to wait before starting the main loop after playing start_sound.
 	var/start_length
-	///Override for volume of end sound
+	/// Override for volume of end sound.
 	var/end_volume
+	/// (soundfile) The sound played after the main loop has concluded.
 	var/end_sound
+	/// Chance per loop to play a mid_sound.
 	var/chance
+	/// Sound output volume.
 	var/volume = 100
+	/// Whether or not the sounds will vary in pitch when played.
 	var/vary = FALSE
+	/// The max amount of loops to run for.
 	var/max_loops
+	/// If true, plays directly to provided atoms instead of from them.
 	var/direct
+	/// The extra range of the sound in tiles, defaults to 0.
 	var/extra_range = 0
+	/// The ID of the timer that's used to loop the sounds.
+	var/timer_id
+	/// How much the sound will be affected by falloff per tile.
 	var/falloff_exponent
-	var/timerid
+	/// The falloff distance of the sound,
 	var/falloff_distance
+	/// Do we skip the starting sounds?
 	var/skip_starting_sounds = FALSE
+	/// Are the sounds affected by pressure? Defaults to TRUE.
+	var/pressure_affected = TRUE
+	/// Are the sounds subject to reverb? Defaults to TRUE.
+	var/use_reverb = TRUE
+	/// Are we ignoring walls? Defaults to TRUE.
+	var/ignore_walls = TRUE
+	/// Has the looping started yet?
 	var/loop_started = FALSE
 
-/datum/looping_sound/New(_parent, start_immediately=FALSE, _direct=FALSE, _skip_starting_sounds = FALSE)
+/datum/looping_sound/New(_parent, start_immediately = FALSE, _direct = FALSE, _skip_starting_sounds = FALSE)
 	if(!mid_sounds)
 		WARNING("A looping sound datum was created without sounds to play.")
 		return
@@ -51,60 +63,101 @@
 	stop(TRUE)
 	return ..()
 
+/**
+ * The proc to actually kickstart the whole sound sequence. This is what you should call to start the `looping_sound`.
+ *
+ * Arguments:
+ * * on_behalf_of - The new object to set as a parent.
+ */
 /datum/looping_sound/proc/start(on_behalf_of)
 	if(on_behalf_of)
 		set_parent(on_behalf_of)
-	if(timerid)
+	if(timer_id)
 		return
 	on_start()
 
+/**
+ * The proc to call to stop the sound loop.
+ *
+ * Arguments:
+ * * null_parent - Whether or not we should set the parent to null (useful when destroying the `looping_sound` itself). Defaults to FALSE.
+ */
 /datum/looping_sound/proc/stop(null_parent = FALSE)
 	if(null_parent)
 		set_parent(null)
-	if(!timerid)
+	if(!timer_id)
 		return
 	on_stop()
-	deltimer(timerid, SSsound_loops)
-	timerid = null
+	deltimer(timer_id, SSsound_loops)
+	timer_id = null
 	loop_started = FALSE
 
+/// The proc that handles starting the actual core sound loop.
 /datum/looping_sound/proc/start_sound_loop()
 	loop_started = TRUE
 	sound_loop()
-	timerid = addtimer(CALLBACK(src, .proc/sound_loop, world.time), mid_length, TIMER_CLIENT_TIME | TIMER_STOPPABLE | TIMER_LOOP | TIMER_DELETE_ME, SSsound_loops)
+	timer_id = addtimer(CALLBACK(src, .proc/sound_loop, world.time), mid_length, TIMER_CLIENT_TIME | TIMER_STOPPABLE | TIMER_LOOP | TIMER_DELETE_ME, SSsound_loops)
 
-/datum/looping_sound/proc/sound_loop(starttime)
-	if(max_loops && world.time >= starttime + mid_length * max_loops)
+/**
+ * A simple proc handling the looping of the sound itself.
+ *
+ * Arguments:
+ * * start_time - The time at which the `mid_sounds` started being played (so we know when to stop looping).
+ */
+/datum/looping_sound/proc/sound_loop(start_time)
+	if(max_loops && world.time >= start_time + mid_length * max_loops)
 		stop()
 		return
 	if(!chance || prob(chance))
-		play(get_sound(starttime))
+		play(get_sound())
 
+/**
+ * The proc that handles actually playing the sound.
+ *
+ * Arguments:
+ * * soundfile - The soundfile we want to play.
+ * * volume_override - The volume we want to play the sound at, overriding the `volume` variable.
+ */
 /datum/looping_sound/proc/play(soundfile, volume_override)
-	var/sound/S = sound(soundfile)
+	var/sound/sound_to_play = sound(soundfile)
 	if(direct)
-		S.channel = SSsounds.random_available_channel()
-		S.volume = volume_override || volume //Use volume as fallback if theres no override
-		SEND_SOUND(parent, S)
+		sound_to_play.channel = SSsounds.random_available_channel()
+		sound_to_play.volume = volume_override || volume //Use volume as fallback if theres no override
+		SEND_SOUND(parent, sound_to_play)
 	else
-		playsound(parent, S, volume, vary, extra_range, falloff_exponent = falloff_exponent, falloff_distance = falloff_distance)
+		playsound(
+			parent,
+			sound_to_play,
+			volume,
+			vary,
+			extra_range,
+			falloff_exponent = falloff_exponent,
+			pressure_affected = pressure_affected,
+			ignore_walls = ignore_walls,
+			falloff_distance = falloff_distance,
+			use_reverb = use_reverb
+		)
 
-/datum/looping_sound/proc/get_sound(starttime, _mid_sounds)
+/// Returns the sound we should now be playing.
+/datum/looping_sound/proc/get_sound(_mid_sounds)
 	. = _mid_sounds || mid_sounds
 	while(!isfile(.) && !isnull(.))
 		. = pick_weight(.)
 
+/// A proc that's there to handle delaying the main sounds if there's a start_sound, and simply starting the sound loop in general.
 /datum/looping_sound/proc/on_start()
 	var/start_wait = 0
 	if(start_sound && !skip_starting_sounds)
 		play(start_sound, start_volume)
 		start_wait = start_length
-	timerid = addtimer(CALLBACK(src, .proc/start_sound_loop), start_wait, TIMER_CLIENT_TIME | TIMER_DELETE_ME | TIMER_STOPPABLE, SSsound_loops)
+	timer_id = addtimer(CALLBACK(src, .proc/start_sound_loop), start_wait, TIMER_CLIENT_TIME | TIMER_DELETE_ME | TIMER_STOPPABLE, SSsound_loops)
 
+/// Simple proc that's executed when the looping sound is stopped, so that the `end_sound` can be played, if there's one.
 /datum/looping_sound/proc/on_stop()
 	if(end_sound && loop_started)
 		play(end_sound, end_volume)
 
+/// A simple proc to change who our parent is set to, also handling registering and unregistering the QDELETING signals on the parent.
 /datum/looping_sound/proc/set_parent(new_parent)
 	if(parent)
 		UnregisterSignal(parent, COMSIG_PARENT_QDELETING)
@@ -112,9 +165,11 @@
 	if(parent)
 		RegisterSignal(parent, COMSIG_PARENT_QDELETING, .proc/handle_parent_del)
 
+/// A simple proc that lets us know whether the sounds are currently active or not.
 /datum/looping_sound/proc/is_active()
-	return !!timerid
+	return !!timer_id
 
+/// A simple proc to handle the deletion of the parent, so that it does not force it to hard-delete.
 /datum/looping_sound/proc/handle_parent_del(datum/source)
 	SIGNAL_HANDLER
 	set_parent(null)

--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -1,7 +1,7 @@
 /datum/looping_sound/showering
 	start_sound = 'sound/machines/shower/shower_start.ogg'
 	start_length = 2
-	mid_sounds = list('sound/machines/shower/shower_mid1.ogg'=1,'sound/machines/shower/shower_mid2.ogg'=1,'sound/machines/shower/shower_mid3.ogg'=1)
+	mid_sounds = list('sound/machines/shower/shower_mid1.ogg' = 1, 'sound/machines/shower/shower_mid2.ogg' = 1, 'sound/machines/shower/shower_mid3.ogg' = 1)
 	mid_length = 10
 	end_sound = 'sound/machines/shower/shower_end.ogg'
 	volume = 20
@@ -40,7 +40,7 @@
 /datum/looping_sound/generator
 	start_sound = 'sound/machines/generator/generator_start.ogg'
 	start_length = 4
-	mid_sounds = list('sound/machines/generator/generator_mid1.ogg'=1, 'sound/machines/generator/generator_mid2.ogg'=1, 'sound/machines/generator/generator_mid3.ogg'=1)
+	mid_sounds = list('sound/machines/generator/generator_mid1.ogg' = 1, 'sound/machines/generator/generator_mid2.ogg' = 1, 'sound/machines/generator/generator_mid3.ogg' = 1)
 	mid_length = 4
 	end_sound = 'sound/machines/generator/generator_end.ogg'
 	volume = 40
@@ -87,7 +87,7 @@
 /datum/looping_sound/microwave
 	start_sound = 'sound/machines/microwave/microwave-start.ogg'
 	start_length = 10
-	mid_sounds = list('sound/machines/microwave/microwave-mid1.ogg'=10, 'sound/machines/microwave/microwave-mid2.ogg'=1)
+	mid_sounds = list('sound/machines/microwave/microwave-mid1.ogg' = 10, 'sound/machines/microwave/microwave-mid2.ogg' = 1)
 	mid_length = 10
 	end_sound = 'sound/machines/microwave/microwave-end.ogg'
 	volume = 90
@@ -96,20 +96,28 @@
 
 /datum/looping_sound/jackpot
 	mid_length = 11
-	mid_sounds = list('sound/machines/roulettejackpot.ogg'=1)
+	mid_sounds = list('sound/machines/roulettejackpot.ogg' = 1)
 	volume = 85
 	vary = TRUE
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/looping_sound/server
-	mid_sounds = list('sound/machines/tcomms/tcomms_mid1.ogg'=1,'sound/machines/tcomms/tcomms_mid2.ogg'=1,'sound/machines/tcomms/tcomms_mid3.ogg'=1,'sound/machines/tcomms/tcomms_mid4.ogg'=1,\
-										'sound/machines/tcomms/tcomms_mid5.ogg'=1,'sound/machines/tcomms/tcomms_mid6.ogg'=1,'sound/machines/tcomms/tcomms_mid7.ogg'=1)
+	mid_sounds = list(
+		'sound/machines/tcomms/tcomms_mid1.ogg' = 1,
+		'sound/machines/tcomms/tcomms_mid2.ogg' = 1,
+		'sound/machines/tcomms/tcomms_mid3.ogg' = 1,
+		'sound/machines/tcomms/tcomms_mid4.ogg' = 1,
+		'sound/machines/tcomms/tcomms_mid5.ogg' = 1,
+		'sound/machines/tcomms/tcomms_mid6.ogg' = 1,
+		'sound/machines/tcomms/tcomms_mid7.ogg' = 1,
+	)
 	mid_length = 1.8 SECONDS
 	extra_range = -11
 	falloff_distance = 1
 	falloff_exponent = 5
 	volume = 50
+	ignore_walls = FALSE
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -117,7 +125,7 @@
 	start_sound = 'sound/machines/computer/computer_start.ogg'
 	start_length = 7.2 SECONDS
 	start_volume = 10
-	mid_sounds = list('sound/machines/computer/computer_mid1.ogg'=1, 'sound/machines/computer/computer_mid2.ogg'=1)
+	mid_sounds = list('sound/machines/computer/computer_mid1.ogg', 'sound/machines/computer/computer_mid2.ogg')
 	mid_length = 1.8 SECONDS
 	end_sound = 'sound/machines/computer/computer_end.ogg'
 	end_volume = 10
@@ -129,7 +137,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/looping_sound/gravgen
-	mid_sounds = list('sound/machines/gravgen/gravgen_mid1.ogg'=1,'sound/machines/gravgen/gravgen_mid2.ogg'=1,'sound/machines/gravgen/gravgen_mid3.ogg'=1,'sound/machines/gravgen/gravgen_mid4.ogg'=1,)
+	mid_sounds = list('sound/machines/gravgen/gravgen_mid1.ogg' = 1, 'sound/machines/gravgen/gravgen_mid2.ogg' = 1, 'sound/machines/gravgen/gravgen_mid3.ogg' = 1, 'sound/machines/gravgen/gravgen_mid4.ogg' = 1)
 	mid_length = 1.8 SECONDS
 	extra_range = 10
 	volume = 40
@@ -139,7 +147,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/looping_sound/firealarm
-	mid_sounds = list('sound/machines/FireAlarm1.ogg'=1,'sound/machines/FireAlarm2.ogg'=1,'sound/machines/FireAlarm3.ogg'=1,'sound/machines/FireAlarm4.ogg'=1 )
+	mid_sounds = list('sound/machines/FireAlarm1.ogg' = 1,'sound/machines/FireAlarm2.ogg' = 1,'sound/machines/FireAlarm3.ogg' = 1,'sound/machines/FireAlarm4.ogg' = 1)
 	mid_length = 2.4 SECONDS
 	volume = 75
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -46,7 +46,7 @@
 	///The merger_id and merger_typecache variables are used to make rows of firelocks activate at the same time.
 	var/merger_id = "firelocks"
 	var/static/list/merger_typecache
-	
+
 	///Overlay object for the warning lights. This and some plane settings allows the lights to glow in the dark.
 	var/mutable_appearance/warn_lights
 
@@ -239,7 +239,7 @@
 /obj/machinery/door/firedoor/proc/unregister_adjacent_turfs(atom/loc)
 	for(var/dir in GLOB.cardinals)
 		var/turf/checked_turf = get_step(get_turf(loc), dir)
-	
+
 		if(!checked_turf)
 			continue
 
@@ -278,7 +278,7 @@
 		issue_turfs -= checked_turf
 		if(!length(issue_turfs))
 			start_deactivation_process()
-	
+
 
 /**
  * Begins activation process of us and our neighbors.

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -489,7 +489,7 @@
 /// Start the process of disabling the buffer. Plays some effects, waits a bit, then finishes
 /datum/action/toggle_buffer/proc/deactivate_wash()
 	var/mob/living/silicon/robot/robot_owner = owner
-	var/time_left = timeleft(wash_audio.timerid) // We delay by the timer of our wash cause well, we want to hear the ramp down
+	var/time_left = timeleft(wash_audio.timer_id) // We delay by the timer of our wash cause well, we want to hear the ramp down
 	var/finished_by = time_left + 2.6 SECONDS
 	// Need to ensure that people don't spawn the deactivate button
 	COOLDOWN_START(src, toggle_cooldown, finished_by)


### PR DESCRIPTION
## About The Pull Request
Have you ever been by engineering, in maintenance, and just felt your ears shattered by the noises of machines that you couldn't even see, and that would realistically not be too loud due to a very small amount of actual physical parts, through like two meters of solid metal walls?

Have you ever wondered why the gravity generators was so obnoxiously loud, even when you couldn't see it?

Have you ever wondered why ***every single looping sound*** was forced to be heard through walls?

I did. So I looked into the file, and I was mortified by the total lack of documentation. So, you know me, I went ahead and documented everything, as it was a rather simple task.

I then added three new variables to looping sound: `pressure_affected`, `ignore_walls` and `use_reverb`, which are all in reference to the variables of `playsound()` itself, and are only useful for it. This finally makes it possible to have full control over looping sounds as we should have.

As a demonstration of it working, I gave the gravity generator and telecomms' servers `ignore_walls` set to `FALSE`, which should also make it much more enjoyable to make stuff in maintenance around those otherwise really noisy and headache-inducing parts of the station.

## Why It's Good For The Game
Some sounds are better when they're not going through walls. Others are better when not affected by pressure. And some sounds shouldn't be affected by reverb.

## Changelog
:cl: GoldenAlpharex
qol: Telecomms and the gravity generator are no longer ear-deafening when you don't have a direct line of sight with them, meaning that you can now peacefully build things in maintenance around them, without having to turn off the sound of your game.
code: Added complete documentation and extra configurability to looping sounds, allowing them to be stopped by walls, to ignore pressure or to be unaffected by reverb!
/:cl: