### PR TITLE
Add tcomms relay to DJ station

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -13,6 +13,13 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/space/nearstation)
+"f" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Telecommunications"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/djstation/service)
 "h" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/closet/crate,
@@ -24,6 +31,11 @@
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
 	},
+/turf/open/floor/plating,
+/area/ruin/space/djstation/service)
+"j" = (
+/obj/machinery/light/small/directional/south,
+/obj/item/taperecorder,
 /turf/open/floor/plating,
 /area/ruin/space/djstation/service)
 "n" = (
@@ -39,6 +51,10 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"u" = (
+/obj/machinery/telecomms/relay/preset/telecomms,
+/turf/open/floor/plating,
+/area/ruin/space/djstation/service)
 "v" = (
 /turf/closed/wall,
 /area/ruin/space/djstation/service)
@@ -555,9 +571,9 @@ o
 e
 e
 v
-y
-P
-y
+v
+f
+v
 v
 o
 o
@@ -581,11 +597,11 @@ o
 o
 o
 o
-o
-o
-U
-o
-o
+v
+u
+A
+j
+v
 o
 o
 b
@@ -608,11 +624,11 @@ o
 o
 o
 o
-o
-o
-o
-o
-o
+v
+y
+P
+y
+v
 o
 o
 o
@@ -637,7 +653,7 @@ o
 o
 o
 o
-o
+U
 o
 o
 o


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a telecomms relay to DJ station, put in its own tiny room (to be consistent with other ruins/stations) and with a tape recorder as filler.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #66381 , makes the intercoms actually usable
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The DJ station space ruin's intercoms can now actually be used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
