### PR TITLE
Allergies no longer keep triggering while the subject is dead

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -794,6 +794,9 @@
 	if(IS_IN_STASIS(quirk_holder))
 		return
 
+	if(quirk_holder.stat == DEAD)
+		return
+
 	var/mob/living/carbon/carbon_quirk_holder = quirk_holder
 	for(var/allergy in allergies)
 		var/datum/reagent/instantiated_med = carbon_quirk_holder.reagents.has_reagent(allergy)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

People with allergies will no longer keep producing histamine while they're dead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Seems like an oversight that was missed when allergies were patched to not trigger while on stasis. Blood deficiency has the same check that this PR adds to allergies.

Quirks in general could probably use a rework to work on on_life ticks rather than process but that's an issue for another day.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Allergies no longer continue triggering and producing histamine while the subject is dead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
