### PR TITLE
Fixes "error" state in the slimeperson body change menu

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -341,7 +341,7 @@
 		switch(body.stat)
 			if(CONSCIOUS)
 				stat = "Conscious"
-			if(UNCONSCIOUS)
+			if(SOFT_CRIT to HARD_CRIT) // Also includes UNCONSCIOUS
 				stat = "Unconscious"
 			if(DEAD)
 				stat = "Dead"


### PR DESCRIPTION
## About The Pull Request

Fixes a bug that would cause a slimeperson's state to be listed as "error" in the "swap body" menu if their body was in crit.

## Why It's Good For The Game

This is not epic:
![image](https://user-images.githubusercontent.com/50628162/163692327-2e9a66c3-3996-4a36-825b-cb9cf0d8ea4f.png)


This however, is epic:
![image](https://user-images.githubusercontent.com/50628162/163692341-87f55359-eb5b-468c-9339-1bc4d4804d2b.png)


## Changelog
:cl:
fix: slimepeople's state will no longer be listed as "error" in the "swap body" menu if their body is in crit
/:cl: