### PR TITLE
Fixes The Lizard's Gas Posters Showing Up On-Station

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
+++ b/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
@@ -31,6 +31,9 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/thelizardsgas)
 "bt" = (
+/obj/structure/sign/poster/fluff/lizards_gas_payment{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
@@ -49,9 +52,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
-	},
-/obj/structure/sign/poster/contraband/lizards_gas_power{
-	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/thelizardsgas)
@@ -235,9 +235,6 @@
 "zz" = (
 /obj/machinery/door/window,
 /obj/structure/cable,
-/obj/structure/sign/poster/contraband/lizards_gas_payment{
-	pixel_x = -32
-	},
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},
@@ -407,6 +404,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/structure/sign/poster/fluff/lizards_gas_power{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/thelizardsgas)
 "MB" = (
@@ -466,7 +466,7 @@
 /area/ruin/space/has_grav/thelizardsgas)
 "Ss" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden,
-/obj/structure/sign/poster/contraband/lizards_gas_payment{
+/obj/structure/sign/poster/fluff/lizards_gas_payment{
 	pixel_x = -32
 	},
 /turf/open/floor/iron/white/corner{

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -457,16 +457,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/random, 32)
 	desc = "DONK CO. BRAND MICROWAVABLE FOOD: MADE BY STARVING COLLEGE STUDENTS, FOR STARVING COLLEGE STUDENTS."
 	icon_state = "donk_co"
 
-/obj/structure/sign/poster/contraband/lizards_gas_payment
-	name = "Please Pay"
-	desc = "A crudely-made poster asking the reader to please pay for any items they may wish to leave the station with."
-	icon_state = "gas_payment"
-
-/obj/structure/sign/poster/contraband/lizards_gas_power
-	name = "Conserve Power"
-	desc = "A crudely-made poster asking the reader to turn off the power before they leave. Hopefully, it's turned on for their re-opening."
-	icon_state = "gas_power"
-
 /obj/structure/sign/poster/contraband/donk_co/examine_more(mob/user)
 	. = ..()
 	. += span_notice("<i>You browse some of the poster's information...</i>")
@@ -784,5 +774,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/random, 32)
 	icon_state = "aspev_delam"
 //End of AspEv posters
 
+/obj/structure/sign/poster/fluff/lizards_gas_payment
+	name = "Please Pay"
+	desc = "A crudely-made poster asking the reader to please pay for any items they may wish to leave the station with."
+	icon_state = "gas_payment"
+
+/obj/structure/sign/poster/fluff/lizards_gas_power
+	name = "Conserve Power"
+	desc = "A crudely-made poster asking the reader to turn off the power before they leave. Hopefully, it's turned on for their re-opening."
+	icon_state = "gas_power"
 
 #undef PLACE_SPEED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

There's been a bug the last four months where the posters made for The Lizard's Gas would show up in random poster spawners. I was aware of it within days of its first sighting, but I elected not to fix it because I thought it was cute with the implication that the crew was going to the gas station and looting the posters, bringing it back to station. Anyways, I've been told to change it, but that's fine. I just turn it into a "fluff" subtype, which shouldn't show up on station or in consoles any more. Very epic.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's not great posters, and it doesn't really make too much sense showing up on station. I liked the concept of it, but I'll cope.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Posters from "The Lizard's Gas" station will no longer show up station-side, shuttle-side, nor anywhere outside of the aforementioned gas station after a decree from a commander at the highest level of Nanotrasen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
