### PR TITLE
Blind people can no longer use PDAs, tablets, or laptops

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -681,6 +681,9 @@
 
 /obj/item/card/id/examine(mob/user)
 	. = ..()
+	if(!user.can_read(src))
+		return
+
 	if(registered_account)
 		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [registered_account.account_balance] cr."
 	. += span_notice("<i>There's more information below, you can look again to take a closer look...</i>")
@@ -1165,6 +1168,9 @@
 
 /obj/item/card/id/advanced/prisoner/examine(mob/user)
 	. = ..()
+	if(!user.can_read(src))
+		return
+
 	if(timed)
 		if(time_left <= 0)
 			. += span_notice("The digital timer on the card has zero seconds remaining. You leave a changed man, but a free man nonetheless.")

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -249,6 +249,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 		explode(user, from_message_menu = TRUE)
 		return
 
+	if(!user.can_read(src))
+		return
+
 	..()
 
 	var/datum/asset/spritesheet/assets = get_asset_datum(/datum/asset/spritesheet/simple/pda)
@@ -480,7 +483,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/mob/living/U = usr
 	//Looking for master was kind of pointless since PDAs don't appear to have one.
 
-	if(!href_list["close"] && usr.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+	if(!href_list["close"] && usr.canUseTopic(src, BE_CLOSE, FALSE, NO_TK) && usr.can_read(src))
 		add_fingerprint(U)
 		U.set_machine(src)
 

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -13,6 +13,9 @@
 			ui.close()
 		return
 
+	if(!user.can_read(src))
+		return
+
 	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))
 		to_chat(user, span_warning("Your fingers are too big to use this right now!"))
 		return

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -13,7 +13,7 @@
 			ui.close()
 		return
 
-	if(!user.can_read(src, check_for_light = FALSE))
+	if(!user.can_read(src))
 		return
 
 	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -13,7 +13,7 @@
 			ui.close()
 		return
 
-	if(!user.can_read(src))
+	if(!user.can_read(src, check_for_light = FALSE))
 		return
 
 	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This was split off of https://github.com/tgstation/tgstation/pull/65668 into its own separate PR.

Fixes #41396

This removes inconsistencies with blind mobs and objects that require reading.  One important thing is that this will prevent traitors from accessing their PDA uplink if they are blind.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Blindness has always been one of the most lethal status conditions for a player to have.  

This has been the case since it was implemented sometime [before 2008](https://github.com/Glloyd/Pre-Open-SS13-Host-Files-and-Source/blob/32ba79de7e56ec93f0849e3a4532a5b7c74b59b2/ss13-40.93.2-base/ss13-40.93.2-base/mob.dm) as one of the first disabilities in the game. It is not just a black HUD overlay, there are several existing code checks that restrict a blind character's actions.  These restrictions were made to further punish players severely if they had the _stupidity_ (welding without a mask) or _misfortune_ (stabbed in the eye by the clown) of acquiring the status condition in a variety of ways.  This didn't affect balance too much because... **it was curable**.  There were half a dozen different methods to fix it and nobody seriously was expected to try to play while blind.  It was designed to be temporary!

With that in mind, I thought it would be cool if I could expand the blindness code in my original [Paper DLC PR](https://github.com/tgstation/tgstation/pull/65668) to use for my illiterate quirk.  The problem was that there was a lot of consistency issues with blindness code that I attempted to resolve.  What fun is an illiterate quirk if it only stops you from reading newspapers and books?!  It would be silly and pointless so I set out to make it difficult by restricting more stuff.  People who don't know how to read and people who cannot see, results in the same literacy checks in the code.  Both illiterate and blindness use the same `can_read` proc that is used to read and write which means... 

They are identical!  Surprise surprise!!!

I received an overwhelming positive response for making a new quirk that had ALL the restrictions of blindness EXCEPT the vision loss.  

![chrome_W9d5ipPTNk](https://user-images.githubusercontent.com/5195984/163885232-53c85c76-1954-4570-aba7-95320864b39b.png)

Yet when I was forced to split my changes into separate blindness PRs they got the opposite reception:

![chrome_JhbYoqB5mo](https://user-images.githubusercontent.com/5195984/163885256-5ba3d205-d58f-4a57-a466-f4a752a5d88b.png)

- #66285
- #66287
- #66291
- #66290

The cherry on top is that several people were complaining about restricting certain items to blindness when those items already had blindness restrictions for years. (cough health cough analyzers cough)  This is pretty amusing to me since it shows that:

1. People have a knee jerk negative reaction to anything removed/nerfed
2. People will have the above reaction even if they have never experienced it or used it
3. People will have a positive reaction if you are adding something "new" to the game

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Blind people can no longer use PDAs, tablets, or laptops (this will prevent traitors from accessing their PDAs while blind)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
