### PR TITLE
limits runtime station to 1 space ruin z level

### DIFF
--- a/_maps/runtimestation.json
+++ b/_maps/runtimestation.json
@@ -3,6 +3,7 @@
 	"map_name": "Runtime Station",
 	"map_path": "map_files/debug",
 	"map_file": "runtimestation.dmm",
+	"space_ruin_levels": 1,
 	"shuttles": {
 		"cargo": "cargo_delta"
 	}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
limits runtime station's config to 1 z level (i think coders would need to switch to a different map on their local and then switch back to runtime for it to apply if this is merged)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
runtime should load as fast as possible, we dont need to generate 7 levels, if someone wants to spawn a ruin they shouldnt rely on rng, but just spawn it with debug tools

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: runtimestation should load faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
