### PR TITLE
Fixes hair and facial hair not blocking emissives as they should

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -247,7 +247,7 @@
 				if(sprite_accessory)
 					//Create the overlay
 					facial_overlay = mutable_appearance(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER)
-					facial_overlay.overlays += emissive_blocker(facial_overlay.icon, facial_overlay.icon_state, alpha = facial_overlay.alpha)
+					facial_overlay.overlays += emissive_blocker(facial_overlay.icon, facial_overlay.icon_state, alpha = hair_alpha)
 					//Gradients
 					facial_hair_gradient_style = LAZYACCESS(human_head_owner.grad_style, GRADIENT_FACIAL_HAIR_KEY)
 					if(facial_hair_gradient_style)
@@ -260,7 +260,7 @@
 				sprite_accessory = GLOB.hairstyles_list[hair_style]
 				if(sprite_accessory)
 					hair_overlay = mutable_appearance(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER)
-					hair_overlay.overlays += emissive_blocker(hair_overlay.icon, hair_overlay.icon_state, alpha = hair_overlay.alpha)
+					hair_overlay.overlays += emissive_blocker(hair_overlay.icon, hair_overlay.icon_state, alpha = hair_alpha)
 					hair_gradient_style = LAZYACCESS(human_head_owner.grad_style, GRADIENT_HAIR_KEY)
 					if(hair_gradient_style)
 						hair_gradient_color = LAZYACCESS(human_head_owner.grad_color, GRADIENT_HAIR_KEY)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -247,6 +247,7 @@
 				if(sprite_accessory)
 					//Create the overlay
 					facial_overlay = mutable_appearance(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER)
+					facial_overlay.overlays += emissive_blocker(facial_overlay.icon, facial_overlay.icon_state, alpha = facial_overlay.alpha)
 					//Gradients
 					facial_hair_gradient_style = LAZYACCESS(human_head_owner.grad_style, GRADIENT_FACIAL_HAIR_KEY)
 					if(facial_hair_gradient_style)
@@ -259,6 +260,7 @@
 				sprite_accessory = GLOB.hairstyles_list[hair_style]
 				if(sprite_accessory)
 					hair_overlay = mutable_appearance(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER)
+					hair_overlay.overlays += emissive_blocker(hair_overlay.icon, hair_overlay.icon_state, alpha = hair_overlay.alpha)
 					hair_gradient_style = LAZYACCESS(human_head_owner.grad_style, GRADIENT_HAIR_KEY)
 					if(hair_gradient_style)
 						hair_gradient_color = LAZYACCESS(human_head_owner.grad_color, GRADIENT_HAIR_KEY)


### PR DESCRIPTION
## About The Pull Request
Basically, everything that composes the sprites of mobs blocks emissive.

Everything, except hair, for some reason, which leads to silly stuff like this being possible:
![image](https://user-images.githubusercontent.com/58045821/165204677-5d04a78f-c63c-48ce-a3d8-b4f2f3f2e036.png)
The bottom portion of the hair is blocking the emissives, because it's actually the head that's underneath that's blocking said emissives, whereas the top, isn't.

This PR aims to fix that, and it works just as expected.

## Why It's Good For The Game
Having parts of your body be completely illuminated when they shouldn't be makes them look really stupid.

## Changelog

:cl: GoldenAlpharex
fix: Fixed hair not blocking emissives, which ended up creating some rather silly visual glitches at times, in darker areas.
/:cl: