### PR TITLE
Blind people can no longer read newspapers and id cards

### DIFF
--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -33,10 +33,8 @@
 	return(TOXLOSS)
 
 /obj/item/newspaper/attack_self(mob/user)
-	if(!ishuman(user))
-		to_chat(user, span_warning("The paper is full of unintelligible symbols!"))
+	if(!istype(user) || !user.can_read(src))
 		return
-	var/mob/living/carbon/human/human_user = user
 	var/dat
 	pages = 0
 	switch(screen)
@@ -61,7 +59,7 @@
 				dat+="</ul>"
 			if(scribble_page==curr_page)
 				dat+="<BR><I>There is a small scribble near the end of this page... It reads: \"[scribble]\"</I>"
-			dat+= "<HR><DIV STYLE='float:right;'><A href='?src=[REF(src)];next_page=1'>Next Page</A></DIV> <div style='float:left;'><A href='?src=[REF(human_user)];mach_close=newspaper_main'>Done reading</A></DIV>"
+			dat+= "<HR><DIV STYLE='float:right;'><A href='?src=[REF(src)];next_page=1'>Next Page</A></DIV> <div style='float:left;'><A href='?src=[REF(user)];mach_close=newspaper_main'>Done reading</A></DIV>"
 		if(1) // X channel pages inbetween.
 			for(var/datum/feed_channel/NP in news_content)
 				pages++
@@ -110,8 +108,8 @@
 				dat+="<BR><I>There is a small scribble near the end of this page... It reads: \"[scribble]\"</I>"
 			dat+= "<HR><DIV STYLE='float:left;'><A href='?src=[REF(src)];prev_page=1'>Previous Page</A></DIV>"
 	dat+="<BR><HR><div align='center'>[curr_page+1]</div>"
-	human_user << browse(dat, "window=newspaper_main;size=300x400")
-	onclose(human_user, "newspaper_main")
+	user << browse(dat, "window=newspaper_main;size=300x400")
+	onclose(user, "newspaper_main")
 
 /obj/item/newspaper/proc/notContent(list/L)
 	if(!L.len)
@@ -160,8 +158,7 @@
 		return
 
 	if(istype(W, /obj/item/pen))
-		if(!user.is_literate())
-			to_chat(user, span_notice("You scribble illegibly on [src]!"))
+		if(!user.can_write(W))
 			return
 		if(scribble_page == curr_page)
 			to_chat(user, span_warning("There's already a scribble in this page... You wouldn't want to make things too cluttered, would you?"))

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -158,6 +158,9 @@
 		return
 
 	if(istype(W, /obj/item/pen))
+		if(!user.is_literate())
+			to_chat(user, span_notice("You scribble illegibly on [src]!"))
+			return
 		if(scribble_page == curr_page)
 			to_chat(user, span_warning("There's already a scribble in this page... You wouldn't want to make things too cluttered, would you?"))
 		else

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -158,8 +158,6 @@
 		return
 
 	if(istype(W, /obj/item/pen))
-		if(!user.can_write(W))
-			return
 		if(scribble_page == curr_page)
 			to_chat(user, span_warning("There's already a scribble in this page... You wouldn't want to make things too cluttered, would you?"))
 		else

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -32,7 +32,7 @@
 
 	return(TOXLOSS)
 
-/obj/item/newspaper/attack_self(mob/user)
+/obj/item/newspaper/attack_self(mob/living/carbon/human/user)
 	if(!istype(user) || !user.can_read(src))
 		return
 	var/dat

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -681,12 +681,18 @@
 
 /obj/item/card/id/examine(mob/user)
 	. = ..()
+	if(!user.can_read(src))
+		return
+
 	if(registered_account)
 		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [registered_account.account_balance] cr."
 	. += span_notice("<i>There's more information below, you can look again to take a closer look...</i>")
 
 /obj/item/card/id/examine_more(mob/user)
 	. = ..()
+	if(!user.can_read(src))
+		return
+
 	. += span_notice("<i>You examine [src] closer, and note the following...</i>")
 
 	if(registered_age)
@@ -1165,6 +1171,9 @@
 
 /obj/item/card/id/advanced/prisoner/examine(mob/user)
 	. = ..()
+	if(!user.can_read(src))
+		return
+
 	if(timed)
 		if(time_left <= 0)
 			. += span_notice("The digital timer on the card has zero seconds remaining. You leave a changed man, but a free man nonetheless.")

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -13,6 +13,9 @@
 			ui.close()
 		return
 
+	if(!user.can_read(src))
+		return
+
 	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))
 		to_chat(user, span_warning("Your fingers are too big to use this right now!"))
 		return

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -13,9 +13,6 @@
 			ui.close()
 		return
 
-	if(!user.can_read(src))
-		return
-
 	if(HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))
 		to_chat(user, span_warning("Your fingers are too big to use this right now!"))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This was split off of https://github.com/tgstation/tgstation/pull/65668 into its own separate PR.

This removes inconsistencies with blind mobs and objects that require reading.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Blindness has always been one of the most lethal status conditions for a player to have.  

This has been the case since it was implemented sometime [before 2008](https://github.com/Glloyd/Pre-Open-SS13-Host-Files-and-Source/blob/32ba79de7e56ec93f0849e3a4532a5b7c74b59b2/ss13-40.93.2-base/ss13-40.93.2-base/mob.dm) as one of the first disabilities in the game. It is not just a black HUD overlay, there are several existing code checks that restrict a blind character's actions.  These restrictions were made to further punish players severely if they had the _stupidity_ (welding without a mask) or _misfortune_ (stabbed in the eye by the clown) of acquiring the status condition in a variety of ways.  This didn't affect balance too much because... **it was curable**.  There were half a dozen different methods to fix it and nobody seriously was expected to try to play while blind.  It was designed to be temporary!

With that in mind, I thought it would be cool if I could expand the blindness code in my original [Paper DLC PR](https://github.com/tgstation/tgstation/pull/65668) to use for my illiterate quirk.  The problem was that there was a lot of consistency issues with blindness code that I attempted to resolve.  What fun is an illiterate quirk if it only stops you from reading newspapers and books?!  It would be silly and pointless so I set out to make it difficult by restricting more stuff.  People who don't know how to read and people who cannot see, results in the same literacy checks in the code.  Both illiterate and blindness use the same `can_read` proc that is used to read and write which means... 

They are identical!  Surprise surprise!!!

I received an overwhelming positive response for making a new quirk that had ALL the restrictions of blindness EXCEPT the vision loss.  

![chrome_W9d5ipPTNk](https://user-images.githubusercontent.com/5195984/163885232-53c85c76-1954-4570-aba7-95320864b39b.png)

Yet when I was forced to split my changes into separate blindness PRs they got the opposite reception:

![chrome_JhbYoqB5mo](https://user-images.githubusercontent.com/5195984/163885256-5ba3d205-d58f-4a57-a466-f4a752a5d88b.png)

- #66285
- #66287
- #66291
- #66290

The cherry on top is that several people were complaining about restricting certain items to blindness when those items already had blindness restrictions for years. (cough health cough analyzers cough)  This is pretty amusing to me since it shows that:

1. People have a knee jerk negative reaction to anything removed/nerfed
2. People will have the above reaction even if they have never experienced it or used it
3. People will have a positive reaction if you are adding something "new" to the game

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Blind people can no longer read newspapers or ids
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
