### PR TITLE
Nearsighted people can't read without glasses

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -770,16 +770,11 @@
 /mob/living/carbon/human/is_nearsighted()
 	if(!HAS_TRAIT(src, TRAIT_NEARSIGHT))
 		return FALSE
-		
-	// we should prolly delete this if it's not needed
-	//if(!src.glasses)
-	//	return TRUE	
-	
-	// we should probably double check this code logic to make sure it works...
+
 	var/obj/item/clothing/glasses/eyewear = src.glasses
-	if(eyewear && istype(eyewear) && eyewear.vision_correction)
+	if(istype(eyewear) && eyewear.vision_correction)
 		return FALSE
-		
+
 	return TRUE
 
 /mob/living/carbon/human/is_literate()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -767,6 +767,16 @@
 	heat_exposure_stacks = 0
 	return ..()
 
+/mob/living/carbon/human/has_nearsight_blindness()
+	if(!HAS_TRAIT(src, TRAIT_NEARSIGHT)) // check for x-ray vision and the x-ray trait too?
+		return FALSE
+	if(!src.glasses)
+		return TRUE	
+	var/obj/item/clothing/glasses/glass = src.glasses
+	if(!glass.vision_correction)
+		return TRUE
+	return FALSE
+
 /mob/living/carbon/human/is_literate()
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -767,15 +767,20 @@
 	heat_exposure_stacks = 0
 	return ..()
 
-/mob/living/carbon/human/has_nearsight_blindness()
-	if(!HAS_TRAIT(src, TRAIT_NEARSIGHT)) // check for x-ray vision and the x-ray trait too?
+/mob/living/carbon/human/is_nearsighted()
+	if(!HAS_TRAIT(src, TRAIT_NEARSIGHT))
 		return FALSE
-	if(!src.glasses)
-		return TRUE	
-	var/obj/item/clothing/glasses/glass = src.glasses
-	if(!glass.vision_correction)
-		return TRUE
-	return FALSE
+		
+	// we should prolly delete this if it's not needed
+	//if(!src.glasses)
+	//	return TRUE	
+	
+	// we should probably double check this code logic to make sure it works...
+	var/obj/item/clothing/glasses/eyewear = src.glasses
+	if(eyewear && istype(eyewear) && eyewear.vision_correction)
+		return FALSE
+		
+	return TRUE
 
 /mob/living/carbon/human/is_literate()
 	return TRUE

--- a/code/modules/mob/living/living_fov.dm
+++ b/code/modules/mob/living/living_fov.dm
@@ -45,7 +45,7 @@
 		. = TRUE
 
 	// Handling nearsightnedness
-	if(. && has_nearsight_blindness())					
+	if(. && is_nearsighted())					
 		if((rel_x >= NEARSIGHTNESS_FOV_BLINDNESS || rel_x <= -NEARSIGHTNESS_FOV_BLINDNESS) || (rel_y >= NEARSIGHTNESS_FOV_BLINDNESS || rel_y <= -NEARSIGHTNESS_FOV_BLINDNESS))
 			return FALSE
 

--- a/code/modules/mob/living/living_fov.dm
+++ b/code/modules/mob/living/living_fov.dm
@@ -45,14 +45,7 @@
 		. = TRUE
 
 	// Handling nearsightnedness
-	if(. && HAS_TRAIT(src, TRAIT_NEARSIGHT))
-		//Checking if our dude really is suffering from nearsightness! (very nice nearsightness code)
-		if(iscarbon(src))
-			var/mob/living/carbon/carbon_me = src
-			if(carbon_me.glasses)
-				var/obj/item/clothing/glasses/glass = carbon_me.glasses
-				if(glass.vision_correction)
-					return
+	if(. && has_nearsight_blindness())					
 		if((rel_x >= NEARSIGHTNESS_FOV_BLINDNESS || rel_x <= -NEARSIGHTNESS_FOV_BLINDNESS) || (rel_y >= NEARSIGHTNESS_FOV_BLINDNESS || rel_y <= -NEARSIGHTNESS_FOV_BLINDNESS))
 			return FALSE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1104,43 +1104,6 @@
 /mob/proc/is_nearsighted()
 	return FALSE
 
-/** Can this mob see in the dark
-  *
-  * This checks all traits, glasses, and robotic eyeball implants to see if the mob can see in the dark
-  * this does NOT check if the mob is missing it's eyeballs. Also see_in_dark is a BYOND mob var (that defaults to 2)
-**/
-/mob/proc/has_nightvision()
-	return see_in_dark >= 8 // the 8 should probably not be hardcoded
-
-/** Checks if there is enough light where the mob is located
-  *
-  * Args:
-  *  light_amount (optional) - A decimal amount between 1.0 through 0.0 (default is 0.2)
-**/
-/mob/proc/has_light_nearby(light_amount = LIGHTING_TILE_IS_DARK)
-	var/turf/mob_location = get_turf(src)
-	return mob_location.get_lumcount() > light_amount
-
-///Can this mob write (is literate and not blind)
-/mob/proc/can_write(obj/O)
-	if(is_blind())
-		to_chat(src, span_warning("You are blind and can't write anything!"))
-		return FALSE
-
-	if(is_nearsighted())
-		to_chat(src, span_warning("Your vision is too blurry to write anything!"))
-		return FALSE
-
-	if(!is_literate())
-		to_chat(src, span_warning("You don't know how to write."))
-		return FALSE
-
-	if(!has_light_nearby() && !has_nightvision())
-		to_chat(src, span_warning("It's too dark in here to write!"))
-		return FALSE
-
-	return TRUE
-
 /// Can this mob read
 /mob/proc/can_read(obj/O)
 	if(is_blind())
@@ -1153,10 +1116,6 @@
 
 	if(!is_literate())
 		to_chat(src, span_warning("You try to read [O], but can't comprehend any of it."))
-		return FALSE
-
-	if(!has_light_nearby() && !has_nightvision())
-		to_chat(src, span_warning("It's too dark in here to read!"))
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1100,11 +1100,16 @@
 /mob/proc/is_literate()
 	return FALSE
 
-/// Can this mob read
+///Is this mob affected by nearsight effects
+/mob/proc/has_nearsight_blindness()
+	return FALSE
+
+///Can this mob read
 /mob/proc/can_read(obj/O)
 	if(is_blind())
 		to_chat(src, span_warning("As you are trying to read [O], you suddenly feel very stupid!"))
-		return
+		return FALSE
+
 	if(!is_literate())
 		to_chat(src, span_notice("You try to read [O], but can't comprehend any of it."))
 		return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1104,7 +1104,42 @@
 /mob/proc/has_nearsight_blindness()
 	return FALSE
 
-///Can this mob read
+///Can this mob write (is literate and not blind)
+/mob/proc/can_write(obj/O)
+	if(is_blind())
+		to_chat(src, span_warning("You are blind and can't write anything!"))
+		return FALSE
+
+	if(has_nearsight_blindness())
+		to_chat(src, span_warning("Your vision is too blurry to write anything!"))
+		return FALSE
+
+	if(!is_literate())
+		to_chat(src, span_warning("You don't know how to write."))
+		return FALSE
+
+	var/turf/writing_spot = get_turf(src)
+	var/has_light_to_write = writing_spot.get_lumcount() > LIGHTING_TILE_IS_DARK
+
+	var/can_see_in_darkness = HAS_TRAIT(TRAIT_XRAY_VISION) || HAS_TRAIT(TRAIT_TRUE_NIGHT_VISION)
+	// we need to check for x-ray implants in eyeballs sight flags and other vision flags since the trait isn't always granted
+
+	var/has_nightvision_glasses = FALSE
+	var/mob/living/carbon/human/reader = src
+	if(ishuman(reader))
+		var/obj/item/clothing/glasses/eyewear = reader.glasses
+		if(istype(eyewear, /obj/item/clothing/glasses/meson/night) ||
+		istype(eyewear, /obj/item/clothing/glasses/night) ||
+		istype(eyewear, /obj/item/clothing/glasses/thermal/xray))
+			has_nightvision_glasses = TRUE
+
+	if(!has_light_to_read && !can_see_in_darkness && !has_nightvision_glasses)
+		to_chat(M, span_warning("It's too dark in here to read!"))
+		return FALSE
+
+	return TRUE
+
+///Can this mob read (is literate and not blind)
 /mob/proc/can_read(obj/O)
 	if(is_blind())
 		to_chat(src, span_warning("As you are trying to read [O], you suddenly feel very stupid!"))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1096,13 +1096,30 @@
 /mob/proc/has_nightvision()
 	return see_in_dark >= NIGHTVISION_FOV_RANGE
 
-///This mob is abile to read books
+/// This mob is abile to read books
 /mob/proc/is_literate()
 	return FALSE
 
-///Is this mob affected by nearsight effects
-/mob/proc/has_nearsight_blindness()
+/// Is this mob affected by nearsight
+/mob/proc/is_nearsighted()
 	return FALSE
+
+/** Can this mob see in the dark
+  *
+  * This checks all traits, glasses, and robotic eyeball implants to see if the mob can see in the dark
+  * this does NOT check if the mob is missing it's eyeballs. Also see_in_dark is a BYOND mob var (that defaults to 2)
+**/
+/mob/proc/has_nightvision()
+	return see_in_dark >= 8 // the 8 should probably not be hardcoded
+
+/** Checks if there is enough light where the mob is located
+  *
+  * Args:
+  *  light_amount (optional) - A decimal amount between 1.0 through 0.0 (default is 0.2)
+**/
+/mob/proc/has_light_nearby(light_amount = LIGHTING_TILE_IS_DARK)
+	var/turf/mob_location = get_turf(src)
+	return mob_location.get_lumcount() > light_amount
 
 ///Can this mob write (is literate and not blind)
 /mob/proc/can_write(obj/O)
@@ -1110,7 +1127,7 @@
 		to_chat(src, span_warning("You are blind and can't write anything!"))
 		return FALSE
 
-	if(has_nearsight_blindness())
+	if(is_nearsighted())
 		to_chat(src, span_warning("Your vision is too blurry to write anything!"))
 		return FALSE
 
@@ -1118,36 +1135,30 @@
 		to_chat(src, span_warning("You don't know how to write."))
 		return FALSE
 
-	var/turf/writing_spot = get_turf(src)
-	var/has_light_to_write = writing_spot.get_lumcount() > LIGHTING_TILE_IS_DARK
-
-	var/can_see_in_darkness = HAS_TRAIT(TRAIT_XRAY_VISION) || HAS_TRAIT(TRAIT_TRUE_NIGHT_VISION)
-	// we need to check for x-ray implants in eyeballs sight flags and other vision flags since the trait isn't always granted
-
-	var/has_nightvision_glasses = FALSE
-	var/mob/living/carbon/human/reader = src
-	if(ishuman(reader))
-		var/obj/item/clothing/glasses/eyewear = reader.glasses
-		if(istype(eyewear, /obj/item/clothing/glasses/meson/night) ||
-		istype(eyewear, /obj/item/clothing/glasses/night) ||
-		istype(eyewear, /obj/item/clothing/glasses/thermal/xray))
-			has_nightvision_glasses = TRUE
-
-	if(!has_light_to_read && !can_see_in_darkness && !has_nightvision_glasses)
-		to_chat(M, span_warning("It's too dark in here to read!"))
+	if(!has_light_nearby() && !has_nightvision())
+		to_chat(src, span_warning("It's too dark in here to write!"))
 		return FALSE
 
 	return TRUE
 
-///Can this mob read (is literate and not blind)
+/// Can this mob read
 /mob/proc/can_read(obj/O)
 	if(is_blind())
-		to_chat(src, span_warning("As you are trying to read [O], you suddenly feel very stupid!"))
+		to_chat(src, span_warning("You are blind and can't read anything!"))
+		return FALSE
+
+	if(is_nearsighted())
+		to_chat(src, span_warning("Your vision is too blurry to read anything!"))
 		return FALSE
 
 	if(!is_literate())
-		to_chat(src, span_notice("You try to read [O], but can't comprehend any of it."))
-		return
+		to_chat(src, span_warning("You try to read [O], but can't comprehend any of it."))
+		return FALSE
+
+	if(!has_light_nearby() && !has_nightvision())
+		to_chat(src, span_warning("It's too dark in here to read!"))
+		return FALSE
+
 	return TRUE
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This was split off of https://github.com/tgstation/tgstation/pull/65668 into its own separate PR.

There was discussion in the original PR about how the medical definition for nearsighted is only for far away objects instead of bad vision.  I tried to resolve this by renaming nearsighted to halfsighted in: 

- #66275 

Feel free to close this at will if this isn't going to workout.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Time to powergame by stealing all the prescription glasses.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Nearsighted people can no longer read without glasses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
