### PR TITLE
Makes tablets show name when not spawned on the belt

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -170,14 +170,6 @@
 		for(var/i in roundstart_experience)
 			experiencer.mind.adjust_experience(i, roundstart_experience[i], TRUE)
 
-	var/obj/item/modular_computer/tablet/pda/PDA = spawned.get_item_by_slot(ITEM_SLOT_BELT)
-	if(istype(PDA))
-		var/obj/item/computer_hardware/identifier/id = PDA.all_components[MC_IDENTIFY]
-
-		if(id)
-			id.UpdateDisplay()
-
-
 /datum/job/proc/announce_job(mob/living/joining_mob)
 	if(head_announce)
 		announce_head(joining_mob, head_announce)
@@ -324,6 +316,10 @@
 	if(istype(PDA))
 		PDA.saved_identification = H.real_name
 		PDA.saved_job = J.title
+
+		var/obj/item/computer_hardware/identifier/id = PDA.all_components[MC_IDENTIFY]
+		if(id)
+			id.UpdateDisplay()
 
 
 /datum/outfit/job/get_chameleon_disguise_info()


### PR DESCRIPTION
## About The Pull Request

Some jobs (like Atmos techs) spawn with tablets not on their belt slot, but the new tablet code assumes it does. This fixes that problem by making it use the same code that gives the tablet's info, which does check the tablet's slot.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/66515

## Changelog

:cl:
fix: Jobs who spawn with tablets not on the belt, have their name and job properly displayed on the tablet, like everyone else.
/:cl: