### PR TITLE
adds a config folder for off-repo modular ruins

### DIFF
--- a/code/modules/mapping/modular_map_loader/modular_map_loader.dm
+++ b/code/modules/mapping/modular_map_loader/modular_map_loader.dm
@@ -8,37 +8,10 @@
 
 	/// Points to a .toml file storing configuration data about the modules associated with this root
 	var/config_file = null
-	/// Used for off-repo modular maps. Give a list of valid http links and one is picked at random to be requested.
-	var/external_map_urls = list()
-	/// The off-repo modular map that was picked and fetched from one of the above links.
-	var/external_map_file
 	/// Key used to look up the appropriate map paths in the associated .toml file
 	var/key = null
-	/// If we load from an external http link, defaults to FALSE
-	var/load_from_external = FALSE
 
 INITIALIZE_IMMEDIATE(/obj/modular_map_root)
-
-/obj/modular_map_root/proc/get_external_map()
-	var/picked_url = pick(external_map_urls)
-	var/static/query_in_progress = FALSE
-	if(query_in_progress)
-		UNTIL(!query_in_progress)
-	log_asset("Modular map fetching custom map from: [picked_url]")
-	var/datum/http_request/request = new()
-	var/file_name = "tmp/custom_modular_map.dmm"
-	request.prepare(RUSTG_HTTP_METHOD_GET, picked_url, "", "", file_name)
-	query_in_progress = TRUE
-	request.begin_async()
-	UNTIL(request.is_complete())
-	var/datum/http_response/response = request.into_response()
-	if(response.errored || response.status_code != 200)
-		query_in_progress = FALSE
-		CRASH("Failed to fetch custom modular map from url: [picked_url], code: [response.status_code], error: [response.error]")
-	external_map_file = file(file_name)
-	query_in_progress = FALSE
-	log_asset("External modular map loaded: [external_map_file]")
-	return TRUE
 
 /obj/modular_map_root/Initialize(mapload)
 	. = ..()
@@ -50,23 +23,15 @@ INITIALIZE_IMMEDIATE(/obj/modular_map_root)
 
 	var/datum/map_template/map_module/map = new()
 
-	if(load_from_external)
-		if(!get_external_map())
-			return
-
-	if(!config_file && !load_from_external)
+	if(!config_file)
 		return
 
-	if(!key && !load_from_external)
+	if(!key)
 		return
 
 	var/config = rustg_read_toml_file(config_file)
 
-	var/mapfile
-	if(load_from_external)
-		mapfile = "[external_map_file]"
-	else
-		mapfile = config["directory"] + pick(config["rooms"][key]["modules"])
+	var/mapfile = config["directory"] + pick(config["rooms"][key]["modules"])
 
 	map.load(spawn_area, FALSE, mapfile)
 

--- a/code/modules/mapping/modular_map_loader/modular_map_loader.dm
+++ b/code/modules/mapping/modular_map_loader/modular_map_loader.dm
@@ -1,5 +1,5 @@
 /obj/modular_map_root
-	//invisibility = INVISIBILITY_ABSTRACT
+	invisibility = INVISIBILITY_ABSTRACT
 	icon = 'icons/obj/device.dmi'
 	icon_state = "pinonclose"
 
@@ -70,7 +70,7 @@ INITIALIZE_IMMEDIATE(/obj/modular_map_root)
 
 	map.load(spawn_area, FALSE, mapfile)
 
-	//qdel(src, force=TRUE)
+	qdel(src, force=TRUE)
 
 /datum/map_template/map_module
 	name = "Base Map Module Template"

--- a/code/modules/mapping/modular_map_loader/modular_map_loader.dm
+++ b/code/modules/mapping/modular_map_loader/modular_map_loader.dm
@@ -1,5 +1,5 @@
 /obj/modular_map_root
-	invisibility = INVISIBILITY_ABSTRACT
+	//invisibility = INVISIBILITY_ABSTRACT
 	icon = 'icons/obj/device.dmi'
 	icon_state = "pinonclose"
 
@@ -8,10 +8,37 @@
 
 	/// Points to a .toml file storing configuration data about the modules associated with this root
 	var/config_file = null
+	/// Used for off-repo modular maps. Give a list of valid http links and one is picked at random to be requested.
+	var/external_map_urls = list()
+	/// The off-repo modular map that was picked and fetched from one of the above links.
+	var/external_map_file
 	/// Key used to look up the appropriate map paths in the associated .toml file
 	var/key = null
+	/// If we load from an external http link, defaults to FALSE
+	var/load_from_external = FALSE
 
 INITIALIZE_IMMEDIATE(/obj/modular_map_root)
+
+/obj/modular_map_root/proc/get_external_map()
+	var/picked_url = pick(external_map_urls)
+	var/static/query_in_progress = FALSE
+	if(query_in_progress)
+		UNTIL(!query_in_progress)
+	log_asset("Modular map fetching custom map from: [picked_url]")
+	var/datum/http_request/request = new()
+	var/file_name = "tmp/custom_modular_map.dmm"
+	request.prepare(RUSTG_HTTP_METHOD_GET, picked_url, "", "", file_name)
+	query_in_progress = TRUE
+	request.begin_async()
+	UNTIL(request.is_complete())
+	var/datum/http_response/response = request.into_response()
+	if(response.errored || response.status_code != 200)
+		query_in_progress = FALSE
+		CRASH("Failed to fetch custom modular map from url: [picked_url], code: [response.status_code], error: [response.error]")
+	external_map_file = file(file_name)
+	query_in_progress = FALSE
+	log_asset("External modular map loaded: [external_map_file]")
+	return TRUE
 
 /obj/modular_map_root/Initialize(mapload)
 	. = ..()
@@ -23,19 +50,27 @@ INITIALIZE_IMMEDIATE(/obj/modular_map_root)
 
 	var/datum/map_template/map_module/map = new()
 
-	if(!config_file)
+	if(load_from_external)
+		if(!get_external_map())
+			return
+
+	if(!config_file && !load_from_external)
 		return
 
-	if(!key)
+	if(!key && !load_from_external)
 		return
 
 	var/config = rustg_read_toml_file(config_file)
 
-	var/mapfile = config["directory"] + pick(config["rooms"][key]["modules"])
+	var/mapfile
+	if(load_from_external)
+		mapfile = "[external_map_file]"
+	else
+		mapfile = config["directory"] + pick(config["rooms"][key]["modules"])
 
 	map.load(spawn_area, FALSE, mapfile)
 
-	qdel(src, force=TRUE)
+	//qdel(src, force=TRUE)
 
 /datum/map_template/map_module
 	name = "Base Map Module Template"

--- a/config/modular_maps/Config Files/README.md
+++ b/config/modular_maps/Config Files/README.md
@@ -1,0 +1,3 @@
+Add the config files for modular maps here.
+
+**These are fully cached so keep this directory empty by default.**

--- a/config/modular_maps/README.md
+++ b/config/modular_maps/README.md
@@ -1,0 +1,3 @@
+Add modular maps here.
+
+**These are fully cached so keep this directory empty by default.**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a location to load in off-repo modular maps/config files.

## Why It's Good For The Game
Sticking with the theme of away missions being revitalized, we have a system in place for off-repo away missions but not off-repo modular maps. This allows for randomization in these missions while still keeping the actual map contents a secret to the regular playerbase.

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

this just adds a config folder location to throw modular maps/their config files.
