### PR TITLE
Fixes a copy+paste issue with "open the hatch" surgery step sound

### DIFF
--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -122,7 +122,7 @@
 		span_notice("[user] begins to open the hatch holders in [target]'s [parse_zone(target_zone)]."))
 	display_pain(target, "The last faint pricks of tactile sensation fade from your [parse_zone(target_zone)] as the hatch is opened.", TRUE)
 
-/datum/surgery_step/mechanic_unwrench/tool_check(mob/user, obj/item/tool)
+/datum/surgery_step/open_hatch/tool_check(mob/user, obj/item/tool)
 	if(tool.usesound)
 		preop_sound = tool.usesound
 


### PR DESCRIPTION
## About The Pull Request

`/datum/surgery_step/open_hatch` 's `tool_check()` was not copy+pasted correctly, so the sound was incorrect. 

## Why It's Good For The Game

Makes a surgery Step plays the right sound.

## Changelog

:cl: Melbert
fix: "Open the Hatch" surgery step plays a sound that is potentially more accurate to the tool being used. 
/:cl:
