### PR TITLE
Fixes the mask of madness only applying stamina damage to people ABOVE the intended threshold

### DIFF
--- a/code/modules/antagonists/heretic/items/madness_mask.dm
+++ b/code/modules/antagonists/heretic/items/madness_mask.dm
@@ -66,7 +66,7 @@
 		if(DT_PROB(40, delta_time))
 			human_in_range.Jitter(5)
 
-		if(human_in_range.getStaminaLoss() >= 85 && DT_PROB(30, delta_time))
+		if(human_in_range.getStaminaLoss() <= 85 && DT_PROB(30, delta_time))
 			human_in_range.emote(pick("giggle", "laugh"))
 			human_in_range.adjustStaminaLoss(10)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The greater than sign (>) denotes that the number after the more than sign is smaller than the number before the symbol. The less than sign (<) denotes that the number after the sign is bigger than the number before the sign. The more than sign and the less than sign are simply inverted versions of the same symbol.

There are also signs that say greater than or equal, less than or equal, and not eq

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fix bug fix bug fix bug fix bug fix bug fix bug fix bug fix bug

Closes #66283

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Mask of Madness will now properly apply stamina damage to its victims.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
