### PR TITLE
Fixes href exploits with the gas vendor

### DIFF
--- a/code/modules/atmospherics/machinery/bluespace_vendor.dm
+++ b/code/modules/atmospherics/machinery/bluespace_vendor.dm
@@ -249,28 +249,31 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/bluespace_vendor, 30)
 
 	switch(action)
 		if("start_pumping")
-			pumping = TRUE
-			selected_gas = params["gas_id"]
-			mode = BS_MODE_PUMPING
-			update_appearance()
+			if(inserted_tank && !pumping)
+				pumping = TRUE
+				selected_gas = params["gas_id"]
+				mode = BS_MODE_PUMPING
+				update_appearance()
 			. = TRUE
 		if("stop_pumping")
-			pumping = FALSE
-			selected_gas = null
-			mode = BS_MODE_IDLE
-			update_appearance()
+			if(inserted_tank && pumping)
+				pumping = FALSE
+				selected_gas = null
+				mode = BS_MODE_IDLE
+				update_appearance()
 			. = TRUE
 		if("pumping_rate")
 			tank_filling_amount = clamp(params["rate"], 0, 100)
 			. = TRUE
 		if("tank_prepare")
-			if(empty_tanks)
+			if(empty_tanks && !inserted_tank)
 				inserted_tank = TRUE
 				internal_tank = new(src)
 				empty_tanks = max(empty_tanks - 1, 0)
 			. = TRUE
 		if("tank_expel")
-			check_price(usr)
+			if(inserted_tank && !pumping)
+				check_price(usr)
 			. = TRUE
 
 #undef BS_MODE_OFF

--- a/code/modules/atmospherics/machinery/bluespace_vendor.dm
+++ b/code/modules/atmospherics/machinery/bluespace_vendor.dm
@@ -264,9 +264,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/bluespace_vendor, 30)
 			tank_filling_amount = clamp(params["rate"], 0, 100)
 			. = TRUE
 		if("tank_prepare")
-			inserted_tank = TRUE
-			internal_tank = new(src)
-			empty_tanks = max(empty_tanks - 1, 0)
+			if(empty_tanks)
+				inserted_tank = TRUE
+				internal_tank = new(src)
+				empty_tanks = max(empty_tanks - 1, 0)
 			. = TRUE
 		if("tank_expel")
 			check_price(usr)


### PR DESCRIPTION
## About The Pull Request

The buttons for the various actions of the bluespace gas vendor are only disabled client-side. This doesn't prevent href exploiters from performing actions at inappropriate times. At best, it causes runtimes, and at worst, it allows for printing infinite tanks.

## Why It's Good For The Game

We don't want href exploits, no matter how minor they may be.

## Changelog

:cl:
fix: Fixed several href exploits with the bluespace gas vendor, including one allowing it to produce infinite tanks.
/:cl:
