### PR TITLE
fixes ethereal feeding breaking APC charging

### DIFF
--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -213,7 +213,7 @@
 				return
 			to_chat(ethereal, span_notice("You receive some charge from the APC."))
 			stomach.adjust_charge(APC_POWER_GAIN)
-			cell.charge -= APC_POWER_GAIN
+			cell.use(APC_POWER_GAIN)
 		return
 
 	if(cell.charge >= cell.maxcharge - APC_POWER_GAIN)
@@ -232,7 +232,7 @@
 	if(istype(stomach))
 		to_chat(ethereal, span_notice("You transfer some power to the APC."))
 		stomach.adjust_charge(-APC_POWER_GAIN)
-		cell.charge += APC_POWER_GAIN
+		cell.give(APC_POWER_GAIN)
 	else
 		to_chat(ethereal, span_warning("You can't transfer power to the APC!"))
 


### PR DESCRIPTION


## About The Pull Request

This PR actually makes ethereal charging use the proper methods to talk to APCs and cells instead of a hamfisted janky way.

## Why It's Good For The Game

ethereals will eventually need be unable to charge from any APCs in their area as of current. This prevents that.

## Changelog

:cl:
fix: fixed ethereal feeding breaking APC charging
/:cl:
