### PR TITLE
Statue wrench fix

### DIFF
--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -23,7 +23,7 @@
 	AddElement(/datum/element/beauty, impressiveness * 75)
 	AddComponent(/datum/component/simple_rotation)
 
-/obj/structure/cannon/wrench_act(mob/living/user, obj/item/tool)
+/obj/structure/statue/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
 	if(flags_1 & NODECONSTRUCT_1)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Fixes typo from https://github.com/tgstation/tgstation/pull/65425

## Changelog
:cl:
fix: Statues can now once again be wrenched.
/:cl:
