### PR TITLE
Increase the amount of health HUDs, nitrile gloves and medical belts in Tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -61113,6 +61113,11 @@
 /area/security/checkpoint)
 "uFX" = (
 /obj/structure/closet/secure_closet/medical3,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/storage/belt/medical,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "uGI" = (


### PR DESCRIPTION
## About The Pull Request

Triples the amount of HUDs, nitrile gloves and doubles the amount of medical belts in both lockers in Tramstation medbay. (3 Health HUDs, 3 pair of nitrile gloves and 2 medical belts for each lockers, for a total of 6 HUDs, 6 pair of gloves and 4 belts)

## Why It's Good For The Game

Tramstation is the only map that provides only a pair of medical HUDs, gloves and medical belts, this change makes the amount of these similar to the other maps so the entire medical team can be properly equipped.

## Changelog

:cl: BebeYoshi
add: Adds more health HUDs, nitrile gloves and medical belts to locker in Tramstation medbay
/:cl:

