### PR TITLE
Adds alt mob emotes, and changes the emote for humans *flap-ing

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -47,6 +47,13 @@
 	var/list/mob_type_blacklist_typecache
 	/// Types that can use this emote regardless of their state.
 	var/list/mob_type_ignore_stat_typecache
+	/**
+	 * Assoc list containing alt mob emotes
+	 *
+	 * Example:
+	 * list(/type/of/mob = "emote")
+	 */
+	var/list/mob_alt_emotes
 	/// In which state can you use this emote? (Check stat.dm for a full list of them)
 	var/stat_allowed = CONSCIOUS
 	/// Sound to play when emote is called.
@@ -203,6 +210,11 @@
 		. = message_monkey
 	else if(isanimal(user) && message_simple)
 		. = message_simple
+	if (mob_alt_emotes)
+		for (var/mob_type in mob_alt_emotes)
+			if (istype(user, mob_type))
+				. = mob_alt_emotes[mob_type]
+				break
 
 /**
  * Replaces the %t in the message in message_param by params.

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -141,6 +141,10 @@
 	key_third_person = "flaps"
 	message = "flaps their wings."
 	hands_use_check = TRUE
+	mob_alt_emotes = list(
+		/mob/living/carbon/human/species/moth = "flaps their wings.",
+		/mob/living/carbon/human = "flaps their arms up and down, like an idiot.",
+	)
 	var/wing_time = 20
 
 /datum/emote/living/flap/run_emote(mob/user, params, type_override, intentional)
@@ -163,6 +167,10 @@
 	message = "flaps their wings ANGRILY!"
 	hands_use_check = TRUE
 	wing_time = 10
+	mob_alt_emotes = list(
+		/mob/living/carbon/human/species/moth = "flaps their wings ANGRILY!",
+		/mob/living/carbon/human = "violently flails their arms around!",
+	)
 
 /datum/emote/living/frown
 	key = "frown"


### PR DESCRIPTION

## About The Pull Request

adds the ability to specify mob types to have alternative emote messages
uses this to give humans (and every species save for moths) to have a
separate flap (and aflap) message:
![image](https://user-images.githubusercontent.com/16159590/165218244-53583f41-0c1d-4bfb-a37f-7243c6ea029d.png)


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Humans don't have wings! Plus this is funnier, I think.
also, 
![image](https://user-images.githubusercontent.com/16159590/165218382-6b744495-592c-4f8c-a4c3-a88ddf4d42f3.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Closes https://github.com/tgstation/tgstation/issues/65397

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds alternative mob emotes, allowing for more customisable emotes.
fix: Humans can no longer flap their non existent wings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
