### PR TITLE
Re-adds #55907 because someone removed it for a stupid reason, meaning medbay can't tell between a body the user can't re-enter and a body that logged out for 5 seconds.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -211,11 +211,14 @@
 	var/t_He = p_they(TRUE)
 	var/t_his = p_their()
 	var/t_is = p_are()
-	//This checks to see if the body is revivable
-	if(key || !getorgan(/obj/item/organ/brain) || ghost?.can_reenter_corpse)
-		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life...")
-	else
-		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...")
+	if(key || !getorgan(/obj/item/organ/brain))
+		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life...") //Default death message
+	//The death mob has a brain and no client/player that is assigned to the mob
+	if(!ghost?.can_reenter_corpse)  //And there is no ghost that could reenter the body
+		//There is no way this mob can in any normal way get a player, so they lost the will to live
+		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has lost the will to live...")
+	//This mob has a ghost linked that could still reenter the body, so the soul only departed
+	return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed, but the link is not yet fully broken...")
 
 ///copies over clothing preferences like underwear to another human
 /mob/living/carbon/human/proc/copy_clothing_prefs(mob/living/carbon/human/destination)


### PR DESCRIPTION
## About The Pull Request

Corpses now tell you if they're properly DNR or not now.

## Why It's Good For The Game

This is fucking stupid I don't know why we removed this

if you can't intuit why it might be good for the game for medbay to be able to tell between someone who DC'd due to lag or a network error, and someone who can't be revived like someone who ghosted, then you shouldn't be developing for this game.

## Changelog

:cl:
fix: Corpses now properly differentiate between disconnected and DNR instead of having the exact same text for both.
/:cl:
