### PR TITLE
Adjustments to IceBox departures and xeno

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -11273,7 +11273,6 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "euu" = (
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -23817,6 +23816,7 @@
 	dir = 9
 	},
 /obj/item/radio/off,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/hallway/secondary/exit/departure_lounge)
 "kCj" = (
@@ -27753,7 +27753,6 @@
 /area/science/server)
 "mIW" = (
 /obj/machinery/light/directional/east,
-/obj/item/radio/intercom/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -32126,11 +32125,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"oPR" = (
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "oPY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -38832,6 +38826,8 @@
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/clothing/shoes/winterboots,
 /obj/item/clothing/shoes/winterboots,
+/obj/machinery/firealarm/directional/south,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/hallway/secondary/exit/departure_lounge)
 "seL" = (
@@ -100142,7 +100138,7 @@ eKT
 sef
 euu
 mIW
-oPR
+xze
 rkI
 tnE
 xze


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Addresses #66335 - moves the fire extinguisher to the back wall (visible from the door), the fire alarm to the sound wall (next to the door), and the intercom to the southwest wall (Not next to the station-bounced radios, near the door).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

San says so. Also, if someone takes down the nearby walls, the once-shared space doesn't look hideous; see #66335
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

![image](https://user-images.githubusercontent.com/101627558/164177708-66f5e8c4-765f-4189-900d-97458d93723e.png)

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Overlapping sprites in IceBox departures corrected by moving wall-mounted items to other walls.
/:cl:

If this should be tagged as fix, feel free to adjust it, I guess?

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
