### PR TITLE
Fixes nopower disabling RND servers permanently

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -54,17 +54,15 @@
 	return ..()
 
 /obj/machinery/rnd/server/power_change()
-	. = ..()
 	refresh_working()
-	return
+	return ..()
 
 /obj/machinery/rnd/server/proc/refresh_working()
 	if(machine_stat & EMPED || research_disabled || machine_stat & NOPOWER)
 		working = FALSE
-		update_use_power(NO_POWER_USE)
 	else
 		working = TRUE
-		update_use_power(ACTIVE_POWER_USE)
+	update_current_power_usage()
 	update_appearance()
 
 /obj/machinery/rnd/server/emp_act()


### PR DESCRIPTION
## About The Pull Request

It was using `update_user_power(NO_POWER_USE)` to disable power use
while off, but that will actually unregister the power_change signal
 (which is what the RND server uses to call this) so, it was
being called once and then never working again because it wasn't
receiving the signal to redo it

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes https://github.com/tgstation/tgstation/issues/66444
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: RnD servers will no longer permanently stop working when depowered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
