### PR TITLE
Makes the third level of icebox count as station

### DIFF
--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -19,7 +19,6 @@
 		{
 			"Up": 1,
 			"Mining": true,
-			"Station": false,
 			"Linkage": null,
 			"Gravity": true,
 			"Ice Ruins Underground": true,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the third level of icebox function as a station level.

There are pros and cons to making the third level a station, but there were many reports from confused players that accidentally teleported the disk, lost their revolutionary rounds, etc., because we have station-esque structures on the third level but don't count it as a station.

While this fix does not completely solve the problem, it was requested so that we would remove the confusion and hopefully adopt a stronger solution in the near future.

## Why It's Good For The Game

See above for problems related to the 3rd level not being a station level.

Fixes #66341 

## Changelog

:cl:

fix: The 3rd Level of IceBox is now counted as being a part of the station.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
