### PR TITLE
Adds Icons to Crew Monitor Console

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -101,7 +101,7 @@ const CrewTable = (props, context) => {
         <Table.Cell bold collapsing textAlign="center">
           Position
         </Table.Cell>
-        {(
+        {!!data.link_allowed && (
           <Table.Cell bold collapsing textAlign="center">
             Tracking
           </Table.Cell>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -1,16 +1,25 @@
 import { sortBy } from 'common/collections';
 import { useBackend } from '../backend';
-import { Box, Button, ColorBox, Section, Table } from '../components';
+import { Box, Button, Section, Table, Icon } from '../components';
 import { COLORS } from '../constants';
 import { Window } from '../layouts';
 
 const HEALTH_COLOR_BY_LEVEL = [
   '#17d568',
-  '#2ecc71',
+  '#c4cf2d', 
   '#e67e22',
   '#ed5100',
   '#e74c3c',
-  '#ed2814',
+  '#801308', 
+];
+
+const HEALTH_ICON_BY_LEVEL = [
+  'heart',
+  'heart',
+  'heart',
+  'heart',
+  'heartbeat',
+  'skull',
 ];
 
 const jobIsHead = jobId => jobId % 10 === 0;
@@ -40,10 +49,10 @@ const jobToColor = jobId => {
   return COLORS.department.other;
 };
 
-const healthToColor = (oxy, tox, burn, brute) => {
+const healthToAttribute = (oxy, tox, burn, brute, attributeList) => {
   const healthSum = oxy + tox + burn + brute;
   const level = Math.min(Math.max(Math.ceil(healthSum / 25), 0), 5);
-  return HEALTH_COLOR_BY_LEVEL[level];
+  return attributeList[level];
 };
 
 const HealthStat = props => {
@@ -89,11 +98,11 @@ const CrewTable = (props, context) => {
         <Table.Cell bold collapsing textAlign="center">
           Vitals
         </Table.Cell>
-        <Table.Cell bold>
+        <Table.Cell bold collapsing textAlign="center">
           Position
         </Table.Cell>
-        {!!data.link_allowed && (
-          <Table.Cell bold collapsing>
+        {(
+          <Table.Cell bold collapsing textAlign="center">
             Tracking
           </Table.Cell>
         )}
@@ -130,16 +139,27 @@ const CrewTableEntry = (props, context) => {
         {name}{assignment !== undefined ? ` (${assignment})` : ""}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
-        {life_status ? (
-          <ColorBox
-            color={healthToColor(
+      {oxydam !== undefined ? (
+          <Icon
+            name={healthToAttribute(
               oxydam,
               toxdam,
               burndam,
-              brutedam)} />
+              brutedam,
+              HEALTH_ICON_BY_LEVEL)}
+            color={healthToAttribute(
+              oxydam,
+              toxdam,
+              burndam,
+              brutedam,
+              HEALTH_COLOR_BY_LEVEL)}
+            size={1} />
         ) : (
-          <ColorBox color={'#ed2814'} />
-        )}
+          life_status ? (
+            <Icon name="heart" color="#17d568" size={1} />
+          ) : (
+            <Icon name="skull" color="#B7410E" size={1} />
+          ))}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (
@@ -157,7 +177,7 @@ const CrewTableEntry = (props, context) => {
         )}
       </Table.Cell>
       <Table.Cell>
-        {area !== undefined ? area : 'N/A'}
+        {area !== undefined ? area : <Icon name="question" color="#ffffff" size={1} />}
       </Table.Cell>
       {!!link_allowed && (
         <Table.Cell collapsing>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -158,7 +158,7 @@ const CrewTableEntry = (props, context) => {
           life_status ? (
             <Icon name="heart" color="#17d568" size={1} />
           ) : (
-            <Icon name="skull" color="#B7410E" size={1} />
+            <Icon name="skull" color="#801308" size={1} />
           ))}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -139,7 +139,7 @@ const CrewTableEntry = (props, context) => {
         {name}{assignment !== undefined ? ` (${assignment})` : ""}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
-      {oxydam !== undefined ? (
+        {oxydam !== undefined ? (
           <Icon
             name={healthToAttribute(
               oxydam,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports this Pull Request from Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/12744
They said it wouldn't work on TGStation for some reason but I don't know why they said that because everything works and there's no reason it shouldn't. 

My test picture on TG:
![image](https://user-images.githubusercontent.com/47338680/164844253-390bdc32-89ba-4a71-a2bc-68d661930183.png)
Skyrat picture which neatly shows all the icons:
![image](https://user-images.githubusercontent.com/47338680/164845131-565e7d91-febb-45d1-b3a6-700926b7d9e9.png)


- Replaces the vague ColorBox in the Crew Monitor Console with icons that are more descriptive 
- Centers the title text in the Crew Monitor Console
- Replaces the N/A text with a Question Mark



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The ColorBox was vague and unclear to understand. Adding icons will make it simpler to understand the state of people tracked on the Crew Monitor Console.



<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Replaces the ColorBox in Crew Monitor Console with various Icons
expansion: Replaces the N/A for unknown locations in Crew Monitor Console with a Question Mark
spellcheck: Centers title text in the Crew Monitor Console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
