### PR TITLE
Mobs can no longer read in the dark

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -53,6 +53,8 @@
 #define LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE 128
 #define LIGHTING_PLANE_ALPHA_INVISIBLE 0
 
+/// The amount of lumcount on a tile for it to be considered dark (used to determine reading and nyctophobia)
+#define LIGHTING_TILE_IS_DARK 0.2
 
 //code assumes higher numbers override lower numbers.
 #define LIGHTING_NO_UPDATE 0

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -342,7 +342,7 @@
 
 	var/lums = holder_turf.get_lumcount()
 
-	if(lums > 0.2)
+	if(lums > LIGHTING_TILE_IS_DARK)
 		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
 		return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1114,24 +1114,22 @@
 		to_chat(src, span_warning("You try to read [O], but can't comprehend any of it."))
 		return FALSE
 
-
-
 	var/turf/reading_spot = get_turf(src)
-	var/light_amount = reading_spot.get_lumcount()
+	var/has_light_to_read = reading_spot.get_lumcount() > LIGHTING_TILE_IS_DARK
+
 	var/can_see_in_darkness = HAS_TRAIT(TRAIT_XRAY_VISION) || HAS_TRAIT(TRAIT_TRUE_NIGHT_VISION)
+	// we need to check for x-ray implants in eyeballs sight flags and other vision flags since the trait isn't always granted
 
+	var/has_nightvision_glasses = FALSE
 	var/mob/living/carbon/human/reader = src
-	var/obj/item/clothing/glasses/eyewear = reader.glasses
 	if(ishuman(reader))
+		var/obj/item/clothing/glasses/eyewear = reader.glasses
+		if(istype(eyewear, /obj/item/clothing/glasses/meson/night) ||
+		istype(eyewear, /obj/item/clothing/glasses/night) ||
+		istype(eyewear, /obj/item/clothing/glasses/thermal/xray))
+			has_nightvision_glasses = TRUE
 
-	if(istype(eyewear, /obj/item/clothing/glasses/meson/night) || istype(eyewear,
-
-	var/has_nightvision_glasses =
-
-	if(light_amount < 0.2)
-
-
-		/obj/item/clothing/glasses/night
+	if(!has_light_to_read && !can_see_in_darkness && !has_nightvision_glasses)
 		to_chat(M, span_warning("It's too dark in here to read!"))
 		return FALSE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1103,11 +1103,38 @@
 /// Can this mob read
 /mob/proc/can_read(obj/O)
 	if(is_blind())
-		to_chat(src, span_warning("As you are trying to read [O], you suddenly feel very stupid!"))
-		return
+		to_chat(src, span_warning("You are blind and can't read anything!"))
+		return FALSE
+
+	if(has_nearsight_blindness())
+		to_chat(src, span_warning("Your vision is too blurry to read anything!"))
+		return FALSE
+
 	if(!is_literate())
-		to_chat(src, span_notice("You try to read [O], but can't comprehend any of it."))
-		return
+		to_chat(src, span_warning("You try to read [O], but can't comprehend any of it."))
+		return FALSE
+
+
+
+	var/turf/reading_spot = get_turf(src)
+	var/light_amount = reading_spot.get_lumcount()
+	var/can_see_in_darkness = HAS_TRAIT(TRAIT_XRAY_VISION) || HAS_TRAIT(TRAIT_TRUE_NIGHT_VISION)
+
+	var/mob/living/carbon/human/reader = src
+	var/obj/item/clothing/glasses/eyewear = reader.glasses
+	if(ishuman(reader))
+
+	if(istype(eyewear, /obj/item/clothing/glasses/meson/night) || istype(eyewear,
+
+	var/has_nightvision_glasses =
+
+	if(light_amount < 0.2)
+
+
+		/obj/item/clothing/glasses/night
+		to_chat(M, span_warning("It's too dark in here to read!"))
+		return FALSE
+
 	return TRUE
 
 /**

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1087,14 +1087,6 @@
 	if(client.mouse_override_icon)
 		client.mouse_pointer_icon = client.mouse_override_icon
 
-/// This mob is abile to read books
-/mob/proc/is_literate()
-	return FALSE
-
-/// Is this mob affected by nearsight
-/mob/proc/is_nearsighted()
-	return FALSE
-
 /** Can this mob see in the dark
   *
   * This checks all traits, glasses, and robotic eyeball implants to see if the mob can see in the dark
@@ -1102,6 +1094,10 @@
 **/
 /mob/proc/has_nightvision()
 	return see_in_dark >= NIGHTVISION_FOV_RANGE
+
+/// This mob is abile to read books
+/mob/proc/is_literate()
+	return FALSE
 
 /** Checks if there is enough light where the mob is located
   *
@@ -1112,34 +1108,10 @@
 	var/turf/mob_location = get_turf(src)
 	return mob_location.get_lumcount() > light_amount
 
-///Can this mob write (is literate and not blind)
-/mob/proc/can_write(obj/O)
-	if(is_blind())
-		to_chat(src, span_warning("You are blind and can't write anything!"))
-		return FALSE
-
-	if(is_nearsighted())
-		to_chat(src, span_warning("Your vision is too blurry to write anything!"))
-		return FALSE
-
-	if(!is_literate())
-		to_chat(src, span_warning("You don't know how to write."))
-		return FALSE
-
-	if(!has_light_nearby() && !has_nightvision())
-		to_chat(src, span_warning("It's too dark in here to write!"))
-		return FALSE
-
-	return TRUE
-
 /// Can this mob read
 /mob/proc/can_read(obj/O)
 	if(is_blind())
 		to_chat(src, span_warning("You are blind and can't read anything!"))
-		return FALSE
-
-	if(is_nearsighted())
-		to_chat(src, span_warning("Your vision is too blurry to read anything!"))
 		return FALSE
 
 	if(!is_literate())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1101,7 +1101,7 @@
   * this does NOT check if the mob is missing it's eyeballs. Also see_in_dark is a BYOND mob var (that defaults to 2)
 **/
 /mob/proc/has_nightvision()
-	return see_in_dark >= 8 // the 8 should probably not be hardcoded
+	return see_in_dark >= NIGHTVISION_FOV_RANGE
 
 /** Checks if there is enough light where the mob is located
   *

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1087,10 +1087,11 @@
 	if(client.mouse_override_icon)
 		client.mouse_pointer_icon = client.mouse_override_icon
 
-/** Can this mob see in the dark
-  *
-  * This checks all traits, glasses, and robotic eyeball implants to see if the mob can see in the dark
-  * this does NOT check if the mob is missing it's eyeballs. Also see_in_dark is a BYOND mob var (that defaults to 2)
+/**
+ * Can this mob see in the dark
+ *
+ * This checks all traits, glasses, and robotic eyeball implants to see if the mob can see in the dark
+ * this does NOT check if the mob is missing it's eyeballs. Also see_in_dark is a BYOND mob var (that defaults to 2)
 **/
 /mob/proc/has_nightvision()
 	return see_in_dark >= NIGHTVISION_FOV_RANGE
@@ -1099,10 +1100,11 @@
 /mob/proc/is_literate()
 	return FALSE
 
-/** Checks if there is enough light where the mob is located
-  *
-  * Args:
-  *  light_amount (optional) - A decimal amount between 1.0 through 0.0 (default is 0.2)
+/**
+ * Checks if there is enough light where the mob is located
+ *
+ * Args:
+ *  light_amount (optional) - A decimal amount between 1.0 through 0.0 (default is 0.2)
 **/
 /mob/proc/has_light_nearby(light_amount = LIGHTING_TILE_IS_DARK)
 	var/turf/mob_location = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This was split off of https://github.com/tgstation/tgstation/pull/65668 into its own separate PR.

Reading must now have a source of light nearby. Of course if you happen to have the ability to see in the dark then you don't need light.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

> Having a lightsource requirement to read is something I found funny. I used to play roguelike games where they wouldn't let a player read from scrolls or use magic books unless they had light. It's silly stuff like this that makes SS13 and other games amazing. It gives it depth that 99% of AAA games don't have. In testing the PDA light is sufficient enough to allow someone to read. I haven't tested other light sources, but I would find it amusing if this forces people to use lighters and candles to read.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: timothymtorres, TheBonded
expansion: Mobs can no longer read in the dark unless they have some type of night vision.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
