### PR TITLE
Thermomachine upgrade fix

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -73,12 +73,16 @@
 			new /obj/item/stack/sheet/mineral/metal_hydrogen(loc)
 	return ..()
 
-/obj/machinery/atmospherics/components/binary/thermomachine/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/stack/sheet/mineral/metal_hydrogen) && panel_open)
-		var/obj/item/stack/sheet/mineral/metal_hydrogen/metalh2 = W
+/obj/machinery/atmospherics/components/binary/thermomachine/attackby(obj/item/used_item, mob/user, params)
+	if(istype(used_item, /obj/item/stack/sheet/mineral/metal_hydrogen) && panel_open)
+		if(has_metalh2)
+			balloon_alert(user, "already upgraded!")
+			return
+		var/obj/item/stack/sheet/mineral/metal_hydrogen/metalh2 = used_item
 		if(!metalh2.use(3))
 			balloon_alert(user, "3 sheets are needed to upgrade")
 			return
+		to_chat(user, span_notice("You upgrade [src] with [used_item]."))
 		has_metalh2 = TRUE
 		return
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Fixes thermomachines to no longer keep accepting infinite metal h2 once upgraded
Gives a message in chat when upgrading them

## Changelog
:cl:
fix: Thermomachines will no longer continue to consume metal hydrogen once upgraded, as well as giving feedback in chat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
