### PR TITLE
Remaps meta's ordnance take two

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2666,6 +2666,10 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
+/obj/machinery/door/window/left/directional/east{
+	name = "Ordnance Freezer Chamber Access";
+	req_access_txt = "8"
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "aCU" = (
@@ -3850,7 +3854,7 @@
 	sortType = 25
 	},
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "aVa" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/dark,
@@ -3991,6 +3995,11 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "rdordnance";
+	name = "Ordnance Containment Control";
+	req_access_txt = "30"
+	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "aWz" = (
@@ -7469,7 +7478,7 @@
 	name = "Burn Chamber Exterior Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "bSS" = (
@@ -8691,9 +8700,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "cnV" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -8706,7 +8712,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "coi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -9494,7 +9500,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance_storage,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
 /turf/open/floor/plating,
 /area/science/storage)
 "cAN" = (
@@ -13831,7 +13837,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "dMu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
@@ -15541,7 +15547,7 @@
 "eqN" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "eqO" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/light/small/directional/north,
@@ -16018,7 +16024,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "eyk" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_secure_all,
@@ -16342,14 +16348,9 @@
 /turf/open/floor/iron,
 /area/security/office)
 "eEK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "eEU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -16553,7 +16554,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/plating,
 /area/science/mixing)
 "eIn" = (
@@ -16606,9 +16607,9 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "eIK" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/science/mixing/hallway)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "eIP" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/sign/poster/official/safety_eye_protection{
@@ -16640,7 +16641,7 @@
 "eJw" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "eJA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16794,7 +16795,7 @@
 "eLK" = (
 /obj/structure/closet/bombcloset,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "eLR" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -17498,15 +17499,12 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "eZr" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "eZU" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
@@ -20171,7 +20169,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "gbH" = (
 /obj/structure/chair/stool/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21309,7 +21307,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/plating,
 /area/science/mixing)
 "gxC" = (
@@ -21369,7 +21367,7 @@
 	},
 /obj/structure/closet/bombcloset,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "gyB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room"
@@ -22200,6 +22198,10 @@
 	},
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/newscaster/directional/south,
+/obj/machinery/door/window/right/directional/east{
+	req_access_txt = "8";
+	name = "Ordnance Freezer Chamber Access"
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "gSm" = (
@@ -22438,6 +22440,11 @@
 	pixel_y = 9
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/requests_console/directional/west{
+	department = "Ordnance Test Range";
+	departmentType = 5;
+	name = "Test Range Requests Console"
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "gVP" = (
@@ -23183,6 +23190,7 @@
 	c_tag = "Science Ordnance Storage";
 	network = list("ss13","rd")
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "hin" = (
@@ -25451,7 +25459,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance_storage,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "ibf" = (
@@ -28616,6 +28624,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/dark/airless,
 /area/science/mixing/chamber)
 "jnU" = (
@@ -29267,6 +29276,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/mixing/hallway)
 "jyK" = (
@@ -31367,6 +31377,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/science/research)
 "koy" = (
@@ -32572,6 +32585,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/dark/airless,
 /area/science/mixing/chamber)
 "kKj" = (
@@ -36084,15 +36098,15 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "lZH" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/structure/closet/firecloset,
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "lZJ" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -36216,7 +36230,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "mbm" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/duct,
@@ -36534,7 +36548,7 @@
 /obj/effect/spawner/random/clothing/costume,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "mfg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/reagent_dispensers/watertank,
@@ -37785,7 +37799,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance_storage,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "mBU" = (
@@ -38478,6 +38492,7 @@
 /obj/structure/sign/poster/random/directional/east{
 	pixel_y = 32
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "mLC" = (
@@ -39566,6 +39581,7 @@
 	pixel_y = 9
 	},
 /obj/item/raw_anomaly_core/random,
+/obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "nbL" = (
@@ -39889,7 +39905,7 @@
 /area/service/kitchen)
 "nhe" = (
 /obj/machinery/door/poddoor/incinerator_ordmix,
-/turf/open/space/basic,
+/turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "nht" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40351,11 +40367,6 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/machinery/requests_console/directional/west{
-	department = "Ordnance Test Range";
-	departmentType = 5;
-	name = "Test Range Requests Console"
-	},
 /obj/item/assembly/signaler{
 	pixel_x = 6;
 	pixel_y = 5
@@ -40372,6 +40383,7 @@
 	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "npp" = (
@@ -42466,7 +42478,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "ofK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -45828,7 +45840,7 @@
 	pixel_x = 24;
 	pixel_y = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "ptF" = (
@@ -46813,8 +46825,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "pNi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -50431,7 +50446,7 @@
 	name = "Ordnance Lab"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/white,
 /area/science/mixing/hallway)
 "rhj" = (
@@ -50464,7 +50479,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/plating,
 /area/science/mixing/launch)
 "rhP" = (
@@ -50722,10 +50737,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/science/mixing/launch)
-"rmm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/science/mixing/hallway)
 "rmt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
@@ -52856,6 +52867,9 @@
 	req_one_access_txt = "12;47"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "scS" = (
@@ -53436,7 +53450,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/white,
 /area/science/mixing/hallway)
 "spA" = (
@@ -55289,9 +55303,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"tdx" = (
-/turf/open/floor/plating,
-/area/science/mixing/hallway)
 "tdz" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -55516,6 +55527,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/mixing/hallway)
 "thR" = (
@@ -56505,7 +56517,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "tyZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -58326,11 +58338,6 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/machinery/button/door/directional/north{
-	id = "rdordnance";
-	name = "Ordnance Containment Control";
-	req_access_txt = "30"
-	},
 /turf/open/floor/iron/white,
 /area/science/storage)
 "ukF" = (
@@ -59701,7 +59708,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/general,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "uPR" = (
@@ -60449,6 +60456,7 @@
 	c_tag = "Science Ordnance Office";
 	network = list("ss13","rd")
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/grass,
 /area/science/mixing/hallway)
 "vet" = (
@@ -61659,16 +61667,13 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "vCY" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
 /obj/effect/spawner/random/trash/bin,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "vDb" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -62465,6 +62470,7 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/grass,
 /area/science/mixing/hallway)
 "vPU" = (
@@ -63587,7 +63593,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "wng" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -65368,7 +65374,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "wUr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66018,6 +66024,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "xhO" = (
@@ -67595,7 +67604,7 @@
 "xIX" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
-/area/science/mixing/hallway)
+/area/maintenance/aft/lesser)
 "xJd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -68636,6 +68645,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/east{
+	c_tag = "Science Ordnance Storage";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "ygI" = (
@@ -99546,7 +99559,7 @@ wbw
 wbw
 wbw
 wrP
-kkO
+eEK
 wbw
 lMJ
 aaa
@@ -100562,7 +100575,7 @@ pOT
 cyK
 hnc
 nYA
-nYA
+eIK
 nYA
 ovj
 lHb
@@ -101325,18 +101338,18 @@ uLH
 uLH
 uLH
 uLH
-uLH
-uLH
+qBs
+qBs
 cAH
-uLH
-uLH
-uLH
-uLH
-uLH
+qBs
+qBs
+qBs
+qBs
+qBs
 eIm
-uLH
-uLH
-uLH
+qBs
+qBs
+qBs
 qBs
 eSf
 qBs
@@ -101582,17 +101595,17 @@ ktU
 vaJ
 oVD
 fJH
-ktU
+wbw
 cnV
 tyU
 lZH
-eIK
+lRR
 xIX
 eLK
 gyl
-eEK
+fVp
 vCY
-uLH
+qBs
 eJw
 pqd
 pmG
@@ -101848,7 +101861,7 @@ mbj
 mbj
 mbj
 eyd
-rmm
+eTY
 pNc
 eTY
 eTY
@@ -102096,17 +102109,17 @@ ktU
 ghV
 ccZ
 hHW
-ktU
+wbw
 ofF
 wUi
-tdx
-uLH
+kkO
+qBs
 eqN
 eqN
 wmY
 dLV
 eZr
-uLH
+qBs
 mff
 kiY
 dFn
@@ -102353,18 +102366,18 @@ uLH
 tgJ
 oFb
 cXd
-nOc
-dvY
+qBs
+wrP
 scO
-dvY
-nOc
-uLH
-uLH
-uLH
+wrP
+qBs
+qBs
+qBs
+qBs
 rhB
-uLH
-uLH
-uLH
+qBs
+qBs
+qBs
 qBs
 wrP
 wrP

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -672,11 +672,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "ahP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "ahS" = (
@@ -1599,6 +1599,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"asu" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/science/mixing/launch)
 "asz" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -1680,11 +1685,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
 "atF" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/turf/open/floor/iron/white,
+/area/science/research)
 "atL" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -2501,6 +2506,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"aBH" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "aBN" = (
 /obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -2650,16 +2659,34 @@
 	},
 /area/command/gateway)
 "aCR" = (
-/obj/machinery/light/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/storage)
-"aCU" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_mixing_input{
+/obj/machinery/meter/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/turf/open/floor/engine/airless,
-/area/science/mixing/chamber)
+/turf/open/floor/iron/dark,
+/area/science/mixing)
+"aCU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 5
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/light/directional/north,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/wtf_is_co2{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "aDa" = (
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
@@ -2740,8 +2767,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "aEk" = (
-/obj/effect/landmark/blobstart,
-/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "aED" = (
@@ -2850,7 +2878,6 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/research)
 "aFC" = (
@@ -2872,9 +2899,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -3193,11 +3217,10 @@
 /area/maintenance/starboard/fore)
 "aMl" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 14
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "aMq" = (
@@ -3816,10 +3839,17 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aUW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	sortType = 25
+	},
+/turf/open/floor/plating,
 /area/science/mixing/hallway)
 "aVa" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -3953,11 +3983,16 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "aWu" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/portable_atmospherics/pump{
+	name = "Lil Pump"
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 5
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "aWz" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -4185,15 +4220,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aZO" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south{
-	pixel_x = 26
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/storage)
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "aZZ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -4613,6 +4644,7 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "bgQ" = (
@@ -4767,6 +4799,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/chair,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "biQ" = (
@@ -5525,7 +5558,6 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
@@ -6071,9 +6103,20 @@
 /turf/open/floor/iron,
 /area/security/office)
 "bAH" = (
-/obj/machinery/air_sensor/ordnance_mixing_tank,
-/turf/open/floor/engine/airless,
-/area/science/mixing/chamber)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "bAJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -6162,13 +6205,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "bBv" = (
-/obj/structure/cable,
+/obj/item/shard,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/space/nearstation)
 "bBy" = (
 /obj/structure/sign/directions/command{
 	dir = 4;
@@ -6239,11 +6281,19 @@
 /area/hallway/primary/central)
 "bCg" = (
 /obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/machinery/computer/security/telescreen/ordnance{
-	dir = 1
+/obj/item/transfer_valve{
+	pixel_x = 5
 	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/transfer_valve,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "bCv" = (
@@ -6491,12 +6541,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "bEE" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bEF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6777,11 +6827,12 @@
 /area/science/research)
 "bHO" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/doppler_array{
-	dir = 4
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/ordnance{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "bHT" = (
@@ -7062,17 +7113,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bLu" = (
-/obj/structure/rack,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_y = 2
-	},
-/turf/open/floor/iron/white,
-/area/maintenance/aft/lesser)
+/obj/machinery/igniter/incinerator_ordmix,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "bLv" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/neutral,
@@ -7422,17 +7465,13 @@
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "bSF" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior{
+	name = "Burn Chamber Exterior Airlock"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "bSS" = (
 /turf/closed/wall,
 /area/hallway/primary/central)
@@ -7719,13 +7758,12 @@
 /area/commons/locker)
 "bWz" = (
 /obj/machinery/airalarm/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "bWK" = (
@@ -7796,11 +7834,12 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bYi" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/closed/wall,
-/area/science/mixing)
+/turf/open/floor/iron/white,
+/area/science/storage)
 "bYC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7980,6 +8019,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "caX" = (
@@ -8140,6 +8180,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"ccZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "cdf" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -8586,6 +8633,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"cmL" = (
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "cmP" = (
 /turf/closed/wall,
 /area/science/genetics)
@@ -8624,11 +8674,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cnJ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "cnL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -8642,8 +8691,21 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "cnV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/obj/effect/spawner/random/structure/closet_empty,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/science/mixing/hallway)
 "coi" = (
 /obj/effect/turf_decal/stripes/line{
@@ -9333,8 +9395,14 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
 "czD" = (
-/turf/closed/wall,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "czJ" = (
 /turf/closed/wall,
 /area/science/test_area)
@@ -9351,9 +9419,7 @@
 "czT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -9418,12 +9484,19 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "cAH" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "ordnanceaccess";
-	name = "Ordnance Access"
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab"
 	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance_storage,
+/turf/open/floor/plating,
+/area/science/storage)
 "cAN" = (
 /obj/structure/closet/secure_closet/cytology,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -9474,9 +9547,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cBl" = (
-/obj/effect/spawner/random/structure/chair_maintenance,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/effect/turf_decal/siding/purple{
+	dir = 6
+	},
+/obj/machinery/airalarm/mixingchamber{
+	dir = 4;
+	pixel_x = 25
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/mixing/chamber)
 "cBo" = (
 /obj/structure/chair{
 	dir = 4
@@ -9825,6 +9906,7 @@
 "cEU" = (
 /obj/item/toy/figure/roboticist,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "cFb" = (
@@ -9893,9 +9975,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/evac/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -10065,17 +10144,11 @@
 /turf/open/floor/iron,
 /area/science/research)
 "cHo" = (
-/obj/effect/turf_decal/trimline/purple/corner,
-/obj/item/radio/intercom/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science/research)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "cHp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -10211,18 +10284,9 @@
 /turf/open/floor/engine,
 /area/engineering/atmospherics_engine)
 "cIY" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cJe" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -10656,9 +10720,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -11083,11 +11144,9 @@
 /turf/open/floor/iron,
 /area/science/research)
 "cTs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2,
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "cTA" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
@@ -11295,10 +11354,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "cXd" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/effect/turf_decal/siding/purple{
+	dir = 6
 	},
-/area/maintenance/aft/lesser)
+/obj/structure/table,
+/obj/item/clipboard,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "cXm" = (
 /obj/machinery/computer/department_orders/science{
 	dir = 4
@@ -11409,14 +11471,10 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "cYS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/science/research)
 "cYU" = (
@@ -11584,9 +11642,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dbG" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "dbN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -11617,11 +11680,14 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "dcJ" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
 	},
-/area/maintenance/aft/lesser)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine/vacuum,
+/area/space/nearstation)
 "dcQ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -11674,9 +11740,6 @@
 "ddz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -12572,9 +12635,8 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "dsd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/turf/open/floor/iron/white,
+/area/science/storage)
 "dsh" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -13371,8 +13433,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "dFn" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "dFr" = (
@@ -13748,6 +13809,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "dLT" = (
@@ -13759,18 +13821,17 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dLV" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/science/mixing/hallway)
 "dMu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
@@ -14654,11 +14715,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ecE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/box/red,
+/turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "ecH" = (
 /obj/structure/table,
@@ -14972,13 +15035,9 @@
 	},
 /area/engineering/atmos/storage/gas)
 "efz" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "efD" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -15011,14 +15070,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/pumproom)
 "egU" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Ordnance Lab Maintenance"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "ehk" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -15380,9 +15436,9 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "eoI" = (
-/obj/machinery/igniter/incinerator_ordmix,
-/turf/open/floor/engine/airless,
-/area/science/mixing/chamber)
+/obj/structure/sign/poster/random/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "eoM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output{
 	dir = 1
@@ -15468,9 +15524,11 @@
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos/pumproom)
 "eqC" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "eqE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15481,9 +15539,9 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/central)
 "eqN" = (
-/obj/effect/turf_decal/siding,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
 "eqO" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/light/small/directional/north,
@@ -15698,6 +15756,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"etJ" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/maintenance/aft/lesser)
 "etM" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -15812,6 +15877,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"evd" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ordnancebridge"
+	},
+/obj/machinery/button/door{
+	id = "ordnancebridge";
+	pixel_x = -24;
+	req_one_access_txt = "12;47"
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "evj" = (
 /obj/structure/light_construct/directional/east,
 /turf/open/floor/wood,
@@ -15920,9 +15999,9 @@
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "exL" = (
-/obj/machinery/light/directional/north,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "exS" = (
 /obj/effect/turf_decal/tile/bar,
@@ -15931,6 +16010,15 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
+"eyd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
 "eyk" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_secure_all,
@@ -15953,13 +16041,12 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tcomms)
 "eyW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "ezz" = (
@@ -15996,13 +16083,12 @@
 /turf/open/floor/plating,
 /area/maintenance/space_hut)
 "eAm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/storage)
 "eAD" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
@@ -16115,13 +16201,12 @@
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "eCP" = (
@@ -16257,12 +16342,14 @@
 /turf/open/floor/iron,
 /area/security/office)
 "eEK" = (
-/obj/effect/turf_decal/siding,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
 "eEU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -16453,14 +16540,22 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "eIk" = (
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 8
+/obj/effect/turf_decal/siding/purple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
+"eIm" = (
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/turf/open/floor/plating,
+/area/science/mixing)
 "eIn" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
@@ -16491,8 +16586,12 @@
 "eID" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/camera/directional/east{
-	c_tag = "Science Ordnance Test Lab 2";
+	c_tag = "Science Ordnance Test Lab";
 	network = list("ss13","rd")
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/purple{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing/launch)
@@ -16507,14 +16606,9 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "eIK" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/aft/lesser)
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
 "eIP" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/sign/poster/official/safety_eye_protection{
@@ -16544,10 +16638,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "eJw" = (
-/obj/structure/rack,
-/obj/item/wrench,
+/obj/structure/girder,
 /turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/science/mixing/hallway)
 "eJA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16649,6 +16742,14 @@
 /obj/item/kirbyplants/dead,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
+"eKJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/warning/vacuum{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "eKM" = (
 /obj/effect/landmark/start/chief_medical_officer,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -16691,11 +16792,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/greater)
 "eLK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/closet/bombcloset,
 /turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/science/mixing/hallway)
 "eLR" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -17058,17 +17157,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "eSf" = (
-/obj/machinery/firealarm/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science/research)
+/turf/closed/wall/r_wall,
+/area/maintenance/aft/lesser)
 "eSi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17213,8 +17304,8 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "eTY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "eUu" = (
 /obj/structure/transit_tube/crossing/horizontal,
@@ -17278,7 +17369,6 @@
 /turf/open/floor/carpet,
 /area/service/chapel/funeral)
 "eVT" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
@@ -17408,9 +17498,15 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "eZr" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/science/mixing/hallway)
 "eZU" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
@@ -17466,8 +17562,8 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "fbD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/spawner/random/structure/chair_comfy{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -17515,7 +17611,6 @@
 "fcF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/research)
 "fcJ" = (
@@ -17659,10 +17754,10 @@
 "ffE" = (
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "ffP" = (
@@ -17920,8 +18015,14 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "fmA" = (
-/turf/open/floor/engine/airless,
-/area/science/mixing/chamber)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "fmR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -18317,9 +18418,14 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "ftO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/trinary/filter/flipped,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
 /area/science/mixing)
 "fub" = (
 /obj/structure/closet,
@@ -18393,7 +18499,7 @@
 /area/hallway/primary/port)
 "fvg" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -18870,13 +18976,12 @@
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
 "fEn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "fEo" = (
@@ -18989,6 +19094,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"fFq" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/science/mixing/launch)
 "fFD" = (
 /obj/structure/cable,
 /obj/machinery/photocopier,
@@ -19155,10 +19269,15 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "fJH" = (
-/obj/machinery/light/small/broken/directional/north,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "fJL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -19319,9 +19438,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/line,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/research)
 "fMR" = (
@@ -19499,20 +19616,12 @@
 /turf/open/floor/wood,
 /area/commons/lounge)
 "fQU" = (
-/obj/structure/closet/bombcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/components/tank,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
 	},
-/obj/machinery/requests_console/directional/west{
-	department = "Ordnance Lab";
-	departmentType = 5;
-	name = "Ordnance Requests Console"
-	},
-/obj/effect/turf_decal/siding{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "fRb" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -19542,14 +19651,12 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "fRD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/checker,
 /area/maintenance/aft/lesser)
 "fRE" = (
 /obj/effect/landmark/event_spawn,
@@ -19610,9 +19717,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -19769,6 +19873,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "fVN" = (
@@ -20059,9 +20164,13 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "gbE" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/science/mixing/hallway)
 "gbH" = (
 /obj/structure/chair/stool/directional/west,
@@ -20439,12 +20548,12 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "ghV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
 	},
-/area/maintenance/aft/lesser)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "ghY" = (
 /mob/living/simple_animal/pet/penguin/baby{
 	dir = 8
@@ -20640,15 +20749,20 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "gmo" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/trash/garbage{
+	spawn_scatter_radius = 1
+	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "gmC" = (
-/obj/structure/chair/office/light{
-	dir = 8
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
 	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "gmH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -20844,19 +20958,12 @@
 /obj/structure/table,
 /obj/effect/turf_decal/bot,
 /obj/item/computer_hardware/hard_drive/portable{
-	pixel_x = -2
-	},
-/obj/item/computer_hardware/hard_drive/portable{
 	pixel_x = 7;
 	pixel_y = 2
 	},
 /obj/item/computer_hardware/hard_drive/portable{
 	pixel_x = -5;
 	pixel_y = 8
-	},
-/obj/item/computer_hardware/hard_drive/portable{
-	pixel_x = -8;
-	pixel_y = -3
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -21196,20 +21303,14 @@
 /turf/open/floor/iron/dark/corner,
 /area/engineering/storage_shared)
 "gwk" = (
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Lab"
+/obj/machinery/door/airlock/maintenance{
+	name = "Ordnance Lab Maintenance"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rdordnance";
-	name = "Ordnance Lab Shutters"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/turf/open/floor/iron/white,
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/turf/open/floor/plating,
 /area/science/mixing)
 "gxC" = (
 /obj/effect/turf_decal/stripes/line{
@@ -21260,9 +21361,15 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "gyl" = (
-/obj/structure/window/reinforced/plasma/spawner/east,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/closet/bombcloset,
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
 "gyB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room"
@@ -21319,13 +21426,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "gzx" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "gzI" = (
 /obj/machinery/power/shieldwallgen,
 /obj/structure/window/reinforced{
@@ -21350,11 +21453,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "gAo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /obj/machinery/meter,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/science/storage)
 "gAs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -21637,6 +21741,11 @@
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"gFn" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/mixing/launch)
 "gFw" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
@@ -21763,6 +21872,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"gJo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "gJp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance"
@@ -21800,6 +21918,9 @@
 /obj/item/surgical_drapes,
 /obj/item/cautery,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "gKu" = (
@@ -21893,11 +22014,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gNW" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "gNY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/brown/filled/warning,
@@ -21969,6 +22090,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "gPM" = (
@@ -22033,7 +22155,10 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "gRv" = (
-/obj/effect/landmark/start/scientist,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing/launch)
 "gRy" = (
@@ -22070,10 +22195,13 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "gSf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/purple,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "gSm" = (
 /obj/machinery/teleport/station,
 /obj/machinery/firealarm/directional/west,
@@ -22283,14 +22411,9 @@
 /area/hallway/secondary/entry)
 "gVE" = (
 /obj/item/radio/intercom/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "gVL" = (
@@ -22357,16 +22480,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "gWX" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/camera/directional/east{
-	c_tag = "Science Ordnance Gas Storage 2";
-	network = list("ss13","rd")
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "gXE" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/trimline/brown/warning,
@@ -22468,12 +22586,14 @@
 /turf/open/floor/grass,
 /area/science/research)
 "gZu" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "gZv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -22610,7 +22730,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
@@ -22836,16 +22955,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "heZ" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Science Ordnance Lab";
-	network = list("ss13","rd")
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding{
-	dir = 6
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/storage)
 "hfd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22861,6 +22979,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/insectguts,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/science/mixing/launch)
 "hfm" = (
@@ -23056,9 +23175,16 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "him" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Science Ordnance Storage";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "hin" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -23172,12 +23298,10 @@
 /turf/open/floor/plating,
 /area/service/bar)
 "hkS" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "hkW" = (
 /obj/machinery/camera/directional/north{
@@ -23185,9 +23309,6 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light_switch/directional/north{
 	pixel_x = 9
 	},
@@ -23222,11 +23343,22 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
+"hlN" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/space/nearstation)
 "hlP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	chamber_id = "ordnancegas2";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "hmi" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -23283,11 +23415,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "hnc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/turf/open/floor/engine/airless,
-/area/science/mixing/chamber)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "hnm" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -23431,6 +23564,12 @@
 /obj/item/computer_hardware/hard_drive/role/signal/ordnance,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
+"hoX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "hpk" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -24446,6 +24585,11 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"hHW" = (
+/obj/effect/turf_decal/siding/purple,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "hIa" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/chaplain,
@@ -24554,6 +24698,13 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hKy" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "hKH" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/commons/fitness/recreation)
@@ -24608,7 +24759,6 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/research)
 "hMd" = (
@@ -24857,11 +25007,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/greater)
 "hRN" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "hSw" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -25078,12 +25227,14 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "hWc" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/science/storage)
+/area/science/mixing)
 "hWg" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance"
@@ -25288,19 +25439,21 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "iaT" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab"
 	},
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance_storage,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "ibf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
@@ -25343,8 +25496,9 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/greater)
 "ibD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "ibS" = (
@@ -25566,7 +25720,8 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "iht" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "ihu" = (
@@ -25786,10 +25941,10 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "img" = (
@@ -26387,7 +26542,6 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "iyv" = (
@@ -26582,6 +26736,7 @@
 "iDF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/science/mixing/launch)
 "iDJ" = (
@@ -27370,15 +27525,11 @@
 /turf/open/floor/plating,
 /area/medical/treatment_center)
 "iRM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/directional/south{
-	c_tag = "Science Ordnance Mix";
-	network = list("ss13","rd")
+/obj/effect/spawner/random/structure/table,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/machinery/firealarm/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/mixing)
+/area/maintenance/aft/lesser)
 "iRO" = (
 /obj/machinery/computer/upload/ai,
 /obj/structure/window/reinforced{
@@ -27451,9 +27602,17 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "iSy" = (
-/obj/machinery/door/poddoor/incinerator_ordmix,
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "iSA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/camera/directional/north{
@@ -27534,14 +27693,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "iUd" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
 	},
-/obj/machinery/airalarm/mixingchamber{
-	pixel_y = -24
-	},
-/turf/open/floor/iron,
-/area/science/mixing/chamber)
+/turf/open/floor/iron/white,
+/area/science/storage)
 "iUe" = (
 /obj/machinery/button/door/directional/west{
 	id = "transitlockdown";
@@ -27616,11 +27772,12 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "iVt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/decal/remains/human{
+	desc = "They look like human remains. The bones are charred and burned.";
+	name = "charred remains"
 	},
-/turf/open/floor/iron/white,
-/area/science/research)
+/turf/open/floor/engine/vacuum,
+/area/space/nearstation)
 "iVQ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/east,
@@ -27691,7 +27848,6 @@
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "iXV" = (
-/obj/structure/chair,
 /obj/structure/sign/map/left{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
 	icon_state = "map-left-MS";
@@ -28235,9 +28391,6 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "jjQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
@@ -28246,6 +28399,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/status_display/evac/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/research)
 "jkv" = (
@@ -28409,14 +28566,9 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "jmX" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rdordnance";
-	name = "Ordnance Lab Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
+/obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/plating,
-/area/science/mixing)
+/area/maintenance/aft/lesser)
 "jmZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28456,13 +28608,21 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "jnH" = (
-/obj/effect/landmark/start/scientist,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/door/airlock/research/glass{
+	name = "Ordnance Lab";
+	req_access_txt = "8"
 	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "jnU" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 5
+	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/science/mixing/launch)
 "jnX" = (
@@ -28956,14 +29116,14 @@
 	},
 /area/maintenance/port/aft)
 "jvq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rdordnance";
 	name = "Ordnance Lab Shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
-/area/science/mixing)
+/area/science/storage)
 "jvt" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -29103,9 +29263,12 @@
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "jyz" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/maintenance/aft/lesser)
+/area/science/mixing/hallway)
 "jyK" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -29327,6 +29490,11 @@
 /area/service/theater)
 "jDE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/science/mixing/launch)
 "jDH" = (
@@ -29438,6 +29606,8 @@
 "jFj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/purple,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/science/mixing/launch)
 "jFo" = (
@@ -29653,18 +29823,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "jIS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/science/mixing/hallway)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "jIZ" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -29730,6 +29891,9 @@
 	name = "MOD core crate"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "jJX" = (
@@ -29748,6 +29912,7 @@
 /area/commons/fitness/recreation)
 "jKn" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/office/light,
 /turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "jKo" = (
@@ -29861,12 +30026,12 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "jMn" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "jMp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -29975,6 +30140,7 @@
 "jOp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "jOK" = (
@@ -30004,14 +30170,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "jPX" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "jPY" = (
 /obj/structure/cable,
@@ -30020,9 +30182,15 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "jPZ" = (
-/obj/structure/sign/warning/explosives,
-/turf/closed/wall/r_wall,
-/area/science/storage)
+/obj/machinery/atmospherics/components/binary/tank_compressor{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/science/mixing/launch)
 "jQb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30244,6 +30412,7 @@
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "jTu" = (
@@ -30320,9 +30489,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "jXc" = (
@@ -30838,10 +31004,13 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/pharmacy)
 "kgf" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/red,
+/turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "kgg" = (
 /obj/structure/railing,
@@ -30958,18 +31127,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kiq" = (
-/obj/structure/table,
 /obj/effect/turf_decal/bot,
-/obj/item/raw_anomaly_core/random{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/raw_anomaly_core/random{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/raw_anomaly_core/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/doppler_array,
 /turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "kiw" = (
@@ -30992,14 +31152,12 @@
 	},
 /area/maintenance/port/aft)
 "kiY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/rack,
+/obj/effect/spawner/random/clothing/costume,
+/obj/effect/spawner/random/clothing/costume,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft/lesser)
 "kjd" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -31123,10 +31281,16 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "kmH" = (
-/obj/structure/sign/warning/fire,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/obj/structure/table,
+/obj/item/pipe_dispenser{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/pipe_dispenser,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "kmP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31192,17 +31356,17 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "koo" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-maint-passthrough"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/science/research)
 "koy" = (
@@ -31225,16 +31389,11 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "koH" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/components/binary/tank_compressor{
-	dir = 8
+/obj/effect/spawner/random/structure/chair_maintenance{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/firealarm/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/mixing/launch)
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "koV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31310,6 +31469,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "kqz" = (
@@ -31317,14 +31477,11 @@
 /turf/closed/wall,
 /area/hallway/primary/port)
 "kqO" = (
-/obj/effect/landmark/blobstart,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/iron/white,
-/area/maintenance/aft/lesser)
+/area/space/nearstation)
 "kqR" = (
 /obj/machinery/suit_storage_unit/hos,
 /obj/item/radio/intercom/directional/east,
@@ -31490,8 +31647,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ktU" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/science/mixing/hallway)
 "ktW" = (
 /obj/structure/showcase/cyborg/old{
@@ -31596,6 +31753,9 @@
 "kvj" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "kvt" = (
@@ -31764,6 +31924,16 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
+"kyz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "kyF" = (
 /turf/closed/wall,
 /area/maintenance/starboard/greater)
@@ -31977,11 +32147,10 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "kCd" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "kCn" = (
 /obj/item/bodypart/l_arm,
 /turf/open/floor/plating/airless,
@@ -32033,14 +32202,12 @@
 	},
 /area/service/kitchen)
 "kDc" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/white/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "kDK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -32398,13 +32565,15 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "kKe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/door/airlock/research/glass{
+	name = "Ordnance Lab";
+	req_access_txt = "8"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "kKj" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet3";
@@ -32529,9 +32698,6 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "kNb" = (
@@ -32608,11 +32774,11 @@
 /turf/open/floor/iron/white/side,
 /area/medical/treatment_center)
 "kPl" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/air_sensor{
+	chamber_id = "ordnancegas1"
+	},
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "kPq" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -32967,12 +33133,10 @@
 "kXd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "kXp" = (
@@ -33266,22 +33430,9 @@
 /turf/open/floor/wood,
 /area/service/theater)
 "lci" = (
-/obj/machinery/light_switch/directional/west,
-/obj/structure/table,
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/item/transfer_valve{
-	pixel_x = 5
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing/launch)
@@ -33339,6 +33490,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/genetics,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
@@ -33528,10 +33680,12 @@
 /turf/closed/wall,
 /area/commons/locker)
 "lgD" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "lgI" = (
 /obj/structure/table,
 /obj/item/paper_bin/bundlenatural{
@@ -34284,9 +34438,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "luN" = (
@@ -34580,8 +34733,6 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "lAu" = (
@@ -34880,9 +35031,9 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "lET" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing/launch)
 "lFh" = (
@@ -34991,9 +35142,12 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "lHb" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "lHg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -35133,17 +35287,12 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "lJL" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/research)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/directional/east,
+/turf/open/floor/grass,
+/area/science/mixing/hallway)
 "lJT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -35312,9 +35461,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lMh" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/item/instrument/guitar,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/space/nearstation)
 "lMp" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -35327,13 +35478,11 @@
 /turf/open/misc/asteroid/basalt/airless,
 /area/space/nearstation)
 "lMy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "lMJ" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -35420,18 +35569,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "lOW" = (
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Test Lab"
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/science/mixing/launch)
 "lOX" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/delivery,
@@ -35486,11 +35633,9 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "lPV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/machinery/atmospherics/components/tank,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "lPW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35582,6 +35727,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"lRR" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "lSa" = (
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
@@ -35934,14 +36083,28 @@
 /obj/item/ai_module/reset,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"lZJ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
+"lZH" = (
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
+"lZJ" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "lZK" = (
 /obj/machinery/shower{
 	dir = 8
@@ -36048,10 +36211,12 @@
 /turf/open/floor/iron/white,
 /area/medical/abandoned)
 "mbj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/structure/grille,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/science/mixing/hallway)
 "mbm" = (
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/duct,
@@ -36091,14 +36256,14 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "mbI" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/machinery/door/airlock/research{
-	name = "Robotics Lab"
+	name = "Robotics Lab";
+	req_access_txt = "29"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "mbK" = (
@@ -36364,11 +36529,12 @@
 /turf/open/floor/wood,
 /area/commons/lounge)
 "mff" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/clothing/costume,
+/obj/effect/spawner/random/clothing/costume,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/aft/lesser)
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
 "mfg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/reagent_dispensers/watertank,
@@ -36453,14 +36619,14 @@
 /turf/open/floor/plating,
 /area/cargo/qm)
 "mgc" = (
-/obj/machinery/button/door/incinerator_vent_ordmix{
-	id = "ordnanceaccess";
-	name = "Ordnance Access";
-	pixel_x = -26;
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/science/storage)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "mge" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -36959,9 +37125,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "mpV" = (
@@ -37610,13 +37773,21 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "mBC" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior{
-	name = "Burn Chamber Exterior Airlock"
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance_storage,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "mBU" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -37631,6 +37802,7 @@
 	},
 /obj/item/storage/box/bodybags,
 /obj/item/healthanalyzer,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "mBY" = (
@@ -37684,6 +37856,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "mDh" = (
@@ -37713,7 +37886,6 @@
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/research)
 "mDH" = (
@@ -37742,6 +37914,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/warden)
+"mEd" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance/glass,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "mEl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -38025,9 +38204,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mHs" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/item/shard,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/space/nearstation)
 "mHw" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -38294,11 +38475,11 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "mLw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/structure/sign/poster/random/directional/east{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "mLC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -38923,13 +39104,18 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
 "mUB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/airalarm/mixingchamber{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing/chamber)
 "mUK" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38950,7 +39136,6 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "mVg" = (
@@ -39112,12 +39297,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "mWI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/iron/white,
-/area/science/research)
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "mXf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -39243,12 +39426,14 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/captain/private)
 "mZm" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "mZn" = (
 /obj/machinery/door/window/right/directional/north{
 	base_state = "left";
@@ -39370,13 +39555,18 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "nbE" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table,
+/obj/item/raw_anomaly_core/random{
+	pixel_x = -5;
+	pixel_y = 7
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/white,
+/obj/item/raw_anomaly_core/random{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/raw_anomaly_core/random,
+/turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "nbL" = (
 /obj/structure/table/glass,
@@ -39613,12 +39803,14 @@
 /turf/open/floor/iron/dark,
 /area/medical/break_room)
 "ngk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/space_heater,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "ngl" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/stripes/corner{
@@ -39696,20 +39888,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "nhe" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/door/poddoor/incinerator_ordmix,
+/turf/open/space/basic,
+/area/science/mixing/chamber)
 "nht" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39858,18 +40039,16 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/storage/gas)
 "njs" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/item/stack/cable_coil/five,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine/vacuum,
+/area/space/nearstation)
 "njy" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/white,
+/area/science/mixing/launch)
 "njH" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -40310,15 +40489,17 @@
 /turf/open/floor/wood,
 /area/commons/lounge)
 "nrI" = (
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/maintenance/aft/lesser)
 "nrQ" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "nsr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -40872,9 +41053,9 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nCU" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "nDl" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -41615,11 +41796,18 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "nSp" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/science/storage)
 "nSs" = (
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
@@ -41805,18 +41993,21 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "nXE" = (
-/obj/machinery/button/door/incinerator_vent_ordmix{
-	pixel_x = 8;
-	pixel_y = -30
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_x = -6;
-	pixel_y = -30
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "nXS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -41876,18 +42067,8 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "nYA" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "nYJ" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -42147,13 +42328,14 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "odJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/white/corner{
-	color = null;
-	dir = 8
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4;
+	piping_layer = 2
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/siding/purple{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/science/mixing)
 "odL" = (
 /obj/structure/sign/map/right{
@@ -42278,20 +42460,17 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "ofF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/structure/crate_loot,
+/turf/open/floor/plating,
 /area/science/mixing/hallway)
 "ofK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/camera/directional/west{
-	c_tag = "Science Ordnance Corridor";
-	network = list("ss13","rd")
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing/hallway)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "ofT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42374,6 +42553,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"oib" = (
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/space/nearstation)
 "oij" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
@@ -42612,14 +42797,8 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "onc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Ordnance Gas Storage Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/ordnance_storage,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ong" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -42690,9 +42869,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/lesser)
 "ooO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "ooS" = (
 /obj/machinery/light/directional/north,
 /obj/structure/chair/sofa/corp/right,
@@ -43000,6 +43183,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"ovj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "ovn" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/blue{
@@ -43548,11 +43737,14 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "oFb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/broken/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "oFf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -43753,12 +43945,15 @@
 	},
 /area/engineering/atmospherics_engine)
 "oIu" = (
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/pipe_dispenser,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "oII" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -43982,6 +44177,13 @@
 	icon_state = "wood-broken"
 	},
 /area/service/library)
+"oNJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "oNN" = (
 /obj/structure/cable,
 /obj/structure/bed/dogbed/mcgriff,
@@ -44150,11 +44352,17 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
 "oRg" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airlock_sensor/incinerator_ordmix{
+	pixel_x = -24
+	},
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "oRj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/bz,
@@ -44186,6 +44394,7 @@
 /area/cargo/qm)
 "oRD" = (
 /obj/machinery/vending/coffee,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/research)
 "oRH" = (
@@ -44393,12 +44602,21 @@
 "oVk" = (
 /obj/structure/table/glass,
 /obj/machinery/light/directional/west,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/research)
+"oVD" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "oVG" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44767,12 +44985,12 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/theatre)
 "pdq" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_x = 32
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "pdr" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -44815,9 +45033,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "peh" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -45229,9 +45444,11 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "pmG" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/structure/chair_flipped,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/aft/lesser)
 "pmN" = (
 /obj/structure/disposalpipe/segment{
@@ -45367,7 +45584,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
@@ -45420,19 +45636,9 @@
 /turf/closed/wall,
 /area/maintenance/port/aft)
 "ppA" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Science Ordnance Gas Storage";
-	network = list("ss13","rd")
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/obj/item/radio/intercom/directional/west{
-	pixel_y = -10
-	},
-/obj/machinery/light_switch/directional/west{
-	pixel_x = -42
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ppH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45452,12 +45658,21 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "ppN" = (
-/obj/structure/window/reinforced/plasma/spawner/west,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/moth_piping{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "pqd" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "pqe" = (
@@ -45505,9 +45720,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 8
 	},
@@ -45603,19 +45815,22 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "ptE" = (
-/obj/effect/turf_decal/trimline/purple/corner{
-	dir = 8
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
+	pixel_x = -24
 	},
-/obj/machinery/light/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/button/ignition/incinerator/ordmix{
+	pixel_x = 24;
+	pixel_y = -6
 	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
+/obj/machinery/button/door/incinerator_vent_ordmix{
+	pixel_x = 24;
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/research)
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "ptF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -46454,15 +46669,11 @@
 /turf/open/floor/wood,
 /area/service/library)
 "pJx" = (
-/obj/machinery/door/airlock/external{
-	name = "Auxiliary Escape Airlock"
+/obj/item/shard,
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/space/nearstation)
 "pJK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -46491,17 +46702,9 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain/private)
 "pKN" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/effect/spawner/random/structure/chair_maintenance,
+/turf/open/floor/iron/checker,
+/area/maintenance/aft/lesser)
 "pKY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -46606,12 +46809,12 @@
 /area/medical/medbay/central)
 "pNc" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Science Tool Closet"
+	req_one_access_txt = "12;47"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/science/mixing/hallway)
 "pNi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -46697,17 +46900,9 @@
 /turf/open/floor/wood,
 /area/commons/lounge)
 "pOT" = (
-/obj/machinery/airlock_sensor/incinerator_ordmix{
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/white,
+/area/science/storage)
 "pPb" = (
 /mob/living/simple_animal/chicken{
 	name = "Featherbottom";
@@ -46906,6 +47101,9 @@
 /area/maintenance/starboard/fore)
 "pSF" = (
 /obj/effect/spawner/random/vending/snackvend,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "pSI" = (
@@ -47018,8 +47216,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "pUH" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/white,
 /area/science/mixing/launch)
 "pUY" = (
@@ -47543,21 +47746,17 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "qei" = (
-/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Lab"
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rdordnance";
-	name = "Ordnance Lab Shutters"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/mixing/launch)
 "qeQ" = (
 /obj/machinery/turretid{
 	icon_state = "control_stun";
@@ -47631,6 +47830,12 @@
 /obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron,
 /area/commons/locker)
+"qge" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/aft/lesser)
 "qgo" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes{
@@ -47660,16 +47865,15 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "qgC" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/components/binary/pump,
-/obj/structure/sign/warning/gasmask{
-	pixel_x = 32
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/siding/purple{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "qgH" = (
 /obj/structure/chair/comfy/beige,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47739,16 +47943,13 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "qhS" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_ordmix{
-	pixel_x = -22
+/obj/machinery/atmospherics/components/binary/valve/digital,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
-	name = "Burn Chamber Interior Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/science/storage)
 "qia" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -48040,9 +48241,6 @@
 "qmv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
@@ -48069,11 +48267,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qmW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ordnancebridge"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/door{
+	id = "ordnancebridge";
+	pixel_y = 24;
+	req_one_access_txt = "12;47"
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "qmX" = (
@@ -49565,6 +49769,15 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"qTl" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "qTm" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -49841,9 +50054,12 @@
 /turf/closed/wall/r_wall,
 /area/command/bridge)
 "qZN" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "rah" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
@@ -49866,6 +50082,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"raF" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/science/mixing/launch)
 "raQ" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -50203,14 +50427,13 @@
 /turf/open/floor/iron,
 /area/science/lab)
 "rhi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "rhj" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -50231,12 +50454,19 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "rhB" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Ordnance Test Lab Maintenance"
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab";
+	req_access_txt = "8"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
 /turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/science/mixing/launch)
 "rhP" = (
 /obj/machinery/shower{
 	name = "emergency shower";
@@ -50493,10 +50723,9 @@
 /turf/open/floor/plating,
 /area/science/mixing/launch)
 "rmm" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/science/mixing/hallway)
 "rmt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
@@ -50764,11 +50993,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rqP" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/red,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "rqT" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Science Petting Zoo";
@@ -50864,6 +51098,12 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"rsv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "rsW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51080,9 +51320,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
@@ -51095,6 +51332,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"rxQ" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "rxX" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral,
@@ -51133,14 +51375,9 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ryS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "rzv" = (
@@ -51161,12 +51398,12 @@
 /area/science/robotics/lab)
 "rzQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "rzR" = (
@@ -51340,9 +51577,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "rFa" = (
-/obj/machinery/research/anomaly_refinery,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table,
+/obj/item/binoculars,
 /turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "rFq" = (
@@ -51741,11 +51979,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "rNz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/status_display/evac/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2,
+/obj/machinery/air_sensor{
+	chamber_id = "ordnancegas2"
+	},
+/turf/open/floor/iron/dark/airless,
+/area/science/mixing/chamber)
 "rNE" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
@@ -52318,15 +52557,12 @@
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai_upload)
 "rVU" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "rWr" = (
@@ -52610,16 +52846,30 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "scO" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "ordnanceaccess";
-	name = "Ordnance Access"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "scS" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall,
-/area/maintenance/aft/lesser)
+/obj/effect/turf_decal/siding/purple,
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("ordnancegas1" = "Burn Chamber", "ordnancegas2" = "Freezer Chamber");
+	dir = 1
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Science Ordnance Mix Lab";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "scT" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -53013,17 +53263,18 @@
 /turf/closed/wall,
 /area/medical/medbay/lobby)
 "slV" = (
-/obj/machinery/door/airlock/research{
-	name = "Abandoned Space Bridge";
-	req_access_txt = "55"
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = -2
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron/white,
-/area/maintenance/aft/lesser)
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "slZ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine/cult,
@@ -53178,14 +53429,16 @@
 /turf/open/floor/wood,
 /area/service/library)
 "sps" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = -4
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab"
 	},
-/obj/item/stack/sheet/iron/fifty,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/science/ordnance,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "spA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -53262,9 +53515,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ssy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/science/mixing/launch)
+/obj/effect/spawner/random/trash/bin,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ssN" = (
 /obj/machinery/oven,
 /turf/open/floor/iron/cafeteria,
@@ -53451,12 +53704,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "swS" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "sxa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -53607,7 +53857,6 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "sBb" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
@@ -54061,9 +54310,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "sKE" = (
-/obj/item/radio/intercom/directional/east,
-/obj/structure/tank_dispenser,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/research/anomaly_refinery,
+/turf/open/floor/iron/dark,
 /area/science/mixing/launch)
 "sKJ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -54370,13 +54620,14 @@
 /turf/open/floor/plating,
 /area/science/cytology)
 "sQG" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch/directional/north,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "sRo" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -54777,6 +55028,9 @@
 "sYk" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "sYq" = (
@@ -55036,18 +55290,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "tdx" = (
-/obj/effect/turf_decal/trimline/purple/line,
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 25
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
 "tdz" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -55160,9 +55404,9 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "tgb" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "tgh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55213,11 +55457,13 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "tgJ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/effect/turf_decal/siding/purple{
+	dir = 5
 	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/structure/filingcabinet,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/white,
+/area/science/mixing/hallway)
 "tgO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment{
@@ -55234,10 +55480,15 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "thg" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/purple{
+	dir = 9
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/dark,
 /area/science/mixing)
 "thq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55260,18 +55511,12 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "thN" = (
+/obj/effect/turf_decal/siding/purple,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
 /area/science/mixing/hallway)
 "thR" = (
 /obj/machinery/food_cart,
@@ -55395,6 +55640,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"tjE" = (
+/obj/machinery/atmospherics/components/binary/pump/on,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "tjS" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Bridge - Starboard Access"
@@ -55878,13 +56130,11 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "tsK" = (
-/obj/machinery/door/airlock/external{
-	name = "Auxiliary Escape Airlock"
+/obj/item/reagent_containers/food/drinks/bottle/wine/unlabeled,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/space/nearstation)
 "tsL" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chem_lockdown";
@@ -56245,8 +56495,16 @@
 	},
 /area/engineering/main)
 "tyU" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
 /area/science/mixing/hallway)
 "tyZ" = (
 /obj/structure/cable,
@@ -56573,13 +56831,9 @@
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "tFQ" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "tFU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57230,9 +57484,14 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "tUz" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "tUB" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -57277,9 +57536,13 @@
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "tUN" = (
-/obj/structure/tank_dispenser,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/white,
+/area/science/storage)
 "tVh" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -57632,16 +57895,12 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "ucy" = (
-/obj/effect/turf_decal/stripes/white/line{
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	chamber_id = "ordnancegas1";
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "ucI" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral,
@@ -57930,12 +58189,16 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "uhI" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/science/storage)
+/area/science/mixing)
 "uhU" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -58053,14 +58316,23 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ukD" = (
-/obj/machinery/computer/atmos_control/nocontrol/ordnancemix,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/siding{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "rdordnance";
+	name = "Ordnance Containment Control";
+	req_access_txt = "30"
+	},
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/storage)
 "ukF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/corner,
@@ -58246,9 +58518,11 @@
 /turf/open/floor/wood,
 /area/commons/lounge)
 "uox" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/science/storage)
 "uoO" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics - Entrance"
@@ -58463,15 +58737,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uug" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Storage Room"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "uui" = (
@@ -58713,12 +58979,14 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "uxR" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/directional/north,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/purple,
+/obj/structure/sign/warning/testchamber{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing/launch)
 "uxX" = (
 /obj/structure/cable,
 /obj/structure/rack,
@@ -58916,11 +59184,9 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "uCj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "uCo" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -59300,7 +59566,6 @@
 /turf/open/floor/iron,
 /area/construction/storage_wing)
 "uLH" = (
-/obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/science/mixing/hallway)
 "uLR" = (
@@ -59358,11 +59623,10 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/funeral)
 "uNE" = (
-/obj/effect/turf_decal/siding{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "uNH" = (
 /obj/machinery/shower{
 	pixel_y = 12
@@ -59437,11 +59701,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "uPR" = (
@@ -59573,9 +59833,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology/hallway)
 "uSS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59851,11 +60108,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uXX" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/effect/spawner/random/trash/garbage{
+	spawn_scatter_radius = 1
+	},
+/turf/open/floor/iron/checker,
+/area/maintenance/aft/lesser)
 "uYd" = (
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
@@ -59956,27 +60213,21 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vaJ" = (
-/obj/machinery/airalarm/directional/west,
 /obj/structure/table,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/item/computer_hardware/hard_drive/portable{
-	pixel_x = -2
-	},
-/obj/item/computer_hardware/hard_drive/portable{
-	pixel_x = 7;
-	pixel_y = 2
+	pixel_x = -8;
+	pixel_y = -3
 	},
 /obj/item/computer_hardware/hard_drive/portable{
 	pixel_x = -5;
 	pixel_y = 8
 	},
-/obj/item/computer_hardware/hard_drive/portable{
-	pixel_x = -8;
-	pixel_y = -3
+/obj/effect/turf_decal/siding/purple{
+	dir = 9
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/mixing/hallway)
 "vaK" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -60191,11 +60442,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "vep" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/camera/directional/east{
+	c_tag = "Science Ordnance Office";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/grass,
+/area/science/mixing/hallway)
 "vet" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -60346,11 +60601,14 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "vgY" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "vhr" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -61400,6 +61658,17 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"vCY" = (
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/west,
+/obj/effect/spawner/random/trash/bin,
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
 "vDb" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -61855,6 +62124,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vJH" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "vJR" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass,
@@ -61972,9 +62247,13 @@
 /turf/open/floor/iron,
 /area/science/lab)
 "vLF" = (
-/obj/effect/landmark/blobstart,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft/lesser)
 "vLK" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -62183,14 +62462,11 @@
 	},
 /area/maintenance/starboard/aft)
 "vPP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard/aft)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/science/mixing/hallway)
 "vPU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/carbon_output{
 	dir = 1
@@ -62803,14 +63079,12 @@
 /area/construction/storage_wing)
 "wdp" = (
 /obj/effect/decal/cleanable/insectguts,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "wdq" = (
@@ -62937,8 +63211,8 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wfJ" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -63006,13 +63280,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wgY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/atmospherics/components/tank,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "wgZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -63309,11 +63582,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "wmY" = (
-/obj/effect/spawner/random/trash/garbage{
-	spawn_scatter_radius = 1
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
-/area/maintenance/aft/lesser)
+/area/science/mixing/hallway)
 "wng" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -63442,13 +63716,10 @@
 /area/science/research)
 "woO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/trash/garbage{
-	spawn_scatter_radius = 1
-	},
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -63569,20 +63840,11 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "wrL" = (
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-toxins-passthrough"
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
 	},
-/obj/machinery/door/airlock/research{
-	name = "Ordnance Gas Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
-/turf/open/floor/iron/white,
-/area/science/storage)
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "wrP" = (
 /turf/closed/wall,
 /area/maintenance/aft/lesser)
@@ -63693,6 +63955,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "wtR" = (
@@ -64061,16 +64324,12 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "wBz" = (
-/obj/structure/closet/bombcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/components/tank,
+/obj/effect/turf_decal/siding/purple{
+	dir = 9
 	},
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/siding{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "wBX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -64463,18 +64722,11 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wIK" = (
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/item/storage/medkit/toxin{
-	pixel_x = -4;
-	pixel_y = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/book/manual/wiki/ordnance{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "wIS" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -64575,11 +64827,11 @@
 /area/hallway/secondary/command)
 "wKM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "wKW" = (
@@ -64722,6 +64974,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/science_wardrobe,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science/research)
 "wMT" = (
@@ -64776,6 +65029,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -65107,13 +65361,13 @@
 /turf/closed/wall,
 /area/service/bar)
 "wUi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/white,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/science/mixing/hallway)
 "wUr" = (
 /obj/structure/cable,
@@ -65370,9 +65624,20 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "wZN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/science/storage)
 "xad" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/multiver{
@@ -65440,17 +65705,14 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "xbB" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 14
+	},
 /turf/open/floor/iron/dark,
-/area/science/storage)
+/area/science/robotics/lab)
 "xbN" = (
 /obj/machinery/computer/med_data{
 	dir = 8
@@ -65749,13 +66011,13 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "xhy" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "xhO" = (
@@ -66317,12 +66579,23 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"xsn" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot_white,
+"xsl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark,
-/area/science/storage)
+/area/science/mixing/launch)
+"xsn" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/red,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "xsq" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/structure/cable,
@@ -66792,21 +67065,13 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "xzp" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "xzt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/obj/machinery/atmospherics/components/binary/valve/digital,
+/turf/open/floor/iron/white,
+/area/science/storage)
 "xzA" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/exoscanner{
@@ -66888,9 +67153,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xAu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/science/mixing/launch)
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "xAx" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -67328,13 +67593,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/lesser)
 "xIX" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/science/mixing/hallway)
 "xJd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -68155,12 +68416,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ybT" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "ycp" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -68373,14 +68631,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ygE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "ygI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -68464,12 +68721,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "yid" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "yie" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/tcomms_all,
@@ -97458,7 +97717,7 @@ kRP
 mDh
 hnw
 tKF
-lMy
+dDl
 iia
 rog
 nIP
@@ -97482,7 +97741,7 @@ wrP
 wrP
 mPi
 wrP
-ibD
+aZO
 wrP
 iXV
 cNR
@@ -97716,10 +97975,10 @@ rzE
 hnw
 mJx
 ffE
-qaV
+uNE
 jTp
 cEU
-dDl
+xbB
 vMD
 rzQ
 oyA
@@ -97734,7 +97993,7 @@ caV
 dLK
 mCY
 lcN
-ahP
+ibD
 ibD
 ibD
 ibD
@@ -97991,21 +98250,21 @@ fFl
 nZO
 vfL
 qBs
-ibD
+vJH
+uug
+kkO
+kkO
+kkO
+gmC
 wrP
-wrP
-wrP
-wrP
-ibD
-wrP
-wrP
-wrP
-wrP
-wrP
-anS
-anS
-lMJ
-quc
+cPb
+cPb
+cPb
+cPb
+kqO
+blx
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98248,19 +98507,19 @@ cgq
 cgq
 cgq
 qBs
-ibD
-wrP
-eLK
-fRD
+qBs
+qBs
+qBs
+qBs
 uug
-ibD
-wOJ
+iht
+wrP
 lMh
 tsK
-pdq
+nRb
 pJx
-aox
 lMJ
+blx
 aaa
 aaa
 aaa
@@ -98494,30 +98753,30 @@ gJS
 cDi
 cFy
 ipr
-cHo
-cyK
+eyW
+jvq
 wBz
 fQU
 lZJ
 kDc
 lgD
-atF
+cyK
 gNW
 cTs
 egU
-qmW
-wrP
+wQA
+odJ
 ngk
-kkO
-wrP
+qBs
+lRR
 iht
-aEk
-mZm
 wrP
-wrP
-wrP
-aox
 lMJ
+lMJ
+tPH
+lMJ
+lMJ
+blx
 aaa
 aaa
 aaa
@@ -98751,33 +99010,33 @@ mtF
 kIu
 uSS
 ipr
-tdx
-qei
+eyW
+jvq
 wgY
-odJ
+lPV
 eAm
 efz
-hlP
-hlP
+mWI
+cyK
 hlP
 rNz
-qBs
+mZm
 kKe
-wrP
+aCR
 gSf
-cXd
+qBs
+dFn
+cHo
 wrP
-kkO
-sps
-kkO
+wbw
+wbw
+wbw
+wbw
+wbw
 wrP
-aaa
+nRb
 lMJ
-aox
-lMJ
-aaa
-aaa
-aaa
+quc
 aaa
 aaa
 aaa
@@ -99008,32 +99267,32 @@ bkP
 cDi
 ddz
 ipr
-ptE
-cyK
+eyW
+jvq
 sQG
 lPV
-eEK
+eAm
 swS
-tUz
-nrI
+rxQ
+cyK
 jnH
-iRM
-qBs
-dLV
-wrP
-wrP
-wrP
-wrP
-wrP
-wrP
-wrP
-wrP
+wQA
+jnH
+wQA
+hKy
+eIk
+gwk
+eKJ
+nrQ
+evd
+wIK
+kkO
+kkO
+kkO
+mLw
+wbw
 lMJ
-tPH
-anS
-nRb
-lMJ
-quc
+aaa
 aaa
 aaa
 aaa
@@ -99266,30 +99525,30 @@ cDi
 cOd
 ipr
 eyW
-jmX
+jvq
 oIu
 qZN
-eqN
+eAm
 gzx
 hRN
-tgJ
+cyK
 thg
 mUB
-qBs
+hWc
 rqP
-lMh
+wrL
+kmH
+qBs
 wrP
-rmm
-bLu
+mEd
 wrP
-aaa
-aaa
-aaa
-aaa
+wbw
+wbw
+wbw
+wrP
+kkO
+wbw
 lMJ
-aox
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -99524,29 +99783,29 @@ jWa
 ipr
 eyW
 jvq
-wIK
-gmC
-eqN
+oIu
+qZN
+eAm
 tFQ
 cnJ
-njy
+cyK
 ftO
-xIX
-qBs
-kqO
-lMh
+nYA
+nYA
+nYA
+jIS
 slV
-kkO
-kkO
-wrP
-aaa
-aaa
-aaa
-aaa
+cyK
+iVt
+bBv
+oib
+tPH
 lMJ
-aox
 lMJ
-aaa
+wbw
+uug
+wbw
+lMJ
 aaa
 aaa
 aaa
@@ -99780,30 +100039,30 @@ lGF
 mUS
 iyu
 fEn
-jvq
+crR
 ukD
-uNE
+bYi
 heZ
 bYi
 tUN
 cyK
 ppN
-ppN
-qBs
-oFb
-jyz
+nYA
+nYA
+nYA
+nYA
 scS
-fJH
+cyK
 dcJ
-wrP
-aaa
-aaa
-aaa
-aaa
+njs
+hlN
+mHs
+tPH
 lMJ
-aox
+wbw
+kkO
+wbw
 lMJ
-aaa
 aaa
 aaa
 aaa
@@ -100036,32 +100295,32 @@ jvx
 iLf
 xUf
 joB
-mWI
-cyK
+hSZ
+jvq
 czD
-njs
+lsU
 iUd
 xzt
-xzt
-wQA
+qTl
+iaT
 iSy
-iSy
-qBs
 nYA
-wrP
-wrP
-wrP
-wrP
-wrP
+nYA
+nYA
+xsn
+pdq
+wQA
+ofK
+wQA
+wQA
+wQA
+wQA
 lMJ
+wbw
+kkO
+wbw
 lMJ
 aaa
-lMJ
-anS
-anS
-tPH
-lMJ
-quc
 aaa
 aaa
 aaa
@@ -100300,24 +100559,24 @@ uox
 gAo
 dsd
 pOT
-dsd
+cyK
 hnc
-fmA
-qBs
-fVp
-kkO
+nYA
+nYA
+nYA
+ovj
 lHb
-wrP
+tgb
+oRg
+tgb
+hoX
+cmL
+nhe
 lMJ
-aaa
-aaa
-aaa
-aaa
-aaa
+wbw
+kkO
+wbw
 lMJ
-aox
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -100547,10 +100806,10 @@ jeM
 isH
 aVe
 suh
-eIk
+hMa
 hMa
 mDG
-iVt
+hSZ
 jvq
 dbG
 tUz
@@ -100559,22 +100818,22 @@ qhS
 nSp
 mBC
 bAH
-eoI
-qBs
-ibD
-wmY
+nYA
+nYA
+nYA
+nYA
 nCU
-wrP
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ptE
+lMy
+bSF
+kPl
+bLu
+nhe
 lMJ
-aox
+wbw
+kkO
+wbw
 lMJ
-aaa
 aaa
 aaa
 aaa
@@ -100804,34 +101063,34 @@ jeM
 lXi
 tav
 dvC
-hSZ
+atF
 oRD
 wMR
 pSF
-jvq
+crR
 aWu
 him
 nXE
 ooO
 qgC
-kmH
+cyK
 aCU
 fmA
-qBs
-ibD
-kkO
+kyz
+ygE
+uhI
 cBl
+ybT
+tjE
+ybT
+ucy
+cmL
+nhe
+lMJ
+wbw
+uJy
 wbw
 lMJ
-aaa
-aaa
-aaa
-aaa
-aaa
-lMJ
-aox
-lMJ
-aaa
 aaa
 aaa
 aaa
@@ -101062,35 +101321,35 @@ bZn
 cNY
 vqz
 jjQ
-nOc
-nOc
-nOc
-nOc
 uLH
-gwk
+uLH
+uLH
+uLH
+uLH
+uLH
 cAH
+uLH
+uLH
+uLH
+uLH
+uLH
+eIm
+uLH
+uLH
+uLH
 qBs
-eTY
+eSf
 qBs
-iSy
-iSy
 qBs
-ghV
+qBs
+qBs
+qBs
+qBs
+qmW
 wrP
-wrP
-wrP
-wrP
-wrP
-lMJ
-aaa
-lMJ
-lMJ
-anS
-tPH
 anS
 lMJ
 quc
-aaa
 aaa
 aaa
 aaa
@@ -101319,32 +101578,32 @@ dsa
 arS
 lAs
 rVU
-nOc
-dwv
-mAW
-dvY
-ofK
+ktU
+vaJ
+oVD
+fJH
+ktU
 cnV
 tyU
-wrP
+lZH
 eIK
-wrP
+xIX
+eLK
 gyl
-gyl
-qBs
-ibD
-wrP
+eEK
+vCY
+uLH
 eJw
 pqd
 pmG
+iRM
+koH
 wrP
-aaa
-aaa
-aaa
-aaa
-lMJ
-aox
-lMJ
+xAu
+kkO
+wOJ
+rsv
+wrP
 aaa
 aaa
 aaa
@@ -101576,32 +101835,32 @@ uDv
 sXl
 ipr
 wdp
-nOc
-kEV
+rhi
+jyz
 gZu
 thN
-aUW
+sps
 aUW
 gbE
-jIS
-ahP
 mbj
-ibD
-ibD
-ibD
-ibD
+mbj
+mbj
+mbj
+mbj
+eyd
+rmm
 pNc
+eTY
+eTY
+qge
+uug
+eoI
+jmX
 kkO
 kkO
+bOt
 kkO
 wrP
-aaa
-aaa
-aaa
-aaa
-lMJ
-aox
-lMJ
 aaa
 aaa
 aaa
@@ -101832,33 +102091,33 @@ hAA
 nhL
 aXb
 ipr
-eSf
-nOc
-jcD
-dww
-dvY
+ryS
+ktU
+ghV
+ccZ
+hHW
 ktU
 ofF
 wUi
-wrP
-iht
-iht
-iht
+tdx
+uLH
+eqN
+eqN
 wmY
-uJy
+dLV
 eZr
-wrP
+uLH
 mff
-kkO
+kiY
 dFn
+aBH
 wrP
-aaa
-aaa
-aaa
-aaa
-lMJ
-aox
-lMJ
+etJ
+nrI
+nrI
+wrP
+ahP
+wrP
 aaa
 aaa
 aaa
@@ -102090,34 +102349,34 @@ nhL
 eWM
 ipr
 gVE
+uLH
+tgJ
+oFb
+cXd
 nOc
-jcD
-nOc
+dvY
+scO
+dvY
 nOc
 uLH
-wrL
-scO
-qBs
-qBs
-qBs
-qBs
-qBs
+uLH
+uLH
 rhB
-qBs
-qBs
-qBs
+uLH
+uLH
+uLH
 qBs
 wrP
 wrP
-lMJ
-lMJ
-lMJ
-lMJ
-nRb
-anS
-tPH
-lMJ
-quc
+wrP
+pKN
+uXX
+fRD
+wrP
+aEk
+wrP
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102347,32 +102606,32 @@ eLC
 vcQ
 ipr
 ryS
-nOc
+uLH
 vPP
-nOc
+lJL
 vep
-uhI
-mLw
+nOc
+ciL
 mgc
 ppA
-vaJ
-crR
+nOc
+raF
 eqC
 lci
-jnU
+qei
 npa
 gVL
 jyd
 bAp
-aaa
 lMJ
-aaa
-aaa
-aaa
-aaa
 lMJ
-aox
-lMJ
+wrP
+wrP
+wbw
+wrP
+wrP
+vLF
+wrP
 aaa
 aaa
 aaa
@@ -102605,23 +102864,23 @@ sGS
 ipr
 cYS
 nOc
-jcD
 nOc
-xsn
-ybT
+nOc
+nOc
+nOc
 uCj
-tgb
-lsU
-aCR
+mgc
+uVu
+nOc
 jPZ
 exL
-jDE
+lET
 jDE
 wIS
 peh
 bCg
 bAp
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -102860,16 +103119,16 @@ kYf
 uDv
 mqF
 ipr
-lJL
+ryS
 uPJ
-kiY
-nOc
-hWc
+kEV
+gJo
 bEE
-ygE
+bEE
+bEE
 yid
-yid
-aZO
+mAW
+nOc
 lOW
 ecE
 lET
@@ -102878,8 +103137,8 @@ pdM
 jKn
 bHO
 uwn
-aaa
 lMJ
+aaa
 aaa
 aaa
 aaa
@@ -103119,24 +103378,24 @@ qcO
 ipr
 mpI
 nOc
-bBv
-nOc
+jcD
+oNJ
 xzp
-pKN
+ciL
 cIY
-bSF
-xbB
-xbB
-crR
+ciL
+dzc
+nOc
+fFq
 kgf
-jFj
+lET
 hfj
 pnR
 vdo
 rFa
 bAp
-aaa
 lMJ
+aaa
 aaa
 aaa
 aaa
@@ -103376,23 +103635,23 @@ aXb
 ipr
 mcC
 nOc
-bBv
+jcD
+jMn
+dvY
+nxf
+dvY
+dvY
+dvY
 nOc
-uXX
-uXX
-nhe
-oRg
-oRg
-oRg
-crR
+xsl
 hkS
 gRv
-jFj
+njy
 umW
 gpy
 kiq
 bAp
-aaa
+lMJ
 lMJ
 aaa
 quc
@@ -103634,16 +103893,16 @@ ipr
 hdl
 nOc
 czT
+fvg
+dvY
+ciL
+ciL
+ciL
+kCd
 nOc
-uxR
-kPl
-iaT
-kCd
-kCd
-nrQ
-crR
-koH
-ssy
+gFn
+exL
+lET
 jFj
 rZE
 rZE
@@ -103890,18 +104149,18 @@ kAo
 ipr
 mAt
 nOc
-bBv
-nOc
-kPl
+jcD
+fvg
+dvY
 gWX
-ucy
-jMn
-kCd
-kCd
-crR
+ciL
+ciL
+dwv
+nOc
+asu
 jPX
 wfJ
-iDF
+uxR
 rZE
 sSe
 onz
@@ -104147,17 +104406,17 @@ qhC
 ipr
 hdl
 nOc
-bBv
-nOc
-nOc
-nOc
+jcD
+fvg
+dvY
+ssy
 onc
-nOc
+uVu
 dvY
 dvY
 nOc
 nbE
-xAu
+lET
 iDF
 jjp
 xgv
@@ -104404,12 +104663,12 @@ itl
 mvx
 jZi
 nOc
-bBv
-nxf
-mHs
-vLF
-rhi
-dzc
+jcD
+fvg
+dvY
+dvY
+dvY
+dvY
 dvY
 mub
 nOc
@@ -104661,10 +104920,10 @@ bZn
 jJa
 bZn
 nOc
-bBv
+jcD
 fvg
 gmo
-gmo
+dvY
 fbD
 mAW
 dvY
@@ -104922,8 +105181,8 @@ luD
 woO
 ciL
 dvY
-dvY
-dvY
+ciL
+ciL
 dvY
 nqe
 rnC

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -68648,10 +68648,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/east{
-	c_tag = "Science Ordnance Storage";
-	network = list("ss13","rd")
-	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "ygI" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16347,10 +16347,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"eEK" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/maintenance/aft/lesser)
 "eEU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -38492,7 +38488,6 @@
 /obj/structure/sign/poster/random/directional/east{
 	pixel_y = 32
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "mLC" = (
@@ -50737,6 +50732,10 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/science/mixing/launch)
+"rmm" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "rmt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
@@ -55303,6 +55302,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"tdx" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/aft/lesser)
 "tdz" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -99301,7 +99304,7 @@ evd
 wIK
 kkO
 kkO
-kkO
+rmm
 mLw
 wbw
 lMJ
@@ -99559,7 +99562,7 @@ wbw
 wbw
 wbw
 wrP
-eEK
+tdx
 wbw
 lMJ
 aaa


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
Click me!
</summary>
<img src="https://user-images.githubusercontent.com/54709710/164916459-f0bddd89-b204-46be-8403-d7c9f1db5136.png"/>
</details>

Redo of https://github.com/tgstation/tgstation/pull/65807 but by sticking closer to the old layout. Some folks were very fond of parts of the old meta sci & hydroponics that i had to change significantly if i were to continue with the layout in the linked PR. So I did less changes overall except for the chamber room, ordnance office and maint rerouting.

Oh and rearranged disposals a bit to be nicer.

I honestly prefer my old layout more than this one, since there are distinct feels from different maps, with meta being the most "linear" of all the others and icebox being the most open. But I'm content with this.

Yes this one is very similar to the delta one.

## Why It's Good For The Game
Adds a freeze chamber, adding oxygen to the chamber is more obvious, nicer loop, computers, significantly more space, etc.

## Changelog
:cl:
add: Remapped meta's ordnance.
/:cl: