### PR TITLE
Adds sound effect to ethereal APC/light/cell channeling.

### DIFF
--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -212,6 +212,7 @@
 			if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
 				return
 			to_chat(ethereal, span_notice("You receive some charge from the APC."))
+			playsound(src, 'sound/effects/sparks4.ogg', 75, TRUE)
 			stomach.adjust_charge(APC_POWER_GAIN)
 			cell.charge -= APC_POWER_GAIN
 		return
@@ -231,6 +232,7 @@
 		return
 	if(istype(stomach))
 		to_chat(ethereal, span_notice("You transfer some power to the APC."))
+		playsound(src, 'sound/effects/sparks4.ogg', 75, TRUE)
 		stomach.adjust_charge(-APC_POWER_GAIN)
 		cell.charge += APC_POWER_GAIN
 	else

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -194,6 +194,7 @@
 					return
 				if(istype(stomach))
 					to_chat(H, span_notice("You receive some charge from [src], wasting some in the process."))
+					playsound(src, 'sound/effects/sparks2.ogg', 75, TRUE)
 					stomach.adjust_charge(CELL_POWER_GAIN)
 					charge -= CELL_POWER_DRAIN //you waste way more than you receive, so that ethereals cant just steal one cell and forget about hunger
 				else

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -459,6 +459,7 @@
 				stomach.drain_time = world.time + LIGHT_DRAIN_TIME
 				if(istype(stomach))
 					to_chat(electrician, span_notice("You receive some charge from the [fitting]."))
+					playsound(src, 'sound/effects/sparks2.ogg', 75, TRUE)
 					stomach.adjust_charge(LIGHT_POWER_GAIN)
 				else
 					to_chat(electrician, span_warning("You can't receive charge from the [fitting]!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Channeling now plays a sparks.ogg sound effect whenever an ethereal channels power from a lightbulb/cell/APC.

## Why It's Good For The Game

More sound effects are good, we already had the spark effects in the code so I just implemented them here. You'll now be able to tell that an ethereal is charging by the sound effect, where before it would just look like they were standing next to a lightbulb or apc for an extended period of time.

## Changelog

:cl:
qol: Ethereal channeling from cells/APCs/lights now plays a sound effect
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
