### PR TITLE
[Icebox] Adds Scrubbers and Vents to Atmos

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -43,6 +43,12 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"acQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "adY" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -1729,6 +1735,7 @@
 /area/hallway/primary/central)
 "aIg" = (
 /obj/structure/reagent_dispensers/fueltank/large,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "aIF" = (
@@ -7178,9 +7185,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "cyS" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -8176,6 +8185,15 @@
 	dir = 8
 	},
 /area/security/checkpoint/auxiliary)
+"cSO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cTe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/coldtemp,
@@ -10769,6 +10787,7 @@
 /obj/structure/table,
 /obj/item/book/manual/wiki/atmospherics,
 /obj/item/analyzer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "eim" = (
@@ -12653,6 +12672,7 @@
 "fhl" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "fhF" = (
@@ -15133,6 +15153,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"gsX" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gte" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -17152,6 +17179,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hof" = (
@@ -17959,7 +17987,6 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hIx" = (
@@ -19253,6 +19280,7 @@
 	c_tag = "Atmospherics South West";
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ism" = (
@@ -20791,6 +20819,7 @@
 /area/commons/locker)
 "jaU" = (
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "jbd" = (
@@ -22100,7 +22129,6 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jJj" = (
@@ -24433,6 +24461,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kQo" = (
@@ -24837,6 +24866,7 @@
 	dir = 8
 	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "laM" = (
@@ -30815,6 +30845,7 @@
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ojf" = (
@@ -32326,6 +32357,7 @@
 	},
 /obj/machinery/duct,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "oTY" = (
@@ -32895,6 +32927,7 @@
 /area/command/bridge)
 "pmK" = (
 /obj/machinery/space_heater,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "pmR" = (
@@ -34843,6 +34876,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/large,
 /area/engineering/atmos)
 "qgp" = (
@@ -36047,6 +36081,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qOd" = (
@@ -36083,6 +36118,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/pharmacy)
+"qPA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qQb" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -37306,6 +37347,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rvf" = (
@@ -38087,6 +38129,7 @@
 	req_access_txt = "24"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "rNv" = (
@@ -39859,6 +39902,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sDh" = (
@@ -41065,6 +41110,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tjK" = (
@@ -43992,6 +44038,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uCs" = (
@@ -44250,6 +44297,7 @@
 /area/command/heads_quarters/rd)
 "uHm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uHn" = (
@@ -44614,6 +44662,7 @@
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uQt" = (
@@ -49807,6 +49856,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xyX" = (
@@ -83476,7 +83527,7 @@ xNI
 dTN
 hIm
 jIW
-jIW
+gsX
 cyS
 ojc
 ruZ
@@ -83734,7 +83785,7 @@ rMX
 sDg
 xyM
 xyM
-xyM
+cSO
 kGc
 bKp
 qnj
@@ -83747,7 +83798,7 @@ sUc
 eYL
 rLU
 hnq
-rLU
+acQ
 bKp
 rLU
 nmi
@@ -84004,7 +84055,7 @@ xjx
 xjx
 xXV
 hnq
-rLU
+qPA
 rGD
 ciH
 qbd


### PR DESCRIPTION
## About The Pull Request

Title
Closes #66370

Adds 2 pairs of Vents/Scrubbers to Icebox Atmos

## Why It's Good For The Game

They could produce air for the station, but not themselves. Ironic.

## Changelog
:cl:
fix: Atmos Technicians have finally gotten off their bums and done their jobs- installing vents and scrubbers into atmos. 
/:cl: