### PR TITLE
Actually Actually Fixes Illegal Tech

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -120,7 +120,6 @@
 #define INIT_ORDER_VIS 80
 #define INIT_ORDER_DISCORD 78
 #define INIT_ORDER_ACHIEVEMENTS 77
-#define INIT_ORDER_RESEARCH 75
 #define INIT_ORDER_STATION 74 //This is high priority because it manipulates a lot of the subsystems that will initialize after it.
 #define INIT_ORDER_QUIRKS 73
 #define INIT_ORDER_REAGENTS 72 //HAS to be before mapping and assets - both create objects, which creates reagents, which relies on lists made in this subsystem
@@ -133,7 +132,8 @@
 #define INIT_ORDER_TCG 55
 #define INIT_ORDER_MAPPING 50
 #define INIT_ORDER_EARLY_ASSETS 48
-#define INIT_ORDER_TIMETRACK 47
+#define INIT_ORDER_RESEARCH 47
+#define INIT_ORDER_TIMETRACK 46
 #define INIT_ORDER_NETWORKS 45
 #define INIT_ORDER_SPATIAL_GRID 43
 #define INIT_ORDER_ECONOMY 40

--- a/code/modules/asset_cache/assets/uplink.dm
+++ b/code/modules/asset_cache/assets/uplink.dm
@@ -1,6 +1,7 @@
 /// Sends information needed for uplinks
 /datum/asset/json/uplink
 	name = "uplink"
+	early = TRUE
 
 /datum/asset/json/uplink/generate()
 	var/list/data = list()

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -2002,8 +2002,8 @@
 
 /datum/techweb_node/syndicate_basic/New() //Crappy way of making syndicate gear decon supported until there's another way.
 	. = ..()
-	if(!SSassets.initialized)
-		RegisterSignal(SSassets, COMSIG_SUBSYSTEM_POST_INITIALIZE, .proc/register_uplink_items)
+	if(!SSearly_assets.initialized)
+		RegisterSignal(SSearly_assets, COMSIG_SUBSYSTEM_POST_INITIALIZE, .proc/register_uplink_items)
 	else
 		register_uplink_items()
 
@@ -2013,7 +2013,7 @@
  */
 /datum/techweb_node/syndicate_basic/proc/register_uplink_items()
 	SIGNAL_HANDLER
-	UnregisterSignal(SSassets, COMSIG_SUBSYSTEM_POST_INITIALIZE)
+	UnregisterSignal(SSearly_assets, COMSIG_SUBSYSTEM_POST_INITIALIZE)
 	boost_item_paths = list()
 	for(var/datum/uplink_item/item_path as anything in SStraitor.uplink_items_by_type)
 		var/datum/uplink_item/item = SStraitor.uplink_items_by_type[item_path]


### PR DESCRIPTION
## About The Pull Request

The uplink item json asset needs to be registered before SSresearch initializes if illegal tech is to work. SSassets initializes far too late, and due to its very nature, should not be pushed forward any earlier in the subsystem init process. To this end, the uplink item asset has been made an early asset, and SSresearch has been pushed back to initializing just after SSearly_assets

## Why It's Good For The Game

Actually fixes illegal tech, for real. Test your damn fixes before just PRing/merging them willy nilly.

## Changelog

:cl:
fix: After two failed attempts at rectifying the issue, illegal tech is once again unlockable.
/:cl:
