### PR TITLE
tank compressor qol

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -592,6 +592,10 @@
 /obj/machinery/atmospherics/proc/paint(paint_color)
 	return FALSE
 
+/**
+ * Disconnects all nodes from ourselves, remove us from the node's nodes.
+ * Nullify our parent pipenet
+ */
 /obj/machinery/atmospherics/proc/disconnect_nodes()
 	for(var/i in 1 to device_type)
 		var/obj/machinery/atmospherics/node = nodes[i]
@@ -602,6 +606,10 @@
 		if(parents[i])
 			nullify_pipenet(parents[i])
 
+/**
+ * Connects all nodes to ourselves, add us to the node's nodes.
+ * Calls atmos_init() on the node and on us.
+ */
 /obj/machinery/atmospherics/proc/connect_nodes()
 	atmos_init()
 	for(var/i in 1 to device_type)
@@ -612,6 +620,12 @@
 			node.add_member(src)
 	SSair.add_to_rebuild_queue(src)
 
+/**
+ * Easy way to toggle nodes connection and disconnection.
+ *
+ * Arguments:
+ * * disconnect - if TRUE, disconnects all nodes. If FALSE, connects all nodes.
+ */
 /obj/machinery/atmospherics/proc/change_nodes_connection(disconnect)
 	if(disconnect)
 		disconnect_nodes()

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -9,12 +9,8 @@
 	var/showpipe = TRUE
 	///When the component is on a non default layer should we shift everything? Or just the underlay pipe
 	var/shift_underlay_only = TRUE
-	///Stores the component pipeline
-	var/list/datum/pipeline/parents
 	///If this is queued for a rebuild this var signifies whether parents should be updated after it's done
 	var/update_parents_after_rebuild = FALSE
-	///Stores the component gas mixture
-	var/list/datum/gas_mixture/airs
 	///Handles whether the custom reconcilation handling should be used
 	var/custom_reconcilation = FALSE
 
@@ -113,35 +109,6 @@
 		parents[i] = new /datum/pipeline()
 		to_return += parents[i]
 	return to_return
-
-/**
- * Called by nullify_node(), used to remove the pipeline the component is attached to
- * Arguments:
- * * -reference: the pipeline the component is attached to
- */
-/obj/machinery/atmospherics/components/proc/nullify_pipenet(datum/pipeline/reference)
-	if(!reference)
-		CRASH("nullify_pipenet(null) called by [type] on [COORD(src)]")
-
-	for (var/i in 1 to parents.len)
-		if (parents[i] == reference)
-			reference.other_airs -= airs[i] // Disconnects from the pipeline side
-			parents[i] = null // Disconnects from the machinery side.
-
-	reference.other_atmos_machines -= src
-
-	/**
-	 *  We explicitly qdel pipeline when this particular pipeline
-	 *  is projected to have no member and cause GC problems.
-	 *  We have to do this because components don't qdel pipelines
-	 *  while pipes must and will happily wreck and rebuild everything
-	 * again every time they are qdeleted.
-	 */
-
-	if(!length(reference.other_atmos_machines) && !length(reference.members))
-		if(QDESTROYING(reference))
-			CRASH("nullify_pipenet() called on qdeleting [reference]")
-		qdel(reference)
 
 /obj/machinery/atmospherics/components/return_pipenet_airs(datum/pipeline/reference)
 	var/list/returned_air = list()

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -9,14 +9,14 @@
 	var/showpipe = TRUE
 	///When the component is on a non default layer should we shift everything? Or just the underlay pipe
 	var/shift_underlay_only = TRUE
-	///If this is queued for a rebuild this var signifies whether parents should be updated after it's done
-	var/update_parents_after_rebuild = FALSE
-	///Handles whether the custom reconcilation handling should be used
-	var/custom_reconcilation = FALSE
 	///Stores the parent pipeline, used in components
 	var/list/datum/pipeline/parents
+	///If this is queued for a rebuild this var signifies whether parents should be updated after it's done
+	var/update_parents_after_rebuild = FALSE
 	///Stores the gasmix for each node, used in components
 	var/list/datum/gas_mixture/airs
+	///Handles whether the custom reconcilation handling should be used
+	var/custom_reconcilation = FALSE
 
 /obj/machinery/atmospherics/components/New()
 	parents = new(device_type)
@@ -113,6 +113,35 @@
 		parents[i] = new /datum/pipeline()
 		to_return += parents[i]
 	return to_return
+
+/**
+ * Called by nullify_node(), used to remove the pipeline the component is attached to
+ * Arguments:
+ * * -reference: the pipeline the component is attached to
+ */
+/obj/machinery/atmospherics/components/proc/nullify_pipenet(datum/pipeline/reference)
+	if(!reference)
+		CRASH("nullify_pipenet(null) called by [type] on [COORD(src)]")
+
+	for (var/i in 1 to parents.len)
+		if (parents[i] == reference)
+			reference.other_airs -= airs[i] // Disconnects from the pipeline side
+			parents[i] = null // Disconnects from the machinery side.
+
+	reference.other_atmos_machines -= src
+
+	/**
+	 *  We explicitly qdel pipeline when this particular pipeline
+	 *  is projected to have no member and cause GC problems.
+	 *  We have to do this because components don't qdel pipelines
+	 *  while pipes must and will happily wreck and rebuild everything
+	 * again every time they are qdeleted.
+	 */
+
+	if(!length(reference.other_atmos_machines) && !length(reference.members))
+		if(QDESTROYING(reference))
+			CRASH("nullify_pipenet() called on qdeleting [reference]")
+		qdel(reference)
 
 /obj/machinery/atmospherics/components/return_pipenet_airs(datum/pipeline/reference)
 	var/list/returned_air = list()
@@ -215,35 +244,6 @@
 		pipe_color = paint_color
 		update_node_icon()
 	return paintable
-
-/**
- * Called by nullify_node(), used to remove the pipeline the component is attached to
- * Arguments:
- * * -reference: the pipeline the component is attached to
- */
-/obj/machinery/atmospherics/components/proc/nullify_pipenet(datum/pipeline/reference)
-	if(!reference)
-		CRASH("nullify_pipenet(null) called by [type] on [COORD(src)]")
-
-	for (var/i in 1 to parents.len)
-		if (parents[i] == reference)
-			reference.other_airs -= airs[i] // Disconnects from the pipeline side
-			parents[i] = null // Disconnects from the machinery side.
-
-	reference.other_atmos_machines -= src
-
-	/**
-	 *  We explicitly qdel pipeline when this particular pipeline
-	 *  is projected to have no member and cause GC problems.
-	 *  We have to do this because components don't qdel pipelines
-	 *  while pipes must and will happily wreck and rebuild everything
-	 * again every time they are qdeleted.
-	 */
-
-	if(!length(reference.other_atmos_machines) && !length(reference.members))
-		if(QDESTROYING(reference))
-			CRASH("nullify_pipenet() called on qdeleting [reference]")
-		qdel(reference)
 
 /**
  * Disconnects all nodes from ourselves, remove us from the node's nodes.

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -13,6 +13,10 @@
 	var/update_parents_after_rebuild = FALSE
 	///Handles whether the custom reconcilation handling should be used
 	var/custom_reconcilation = FALSE
+	///Stores the parent pipeline, used in components
+	var/list/datum/pipeline/parents
+	///Stores the gasmix for each node, used in components
+	var/list/datum/gas_mixture/airs
 
 /obj/machinery/atmospherics/components/New()
 	parents = new(device_type)
@@ -211,3 +215,72 @@
 		pipe_color = paint_color
 		update_node_icon()
 	return paintable
+
+/**
+ * Called by nullify_node(), used to remove the pipeline the component is attached to
+ * Arguments:
+ * * -reference: the pipeline the component is attached to
+ */
+/obj/machinery/atmospherics/components/proc/nullify_pipenet(datum/pipeline/reference)
+	if(!reference)
+		CRASH("nullify_pipenet(null) called by [type] on [COORD(src)]")
+
+	for (var/i in 1 to parents.len)
+		if (parents[i] == reference)
+			reference.other_airs -= airs[i] // Disconnects from the pipeline side
+			parents[i] = null // Disconnects from the machinery side.
+
+	reference.other_atmos_machines -= src
+
+	/**
+	 *  We explicitly qdel pipeline when this particular pipeline
+	 *  is projected to have no member and cause GC problems.
+	 *  We have to do this because components don't qdel pipelines
+	 *  while pipes must and will happily wreck and rebuild everything
+	 * again every time they are qdeleted.
+	 */
+
+	if(!length(reference.other_atmos_machines) && !length(reference.members))
+		if(QDESTROYING(reference))
+			CRASH("nullify_pipenet() called on qdeleting [reference]")
+		qdel(reference)
+
+/**
+ * Disconnects all nodes from ourselves, remove us from the node's nodes.
+ * Nullify our parent pipenet
+ */
+/obj/machinery/atmospherics/components/proc/disconnect_nodes()
+	for(var/i in 1 to device_type)
+		var/obj/machinery/atmospherics/node = nodes[i]
+		if(node)
+			if(src in node.nodes) //Only if it's actually connected. On-pipe version would is one-sided.
+				node.disconnect(src)
+			nodes[i] = null
+		if(parents[i])
+			nullify_pipenet(parents[i])
+
+/**
+ * Connects all nodes to ourselves, add us to the node's nodes.
+ * Calls atmos_init() on the node and on us.
+ */
+/obj/machinery/atmospherics/components/proc/connect_nodes()
+	atmos_init()
+	for(var/i in 1 to device_type)
+		var/obj/machinery/atmospherics/node = nodes[i]
+		node = nodes[1]
+		if(node)
+			node.atmos_init()
+			node.add_member(src)
+	SSair.add_to_rebuild_queue(src)
+
+/**
+ * Easy way to toggle nodes connection and disconnection.
+ *
+ * Arguments:
+ * * disconnect - if TRUE, disconnects all nodes. If FALSE, connects all nodes.
+ */
+/obj/machinery/atmospherics/components/proc/change_nodes_connection(disconnect)
+	if(disconnect)
+		disconnect_nodes()
+		return
+	connect_nodes()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Change the color of the input port from blue to green to be more in line with the current machine color coding for input and output.
Put in the examine message how to rotate the machine and what each pipe is (input or output) for more clarity
Increased by one atmosphere the max ejection pressure for tanks so that toxins can use the machine for their bombs preparations.
Cleaned up some atmos code for connecting and disconnecting pipes, clear some repeated code
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it easier for new players to know what each pipe does and allows a little more flexibility when compressing gases inside the tank with the small increased window of pressure.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Made the tank compressor input pipe green color to be in line with the current atmos machines color scheme, increased by 100 kPa the window for tank ejection to allow more flexibility when filling up the tank
code: cleaned up some of the code for disconnecting pipes and removed repeated code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
