### PR TITLE
unit test for /obj/item/stack singular_name

### DIFF
--- a/code/game/objects/items/devices/polycircuit.dm
+++ b/code/game/objects/items/devices/polycircuit.dm
@@ -6,6 +6,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	max_amount = 8
 	merge_type = /obj/item/stack/circuit_stack
+	singular_name = "circuit aggregate"
 	var/circuit_type = /obj/item/electronics/airlock
 	var/chosen_circuit = "airlock"
 

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -297,7 +297,7 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 /obj/item/stack/sheet/animalhide/carp
 	name = "carp scales"
 	desc = "The scaly skin of a space carp. It looks quite beatiful when detached from the foul creature who once wore it."
-	singular_name = "carp scales"
+	singular_name = "carp scale"
 	icon_state = "sheet-carp"
 	inhand_icon_state = "sheet-carp"
 	merge_type = /obj/item/stack/sheet/animalhide/carp

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -300,7 +300,6 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	singular_name = "carp scales"
 	icon_state = "sheet-carp"
 	inhand_icon_state = "sheet-carp"
-	singular_name = "carp scale"
 	merge_type = /obj/item/stack/sheet/animalhide/carp
 
 GLOBAL_LIST_INIT(carp_recipes, list ( \

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -300,6 +300,7 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	singular_name = "carp scales"
 	icon_state = "sheet-carp"
 	inhand_icon_state = "sheet-carp"
+	singular_name = "carp scale"
 	merge_type = /obj/item/stack/sheet/animalhide/carp
 
 GLOBAL_LIST_INIT(carp_recipes, list ( \

--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -15,6 +15,7 @@
 	max_amount = 25
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/wrapping_paper
+	singular_name = "wrapping paper"
 
 /obj/item/stack/wrapping_paper/Initialize(mapload)
 	. = ..()

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -110,6 +110,7 @@
 #include "species_config_sanity.dm"
 #include "species_unique_id.dm"
 #include "species_whitelists.dm"
+#include "stack_singular_name.dm"
 #include "stomach.dm"
 #include "strippable.dm"
 #include "subsystem_init.dm"

--- a/code/modules/unit_tests/stack_singular_name.dm
+++ b/code/modules/unit_tests/stack_singular_name.dm
@@ -10,7 +10,8 @@
 		/obj/item/stack/sheet,
 		/obj/item/stack/sheet/mineral,
 		/obj/item/stack/license_plates,
-		/obj/item/stack/sheet/animalhide,)
+		/obj/item/stack/sheet/animalhide,
+	)
 
 	for(var/obj/item/stack/stack_check as anything in subtypesof(/obj/item/stack) - blacklist)
 		if(!initial(stack_check.singular_name))

--- a/code/modules/unit_tests/stack_singular_name.dm
+++ b/code/modules/unit_tests/stack_singular_name.dm
@@ -1,0 +1,16 @@
+/**
+ * Goes through every subtype of /obj/item/stack to check for a singular name, var/singular_name.
+ * Everything within the blacklist does not need to be tested because it exists to be overriden.
+ * This test will fail if a subtype of /obj/item/stack is missing a singular name.
+ */
+/datum/unit_test/stack_singular_name
+
+/datum/unit_test/stack_singular_name/Run()
+	var/list/blacklist = list(/obj/item/stack/sheet,
+							/obj/item/stack/sheet/mineral,
+							/obj/item/stack/license_plates,
+							/obj/item/stack/sheet/animalhide,)
+
+	for(var/obj/item/stack/stack_check as anything in subtypesof(/obj/item/stack) - blacklist)
+		if(!initial(stack_check.singular_name))
+			Fail("[stack_check] is missing a singular name!")

--- a/code/modules/unit_tests/stack_singular_name.dm
+++ b/code/modules/unit_tests/stack_singular_name.dm
@@ -6,10 +6,11 @@
 /datum/unit_test/stack_singular_name
 
 /datum/unit_test/stack_singular_name/Run()
-	var/list/blacklist = list(/obj/item/stack/sheet,
-							/obj/item/stack/sheet/mineral,
-							/obj/item/stack/license_plates,
-							/obj/item/stack/sheet/animalhide,)
+	var/list/blacklist = list( // all of these are generally parents that exist to be overriden; ex. /obj/item/stack/license_plates exists to branch into /filled and /empty
+		/obj/item/stack/sheet,
+		/obj/item/stack/sheet/mineral,
+		/obj/item/stack/license_plates,
+		/obj/item/stack/sheet/animalhide,)
 
 	for(var/obj/item/stack/stack_check as anything in subtypesof(/obj/item/stack) - blacklist)
 		if(!initial(stack_check.singular_name))


### PR DESCRIPTION
## About The Pull Request

checks if all non-blacklisted materials have `singular_name` because apparently that's pretty important
gives it to a few ones that didn't, naughty naughty

## Why It's Good For The Game

some stacks will now have proper syntax with singulars, verifies future ones will too

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: some stacks that need a singular name now have said singular name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
