### PR TITLE
Corrects crab pathway. Crab can be cooked again.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -175,8 +175,8 @@
 /obj/item/food/meat/rawbacon,
 /obj/item/food/meat/rawcutlet,
 /obj/item/food/meat/rawcutlet,
-/obj/item/food/meat/rawcrab,
-/obj/item/food/meat/rawcrab,
+/obj/item/food/meat/slab/rawcrab,
+/obj/item/food/meat/slab/rawcrab,
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "dc" = (

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -932,7 +932,7 @@
 /obj/item/food/meat/slab/penguin/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/penguin, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE) //Add medium rare later maybe?
 
-/obj/item/food/meat/rawcrab
+/obj/item/food/meat/slab/rawcrab
 	name = "raw crab meat"
 	desc = "A pile of raw crab meat."
 	icon_state = "crabmeatraw"
@@ -941,7 +941,7 @@
 	tastes = list("raw crab" = 1)
 	foodtypes = RAW | MEAT
 
-/obj/item/food/meat/rawcrab/MakeGrillable()
+/obj/item/food/meat/slab/rawcrab/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/crab, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE) //Add medium rare later maybe?
 
 /obj/item/food/meat/crab

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -941,7 +941,7 @@
 	tastes = list("raw crab" = 1)
 	foodtypes = RAW | MEAT
 
-/obj/item/food/meat/slab/rawcrab/MakeGrillable()
+/obj/item/food/meat/rawcrab/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/crab, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE) //Add medium rare later maybe?
 
 /obj/item/food/meat/crab

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -178,7 +178,7 @@
 		/obj/item/food/doughslice = 1,
 		/datum/reagent/consumable/cream = 5,
 		/obj/item/food/cheese/wedge = 1,
-		/obj/item/food/meat/rawcrab = 1
+		/obj/item/food/meat/slab/rawcrab = 1
 	)
 	result = /obj/item/food/crab_rangoon
 	subcategory = CAT_MISCFOOD

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -10,7 +10,7 @@
 	emote_see = list("clacks.")
 	speak_chance = 1
 	turns_per_move = 5
-	butcher_results = list(/obj/item/food/meat/rawcrab = 2)
+	butcher_results = list(/obj/item/food/meat/slab/rawcrab = 2)
 	response_help_continuous = "pets"
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"


### PR DESCRIPTION
## About The Pull Request

Someone listed the raw crab meat grilling process with /slab/ in the path. I don't think crab was ever actually cookable since this happened so uh... yeah, I guess we went almost a year without noticing this.

Edit: Okay, apparently a bunch of maps were checking for /slab/ for their crab. Crab has been updated to include the /slab/ pathway so that maps won't scream at me.

## Why It's Good For The Game

Fixing broken things is good.

![image](https://user-images.githubusercontent.com/16896032/164856294-e1d809b4-e401-4c1d-b45c-86bb66745a83.png)


## Changelog


:cl:
fix: error in crab pathway. Crab can be grilled again.
/:cl:
