### PR TITLE
Adds materials to tablets

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -16,6 +16,7 @@
 	has_light = TRUE //LED flashlight!
 	comp_light_luminosity = 2.3 //Same as the PDA
 	looping_sound = FALSE
+	custom_materials = list(/datum/material/iron=300, /datum/material/glass=100, /datum/material/plastic=100)
 
 	var/has_variants = TRUE
 	var/finish_color = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Materials got removed from the PDA that all crew members spawned with when we switched over to tablets.
This readds that as that was originally done in https://github.com/tgstation/tgstation/pull/57923

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/51932756/165018542-7b122855-c117-4315-adf6-27a6f464de0f.png)
Allowing players to interact through obscure mechanics to bait each other to blow up a microwave in an attempt to charge their tablet is fucking hilarious.

## Changelog

:cl:
add: Hey did you know you can charge your tablet by microwaving it?
/:cl: