### PR TITLE
Makes supermatter dusting independent of the reference frame.

### DIFF
--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -245,6 +245,49 @@
 	playsound(get_turf(src), 'sound/effects/supermatter.ogg', 50, TRUE)
 	Consume(hit_object)
 
+/obj/machinery/power/supermatter_crystal/Bump(atom/bumped_atom)
+	. = ..()
+	if(isturf(bumped_atom))
+		var/turf/bumped_turf = bumped_atom
+		var/bumped_name = "\the [bumped_atom]"
+		var/bumped_text = span_danger("\The [src] smacks into [bumped_name] and [bumped_atom.p_they()] rapidly flashes to ash!")
+		if(!bumped_turf.Melt())
+			return
+
+		visible_message(
+			bumped_text,
+			null,
+			span_hear("You hear a loud crack as you are washed with a wave of heat.")
+		)
+		playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
+
+		var/suspicion = null
+		if (fingerprintslast)
+			suspicion = "- and was last touched by [fingerprintslast]"
+			message_admins("\The [src] has consumed [bumped_name][suspicion].")
+		investigate_log("has consumed [bumped_name][suspicion].")
+
+		radiation_pulse(src, max_range = 6, threshold = 0.2, chance = 50)
+		return
+
+	if(isliving(bumped_atom))
+		visible_message(
+			span_danger("\The [src] slams into \the [bumped_atom] inducing a resonance... [bumped_atom.p_their()] body starts to glow and burst into flames before flashing into dust!"),
+			span_userdanger("\The [src] slams into you as your ears are filled with unearthly ringing. Your last thought is \"Oh, fuck.\""),
+			span_hear("You hear an unearthly noise as a wave of heat washes over you.")
+		)
+	else if(isobj(bumped_atom) && !iseffect(bumped_atom))
+		visible_message(
+			span_danger("\The [src] smacks into \the [bumped_atom] and [bumped_atom.p_they()] rapidly flashes to ash."),
+			null,
+			span_hear("You hear a loud crack as you are washed with a wave of heat.")
+		)
+	else
+		return
+
+	playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
+	Consume(bumped_atom)
+
 /obj/machinery/power/supermatter_crystal/intercept_zImpact(list/falling_movables, levels)
 	. = ..()
 	for(var/atom/movable/hit_object as anything in falling_movables)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the supermatter running into you just as deadly as you running into the supermatter.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The supermatter running into you is just as deadly as you running into the supermatter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
