### PR TITLE
Fix books to only give mood bonus when read the first time

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -92,6 +92,8 @@
 	var/list/active_addictions
 	///List of objective-specific equipment that couldn't properly be given to the mind
 	var/list/failed_special_equipment
+	/// A list to keep track of which books a person has read (to prevent people from reading the same book again and again for positive mood events)
+	var/list/book_titles_read
 
 /datum/mind/New(_key)
 	key = _key

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -104,12 +104,12 @@
 	if(book_data?.content)
 		user << browse("<meta charset=UTF-8><TT><I>Penned by [book_data.author].</I></TT> <BR>" + "[book_data.content]", "window=book[window_size != null ? ";size=[window_size]" : ""]")
 
-		LAZYINITLIST(user.mind.book_titles_read)
-		var/has_not_read_book = isnull(user.mind.book_titles_read[starting_title])
+		LAZYINITLIST(user.mind?.book_titles_read)
+		var/has_not_read_book = isnull(user.mind?.book_titles_read[starting_title])
 
 		if(has_not_read_book) // any new books give bonus mood
 			SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "book_nerd", /datum/mood_event/book_nerd)
-			user.mind.book_titles_read[starting_title] = TRUE
+			user.mind?.book_titles_read[starting_title] = TRUE
 		onclose(user, "book")
 	else
 		to_chat(user, span_notice("This book is completely blank!"))

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -106,12 +106,12 @@
 
 		if(ishuman(user))
 			var/mob/living/carbon/human/reader = user
-			LAZYINITLIST(reader.book_titles_read)
-			var/has_not_read_book = isnull(reader.book_titles_read[starting_title])
+			LAZYINITLIST(reader.mind.book_titles_read)
+			var/has_not_read_book = isnull(reader.mind.book_titles_read[starting_title])
 
 			if(has_not_read_book) // any new books give bonus mood
 				SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "book_nerd", /datum/mood_event/book_nerd)
-			reader.book_titles_read[starting_title] = TRUE
+			reader.mind.book_titles_read[starting_title] = TRUE
 		onclose(user, "book")
 	else
 		to_chat(user, span_notice("This book is completely blank!"))

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -103,6 +103,15 @@
 /obj/item/book/proc/on_read(mob/user)
 	if(book_data?.content)
 		user << browse("<meta charset=UTF-8><TT><I>Penned by [book_data.author].</I></TT> <BR>" + "[book_data.content]", "window=book[window_size != null ? ";size=[window_size]" : ""]")
+
+		if(ishuman(user))
+			var/mob/living/carbon/human/reader = user
+			LAZYINITLIST(reader.book_titles_read)
+			var/has_not_read_book = isnull(reader.book_titles_read[starting_title])
+
+			if(has_not_read_book) // any new books give bonus mood
+				SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "book_nerd", /datum/mood_event/book_nerd)
+			reader.book_titles_read[starting_title] = TRUE
 		onclose(user, "book")
 	else
 		to_chat(user, span_notice("This book is completely blank!"))
@@ -115,7 +124,6 @@
 	if(!user.can_read(src))
 		return
 	user.visible_message(span_notice("[user] opens a book titled \"[book_data.title]\" and begins reading intently."))
-	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "book_nerd", /datum/mood_event/book_nerd)
 	on_read(user)
 
 /obj/item/book/attackby(obj/item/I, mob/user, params)

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -104,14 +104,12 @@
 	if(book_data?.content)
 		user << browse("<meta charset=UTF-8><TT><I>Penned by [book_data.author].</I></TT> <BR>" + "[book_data.content]", "window=book[window_size != null ? ";size=[window_size]" : ""]")
 
-		if(ishuman(user))
-			var/mob/living/carbon/human/reader = user
-			LAZYINITLIST(reader.mind.book_titles_read)
-			var/has_not_read_book = isnull(reader.mind.book_titles_read[starting_title])
+		LAZYINITLIST(user.mind.book_titles_read)
+		var/has_not_read_book = isnull(user.mind.book_titles_read[starting_title])
 
-			if(has_not_read_book) // any new books give bonus mood
-				SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "book_nerd", /datum/mood_event/book_nerd)
-			reader.mind.book_titles_read[starting_title] = TRUE
+		if(has_not_read_book) // any new books give bonus mood
+			SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "book_nerd", /datum/mood_event/book_nerd)
+			user.mind.book_titles_read[starting_title] = TRUE
 		onclose(user, "book")
 	else
 		to_chat(user, span_notice("This book is completely blank!"))

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -84,5 +84,3 @@
 	var/hal_screwydoll
 	/// When an braindead player has their equipment fiddled with, we log that info here for when they come back so they know who took their ID while they were DC'd for 30 seconds
 	var/list/afk_thefts
-	/// A list to keep track of which books a person has read (to prevent people from reading the same book again and again for positive mood events)
-	var/list/book_titles_read

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -84,3 +84,5 @@
 	var/hal_screwydoll
 	/// When an braindead player has their equipment fiddled with, we log that info here for when they come back so they know who took their ID while they were DC'd for 30 seconds
 	var/list/afk_thefts
+	/// A list to keep track of which books a person has read (to prevent people from reading the same book again and again for positive mood events)
+	var/list/book_titles_read


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Rereading the same book over and over again will no longer give a mood bonus.  You will now only get it if you have the read the book the first time.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Encourages people to actually go to the library and read multiple books.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: timothymtorres, TheBonded
fix: Fix books to only give mood bonus when read the first time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
