### PR TITLE
Megafauna chests will now require 7 skeleton keys to open. Hierophant will now drop their chest instead of their loot.

### DIFF
--- a/_maps/shuttles/emergency_arena.dmm
+++ b/_maps/shuttles/emergency_arena.dmm
@@ -11,7 +11,7 @@
 	},
 /area/shuttle/escape/arena)
 "i" = (
-/obj/structure/closet/crate/necropolis/dragon,
+/obj/structure/closet/crate/necropolis/megafauna/dragon,
 /turf/open/indestructible{
 	icon_state = "cult"
 	},

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -7,6 +7,41 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	can_install_electronics = FALSE
 
+/obj/structure/closet/crate/necropolis/megafauna
+	var/required_keys = 7
+	desc = "It's watching you suspiciously. There are 7 keyholes."
+	var/list/loot = list()
+	integrity_failure = 0
+
+/obj/structure/closet/crate/necropolis/megafauna/proc/spawn_loot()
+	return
+
+/obj/structure/closet/crate/necropolis/megafauna/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_PARENT_ATTACKBY, .proc/try_spawn_loot)
+
+/obj/structure/closet/crate/necropolis/megafauna/proc/try_spawn_loot(datum/source, obj/item/item, mob/user)
+	SIGNAL_HANDLER
+
+	if(!istype(item, /obj/item/skeleton_key) || !required_keys)
+		return FALSE
+
+	required_keys -= 1
+	qdel(item)
+	if(!required_keys && loot)
+		to_chat(user, span_notice("You disable the magic lock, revealing the loot."))
+		desc = "It's watching you suspiciously."
+		spawn_loot()
+		return TRUE
+	else
+		to_chat(user, span_notice("You insert the key into the [src]. There are [required_keys] empty keyholes left."))
+		desc = "It's watching you suspiciously. There are [required_keys] keyholes."
+
+/obj/structure/closet/crate/necropolis/megafauna/can_open(mob/living/user, force = FALSE)
+	if(required_keys)
+		return FALSE
+	return ..()
+
 /obj/structure/closet/crate/necropolis/tendril
 	desc = "It's watching you suspiciously. You need a skeleton key to open it."
 	integrity_failure = 0 //prevents bust_open from firing
@@ -86,10 +121,10 @@
 
 //Megafauna chests
 
-/obj/structure/closet/crate/necropolis/dragon
+/obj/structure/closet/crate/necropolis/megafauna/dragon
 	name = "dragon chest"
 
-/obj/structure/closet/crate/necropolis/dragon/PopulateContents()
+/obj/structure/closet/crate/necropolis/megafauna/dragon/spawn_loot()
 	var/loot = rand(1,4)
 	switch(loot)
 		if(1)
@@ -101,17 +136,17 @@
 		if(4)
 			new /obj/item/dragons_blood(src)
 
-/obj/structure/closet/crate/necropolis/dragon/crusher
+/obj/structure/closet/crate/necropolis/megafauna/dragon/crusher
 	name = "firey dragon chest"
 
-/obj/structure/closet/crate/necropolis/dragon/crusher/PopulateContents()
+/obj/structure/closet/crate/necropolis/megafauna/dragon/crusher/spawn_loot()
 	..()
 	new /obj/item/crusher_trophy/tail_spike(src)
 
-/obj/structure/closet/crate/necropolis/bubblegum
+/obj/structure/closet/crate/necropolis/megafauna/bubblegum
 	name = "bubblegum chest"
 
-/obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
+/obj/structure/closet/crate/necropolis/megafauna/bubblegum/spawn_loot()
 	new /obj/item/clothing/suit/hooded/hostile_environment(src)
 	var/loot = rand(1,2)
 	switch(loot)
@@ -120,33 +155,46 @@
 		if(2)
 			new /obj/item/soulscythe(src)
 
-/obj/structure/closet/crate/necropolis/bubblegum/crusher
+/obj/structure/closet/crate/necropolis/megafauna/bubblegum/crusher
 	name = "bloody bubblegum chest"
 
-/obj/structure/closet/crate/necropolis/bubblegum/crusher/PopulateContents()
+/obj/structure/closet/crate/necropolis/megafauna/bubblegum/crusher/spawn_loot()
 	..()
 	new /obj/item/crusher_trophy/demon_claws(src)
 
-/obj/structure/closet/crate/necropolis/colossus
+/obj/structure/closet/crate/necropolis/megafauna/colossus
 	name = "colossus chest"
 
-/obj/structure/closet/crate/necropolis/colossus/bullet_act(obj/projectile/P)
+/obj/structure/closet/crate/necropolis/megafauna/colossus/bullet_act(obj/projectile/P)
 	if(istype(P, /obj/projectile/colossus))
 		return BULLET_ACT_FORCE_PIERCE
 	return ..()
 
-/obj/structure/closet/crate/necropolis/colossus/PopulateContents()
+/obj/structure/closet/crate/necropolis/megafauna/colossus/spawn_loot()
 	var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
 	var/random_crystal = pick(choices)
 	new random_crystal(src)
 	new /obj/item/organ/vocal_cords/colossus(src)
 
-/obj/structure/closet/crate/necropolis/colossus/crusher
+/obj/structure/closet/crate/necropolis/megafauna/colossus/crusher
 	name = "angelic colossus chest"
 
-/obj/structure/closet/crate/necropolis/colossus/crusher/PopulateContents()
+/obj/structure/closet/crate/necropolis/megafauna/colossus/crusher/spawn_loot()
 	..()
 	new /obj/item/crusher_trophy/blaster_tubes(src)
+
+/obj/structure/closet/crate/necropolis/megafauna/hierophant
+	name = "hierophant chest"
+
+/obj/structure/closet/crate/necropolis/megafauna/hierophant/spawn_loot()
+	new /obj/item/hierophant_club(src)
+
+/obj/structure/closet/crate/necropolis/megafauna/hierophant/crusher
+	name = "zealous hierophant chest"
+
+/obj/structure/closet/crate/necropolis/megafauna/hierophant/crusher/spawn_loot()
+	new /obj/item/hierophant_club(src)
+	new /obj/item/crusher_trophy/vortex_talisman(src)
 
 //Other chests and minor stuff
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -8,7 +8,7 @@
 	can_install_electronics = FALSE
 
 /obj/structure/closet/crate/necropolis/megafauna
-	var/required_keys = 7
+	var/required_keys = 3
 	desc = "It's watching you suspiciously. There are 7 keyholes."
 	var/list/loot = list()
 	integrity_failure = 0

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -58,8 +58,8 @@ Difficulty: Hard
 	maptext_height = 96
 	maptext_width = 96
 	del_on_death = TRUE
-	crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/crusher)
-	loot = list(/obj/structure/closet/crate/necropolis/bubblegum)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/megafauna/bubblegum/crusher)
+	loot = list(/obj/structure/closet/crate/necropolis/megafauna/bubblegum)
 	blood_volume = BLOOD_VOLUME_MAXIMUM //BLEED FOR ME
 	gps_name = "Bloody Signal"
 	achievement_type = /datum/award/achievement/boss/bubblegum_kill

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -51,8 +51,8 @@
 	achievement_type = /datum/award/achievement/boss/colossus_kill
 	crusher_achievement_type = /datum/award/achievement/boss/colossus_crusher
 	score_achievement_type = /datum/award/score/colussus_score
-	crusher_loot = list(/obj/structure/closet/crate/necropolis/colossus/crusher)
-	loot = list(/obj/structure/closet/crate/necropolis/colossus)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/megafauna/colossus/crusher)
+	loot = list(/obj/structure/closet/crate/necropolis/megafauna/colossus)
 	deathmessage = "disintegrates, leaving a glowing core in its wake."
 	deathsound = 'sound/magic/demon_dies.ogg'
 	small_sprite_type = /datum/action/small_sprite/megafauna/colossus

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -60,8 +60,8 @@
 	base_pixel_x = -16
 	maptext_height = 64
 	maptext_width = 64
-	crusher_loot = list(/obj/structure/closet/crate/necropolis/dragon/crusher)
-	loot = list(/obj/structure/closet/crate/necropolis/dragon)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/megafauna/dragon/crusher)
+	loot = list(/obj/structure/closet/crate/necropolis/megafauna/dragon)
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)
 	guaranteed_butcher_results = list(/obj/item/stack/sheet/animalhide/ashdrake = 10)
 	var/swooping = NONE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -58,8 +58,8 @@ Difficulty: Hard
 	ranged = TRUE
 	ranged_cooldown_time = 4 SECONDS
 	aggro_vision_range = 21 //so it can see to one side of the arena to the other
-	loot = list(/obj/item/hierophant_club)
-	crusher_loot = list(/obj/item/hierophant_club, /obj/item/crusher_trophy/vortex_talisman)
+	loot = list(/obj/structure/closet/crate/necropolis/megafauna/hierophant)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/megafauna/hierophant/crusher)
 	wander = FALSE
 	gps_name = "Zealous Signal"
 	achievement_type = /datum/award/achievement/boss/hierophant_kill


### PR DESCRIPTION
Adds megafauna subtype of necropolis chests.  Megafauna will drop them.

The chests require 7 keys to unlock.

Hierophant will now drop megafauna chest.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Chests dropped from megafauna will now require you to insert 3 skeleton keys to open, requiring 2,331 points per chest. Hierophant will now drop a chest with their loot in it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents miners from just rushing megafauna to get all of their loot quickly. The requirement should now allow progression to match closer to the 90 minute round duration.

The problem with the actual fight being the only limiter to the rewards means there isn't a very strong time barrier to obtain powerful gear.

Adding a key requirement will mean there will be a stronger and more stable requirement to get the gear, making it easier to balance when they get a chest, how much work they need to get a chest, and how many they can get in a round.

Balancing the barrier purely around combat isn't a very strong enforcement, unless it takes a very long time to kill the megafauna.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Megafauna chests will now require 3 skeleton keys to unlock.
balance: Hierophant will now drop their megafauna chest with their loot in it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
