### PR TITLE
Makes the blood filter not suck so much

### DIFF
--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -19,9 +19,22 @@
 /datum/surgery_step/filter_blood/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	if(!..())
 		return
-	while(target.reagents?.total_volume)
+	while(has_whitelisted_chems(target, tool))
 		if(!..())
 			break
+
+/datum/surgery_step/filter_blood/proc/has_whitelisted_chems(mob/living/carbon/target, obj/item/blood_filter/bf)
+	if(!target.reagents || !target.reagents.reagent_list.len)
+		return FALSE
+
+	if(!bf.whitelist_ids.len)
+		return TRUE
+
+	for(var/datum/reagent/chem in target.reagents.reagent_list)
+		if(bf.whitelist_ids.Find(chem.type))
+			return TRUE
+
+	return FALSE
 
 /datum/surgery_step/filter_blood
 	name = "Filter blood"

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -37,9 +37,11 @@
 	display_pain(target, "You feel a throbbing pain in your chest!")
 
 /datum/surgery_step/filter_blood/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	var/obj/item/blood_filter/bf = tool
 	if(target.reagents?.total_volume)
 		for(var/datum/reagent/chem as anything in target.reagents.reagent_list)
-			target.reagents.remove_reagent(chem.type, min(chem.volume * 0.22, 10))
+			if(!bf.whitelist_ids.len || bf.whitelist_ids.Find(chem.type))
+				target.reagents.remove_reagent(chem.type, min(chem.volume * 0.22, 10))
 	display_results(user, target, span_notice("\The [tool] pings as it finishes filtering [target]'s blood."),
 		span_notice("\The [tool] pings as it stops pumping [target]'s blood."),
 		"\The [tool] pings as it stops pumping.")

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -24,7 +24,7 @@
 			break
 
 /datum/surgery_step/filter_blood/proc/has_whitelisted_chems(mob/living/carbon/target, obj/item/blood_filter/bf)
-	if(!target.reagents || !target.reagents.reagent_list.len)
+	if(!target.reagents?.reagent_list.len)
 		return FALSE
 
 	if(!bf.whitelist_ids.len)

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -16,6 +16,13 @@
 		return FALSE
 	return ..()
 
+/datum/surgery_step/filter_blood/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
+	if(!..())
+		return
+	while(target.reagents?.total_volume)
+		if(!..())
+			break
+
 /datum/surgery_step/filter_blood
 	name = "Filter blood"
 	implements = list(/obj/item/blood_filter = 95)

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -19,19 +19,29 @@
 /datum/surgery_step/filter_blood/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	if(!..())
 		return
-	while(has_whitelisted_chems(target, tool))
+	while(has_filterable_chems(target, tool))
 		if(!..())
 			break
 
-/datum/surgery_step/filter_blood/proc/has_whitelisted_chems(mob/living/carbon/target, obj/item/blood_filter/bf)
-	if(!target.reagents?.reagent_list.len)
+/**
+ * Checks if the mob contains chems we can filter
+ *
+ * If the blood filter's whitelist is empty this checks if the mob contains any chems
+ * If the whitelist contains chems it checks if any chems in the mob match chems in the whitelist
+ *
+ * Arguments:
+ * * target - The mob to check the chems of
+ * * bloodfilter - The blood filter to check the whitelist of
+ */
+/datum/surgery_step/filter_blood/proc/has_filterable_chems(mob/living/carbon/target, obj/item/blood_filter/bloodfilter)
+	if(!length(target.reagents?.reagent_list))
 		return FALSE
 
-	if(!bf.whitelist_ids.len)
+	if(!length(bloodfilter.whitelist))
 		return TRUE
 
-	for(var/datum/reagent/chem in target.reagents.reagent_list)
-		if(bf.whitelist_ids.Find(chem.type))
+	for(var/datum/reagent/chem as anything in target.reagents.reagent_list)
+		if(chem.type in bloodfilter.whitelist)
 			return TRUE
 
 	return FALSE
@@ -50,10 +60,10 @@
 	display_pain(target, "You feel a throbbing pain in your chest!")
 
 /datum/surgery_step/filter_blood/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
-	var/obj/item/blood_filter/bf = tool
+	var/obj/item/blood_filter/bloodfilter = tool
 	if(target.reagents?.total_volume)
 		for(var/datum/reagent/chem as anything in target.reagents.reagent_list)
-			if(!bf.whitelist_ids.len || bf.whitelist_ids.Find(chem.type))
+			if(!length(bloodfilter.whitelist) || (chem.type in bloodfilter.whitelist))
 				target.reagents.remove_reagent(chem.type, min(chem.volume * 0.22, 10))
 	display_results(user, target, span_notice("\The [tool] pings as it finishes filtering [target]'s blood."),
 		span_notice("\The [tool] pings as it stops pumping [target]'s blood."),

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -45,6 +45,10 @@
 	display_results(user, target, span_notice("\The [tool] pings as it finishes filtering [target]'s blood."),
 		span_notice("\The [tool] pings as it stops pumping [target]'s blood."),
 		"\The [tool] pings as it stops pumping.")
+
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		chemscan(user, target)
+
 	return ..()
 
 /datum/surgery_step/filter_blood/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -453,3 +453,39 @@
 	attack_verb_simple = list("pump", "siphon")
 	tool_behaviour = TOOL_BLOODFILTER
 	toolspeed = 1
+	var/list/whitelist_ids = list()
+	var/list/whitelist_english = list()
+
+/obj/item/blood_filter/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "BloodFilter", name)
+		ui.open()
+
+/obj/item/blood_filter/ui_data(mob/user)
+	var/list/data = list()
+	data["whitelist"] = whitelist_english
+	return data
+
+/obj/item/blood_filter/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+	. = TRUE
+	switch(action)
+		if("add")
+			var/new_chem_name = params["name"]
+			var/chem_id = get_chem_id(new_chem_name)
+			if(!chem_id)
+				to_chat(usr, span_warning("No such known reagent exists!"))
+				return
+			if(!whitelist_ids.Find(chem_id))
+				whitelist_english += new_chem_name
+				whitelist_ids += chem_id
+
+		if("remove")
+			var/chem_name = params["reagent"]
+			var/chem_id = get_chem_id(chem_name)
+			if(whitelist_english.Find(chem_name))
+				whitelist_english -= chem_name
+				whitelist_ids -= chem_id

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -453,8 +453,8 @@
 	attack_verb_simple = list("pump", "siphon")
 	tool_behaviour = TOOL_BLOODFILTER
 	toolspeed = 1
-	var/list/whitelist_ids = list()
-	var/list/whitelist_english = list()
+	/// Assoc list of chem ids to names, used for deciding which chems to filter when used for surgery
+	var/list/whitelist = list()
 
 /obj/item/blood_filter/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -464,7 +464,10 @@
 
 /obj/item/blood_filter/ui_data(mob/user)
 	var/list/data = list()
-	data["whitelist"] = whitelist_english
+	var/list/chem_names = list()
+	for(var/key in whitelist)
+		chem_names += whitelist[key]
+	data["whitelist"] = chem_names
 	return data
 
 /obj/item/blood_filter/ui_act(action, params)
@@ -476,16 +479,14 @@
 		if("add")
 			var/new_chem_name = params["name"]
 			var/chem_id = get_chem_id(new_chem_name)
-			if(!chem_id)
+			if(!chem_id || !new_chem_name)
 				to_chat(usr, span_warning("No such known reagent exists!"))
 				return
-			if(!whitelist_ids.Find(chem_id))
-				whitelist_english += new_chem_name
-				whitelist_ids += chem_id
+			if(!(chem_id in whitelist))
+				whitelist[chem_id] = new_chem_name
+
 
 		if("remove")
 			var/chem_name = params["reagent"]
 			var/chem_id = get_chem_id(chem_name)
-			if(whitelist_english.Find(chem_name))
-				whitelist_english -= chem_name
-				whitelist_ids -= chem_id
+			whitelist -= chem_id

--- a/tgui/packages/tgui/interfaces/BloodFilter.js
+++ b/tgui/packages/tgui/interfaces/BloodFilter.js
@@ -1,0 +1,29 @@
+import { useBackend, useLocalState } from '../backend';
+import { Stack } from '../components';
+import { Window } from '../layouts';
+import { ChemFilterPane } from './ChemFilter';
+
+export const BloodFilter = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    whitelist = [],
+  } = data;
+  const [chemName, setChemName] = useLocalState(context, 'chemName', '');
+  return (
+    <Window
+      width={500}
+      height={300}>
+      <Window.Content scrollable>
+        <Stack>
+          <Stack.Item grow>
+            <ChemFilterPane
+              title="Whitelist"
+              list={whitelist}
+              reagentName={chemName}
+              onReagentInput={value => setChemName(value)} />
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a whitelist to the blood filter, you can use it in hand to bring up a UI similar to the plumbing filters. When using the blood filter for surgery it will only filter out chems in the whitelist, unless the list is empty in which case it will filter all chems.

Makes the surgery loop until all filterable chems are removed, similar to tend wounds.

Holding a health analyzer in your off hand while using the blood filter will display a chem scan of the subject after each surgery step similar to tend wounds.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
In its current state the blood filter is just awful to use. It does nothing unique, is flat out worse at its job that most purging chems, you have to click the patient after every use even though it usually takes a lot of steps to actually filter out all the chems from someone, and you can't even see how much more you have to filter without pausing the surgery to swap to a health analyzer to chem scan separately.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a whitelist to blood filters, unless the list is empty they will only remove chems in this whitelist. You can edit the list by using the filter in your hand
qol: Blood filter surgery now automatically does a chem scan after each step if you're holding a health analyzer.
qol: Blood filter surgery now automatically loops if the patient has any filterable chems in them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
