### PR TITLE
overflow job priority adjustment

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -441,10 +441,13 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/character_preview_view)
 	if (!job)
 		return FALSE
 
-	if (level == JP_HIGH)
-		var/datum/job/overflow_role = SSjob.overflow_role
-		var/overflow_role_title = initial(overflow_role.title)
+	var/datum/job/overflow_role = SSjob.overflow_role
+	var/overflow_role_title = initial(overflow_role.title)
 
+	if(!istype(job, overflow_role))
+		job_preferences[overflow_role_title] = null
+
+	if (level == JP_HIGH)
 		for(var/other_job in job_preferences)
 			if(job_preferences[other_job] == JP_HIGH)
 				// Overflow role needs to go to NEVER, not medium!
@@ -452,6 +455,8 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/character_preview_view)
 					job_preferences[other_job] = null
 				else
 					job_preferences[other_job] = JP_MEDIUM
+			if(istype(job, overflow_role))
+				job_preferences[other_job] = null // assistant auto takes over all other jobs so dont even try
 
 	job_preferences[job.title] = level
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the overflow job preference will now automatically be set to `null` if any other job priority is selected, and all other job priorities will be set to `null` if the overflow job priority is set to on

## Why It's Good For The Game

i keep forgetting to fucking disable assistant when i roll other jobs and it hurts so bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: setting your overflow job priority to on will now disable all other job priorities, and vice versa
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
