### PR TITLE
Icebox Brig usability fixes

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1903,6 +1903,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aKV" = (
@@ -6052,6 +6053,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
+"cfp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "cfv" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firefighting Equipment";
@@ -11768,6 +11775,7 @@
 "eGQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "eGW" = (
@@ -20711,6 +20719,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"iYc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/security/warden)
 "iYj" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/chair/stool/directional/south,
@@ -26387,6 +26401,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"lRN" = (
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/security/checkpoint/auxiliary)
 "lRP" = (
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plating,
@@ -27888,6 +27909,7 @@
 "mJH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/security/warden)
 "mJP" = (
@@ -36181,6 +36203,7 @@
 "qQS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "qQV" = (
@@ -39605,6 +39628,9 @@
 /area/maintenance/starboard/fore)
 "suE" = (
 /obj/effect/turf_decal/tile/red/full,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/checkpoint/auxiliary)
 "suH" = (
@@ -44910,6 +44936,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured,
 /area/security/medical)
 "uXt" = (
@@ -45227,6 +45254,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"vhX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured,
+/area/security/medical)
 "vid" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable,
@@ -50461,6 +50494,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/security/warden)
 "xOt" = (
@@ -77508,7 +77542,7 @@ hCj
 sch
 mRQ
 wWP
-mJH
+iYc
 mJH
 xOn
 qQS
@@ -77766,7 +77800,7 @@ hCj
 hCj
 oFu
 rLW
-rLW
+cfp
 whX
 agt
 qQS
@@ -80094,7 +80128,7 @@ cEs
 cEs
 cEs
 lxm
-suE
+lRN
 wTW
 suE
 lxm
@@ -81107,7 +81141,7 @@ gQb
 gQb
 hIX
 cSp
-rXK
+vhX
 uWM
 eGQ
 feP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds vent+scrubber to the Warden's passage to the Armory and the entryway airlocks.
![image](https://user-images.githubusercontent.com/101627558/165090394-d9f70def-5669-4b59-85b9-6f29de9e66db.png)

Adds a wire line running to the Brig Medical area.
![image](https://user-images.githubusercontent.com/101627558/165090776-84cd1bec-96f7-4adf-86c1-5343e36adca2.png) to ![image](https://user-images.githubusercontent.com/101627558/165090586-6ca4f488-68d9-4088-84f5-1111c3d8833b.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The Brig Medical APC giving power alarms every round on IceBox was annoying as hell to AIs.
The scrubber/vents can now use the Warden's office and Security office to fix air problems there without having to leave weird doors or windoors jacked open to other places for air supply.

(I did NOT put any on on the bridge because the bridge just feels, to me, like it's supposed to be sketchy, precarious, and prone to problems. Nothing but R-glass to each side and below you separating you from a swim in the plasma lake, and all that.)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Added vent/scrubber pair to the Icebox security entryway and the warden's backdoor to the armory.
fix: Icebox Brig Medical now has a wire connecting it to the powernet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
