### PR TITLE
Nuke Ops Ordnance Lab usability fixes

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -421,7 +421,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_mixing_input{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/vacuum,
 /area/syndicate_mothership/expansion_bombthreat)
 "br" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -992,10 +992,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/sign/poster/contraband/c20r{
 	pixel_x = 32
 	},
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/plating,
 /area/syndicate_mothership/expansion_bombthreat)
 "cR" = (
@@ -1299,6 +1299,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/tdome/administration)
+"dK" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/pipe_dispenser,
+/turf/open/floor/mineral/plastitanium/red,
+/area/syndicate_mothership/expansion_bombthreat)
 "dL" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron,
@@ -3603,11 +3611,8 @@
 /turf/open/floor/catwalk_floor/titanium,
 /area/syndicate_mothership/control)
 "kf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/pump/on,
-/obj/machinery/light/small/red/directional/east,
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/syndicate_mothership/expansion_bombthreat)
 "kg" = (
@@ -3623,13 +3628,28 @@
 /area/syndicate_mothership/expansion_chemicalwarfare)
 "ki" = (
 /obj/structure/rack,
+/obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/item/stock_parts/micro_laser/high{
+	pixel_x = 12
+	},
 /obj/item/wrench{
 	desc = "A little smidgeon of Freon...";
 	name = "Freon"
 	},
-/obj/machinery/light/cold/directional/west,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 8
+/obj/item/stock_parts/micro_laser/high{
+	pixel_x = -4;
+	pixel_y = -8
+	},
+/obj/item/stock_parts/micro_laser/high{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/micro_laser/high{
+	pixel_x = -8;
+	pixel_y = -4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -5303,7 +5323,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/control)
 "oY" = (
-/turf/open/floor/engine,
+/turf/open/floor/engine/vacuum,
 /area/syndicate_mothership/expansion_bombthreat)
 "oZ" = (
 /obj/structure/closet/secure_closet/freezer/meat/open,
@@ -5324,6 +5344,12 @@
 /obj/item/food/meat/slab/synthmeat,
 /turf/open/floor/catwalk_floor,
 /area/centcom/holding)
+"pa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/indestructible/opsglass,
+/area/syndicate_mothership/expansion_bombthreat)
 "pb" = (
 /turf/open/misc/asteroid/snow/airless,
 /area/syndicate_mothership/control)
@@ -5920,6 +5946,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
+"qK" = (
+/obj/machinery/air_sensor{
+	chamber_id = "nukiebase"
+	},
+/turf/open/floor/engine/vacuum,
+/area/syndicate_mothership/expansion_bombthreat)
 "qM" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -6707,7 +6739,6 @@
 /turf/open/floor/iron/textured_large,
 /area/syndicate_mothership/control)
 "tC" = (
-/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 6
 	},
@@ -7070,7 +7101,7 @@
 /obj/machinery/door/poddoor/incinerator_ordmix{
 	id = "syn_ordmix_vent"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/vacuum,
 /area/syndicate_mothership/expansion_bombthreat)
 "uV" = (
 /obj/item/paper_bin,
@@ -7134,6 +7165,13 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
 /area/centcom/ferry)
+"vc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/syndicate_mothership/expansion_bombthreat)
 "vd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -7325,13 +7363,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/centcom/control)
-"vI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plating,
-/area/syndicate_mothership/expansion_bombthreat)
 "vJ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -8488,7 +8519,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
 "zh" = (
@@ -9658,6 +9689,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
 /turf/open/floor/catwalk_floor/iron,
 /area/syndicate_mothership/control)
+"Cl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/syndicate_mothership/control)
 "Cm" = (
 /obj/structure/closet/crate/freezer{
 	name = "pantry crate"
@@ -10480,7 +10517,7 @@
 /obj/machinery/igniter/incinerator_ordmix{
 	id = "syn_ordmix_igniter"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/vacuum,
 /area/syndicate_mothership/expansion_bombthreat)
 "EI" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -10727,6 +10764,9 @@
 "Fn" = (
 /obj/machinery/light/cold/directional/south,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership/control)
 "Fo" = (
@@ -10739,10 +10779,10 @@
 /turf/open/floor/plating,
 /area/centcom/prison)
 "Fp" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
 "Fr" = (
@@ -11034,6 +11074,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/machinery/camera/autoname/directional/south{
 	network = list("nukie")
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership/control)
@@ -11406,6 +11449,12 @@
 "Hv" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/courtroom)
+"Hw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/indestructible/syndicate,
+/area/syndicate_mothership/expansion_bombthreat)
 "Hy" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/catwalk_floor,
@@ -11500,7 +11549,10 @@
 /area/syndicate_mothership/control)
 "HO" = (
 /obj/effect/turf_decal/stripes/box,
-/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/portable_atmospherics/pump{
+	name = "Lil Pump";
+	desc = "A betrayer to pump-kind."
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership/expansion_bombthreat)
 "HQ" = (
@@ -11636,6 +11688,9 @@
 /obj/structure/sign/poster/contraband/energy_swords{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership/control)
 "Ii" = (
@@ -11646,12 +11701,11 @@
 /area/centcom/evacuation/ship)
 "Ik" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/light/small/red/directional/south,
 /obj/structure/sign/poster/contraband/fun_police{
 	pixel_x = -32
 	},
@@ -11980,6 +12034,12 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/arena)
+"Je" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/indestructible/rock/snow,
+/area/syndicate_mothership/control)
 "Jg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -12830,12 +12890,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/syndicate_mothership/control)
 "Mc" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/south{
-	network = list("nukie")
 	},
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -12852,7 +12908,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/canister/tier_2,
 /turf/open/floor/plating,
 /area/syndicate_mothership/expansion_bombthreat)
 "Mg" = (
@@ -13255,6 +13311,14 @@
 	heat_capacity = 1e+006
 	},
 /area/tdome/observation)
+"Nm" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/light/small/red/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/syndicate_mothership/expansion_bombthreat)
 "Nn" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/lockbox/loyalty,
@@ -14162,6 +14226,12 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/catwalk_floor,
 /area/centcom/holding)
+"PJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/indestructible/syndicate,
+/area/syndicate_mothership/control)
 "PK" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -14344,6 +14414,13 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/observation)
+"Qj" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/syndicate_mothership/control)
 "Qk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/indestructible{
@@ -14405,6 +14482,11 @@
 /obj/structure/flora/grass/both,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/syndicate_mothership/control)
+"Qt" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/airalarm/directional/south,
+/turf/closed/indestructible/syndicate,
+/area/syndicate_mothership/expansion_bioterrorism)
 "Qu" = (
 /obj/structure/window/paperframe{
 	can_atmos_pass = 0
@@ -15119,7 +15201,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/canister/tier_2,
 /turf/open/floor/plating,
 /area/syndicate_mothership/expansion_bombthreat)
 "Su" = (
@@ -16014,6 +16096,18 @@
 /obj/item/stack/spacecash/c20,
 /turf/open/floor/iron/dark/textured_half,
 /area/syndicate_mothership/control)
+"UK" = (
+/obj/machinery/computer/atmos_control/noreconnect{
+	dir = 1;
+	pixel_y = -1;
+	atmos_chambers = list("nukiebase" = "Burn Chamber")
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small/red/directional/east{
+	dir = 2
+	},
+/turf/open/floor/mineral/titanium/tiled/yellow,
+/area/syndicate_mothership/expansion_bombthreat)
 "UL" = (
 /obj/machinery/light/floor{
 	pixel_x = 4;
@@ -16073,11 +16167,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/centcom/holding)
 "UT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -16322,6 +16416,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/centcom/admin)
+"VA" = (
+/obj/machinery/computer/atmos_control/noreconnect{
+	dir = 4;
+	pixel_x = -5;
+	pixel_y = -2;
+	atmos_chambers = list("nukiebase" = "Burn Chamber")
+	},
+/obj/machinery/computer/atmos_control/noreconnect{
+	dir = 4;
+	pixel_x = -5;
+	pixel_y = -2;
+	atmos_chambers = list("nukiebase" = "Burn Chamber")
+	},
+/turf/closed/indestructible/opsglass,
+/area/syndicate_mothership/expansion_bioterrorism)
 "VB" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -16440,7 +16549,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/vacuum,
 /area/syndicate_mothership/expansion_bombthreat)
 "VV" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -17196,6 +17305,9 @@
 	pixel_x = 5;
 	pixel_y = -29
 	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("nukie")
+	},
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/syndicate_mothership/expansion_bombthreat)
 "XH" = (
@@ -17384,6 +17496,12 @@
 "Yn" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/supplypod)
+"Yp" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/closed/indestructible/rock/snow,
+/area/syndicate_mothership/control)
 "Yq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -17606,7 +17724,6 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
 	},
-/obj/machinery/light/small/red/directional/west,
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/syndicate_mothership/expansion_bombthreat)
 "YY" = (
@@ -17863,8 +17980,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/light/cold/directional/east,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/syndicate_mothership/expansion_bombthreat)
 "ZE" = (
@@ -22542,9 +22659,9 @@ kb
 kb
 kb
 kb
-aa
-aa
-aa
+kb
+kb
+kb
 aa
 aa
 aa
@@ -22799,8 +22916,8 @@ nH
 nH
 nH
 kb
-aa
 kb
+Yp
 kb
 kb
 kb
@@ -23057,7 +23174,7 @@ zX
 nH
 kb
 kb
-kb
+Je
 CN
 CN
 CN
@@ -23314,7 +23431,7 @@ EN
 nH
 ng
 ng
-ng
+PJ
 CN
 cj
 VV
@@ -23571,7 +23688,7 @@ ax
 nH
 nw
 nw
-nw
+Cl
 CN
 UY
 Gj
@@ -23828,8 +23945,8 @@ tx
 nH
 nw
 nw
-nw
-CN
+Cl
+Qt
 Kw
 pS
 uk
@@ -24085,7 +24202,7 @@ SA
 nH
 ng
 ac
-ng
+PJ
 CN
 IH
 pS
@@ -24343,7 +24460,7 @@ nH
 gL
 FD
 Ih
-RK
+VA
 Il
 Na
 Sf
@@ -24599,7 +24716,7 @@ Ev
 we
 br
 Bq
-fQ
+Qj
 DB
 qM
 uk
@@ -24856,7 +24973,7 @@ EN
 HU
 br
 Bq
-fQ
+Qj
 RK
 mb
 HV
@@ -25371,14 +25488,14 @@ nH
 ay
 Bq
 Fn
-kv
+Hw
 Ma
 IV
 ki
 Td
 Zp
 Ik
-kv
+Nm
 kv
 kv
 kv
@@ -25628,7 +25745,7 @@ nz
 br
 Bq
 fQ
-of
+pa
 Ch
 BD
 uu
@@ -25894,7 +26011,7 @@ Nv
 HO
 XG
 kv
-oY
+qK
 EH
 kv
 kb
@@ -26143,7 +26260,7 @@ br
 Bq
 fQ
 of
-Fp
+dK
 UT
 Fp
 zg
@@ -26406,8 +26523,8 @@ BD
 Us
 Ks
 Mc
+UK
 Yg
-kv
 uU
 uU
 kv
@@ -26658,8 +26775,8 @@ tz
 ng
 kv
 Me
-vI
 bF
+vc
 Ia
 Hl
 sh

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1308,10 +1308,14 @@
 	},
 /obj/structure/rack,
 /obj/item/analyzer{
-	pixel_y = -7;
-	pixel_x = 7
+	pixel_y = 1;
+	pixel_x = 2
 	},
-/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_y = -3;
+	desc = "A device used to rapidly pipe things. This one has a curious abundance of warning labels.";
+	name = "Syndicate Rapid Pipe Dispenser (RPD)"
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
 "dL" = (
@@ -4236,9 +4240,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 10
 	},
-/obj/machinery/light/cold/directional/west{
-	dir = 4
-	},
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/syndicate_mothership/expansion_bombthreat)
 "lV" = (
@@ -4806,6 +4808,12 @@
 "nE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /turf/closed/indestructible/opsglass,
+/area/syndicate_mothership/expansion_bombthreat)
+"nF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/indestructible/syndicate,
 /area/syndicate_mothership/expansion_bombthreat)
 "nG" = (
 /obj/machinery/computer/security/mining{
@@ -6860,12 +6868,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
-"tQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/indestructible/opsglass,
-/area/syndicate_mothership/expansion_bombthreat)
 "tR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9699,7 +9701,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
 "Ci" = (
@@ -9996,12 +10000,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/control)
-"Db" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/closed/indestructible/syndicate,
-/area/syndicate_mothership/expansion_bombthreat)
 "Dd" = (
 /obj/machinery/door/window/survival_pod{
 	dir = 8;
@@ -10948,6 +10946,15 @@
 	dir = 8
 	},
 /area/syndicate_mothership/control)
+"FL" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/syndicate_mothership/expansion_bombthreat)
 "FM" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
@@ -11713,14 +11720,15 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evacuation/ship)
 "Ik" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
 /obj/structure/sign/poster/contraband/fun_police{
 	pixel_x = -32
+	},
+/obj/machinery/light/cold/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -11998,8 +12006,8 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -12890,7 +12898,9 @@
 /turf/closed/mineral/ash_rock,
 /area/awaymission/errorroom)
 "Ma" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
@@ -13328,16 +13338,6 @@
 	heat_capacity = 1e+006
 	},
 /area/tdome/observation)
-"Nm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/airalarm/unlocked{
-	pixel_y = -24
-	},
-/obj/machinery/light/cold/directional/west,
-/turf/open/floor/mineral/plastitanium,
-/area/syndicate_mothership/expansion_bombthreat)
 "Nn" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/lockbox/loyalty,
@@ -15036,7 +15036,7 @@
 /area/centcom/control)
 "RS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
+	dir = 10
 	},
 /turf/closed/indestructible/syndicate,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -16257,6 +16257,12 @@
 	dir = 4
 	},
 /area/centcom/holding)
+"Va" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/indestructible/syndicate,
+/area/syndicate_mothership/expansion_bombthreat)
 "Vc" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/iron/dark,
@@ -17716,6 +17722,10 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
+	},
+/obj/machinery/airalarm/unlocked{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -25225,8 +25235,8 @@ br
 Bq
 Gm
 RS
-kv
-kv
+nF
+Va
 kv
 kv
 kv
@@ -25481,14 +25491,14 @@ nH
 ay
 Bq
 Fn
-Db
+kv
 Ma
 IV
 ki
 Td
 Zp
 Ik
-Nm
+kv
 kv
 kv
 kv
@@ -25738,9 +25748,9 @@ nz
 br
 Bq
 fQ
-tQ
+of
 Ch
-BD
+FL
 uu
 tk
 rE

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6742,12 +6742,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/syndicate_mothership/control)
-"tA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/indestructible/syndicate,
-/area/syndicate_mothership/expansion_bombthreat)
 "tB" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -6866,6 +6860,12 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
+"tQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/indestructible/opsglass,
+/area/syndicate_mothership/expansion_bombthreat)
 "tR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9699,9 +9699,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
 "Ci" = (
@@ -9998,6 +9996,12 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/control)
+"Db" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/closed/indestructible/syndicate,
+/area/syndicate_mothership/expansion_bombthreat)
 "Dd" = (
 /obj/machinery/door/window/survival_pod{
 	dir = 8;
@@ -11467,12 +11471,6 @@
 "Hv" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/courtroom)
-"Hw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/closed/indestructible/syndicate,
-/area/syndicate_mothership/expansion_bombthreat)
 "Hy" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/catwalk_floor,
@@ -12000,8 +11998,8 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -12892,9 +12890,7 @@
 /turf/closed/mineral/ash_rock,
 /area/awaymission/errorroom)
 "Ma" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
@@ -14119,15 +14115,6 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
 /area/centcom/holding)
-"Pp" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/syndicate_mothership/expansion_bombthreat)
 "Pq" = (
 /turf/open/floor/iron/grimy,
 /area/centcom/prison)
@@ -15049,7 +15036,7 @@
 /area/centcom/control)
 "RS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 10
+	dir = 8
 	},
 /turf/closed/indestructible/syndicate,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -25238,8 +25225,8 @@ br
 Bq
 Gm
 RS
-Hw
-tA
+kv
+kv
 kv
 kv
 kv
@@ -25494,7 +25481,7 @@ nH
 ay
 Bq
 Fn
-kv
+Db
 Ma
 IV
 ki
@@ -25751,9 +25738,9 @@ nz
 br
 Bq
 fQ
-of
+tQ
 Ch
-Pp
+BD
 uu
 tk
 rE

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -418,7 +418,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/control)
 "bq" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_mixing_input{
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	chamber_id = "nukiebase";
 	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
@@ -1304,6 +1305,10 @@
 	dir = 8
 	},
 /obj/structure/rack,
+/obj/item/analyzer{
+	pixel_y = -7;
+	pixel_x = 7
+	},
 /obj/item/pipe_dispenser,
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -4223,7 +4228,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 10
 	},
-/obj/machinery/light/small/directional/east,
+/obj/machinery/light/cold/directional/west{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/syndicate_mothership/expansion_bombthreat)
 "lV" = (
@@ -8627,6 +8634,9 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
 /area/tdome/observation)
+"zy" = (
+/turf/open/misc/asteroid/snow/atmosphere,
+/area/syndicate_mothership/control)
 "zz" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs/cable/zipties,
@@ -11437,6 +11447,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/syndicate_mothership/control)
+"Hs" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_mixing_input{
+	dir = 1;
+	chamber_id = "nukielab";
+	id_tag = "nukielab"
+	},
+/turf/closed/indestructible/syndicate,
+/area/syndicate_mothership/control)
 "Ht" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -11676,7 +11694,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/turf/open/misc/asteroid/snow/icemoon,
+/turf/open/misc/asteroid/snow/airless,
 /area/syndicate_mothership/expansion_bombthreat)
 "Ig" = (
 /turf/closed/wall/mineral/diamond,
@@ -12038,7 +12056,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 8
 	},
-/turf/closed/indestructible/rock/snow,
+/turf/open/misc/asteroid/snow/atmosphere,
 /area/syndicate_mothership/control)
 "Jg" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -13312,11 +13330,13 @@
 	},
 /area/tdome/observation)
 "Nm" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/light/small/red/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/airalarm/unlocked{
+	pixel_y = -24
+	},
+/obj/machinery/light/cold/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership/expansion_bombthreat)
 "Nn" = (
@@ -14482,11 +14502,6 @@
 /obj/structure/flora/grass/both,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/syndicate_mothership/control)
-"Qt" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/airalarm/directional/south,
-/turf/closed/indestructible/syndicate,
-/area/syndicate_mothership/expansion_bioterrorism)
 "Qu" = (
 /obj/structure/window/paperframe{
 	can_atmos_pass = 0
@@ -16103,7 +16118,7 @@
 	atmos_chambers = list("nukiebase" = "Burn Chamber")
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small/red/directional/east{
+/obj/machinery/light/cold/directional/west{
 	dir = 2
 	},
 /turf/open/floor/mineral/titanium/tiled/yellow,
@@ -16416,21 +16431,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/centcom/admin)
-"VA" = (
-/obj/machinery/computer/atmos_control/noreconnect{
-	dir = 4;
-	pixel_x = -5;
-	pixel_y = -2;
-	atmos_chambers = list("nukiebase" = "Burn Chamber")
-	},
-/obj/machinery/computer/atmos_control/noreconnect{
-	dir = 4;
-	pixel_x = -5;
-	pixel_y = -2;
-	atmos_chambers = list("nukiebase" = "Burn Chamber")
-	},
-/turf/closed/indestructible/opsglass,
-/area/syndicate_mothership/expansion_bioterrorism)
 "VB" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -17500,7 +17500,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/turf/closed/indestructible/rock/snow,
+/turf/open/misc/asteroid/snow/atmosphere,
 /area/syndicate_mothership/control)
 "Yq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -22915,8 +22915,8 @@ nH
 nH
 nH
 nH
-kb
-kb
+zy
+zy
 Yp
 kb
 kb
@@ -23172,8 +23172,8 @@ Gx
 HY
 zX
 nH
-kb
-kb
+zy
+zy
 Je
 CN
 CN
@@ -23946,7 +23946,7 @@ nH
 nw
 nw
 Cl
-Qt
+CN
 Kw
 pS
 uk
@@ -24460,7 +24460,7 @@ nH
 gL
 FD
 Ih
-VA
+RK
 Il
 Na
 Sf
@@ -27809,7 +27809,7 @@ Yz
 Yz
 Dd
 Dd
-ng
+Hs
 kb
 kb
 kb

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -420,7 +420,9 @@
 "bq" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	chamber_id = "nukiebase";
-	dir = 1
+	dir = 1;
+	name = "syndicate air injector";
+	desc = "Has a valve and pump attached to it. Slightly more menacing than Nanotrasen's standard."
 	},
 /turf/open/floor/engine/vacuum,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -2886,6 +2888,12 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/iron/white,
 /area/tdome/observation)
+"if" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/indestructible/syndicate,
+/area/syndicate_mothership/expansion_bioterrorism)
 "ig" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -5351,12 +5359,6 @@
 /obj/item/food/meat/slab/synthmeat,
 /turf/open/floor/catwalk_floor,
 /area/centcom/holding)
-"pa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/indestructible/opsglass,
-/area/syndicate_mothership/expansion_bombthreat)
 "pb" = (
 /turf/open/misc/asteroid/snow/airless,
 /area/syndicate_mothership/control)
@@ -5955,7 +5957,8 @@
 /area/centcom/supplypod)
 "qK" = (
 /obj/machinery/air_sensor{
-	chamber_id = "nukiebase"
+	chamber_id = "nukiebase";
+	name = "syndicate ordnance gas sensor"
 	},
 /turf/open/floor/engine/vacuum,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -6038,6 +6041,12 @@
 /obj/structure/railing,
 /turf/open/lava/plasma/ice_moon,
 /area/syndicate_mothership/control)
+"rh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/indestructible/opsglass,
+/area/syndicate_mothership/expansion_bioterrorism)
 "ri" = (
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/mineral/titanium/yellow,
@@ -6733,6 +6742,12 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/syndicate_mothership/control)
+"tA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/indestructible/syndicate,
+/area/syndicate_mothership/expansion_bombthreat)
 "tB" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -9681,9 +9696,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/evacuation)
 "Ch" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/heater,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
@@ -9698,12 +9715,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
 /turf/open/floor/catwalk_floor/iron,
-/area/syndicate_mothership/control)
-"Cl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor/iron_smooth,
 /area/syndicate_mothership/control)
 "Cm" = (
 /obj/structure/closet/crate/freezer{
@@ -10171,6 +10182,9 @@
 	},
 /obj/machinery/door/puzzle/keycard/syndicate_bio,
 /obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -10774,9 +10788,6 @@
 "Fn" = (
 /obj/machinery/light/cold/directional/south,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 10
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership/control)
 "Fo" = (
@@ -11084,9 +11095,6 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/machinery/camera/autoname/directional/south{
 	network = list("nukie")
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership/control)
@@ -11447,14 +11455,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/syndicate_mothership/control)
-"Hs" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_mixing_input{
-	dir = 1;
-	chamber_id = "nukielab";
-	id_tag = "nukielab"
-	},
-/turf/closed/indestructible/syndicate,
-/area/syndicate_mothership/control)
 "Ht" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -11705,9 +11705,6 @@
 	},
 /obj/structure/sign/poster/contraband/energy_swords{
 	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/syndicate_mothership/control)
@@ -11999,13 +11996,13 @@
 /turf/open/floor/iron,
 /area/tdome/arena)
 "IV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/expansion_bombthreat)
 "IW" = (
@@ -12054,7 +12051,7 @@
 /area/tdome/arena)
 "Je" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
+	dir = 1
 	},
 /turf/open/misc/asteroid/snow/atmosphere,
 /area/syndicate_mothership/control)
@@ -12377,6 +12374,10 @@
 /area/syndicate_mothership)
 "Ki" = (
 /turf/open/lava/plasma/ice_moon,
+/area/syndicate_mothership/control)
+"Kj" = (
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/turf/open/misc/asteroid/snow/atmosphere,
 /area/syndicate_mothership/control)
 "Kk" = (
 /obj/docking_port/stationary{
@@ -12891,7 +12892,9 @@
 /turf/closed/mineral/ash_rock,
 /area/awaymission/errorroom)
 "Ma" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
@@ -14116,6 +14119,15 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
 /area/centcom/holding)
+"Pp" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/syndicate_mothership/expansion_bombthreat)
 "Pq" = (
 /turf/open/floor/iron/grimy,
 /area/centcom/prison)
@@ -14246,12 +14258,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/catwalk_floor,
 /area/centcom/holding)
-"PJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/closed/indestructible/syndicate,
-/area/syndicate_mothership/control)
 "PK" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -14434,13 +14440,6 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/observation)
-"Qj" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/syndicate_mothership/control)
 "Qk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/indestructible{
@@ -15048,6 +15047,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"RS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/indestructible/syndicate,
+/area/syndicate_mothership/expansion_bombthreat)
 "RT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -16114,8 +16119,9 @@
 "UK" = (
 /obj/machinery/computer/atmos_control/noreconnect{
 	dir = 1;
-	pixel_y = -1;
-	atmos_chambers = list("nukiebase" = "Burn Chamber")
+	atmos_chambers = list("nukiebase" = "Burn Chamber");
+	name = "Ordnance Chamber Monitor";
+	desc = "Used to monitor the Syndicate Ordnance Laboratory's burn chamber."
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/cold/directional/west{
@@ -17420,6 +17426,12 @@
 "Ya" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/armory)
+"Yb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/indestructible/syndicate,
+/area/syndicate_mothership/expansion_bioterrorism)
 "Yc" = (
 /obj/structure/fireplace,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -17496,12 +17508,6 @@
 "Yn" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/supplypod)
-"Yp" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4
-	},
-/turf/open/misc/asteroid/snow/atmosphere,
-/area/syndicate_mothership/control)
 "Yq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -22917,7 +22923,7 @@ nH
 nH
 zy
 zy
-Yp
+zy
 kb
 kb
 kb
@@ -23173,9 +23179,9 @@ HY
 zX
 nH
 zy
-zy
+Kj
 Je
-CN
+Yb
 CN
 CN
 CN
@@ -23431,8 +23437,8 @@ EN
 nH
 ng
 ng
-PJ
-CN
+ng
+if
 cj
 VV
 Xe
@@ -23688,8 +23694,8 @@ ax
 nH
 nw
 nw
-Cl
-CN
+nw
+if
 UY
 Gj
 Gu
@@ -23945,8 +23951,8 @@ tx
 nH
 nw
 nw
-Cl
-CN
+nw
+if
 Kw
 pS
 uk
@@ -24202,8 +24208,8 @@ SA
 nH
 ng
 ac
-PJ
-CN
+ng
+if
 IH
 pS
 Gu
@@ -24460,7 +24466,7 @@ nH
 gL
 FD
 Ih
-RK
+rh
 Il
 Na
 Sf
@@ -24716,7 +24722,7 @@ Ev
 we
 br
 Bq
-Qj
+fQ
 DB
 qM
 uk
@@ -24973,8 +24979,8 @@ EN
 HU
 br
 Bq
-Qj
-RK
+fQ
+rh
 mb
 HV
 Uc
@@ -25231,9 +25237,9 @@ we
 br
 Bq
 Gm
-kv
-kv
-kv
+RS
+Hw
+tA
 kv
 kv
 kv
@@ -25488,7 +25494,7 @@ nH
 ay
 Bq
 Fn
-Hw
+kv
 Ma
 IV
 ki
@@ -25745,9 +25751,9 @@ nz
 br
 Bq
 fQ
-pa
+of
 Ch
-BD
+Pp
 uu
 tk
 rE
@@ -27809,7 +27815,7 @@ Yz
 Yz
 Dd
 Dd
-Hs
+ng
 kb
 kb
 kb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Examination of the new Nuke Ops Ordnance Lab on Campbell yielded a number of visible usability problems. 

Nuclear Ops Ordnance lab now has...
an air alarm + a console for the burn chamber and corresponding sensor (EDIT: The air alarm now starts unlocked so they don't have to hack into it).
![image](https://user-images.githubusercontent.com/101627558/164157179-5042e803-ffbf-4ae5-83e1-f6d37dbb75b7.png)
a burn chamber without starting gasses
a scrubber to empty tanks
one RPD to rearrange pipes as needed (EDIT: And a Gas Analyzer so they don't have to run all the way over to the YouTool for one).
four Tier-2 Lasers to make the freezers properly usable for bombmaking
![image](https://user-images.githubusercontent.com/101627558/164157281-cb5498ac-df1f-43d5-b0d9-890b6c169144.png)
two Tier-2 Canisters to receive hot gasses from the burn chamber without immediately rupturing
a waste pipe for the freezers so they can vent their heat
![image](https://user-images.githubusercontent.com/101627558/164156944-2d730009-56cc-4b55-915e-9f5f908d1d73.png)
two Tier-2 Canisters to receive hot gasses from the burn chamber without immediately rupturing
a waste pipe for the freezers so they can vent their heat (EDIT: Adjusted snow turf with the passive vent so that it actually provides gas to the waste piping)
two more O2 canisters so they can make a usable amount of tritium and have O2 left to cool for payload gas.

Removed N2 and N2O, which are only used in exotic gas production
Replaced two walls with floors to make room for the air alarm and burn chamber console.
Shortened a couple of pipes to put things in the spaces freed up by doing so.

Wall camera, light positions, decals adjusted accordingly. (EDIT: Lights tampered with further)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The Nukie Ordnance Lab should be harder to use than the Station Ordnance Lab, but it does need the bare minimum functional equipment for operatives to actually make Tritium with it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nuclear Operative Ordnance Lab now has minimum functional equipment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
