### PR TITLE
Fix putting plasma cutter blowing you up if you have plasma equipped.

### DIFF
--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -33,8 +33,6 @@
 			RegisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), .proc/explodable_attack)
 			RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 			RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)
-
-
 	if(SEND_SIGNAL(parent, COMSIG_CONTAINS_STORAGE))
 		RegisterSignal(parent, COMSIG_TRY_STORAGE_INSERT, .proc/explodable_insert_item)
 

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -24,7 +24,6 @@
 		return COMPONENT_INCOMPATIBLE
 
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/explodable_attack)
-	RegisterSignal(parent, COMSIG_TRY_STORAGE_INSERT, .proc/explodable_insert_item)
 	RegisterSignal(parent, COMSIG_ATOM_EX_ACT, .proc/detonate)
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), .proc/welder_react)
 	if(ismovable(parent))
@@ -34,6 +33,10 @@
 			RegisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), .proc/explodable_attack)
 			RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 			RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)
+
+
+	if(SEND_SIGNAL(parent, COMSIG_CONTAINS_STORAGE))
+		RegisterSignal(parent, COMSIG_TRY_STORAGE_INSERT, .proc/explodable_insert_item)
 
 	if (devastation_range)
 		src.devastation_range = devastation_range
@@ -48,6 +51,7 @@
 	src.uncapped = uncapped
 	src.delete_after = delete_after
 
+/// Explode if our parent is a storage place and something with high heat is inserted in.
 /datum/component/explodable/proc/explodable_insert_item(datum/source, obj/item/I, mob/M, silent = FALSE, force = FALSE)
 	SIGNAL_HANDLER
 


### PR DESCRIPTION
## About The Pull Request
Fixes #65548

Content expansion and tweak removal hits hard man

Basically https://github.com/tgstation/tgstation/blob/a3343c5a3ece5fd3156b9a6e5bc7d17780fb2e0c/code/modules/mob/inventory.dm#L416-L421 loops through possible places when you try to put an item in. If you happen to be holding a plascutter which is hot, its gonna try to insert it into the plasma stack and blow you up.

## Why It's Good For The Game
As funny as griefing miners is, I want GBP.

## Changelog
:cl:
fix: trying to store a plasma cutter while holding plasma should no longer blow you up.
/:cl: