### PR TITLE
fixes problems with access helpers

### DIFF
--- a/code/modules/mapping/access_helpers.dm
+++ b/code/modules/mapping/access_helpers.dm
@@ -77,6 +77,11 @@
 	access_list += ACCESS_ENGINE
 	return access_list
 
+/obj/effect/mapping_helpers/airlock/access/any/engineering/engine_equipment/get_access()
+	var/list/access_list = ..()
+	access_list += ACCESS_ENGINE_EQUIP
+	return access_list
+
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction/get_access()
 	var/list/access_list = ..()
 	access_list += ACCESS_CONSTRUCTION
@@ -286,16 +291,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/crematorium/get_access()
 	var/list/access_list = ..()
 	access_list += ACCESS_CREMATORIUM
-	return access_list
-
-/obj/effect/mapping_helpers/airlock/access/any/service/crematorium/get_access()
-	var/list/access_list = ..()
-	access_list += ACCESS_CREMATORIUM
-	return access_list
-
-/obj/effect/mapping_helpers/airlock/access/any/service/library/get_access()
-	var/list/access_list = ..()
-	access_list += ACCESS_LIBRARY
 	return access_list
 
 /obj/effect/mapping_helpers/airlock/access/any/service/library/get_access()
@@ -617,17 +612,12 @@
 	access_list += ACCESS_CREMATORIUM
 	return access_list
 
-/obj/effect/mapping_helpers/airlock/access/all/service/crematorium/get_access()
-	var/list/access_list = ..()
-	access_list += ACCESS_CREMATORIUM
-	return access_list
-
 /obj/effect/mapping_helpers/airlock/access/all/service/library/get_access()
 	var/list/access_list = ..()
 	access_list += ACCESS_LIBRARY
 	return access_list
 
-/obj/effect/mapping_helpers/airlock/access/all/service/library/get_access()
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre/get_access()
 	var/list/access_list = ..()
 	access_list += ACCESS_THEATRE
 	return access_list

--- a/code/modules/mapping/access_helpers.dm
+++ b/code/modules/mapping/access_helpers.dm
@@ -300,6 +300,11 @@
 
 /obj/effect/mapping_helpers/airlock/access/any/service/library/get_access()
 	var/list/access_list = ..()
+	access_list += ACCESS_LIBRARY
+	return access_list
+
+/obj/effect/mapping_helpers/airlock/access/any/service/theatre/get_access()
+	var/list/access_list = ..()
 	access_list += ACCESS_THEATRE
 	return access_list
 
@@ -394,6 +399,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general/get_access()
 	var/list/access_list = ..()
 	access_list += ACCESS_ENGINE
+	return access_list
+
+/obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment/get_access()
+	var/list/access_list = ..()
+	access_list += ACCESS_ENGINE_EQUIP
 	return access_list
 
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction/get_access()


### PR DESCRIPTION
## About The Pull Request

1. Makes Library access helper use Library access instead of Theatre
2. Adds a Theatre access helper for Theatre
3. Adds an Engine equip access helper for Engine equip (SMES/Grav gen, in the case of Pubby, aka the whole reason I made this PR).
4. Removes double crematoriums

## Why It's Good For The Game

It's nice when helpers work as they are supposed to, and if used in the future, will help our maps have less varediting. pretty cool.

## Changelog

Not needed.