### PR TITLE
updateDialog and updateUsrDialog cleanup

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -193,7 +193,7 @@
 			inserted_scan_id = null
 	. = TRUE
 
-///Self explanitory, holds the ID card inthe console for bounty payout and manipulation.
+///Self explanitory, holds the ID card in the console for bounty payout and manipulation.
 /obj/machinery/computer/piratepad_control/civilian/proc/id_insert(mob/user, obj/item/inserting_item, obj/item/target)
 	var/obj/item/card/id/card_to_insert = inserting_item
 	var/holder_item = FALSE
@@ -214,7 +214,7 @@
 	user.visible_message(span_notice("[user] inserts \the [card_to_insert] into \the [src]."),
 						span_notice("You insert \the [card_to_insert] into \the [src]."))
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
-	updateUsrDialog()
+	ui_interact(user)
 	return TRUE
 
 ///Removes A stored ID card.
@@ -230,7 +230,6 @@
 							span_notice("You get \the [target] from \the [src]."))
 		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
 		inserted_scan_id = null
-		updateUsrDialog()
 		return TRUE
 
 ///Upon completion of a civilian bounty, one of these is created. It is sold to cargo to give the cargo budget bounty money, and the person who completed it cash.

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -389,15 +389,12 @@
 		if(secondsMainPowerLost>0)
 			if(!wires.is_cut(WIRE_POWER1) && !wires.is_cut(WIRE_POWER2))
 				secondsMainPowerLost -= 1
-				updateDialog()
 			cont = TRUE
 		if(secondsBackupPowerLost>0)
 			if(!wires.is_cut(WIRE_BACKUP1) && !wires.is_cut(WIRE_BACKUP2))
 				secondsBackupPowerLost -= 1
-				updateDialog()
 			cont = TRUE
 	spawnPowerRestoreRunning = FALSE
-	updateDialog()
 	update_appearance()
 
 /obj/machinery/door/airlock/proc/loseMainPower()
@@ -761,31 +758,11 @@
 			return
 
 		secondsElectrified--
-		updateDialog()
 	// This is to protect against changing to permanent, mid loop.
 	if(secondsElectrified == MACHINE_NOT_ELECTRIFIED)
 		set_electrified(MACHINE_NOT_ELECTRIFIED)
 	else
 		set_electrified(MACHINE_ELECTRIFIED_PERMANENT)
-	updateDialog()
-
-/obj/machinery/door/airlock/Topic(href, href_list, nowindow = 0)
-	// If you add an if(..()) check you must first remove the var/nowindow parameter.
-	// Otherwise it will runtime with this kind of error: null.Topic()
-	if(!nowindow)
-		..()
-	if(!usr.canUseTopic(src) && !isAdminGhostAI(usr))
-		return
-	add_fingerprint(usr)
-
-	if((in_range(src, usr) && isturf(loc)) && panel_open)
-		usr.set_machine(src)
-
-	add_fingerprint(usr)
-	if(!nowindow)
-		updateUsrDialog()
-	else
-		updateDialog()
 
 /obj/machinery/door/airlock/screwdriver_act(mob/living/user, obj/item/tool)
 	if(panel_open && detonated)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -52,9 +52,6 @@ The console is located at computer/gulag_teleporter.dm
 		return
 	toggle_open()
 
-/obj/machinery/gulag_teleporter/updateUsrDialog()
-	return
-
 /obj/machinery/gulag_teleporter/attackby(obj/item/I, mob/user)
 	if(!occupant && default_deconstruction_screwdriver(user, "[icon_state]", "[icon_state]",I))
 		update_appearance()

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -222,7 +222,6 @@
 		log_msg += "nothing"
 	log_msg += " [sending ? "to" : "from"] [target_x], [target_y], [z] ([A ? A.name : "null area"])"
 	log_game(log_msg.Join())
-	updateDialog()
 
 //Starts in the briefcase. Don't spawn this directly, or it will runtime when closing.
 /obj/machinery/launchpad/briefcase

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -361,6 +361,7 @@
 			return
 		replace_beaker(user, container)
 		to_chat(user, span_notice("You add [container] to [src]'s water bath."))
+		ui_interact(user)
 		return
 	//Dropper tools
 	if(beaker)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -361,7 +361,6 @@
 			return
 		replace_beaker(user, container)
 		to_chat(user, span_notice("You add [container] to [src]'s water bath."))
-		updateUsrDialog()
 		return
 	//Dropper tools
 	if(beaker)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -331,7 +331,6 @@
 		holder.delayedlittle = FALSE
 		holder.explode_now = FALSE
 		holder.update_appearance()
-		holder.updateDialog()
 		STOP_PROCESSING(SSfastprocess, holder)
 
 /obj/item/bombcore/training/detonate()

--- a/code/game/objects/items/devices/portable_chem_mixer.dm
+++ b/code/game/objects/items/devices/portable_chem_mixer.dm
@@ -48,7 +48,7 @@
 			return
 		replace_beaker(user, B)
 		update_appearance()
-		updateUsrDialog()
+		ui_interact(user)
 		return
 	return ..()
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -810,7 +810,8 @@
 		if(src.allowed(usr) && !wires.is_cut(WIRE_IDSCAN))
 			locked = !locked
 			to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the air alarm interface."))
-			ui_interact(user)
+			if(!locked)
+				ui_interact(user)
 		else
 			to_chat(user, span_danger("Access denied."))
 	return

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -810,7 +810,7 @@
 		if(src.allowed(usr) && !wires.is_cut(WIRE_IDSCAN))
 			locked = !locked
 			to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the air alarm interface."))
-			updateUsrDialog()
+			ui_interact(user)
 		else
 			to_chat(user, span_danger("Access denied."))
 	return

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -184,7 +184,6 @@
 	..()
 	if(A == beaker)
 		beaker = null
-		updateUsrDialog()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/on_deconstruction()
 	if(beaker)

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -136,7 +136,6 @@
 	else if (istype(O, /obj/item/seeds))
 		if(add_seed(O))
 			to_chat(user, span_notice("You add [O] to [src.name]."))
-			updateUsrDialog()
 		return
 	else if(!user.combat_mode)
 		to_chat(user, span_warning("You can't extract any seeds from \the [O.name]!"))

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -167,7 +167,6 @@
 
 /obj/machinery/mineral/ore_redemption/attackby(obj/item/W, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "ore_redemption-open", "ore_redemption", W))
-		updateUsrDialog()
 		return
 	if(default_deconstruction_crowbar(W))
 		return

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -59,7 +59,6 @@
 		icon_state = "[initial(icon_state)]-open"
 		sleep(5)
 		icon_state = initial(icon_state)
-		updateUsrDialog()
 	else if(!user.combat_mode)
 		to_chat(user, span_warning("You can't put [P] in [src]!"))
 	else
@@ -99,7 +98,6 @@
 			var/obj/item/content = locate(params["ref"]) in src
 			if(istype(content) && in_range(src, usr))
 				usr.put_in_hands(content)
-				updateUsrDialog()
 				icon_state = "[initial(icon_state)]-open"
 				addtimer(VARSET_CALLBACK(src, icon_state, initial(icon_state)), 5)
 
@@ -121,21 +119,6 @@
 			to_chat(user, span_notice("You pull \a [I] out of [src] at random."))
 			return
 	to_chat(user, span_notice("You find nothing in [src]."))
-
-
-/obj/structure/filingcabinet/Topic(href, href_list)
-	if(!usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(usr)))
-		return
-	if(href_list["retrieve"])
-		usr << browse("", "window=filingcabinet") // Close the menu
-
-		var/obj/item/P = locate(href_list["retrieve"]) in src //contents[retrieveindex]
-		if(istype(P) && in_range(src, usr))
-			usr.put_in_hands(P)
-			updateUsrDialog()
-			icon_state = "[initial(icon_state)]-open"
-			addtimer(VARSET_CALLBACK(src, icon_state, initial(icon_state)), 5)
-
 
 /*
  * Security Record Cabinets

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -30,7 +30,6 @@
 /obj/structure/filingcabinet/filingcabinet //not changing the path to avoid unnecessary map issues, but please don't name stuff like this in the future -Pete
 	icon_state = "tallcabinet"
 
-
 /obj/structure/filingcabinet/Initialize(mapload)
 	. = ..()
 	if(mapload)
@@ -86,7 +85,6 @@
 
 	return data
 
-
 /obj/structure/filingcabinet/ui_act(action, params)
 	. = ..()
 	if(.)
@@ -100,13 +98,12 @@
 				usr.put_in_hands(content)
 				icon_state = "[initial(icon_state)]-open"
 				addtimer(VARSET_CALLBACK(src, icon_state, initial(icon_state)), 5)
-
+				return TRUE
 
 /obj/structure/filingcabinet/attack_tk(mob/user)
 	if(anchored)
 		return attack_self_tk(user)
 	return ..()
-
 
 /obj/structure/filingcabinet/attack_self_tk(mob/user)
 	. = COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -209,7 +209,6 @@
 	if(atom_to_check == cell)
 		cell = null
 		update_appearance()
-		updateUsrDialog()
 
 /obj/machinery/power/apc/examine(mob/user)
 	. = ..()

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -217,6 +217,6 @@
 			locked = !locked
 			to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the APC interface."))
 			update_appearance()
-			updateUsrDialog()
+			ui_interact(user)
 		else
 			to_chat(user, span_warning("Access denied."))

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -217,6 +217,7 @@
 			locked = !locked
 			to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the APC interface."))
 			update_appearance()
-			ui_interact(user)
+			if(!locked)
+				ui_interact(user)
 		else
 			to_chat(user, span_warning("Access denied."))

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -333,7 +333,6 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 /obj/machinery/gravity_generator/main/proc/complete_state_update()
 	update_appearance()
 	update_list()
-	updateUsrDialog()
 
 // Set the state of the gravity.
 /obj/machinery/gravity_generator/main/proc/set_state(new_state)
@@ -369,8 +368,6 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 
 			if(charge_count % 4 == 0 && prob(75)) // Let them know it is charging/discharging.
 				playsound(src.loc, 'sound/effects/empulse.ogg', 100, TRUE)
-
-			updateDialog()
 
 			var/overlay_state = null
 			switch(charge_count)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -371,7 +371,7 @@
 			return
 		replace_beaker(user, B)
 		to_chat(user, span_notice("You add [B] to [src]."))
-		updateUsrDialog()
+		ui_interact(user)
 	else if(!user.combat_mode && !istype(I, /obj/item/card/emag))
 		to_chat(user, span_warning("You can't load [I] into [src]!"))
 		return ..()

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -170,7 +170,7 @@
 			return
 		replace_beaker(user, B)
 		to_chat(user, span_notice("You add [B] to [src]."))
-		updateUsrDialog()
+		ui_interact(user)
 		update_appearance()
 		return
 

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -89,7 +89,7 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 		replace_beaker(user, BEAKER1, beaker)
 		to_chat(user, span_notice("You add [beaker] to [src]."))
 		update_appearance()
-		updateUsrDialog()
+		ui_interact(user)
 		return
 	..()
 
@@ -109,7 +109,7 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 			return
 		replace_beaker(user, BEAKER2, beaker)
 		to_chat(user, span_notice("You add [beaker] to [src]."))
-		updateUsrDialog()
+		ui_interact(user)
 		. = SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	update_appearance()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -146,7 +146,7 @@
 			return
 		replace_beaker(user, B)
 		to_chat(user, span_notice("You add [B] to [src]."))
-		updateUsrDialog()
+		ui_interact(user)
 		update_appearance()
 	else if(!condi && istype(I, /obj/item/storage/pill_bottle))
 		if(bottle)
@@ -156,7 +156,7 @@
 			return
 		bottle = I
 		to_chat(user, span_notice("You add [I] into the dispenser slot."))
-		updateUsrDialog()
+		ui_interact(user)
 	else
 		return ..()
 

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -416,8 +416,6 @@
 				do_flush()
 		flush_count = 0
 
-	updateDialog()
-
 	if(flush && air_contents.return_pressure() >= SEND_PRESSURE) // flush can happen even without power
 		do_flush()
 

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -115,11 +115,8 @@
 		if(wipe_custom_designs)
 			custom_designs = list()
 	for(var/id in processing)
-		update_node_status(SSresearch.techweb_node_by_id(id), FALSE)
+		update_node_status(SSresearch.techweb_node_by_id(id))
 		CHECK_TICK
-	for(var/v in consoles_accessing)
-		var/obj/machinery/computer/rdconsole/V = v
-		V.updateUsrDialog()
 
 /datum/techweb/proc/add_point_list(list/pointlist)
 	for(var/i in pointlist)
@@ -386,7 +383,7 @@
 					next += SSresearch.techweb_node_by_id(id)
 		current = next
 
-/datum/techweb/proc/update_node_status(datum/techweb_node/node, autoupdate_consoles = TRUE)
+/datum/techweb/proc/update_node_status(datum/techweb_node/node)
 	var/researched = FALSE
 	var/available = FALSE
 	var/visible = FALSE
@@ -415,10 +412,6 @@
 			if(visible)
 				visible_nodes[node.id] = TRUE
 	update_tiers(node)
-	if(autoupdate_consoles)
-		for(var/v in consoles_accessing)
-			var/obj/machinery/computer/rdconsole/V = v
-			V.updateUsrDialog()
 
 //Laggy procs to do specific checks, just in case. Don't use them if you can just use the vars that already store all this!
 /datum/techweb/proc/designHasReqs(datum/design/D)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -446,7 +446,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(anchored)
 		default_deconstruction_screwdriver(user, icon_state, icon_state, I)
 		update_appearance()
-		updateUsrDialog()
 	else
 		to_chat(user, span_warning("You must first secure [src]."))
 	return TRUE
@@ -477,7 +476,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(compartmentLoadAccessCheck(user) && !user.combat_mode)
 		if(canLoadItem(I))
 			loadingAttempt(I,user)
-			updateUsrDialog() //can't put this on the proc above because we spam it below
 
 		if(istype(I, /obj/item/storage/bag)) //trays USUALLY
 			var/obj/item/storage/T = I
@@ -496,7 +494,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 				to_chat(user, span_warning("[src] refuses some items!"))
 			if(loaded)
 				to_chat(user, span_notice("You insert [loaded] dishes into [src]'s compartment."))
-				updateUsrDialog()
 	else
 		. = ..()
 		if(tiltable && !tilted && I.force)
@@ -1207,7 +1204,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 			if(isliving(usr))
 				vend_act(usr, params["item"])
 			vend_ready = TRUE
-			updateUsrDialog()
 			return TRUE
 
 /obj/machinery/vending/custom/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR focuses on cleaning up two procs - updateDialog and updateUsrDialog. Both of which are/were used updating for old HTML UIs. As these UIs got converted to TGUI over time, these old code fragments started to pile up, often due to coders simply overlooking them. This resulted in them being dead code doing nothing when called, or randomly opening up windows when they shouldnt, for example when a vending machine is screwdrivered and UI cannot even be interacted with.

However, there were also some desirable uses - like opening a window when an ID is inserted into civilian bounty console, which you are then gonna obviously use to pick a bounty. I kept these uses and replaced them with proper ui_interact, so they now always work, instead of them working only when you had them set as a currently used machine on mob. The list of these changes is:

- Civilian Bounty Console will now always bring up its UI when you insert the ID.
- Air Alarm and APC will now always bring up its UI when you unlock their controls.
- Portable Chem Mixer, Chem Dispenser, Chem Heater, Improvised Chem Heater, Chem Spectometer and Chem Master will now always bring up their UI when you add or replace beaker to them.

Two old /Topic calls were cleaned up as well, as they were no longer relevant.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Removes dead or outdated code, adds sensible UX when working with certain UIs.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Arkatos
qol: Civilian Bounty Console will now always bring up its UI when you insert the ID.
qol: Air Alarm and APC will now always bring up its UI when you unlock their controls.
qol: Portable Chem Mixer, Chem Dispenser, Chem Heater, Improvised Chem Heater, Chem Spectometer and Chem Master will now always bring up their UI when you add or replace beaker to them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
