### PR TITLE
Fixes that one duplicate plasma window on icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -7746,11 +7746,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cIv" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/engineering/supermatter/room)
 "cIL" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 4
@@ -79404,7 +79399,7 @@ hua
 vvt
 jnr
 nHI
-cIv
+iLd
 wfC
 fQX
 oJZ


### PR DESCRIPTION
## About The Pull Request

Removes a duplicated R-Plasmaglass window in Ice Box's engine room

## Why It's Good For The Game

map moment

## Changelog

:cl:
fix: Removed a stacked RPlasmaGlass window on Ice Box
/:cl: