### PR TITLE
Fixes missing area in some of the crashed ship rocks.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -144,9 +144,6 @@
 "fQ" = (
 /turf/open/floor/iron,
 /area/awaymission/bmpship/aft)
-"fW" = (
-/turf/closed/mineral/random,
-/area/template_noop)
 "fY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -2790,11 +2787,11 @@ kc
 kc
 kc
 kc
-fW
-fW
-fW
-fW
-fW
+Au
+Au
+Au
+Au
+Au
 kc
 kc
 kc
@@ -2819,9 +2816,9 @@ kc
 kc
 kc
 kc
-fW
-fW
-fW
+Au
+Au
+Au
 kc
 kc
 kc

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1150,6 +1150,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/template_noop,
 /area/template_noop)
+"Mb" = (
+/turf/closed/mineral/random,
+/area/template_noop)
 "Me" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
@@ -2816,7 +2819,7 @@ kc
 kc
 kc
 kc
-Au
+Mb
 Au
 Au
 kc

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1150,9 +1150,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/template_noop,
 /area/template_noop)
-"Mb" = (
-/turf/closed/mineral/random,
-/area/template_noop)
 "Me" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
@@ -2819,7 +2816,7 @@ kc
 kc
 kc
 kc
-Mb
+Au
 Au
 Au
 kc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Howdy, those rocks have an area passthrough. It's very ugly in-game, as it makes them fully lit up instead of dark like the other rocks.
![image](https://user-images.githubusercontent.com/42174630/165101057-f5d616a5-e16e-43b0-a776-82d0f21cebc2.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's not ugly anymore!
![image](https://user-images.githubusercontent.com/42174630/165101181-b1e64db1-29c6-467d-94e7-0c5d5882fd77.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The lit up rocks in the crashed ship space ruin are now dark like the others.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
