### PR TITLE
Adds new sounds to the circuit sound synthesizer

### DIFF
--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -50,6 +50,11 @@
 		"Warpwhistle" = 'sound/magic/warpwhistle.ogg',
 		"Hiss" = 'sound/voice/hiss1.ogg',
 		"Lizard" = 'sound/voice/lizard/lizard_scream_1.ogg',
+		"Flashbang" = 'sound/weapons/flashbang.ogg',
+		"Flash" = 'sound/weapons/flash.ogg',
+		"Whip" = 'sound/weapons/whip.ogg',
+		"Laugh Track" = 'sound/items/SitcomLaugh1.ogg',
+		"Gavel" = 'sound/items/gavel.ogg',
 	)
 	sound_file = add_option_port("Sound Option", component_options)
 	options_map = component_options

--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -42,6 +42,11 @@
 		"Sad Trombone" = 'sound/misc/sadtrombone.ogg',
 		"Warn" = 'sound/machines/warning-buzzer.ogg',
 		"Slow Clap" = 'sound/machines/slowclap.ogg',
+		"Moth Buzz" = 'sound/voice/moth/scream_moth.ogg',
+		"Squeak" = 'sound/items/toysqueak1.ogg',
+		"Rip" = 'sound/items/poster_ripped.ogg',
+		"Coinflip" = 'sound/items/coinflip.ogg',
+		"Megaphone" = 'sound/items/megaphone.ogg',
 	)
 	sound_file = add_option_port("Sound Option", component_options)
 	options_map = component_options

--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -47,6 +47,8 @@
 		"Rip" = 'sound/items/poster_ripped.ogg',
 		"Coinflip" = 'sound/items/coinflip.ogg',
 		"Megaphone" = 'sound/items/megaphone.ogg',
+		"Warpwhistle" = 'sound/magic/warpwhistle.ogg',
+		"Hiss" = 'sound/voice/hiss1.ogg',
 	)
 	sound_file = add_option_port("Sound Option", component_options)
 	options_map = component_options

--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -49,6 +49,7 @@
 		"Megaphone" = 'sound/items/megaphone.ogg',
 		"Warpwhistle" = 'sound/magic/warpwhistle.ogg',
 		"Hiss" = 'sound/voice/hiss1.ogg',
+		"Lizard" = 'sound/voice/lizard/lizard_scream_1.ogg',
 	)
 	sound_file = add_option_port("Sound Option", component_options)
 	options_map = component_options


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds Lizard Scream, Moth Buzz, Toy Squeak, Xenomorph Hiss, Warp Whistle, Poster Rip, Coinflip, Flash, Flashbang, Laugh Track, Whip, Gavel, and Megaphone to the circuit sound synthesizer
please comment other sounds you want to see in this since its easy to add and gives more creativity to circuit makers
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
more creativity for circuit coders
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Bondismyname but I wish it wasnt
qol: Circuit Sound Synthesizers have a few more options of sounds they can play
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
