### PR TITLE
Activating the Supermatter with a projectile now logs who did it and with what weapon.

### DIFF
--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -24,19 +24,17 @@
 		if(power_changes) //This needs to be here I swear
 			power += projectile.damage * bullet_energy + kiss_power
 			if(!has_been_powered)
-				var/fired_from_exists = projectile.fired_from \
-					? " with [projectile.fired_from]" \
-					: ""
+				var/fired_from_str = projectile.fired_from ? " with [projectile.fired_from]" : ""
 				investigate_log(
 					projectile.firer \
-						? "has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_exists]." \
+						? "has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_str]." \
 						: "has been powered for the first time.",
 					INVESTIGATE_ENGINE
 				)
 				message_admins(
 					projectile.firer \
-						? "[src] [ADMIN_JMP(src)] has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_exists]." \
-						: "[src] has been powered for the first time [ADMIN_JMP(src)]."
+						? "[src] [ADMIN_JMP(src)] has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_str]." \
+						: "[src] [ADMIN_JMP(src)] has been powered for the first time."
 				)
 				has_been_powered = TRUE
 	else if(takes_damage)

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -24,8 +24,9 @@
 		if(power_changes) //This needs to be here I swear
 			power += projectile.damage * bullet_energy + kiss_power
 			if(!has_been_powered)
-				investigate_log("has been powered for the first time.", INVESTIGATE_ENGINE)
-				message_admins("[src] has been powered for the first time [ADMIN_JMP(src)].")
+				var/fired_from_exists = projectile.fired_from ? " with [projectile.fired_from]" : ""
+				investigate_log(projectile.firer ? "has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_exists]." : "has been powered for the first time.", INVESTIGATE_ENGINE)
+				message_admins(projectile.firer ? "[src] [ADMIN_JMP(src)] has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_exists]." : "[src] has been powered for the first time [ADMIN_JMP(src)].")
 				has_been_powered = TRUE
 	else if(takes_damage)
 		damage += (projectile.damage * bullet_energy) * clamp((emergency_point - damage) / emergency_point, 0, 1)

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -27,7 +27,7 @@
 				var/fired_from_str = projectile.fired_from ? " with [projectile.fired_from]" : ""
 				investigate_log(
 					projectile.firer \
-						? "has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_str]." \
+						? "has been powered for the first time by [key_name(projectile.firer)][fired_from_str]." \
 						: "has been powered for the first time.",
 					INVESTIGATE_ENGINE
 				)

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -24,9 +24,20 @@
 		if(power_changes) //This needs to be here I swear
 			power += projectile.damage * bullet_energy + kiss_power
 			if(!has_been_powered)
-				var/fired_from_exists = projectile.fired_from ? " with [projectile.fired_from]" : ""
-				investigate_log(projectile.firer ? "has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_exists]." : "has been powered for the first time.", INVESTIGATE_ENGINE)
-				message_admins(projectile.firer ? "[src] [ADMIN_JMP(src)] has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_exists]." : "[src] has been powered for the first time [ADMIN_JMP(src)].")
+				var/fired_from_exists = projectile.fired_from \
+					? " with [projectile.fired_from]" \
+					: ""
+				investigate_log(
+					projectile.firer \
+						? "has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_exists]." \
+						: "has been powered for the first time.",
+					INVESTIGATE_ENGINE
+				)
+				message_admins(
+					projectile.firer \
+						? "[src] [ADMIN_JMP(src)] has been powered for the first time by [ADMIN_FULLMONTY(projectile.firer)][fired_from_exists]." \
+						: "[src] has been powered for the first time [ADMIN_JMP(src)]."
+				)
 				has_been_powered = TRUE
 	else if(takes_damage)
 		damage += (projectile.damage * bullet_energy) * clamp((emergency_point - damage) / emergency_point, 0, 1)


### PR DESCRIPTION
## About The Pull Request

Activating the Supermatter with a projectile now logs who did it and with what weapon.

## Why It's Good For The Game

Being able to drive-by start the SM with a kiss and have it be completely unlogged is bad, actually.
## Changelog
:cl:
admin: Activating the Supermatter with a projectile now logs who did it and with what weapon.
/:cl: