### PR TITLE
Buffs pump and scrubber's heat and pressure limit. Buffs pump's output. Refactors their damage calculation along the way.

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -62,7 +62,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	var/can_max_release_pressure = (ONE_ATMOSPHERE * 10)
 	///Minimum pressure allower for release_pressure var
 	var/can_min_release_pressure = (ONE_ATMOSPHERE * 0.1)
-	///Maximum amount of heat that the canister can handle before taking damage
+	///Maximum amount of external heat that the canister can handle before taking damage
 	var/temperature_resistance = 1000 + T0C
 	///Initial temperature gas mixture
 	var/starter_temp
@@ -418,6 +418,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	window.overlays = window_overlays
 	add_overlay(window)
 
+// Both of these procs handle the external temperature damage.
 /obj/machinery/portable_atmospherics/canister/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
 	return (exposed_temperature > temperature_resistance && !shielding_powered)
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -755,6 +755,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 
 		if("shielding")
 			shielding_powered = !shielding_powered
+			SSair.start_processing_machine(src)
 			message_admins("[ADMIN_LOOKUPFLW(usr)] turned [shielding_powered ? "on" : "off"] the [src] powered shielding.")
 			investigate_log("[key_name(usr)] turned [shielding_powered ? "on" : "off"] the [src] powered shielding.")
 			. = TRUE

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	///Player controlled var that set the release pressure of the canister
 	var/release_pressure = ONE_ATMOSPHERE
 	///Maximum pressure allowed for release_pressure var
-	var/can_max_release_pressure = (ONE_ATMOSPHERE * 10)
+	var/can_max_release_pressure = TANK_LEAK_PRESSURE
 	///Minimum pressure allower for release_pressure var
 	var/can_min_release_pressure = (ONE_ATMOSPHERE * 0.1)
 	///Maximum amount of external heat that the canister can handle before taking damage

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -62,10 +62,6 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	var/can_max_release_pressure = (ONE_ATMOSPHERE * 10)
 	///Minimum pressure allower for release_pressure var
 	var/can_min_release_pressure = (ONE_ATMOSPHERE * 0.1)
-	///Max amount of heat allowed inside of the canister before it starts to melt (different tiers have different limits)
-	var/heat_limit = 10000
-	///Max amount of pressure allowed inside of the canister before it starts to break (different tiers have different limits)
-	var/pressure_limit = 500000
 	///Maximum amount of heat that the canister can handle before taking damage
 	var/temperature_resistance = 1000 + T0C
 	///Initial temperature gas mixture
@@ -126,7 +122,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 
 /obj/machinery/portable_atmospherics/canister/examine(user)
 	. = ..()
-	. += span_notice("A sticker on its side says <b>MAX SAFE PRESSURE: [siunit_pressure(initial(pressure_limit), 0)]; MAX SAFE TEMPERATURE: [siunit(heat_limit, "K", 0)]</b>.")
+	. += span_notice("A sticker on its side says <b>MAX SAFE PRESSURE: [siunit_pressure(initial(pressure_limit), 0)]; MAX SAFE TEMPERATURE: [siunit(temp_limit, "K", 0)]</b>.")
 	if(internal_cell)
 		. += span_notice("The internal cell has [internal_cell.percent()]% of its total charge.")
 	else
@@ -278,7 +274,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 /obj/machinery/portable_atmospherics/canister/fusion_test
 	name = "fusion test canister"
 	desc = "Don't be a badmin."
-	heat_limit = 1e12
+	temp_limit = 1e12
 	pressure_limit = 1e14
 
 /obj/machinery/portable_atmospherics/canister/fusion_test/create_gas()
@@ -565,7 +561,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 
 	protected_contents = FALSE
 	if(shielding_powered)
-		var/power_factor = round(log(10, max(our_pressure - pressure_limit, 1)) + log(10, max(our_temperature - heat_limit, 1)))
+		var/power_factor = round(log(10, max(our_pressure - pressure_limit, 1)) + log(10, max(our_temperature - temp_limit, 1)))
 		var/power_consumed = power_factor * 250 * delta_time
 		if(powered(AREA_USAGE_EQUIP, ignore_use_power = TRUE))
 			use_power(power_consumed, AREA_USAGE_EQUIP)
@@ -574,11 +570,6 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 			protected_contents = TRUE
 		else
 			shielding_powered = FALSE
-
-	///function used to check the limit of the canisters and also set the amount of damage that the canister can receive, if the heat and pressure are way higher than the limit the more damage will be done
-	if(!excited && !protected_contents && (our_temperature > heat_limit || our_pressure > pressure_limit))
-		take_damage(clamp((our_temperature/heat_limit) * (our_pressure/pressure_limit), 5, 50), BURN, 0)
-		excited = TRUE
 
 /obj/machinery/portable_atmospherics/canister/process_atmos()
 	if(machine_stat & BROKEN)
@@ -596,15 +587,8 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 		if(air_contents.release_gas_to(target_air, release_pressure) && !holding)
 			air_update_turf(FALSE, FALSE)
 
-	var/our_pressure = air_contents.return_pressure()
-	var/our_temperature = air_contents.return_temperature()
-
-	///function used to check the limit of the canisters and also set the amount of damage that the canister can receive, if the heat and pressure are way higher than the limit the more damage will be done
-	if(!protected_contents && (our_temperature > heat_limit || our_pressure > pressure_limit))
-		take_damage(clamp((our_temperature/heat_limit) * (our_pressure/pressure_limit), 5, 50), BURN, 0)
-		excited = TRUE
+	excited = take_atmos_damage() // A bit different than other atmos devices it seems. Wont stop if currently taking damage.
 	update_appearance()
-
 	return ..()
 
 /obj/machinery/portable_atmospherics/canister/ui_state(mob/user)
@@ -778,4 +762,9 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 
 /obj/machinery/portable_atmospherics/canister/unregister_holding()
 	valve_open = FALSE
+	return ..()
+
+/obj/machinery/portable_atmospherics/canister/take_atmos_damage()
+	if(shielding_powered)
+		return FALSE
 	return ..()

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -67,11 +67,11 @@
 
 	if(temp_limit != PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT)
 		temp_damage = air_contents.temperature / temp_limit
-		taking_damage = temp_damage > 0
+		taking_damage = temp_damage > 1
 
 	if(pressure_limit != PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT)
 		pressure_damage = air_contents.return_pressure() / pressure_limit
-		taking_damage = taking_damage || pressure_damage > 0
+		taking_damage = taking_damage || pressure_damage > 1
 
 	if(!taking_damage)
 		return FALSE

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -1,3 +1,5 @@
+#define PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT -1
+
 /obj/machinery/portable_atmospherics
 	name = "portable_atmospherics"
 	icon = 'icons/obj/atmos.dmi'
@@ -16,6 +18,11 @@
 	var/volume = 0
 	///Used to track if anything of note has happen while running process_atmos()
 	var/excited = TRUE
+
+	/// Max amount of heat allowed inside the machine before it starts to melt. -1 is special value meaning we wont check.
+	var/temp_limit = 10000
+	/// Max amount of pressure allowed inside of the canister before it starts to break. -1 is special value meaning we wont check.
+	var/pressure_limit = 500000
 
 /obj/machinery/portable_atmospherics/Initialize(mapload)
 	. = ..()
@@ -48,6 +55,29 @@
 		if(!excited)
 			return PROCESS_KILL
 	excited = FALSE
+
+/// Take damage if a variable is exceeded. Damage is equal to temp/limit * heat/limit.
+/// The damage multiplier is treated as 1 if something is being ignored while the other one is exceeded.
+/// On most cases only one will be exceeded, so the other one is scaled down.
+/obj/machinery/portable_atmospherics/proc/take_atmos_damage()
+	var/taking_damage = FALSE
+	
+	var/temp_damage = 1
+	var/pressure_damage = 1
+
+	if(temp_limit != PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT)
+		temp_damage = air_contents.temperature / temp_limit
+		taking_damage = temp_damage > 0
+
+	if(pressure_limit != PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT)
+		pressure_damage = air_contents.return_pressure() / pressure_limit
+		taking_damage = taking_damage || pressure_damage > 0
+
+	if(!taking_damage)
+		return FALSE
+	
+	take_damage(clamp(temp_damage * pressure_damage, 5, 50), BURN, 0)
+	return TRUE
 
 /obj/machinery/portable_atmospherics/return_air()
 	SSair.start_processing_machine(src)

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -1,4 +1,4 @@
-#define PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT -1
+#define PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT 0
 
 /obj/machinery/portable_atmospherics
 	name = "portable_atmospherics"

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -3,7 +3,7 @@
 ///The machine pumps from the turf to the internal tank
 #define PUMP_IN "in"
 ///Maximum settable pressure
-#define PUMP_MAX_PRESSURE (ONE_ATMOSPHERE * 30)
+#define PUMP_MAX_PRESSURE TANK_LEAK_PRESSURE
 ///Minimum settable pressure
 #define PUMP_MIN_PRESSURE (ONE_ATMOSPHERE / 10)
 ///Defaul pressure, used in the UI to reset the settings

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -3,7 +3,7 @@
 ///The machine pumps from the turf to the internal tank
 #define PUMP_IN "in"
 ///Maximum settable pressure
-#define PUMP_MAX_PRESSURE (ONE_ATMOSPHERE * 25)
+#define PUMP_MAX_PRESSURE (ONE_ATMOSPHERE * 30)
 ///Minimum settable pressure
 #define PUMP_MIN_PRESSURE (ONE_ATMOSPHERE / 10)
 ///Defaul pressure, used in the UI to reset the settings
@@ -14,10 +14,6 @@
 	icon_state = "siphon"
 	density = TRUE
 	max_integrity = 250
-	///Max amount of heat allowed inside of the canister before it starts to melt (different tiers have different limits)
-	var/heat_limit = 5000
-	///Max amount of pressure allowed inside of the canister before it starts to break (different tiers have different limits)
-	var/pressure_limit = 50000
 	///Is the machine on?
 	var/on = FALSE
 	///What direction is the machine pumping (in or out)?
@@ -44,11 +40,7 @@
 		. += "siphon-connector"
 
 /obj/machinery/portable_atmospherics/pump/process_atmos()
-	var/pressure = air_contents.return_pressure()
-	var/temperature = air_contents.return_temperature()
-	///function used to check the limit of the pumps and also set the amount of damage that the pump can receive, if the heat and pressure are way higher than the limit the more damage will be done
-	if(temperature > heat_limit || pressure > pressure_limit)
-		take_damage(clamp((temperature/heat_limit) * (pressure/pressure_limit), 5, 50), BURN, 0)
+	if(take_atmos_damage())
 		excited = TRUE
 		return ..()
 

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -5,10 +5,6 @@
 	max_integrity = 250
 	volume = 1000
 
-	///Max amount of heat allowed inside of the canister before it starts to melt (different tiers have different limits)
-	var/heat_limit = 5000
-	///Max amount of pressure allowed inside of the canister before it starts to break (different tiers have different limits)
-	var/pressure_limit = 50000
 	///Is the machine on?
 	var/on = FALSE
 	///the rate the machine will scrub air
@@ -54,11 +50,7 @@
 		. += "scrubber-connector"
 
 /obj/machinery/portable_atmospherics/scrubber/process_atmos()
-	var/pressure = air_contents.return_pressure()
-	var/temperature = air_contents.return_temperature()
-	///function used to check the limit of the scrubbers and also set the amount of damage that the scrubber can receive, if the heat and pressure are way higher than the limit the more damage will be done
-	if(temperature > heat_limit || pressure > pressure_limit)
-		take_damage(clamp((temperature/heat_limit) * (pressure/pressure_limit), 5, 50), BURN, 0)
+	if(take_atmos_damage())
 		excited = TRUE
 		return ..()
 
@@ -69,8 +61,6 @@
 
 	var/atom/target = holding || get_turf(src)
 	scrub(target.return_air())
-
-
 	return ..()
 
 /**


### PR DESCRIPTION
## About The Pull Request
I think i managed to keep the old temp calculation one-to-one. Also added a currently unused ignore. Just to make the system more robust.

Really want the heat and pressure bump, don't care that much about the pump output but it is nice. Wont mind if a maint object to the second one though.

## Why It's Good For The Game
Temp calculation: Code nice :) 
Heat and pressure bump: Gameplay nice and more consistent :)
Pump output:  This will rectify it to be in-line pre canister tier removal. Not a one-to-one thing with the old one though. As for why it's good, letting folks be limited by their ability instead of their equipment in making bombs is nice I think.

## Changelog
:cl:
balance: Pumps now have a max output of 3039 kpa
balance: Cans now have a max output of 3039 kpa
balance: Scrubber and pumps will have same roundstart temperature resistance as normal cans. No shielding though.
refactor: Generalized how the damage calculation is made in cans, pumps, and scrubbers. No significant gameplay changes expected except for those mentioned above.
/:cl: