### PR TITLE
fix oversight with prop gasmasks having some of the features of normal ones

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -394,6 +394,7 @@
 	inhand_icon_state = "gas_prop"
 	clothing_flags = NONE
 	flags_cover = MASKCOVERSMOUTH
+	resistance_flags = FLAMMABLE
 	has_fov = FALSE
 
 /obj/item/clothing/mask/gas/atmosprop
@@ -403,4 +404,5 @@
 	inhand_icon_state = "gas_atmos"
 	clothing_flags = NONE
 	flags_cover = MASKCOVERSMOUTH
+	resistance_flags = FLAMMABLE
 	has_fov = FALSE

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -392,6 +392,7 @@
 	desc = "A prop gas mask designed for appearance. Unlike a normal gas mask this does not filter gasses or protect against pepper spray."
 	icon_state = "gas_prop"
 	inhand_icon_state = "gas_prop"
+	clothing_flags = NONE
 	flags_cover = MASKCOVERSMOUTH
 	has_fov = FALSE
 
@@ -400,5 +401,6 @@
 	desc = "A prop atmospheric gas mask designed for appearance. Unlike a normal atmospheric gas mask this does not filter gasses or protect against pepper spray."
 	icon_state = "gas_atmos"
 	inhand_icon_state = "gas_atmos"
+	clothing_flags = NONE
 	flags_cover = MASKCOVERSMOUTH
 	has_fov = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#66398 didn't set the clothing_flags to NONE, so you have prop masks without fov but with some of the perks of the normal ones
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix oversight where prop masks acted like normal ones regarding internals/filters and smoke protection
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fix oversight with prop gasmasks having some of the features of normal ones but without fov
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
