### PR TITLE
mapping helpers are ignored by create and destroy

### DIFF
--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -23,13 +23,11 @@
 		/obj/structure/holosign/robot_seat,
 		//Singleton
 		/mob/dview,
-		//Requires a circuit url
-		/obj/effect/mapping_helpers/circuit_spawner,
 		//Template type
 		/obj/item/bodypart,
 	)
 	//Say it with me now, type template
-	ignore += typesof(/obj/effect/mapping_helpers/atom_injector)
+	ignore += typesof(/obj/effect/mapping_helpers)
 	//This turf existing is an error in and of itself
 	ignore += typesof(/turf/baseturf_skipover)
 	ignore += typesof(/turf/baseturf_bottom)
@@ -50,8 +48,6 @@
 	//We don't have a pod
 	ignore += typesof(/obj/effect/pod_landingzone_effect)
 	ignore += typesof(/obj/effect/pod_landingzone)
-	//It's a trapdoor to nowhere
-	ignore += typesof(/obj/effect/mapping_helpers/trapdoor_placer)
 	//We have a baseturf limit of 10, adding more than 10 baseturf helpers will kill CI, so here's a future edge case to fix.
 	ignore += typesof(/obj/effect/baseturf_helper)
 	//There's no shapeshift to hold


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
mapping helpers are ignored by create and destroy

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
they are all objects created for maps to inject/modify something, some of them scream when ran not on mapload, and create and destroy doesnt run mapload
partly fixes this
![image](https://user-images.githubusercontent.com/23585223/164301629-1477908d-7f47-4102-85dd-7ab3177d8f32.png)
