### PR TITLE
fixes unintended merge behavior

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -449,7 +449,7 @@
 		return FALSE
 	if(is_cyborg) // No merging cyborg stacks into other stacks
 		return FALSE
-	if(ismob(loc) && !inhand) // no merging with items that arent on the ground or in the backpack (aka, item slots)
+	if(ismob(loc) && !inhand) // no merging with items that are on the mob
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -441,12 +441,14 @@
  * Arguments:
  * - [check][/obj/item/stack]: The stack to check for mergeability.
  */
-/obj/item/stack/proc/can_merge(obj/item/stack/check)
+/obj/item/stack/proc/can_merge(obj/item/stack/check, inhand = FALSE)
 	if(!istype(check, merge_type))
 		return FALSE
 	if(mats_per_unit ~! check.mats_per_unit) // ~! in case of lists this operator checks only keys, but not values
 		return FALSE
 	if(is_cyborg) // No merging cyborg stacks into other stacks
+		return FALSE
+	if(!(istype(check.loc, /obj/item/storage) || isturf(check.loc)) && !inhand) // no merging with items that arent on the ground or in the backpack (aka, item slots)
 		return FALSE
 	return TRUE
 
@@ -505,7 +507,7 @@
 		INVOKE_ASYNC(src, .proc/merge, arrived)
 
 /obj/item/stack/hitby(atom/movable/hitting, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	if(can_merge(hitting))
+	if(can_merge(hitting, TRUE))
 		merge(hitting)
 	. = ..()
 
@@ -556,7 +558,7 @@
 	is_zero_amount(delete_if_zero = TRUE)
 
 /obj/item/stack/attackby(obj/item/W, mob/user, params)
-	if(can_merge(W))
+	if(can_merge(W, TRUE))
 		var/obj/item/stack/S = W
 		if(merge(S))
 			to_chat(user, span_notice("Your [S.name] stack now contains [S.get_amount()] [S.singular_name]\s."))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -440,6 +440,7 @@
  *
  * Arguments:
  * - [check][/obj/item/stack]: The stack to check for mergeability.
+ * - [inhand][boolean]: Whether or not the stack to check should act like it's in a mob's hand.
  */
 /obj/item/stack/proc/can_merge(obj/item/stack/check, inhand = FALSE)
 	if(!istype(check, merge_type))
@@ -448,7 +449,7 @@
 		return FALSE
 	if(is_cyborg) // No merging cyborg stacks into other stacks
 		return FALSE
-	if(!(istype(check.loc, /obj/item/storage) || isturf(check.loc)) && !inhand) // no merging with items that arent on the ground or in the backpack (aka, item slots)
+	if(ismob(loc) && !inhand) // no merging with items that arent on the ground or in the backpack (aka, item slots)
 		return FALSE
 	return TRUE
 
@@ -507,7 +508,7 @@
 		INVOKE_ASYNC(src, .proc/merge, arrived)
 
 /obj/item/stack/hitby(atom/movable/hitting, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	if(can_merge(hitting, TRUE))
+	if(can_merge(hitting, inhand = TRUE))
 		merge(hitting)
 	. = ..()
 
@@ -558,7 +559,7 @@
 	is_zero_amount(delete_if_zero = TRUE)
 
 /obj/item/stack/attackby(obj/item/W, mob/user, params)
-	if(can_merge(W, TRUE))
+	if(can_merge(W, inhand = TRUE))
 		var/obj/item/stack/S = W
 		if(merge(S))
 			to_chat(user, span_notice("Your [S.name] stack now contains [S.get_amount()] [S.singular_name]\s."))

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -178,7 +178,8 @@
 	mask = /obj/item/clothing/mask/cigarette/cigar/havana
 	l_pocket = /obj/item/lighter
 
-/datum/outfit/mr_runtime
+/// Used primarily by the outfit_sanity unit test, in-hand merging used to cause runtimes 3% of the time. See #66313 and #60901
+/datum/outfit/stacks_in_hands
 	name = "Mr. Runtime"
 
 	uniform = /obj/item/clothing/under/suit/tuxedo

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -178,6 +178,16 @@
 	mask = /obj/item/clothing/mask/cigarette/cigar/havana
 	l_pocket = /obj/item/lighter
 
+/datum/outfit/mr_runtime
+	name = "Mr. Runtime"
+
+	uniform = /obj/item/clothing/under/suit/tuxedo
+	glasses = /obj/item/clothing/glasses/sunglasses
+	mask = /obj/item/clothing/mask/cigarette/cigar/havana
+	shoes = /obj/item/clothing/shoes/laceup
+	l_hand = /obj/item/stack/spacecash/c1000
+	r_hand = /obj/item/stack/spacecash/c1000
+
 /datum/outfit/tunnel_clown
 	name = "Tunnel Clown"
 

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -178,17 +178,6 @@
 	mask = /obj/item/clothing/mask/cigarette/cigar/havana
 	l_pocket = /obj/item/lighter
 
-/// Used primarily by the outfit_sanity unit test, in-hand merging used to cause runtimes 3% of the time. See #66313 and #60901
-/datum/outfit/stacks_in_hands
-	name = "Mr. Runtime"
-
-	uniform = /obj/item/clothing/under/suit/tuxedo
-	glasses = /obj/item/clothing/glasses/sunglasses
-	mask = /obj/item/clothing/mask/cigarette/cigar/havana
-	shoes = /obj/item/clothing/shoes/laceup
-	l_hand = /obj/item/stack/spacecash/c1000
-	r_hand = /obj/item/stack/spacecash/c1000
-
 /datum/outfit/tunnel_clown
 	name = "Tunnel Clown"
 

--- a/code/modules/unit_tests/outfit_sanity.dm
+++ b/code/modules/unit_tests/outfit_sanity.dm
@@ -8,6 +8,17 @@
 	outfit_item.on_outfit_equip(H, FALSE, ##slot_name); \
 }
 
+/// See #66313 and #60901. outfit_sanity used to runtime whenever you had two mergable sheets in either hand. Previously, this only had a 3% chance of occuring. Now 100%.
+/datum/outfit/stacks_in_hands
+	name = "Mr. Runtime"
+
+	uniform = /obj/item/clothing/under/suit/tuxedo
+	glasses = /obj/item/clothing/glasses/sunglasses
+	mask = /obj/item/clothing/mask/cigarette/cigar/havana
+	shoes = /obj/item/clothing/shoes/laceup
+	l_hand = /obj/item/stack/spacecash/c1000
+	r_hand = /obj/item/stack/spacecash/c1000
+
 /datum/unit_test/outfit_sanity/Run()
 	var/mob/living/carbon/human/H = allocate(/mob/living/carbon/human)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

stacks will no longer merge unless `loc` is a turf, storage container, or the stack itself is being hit or collided with by another stack of a valid `merge_type`

adds `/datum/outfit/mr_runtime` too, for `outfit_sanity` unit tests

fixes #66455
fixes #60901

## Why It's Good For The Game

mr runtime
![image](https://user-images.githubusercontent.com/88991542/165004344-394ea5b5-5090-4a00-a103-68bd5cd174fb.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nanotrasen has declared a recall on all item stacks, due to the fact the fact they kept merging in hands and pockets. All stacks will now instead only merge in your storage containers, or on the floor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
