### PR TITLE
Raises the price of skeleton keys to 1,666

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -13,7 +13,7 @@
 		new /datum/data/mining_equipment("1 Marker Beacon", /obj/item/stack/marker_beacon, 10),
 		new /datum/data/mining_equipment("10 Marker Beacons", /obj/item/stack/marker_beacon/ten, 100),
 		new /datum/data/mining_equipment("30 Marker Beacons", /obj/item/stack/marker_beacon/thirty, 300),
-		new /datum/data/mining_equipment("Skeleton Key", /obj/item/skeleton_key, 777),
+		new /datum/data/mining_equipment("Skeleton Key", /obj/item/skeleton_key, 1666),
 		new /datum/data/mining_equipment("Whiskey", /obj/item/reagent_containers/food/drinks/bottle/whiskey, 100),
 		new /datum/data/mining_equipment("Absinthe", /obj/item/reagent_containers/food/drinks/bottle/absinthe/premium, 100),
 		new /datum/data/mining_equipment("Bubblegum Gum Packet", /obj/item/storage/box/gum/bubblegum, 100),


### PR DESCRIPTION
## About The Pull Request

Raises the price of skeleton keys by 114.42%, making them mildly more expensive without effectively eliminating from being obtained at all, like https://github.com/tgstation/tgstation/pull/66239 was stupidly doing by raising the price by 900.9% and was just a grudge PR with a decent incentive but horrendous balancing.

## Why It's Good For The Game

Makes skeleton keys just *a bit* more scarce, requiring now twice the price than before.
You'll be able to get them just fine by mining like normal, being a similar price to the Mining Conscription Kit (1500 points).
Miners will have to mine twice as much to get them, giving a good tradeoff between work and loot.

## Changelog
:cl:
balance: Skeleton keys now cost 1,666 mining points. Get to work, miners.
/:cl: