### PR TITLE
Prevent bullets from sometimes missing if aimed at a diagonal target under certain conditions (See desc)

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -71,9 +71,8 @@
 		new firing_effect_type(get_turf(src), firing_dir)
 
 	var/direct_target
-	if(targloc == curloc)
-		if(target) //if the target is right on our location we'll skip the travelling code in the proj's fire()
-			direct_target = target
+	if(target && curloc.Adjacent(targloc, target=targloc, mover=src)) //if the target is right on our location or adjacent (including diagonally if reachable) we'll skip the travelling code in the proj's fire()
+		direct_target = target
 	if(!direct_target)
 		var/modifiers = params2list(params)
 		loaded_projectile.preparePixelProjectile(target, fired_from, modifiers, spread)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes guns skip the projectile's travelling code if their target is Adjacent() to them (Adjacent accounts for being blocked by things like windows).
The code for /obj/projectile/proc/fire() already does so if the target was on top of the shooter but now adjacent, but this just extends it to the case where if the target is adjacent and reachable.

Why is this needed?
Looking at the image below:
Prior to this fix, the shots at the left would be sometimes blocked depending on the spread (and in fact, they would also sometimes be blocked if only **one** of the two dummy people in between the shooter and the victim was present), including, most noticeably in the case of the issue described by #37705 where execution bullets can hit someone else and kill them instead (in fast-paced combat, issues like this are hard to notice).
After this, the shots at the left would hit the person always (provided they dont move out of range in the split second before /obj/projectile/proc/fire() is called).

In addition, just to make sure that adjacent works as intended, I also tested this in the case to the right with the two (half-broken) windows:
If the victim is at the location marked in purple, and the shooter is at the location marked in green: One of the two windows would be hit.
But however, if the shooter was at the location marked in blue, then the victim would always be hit.
![Demo](https://user-images.githubusercontent.com/31096837/163748992-13fe25b2-120f-4990-b560-102c665222cc.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #37705 (fully) (if the blocking person was on the same tile as the prone one, the issue has already been fixed, but if the blocking person was in the way diagonally, sometimes they'd get hit instead prior to this)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Prevent bullets (most notably those fired aimed at the mouth when intended for executions) from sometimes missing if you're firing at a target diagonally adjacent to you and there's an obstacle (eg. person) between you two.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
