### PR TITLE
Kudzu Rebalances v2

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -146,7 +146,7 @@
 	name = "Explosive"
 	hue = "#D83A56"
 	quality = NEGATIVE
-	severity = SEVERITY_ABOVE_AVERAGE
+	severity = SEVERITY_MAJOR
 
 /datum/spacevine_mutation/explosive/on_explosion(explosion_severity, target, obj/structure/spacevine/holder)
 	if(explosion_severity < 3)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -114,7 +114,7 @@
 /datum/spacevine_mutation/proc/on_explosion(severity, target, obj/structure/spacevine/holder)
 	return
 
-/datum/spacevine_mutation/proc/additional_atmos_processes(datum/gas_mixture/air)
+/datum/spacevine_mutation/proc/additional_atmos_processes(obj/structure/spacevine/holder, datum/gas_mixture/air)
 	return
 
 /datum/spacevine_mutation/aggressive_spread/proc/aggrospread_act(obj/structure/spacevine/vine, mob/living/M)
@@ -199,7 +199,7 @@
 	. = ..()
 	holder.always_atmos_process = TRUE
 
-/datum/spacevine_mutation/temp_stabilisation/additional_atmos_processes(datum/gas_mixture/air)
+/datum/spacevine_mutation/temp_stabilisation/additional_atmos_processes(obj/structure/spacevine/holder, datum/gas_mixture/air)
 	var/heat_capacity = air.heat_capacity()
 	if(!heat_capacity) // No heating up space or vacuums
 		return
@@ -210,7 +210,7 @@
 	if(air.temperature > T20C)
 		delta_temperature *= -1
 	air.temperature += delta_temperature
-	air_update_turf(FALSE, FALSE)
+	holder.air_update_turf(FALSE, FALSE)
 
 /datum/spacevine_mutation/vine_eating
 	name = "Vine eating"
@@ -704,7 +704,7 @@
 
 /obj/structure/spacevine/atmos_expose(datum/gas_mixture/air, exposed_temperature)
 	for(var/datum/spacevine_mutation/mutation in mutations)
-		mutation.additional_atmos_processes(air)
+		mutation.additional_atmos_processes(src, air)
 	if(!can_spread && (exposed_temperature >= VINE_FREEZING_POINT || (trait_flags & SPACEVINE_COLD_RESISTANT)))
 		can_spread = TRUE // not returning here just in case its now a plasmafire and the kudzu should be deleted
 	if(exposed_temperature > FIRE_MINIMUM_TEMPERATURE_TO_SPREAD && !(trait_flags & SPACEVINE_HEAT_RESISTANT))

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -25,14 +25,18 @@
 #define MUTATIVENESS_SCALE_FACTOR 0.1
 
 /// Kudzu maximum mutation severity is a linear function of potency
-#define MAX_SEVERITY_LINEAR_COEFF 0.1
+#define MAX_SEVERITY_LINEAR_COEFF 0.15
 #define MAX_SEVERITY_CONSTANT_TERM 10
+
+/// Additional maximum mutation severity given to kudzu spawned by a random event
+#define MAX_SEVERITY_EVENT_BONUS 10
 
 /// The maximum possible productivity value of a (normal) kudzu plant, used for calculating a plant's spread cap and multiplier
 #define MAX_POSSIBLE_PRODUCTIVITY_VALUE 10
 
 /// Kudzu spread cap is a scaled version of production speed, such that the better the production speed, ie. the lower the speed value is, the faster is spreads
-#define SPREAD_CAP_SCALE_FACTOR 4
+#define SPREAD_CAP_LINEAR_COEFF 4
+#define SPREAD_CAP_CONSTANT_TERM 20
 /// Kudzu spread multiplier is a reciporal function of production speed, such that the better the production speed, ie. the lower the speed value is, the faster it spreads
 #define SPREAD_MULTIPLIER_MAX 50
 
@@ -505,10 +509,12 @@
 		vine_mutations_list[mutation] = max_mutation_severity - mutation.severity // this is intended to be before the potency check as the ideal maximum potency is used for weighting
 	if(potency != null)
 		mutativeness = potency * MUTATIVENESS_SCALE_FACTOR // If potency is 100, 10 mutativeness; if 1: 0.1 mutativeness
-		max_mutation_severity = round(potency * MAX_SEVERITY_LINEAR_COEFF + MAX_SEVERITY_CONSTANT_TERM) // If potency is 100, 20 max mutation severity; if 1, 10 max mutation severity
+		max_mutation_severity = round(potency * MAX_SEVERITY_LINEAR_COEFF + MAX_SEVERITY_CONSTANT_TERM) // If potency is 100, 25 max mutation severity; if 1, 10 max mutation severity
 	if(production != null && production <= MAX_POSSIBLE_PRODUCTIVITY_VALUE) //Prevents runtime in case production is set to 11.
-		spread_cap = SPREAD_CAP_SCALE_FACTOR * (MAX_POSSIBLE_PRODUCTIVITY_VALUE + 1 - production) //Best production speed of 1 increases spread_cap to 40, worst production speed of 10 lowers it to 4, even distribution
+		spread_cap = SPREAD_CAP_LINEAR_COEFF * (MAX_POSSIBLE_PRODUCTIVITY_VALUE + 1 - production) + SPREAD_CAP_CONSTANT_TERM //Best production speed of 1 increases spread_cap to 60, worst production speed of 10 lowers it to 24, even distribution
 		spread_multiplier = SPREAD_MULTIPLIER_MAX / (MAX_POSSIBLE_PRODUCTIVITY_VALUE + 1 - production) // Best production speed of 1: 10% of total vines will spread per second, worst production speed of 10: 1% of total vines (with minimum of 1) will spread per second
+	if(event != null) // spawned by space vine event
+		max_mutation_severity += MAX_SEVERITY_EVENT_BONUS;
 
 /datum/spacevine_controller/vv_get_dropdown()
 	. = ..()
@@ -702,3 +708,11 @@
 #undef SEVERITY_AVERAGE
 #undef SEVERITY_ABOVE_AVERAGE
 #undef SEVERITY_MAJOR
+#undef MUTATIVENESS_SCALE_FACTOR
+#undef MAX_SEVERITY_LINEAR_COEFF
+#undef MAX_SEVERITY_CONSTANT_TERM
+#undef MAX_SEVERITY_EVENT_BONUS
+#undef MAX_POSSIBLE_PRODUCTIVITY_VALUE
+#undef SPREAD_CAP_LINEAR_COEFF
+#undef SPREAD_CAP_CONSTANT_TERM
+#undef SPREAD_MULTIPLIER_MAX

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -24,7 +24,7 @@
 #define SEVERITY_MAJOR 10
 
 /// Kudzu mutativeness is based on a scale factor * potency
-#define MUTATIVENESS_SCALE_FACTOR 0.1
+#define MUTATIVENESS_SCALE_FACTOR 0.2
 
 /// Kudzu maximum mutation severity is a linear function of potency
 #define MAX_SEVERITY_LINEAR_COEFF 0.15
@@ -538,7 +538,7 @@
 	for(var/datum/spacevine_mutation/mutation as anything in vine_mutations_list)
 		vine_mutations_list[mutation] = max_mutation_severity - mutation.severity // this is intended to be before the potency check as the ideal maximum potency is used for weighting
 	if(potency != null)
-		mutativeness = potency * MUTATIVENESS_SCALE_FACTOR // If potency is 100, 10 mutativeness; if 1: 0.1 mutativeness
+		mutativeness = potency * MUTATIVENESS_SCALE_FACTOR // If potency is 100, 20 mutativeness; if 1: 0.2 mutativeness
 		max_mutation_severity = round(potency * MAX_SEVERITY_LINEAR_COEFF + MAX_SEVERITY_CONSTANT_TERM) // If potency is 100, 25 max mutation severity; if 1, 10 max mutation severity
 	if(production != null && production <= MAX_POSSIBLE_PRODUCTIVITY_VALUE) //Prevents runtime in case production is set to 11.
 		spread_cap = SPREAD_CAP_LINEAR_COEFF * (MAX_POSSIBLE_PRODUCTIVITY_VALUE + 1 - production) + SPREAD_CAP_CONSTANT_TERM //Best production speed of 1 increases spread_cap to 60, worst production speed of 10 lowers it to 24, even distribution

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -207,7 +207,7 @@
 	var/delta_temperature = energy_used / heat_capacity
 	if(delta_temperature < 0.1)
 		return
-	if(air.temperature > T20C){
+	if(air.temperature > T20C)
 		delta_temperature *= -1
 	air.temperature += delta_temperature
 	air_update_turf(FALSE, FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -19,6 +19,7 @@
 	opacity = FALSE
 	canSmoothWith = null
 	smoothing_flags = NONE
+	ranged_cooldown_time = 4 SECONDS
 	/// The amount of time it takes to create a venus human trap.
 	var/growth_time = 120 SECONDS
 	var/growth_icon = 0

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -19,7 +19,6 @@
 	opacity = FALSE
 	canSmoothWith = null
 	smoothing_flags = NONE
-	ranged_cooldown_time = 4 SECONDS
 	/// The amount of time it takes to create a venus human trap.
 	var/growth_time = 120 SECONDS
 	var/growth_icon = 0
@@ -129,6 +128,7 @@
 	melee_damage_upper = 20
 	minbodytemp = 100
 	combat_mode = TRUE
+	ranged_cooldown_time = 4 SECONDS
 	del_on_death = TRUE
 	deathmessage = "collapses into bits of plant matter."
 	attacked_sound = 'sound/creatures/venus_trap_hurt.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Increases kudzu's maximum mutation severity to 25 from 20.
- Event-spawned kudzu now will have a flat +10 bonus to its maximum severity, meaning that it'll now range from 27 to 35 to compensate for it not being manually made.
- Explosive kudzu mutation is now classified as maximum severity.
- New "Temperature stabilisation" SEVERITY_AVERAGE mutation as a compensation for coldmos and the worry that cold environments can be too harsh to kudzu without the coldproof mutation by offering another alternative. It has the same power  as the space heater at 40000J per atmos tick (101.325 kPa of air mix at 293.15K has 2079J/C of heat capacity, so around 20C change to that turf per atmos tick, even larger if its depressurised).
- Nerfs the venus human trap's vine throw by making it have the cooldown of a regular baton (4 seconds vs previously 3), since the knockdown is only 1 second long this should be fair in exchange for keeping the 85 stamina damage in.
- Doubles the mutativeness scale factor, meaning that the probability of kudzu mutating in general has been doubled.
- Also adds some previously missing #undef's at the end of the file.
- **NEW CHANGES:**
- Kudzu spread rate has been changed, event kudzu is now guaranteed to spread at least 3 times per second (which is now actually adjusted for delta_time), and in general kudzu now gets a boost when it just spawned to help it not die instantly. A graph of the new formula is https://www.desmos.com/calculator/ynvbzspkmo.
- Slightly more documentation to some of kudzu's variables
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I nerfed kudzu a bit too hard in #64675 , this rebalances it slightly by implementing some of the ideas from #65124 , especially with event kudzu it has been nerfed a bit too hard with a hull breach or crew being next to it instantly killing it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: RandomGamer123, some ideas from the-orange-cow & cacogen
balance: The explosive mutation for kudzu is now classified as a severe instead of just above average mutation
balance: Venus human trap vine throw cooldown increased to 4 seconds
balance: Kudzu's maximum mutation severity in general has been increased
balance: Event-spawned kudzu's maximum mutation severity has been further increased
balance: Kudzu now mutates twice as often in general
balance: Event-spawned kudzu now has its minimum spread rate tripled
balance: Newly spawned kudzu in general has its starting spread rate buffed
expansion: New temperature stabilisation mutation for kudzu as a semi-alternative to cold proof and being a beneficial kudzu mutation in general, effectively functions as a space heater with the target temperature being 20C
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
