### PR TITLE
wizards no longer want to use electronic weaponry

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -213,6 +213,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	/// Used in obj/item/examine to determines whether or not to detail an item's statistics even if it does not meet the force requirements
 	var/override_notes = FALSE
 
+	var/blacklisted_wizard = FALSE
+
 /obj/item/Initialize(mapload)
 
 	if(attack_verb_continuous)
@@ -485,6 +487,16 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 			return
 
 	if(!(interaction_flags_item & INTERACT_ITEM_ATTACK_HAND_PICKUP)) //See if we're supposed to auto pickup.
+		return
+
+	if(blacklisted_wizard && IS_WIZARD(user))
+		var/list/disgust_message = list(
+			"You refuse to touch such revolting item!",
+			"The idea of touching electronic devices nauseate you!"
+			"[src] is too repugnant to touch!"
+			"You will never touch this loathsome item!"
+			)
+		to_chat(user, span_warning(pick(disgust_message)))
 		return
 
 	//Heavy gravity makes picking up things very slow.

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -399,6 +399,8 @@
 
 	context_living_rmb_active = "Harmful Stun"
 
+	blacklisted_wizard = TRUE
+
 	var/throw_stun_chance = 35
 	var/obj/item/stock_parts/cell/cell
 	var/preload_cell_type //if not empty the baton starts with this type of cell

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -12,6 +12,7 @@
 	bare_wound_bonus = 20
 	stealthy_audio = TRUE
 	w_class = WEIGHT_CLASS_SMALL
+	blacklisted_wizard = TRUE
 
 	/// The color of this energy based sword, for use in editing the icon_state.
 	var/sword_color_icon

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -22,6 +22,7 @@
 	light_color = COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
 	light_on = FALSE
+	blacklisted_wizard = TRUE
 	/// Whether we currently have the flashing overlay.
 	var/flashing = FALSE
 	/// The overlay we use for flashing.

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -3,6 +3,7 @@
 	name = "energy gun"
 	desc = "A basic energy-based gun."
 	icon = 'icons/obj/guns/energy.dmi'
+	blacklisted_wizard = TRUE
 
 	/// What type of power cell this uses
 	var/obj/item/stock_parts/cell/cell


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Wizards actively refuses to pickup electronic weaponry.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Wizards should be encouraged to interact more with their spells and get creative with them and the environment they are getting into. Having a wizard looting the armory with jaunt and hiding into maint with rechargers for weapons instead of using spells should not be allowed by design. Hopefully this will get more wizards with cool items like Mjolnir or wand setups.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: wizards are no longer able to use electronic weaponry (flash, stun baton, electronic guns and melee)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
