### PR TITLE
Fixes some inappropriate diagonal corners in Hilberts

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -5180,9 +5180,9 @@ Ba
 Ba
 Ba
 sa
+Ok
 Bo
-Bo
-BJ
+Iy
 sj
 sj
 sj
@@ -5258,9 +5258,9 @@ vr
 vr
 vr
 vr
+Ok
 Bo
-Bo
-BJ
+Iy
 sj
 sj
 sj


### PR DESCRIPTION
## About The Pull Request

While exploring the Hilbert facility as a ghost, Me and a couple of other people noticed some diagonal walls adjacent to airlocks. Simply put, that doesn't look right.

Before:
![hilbertfixbefore](https://user-images.githubusercontent.com/12720844/164793111-012b8f2c-e91a-4982-a522-8da4d23b50bb.png)

After:
![hilbertfixafter](https://user-images.githubusercontent.com/12720844/164793121-49a1a60f-0e48-40b5-b0c9-39c4722d52e9.png)

## Why It's Good For The Game

Ever so slightly prettifies a map.

## Changelog

:cl:
fix: A couple of ugly-looking diagonal walls in the Hilbert Research Facility have been straightened out.
/:cl:
