### PR TITLE
Removes the interaction between the "Irish Car Bomb" drink and the Clown Car for being incredibly distasteful.

### DIFF
--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -49,20 +49,6 @@
 /obj/vehicle/sealed/car/clowncar/mob_forced_enter(mob/M, silent = FALSE)
 	. = ..()
 	playsound(src, pick('sound/vehicles/clowncar_load1.ogg', 'sound/vehicles/clowncar_load2.ogg'), 75)
-	if(iscarbon(M))
-		var/mob/living/carbon/forced_mob = M
-		if(forced_mob.has_reagent(/datum/reagent/consumable/ethanol/irishcarbomb))
-			var/reagent_amount = forced_mob.reagents.get_reagent_amount(/datum/reagent/consumable/ethanol/irishcarbomb)
-			forced_mob.reagents.del_reagent(/datum/reagent/consumable/ethanol/irishcarbomb)
-			if(reagent_amount >= 30)
-				message_admins("[ADMIN_LOOKUPFLW(forced_mob)] was forced into a clown car with [reagent_amount] unit(s) of Irish Car Bomb, causing an explosion.")
-				forced_mob.log_message("was forced into a clown car with [reagent_amount] unit(s) of Irish Car Bomb, causing an explosion.", LOG_GAME)
-				audible_message(span_userdanger("You hear a rattling sound coming from the engine. That can't be good..."), null, 1)
-				addtimer(CALLBACK(src, .proc/irish_car_bomb), 5 SECONDS)
-
-/obj/vehicle/sealed/car/clowncar/proc/irish_car_bomb()
-	dump_mobs()
-	explosion(src, light_impact_range = 1)
 
 /obj/vehicle/sealed/car/clowncar/after_add_occupant(mob/M, control_flags)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Removes the interaction between the "Irish Car Bomb" drink and the Clown Car for being incredibly distasteful.

## Why It's Good For The Game

The Troubles are an active situation still by all accounts from people I've spoken with, and it's really inappropriate for us to be making fun of such a situation with joke features like this. 

The name of the drink is arguably toeing the line as well but it is technically the name of the cocktail so we can't really change it to something less offensive that bars use in place of it without stirring up a bunch of angry commentors on the github, so this'll have to do for now.

## Changelog

:cl:
del: Removes the interaction between the "Irish Car Bomb" drink and the Clown Car for being incredibly distasteful.
/:cl: