### PR TITLE
Converts drugginess to status effect, striking another var processed on life()

### DIFF
--- a/code/__DEFINES/alerts.dm
+++ b/code/__DEFINES/alerts.dm
@@ -35,7 +35,6 @@
 
 //drunk alerts
 #define ALERT_DRUNK "drunk"
-#define ALERT_HIGH "high"
 
 /** Alien related */
 #define ALERT_XENO_FIRE "alien_fire"

--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -15,11 +15,9 @@
 #define LANGUAGE_CURATOR "curator"
 #define LANGUAGE_GLAND "gland"
 #define LANGUAGE_HAT "hat"
-#define LANGUAGE_HIGH "high"
 #define LANGUAGE_MALF "malf"
 #define LANGUAGE_PIRATE "pirate"
 #define LANGUAGE_MASTER "master"
 #define LANGUAGE_SOFTWARE "software"
 #define LANGUAGE_STONER "stoner"
 #define LANGUAGE_VOICECHANGE "voicechange"
-

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -226,11 +226,6 @@
 		or something covering your eyes."
 	icon_state = ALERT_BLIND
 
-/atom/movable/screen/alert/high
-	name = "High"
-	desc = "Whoa man, you're tripping balls! Careful you don't get addicted... if you aren't already."
-	icon_state = "high"
-
 /atom/movable/screen/alert/hypnosis
 	name = "Hypnosis"
 	desc = "Something's hypnotizing you, but you're not really sure about what."

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -55,4 +55,4 @@ Bonus
 			if(M.dizziness <= 70)
 				M.dizziness += 30
 			if(power >= 2)
-				M.set_drugginess(40)
+				M.set_timed_status_effect(80 SECONDS, /datum/status_effect/drugginess)

--- a/code/datums/status_effects/debuffs/drugginess.dm
+++ b/code/datums/status_effects/debuffs/drugginess.dm
@@ -1,0 +1,38 @@
+/// Drugginess / "high" effect, makes your screen rainbow
+/datum/status_effect/drugginess
+	id = "drugged"
+	alert_type = /atom/movable/screen/alert/status_effect/high
+
+/datum/status_effect/drugginess/on_creation(mob/living/new_owner, duration = 10 SECONDS)
+	src.duration = duration
+	return ..()
+
+/datum/status_effect/drugginess/on_apply()
+	RegisterSignal(owner, list(COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_LIVING_DEATH), .proc/remove_drugginess)
+
+	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, id, /datum/mood_event/high)
+	owner.overlay_fullscreen(id, /atom/movable/screen/fullscreen/high)
+	owner.sound_environment_override = SOUND_ENVIRONMENT_DRUGGED
+	owner.grant_language(/datum/language/beachbum, TRUE, TRUE, id)
+	return TRUE
+
+/datum/status_effect/drugginess/on_remove()
+	UnregisterSignal(owner, list(COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_LIVING_DEATH))
+
+	SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, id)
+	owner.clear_fullscreen(id)
+	if(owner.sound_environment_override == SOUND_ENVIRONMENT_DRUGGED)
+		owner.sound_environment_override = SOUND_ENVIRONMENT_NONE
+	owner.remove_language(/datum/language/beachbum, TRUE, TRUE, id)
+
+/// Removes all of our drugginess (self delete) on signal
+/datum/status_effect/drugginess/proc/remove_drugginess(datum/source, admin_revive)
+	SIGNAL_HANDLER
+
+	qdel(src)
+
+/// The status effect for "drugginess"
+/atom/movable/screen/alert/status_effect/high
+	name = "High"
+	desc = "Whoa man, you're tripping balls! Careful you don't get addicted... if you aren't already."
+	icon_state = "high"

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -491,7 +491,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	var/mob/living/carbon/spawned_carbon = hangover_mob
 	spawned_carbon.set_resting(TRUE, silent = TRUE)
 	if(prob(50))
-		spawned_carbon.adjust_drugginess(rand(15, 20))
+		spawned_carbon.adjust_timed_status_effect(rand(30 SECONDS, 40 SECONDS), /datum/status_effect/drugginess)
 	else
 		spawned_carbon.drunkenness += rand(15, 25)
 	spawned_carbon.adjust_disgust(rand(5, 55)) //How hungover are you?

--- a/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
+++ b/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
@@ -18,7 +18,7 @@
 /datum/reagent/blob/regenerative_materia/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/overmind)
 	. = ..()
 	reac_volume = return_mob_expose_reac_volume(exposed_mob, methods, reac_volume, show_message, touch_protection, overmind)
-	exposed_mob.adjust_drugginess(reac_volume)
+	exposed_mob.adjust_timed_status_effect(reac_volume * 2 SECONDS, /datum/status_effect/drugginess)
 	if(exposed_mob.reagents)
 		exposed_mob.reagents.add_reagent(/datum/reagent/blob/regenerative_materia, 0.2*reac_volume)
 		exposed_mob.reagents.add_reagent(/datum/reagent/toxin/spore, 0.2*reac_volume)

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -38,15 +38,3 @@
 	. = ..()
 	if(.)
 		update_hair()
-
-/mob/living/carbon/human/set_drugginess(amount)
-	..()
-	if(!amount)
-		remove_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_HIGH)
-
-/mob/living/carbon/human/adjust_drugginess(amount)
-	..()
-	if(druggy)
-		grant_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_HIGH)
-	else
-		remove_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_HIGH)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -468,9 +468,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	else
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "jittery")
 
-	if(druggy)
-		adjust_drugginess(-0.5 * delta_time)
-
 	if(silent)
 		silent = max(silent - (0.5 * delta_time), 0)
 

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -20,29 +20,6 @@
 	if(getStaminaLoss() < 120) // Puts you a little further into the initial stamcrit, makes stamcrit harder to outright counter with chems.
 		adjustStaminaLoss(30, FALSE)
 
-
-/mob/living/carbon/adjust_drugginess(amount)
-	druggy = max(druggy+amount, 0)
-	if(druggy)
-		overlay_fullscreen("high", /atom/movable/screen/fullscreen/high)
-		throw_alert(ALERT_HIGH, /atom/movable/screen/alert/high)
-		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "high", /datum/mood_event/high)
-		sound_environment_override = SOUND_ENVIRONMENT_DRUGGED
-	else
-		clear_fullscreen("high")
-		clear_alert(ALERT_HIGH)
-		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "high")
-		sound_environment_override = SOUND_ENVIRONMENT_NONE
-
-/mob/living/carbon/set_drugginess(amount)
-	druggy = max(amount, 0)
-	if(druggy)
-		overlay_fullscreen("high", /atom/movable/screen/fullscreen/high)
-		throw_alert(ALERT_HIGH, /atom/movable/screen/alert/high)
-	else
-		clear_fullscreen("high")
-		clear_alert(ALERT_HIGH)
-
 /mob/living/carbon/adjust_disgust(amount)
 	disgust = clamp(disgust+amount, 0, DISGUST_LEVEL_MAXEDOUT)
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -79,7 +79,6 @@
 		if(SSlag_switch.measures[DISABLE_DEAD_KEYLOOP] && !client?.holder)
 			to_chat(src, span_deadsay(span_big("Observer freelook is disabled.\nPlease use Orbit, Teleport, and Jump to look around.")))
 			ghostize(TRUE)
-	set_drugginess(0)
 	set_disgust(0)
 	SetSleeping(0, 0)
 	reset_perspective(null)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1630,9 +1630,6 @@
 				return FALSE
 		if(NAMEOF(src, health)) //this doesn't work. gotta use procs instead.
 			return FALSE
-		if(NAMEOF(src, druggy))
-			set_drugginess(var_value)
-			. = TRUE
 		if(NAMEOF(src, resting))
 			set_resting(var_value)
 			. = TRUE

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -113,14 +113,6 @@
 	else
 		game_plane_master_controller.remove_filter("eye_blur")
 
-///Adjust the drugginess of a mob
-/mob/proc/adjust_drugginess(amount)
-	return
-
-///Set the drugginess of a mob
-/mob/proc/set_drugginess(amount)
-	return
-
 ///Adjust the disgust level of a mob
 /mob/proc/adjust_disgust(amount)
 	return

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1466,7 +1466,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_price = DRINK_PRICE_HIGH
 
 /datum/reagent/consumable/ethanol/atomicbomb/on_mob_life(mob/living/carbon/drinker, delta_time, times_fired)
-	drinker.set_timed_status_effect(50 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
+	drinker.set_timed_status_effect(100 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
 		drinker.set_confusion(max(drinker.get_confusion() + (2 * REM * delta_time),0))
 		drinker.Dizzy(10 * REM * delta_time)
@@ -1503,7 +1503,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			if(DT_PROB(30, delta_time))
 				drinker.set_confusion(max(drinker.get_confusion() + 3, 0))
 		if(55 to 200)
-			drinker.set_timed_status_effect(55 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
+			drinker.set_timed_status_effect(110 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 		if(200 to INFINITY)
 			drinker.adjustToxLoss(2 * REM * delta_time, 0)
 			. = TRUE
@@ -1526,7 +1526,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return (pick(TRAIT_PARALYSIS_L_ARM,TRAIT_PARALYSIS_R_ARM,TRAIT_PARALYSIS_R_LEG,TRAIT_PARALYSIS_L_LEG))
 
 /datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/drinker, delta_time, times_fired)
-	drinker.set_timed_status_effect(50 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
+	drinker.set_timed_status_effect(100 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 	drinker.dizziness += 2 * REM * delta_time
 	drinker.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1 * REM * delta_time, 150)
 	if(DT_PROB(10, delta_time))

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -319,7 +319,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/consumable/ethanol/threemileisland/on_mob_life(mob/living/carbon/drinker, delta_time, times_fired)
-	drinker.set_drugginess(50 * REM * delta_time)
+	drinker.set_timed_status_effect(100 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 	return ..()
 
 /datum/reagent/consumable/ethanol/gin
@@ -965,7 +965,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/drinker, delta_time, times_fired)
-	drinker.set_drugginess(30 * REM * delta_time)
+	drinker.set_timed_status_effect(1 MINUTES * REM * delta_time, /datum/status_effect/drugginess)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda
@@ -1466,7 +1466,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_price = DRINK_PRICE_HIGH
 
 /datum/reagent/consumable/ethanol/atomicbomb/on_mob_life(mob/living/carbon/drinker, delta_time, times_fired)
-	drinker.set_drugginess(50 * REM * delta_time)
+	drinker.set_timed_status_effect(50 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 	if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
 		drinker.set_confusion(max(drinker.get_confusion() + (2 * REM * delta_time),0))
 		drinker.Dizzy(10 * REM * delta_time)
@@ -1503,7 +1503,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			if(DT_PROB(30, delta_time))
 				drinker.set_confusion(max(drinker.get_confusion() + 3, 0))
 		if(55 to 200)
-			drinker.set_drugginess(55 * REM * delta_time)
+			drinker.set_timed_status_effect(55 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 		if(200 to INFINITY)
 			drinker.adjustToxLoss(2 * REM * delta_time, 0)
 			. = TRUE
@@ -1526,7 +1526,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return (pick(TRAIT_PARALYSIS_L_ARM,TRAIT_PARALYSIS_R_ARM,TRAIT_PARALYSIS_R_LEG,TRAIT_PARALYSIS_L_LEG))
 
 /datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/drinker, delta_time, times_fired)
-	drinker.set_drugginess(50 * REM * delta_time)
+	drinker.set_timed_status_effect(50 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 	drinker.dizziness += 2 * REM * delta_time
 	drinker.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1 * REM * delta_time, 150)
 	if(DT_PROB(10, delta_time))
@@ -1576,25 +1576,25 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	switch(current_cycle)
 		if(1 to 5)
 			drinker.Dizzy(10 * REM * delta_time)
-			drinker.set_drugginess(30 * REM * delta_time)
+			drinker.set_timed_status_effect(1 MINUTES * REM * delta_time, /datum/status_effect/drugginess)
 			if(DT_PROB(5, delta_time))
 				drinker.emote(pick("twitch","giggle"))
 		if(5 to 10)
 			drinker.Jitter(20 * REM * delta_time)
 			drinker.Dizzy(20 * REM * delta_time)
-			drinker.set_drugginess(45 * REM * delta_time)
+			drinker.set_timed_status_effect(1.5 MINUTES * REM * delta_time, /datum/status_effect/drugginess)
 			if(DT_PROB(10, delta_time))
 				drinker.emote(pick("twitch","giggle"))
 		if (10 to 200)
 			drinker.Jitter(40 * REM * delta_time)
 			drinker.Dizzy(40 * REM * delta_time)
-			drinker.set_drugginess(60 * REM * delta_time)
+			drinker.set_timed_status_effect(2 MINUTES * REM * delta_time, /datum/status_effect/drugginess)
 			if(DT_PROB(16, delta_time))
 				drinker.emote(pick("twitch","giggle"))
 		if(200 to INFINITY)
 			drinker.Jitter(60 * REM * delta_time)
 			drinker.Dizzy(60 * REM * delta_time)
-			drinker.set_drugginess(75 * REM * delta_time)
+			drinker.set_timed_status_effect(2.5 MINUTES * REM * delta_time, /datum/status_effect/drugginess)
 			if(DT_PROB(23, delta_time))
 				drinker.emote(pick("twitch","giggle"))
 			if(DT_PROB(16, delta_time))

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -466,7 +466,7 @@
 
 /datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.Jitter(20 * REM * delta_time)
-	M.set_drugginess(30 * REM * delta_time)
+	M.set_timed_status_effect(1 MINUTES * REM * delta_time, /datum/status_effect/drugginess)
 	M.dizziness += 1.5 * REM * delta_time
 	M.set_drowsyness(0)
 	M.AdjustSleeping(-40 * REM * delta_time)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -18,7 +18,7 @@
 	addiction_types = list(/datum/addiction/hallucinogens = 10) //4 per 2 seconds
 
 /datum/reagent/drug/space_drugs/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.set_drugginess(15 * REM * delta_time)
+	M.set_timed_status_effect(30 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 	if(isturf(M.loc) && !isspaceturf(M.loc) && !HAS_TRAIT(M, TRAIT_IMMOBILIZED) && DT_PROB(5, delta_time))
 		step(M, pick(GLOB.cardinals))
 	if(DT_PROB(3.5, delta_time))

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -996,7 +996,7 @@
 /datum/reagent/consumable/peanut_butter/on_mob_life(mob/living/carbon/M, delta_time, times_fired) //ET loves peanut butter
 	if(isabductor(M))
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "ET_pieces", /datum/mood_event/et_pieces, name)
-		M.set_drugginess(15 * REM * delta_time)
+		M.set_timed_status_effect(30 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 	..()
 
 /datum/reagent/consumable/vinegar

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -117,7 +117,7 @@
 	..()
 	if(!isplasmaman(M))
 		return
-	M.set_drugginess(15 * REM * delta_time)
+	M.set_timed_status_effect(30 SECONDS * REM * delta_time, /datum/status_effect/drugginess)
 	if(M.hallucination < volume)
 		M.hallucination += 5 * REM * delta_time
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1109,6 +1109,7 @@
 #include "code\datums\status_effects\status_effect.dm"
 #include "code\datums\status_effects\wound_effects.dm"
 #include "code\datums\status_effects\debuffs\debuffs.dm"
+#include "code\datums\status_effects\debuffs\drugginess.dm"
 #include "code\datums\status_effects\debuffs\speech_debuffs.dm"
 #include "code\datums\weather\weather.dm"
 #include "code\datums\weather\weather_types\ash_storm.dm"


### PR DESCRIPTION
## About The Pull Request

Changes drugginess from a var on /living to a status effect.

Changes the beachbum language from drugginess to be granted to anyone experiencing drugginess, rather than just humans. I'm not sure if this was done for any explicit reason but it can easily be restored with an ishuman check - I just didn't see a need for it. 

## Why It's Good For The Game

See #66031 . 
Moves vars off of living processed on Life() to status effect datums.
Makes drugginess more consistently tracked, increased, decreased, and removed. 

## Changelog

:cl: Melbert
refactor: Drugginess is now a status effect. Now any living mob can be high and speak beach-bum instead of just carbons and humanoids. Drug effects should also be more consistently removed on aheal / in rare cases. 
/:cl:
