### PR TITLE
adds pen in tablet flavor text + ctrl click

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -82,6 +82,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	if(id)
 		id.UpdateDisplay()
 	update_appearance()
+	register_context()
 	Add_Messenger()
 
 /obj/item/modular_computer/Destroy()
@@ -282,6 +283,14 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 
 	. += get_modular_computer_parts_examine(user)
 
+/obj/item/modular_computer/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove ID"
+	context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Remove Job Disk"
+
+	. = CONTEXTUAL_SCREENTIP_SET
+
 /obj/item/modular_computer/update_icon_state()
 	if(!bypass_state)
 		icon_state = enabled ? icon_state_powered : icon_state_unpowered
@@ -309,6 +318,17 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		ui_interact(user)
 	else
 		turn_on(user)
+
+/obj/item/modular_computer/CtrlShiftClick(mob/user)
+	. = ..()
+	if(.)
+		return
+
+	var/obj/item/computer_hardware/hard_drive/role/ssd = all_components[MC_HDD_JOB]
+	if(!ssd)
+		return
+	if(uninstall_component(ssd, usr))
+		user.put_in_hands(ssd)
 
 /obj/item/modular_computer/proc/turn_on(mob/user)
 	var/issynth = issilicon(user) // Robots and AIs get different activation messages.
@@ -607,6 +627,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	// Insert new hardware
 	if(istype(W, /obj/item/computer_hardware) && upgradable)
 		if(install_component(W, user))
+			playsound(src, 'sound/machines/card_slide.ogg', 50)
 			return
 
 	if(W.tool_behaviour == TOOL_WRENCH)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -289,7 +289,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove ID"
 	context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Remove Job Disk"
 
-	. = CONTEXTUAL_SCREENTIP_SET
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/modular_computer/update_icon_state()
 	if(!bypass_state)

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -39,6 +39,11 @@
 		explode(usr, from_message_menu = TRUE)
 		return
 
+/obj/item/modular_computer/tablet/examine(mob/user)
+	. = ..()
+	if(inserted_item)
+		. += "Ctrl-click to remove the [inserted_item.name]"
+
 /obj/item/modular_computer/tablet/attackby(obj/item/W, mob/user)
 	. = ..()
 
@@ -53,6 +58,13 @@
 			playsound(src, 'sound/machines/pda_button1.ogg', 50, TRUE)
 
 /obj/item/modular_computer/tablet/AltClick(mob/user)
+	. = ..()
+	if(.)
+		return
+
+	remove_pen(user)
+
+/obj/item/modular_computer/tablet/CtrlClick(mob/user)
 	. = ..()
 	if(.)
 		return

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -42,7 +42,7 @@
 /obj/item/modular_computer/tablet/examine(mob/user)
 	. = ..()
 	if(inserted_item)
-		. += "Ctrl-click to remove the [inserted_item.name]"
+		. += "Ctrl-click to remove the [inserted_item.name]."
 
 /obj/item/modular_computer/tablet/attackby(obj/item/W, mob/user)
 	. = ..()

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -39,10 +39,12 @@
 		explode(usr, from_message_menu = TRUE)
 		return
 
-/obj/item/modular_computer/tablet/examine(mob/user)
+/obj/item/modular_computer/tablet/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
-	if(inserted_item)
-		. += "Ctrl-click to remove the [inserted_item.name]."
+
+	context[SCREENTIP_CONTEXT_CTRL_LMB] = "Remove pen"
+
+	. = CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/modular_computer/tablet/attackby(obj/item/W, mob/user)
 	. = ..()

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -44,7 +44,7 @@
 
 	context[SCREENTIP_CONTEXT_CTRL_LMB] = "Remove pen"
 
-	. = CONTEXTUAL_SCREENTIP_SET
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/modular_computer/tablet/attackby(obj/item/W, mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

people seem to be confused about the fact that pens are actually inside of your tablet because of extremely awful horrible UX, so flavor text has been added

and also ctrl click to remove pens is back

## Why It's Good For The Game
my ux

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: brings back ctrl-click to remove pen + flavor text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
