### PR TITLE
Adds an APC to the IceBox Mining Area on lowest level and seperates area

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
@@ -38,7 +38,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "at" = (
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
@@ -132,7 +132,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/mine/eva)
+/area/mine/eva/lower)
 "cm" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating/snowed/icemoon,
@@ -143,17 +143,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/mine/eva)
+/area/mine/eva/lower)
 "cW" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "cX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "db" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/camera/directional/south{
@@ -168,7 +168,7 @@
 "dd" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/snowed/icemoon,
-/area/mine/eva)
+/area/mine/eva/lower)
 "dh" = (
 /obj/structure/fence{
 	dir = 4
@@ -197,6 +197,19 @@
 /obj/item/stack/sheet/mineral/plasma/thirty,
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/security)
+"dY" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/mine/eva/lower)
 "ea" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -204,7 +217,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/side,
-/area/mine/eva)
+/area/mine/eva/lower)
 "el" = (
 /obj/machinery/computer/prisoner,
 /obj/effect/turf_decal/tile/red{
@@ -239,7 +252,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/iron/dark/side,
-/area/mine/eva)
+/area/mine/eva/lower)
 "eQ" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -305,7 +318,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/mine/eva)
+/area/mine/eva/lower)
 "fk" = (
 /obj/structure/fluff/tram_rail/end{
 	dir = 4;
@@ -395,7 +408,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/mine/eva)
+/area/mine/eva/lower)
 "gW" = (
 /obj/structure/fluff/tram_rail{
 	pixel_y = 17
@@ -448,7 +461,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood/large,
-/area/mine/eva)
+/area/mine/eva/lower)
 "hD" = (
 /obj/structure/fence/corner{
 	dir = 9
@@ -462,7 +475,7 @@
 	name = "Bench"
 	},
 /turf/open/floor/iron/dark,
-/area/mine/eva)
+/area/mine/eva/lower)
 "hN" = (
 /obj/structure/table,
 /obj/item/paper,
@@ -486,7 +499,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/structure/table,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "it" = (
 /obj/structure/sink{
 	dir = 8;
@@ -496,11 +509,11 @@
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
-/area/mine/eva)
+/area/mine/eva/lower)
 "iu" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/wood/large,
-/area/mine/eva)
+/area/mine/eva/lower)
 "iv" = (
 /obj/structure/fence{
 	dir = 4
@@ -521,7 +534,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/mine/eva)
+/area/mine/eva/lower)
 "iD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -580,7 +593,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/mine/eva)
+/area/mine/eva/lower)
 "jU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -597,7 +610,7 @@
 "kc" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
-/area/mine/eva)
+/area/mine/eva/lower)
 "kf" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -633,7 +646,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/side,
-/area/mine/eva)
+/area/mine/eva/lower)
 "kK" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Labor Camp External North";
@@ -675,7 +688,7 @@
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "lq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -690,7 +703,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/mine/eva)
+/area/mine/eva/lower)
 "lr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -709,11 +722,11 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/stone,
-/area/mine/eva)
+/area/mine/eva/lower)
 "lw" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/snowed/icemoon,
-/area/mine/eva)
+/area/mine/eva/lower)
 "lD" = (
 /obj/structure/flora/tree/pine,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -733,7 +746,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "mg" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -766,7 +779,7 @@
 "mw" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/smooth,
-/area/mine/eva)
+/area/mine/eva/lower)
 "mB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner,
@@ -802,7 +815,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/mine/eva)
+/area/mine/eva/lower)
 "mZ" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/security/glass{
@@ -850,7 +863,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/mine/eva)
+/area/mine/eva/lower)
 "oe" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -929,7 +942,7 @@
 "pj" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "pm" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 1
@@ -954,7 +967,7 @@
 "pP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/freezer,
-/area/mine/eva)
+/area/mine/eva/lower)
 "pT" = (
 /obj/structure/lattice/catwalk,
 /turf/open/lava/plasma/ice_moon,
@@ -970,7 +983,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "qI" = (
 /turf/open/genturf,
 /area/icemoon/underground/unexplored/rivers/deep)
@@ -1009,7 +1022,7 @@
 "qX" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/mine/eva)
+/area/mine/eva/lower)
 "rb" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -1023,7 +1036,7 @@
 /area/mine/laborcamp)
 "rd" = (
 /turf/open/floor/iron,
-/area/mine/eva)
+/area/mine/eva/lower)
 "rt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -1114,7 +1127,7 @@
 "sD" = (
 /obj/structure/girder,
 /turf/open/floor/plating/snowed/icemoon,
-/area/mine/eva)
+/area/mine/eva/lower)
 "sL" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -1135,7 +1148,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/stone,
-/area/mine/eva)
+/area/mine/eva/lower)
 "sQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1171,7 +1184,7 @@
 /obj/machinery/newscaster/directional/north,
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
-/area/mine/eva)
+/area/mine/eva/lower)
 "tJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants{
@@ -1267,7 +1280,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side,
-/area/mine/eva)
+/area/mine/eva/lower)
 "vw" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -1293,7 +1306,7 @@
 	pixel_x = 29
 	},
 /turf/open/floor/iron/smooth,
-/area/mine/eva)
+/area/mine/eva/lower)
 "vz" = (
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_y = 32
@@ -1320,7 +1333,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/mine/eva)
+/area/mine/eva/lower)
 "wj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/north,
@@ -1336,7 +1349,7 @@
 /obj/structure/table,
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "wy" = (
 /obj/effect/gibspawner/human,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -1348,7 +1361,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/stone,
-/area/mine/eva)
+/area/mine/eva/lower)
 "wJ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -1361,7 +1374,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/mine/eva)
+/area/mine/eva/lower)
 "wR" = (
 /turf/closed/mineral/random/labormineral/ice,
 /area/icemoon/surface/outdoors/labor_camp)
@@ -1380,7 +1393,7 @@
 	req_access_txt = "29"
 	},
 /turf/open/floor/iron/freezer,
-/area/mine/eva)
+/area/mine/eva/lower)
 "xv" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red,
@@ -1441,11 +1454,11 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood/large,
-/area/mine/eva)
+/area/mine/eva/lower)
 "yV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "zc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/north,
@@ -1457,13 +1470,13 @@
 "zp" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "zq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/mine/eva)
+/area/mine/eva/lower)
 "zs" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
@@ -1501,7 +1514,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/mine/eva)
+/area/mine/eva/lower)
 "Ao" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -1544,7 +1557,7 @@
 /obj/structure/cable,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "AY" = (
 /obj/structure/fence/door{
 	dir = 4
@@ -1582,7 +1595,7 @@
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/smooth,
-/area/mine/eva)
+/area/mine/eva/lower)
 "BJ" = (
 /obj/structure/fence,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -1606,7 +1619,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/side,
-/area/mine/eva)
+/area/mine/eva/lower)
 "BQ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/kirbyplants/fullysynthetic{
@@ -1616,13 +1629,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/stone,
-/area/mine/eva)
+/area/mine/eva/lower)
 "BT" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "BV" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -1641,7 +1654,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/mine/eva)
+/area/mine/eva/lower)
 "BY" = (
 /obj/structure/table,
 /obj/item/paper,
@@ -1686,7 +1699,7 @@
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "CS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1718,7 +1731,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/mine/eva)
+/area/mine/eva/lower)
 "De" = (
 /obj/structure/railing{
 	dir = 4
@@ -1802,8 +1815,10 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/north,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
-/area/mine/eva)
+/area/mine/eva/lower)
 "ER" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "gulag2";
@@ -1861,13 +1876,13 @@
 /obj/item/pen/red,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/large,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Fy" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/stone,
-/area/mine/eva)
+/area/mine/eva/lower)
 "FC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -1926,7 +1941,7 @@
 "Gv" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
-/area/mine/eva)
+/area/mine/eva/lower)
 "GD" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
@@ -1959,7 +1974,7 @@
 /area/mine/laborcamp)
 "GR" = (
 /turf/closed/wall/r_wall,
-/area/mine/eva)
+/area/mine/eva/lower)
 "GU" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2023,7 +2038,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/mine/eva)
+/area/mine/eva/lower)
 "HJ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -2031,7 +2046,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/side,
-/area/mine/eva)
+/area/mine/eva/lower)
 "HQ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -2101,7 +2116,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/side,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Jf" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -2202,7 +2217,7 @@
 "KF" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "KU" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Labor Camp External West";
@@ -2242,7 +2257,7 @@
 	pixel_x = 9
 	},
 /turf/open/floor/stone,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Lo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2287,7 +2302,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/mine/eva)
+/area/mine/eva/lower)
 "LC" = (
 /obj/structure/sign/warning/coldtemp{
 	pixel_y = 32
@@ -2330,7 +2345,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/stone,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Me" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Airlock"
@@ -2383,7 +2398,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/iron/smooth,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Nf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2411,10 +2426,10 @@
 "Nt" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "NB" = (
 /turf/closed/wall,
-/area/mine/eva)
+/area/mine/eva/lower)
 "ND" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -2446,12 +2461,12 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/large,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Ou" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Ow" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/flasher/directional/west{
@@ -2491,7 +2506,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/mine/eva)
+/area/mine/eva/lower)
 "OT" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2526,7 +2541,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/large,
-/area/mine/eva)
+/area/mine/eva/lower)
 "PC" = (
 /obj/structure/fence/end{
 	dir = 1
@@ -2540,7 +2555,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
-/area/mine/eva)
+/area/mine/eva/lower)
 "PV" = (
 /obj/structure/toilet{
 	dir = 8
@@ -2588,7 +2603,7 @@
 	req_access_txt = "48"
 	},
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "QU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/south,
@@ -2621,7 +2636,7 @@
 "Rn" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Ro" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -2634,7 +2649,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/iron/dark/side,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Rp" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/ore_box,
@@ -2661,21 +2676,21 @@
 "RA" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/smooth,
-/area/mine/eva)
+/area/mine/eva/lower)
 "RJ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/stone,
-/area/mine/eva)
+/area/mine/eva/lower)
 "RP" = (
 /obj/structure/stairs/north,
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/mine/eva)
+/area/mine/eva/lower)
 "RQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -2701,7 +2716,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/item/cigbutt,
 /turf/open/floor/wood/large,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Sj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2713,7 +2728,7 @@
 	pixel_x = 29
 	},
 /turf/open/floor/iron/smooth,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2789,13 +2804,13 @@
 	},
 /obj/item/stack/package_wrap,
 /turf/open/floor/wood/large,
-/area/mine/eva)
+/area/mine/eva/lower)
 "TD" = (
 /obj/machinery/door/airlock/silver{
 	name = "Restroom"
 	},
 /turf/open/floor/iron/freezer,
-/area/mine/eva)
+/area/mine/eva/lower)
 "TX" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -2919,7 +2934,7 @@
 "Wd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Wf" = (
 /obj/machinery/vending/security{
 	onstation_override = 1
@@ -2964,7 +2979,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Wl" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/ore_box,
@@ -3078,7 +3093,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/mine/eva)
+/area/mine/eva/lower)
 "Xz" = (
 /obj/structure/gulag_beacon,
 /turf/open/floor/iron,
@@ -3087,7 +3102,7 @@
 /obj/machinery/vending/coffee,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/stone,
-/area/mine/eva)
+/area/mine/eva/lower)
 "XJ" = (
 /obj/structure/ore_box,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -3140,7 +3155,7 @@
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/mine/eva)
+/area/mine/eva/lower)
 "YU" = (
 /obj/machinery/door/airlock{
 	name = "Labor Camp Library"
@@ -24164,7 +24179,7 @@ qC
 cW
 NB
 ED
-BW
+dY
 Dc
 ea
 tZ

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -60,6 +60,10 @@
 	name = "Mining Station EVA"
 	icon_state = "mining_eva"
 
+/area/mine/eva/lower
+	name = "Mining Station Lower EVA"
+	icon_state = "mining_eva"
+
 /area/mine/maintenance
 	name = "Mining Station Communications"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes a "lower eva" area for the lowest level of the mining station on IceBox and adds an APC.

## Why It's Good For The Game

Fixes #66374 

## Changelog

:cl:
fix: Adds an APC and area to the lowest level of the mining station on IceBoxstation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
