### PR TITLE
[Metastation] Toxins Mix Chamber will now start with Airless Turfs

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2652,7 +2652,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_mixing_input{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/science/mixing/chamber)
 "aDa" = (
 /turf/open/floor/plating,
@@ -6058,7 +6058,7 @@
 /area/security/office)
 "bAH" = (
 /obj/machinery/air_sensor/ordnance_mixing_tank,
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/science/mixing/chamber)
 "bAJ" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -15383,7 +15383,7 @@
 /area/medical/treatment_center)
 "eoI" = (
 /obj/machinery/igniter/incinerator_ordmix,
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/science/mixing/chamber)
 "eoM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output{
@@ -17976,7 +17976,7 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "fmA" = (
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/science/mixing/chamber)
 "fmR" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -23323,7 +23323,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/science/mixing/chamber)
 "hnm" = (
 /obj/machinery/status_display/evac/directional/north,
@@ -40051,8 +40051,7 @@
 /obj/structure/chair,
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 4;
-	pixel_x = -30;
-	
+	pixel_x = -30
 	},
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
@@ -52402,9 +52401,9 @@
 /obj/effect/spawner/random/aimodule/harmful,
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/door/window/brigdoor/left/directional/south{
+	dir = 8;
 	name = "High-Risk Modules";
-	req_access_txt = "20";
-	dir = 8
+	req_access_txt = "20"
 	},
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai_upload)


### PR DESCRIPTION
## About The Pull Request

Metastation Toxins Gas Mix Chamber started with the station defined Initial_Gas_Mix. This meant it had to be drained before proper usage for bomb creation. Without going inside or checking the prerequisite air alarm, it's difficult to find this out. 

## Why It's Good For The Game

This should probably start empty.

## Changelog

:cl:
fix: The Metastation Tox-Mix chamber now utilizes the airless ver. of the engine turfs. 
/:cl: