### PR TITLE
removes headpat/tailpull signals

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -2,10 +2,6 @@
 #define COMSIG_CARBON_HUG "carbon_hug"
 ///When a carbon mob is hugged, this is called on the carbon that is hugged. (mob/living/hugger)
 #define COMSIG_CARBON_HUGGED "carbon_hugged"
-///When a carbon mob is headpatted, this is called on the carbon that is headpatted. (mob/living/headpatter)
-#define COMSIG_CARBON_HEADPAT "carbon_headpatted"
-///When a carbon mob has their tail pulled, this is called on the carbon that is the target. (mob/living/tailpuller)
-#define COMSIG_CARBON_TAILPULL "carbon_tailpulled"
 ///Before a carbon mob is shoved, sent to the turf we're trying to shove onto (mob/living/carbon/shover, mob/living/carbon/target)
 #define COMSIG_CARBON_DISARM_PRESHOVE "carbon_disarm_preshove"
 	#define COMSIG_CARBON_ACT_SOLID (1<<0) //Tells disarm code to act as if the mob was shoved into something solid, even we we're not

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -826,10 +826,10 @@
 	hardcore_value = 1
 
 /datum/quirk/bad_touch/add()
-	RegisterSignal(quirk_holder, list(COMSIG_LIVING_GET_PULLED, COMSIG_CARBON_HUGGED, COMSIG_CARBON_HEADPAT, COMSIG_CARBON_TAILPULL), .proc/uncomfortable_touch)
+	RegisterSignal(quirk_holder, list(COMSIG_LIVING_GET_PULLED, COMSIG_CARBON_HUGGED), .proc/uncomfortable_touch)
 
 /datum/quirk/bad_touch/remove()
-	UnregisterSignal(quirk_holder, list(COMSIG_LIVING_GET_PULLED, COMSIG_CARBON_HUGGED, COMSIG_CARBON_HEADPAT, COMSIG_CARBON_TAILPULL))
+	UnregisterSignal(quirk_holder, list(COMSIG_LIVING_GET_PULLED, COMSIG_CARBON_HUGGED))
 
 /datum/quirk/bad_touch/proc/uncomfortable_touch()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -414,7 +414,6 @@
 		to_chat(M, span_notice("You shake [src] trying to pick [p_them()] up!"))
 		to_chat(src, span_notice("[M] shakes you to get you up!"))
 	else if(check_zone(M.zone_selected) == BODY_ZONE_HEAD && get_bodypart(BODY_ZONE_HEAD)) //Headpats!
-		SEND_SIGNAL(src, COMSIG_CARBON_HEADPAT, M)
 		M.visible_message(span_notice("[M] gives [src] a pat on the head to make [p_them()] feel better!"), \
 					null, span_hear("You hear a soft patter."), DEFAULT_MESSAGE_RANGE, list(M, src))
 		to_chat(M, span_notice("You give [src] a pat on the head to make [p_them()] feel better!"))
@@ -424,7 +423,6 @@
 			to_chat(M, span_warning("[src] looks visibly upset as you pat [p_them()] on the head."))
 
 	else if ((M.zone_selected == BODY_ZONE_PRECISE_GROIN) && !isnull(src.getorgan(/obj/item/organ/tail)))
-		SEND_SIGNAL(src, COMSIG_CARBON_TAILPULL, M)
 		M.visible_message(span_notice("[M] pulls on [src]'s tail!"), \
 					null, span_hear("You hear a soft patter."), DEFAULT_MESSAGE_RANGE, list(M, src))
 		to_chat(M, span_notice("You pull on [src]'s tail!"))
@@ -435,8 +433,6 @@
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "tailpulled", /datum/mood_event/tailpulled)
 
 	else
-		SEND_SIGNAL(src, COMSIG_CARBON_HUGGED, M)
-		SEND_SIGNAL(M, COMSIG_CARBON_HUG, M, src)
 		M.visible_message(span_notice("[M] hugs [src] to make [p_them()] feel better!"), \
 					null, span_hear("You hear the rustling of clothes."), DEFAULT_MESSAGE_RANGE, list(M, src))
 		to_chat(M, span_notice("You hug [src] to make [p_them()] feel better!"))
@@ -476,6 +472,8 @@
 		if(HAS_TRAIT(src, TRAIT_BADTOUCH))
 			to_chat(M, span_warning("[src] looks visibly upset as you hug [p_them()]."))
 
+	SEND_SIGNAL(src, COMSIG_CARBON_HUGGED, M)
+	SEND_SIGNAL(M, COMSIG_CARBON_HUG, M, src)
 	adjust_status_effects_on_shake_up()
 	set_resting(FALSE)
 	if(body_position != STANDING_UP && !resting && !buckled && !HAS_TRAIT(src, TRAIT_FLOORED))


### PR DESCRIPTION
## About The Pull Request

This makes no sense to have, it's 3 signals for basically the same action, because you target different bodyparts, which just confuses the hell out of players.

## Why It's Good For The Game

It's not fun losing a greentext because it turns out you forgot you were aiming for the head when you hugged your obsession target. It's not any cooler as a coder to make 3 signals trigger the exact same thing because they all do the same thing. It really just makes no sense to me, so I'm trying to remove it.

## Changelog

:cl:
fix: Obsesseds don't fail the hug objective if they headpat/tail pull instead,
/:cl:
