### PR TITLE
Fixes heretic mask of madness not applying stamina damage when it should

### DIFF
--- a/code/modules/antagonists/heretic/items/madness_mask.dm
+++ b/code/modules/antagonists/heretic/items/madness_mask.dm
@@ -66,7 +66,7 @@
 		if(DT_PROB(40, delta_time))
 			human_in_range.Jitter(5)
 
-		if(human_in_range.getStaminaLoss() >= 85 && DT_PROB(30, delta_time))
+		if(human_in_range.getStaminaLoss() <= 85 && DT_PROB(30, delta_time))
 			human_in_range.emote(pick("giggle", "laugh"))
 			human_in_range.adjustStaminaLoss(10)
 


### PR DESCRIPTION
## About The Pull Request
I rebalanced the mask of madness to only give stamina damage up to 85, after which it would be unable to, preventing people from being (infinite) stam crit (which was very unfun)

Except I used a greater than instead of a less than by mistake, meaning it would almost never apply any stamina damage

Fixes #66283

## Why It's Good For The Game

The mask of madness is actually pretty ungood right now which was not intentional

## Changelog

:cl: Melbert
fix: Heretic's Madness Mask applies stamina damage to people when it should
/:cl:

