### PR TITLE
Adds missing APC to Kilostation's upload.

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -31809,6 +31809,7 @@
 "gif" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai_upload)
 "gih" = (
@@ -35043,6 +35044,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai_upload)
 "hnt" = (
@@ -45203,8 +45205,9 @@
 /area/service/chapel/dock)
 "kzL" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/ai/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "kzS" = (
@@ -64271,7 +64274,9 @@
 /area/commons/storage/primary)
 "qNC" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/ai/directional/west,
+/obj/structure/sign/poster/contraband/self_ai_liberation{
+	pixel_x = -32
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "qNE" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It was missing, now it is not. Even put a little poster as compensation.
![image](https://user-images.githubusercontent.com/81882910/163763763-c0964e9c-6f3b-47ce-b614-1d6415720c6b.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I think having APCs in powered rooms is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Kilostation's AI upload once again has an APC
/:cl: