### PR TITLE
[high-priority] Fix things breaking in tgui if the asset transport type is changed mid round

### DIFF
--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -12,7 +12,8 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 /datum/asset
 	var/_abstract = /datum/asset
-	var/cached_url_mappings
+	var/cached_serialized_url_mappings
+	var/cached_serialized_url_mappings_transport_type
 
 	/// Whether or not this asset should be loaded in the "early assets" SS
 	var/early = FALSE
@@ -31,10 +32,11 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 /// Returns a cached tgui message of URL mappings
 /datum/asset/proc/get_serialized_url_mappings()
-	if (isnull(cached_url_mappings))
-		cached_url_mappings = TGUI_CREATE_MESSAGE("asset/mappings", get_url_mappings())
+	if (isnull(cached_serialized_url_mappings) || cached_serialized_url_mappings_transport_type != SSassets.transport.type)
+		cached_serialized_url_mappings = TGUI_CREATE_MESSAGE("asset/mappings", get_url_mappings())
+		cached_serialized_url_mappings_transport_type = SSassets.transport.type
 
-	return cached_url_mappings
+	return cached_serialized_url_mappings
 
 /datum/asset/proc/register()
 	return


### PR DESCRIPTION
This bug breaks disabling the cdn mid round if the cdn is broken, as well as enabling it mid round if it started the round disabled. some things fail back to byond transfers, but not all things.


High priority because disabling the cdn if it breaks is broken until this is merged.

@stylemistake test merged on the 3 populous ones