### PR TITLE
Fixes grilling deep fried foods creating an error sprite in the overlay

### DIFF
--- a/code/datums/components/sizzle.dm
+++ b/code/datums/components/sizzle.dm
@@ -17,7 +17,7 @@
 
 /datum/component/sizzle/proc/setup_sizzle()
 	var/atom/food = parent
-	var/icon/grill_marks = icon(initial(food.icon), initial(food.icon_state)) //we only want to apply grill marks to the initial icon_state for each object
+	var/icon/grill_marks = icon(food.icon, food.icon_state)
 	grill_marks.Blend("#fff", ICON_ADD) //fills the icon_state with white (except where it's transparent)
 	grill_marks.Blend(icon('icons/obj/kitchen.dmi', "grillmarks"), ICON_MULTIPLY) //adds grill marks and the remaining white areas become transparent
 	sizzling = new(grill_marks)


### PR DESCRIPTION
## About The Pull Request
Deep fried place holder food items have no initial icon state, so it was grabbing an error sprite
This gets rid of the initial because it serves no purpose I can see
![image](https://user-images.githubusercontent.com/51932756/163694757-96fcf47e-e4ff-40a4-a9ad-34d2d6bc1be9.png)


## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/51932756/163694761-9881d5aa-111f-440e-8e8a-9b73b7bd14fc.png)
It cleans up a little cursed cookery

## Changelog
:cl:
fix: Our finest chefs have further refined the art of cookery so grilling random items that have been deep fried will no longer create grill marks on weird lettering above the dish.
/:cl: