### PR TITLE
Increase operations-per-run for github stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,3 +21,4 @@ jobs:
         stale-issue-label: 'Cleanup Flagged'
         remove-issue-stale-when-updated: false
         exempt-pr-labels: 'RED LABEL,Good First PR'
+        operations-per-run: 300


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This increases operations-per-run for the stale workflow to 300.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Github stale action (eg. https://github.com/tgstation/tgstation/actions/runs/2181554927) has been running out of operations often. This leads to the cleanup flagged labelled issues, and some old PRs to have delays in having the stale label processed / being closed.
The default operations-per-run is 30 to avoid running into issues with the rate limit, but since we're running it once per day and the [rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions) is 1000 requests per hour per repository, we can increase it significantly. 300 was extrapolated from the fact that 30 operations got 146 items processed in the last action (its probably vastly overkill given that newer prs/issues need on average more requests than older mostly issues) but it shouldn't hit the rate limit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

No player facing changes.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
