### PR TITLE
Pacman small rework - less power, more consumption - no more super

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -144,6 +144,15 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/iron/grimy,
 /area/maintenance/port/fore)
+"abb" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/maintenance/port/aft)
 "abf" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
@@ -9393,6 +9402,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "clw" = (
@@ -9683,6 +9693,7 @@
 "coK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "coN" = (
@@ -10924,6 +10935,13 @@
 	icon_state = "chapel"
 	},
 /area/service/chapel)
+"cDB" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/iron,
+/area/maintenance/port/greater)
 "cDN" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light/directional/south,
@@ -29085,6 +29103,12 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port/greater)
+"gpE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "gpI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35045,6 +35069,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
+"hYg" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hYu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -38502,6 +38530,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs/aft)
+"iZp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iZx" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Circuits Lab Maintenance";
@@ -40038,6 +40071,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"jxz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/iron,
+/area/maintenance/starboard/aft)
 "jxD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44939,6 +44980,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/random/directional/south,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "kXB" = (
@@ -52746,6 +52788,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"nmF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "nmL" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
@@ -53748,6 +53795,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing/launch)
+"nCT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/port/greater)
 "nCU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -59167,6 +59219,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/medical)
+"phH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/iron,
+/area/maintenance/port/greater)
 "phL" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/brown/corner,
@@ -62001,6 +62061,10 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"pYS" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/port/greater)
 "pYW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -70026,6 +70090,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/engineering/gravity_generator)
+"sqf" = (
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "sqs" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -70039,6 +70108,14 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room)
+"squ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/iron,
+/area/maintenance/starboard/aft)
 "sqw" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -80985,6 +81062,7 @@
 	pixel_x = 32
 	},
 /obj/structure/window/reinforced/plasma/spawner,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
 /area/maintenance/port/lesser)
 "vEY" = (
@@ -86253,6 +86331,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
+"xox" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "xoA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -116443,7 +116525,7 @@ mJi
 lax
 fOD
 laF
-dTM
+nCT
 bzr
 rMT
 rHo
@@ -116696,7 +116778,7 @@ aOr
 spo
 rMk
 bzr
-nQr
+phH
 lax
 gCK
 gCK
@@ -119233,8 +119315,8 @@ uxO
 fOD
 eKZ
 edy
-syw
-edy
+pYS
+cDB
 nua
 syw
 biP
@@ -121345,7 +121427,7 @@ nAL
 oEs
 yfh
 oBJ
-dLW
+iZp
 vsc
 nKI
 dOR
@@ -121873,7 +121955,7 @@ dUY
 dQE
 dWJ
 dLW
-dYu
+hYg
 dZg
 dYu
 dYu
@@ -125207,7 +125289,7 @@ qml
 mIL
 dOM
 rWh
-dYu
+hYg
 dOM
 vQA
 paX
@@ -127255,7 +127337,7 @@ dGc
 dHz
 dIQ
 dLY
-dKO
+abb
 wnM
 dOM
 iZo
@@ -127937,7 +128019,7 @@ ufL
 qiX
 uQn
 ewz
-xIc
+xox
 wQj
 iMI
 ePt
@@ -129214,7 +129296,7 @@ sGR
 hDa
 rVb
 mYZ
-xIc
+xox
 ewz
 gAd
 aTu
@@ -131881,7 +131963,7 @@ mBu
 lWg
 dEc
 dNS
-wXc
+gpE
 hjT
 dNS
 aaa
@@ -132525,7 +132607,7 @@ aeF
 aeF
 aeF
 vLs
-wlV
+sqf
 pEs
 sfM
 vcx
@@ -138042,7 +138124,7 @@ kaO
 sdT
 cHU
 dBt
-cHW
+nmF
 dEh
 cIW
 dyv
@@ -141888,7 +141970,7 @@ lnB
 cHW
 cIX
 rBJ
-dbD
+squ
 cNH
 lnB
 due
@@ -142134,7 +142216,7 @@ lAD
 lvv
 eIy
 cHU
-dLp
+jxz
 nzv
 ueh
 nsS

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3172,6 +3172,7 @@
 /area/security/courtroom)
 "aLZ" = (
 /obj/effect/landmark/blobstart,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -7279,6 +7280,10 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/white,
 /area/science/lobby)
+"bPf" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bPh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -16613,6 +16618,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"eKf" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/aft/greater)
 "eKh" = (
 /obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating,
@@ -17424,6 +17433,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"eZr" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "eZU" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
@@ -19222,6 +19235,7 @@
 /area/engineering/atmospherics_engine)
 "fJH" = (
 /obj/machinery/light/small/broken/directional/north,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "fJL" = (
@@ -25199,6 +25213,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/medical/abandoned)
+"hYI" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hYT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -31824,6 +31842,10 @@
 /obj/machinery/syndicatebomb/training,
 /turf/open/floor/iron,
 /area/security/office)
+"kzo" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "kzp" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral,
@@ -33955,6 +33977,12 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
+"lnf" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore)
 "lnt" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39850,6 +39878,7 @@
 /area/engineering/main)
 "njd" = (
 /obj/machinery/light/small/directional/west,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "njk" = (
@@ -40051,8 +40080,7 @@
 /obj/structure/chair,
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 4;
-	pixel_x = -30;
-	
+	pixel_x = -30
 	},
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
@@ -42661,6 +42689,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"omP" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/fore)
 "omY" = (
 /obj/machinery/light_switch/directional/south,
 /obj/structure/table/wood,
@@ -43539,7 +43573,7 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "oEb" = (
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/maintenance/starboard/greater)
 "oEh" = (
@@ -52402,9 +52436,9 @@
 /obj/effect/spawner/random/aimodule/harmful,
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/door/window/brigdoor/left/directional/south{
+	dir = 8;
 	name = "High-Risk Modules";
-	req_access_txt = "20";
-	dir = 8
+	req_access_txt = "20"
 	},
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -52628,6 +52662,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
+"saV" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "sbk" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark/telecomms,
@@ -58343,6 +58381,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"upU" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "upY" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -60938,6 +60980,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/lockers)
+"vrY" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard/fore)
 "vrZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -67984,6 +68032,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/security/office)
+"xYX" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/maintenance/starboard/lesser)
 "xZf" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -84592,7 +84644,7 @@ bqR
 dSM
 cGq
 alK
-aob
+kzo
 rDS
 iuy
 paD
@@ -84611,7 +84663,7 @@ qUR
 mmb
 gLu
 lvY
-bXE
+hYI
 oAe
 cCk
 dux
@@ -87197,7 +87249,7 @@ sYH
 sSE
 txp
 qiL
-far
+eKf
 gZp
 msm
 gZp
@@ -87367,7 +87419,7 @@ xZo
 oaE
 qtK
 xZo
-aRG
+saV
 rQt
 bOJ
 xZo
@@ -88212,7 +88264,7 @@ pdp
 dXY
 rRs
 dux
-bXE
+hYI
 nXg
 uOc
 dPt
@@ -88400,7 +88452,7 @@ dne
 vlm
 aRG
 drQ
-aRG
+saV
 dnu
 dne
 ivz
@@ -88493,7 +88545,7 @@ moM
 gZp
 aSk
 fqu
-far
+eKf
 tKv
 gZp
 lMJ
@@ -91317,7 +91369,7 @@ hdw
 phT
 cqi
 gZp
-far
+eKf
 dTm
 uKu
 gZp
@@ -101852,7 +101904,7 @@ iht
 iht
 wmY
 uJy
-kkO
+eZr
 wrP
 mff
 kkO
@@ -103040,7 +103092,7 @@ seR
 xRw
 aje
 ale
-ahS
+lnf
 agq
 oix
 agq
@@ -103303,7 +103355,7 @@ jkw
 agq
 arA
 aje
-auc
+omP
 aje
 bJl
 agq
@@ -105171,7 +105223,7 @@ juD
 hCo
 hCo
 pPF
-rah
+xYX
 sLo
 lpg
 xPI
@@ -105440,7 +105492,7 @@ mpa
 nOc
 nxf
 jIn
-ciL
+bPf
 dvY
 stN
 bsN
@@ -108444,7 +108496,7 @@ dnh
 tLb
 atd
 dnS
-atd
+vrY
 dnh
 lZd
 ayR
@@ -109984,7 +110036,7 @@ bcO
 dnS
 dnS
 fFV
-dnS
+upU
 dnh
 vLo
 dqT

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -196,7 +196,8 @@
 /obj/item/circuitboard/machine/pacman/examine(mob/user)
 	. = ..()
 	var/message = high_production_profile ? "high production - high consumption" : "low production - low consumption"
-	. += span_notice("It's set to [message]")
+	. += span_notice("It's set to [message].")
+	. += span_notice("You can switch the mode by using a screwdriver on [src].")
 
 /obj/item/circuitboard/machine/pacman/screwdriver_act(mob/living/user, obj/item/tool)
 	high_production_profile = !high_production_profile

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -187,16 +187,21 @@
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/port_gen/pacman
 	req_components = list(
-		/obj/item/stock_parts/matter_bin = 1,
-		/obj/item/stock_parts/micro_laser = 1,
-		/obj/item/stack/cable_coil = 2,
-		/obj/item/stock_parts/capacitor = 1)
+		/obj/item/stack/cable_coil = 5,
+		/obj/item/stack/sheet/iron = 5
+	)
 	needs_anchored = FALSE
+	var/high_production_profile = FALSE
 
-/obj/item/circuitboard/machine/pacman/super
-	name = "SUPERPACMAN-type Generator (Machine Board)"
-	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
-	build_path = /obj/machinery/power/port_gen/pacman/super
+/obj/item/circuitboard/machine/pacman/examine(mob/user)
+	. = ..()
+	var/message = high_production_profile ? "high production - high consumption" : "low production - low consumption"
+	. += span_notice("It's set to [message]")
+
+/obj/item/circuitboard/machine/pacman/screwdriver_act(mob/living/user, obj/item/tool)
+	high_production_profile = !high_production_profile
+	var/message = high_production_profile ? "high production - high consumption" : "low production - low consumption"
+	to_chat(user, span_notice("You set the board for [message]"))
 
 /obj/item/circuitboard/machine/turbine_compressor
 	name = "Turbine - Inlet Compressor (Machine Board)"

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -81,12 +81,13 @@
 /obj/machinery/power/port_gen/pacman
 	name = "\improper P.A.C.M.A.N.-type portable generator"
 	circuit = /obj/item/circuitboard/machine/pacman
+	power_gen = 2500
 	var/sheets = 0
-	var/max_sheets = 100
+	var/max_sheets = 10
 	var/sheet_name = ""
 	var/sheet_path = /obj/item/stack/sheet/mineral/plasma
 	var/sheet_left = 0 // How much is left of the sheet
-	var/time_per_sheet = 260
+	var/time_per_sheet = 50
 	var/current_heat = 0
 
 /obj/machinery/power/port_gen/pacman/Initialize(mapload)
@@ -101,27 +102,18 @@
 	DropFuel()
 	return ..()
 
-/obj/machinery/power/port_gen/pacman/RefreshParts()
-	. = ..()
-	var/temp_rating = 0
-	var/consumption_coeff = 0
-	for(var/obj/item/stock_parts/SP in component_parts)
-		if(istype(SP, /obj/item/stock_parts/matter_bin))
-			max_sheets = SP.rating * SP.rating * 50
-		else if(istype(SP, /obj/item/stock_parts/capacitor))
-			temp_rating += SP.rating
-		else
-			consumption_coeff += SP.rating
-	power_gen = round(initial(power_gen) * temp_rating * 2)
-	consumption = consumption_coeff
+/obj/machinery/power/port_gen/pacman/on_construction()
+	var/obj/item/circuitboard/machine/pacman/our_board = circuit
+	if(our_board.high_production_profile)
+		max_sheets = 5
+		time_per_sheet = 20
+		power_gen = 10000
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
 	. = ..()
 	. += span_notice("The generator has [sheets] units of [sheet_name] fuel left, producing [display_power(power_gen)] per cycle.")
 	if(anchored)
 		. += span_notice("It is anchored to the ground.")
-	if(in_range(user, src) || isobserver(user))
-		. += span_notice("The status display reads: Fuel efficiency increased by <b>[(consumption*100)-100]%</b>.")
 
 /obj/machinery/power/port_gen/pacman/HasFuel()
 	if(sheets >= 1 / (time_per_sheet / power_output) - sheet_left)
@@ -134,7 +126,7 @@
 		sheets = 0
 
 /obj/machinery/power/port_gen/pacman/UseFuel()
-	var/needed_sheets = 1 / (time_per_sheet * consumption / power_output)
+	var/needed_sheets = 1 / (time_per_sheet / power_output)
 	var/temp = min(needed_sheets, sheet_left)
 	needed_sheets -= temp
 	sheet_left -= temp
@@ -149,9 +141,9 @@
 	var/bias = 0
 	if (power_output > 4)
 		upper_limit = 400
-		bias = power_output - consumption * (4 - consumption)
+		bias = power_output - 3
 	if (current_heat < lower_limit)
-		current_heat += 4 - consumption
+		current_heat += 3
 	else
 		current_heat += rand(-7 + bias, 7 + bias)
 		if (current_heat < lower_limit)
@@ -273,15 +265,3 @@
 			if (power_output < 4 || (obj_flags & EMAGGED))
 				power_output++
 				. = TRUE
-
-/obj/machinery/power/port_gen/pacman/super
-	name = "\improper S.U.P.E.R.P.A.C.M.A.N.-type portable generator"
-	icon_state = "portgen1_0"
-	base_icon = "portgen1"
-	circuit = /obj/item/circuitboard/machine/pacman/super
-	sheet_path = /obj/item/stack/sheet/mineral/uranium
-	power_gen = 15000
-	time_per_sheet = 85
-
-/obj/machinery/power/port_gen/pacman/super/overheat()
-	explosion(src, devastation_range = 3, heavy_impact_range = 3, light_impact_range = 3, flash_range = -1)

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -109,7 +109,8 @@
 		base_icon = "portgen1"
 		max_sheets = 5
 		time_per_sheet = 20
-		power_gen = 10000
+		power_gen = 15000
+		sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
 	. = ..()
@@ -267,3 +268,11 @@
 			if (power_output < 4 || (obj_flags & EMAGGED))
 				power_output++
 				. = TRUE
+
+/obj/machinery/power/port_gen/pacman/super
+	icon_state = "portgen1_0"
+	base_icon = "portgen1"
+	max_sheets = 5
+	time_per_sheet = 20
+	power_gen = 15000
+	sheet_path = /obj/item/stack/sheet/mineral/uranium

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -105,6 +105,8 @@
 /obj/machinery/power/port_gen/pacman/on_construction()
 	var/obj/item/circuitboard/machine/pacman/our_board = circuit
 	if(our_board.high_production_profile)
+		icon_state = "portgen1_0"
+		base_icon = "portgen1"
 		max_sheets = 5
 		time_per_sheet = 20
 		power_gen = 10000

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -276,3 +276,6 @@
 	time_per_sheet = 20
 	power_gen = 15000
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
+
+/obj/machinery/power/port_gen/pacman/pre_loaded
+	sheets = 10

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -74,13 +74,6 @@
 	category = list("Engineering Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
-/datum/design/board/pacman/super
-	name = "Machine Design (SUPERPACMAN-type Generator Board)"
-	desc = "The circuit board that for a SUPERPACMAN-type portable generator."
-	id = "superpacman"
-	build_path = /obj/item/circuitboard/machine/pacman/super
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
-
 /datum/design/turbine_part_compressor
 	name = "Turbine Part - Compressor"
 	desc = "The basic tier of a compressor blade."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -584,7 +584,6 @@
 		"smes",
 		"super_capacitor",
 		"super_cell",
-		"superpacman",
 		"turbine_compressor",
 		"turbine_rotor",
 		"turbine_stator",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This change reworks how pacmans works. The changes are:
- Pacmans no longer require stock parts (no more upgrade memery)
- Base pacman power generation ranges from 2500 W to 10000 W
- Base pacman max held sheets is 10
- Base pacman sheet consumption speed has been quintupled
- Super pacman no longer exists, the circuit board now switches between a low production - low consumption mode to high production - high consumption mode and viceversa
- This new mode has a max held sheet of 5, power generation goes from 15000 W to 60000 W and consumes sheets ~3 times faster than the base pacman

Current pacman generation:
-at t1 they are able to make from 10 kW to 40 kW, quadruple that at t4 so from 40 kW to 160 kW.
-a superpacman will produce from 30 kW to 120 kw at t1, from 120 kW to 480 kW at t4.
New pacman generation:
-ranges from 2.5 kW to 10 kW for normal one
-ranges from 15 kW to 60 kW for the more powerful version
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
With the power rebalance done the SM keep on becoming more and more important as supplier of power for the station.
The pacman is a small machine that can outshine the SM quite easily without any effort whatsoever. This change turns it into a portable power provider that can output enough juices to power a couple of rooms, instead of being this huge power supplier (yes a super pacman could output over 480 kW of power, half of what a basic SM can produce!). It works well enough to kickstart the emitters or any non-power-hungry room when there is a lack of power.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Pacmans no longer require stock parts (no more upgrade memery)
balance: Base pacman power generation changed from 10-40 kW (t1) and 40-160 kW (t4) to 2.5-10 kW 
balance: Base pacman max held sheets is 10
balance: Base pacman sheet consumption speed has been quintupled
balance: Super pacman no longer exists, the circuit board now switches between a low production - low consumption mode to high production - high consumption mode and viceversa
balance: This new mode has a max held sheet of 5, power generation changed from 30-120kW (t1) and 120-480kW (t4) to 15-60 kW and consumes sheets ~3 times faster than the base pacman
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
