### PR TITLE
Fixes offset features

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -158,8 +158,6 @@ There are several things that need to be remembered:
 
 		var/mutable_appearance/uniform_overlay
 
-		//Change check_adjustable_clothing.dm if you change this
-		var/handled_by_bodytype = TRUE
 		var/icon_file
 		var/woman
 		if(!uniform_overlay)
@@ -173,7 +171,6 @@ There are several things that need to be remembered:
 
 			if(!icon_exists(icon_file, RESOLVE_ICON_STATE(U)))
 				icon_file = DEFAULT_UNIFORM_FILE
-				handled_by_bodytype = FALSE
 			//END SPECIES HANDLING
 			uniform_overlay = U.build_worn_icon(
 				default_layer = UNIFORM_LAYER,
@@ -181,10 +178,9 @@ There are several things that need to be remembered:
 				isinhands = FALSE,
 				femaleuniform = woman ? U.adjusted : null,
 				override_state = target_overlay,
-				override_file = handled_by_bodytype ? icon_file : null
 			)
 
-		if(OFFSET_UNIFORM in dna.species.offset_features && !handled_by_bodytype)
+		if(OFFSET_UNIFORM in dna.species.offset_features)
 			uniform_overlay?.pixel_x += dna.species.offset_features[OFFSET_UNIFORM][1]
 			uniform_overlay?.pixel_y += dna.species.offset_features[OFFSET_UNIFORM][2]
 		overlays_standing[UNIFORM_LAYER] = uniform_overlay
@@ -204,18 +200,16 @@ There are several things that need to be remembered:
 	if(wear_id)
 		var/obj/item/worn_item = wear_id
 		update_hud_id(worn_item)
-		var/handled_by_bodytype
 		var/icon_file
 
 		if(!icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item)))
 			icon_file = 'icons/mob/mob.dmi'
-			handled_by_bodytype = FALSE
 
 		id_overlay = wear_id.build_worn_icon(default_layer = ID_LAYER, default_icon_file = icon_file)
 
 		if(!id_overlay)
 			return
-		if(OFFSET_ID in dna.species.offset_features && !handled_by_bodytype)
+		if(OFFSET_ID in dna.species.offset_features)
 			id_overlay.pixel_x += dna.species.offset_features[OFFSET_ID][1]
 			id_overlay.pixel_y += dna.species.offset_features[OFFSET_ID][2]
 		overlays_standing[ID_LAYER] = id_overlay
@@ -249,17 +243,15 @@ There are several things that need to be remembered:
 		var/obj/item/worn_item = gloves
 		update_hud_gloves(worn_item)
 		var/icon_file
-		var/handled_by_bodytype
 
 		if(!icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item)))
 			icon_file = 'icons/mob/clothing/hands.dmi'
-			handled_by_bodytype = FALSE
 
 		gloves_overlay = gloves.build_worn_icon(default_layer = GLOVES_LAYER, default_icon_file = icon_file)
 
 		if(!gloves_overlay)
 			return
-		if(OFFSET_GLOVES in dna.species.offset_features && !handled_by_bodytype)
+		if(OFFSET_GLOVES in dna.species.offset_features)
 			gloves_overlay.pixel_x += dna.species.offset_features[OFFSET_GLOVES][1]
 			gloves_overlay.pixel_y += dna.species.offset_features[OFFSET_GLOVES][2]
 		overlays_standing[GLOVES_LAYER] = gloves_overlay
@@ -281,19 +273,17 @@ There are several things that need to be remembered:
 		var/mutable_appearance/glasses_overlay
 		update_hud_glasses(worn_item)
 
-		var/handled_by_bodytype
 		var/icon_file
 		if(!(head?.flags_inv & HIDEEYES) && !(wear_mask?.flags_inv & HIDEEYES))
 
 			if(!icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item)))
 				icon_file = 'icons/mob/clothing/eyes.dmi'
-				handled_by_bodytype = FALSE
 
 			glasses_overlay = glasses.build_worn_icon(default_layer = GLASSES_LAYER, default_icon_file = icon_file)
 
 		if(!glasses_overlay)
 			return
-		if(OFFSET_GLASSES in dna.species.offset_features && !handled_by_bodytype)
+		if(OFFSET_GLASSES in dna.species.offset_features)
 			glasses_overlay.pixel_x += dna.species.offset_features[OFFSET_GLASSES][1]
 			glasses_overlay.pixel_y += dna.species.offset_features[OFFSET_GLASSES][2]
 		overlays_standing[GLASSES_LAYER] = glasses_overlay
@@ -315,18 +305,16 @@ There are several things that need to be remembered:
 		var/mutable_appearance/ears_overlay
 		update_hud_ears(worn_item)
 
-		var/handled_by_bodytype = TRUE
 		var/icon_file
 
 		if(!(icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item))))
-			handled_by_bodytype = FALSE
 			icon_file = 'icons/mob/clothing/ears.dmi'
 
 		ears_overlay = ears.build_worn_icon(default_layer = EARS_LAYER, default_icon_file = icon_file)
 
 		if(!ears_overlay)
 			return
-		if(OFFSET_EARS in dna.species.offset_features && !handled_by_bodytype)
+		if(OFFSET_EARS in dna.species.offset_features)
 			ears_overlay.pixel_x += dna.species.offset_features[OFFSET_EARS][1]
 			ears_overlay.pixel_y += dna.species.offset_features[OFFSET_EARS][2]
 		overlays_standing[EARS_LAYER] = ears_overlay
@@ -345,17 +333,15 @@ There are several things that need to be remembered:
 		if(!(ITEM_SLOT_NECK in check_obscured_slots()))
 			var/mutable_appearance/neck_overlay
 			var/icon_file
-			var/handled_by_bodytype = TRUE
 
 			if(!(icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item))))
-				handled_by_bodytype = FALSE
 				icon_file = 'icons/mob/clothing/neck.dmi'
 
 			neck_overlay = worn_item.build_worn_icon(default_layer = NECK_LAYER, default_icon_file = icon_file)
 
 			if(!neck_overlay)
 				return
-			if(OFFSET_NECK in dna.species.offset_features && !handled_by_bodytype)
+			if(OFFSET_NECK in dna.species.offset_features)
 				neck_overlay.pixel_x += dna.species.offset_features[OFFSET_NECK][1]
 				neck_overlay.pixel_y += dna.species.offset_features[OFFSET_NECK][2]
 			overlays_standing[NECK_LAYER] = neck_overlay
@@ -378,7 +364,6 @@ There are several things that need to be remembered:
 		var/mutable_appearance/shoes_overlay
 		var/icon_file
 		update_hud_shoes(worn_item)
-		var/handled_by_bodytype = TRUE
 
 		//(Currently) unused digitigrade handling
 		/*if((dna.species.bodytype & BODYTYPE_DIGITIGRADE) && (worn_item.supports_variations_flags & CLOTHING_DIGITIGRADE_VARIATION))
@@ -387,14 +372,13 @@ There are several things that need to be remembered:
 				icon_file = DIGITIGRADE_SHOES_FILE*/
 
 		if(!(icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item))))
-			handled_by_bodytype = FALSE
 			icon_file = DEFAULT_SHOES_FILE
 
 		shoes_overlay = shoes.build_worn_icon(default_layer = SHOES_LAYER, default_icon_file = icon_file)
 
 		if(!shoes_overlay)
 			return
-		if(!(handled_by_bodytype) && (OFFSET_SHOES in dna.species.offset_features))
+		if(OFFSET_SHOES in dna.species.offset_features)
 			shoes_overlay.pixel_x += dna.species.offset_features[OFFSET_SHOES][1]
 			shoes_overlay.pixel_y += dna.species.offset_features[OFFSET_SHOES][2]
 		overlays_standing[SHOES_LAYER] = shoes_overlay
@@ -434,18 +418,16 @@ There are several things that need to be remembered:
 		var/obj/item/worn_item = head
 		var/mutable_appearance/head_overlay
 		update_hud_head(worn_item)
-		var/handled_by_bodytype = FALSE
 		var/icon_file
 
 		if(!(icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item))))
-			handled_by_bodytype = FALSE
 			icon_file = 'icons/mob/clothing/head.dmi'
 
 		head_overlay = head.build_worn_icon(default_layer = HEAD_LAYER, default_icon_file = icon_file)
 
 		if(!head_overlay)
 			return
-		if(!(handled_by_bodytype) && (OFFSET_HEAD in dna.species.offset_features))
+		if(OFFSET_HEAD in dna.species.offset_features)
 			head_overlay.pixel_x += dna.species.offset_features[OFFSET_HEAD][1]
 			head_overlay.pixel_y += dna.species.offset_features[OFFSET_HEAD][2]
 		overlays_standing[HEAD_LAYER] = head_overlay
@@ -464,18 +446,16 @@ There are several things that need to be remembered:
 		var/obj/item/worn_item = belt
 		var/mutable_appearance/belt_overlay
 		update_hud_belt(worn_item)
-		var/handled_by_bodytype = TRUE
 		var/icon_file
 
 		if(!(icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item))))
-			handled_by_bodytype = FALSE
 			icon_file = 'icons/mob/clothing/belt.dmi'
 
 		belt_overlay = belt.build_worn_icon(default_layer = BELT_LAYER, default_icon_file = icon_file)
 
 		if(!belt_overlay)
 			return
-		if(OFFSET_BELT in dna.species.offset_features && !handled_by_bodytype)
+		if(OFFSET_BELT in dna.species.offset_features)
 			belt_overlay.pixel_x += dna.species.offset_features[OFFSET_BELT][1]
 			belt_overlay.pixel_y += dna.species.offset_features[OFFSET_BELT][2]
 		overlays_standing[BELT_LAYER] = belt_overlay
@@ -495,22 +475,19 @@ There are several things that need to be remembered:
 		update_hud_wear_suit(worn_item)
 		var/icon_file
 
-		var/handled_by_bodytype = TRUE
-
 		//More currently unused digitigrade handling
 		/*if(dna.species.bodytype & BODYTYPE_DIGITIGRADE)
 			if(worn_item.supports_variations_flags & CLOTHING_DIGITIGRADE_VARIATION)
 				icon_file = DIGITIGRADE_SUIT_FILE*/
 
 		if(!(icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item))))
-			handled_by_bodytype = FALSE
 			icon_file = DEFAULT_SUIT_FILE
 
 		suit_overlay = wear_suit.build_worn_icon(default_layer = SUIT_LAYER, default_icon_file = icon_file)
 
 		if(!suit_overlay)
 			return
-		if((!handled_by_bodytype) && (OFFSET_SUIT in dna.species.offset_features))
+		if(OFFSET_SUIT in dna.species.offset_features)
 			suit_overlay.pixel_x += dna.species.offset_features[OFFSET_SUIT][1]
 			suit_overlay.pixel_y += dna.species.offset_features[OFFSET_SUIT][2]
 		overlays_standing[SUIT_LAYER] = suit_overlay
@@ -556,19 +533,17 @@ There are several things that need to be remembered:
 		update_hud_wear_mask(worn_item)
 		var/mutable_appearance/mask_overlay
 		var/icon_file = 'icons/mob/clothing/mask.dmi'
-		var/handled_by_bodytype = TRUE
 
 		if(!(ITEM_SLOT_MASK in check_obscured_slots()))
 
 			if(!(icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item))))
 				icon_file = 'icons/mob/clothing/mask.dmi'
-				handled_by_bodytype = FALSE
 
 			mask_overlay = wear_mask.build_worn_icon(default_layer = FACEMASK_LAYER, default_icon_file = icon_file)
 
 		if(!mask_overlay)
 			return
-		if((!handled_by_bodytype) && (OFFSET_FACEMASK in dna.species.offset_features))
+		if(OFFSET_FACEMASK in dna.species.offset_features)
 			mask_overlay.pixel_x += dna.species.offset_features[OFFSET_FACEMASK][1]
 			mask_overlay.pixel_y += dna.species.offset_features[OFFSET_FACEMASK][2]
 
@@ -589,17 +564,15 @@ There are several things that need to be remembered:
 		var/mutable_appearance/back_overlay
 		update_hud_back(worn_item)
 		var/icon_file = 'icons/mob/clothing/back.dmi'
-		var/handled_by_bodytype = TRUE
 
 		if(!icon_exists(icon_file, RESOLVE_ICON_STATE(worn_item)))
 			icon_file = 'icons/mob/clothing/back.dmi'
-			handled_by_bodytype = FALSE
 
 		back_overlay = back.build_worn_icon(default_layer = BACK_LAYER, default_icon_file = icon_file)
 
 		if(!back_overlay)
 			return
-		if((!handled_by_bodytype) && (OFFSET_BACK in dna.species.offset_features))
+		if(OFFSET_BACK in dna.species.offset_features)
 			back_overlay.pixel_x += dna.species.offset_features[OFFSET_BACK][1]
 			back_overlay.pixel_y += dna.species.offset_features[OFFSET_BACK][2]
 		overlays_standing[BACK_LAYER] = back_overlay

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -28,7 +28,22 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	///A bitfield of "bodytypes", updated by /datum/obj/item/bodypart/proc/synchronize_bodytypes()
 	var/bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC
 	///Clothing offsets. If a species has a different body than other species, you can offset clothing so they look less weird.
-	var/list/offset_features = list(OFFSET_UNIFORM = list(0,0), OFFSET_ID = list(0,0), OFFSET_GLOVES = list(0,0), OFFSET_GLASSES = list(0,0), OFFSET_EARS = list(0,0), OFFSET_SHOES = list(0,0), OFFSET_S_STORE = list(0,0), OFFSET_FACEMASK = list(0,0), OFFSET_HEAD = list(0,0), OFFSET_FACE = list(0,0), OFFSET_BELT = list(0,0), OFFSET_BACK = list(0,0), OFFSET_SUIT = list(0,0), OFFSET_NECK = list(0,0))
+	var/list/offset_features = list(
+		OFFSET_UNIFORM = list(0,0),
+		OFFSET_ID = list(0,0),
+		OFFSET_GLOVES = list(0,0),
+		OFFSET_GLASSES = list(0,0),
+		OFFSET_EARS = list(0,0),
+		OFFSET_SHOES = list(0,0),
+		OFFSET_S_STORE = list(0,0),
+		OFFSET_FACEMASK = list(0,0),
+		OFFSET_HEAD = list(0,0),
+		OFFSET_FACE = list(0,0),
+		OFFSET_BELT = list(0,0),
+		OFFSET_BACK = list(0,0),
+		OFFSET_SUIT = list(0,0),
+		OFFSET_NECK = list(0,0),
+	)
 
 	///The maximum number of bodyparts this species can have.
 	var/max_bodypart_count = 6

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -1,7 +1,6 @@
 /datum/species/snail
 	name = "Snailperson"
 	id = SPECIES_SNAIL
-	offset_features = list(OFFSET_GLASSES = list(0,4))
 	default_color = "336600" //vomit green
 	species_traits = list(MUTCOLORS, NO_UNDERWEAR, HAS_FLESH, HAS_BONE)
 	inherent_traits = list(


### PR DESCRIPTION
## About The Pull Request

Fixes offset feature by removing a useless var on a check to see if an icon state for a clothing exists.

tested before and after with snailpeople and it was indeed broken, and this does fix it

Currently:
![image](https://user-images.githubusercontent.com/53777086/164970854-0fdd32ca-ab12-4845-a155-ebc0cce0b30a.png)

With this PR (its on their eyes not their head):
![image](https://user-images.githubusercontent.com/53777086/164971341-9b3afc5d-7b75-4b80-b9ff-56c1d61bee5c.png)

^ Outdated as Snailpeople's offset has now been removed.

## Why It's Good For The Game

I don't understand the point of this, if an icon state doesnt work, you swap the icon over, but don't set the offset? So it just looks weird for species that use said offsets, which currently is just snailpeople so it isn't visible, but it is much worse downstream.

## Changelog

Not needed anymore as snailpeople don't currently have an offset.