### PR TITLE
Blind people can no longer use analyzers of any type

### DIFF
--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -34,46 +34,48 @@
 /obj/item/analyzer/AltClick(mob/user) //Barometer output for measuring when the next storm happens
 	..()
 
-	if(user.canUseTopic(src, BE_CLOSE))
-		if(cooldown)
-			to_chat(user, span_warning("[src]'s barometer function is preparing itself."))
+	if(!user.canUseTopic(src, BE_CLOSE) || !user.can_read(src))
+		return
+
+	if(cooldown)
+		to_chat(user, span_warning("[src]'s barometer function is preparing itself."))
+		return
+
+	var/turf/T = get_turf(user)
+	if(!T)
+		return
+
+	playsound(src, 'sound/effects/pop.ogg', 100)
+	var/area/user_area = T.loc
+	var/datum/weather/ongoing_weather = null
+
+	if(!user_area.outdoors)
+		to_chat(user, span_warning("[src]'s barometer function won't work indoors!"))
+		return
+
+	for(var/V in SSweather.processing)
+		var/datum/weather/W = V
+		if(W.barometer_predictable && (T.z in W.impacted_z_levels) && W.area_type == user_area.type && !(W.stage == END_STAGE))
+			ongoing_weather = W
+			break
+
+	if(ongoing_weather)
+		if((ongoing_weather.stage == MAIN_STAGE) || (ongoing_weather.stage == WIND_DOWN_STAGE))
+			to_chat(user, span_warning("[src]'s barometer function can't trace anything while the storm is [ongoing_weather.stage == MAIN_STAGE ? "already here!" : "winding down."]"))
 			return
 
-		var/turf/T = get_turf(user)
-		if(!T)
-			return
-
-		playsound(src, 'sound/effects/pop.ogg', 100)
-		var/area/user_area = T.loc
-		var/datum/weather/ongoing_weather = null
-
-		if(!user_area.outdoors)
-			to_chat(user, span_warning("[src]'s barometer function won't work indoors!"))
-			return
-
-		for(var/V in SSweather.processing)
-			var/datum/weather/W = V
-			if(W.barometer_predictable && (T.z in W.impacted_z_levels) && W.area_type == user_area.type && !(W.stage == END_STAGE))
-				ongoing_weather = W
-				break
-
-		if(ongoing_weather)
-			if((ongoing_weather.stage == MAIN_STAGE) || (ongoing_weather.stage == WIND_DOWN_STAGE))
-				to_chat(user, span_warning("[src]'s barometer function can't trace anything while the storm is [ongoing_weather.stage == MAIN_STAGE ? "already here!" : "winding down."]"))
-				return
-
-			to_chat(user, span_notice("The next [ongoing_weather] will hit in [butchertime(ongoing_weather.next_hit_time - world.time)]."))
-			if(ongoing_weather.aesthetic)
-				to_chat(user, span_warning("[src]'s barometer function says that the next storm will breeze on by."))
+		to_chat(user, span_notice("The next [ongoing_weather] will hit in [butchertime(ongoing_weather.next_hit_time - world.time)]."))
+		if(ongoing_weather.aesthetic)
+			to_chat(user, span_warning("[src]'s barometer function says that the next storm will breeze on by."))
+	else
+		var/next_hit = SSweather.next_hit_by_zlevel["[T.z]"]
+		var/fixed = next_hit ? timeleft(next_hit) : -1
+		if(fixed < 0)
+			to_chat(user, span_warning("[src]'s barometer function was unable to trace any weather patterns."))
 		else
-			var/next_hit = SSweather.next_hit_by_zlevel["[T.z]"]
-			var/fixed = next_hit ? timeleft(next_hit) : -1
-			if(fixed < 0)
-				to_chat(user, span_warning("[src]'s barometer function was unable to trace any weather patterns."))
-			else
-				to_chat(user, span_warning("[src]'s barometer function says a storm will land in approximately [butchertime(fixed)]."))
-		cooldown = TRUE
-		addtimer(CALLBACK(src,/obj/item/analyzer/proc/ping), cooldown_time)
+			to_chat(user, span_warning("[src]'s barometer function says a storm will land in approximately [butchertime(fixed)]."))
+	cooldown = TRUE
+	addtimer(CALLBACK(src,/obj/item/analyzer/proc/ping), cooldown_time)
 
 /obj/item/analyzer/proc/ping()
 	if(isliving(loc))
@@ -108,24 +110,20 @@
 	return list("gasmixes" = last_gasmix_data)
 
 /obj/item/analyzer/attack_self(mob/user, modifiers)
-	// Check if it requires visibility and if the user is you know, blind.
-	if (user.stat != CONSCIOUS || user.is_blind())
-		to_chat(user, span_warning("You're unable to see [src]'s results!"))
+	if(user.stat != CONSCIOUS || !user.can_read(src))
 		return
 
 	atmos_scan(user=user, target=get_turf(src), tool=src, silent=FALSE)
 
 /obj/item/analyzer/attack_self_secondary(mob/user, modifiers)
-	// Check if it requires visibility and if the user is you know, blind.
-	if (user.stat != CONSCIOUS || user.is_blind())
-		to_chat(user, span_warning("You're unable to see [src]'s results!"))
+	if(user.stat != CONSCIOUS || !user.can_read(src))
 		return
 
 	ui_interact(user)
 
 /**
  * Outputs a message to the user describing the target's gasmixes.
- * 
+ *
  * Gets called by analyzer_act, which in turn is called by tool_act.
  * Also used in other chat-based gas scans.
  */
@@ -133,7 +131,7 @@
 	var/mixture = target.return_analyzable_air()
 	if(!mixture)
 		return FALSE
-	
+
 	var/icon = target
 	var/message = list()
 	if(!silent && isliving(user))
@@ -157,7 +155,7 @@
 
 		if(total_moles > 0)
 			message += span_notice("Moles: [round(total_moles, 0.01)] mol")
-				
+
 			var/list/cached_gases = air.gases
 			for(var/id in cached_gases)
 				var/gas_concentration = cached_gases[id][MOLES]/total_moles
@@ -167,7 +165,7 @@
 			message += span_notice("Pressure: [round(pressure, 0.01)] kPa")
 		else
 			message += airs.len > 1 ? span_notice("This node is empty!") : span_notice("[target] is empty!")
-		
+
 		gasmix_data += list(gas_mixture_parser(air, mix_name))
 
 	if(istype(tool))

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -29,7 +29,6 @@
 
 /obj/item/healthanalyzer/Initialize(mapload)
 	. = ..()
-
 	register_item_context()
 
 /obj/item/healthanalyzer/examine(mob/user)
@@ -41,6 +40,9 @@
 	return BRUTELOSS
 
 /obj/item/healthanalyzer/attack_self(mob/user)
+	if(!user.can_read(src))
+		return
+
 	scanmode = (scanmode + 1) % SCANMODE_COUNT
 	switch(scanmode)
 		if(SCANMODE_HEALTH)
@@ -49,6 +51,9 @@
 			to_chat(user, span_notice("You switch the health analyzer to report extra info on wounds."))
 
 /obj/item/healthanalyzer/attack(mob/living/M, mob/living/carbon/human/user)
+	if(!user.can_read(src))
+		return
+
 	flick("[icon_state]-scan", src) //makes it so that it plays the scan animation upon scanning, including clumsy scanning
 
 	// Clumsiness/brain damage check
@@ -77,6 +82,9 @@
 	add_fingerprint(user)
 
 /obj/item/healthanalyzer/attack_secondary(mob/living/victim, mob/living/user, params)
+	if(!user.can_read(src))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 	chemscan(user, victim)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
@@ -100,7 +108,7 @@
 
 // Used by the PDA medical scanner too
 /proc/healthscan(mob/user, mob/living/target, mode = SCANNER_VERBOSE, advanced = FALSE)
-	if(user.incapacitated() || !user.can_read(src))
+	if(user.incapacitated())
 		return
 
 	// the final list of strings to render
@@ -367,7 +375,7 @@
 	to_chat(user, jointext(render_list, ""), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 
 /proc/chemscan(mob/living/user, mob/living/target)
-	if(user.incapacitated() || !user.can_read(src))
+	if(user.incapacitated())
 		return
 
 	if(istype(target) && target.reagents)
@@ -440,7 +448,7 @@
 
 /// Displays wounds with extended information on their status vs medscanners
 /proc/woundscan(mob/user, mob/living/carbon/patient, obj/item/healthanalyzer/wound/scanner)
-	if(!istype(patient) || user.incapacitated() || !user.can_read(src))
+	if(!istype(patient) || user.incapacitated())
 		return
 
 	var/render_list = ""
@@ -489,6 +497,9 @@
 			L.dropItemToGround(src)
 
 /obj/item/healthanalyzer/wound/attack(mob/living/carbon/patient, mob/living/carbon/human/user)
+	if(!user.can_read(src))
+		return
+
 	add_fingerprint(user)
 	user.visible_message(span_notice("[user] scans [patient] for serious injuries."), span_notice("You scan [patient] for serious injuries."))
 

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -100,11 +100,7 @@
 
 // Used by the PDA medical scanner too
 /proc/healthscan(mob/user, mob/living/target, mode = SCANNER_VERBOSE, advanced = FALSE)
-	if(user.incapacitated())
-		return
-
-	if(user.is_blind())
-		to_chat(user, span_warning("You realize that your scanner has no accessibility support for the blind!"))
+	if(user.incapacitated() !user.can_read(src))
 		return
 
 	// the final list of strings to render
@@ -371,11 +367,7 @@
 	to_chat(user, jointext(render_list, ""), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 
 /proc/chemscan(mob/living/user, mob/living/target)
-	if(user.incapacitated())
-		return
-
-	if(user.is_blind())
-		to_chat(user, span_warning("You realize that your scanner has no accessibility support for the blind!"))
+	if(user.incapacitated() || !user.can_read(src))
 		return
 
 	if(istype(target) && target.reagents)
@@ -434,7 +426,7 @@
 /obj/item/healthanalyzer/AltClick(mob/user)
 	..()
 
-	if(!user.canUseTopic(src, BE_CLOSE))
+	if(!user.canUseTopic(src, BE_CLOSE) || !user.can_read(src))
 		return
 
 	mode = !mode
@@ -448,11 +440,7 @@
 
 /// Displays wounds with extended information on their status vs medscanners
 /proc/woundscan(mob/user, mob/living/carbon/patient, obj/item/healthanalyzer/wound/scanner)
-	if(!istype(patient) || user.incapacitated())
-		return
-
-	if(user.is_blind())
-		to_chat(user, span_warning("You realize that your scanner has no accessibility support for the blind!"))
+	if(!istype(patient) || user.incapacitated() || !user.can_read(src))
 		return
 
 	var/render_list = ""

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -100,7 +100,7 @@
 
 // Used by the PDA medical scanner too
 /proc/healthscan(mob/user, mob/living/target, mode = SCANNER_VERBOSE, advanced = FALSE)
-	if(user.incapacitated() !user.can_read(src))
+	if(user.incapacitated() || !user.can_read(src))
 		return
 
 	// the final list of strings to render

--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -69,25 +69,27 @@
 	var/answer = tgui_input_list(user, "Analyze Potential", "Sequence Analyzer", sort_list(options))
 	if(isnull(answer))
 		return
-	if(ready && user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
-		var/sequence
-		for(var/A in buffer) //this physically hurts but i dont know what anything else short of an assoc list
-			if(get_display_name(A) == answer)
-				sequence = buffer[A]
-				break
+	if(!ready || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK) || !user.can_read(src))
+		return
 
-		if(sequence)
-			var/display
-			for(var/i in 0 to length_char(sequence) / DNA_MUTATION_BLOCKS-1)
-				if(i)
-					display += "-"
-				display += copytext_char(sequence, 1 + i*DNA_MUTATION_BLOCKS, DNA_MUTATION_BLOCKS*(1+i) + 1)
+	var/sequence
+	for(var/A in buffer) //this physically hurts but i dont know what anything else short of an assoc list
+		if(get_display_name(A) == answer)
+			sequence = buffer[A]
+			break
 
-			to_chat(user, "[span_boldnotice("[display]")]<br>")
+	if(sequence)
+		var/display
+		for(var/i in 0 to length_char(sequence) / DNA_MUTATION_BLOCKS-1)
+			if(i)
+				display += "-"
+			display += copytext_char(sequence, 1 + i*DNA_MUTATION_BLOCKS, DNA_MUTATION_BLOCKS*(1+i) + 1)
 
-		ready = FALSE
-		icon_state = "[icon_state]_recharging"
-		addtimer(CALLBACK(src, .proc/recharge), cooldown, TIMER_UNIQUE)
+		to_chat(user, "[span_boldnotice("[display]")]<br>")
+
+	ready = FALSE
+	icon_state = "[icon_state]_recharging"
+	addtimer(CALLBACK(src, .proc/recharge), cooldown, TIMER_UNIQUE)
 
 /obj/item/sequence_scanner/proc/recharge()
 	icon_state = initial(icon_state)

--- a/code/game/objects/items/devices/scanners/slime_scanner.dm
+++ b/code/game/objects/items/devices/scanners/slime_scanner.dm
@@ -14,7 +14,7 @@
 	custom_materials = list(/datum/material/iron=30, /datum/material/glass=20)
 
 /obj/item/slime_scanner/attack(mob/living/M, mob/living/user)
-	if(user.stat || user.is_blind())
+	if(user.stat || !user.can_read(src))
 		return
 	if (!isslime(M))
 		to_chat(user, span_warning("This device can only scan slimes!"))

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -51,14 +51,14 @@
 /// When we attack something, first - try to scan something we hit with left click. Left-clicking uses scans for stats
 /obj/item/plant_analyzer/pre_attack(atom/target, mob/living/user)
 	. = ..()
-	if(user.combat_mode)
+	if(user.combat_mode || !user.can_read(src))
 		return
 
 	return do_plant_stats_scan(target, user)
 
 /// Same as above, but with right click. Right-clicking scans for chemicals.
 /obj/item/plant_analyzer/pre_attack_secondary(atom/target, mob/living/user)
-	if(user.combat_mode)
+	if(user.combat_mode || !user.can_read(src))
 		return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 	return do_plant_chem_scan(target, user) ? SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN : SECONDARY_ATTACK_CONTINUE_CHAIN

--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -36,7 +36,7 @@
 	. = ..()
 	if(!.)
 		return
-	if(!isliving(target))
+	if(!isliving(target) || !mod.wearer.can_read(src))
 		return
 	switch(mode)
 		if(HEALTH_SCAN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This was split off of https://github.com/tgstation/tgstation/pull/65668 into its own separate PR.

Fixes https://github.com/tgstation/tgstation/issues/43119

> Blind people are able to use some analysers like the plant analyser and the chemical scanner from the health analyser but not other such as atmospheric analyers and the damage scanner of the health analyser.

This removes inconsistencies with blind mobs and analyzers.  Now all analyzers cannot be used by blind people.  I also used an early return in the analyzer code to slightly improve the code quality.

Edit - Since this is getting a knee-jerk reaction, I'd like to point out:

### Analyzers that already check for blindness
- Gas Analyzer
- Health Analyzer
- Slime Analyzer

### Analyzers that I'm adding to that list
- Genetics Analyzer
- Plant Analyzer
- Modsuit medical scanner


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Blindness has always been one of the most lethal status conditions for a player to have.  

This has been the case since it was implemented sometime [before 2008](https://github.com/Glloyd/Pre-Open-SS13-Host-Files-and-Source/blob/32ba79de7e56ec93f0849e3a4532a5b7c74b59b2/ss13-40.93.2-base/ss13-40.93.2-base/mob.dm) as one of the first disabilities in the game. It is not just a black HUD overlay, there are several existing code checks that restrict a blind character's actions.  These restrictions were made to further punish players severely if they had the _stupidity_ (welding without a mask) or _misfortune_ (stabbed in the eye by the clown) of acquiring the status condition in a variety of ways.  This didn't affect balance too much because... **it was curable**.  There were half a dozen different methods to fix it and nobody seriously was expected to try to play while blind.  It was designed to be temporary!

With that in mind, I thought it would be cool if I could expand the blindness code in my original [Paper DLC PR](https://github.com/tgstation/tgstation/pull/65668) to use for my illiterate quirk.  The problem was that there was a lot of consistency issues with blindness code that I attempted to resolve.  What fun is an illiterate quirk if it only stops you from reading newspapers and books?!  It would be silly and pointless so I set out to make it difficult by restricting more stuff.  People who don't know how to read and people who cannot see, results in the same literacy checks in the code.  Both illiterate and blindness use the same `can_read` proc that is used to read and write which means... 

They are identical!  Surprise surprise!!!

I received an overwhelming positive response for making a new quirk that had ALL the restrictions of blindness EXCEPT the vision loss.  

![chrome_W9d5ipPTNk](https://user-images.githubusercontent.com/5195984/163885232-53c85c76-1954-4570-aba7-95320864b39b.png)

Yet when I was forced to split my changes into separate blindness PRs they got the opposite reception:

![chrome_JhbYoqB5mo](https://user-images.githubusercontent.com/5195984/163885256-5ba3d205-d58f-4a57-a466-f4a752a5d88b.png)

- #66285
- #66287
- #66291
- #66290

The cherry on top is that several people were complaining about restricting certain items to blindness when those items already had blindness restrictions for years. (cough health cough analyzers cough)  This is pretty amusing to me since it shows that:

1. People have a knee jerk negative reaction to anything removed/nerfed
2. People will have the above reaction even if they have never experienced it or used it
3. People will have a positive reaction if you are adding something "new" to the game

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: timothymtorres, TheBonded
balance: Blind people can no longer use analyzers.
code: Slight improvement to analyzer code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
