### PR TITLE
Fixes another food error sprite

### DIFF
--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -137,7 +137,7 @@
 
 /obj/item/trash/can/food/tomatoes
 	name = "canned San Marzano tomatoes"
-	icon = 'icons/obj/food/food.dmi'
+	icon = 'icons/obj/food/canned.dmi'
 	icon_state = "tomatoescan_empty"
 
 /obj/item/trash/can/food/pine_nuts


### PR DESCRIPTION
## About The Pull Request

Local catgirl demands returned gbp compensation for code services rendered by doing another fix

## Why It's Good For The Game

The canned tomatoes suddenly morphed into an error sprite when you used them all. Error sprite bad

## Changelog
:cl: YakumoChen
fix: Fixes a sprite not appearing when you use up canned tomatoes
fix: Donkfillet has a sprite for real this time
/ :cl: