### PR TITLE
[NO GBP] Fixes firelock overlap of posters on KiloStation

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -35027,17 +35027,6 @@
 /obj/item/reagent_containers/food/drinks/mug/coco,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
-"hwF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/commons/locker)
 "hwO" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -67083,6 +67072,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "rOk" = (
@@ -68354,8 +68344,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/status_display/evac/directional/north,
 /obj/structure/table,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "skt" = (
@@ -71762,7 +71752,6 @@
 	pixel_y = 4
 	},
 /obj/item/storage/backpack,
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "tvd" = (
@@ -109152,7 +109141,7 @@ tzV
 kcq
 ktX
 oCh
-hwF
+riz
 qqe
 shg
 oUT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the firelocks in Kilostation dorms so they don't overlap the posters. Was an oversight when I made the PR to make that escape pod public access.

Removes a display two tiles from another display to add wall space for one of those firelocks.

## Why It's Good For The Game

Fixes #66448 

## Changelog

:cl:
fix: Moved firelocks in KiloStation dorms to not overlap posters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
