### PR TITLE
Fixes safe location on bridge on Kilostation

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -27223,6 +27223,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/item/storage/secure/safe/caps_spare/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "eJC" = (
@@ -62010,7 +62011,6 @@
 	},
 /obj/item/healthanalyzer,
 /obj/item/hand_labeler,
-/obj/item/storage/secure/safe/caps_spare/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "qkL" = (

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -32,15 +32,16 @@
 	callTime = 250;
 	can_move_docking_ports = 1;
 	dir = 8;
-	dwidth = 11;
-	height = 17;
+	dwidth = 14;
+	height = 23;
 	id = "whiteship";
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Salvage Ship";
 	port_direction = 8;
 	preferred_direction = 4;
-	width = 33
+	width = 16;
+	dheight = 18
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned/cargo)

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -32,16 +32,15 @@
 	callTime = 250;
 	can_move_docking_ports = 1;
 	dir = 8;
-	dwidth = 14;
-	height = 23;
+	dwidth = 11;
+	height = 17;
 	id = "whiteship";
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Salvage Ship";
 	port_direction = 8;
 	preferred_direction = 4;
-	width = 16;
-	dheight = 18
+	width = 33
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned/cargo)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the safe to the tile directly west and sets the safe direction to east to fix a strange placement (It was previously over the table and to the north).

## Why It's Good For The Game
Fixes #66449 

## Changelog

:cl:
fix: fixed wonky safe placement on Kilostation bridge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
