### PR TITLE
Adds support for simple subtype repathing for UpdatePaths scripts

### DIFF
--- a/tools/UpdatePaths/__main__.py
+++ b/tools/UpdatePaths/__main__.py
@@ -12,6 +12,7 @@ Replacement syntax example:
     /turf/open/floor/iron/warningline : /obj/effect/turf_decal {dir = @OLD ;tag = @SKIP;icon_state = @SKIP}
     /turf/open/floor/iron/warningline : /obj/effect/turf_decal {@OLD} , /obj/thing {icon_state = @OLD:name; name = "meme"}
     /turf/open/floor/iron/warningline{dir=2} : /obj/thing
+    /turf/open/floor/@SUBTYPES : /turf/open/floor/iron/@SUBTYPES
 New paths properties:
     @OLD - if used as property name copies all modified properties from original path to this one
     property = @SKIP - will not copy this property through when global @OLD is used.
@@ -73,7 +74,7 @@ def update_path(dmm_data, replacement_string, verbose=False):
             print("Looking for subtypes of", old_path)
         subtypes = r"(?:/\w+)*"
 
-    replacement_pattern = re.compile(rf"(?P<path>{re.escape(old_path)}{subtypes})\s*(:?{{(?P<props>.*)}})?$")
+    replacement_pattern = re.compile(rf"(?P<path>{re.escape(old_path)}(?P<subtype>{subtypes}))\s*(:?{{(?P<props>.*)}})?$")
 
     def replace_def(match):
         if match['props']:
@@ -95,8 +96,12 @@ def update_path(dmm_data, replacement_string, verbose=False):
         for new_path, new_props in new_paths:
             if new_path == "@OLD":
                 out = match.group('path')
+            elif new_path.endswith("/@SUBTYPES"):
+                path_start = new_path[:-len("/@SUBTYPES")]
+                out = path_start + match.group('subtype')
             else:
                 out = new_path
+
             out_props = dict()
             for prop_name, prop_value in new_props.items():
                 if prop_name == "@OLD":

--- a/tools/UpdatePaths/__main__.py
+++ b/tools/UpdatePaths/__main__.py
@@ -12,7 +12,8 @@ Replacement syntax example:
     /turf/open/floor/iron/warningline : /obj/effect/turf_decal {dir = @OLD ;tag = @SKIP;icon_state = @SKIP}
     /turf/open/floor/iron/warningline : /obj/effect/turf_decal {@OLD} , /obj/thing {icon_state = @OLD:name; name = "meme"}
     /turf/open/floor/iron/warningline{dir=2} : /obj/thing
-    /turf/open/floor/@SUBTYPES : /turf/open/floor/iron/@SUBTYPES
+Syntax for subtypes also exist, to update a path's type but maintain subtypes:
+    /obj/structure/closet/crate/@SUBTYPES : /obj/structure/new_box/@SUBTYPES {@OLD}
 New paths properties:
     @OLD - if used as property name copies all modified properties from original path to this one
     property = @SKIP - will not copy this property through when global @OLD is used.

--- a/tools/UpdatePaths/grown_food.txt
+++ b/tools/UpdatePaths/grown_food.txt
@@ -1,1 +1,0 @@
-/obj/item/food/grown/@SUBTYPES : /obj/item/grown/@SUBTYPES {@OLD}

--- a/tools/UpdatePaths/grown_food.txt
+++ b/tools/UpdatePaths/grown_food.txt
@@ -1,0 +1,1 @@
+/obj/item/food/grown/@SUBTYPES : /obj/item/grown/@SUBTYPES {@OLD}


### PR DESCRIPTION
## About The Pull Request

*This might already be possible but I couldn't figure out a way. So here we are.*

Adds support to the update paths script for replacing all of a subtype with all of a new type while keeping the subtype part appended.

Here's an example:

`/obj/structure/closet/crate/@SUBTYPES : /obj/structure/new_crate/@SUBTYPES {@OLD}`

This script repaths all crates to `/obj/structure/new_crate` - changing both type exacts and subtypes. 

![image](https://user-images.githubusercontent.com/51863163/164954121-57bef98f-11e2-4aa4-81d2-a7360bf3fc13.png)

![image](https://user-images.githubusercontent.com/51863163/164954126-36ab30d9-29c0-4afb-8b41-3dfad0b9ff19.png)

![image](https://user-images.githubusercontent.com/51863163/164954132-6e40de39-d1de-43f6-823e-5d11c5c00e9e.png)

![image](https://user-images.githubusercontent.com/51863163/164954141-cf777b27-88b8-4775-85be-347f5cae0051.png)

## Why It's Good For The Game

Makes it a bit easier to use the tool without copy+pasting a new instance for all subtypes. 

## Changelog

Nothing player facing. Only affects people who are doing big repaths. 