### PR TITLE
Kills research scanner toggle, moves functionality to examine_more. Improves research scanner code and fixes a modsuit bug.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -258,6 +258,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_NEGATES_GRAVITY "negates_gravity"
 /// Lets us scan reagents
 #define TRAIT_REAGENT_SCANNER "reagent_scanner"
+/// Lets us scan machine parts and tech unlocks
+#define TRAIT_RESEARCH_SCANNER "research_scanner"
 /// Can weave webs into cloth
 #define TRAIT_WEB_WEAVER "web_weaver"
 #define TRAIT_ABDUCTOR_TRAINING "abductor-training"

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -461,28 +461,6 @@
 	check_flags = NONE
 	name = "Activate Explosive Implant"
 
-/datum/action/item_action/toggle_research_scanner
-	name = "Toggle Research Scanner"
-	icon_icon = 'icons/mob/actions/actions_items.dmi'
-	button_icon_state = "scan_mode"
-	var/active = FALSE
-
-/datum/action/item_action/toggle_research_scanner/Trigger(trigger_flags)
-	if(IsAvailable())
-		active = !active
-		if(active)
-			owner.research_scanner++
-		else
-			owner.research_scanner--
-		to_chat(owner, span_notice("[target] research scanner has been [active ? "activated" : "deactivated"]."))
-		return 1
-
-/datum/action/item_action/toggle_research_scanner/Remove(mob/M)
-	if(owner && active)
-		owner.research_scanner--
-		active = FALSE
-	..()
-
 /datum/action/item_action/instrument
 	name = "Use Instrument"
 	desc = "Use the instrument specified"

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -935,7 +935,10 @@
 				. += "It appears heavily damaged."
 			if(0 to 25)
 				. += span_warning("It's falling apart!")
-	if(user.research_scanner && component_parts)
+
+/obj/machinery/examine_more(mob/user)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_RESEARCH_SCANNER) && component_parts)
 		. += display_parts(user, TRUE)
 
 //called on machinery construction (i.e from frame to machinery) but not on initialization

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -342,10 +342,12 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 			. += "[src] is made of cold-resistant materials."
 		if(resistance_flags & FIRE_PROOF)
 			. += "[src] is made of fire-retardant materials."
-
-	if(!user.research_scanner)
 		return
 
+/obj/item/examine_more(mob/user)
+	. = ..()
+	if(!HAS_TRAIT(user, TRAIT_RESEARCH_SCANNER))
+		return
 	/// Research prospects, including boostable nodes and point values. Deliver to a console to know whether the boosts have already been used.
 	var/list/research_msg = list("<font color='purple'>Research prospects:</font> ")
 	///Separator between the items on the list

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -346,8 +346,11 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 /obj/item/examine_more(mob/user)
 	. = ..()
-	if(!HAS_TRAIT(user, TRAIT_RESEARCH_SCANNER))
-		return
+	if(HAS_TRAIT(user, TRAIT_RESEARCH_SCANNER))
+		research_scan(user)
+		. += research_scan()
+
+/obj/item/proc/research_scan(mob/user)
 	/// Research prospects, including boostable nodes and point values. Deliver to a console to know whether the boosts have already been used.
 	var/list/research_msg = list("<font color='purple'>Research prospects:</font> ")
 	///Separator between the items on the list
@@ -381,7 +384,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	else
 		research_msg += "None"
 	research_msg += "."
-	. += research_msg.Join()
+	return research_msg.Join()
 
 /obj/item/interact(mob/user)
 	add_fingerprint(user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -347,8 +347,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 /obj/item/examine_more(mob/user)
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_RESEARCH_SCANNER))
-		research_scan(user)
-		. += research_scan()
+		. += research_scan(user)
 
 /obj/item/proc/research_scan(mob/user)
 	/// Research prospects, including boostable nodes and point values. Deliver to a console to know whether the boosts have already been used.

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -317,7 +317,7 @@
 /obj/structure/blob/examine(mob/user)
 	. = ..()
 	var/datum/atom_hud/hud_to_check = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
-	if(user.research_scanner || hud_to_check.hudusers[user])
+	if(HAS_TRAIT(user, TRAIT_RESEARCH_SCANNER) || hud_to_check.hudusers[user])
 		. += "<b>Your HUD displays an extensive report...</b><br>"
 		if(overmind)
 			. += overmind.blobstrain.examine(user)

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -144,11 +144,10 @@
 	desc = "A pair of snazzy goggles used to protect against chemical spills. Fitted with an analyzer for scanning items and reagents."
 	icon_state = "purple"
 	inhand_icon_state = "glasses"
-	actions_types = list(/datum/action/item_action/toggle_research_scanner)
 	glass_colour_type = /datum/client_colour/glass_colour/purple
 	resistance_flags = ACID_PROOF
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 80, ACID = 100)
-	clothing_traits = list(TRAIT_REAGENT_SCANNER)
+	clothing_traits = list(TRAIT_REAGENT_SCANNER, TRAIT_RESEARCH_SCANNER)
 
 /obj/item/clothing/glasses/science/item_action_slot_check(slot)
 	if(slot == ITEM_SLOT_EYES)
@@ -314,8 +313,7 @@
 	name = "science glasses"
 	icon_state = "sunhudsci"
 	desc = "A pair of tacky purple sunglasses that allow the wearer to recognize various chemical compounds with only a glance."
-	clothing_traits = list(TRAIT_REAGENT_SCANNER)
-	actions_types = list(/datum/action/item_action/toggle_research_scanner)
+	clothing_traits = list(TRAIT_REAGENT_SCANNER, TRAIT_RESEARCH_SCANNER)
 
 /obj/item/clothing/glasses/sunglasses/gar
 	name = "black gar glasses"

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -149,8 +149,6 @@
 	var/datum/component/storage/active_storage
 	/// Active hud
 	var/datum/hud/hud_used = null
-	/// I have no idea tbh
-	var/research_scanner = FALSE
 
 	/// Is the mob throw intent on
 	var/throw_mode = THROW_MODE_DISABLED

--- a/code/modules/mod/modules/modules_science.dm
+++ b/code/modules/mod/modules/modules_science.dm
@@ -35,15 +35,15 @@
 	. = ..()
 	if(!.)
 		return
-	mod.wearer.research_scanner++
+	ADD_TRAIT(mod.wearer, TRAIT_RESEARCH_SCANNER, MOD_TRAIT)
 	RegisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION, .proc/sense_explosion)
 
 /obj/item/mod/module/reagent_scanner/advanced/on_deactivation(display_message = TRUE, deleting = FALSE)
 	. = ..()
 	if(!.)
 		return
-	mod.wearer.research_scanner--
-	RegisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION)
+	REMOVE_TRAIT(mod.wearer, TRAIT_RESEARCH_SCANNER, MOD_TRAIT)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION)
 
 /obj/item/mod/module/reagent_scanner/advanced/proc/sense_explosion(datum/source, turf/epicenter,
 	devastation_range, heavy_impact_range, light_impact_range, took, orig_dev_range, orig_heavy_range, orig_light_range)

--- a/code/modules/research/xenobiology/vatgrowing/vatgrower.dm
+++ b/code/modules/research/xenobiology/vatgrowing/vatgrower.dm
@@ -65,14 +65,14 @@
 	RegisterSignal(biological_sample, COMSIG_SAMPLE_GROWTH_COMPLETED, .proc/on_sample_growth_completed)
 
 ///Adds text for when there is a sample in the vat
-/obj/machinery/plumbing/growing_vat/examine(mob/user)
+/obj/machinery/plumbing/growing_vat/examine_more(mob/user)
 	. = ..()
 	if(!biological_sample)
 		return
 	. += span_notice("It seems to have a sample in it!")
 	for(var/i in biological_sample.micro_organisms)
 		var/datum/micro_organism/MO = i
-		. += MO.get_details(user.research_scanner)
+		. += MO.get_details(HAS_TRAIT(user, TRAIT_RESEARCH_SCANNER))
 
 /obj/machinery/plumbing/growing_vat/plunger_act(obj/item/plunger/P, mob/living/user, reinforced)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR removes the Research Scanner Toggle action button. The functionality it used to enable has been moved to `examine_more` for everything EXCEPT seeing extra details about a Blob. It also turns `research_scanner` into a trait, which should make the code a little nicer.  While testing this PR, my debug instance paused on a runtime due to an existing bug with the MOD advanced reagent scanner module, which was registering a signal twice, instead of registering it and unregistering it. So I fixed that, too.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Research Scanner function of science goggles typically involves a very small amount of examine text, and has relatively niche uses. The toggle button has always seemed very unneccesary, and frankly it drove me insane. The uses for the function are pretty niche, and aren't disruptive to have constantly active. That said, making it a part of `examine_more` instead of just `examine` makes sure you aren't flooding your chat with a list of parts when you don't want to.

I don't understand EXACTLY why making `research_scanner` a trait is better, but if you look at the current code used in the action I'm removing here, it might be obvious? LemonInTheDark seemed to think it was an improvement.

And last but not least, bugs are bad, so fixing a bug is good!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Vladoricious
qol: The research scanner in science goggles and similar eyewear no longer requires you to press a button to turn it on! Instead, simply closely examine your target.
fix: The MOD advanced reagent scanner module no longer detects explosions despite being disabled.
code: Research scanner code cleanup.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
