### PR TITLE
Cut The Caution Crap! - Removing Overlapping Text on IceBox Decals

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -15629,9 +15629,6 @@
 "Sf" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/caution{
-	pixel_y = 9
-	},
 /turf/open/floor/iron/dark/textured,
 /area/hallway/secondary/service)
 "Sg" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Here's a photograph for you:

![image](https://user-images.githubusercontent.com/34697715/163661843-30f91641-e3aa-437a-89eb-83303aec56f0.png)

Yeah, it was meant to be varedited to look like something where the caution would be placed perfectly and beautifully between the <STAND CLEAR> text boxes, but unfortunately whatever code places turf decals on turfs doesn't respect pixel-shifting. This PR just removes the CAUTION from this spot.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Looks ugly, text shouldn't overlap, mappers assuming a game mechanic exists when it doesn't, etc.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: On IceBoxStation, to the northeastern airlock (in relation to the bar), Nanotrasen will no longer paint the word "Caution" over text that says "STAND CLEAR".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
