### PR TITLE
Exporting computer parts fixes (and code improvement)

### DIFF
--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -16,7 +16,8 @@
 	export_types = list(/obj/item/circuitboard/computer/solar_control)
 
 // Computer and Tablet Parts
-//Processors.
+//Processors
+
 /datum/export/modular_part/processor/small
 	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "microprocessor"
@@ -24,13 +25,13 @@
 	include_subtypes = FALSE
 
 /datum/export/modular_part/processor/photonic
-	cost = CARGO_CRATE_VALUE * 0.5
+	cost = CARGO_CRATE_VALUE * 1.2
 	unit_name = "photonic processor board"
 	export_types = list(/obj/item/computer_hardware/processor_unit/photonic)
 	include_subtypes = FALSE
 
 /datum/export/modular_part/processor/photonic/small
-	cost = CARGO_CRATE_VALUE * 0.25
+	cost = CARGO_CRATE_VALUE * 0.6
 	unit_name = "photonic microprocessor"
 	export_types = list(/obj/item/computer_hardware/processor_unit/photonic/small)
 	include_subtypes = FALSE
@@ -41,38 +42,54 @@
 	export_types = list(/obj/item/computer_hardware/processor_unit)
 	include_subtypes = TRUE
 
-//Batteries.
+//Batteries
+
 /datum/export/modular_part/battery/advanced
-	cost = CARGO_CRATE_VALUE * 1.5
+	cost = CARGO_CRATE_VALUE * 0.6
 	unit_name = "advanced computer battery"
 	export_types = list(/obj/item/stock_parts/cell/computer/advanced)
 	include_subtypes = FALSE
 
 /datum/export/modular_part/battery/super
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 0.8
 	unit_name = "super computer battery"
 	export_types = list(/obj/item/stock_parts/cell/computer/super)
 	include_subtypes = FALSE
 
 /datum/export/modular_part/battery/micro
-	cost = CARGO_CRATE_VALUE * 0.5
+	cost = CARGO_CRATE_VALUE * 0.2
 	unit_name = "micro computer battery"
 	export_types = list(/obj/item/stock_parts/cell/computer/micro)
 	include_subtypes = FALSE
 
 /datum/export/modular_part/battery/nano
-	cost = CARGO_CRATE_VALUE * 0.3
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "nano computer battery"
 	export_types = list(/obj/item/stock_parts/cell/computer/nano)
 	include_subtypes = FALSE
 
 /datum/export/modular_part/battery/standard
-	cost = CARGO_CRATE_VALUE * 0.75
+	cost = CARGO_CRATE_VALUE * 0.4
 	unit_name = "computer battery"
 	export_types = list(/obj/item/stock_parts/cell/computer)
 	include_subtypes = TRUE
 
-//Hard Drives.
+//Other Power Parts
+
+/datum/export/modular_part/apc_link
+	cost = CARGO_CRATE_VALUE * 0.5
+	unit_name = "area power connector"
+	export_types = list(/obj/item/computer_hardware/recharger/apc_recharger)
+	include_subtypes = TRUE
+
+/datum/export/modular_part/controller
+	cost = CARGO_CRATE_VALUE * 0.1
+	unit_name = "power cell controller"
+	export_types = list(/obj/item/computer_hardware/battery)
+	include_subtypes = TRUE
+
+//Hard Drives
+
 /datum/export/modular_part/harddrive/advanced
 	cost = CARGO_CRATE_VALUE * 0.6
 	unit_name = "advanced hard disk drive"
@@ -110,6 +127,7 @@
 	include_subtypes = TRUE
 
 //Networking Parts
+
 /datum/export/modular_part/networkcard/advanced
 	cost = CARGO_CRATE_VALUE * 0.5
 	unit_name = "advanced network card"
@@ -128,9 +146,30 @@
 	export_types = list(/obj/item/computer_hardware/network_card)
 	include_subtypes = TRUE
 
-//Card Parts
+//Data Disks
+
+/datum/export/modular_part/portabledrive/advanced
+	cost = CARGO_CRATE_VALUE * 0.4
+	unit_name = "advanced data disk"
+	export_types = list(/obj/item/computer_hardware/hard_drive/portable/advanced)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/portabledrive/super
+	cost = CARGO_CRATE_VALUE * 0.6
+	unit_name = "super data disk"
+	export_types = list(/obj/item/computer_hardware/hard_drive/portable/super)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/portabledrive/standard
+	cost = CARGO_CRATE_VALUE * 0.2
+	unit_name = "data disk"
+	export_types = list(/obj/item/computer_hardware/hard_drive/portable)
+	include_subtypes = TRUE
+
+//Miscellaneous Parts
+
 /datum/export/modular_part/idcard
-	cost = CARGO_CRATE_VALUE * 0.1
+	cost = CARGO_CRATE_VALUE * 0.2
 	unit_name = "computer ID card slot"
 	export_types = list(/obj/item/computer_hardware/card_slot)
 	include_subtypes = TRUE
@@ -141,7 +180,24 @@
 	export_types = list(/obj/item/computer_hardware/ai_slot)
 	include_subtypes = TRUE
 
-//Miscellaneous Parts
+/datum/export/modular_part/miniprinter
+	cost = CARGO_CRATE_VALUE * 0.2
+	unit_name = "miniprinter"
+	export_types = list(/obj/item/computer_hardware/printer/mini)
+	include_subtypes = TRUE
+
+/datum/export/modular_part/sensorpackage
+	cost = CARGO_CRATE_VALUE * 0.2
+	unit_name = "sensor package"
+	export_types = list(/obj/item/computer_hardware/sensorpackage)
+	include_subtypes = TRUE
+
+/datum/export/modular_part/integratedsignaler
+	cost = CARGO_CRATE_VALUE * 0.2
+	unit_name = "integrated computer signaler"
+	export_types = list(/obj/item/computer_hardware/radio_card)
+	include_subtypes = TRUE
+
 /datum/export/modular_part/misc
 	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "miscellaneous computer part"

--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -17,13 +17,6 @@
 
 // Computer and Tablet Parts
 //Processors.
-
-/datum/export/modular_part/processor
-	cost = CARGO_CRATE_VALUE * 0.2
-	unit_name = "processor board"
-	export_types = list(/obj/item/computer_hardware/processor_unit)
-	include_subtypes = FALSE
-
 /datum/export/modular_part/processor/small
 	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "microprocessor"
@@ -42,14 +35,13 @@
 	export_types = list(/obj/item/computer_hardware/processor_unit/photonic/small)
 	include_subtypes = FALSE
 
+/datum/export/modular_part/processor/standard
+	cost = CARGO_CRATE_VALUE * 0.2
+	unit_name = "processor board"
+	export_types = list(/obj/item/computer_hardware/processor_unit)
+	include_subtypes = TRUE
+
 //Batteries.
-
-/datum/export/modular_part/battery
-	cost = CARGO_CRATE_VALUE * 0.75
-	unit_name = "computer battery"
-	export_types = list(/obj/item/stock_parts/cell/computer)
-	include_subtypes = FALSE
-
 /datum/export/modular_part/battery/advanced
 	cost = CARGO_CRATE_VALUE * 1.5
 	unit_name = "advanced computer battery"
@@ -74,14 +66,13 @@
 	export_types = list(/obj/item/stock_parts/cell/computer/nano)
 	include_subtypes = FALSE
 
+/datum/export/modular_part/battery/standard
+	cost = CARGO_CRATE_VALUE * 0.75
+	unit_name = "computer battery"
+	export_types = list(/obj/item/stock_parts/cell/computer)
+	include_subtypes = TRUE
+
 //Hard Drives.
-
-/datum/export/modular_part/harddrive
-	cost = CARGO_CRATE_VALUE * 0.4
-	unit_name = "hard disk drive"
-	export_types = list(/obj/item/computer_hardware/hard_drive)
-	include_subtypes = FALSE
-
 /datum/export/modular_part/harddrive/advanced
 	cost = CARGO_CRATE_VALUE * 0.6
 	unit_name = "advanced hard disk drive"
@@ -112,14 +103,32 @@
 	export_types = list(/obj/item/computer_hardware/hard_drive/micro)
 	include_subtypes = FALSE
 
+/datum/export/modular_part/harddrive/standard
+	cost = CARGO_CRATE_VALUE * 0.4
+	unit_name = "hard disk drive"
+	export_types = list(/obj/item/computer_hardware/hard_drive)
+	include_subtypes = TRUE
 
-//Networking/Card Parts
-/datum/export/modular_part/networkcard
+//Networking Parts
+/datum/export/modular_part/networkcard/advanced
+	cost = CARGO_CRATE_VALUE * 0.5
+	unit_name = "advanced network card"
+	export_types = list(/obj/item/computer_hardware/network_card/advanced)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/networkcard/wired
+	cost = CARGO_CRATE_VALUE
+	unit_name = "wired network card"
+	export_types = list(/obj/item/computer_hardware/network_card/wired)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/networkcard/standard
 	cost = CARGO_CRATE_VALUE * 0.25
-	unit_name = "computer network card"
+	unit_name = "network card"
 	export_types = list(/obj/item/computer_hardware/network_card)
 	include_subtypes = TRUE
 
+//Card Parts
 /datum/export/modular_part/idcard
 	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "computer ID card slot"
@@ -134,7 +143,7 @@
 
 //Miscellaneous Parts
 /datum/export/modular_part/misc
-	cost = CARGO_CRATE_VALUE * 0.075
+	cost = CARGO_CRATE_VALUE * 0.1
 	unit_name = "miscellaneous computer part"
 	export_types = list(/obj/item/computer_hardware)
 	include_subtypes = TRUE

--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -88,6 +88,26 @@
 	export_types = list(/obj/item/computer_hardware/battery)
 	include_subtypes = TRUE
 
+//Data Disks
+
+/datum/export/modular_part/portabledrive/advanced
+	cost = CARGO_CRATE_VALUE * 0.4
+	unit_name = "advanced data disk"
+	export_types = list(/obj/item/computer_hardware/hard_drive/portable/advanced)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/portabledrive/super
+	cost = CARGO_CRATE_VALUE * 0.6
+	unit_name = "super data disk"
+	export_types = list(/obj/item/computer_hardware/hard_drive/portable/super)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/portabledrive/standard
+	cost = CARGO_CRATE_VALUE * 0.2
+	unit_name = "data disk"
+	export_types = list(/obj/item/computer_hardware/hard_drive/portable)
+	include_subtypes = TRUE
+
 //Hard Drives
 
 /datum/export/modular_part/harddrive/advanced
@@ -144,26 +164,6 @@
 	cost = CARGO_CRATE_VALUE * 0.25
 	unit_name = "network card"
 	export_types = list(/obj/item/computer_hardware/network_card)
-	include_subtypes = TRUE
-
-//Data Disks
-
-/datum/export/modular_part/portabledrive/advanced
-	cost = CARGO_CRATE_VALUE * 0.4
-	unit_name = "advanced data disk"
-	export_types = list(/obj/item/computer_hardware/hard_drive/portable/advanced)
-	include_subtypes = FALSE
-
-/datum/export/modular_part/portabledrive/super
-	cost = CARGO_CRATE_VALUE * 0.6
-	unit_name = "super data disk"
-	export_types = list(/obj/item/computer_hardware/hard_drive/portable/super)
-	include_subtypes = FALSE
-
-/datum/export/modular_part/portabledrive/standard
-	cost = CARGO_CRATE_VALUE * 0.2
-	unit_name = "data disk"
-	export_types = list(/obj/item/computer_hardware/hard_drive/portable)
 	include_subtypes = TRUE
 
 //Miscellaneous Parts

--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -15,68 +15,103 @@
 	unit_name = "solar panel control board"
 	export_types = list(/obj/item/circuitboard/computer/solar_control)
 
-//Computer Tablets and Parts
-/datum/export/modular_part
-	cost = CARGO_CRATE_VALUE * 0.075
-	unit_name = "miscellaneous computer part"
-	export_types = list(/obj/item/computer_hardware)
-	include_subtypes = TRUE
-
+// Computer and Tablet Parts
 //Processors.
 
 /datum/export/modular_part/processor
 	cost = CARGO_CRATE_VALUE * 0.2
-	unit_name = "computer processor"
+	unit_name = "processor board"
 	export_types = list(/obj/item/computer_hardware/processor_unit)
 	include_subtypes = FALSE
 
-/datum/export/modular_part/processor/photoic
+/datum/export/modular_part/processor/small
+	cost = CARGO_CRATE_VALUE * 0.1
+	unit_name = "microprocessor"
+	export_types = list(/obj/item/computer_hardware/processor_unit/small)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/processor/photonic
 	cost = CARGO_CRATE_VALUE * 0.5
-	unit_name = "advanced computer processor"
-	export_types = list(/obj/item/computer_hardware/processor_unit)
+	unit_name = "photonic processor board"
+	export_types = list(/obj/item/computer_hardware/processor_unit/photonic)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/processor/photonic/small
+	cost = CARGO_CRATE_VALUE * 0.25
+	unit_name = "photonic microprocessor"
+	export_types = list(/obj/item/computer_hardware/processor_unit/photonic/small)
 	include_subtypes = FALSE
 
 //Batteries.
 
 /datum/export/modular_part/battery
-	cost = CARGO_CRATE_VALUE * 0.2
-	unit_name = "computer power cell"
-	export_types = list(/obj/item/stock_parts/cell/computer/nano)
+	cost = CARGO_CRATE_VALUE * 0.75
+	unit_name = "computer battery"
+	export_types = list(/obj/item/stock_parts/cell/computer)
 	include_subtypes = FALSE
 
+/datum/export/modular_part/battery/advanced
+	cost = CARGO_CRATE_VALUE * 1.5
+	unit_name = "advanced computer battery"
+	export_types = list(/obj/item/stock_parts/cell/computer/advanced)
+	include_subtypes = FALSE
 
-/datum/export/modular_part/battery/upgraded
+/datum/export/modular_part/battery/super
+	cost = CARGO_CRATE_VALUE * 2
+	unit_name = "super computer battery"
+	export_types = list(/obj/item/stock_parts/cell/computer/super)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/battery/micro
 	cost = CARGO_CRATE_VALUE * 0.5
-	unit_name = "upgraded computer power cell"
+	unit_name = "micro computer battery"
 	export_types = list(/obj/item/stock_parts/cell/computer/micro)
 	include_subtypes = FALSE
 
-
-/datum/export/modular_part/battery/advanced
-	cost = CARGO_CRATE_VALUE * 0.75
-	unit_name = "advanced computer power cell"
-	export_types = list(/obj/item/stock_parts/cell/computer)
+/datum/export/modular_part/battery/nano
+	cost = CARGO_CRATE_VALUE * 0.3
+	unit_name = "nano computer battery"
+	export_types = list(/obj/item/stock_parts/cell/computer/nano)
 	include_subtypes = FALSE
 
 //Hard Drives.
 
 /datum/export/modular_part/harddrive
-	cost = CARGO_CRATE_VALUE * 0.05
-	unit_name = "tiny computer harddrive"
-	export_types = list(/obj/item/computer_hardware/hard_drive/micro)
-	include_subtypes = TRUE
+	cost = CARGO_CRATE_VALUE * 0.4
+	unit_name = "hard disk drive"
+	export_types = list(/obj/item/computer_hardware/hard_drive)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/harddrive/advanced
+	cost = CARGO_CRATE_VALUE * 0.6
+	unit_name = "advanced hard disk drive"
+	export_types = list(/obj/item/computer_hardware/hard_drive/advanced)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/harddrive/super
+	cost = CARGO_CRATE_VALUE * 0.8
+	unit_name = "super hard disk drive"
+	export_types = list(/obj/item/computer_hardware/hard_drive/super)
+	include_subtypes = FALSE
+
+/datum/export/modular_part/harddrive/cluster
+	cost = CARGO_CRATE_VALUE * 1
+	unit_name = "cluster hard disk drive"
+	export_types = list(/obj/item/computer_hardware/hard_drive/cluster)
+	include_subtypes = FALSE
 
 /datum/export/modular_part/harddrive/small
-	cost = CARGO_CRATE_VALUE * 0.25
-	unit_name = "small computer harddrive"
+	cost = CARGO_CRATE_VALUE * 0.2
+	unit_name = "solid state drive"
 	export_types = list(/obj/item/computer_hardware/hard_drive/small)
 	include_subtypes = FALSE
 
-/datum/export/modular_part/harddrive/normal
-	cost = CARGO_CRATE_VALUE * 0.4
-	unit_name = "computer harddrive"
-	export_types = list(/obj/item/computer_hardware/hard_drive)
+/datum/export/modular_part/harddrive/micro
+	cost = CARGO_CRATE_VALUE * 0.1
+	unit_name = "micro solid state drive"
+	export_types = list(/obj/item/computer_hardware/hard_drive/micro)
 	include_subtypes = FALSE
+
 
 //Networking/Card Parts
 /datum/export/modular_part/networkcard
@@ -95,4 +130,11 @@
 	cost = CARGO_CRATE_VALUE * 0.2
 	unit_name = "computer intellicard slot"
 	export_types = list(/obj/item/computer_hardware/ai_slot)
+	include_subtypes = TRUE
+
+//Miscellaneous Parts
+/datum/export/modular_part/misc
+	cost = CARGO_CRATE_VALUE * 0.075
+	unit_name = "miscellaneous computer part"
+	export_types = list(/obj/item/computer_hardware)
 	include_subtypes = TRUE


### PR DESCRIPTION
## About The Pull Request

This PR fixes exporting computer parts. Previously none of the unique export datums ever got a change to trigger, because of `/datum/export/modular_part` which, due to its `include_subtypes = TRUE` overwrote all of the other computer part exports.

Also it improves the code of the export datums in a way that doesn't make your head hurt whenever you try to look at it, while making their unit names more intuitive, like just look at the old code:
- Why was this nano cell the default one?
![image](https://user-images.githubusercontent.com/50628162/164976561-d2819114-f7e9-4718-8a4c-a73726455581.png)
- Why was this micro one labelled as "upgraded"??
![image](https://user-images.githubusercontent.com/50628162/164976566-6946c153-5be1-4aaa-a093-151e3c9134e3.png)
- Why is this standard cell labelled as the "advanced"???? 
![image](https://user-images.githubusercontent.com/50628162/164976576-bd6ddb8e-e9b2-4441-a835-058cec77a909.png)

## Why It's Good For The Game

Bugfixes are good and now the code is at least slightly more pleasant to look at.

## Changelog

:cl:
fix: fixed export prices of computer parts being overwritten by a "miscellaneous computer part"
fix: fixed missing export datums for various computer parts
code: improved code of computer part exports
/:cl:
