### PR TITLE
Fixes attacking humans, paintings and some other stuff with items causing the animation to display incorrectly

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1352,6 +1352,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 		attack_image = image('icons/effects/effects.dmi', attacked_atom, visual_effect_icon, attacked_atom.layer + 0.1)
 	else if(used_item)
 		attack_image = image(icon = used_item, loc = attacked_atom, layer = attacked_atom.layer + 0.1)
+		attack_image.plane = attacked_atom.plane + 1
+
 		// Scale the icon.
 		attack_image.transform *= 0.4
 		// The icon should not rotate.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1351,9 +1351,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(visual_effect_icon)
 		attack_image = image('icons/effects/effects.dmi', attacked_atom, visual_effect_icon, attacked_atom.layer + 0.1)
 	else if(used_item)
-		attack_image = image(icon = used_item, loc = attacked_atom)
-		attack_image.appearance = used_item.appearance
-		attack_image.layer = attacked_atom.layer + 0.1
+		attack_image = image(icon = used_item, loc = attacked_atom, layer = attacked_atom.layer + 0.1)
 		// Scale the icon.
 		attack_image.transform *= 0.4
 		// The icon should not rotate.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1351,9 +1351,9 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(visual_effect_icon)
 		attack_image = image('icons/effects/effects.dmi', attacked_atom, visual_effect_icon, attacked_atom.layer + 0.1)
 	else if(used_item)
-		attack_image = image(icon = used_item, loc = attacked_atom, layer = attacked_atom.layer + 0.1)
-		attack_image.plane = attacked_atom.plane
-
+		attack_image = image(icon = used_item, loc = attacked_atom)
+		attack_image.appearance = used_item.appearance
+		attack_image.layer = attacked_atom.layer + 0.1
 		// Scale the icon.
 		attack_image.transform *= 0.4
 		// The icon should not rotate.

--- a/code/game/objects/items/food/deepfried.dm
+++ b/code/game/objects/items/food/deepfried.dm
@@ -1,8 +1,8 @@
 /obj/item/food/deepfryholder
 	name = "Deep Fried Foods Holder Obj"
 	desc = "If you can see this description the code for the deep fryer fucked up."
-	icon = 'icons/obj/food/food.dmi'
-	icon_state = ""
+	icon = 'icons/blanks/32x32.dmi'
+	icon_state = "nothing"
 	bite_consumption = 2
 
 /obj/item/food/deepfryholder/MakeEdible()

--- a/code/game/objects/items/food/deepfried.dm
+++ b/code/game/objects/items/food/deepfried.dm
@@ -1,8 +1,8 @@
 /obj/item/food/deepfryholder
 	name = "Deep Fried Foods Holder Obj"
 	desc = "If you can see this description the code for the deep fryer fucked up."
-	icon = 'icons/blanks/32x32.dmi'
-	icon_state = "nothing"
+	icon = 'icons/obj/food/food.dmi'
+	icon_state = ""
 	bite_consumption = 2
 
 /obj/item/food/deepfryholder/MakeEdible()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #58058.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Attacking humans or other things that have KEEP_TOGETHER (atmos omni tanks, supplypods, paintings) with a deep fried thing will now actually show that thing instead of both that thing and an error sprite.
Attack animations for attacks against those things are no longer black.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Attacking people, atmos omni tanks, supplypods and paintings with deep-fried items no longer shows an error sprite.
fix: Animations for attacking people, atmos omni tanks, supplypods and paintings with items are no longer black.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
