### PR TITLE
Nerfs Reinforced windows.

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -27,10 +27,9 @@
 //reinforced window construction states
 #define RWINDOW_FRAME_BOLTED 3
 #define RWINDOW_BARS_CUT 4
-#define RWINDOW_POPPED 5
-#define RWINDOW_BOLTS_OUT 6
-#define RWINDOW_BOLTS_HEATED 7
-#define RWINDOW_SECURE 8
+#define RWINDOW_BOLTS_OUT 5
+#define RWINDOW_BOLTS_HEATED 6
+#define RWINDOW_SECURE 7
 
 //airlock assembly construction states
 #define AIRLOCK_ASSEMBLY_NEEDS_WIRES 0

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -400,7 +400,7 @@
 	icon_state = "rwindow"
 	reinf = TRUE
 	heat_resistance = 1600
-	armor = list(MELEE = 20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, FIRE = 80, ACID = 100)
+	armor = list(MELEE = 60, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, FIRE = 80, ACID = 100)
 	max_integrity = 75
 	explosion_block = 1
 	damage_deflection = 10

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -433,7 +433,7 @@
 			if(tool.tool_behaviour == TOOL_SCREWDRIVER)
 				user.visible_message(span_notice("[user] digs into the heated security screws and starts removing them..."),
 										span_notice("You dig into the heated screws hard and they start turning..."))
-				if(tool.use_tool(src, user, 4 SECONDS, volume = 50))
+				if(tool.use_tool(src, user, 5 SECONDS, volume = 50))
 					state = RWINDOW_BOLTS_OUT
 					to_chat(user, span_notice("The screws come out, and a gap forms around the edge of the pane."))
 			else if (tool.tool_behaviour)
@@ -452,7 +452,7 @@
 			if(tool.tool_behaviour == TOOL_WRENCH)
 				user.visible_message(span_notice("[user] starts unfastening \the [src] from the frame..."),
 					span_notice("You start unfastening the bolts from the frame..."))
-				if(tool.use_tool(src, user, 5 SECONDS, volume = 50))
+				if(tool.use_tool(src, user, 4 SECONDS, volume = 50))
 					to_chat(user, span_notice("You unscrew the bolts from the frame and the window pops loose."))
 					state = WINDOW_OUT_OF_FRAME
 					set_anchored(FALSE)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -400,10 +400,10 @@
 	icon_state = "rwindow"
 	reinf = TRUE
 	heat_resistance = 1600
-	armor = list(MELEE = 80, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, FIRE = 80, ACID = 100)
+	armor = list(MELEE = 20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, FIRE = 80, ACID = 100)
 	max_integrity = 75
 	explosion_block = 1
-	damage_deflection = 11
+	damage_deflection = 10
 	state = RWINDOW_SECURE
 	glass_type = /obj/item/stack/sheet/rglass
 	rad_insulation = RAD_HEAVY_INSULATION
@@ -413,6 +413,7 @@
 //If you find this like 4 years later and construction still hasn't been refactored, I'm so sorry for this //Adding a timestamp, I found this in 2020, I hope it's from this year -Lemon
 //2021 AND STILLLL GOING STRONG
 //2022 BABYYYYY ~lewc
+//Easy was here
 /obj/structure/window/reinforced/attackby_secondary(obj/item/tool, mob/user, params)
 	switch(state)
 		if(RWINDOW_SECURE)
@@ -421,7 +422,7 @@
 				if(welder.isOn())
 					user.visible_message(span_notice("[user] holds \the [tool] to the security screws on \the [src]..."),
 						span_notice("You begin heating the security screws on \the [src]..."))
-				if(tool.use_tool(src, user, 150, volume = 100))
+				if(tool.use_tool(src, user, 10 SECONDS, volume = 100))
 					to_chat(user, span_notice("The security screws are glowing white hot and look ready to be removed."))
 					state = RWINDOW_BOLTS_HEATED
 					addtimer(CALLBACK(src, .proc/cool_bolts), 300)
@@ -432,29 +433,18 @@
 			if(tool.tool_behaviour == TOOL_SCREWDRIVER)
 				user.visible_message(span_notice("[user] digs into the heated security screws and starts removing them..."),
 										span_notice("You dig into the heated screws hard and they start turning..."))
-				if(tool.use_tool(src, user, 50, volume = 50))
+				if(tool.use_tool(src, user, 6 SECONDS, volume = 50))
 					state = RWINDOW_BOLTS_OUT
 					to_chat(user, span_notice("The screws come out, and a gap forms around the edge of the pane."))
 			else if (tool.tool_behaviour)
 				to_chat(user, span_warning("The security screws need to be removed first!"))
 
 		if(RWINDOW_BOLTS_OUT)
-			if(tool.tool_behaviour == TOOL_CROWBAR)
-				user.visible_message(span_notice("[user] wedges \the [tool] into the gap in the frame and starts prying..."),
-										span_notice("You wedge \the [tool] into the gap in the frame and start prying..."))
-				if(tool.use_tool(src, user, 40, volume = 50))
-					state = RWINDOW_POPPED
-					to_chat(user, span_notice("The panel pops out of the frame, exposing some thin metal bars that looks like they can be cut."))
-			else if (tool.tool_behaviour)
-				to_chat(user, span_warning("The gap needs to be pried first!"))
-
-		if(RWINDOW_POPPED)
 			if(tool.tool_behaviour == TOOL_WIRECUTTER)
-				user.visible_message(span_notice("[user] starts cutting the exposed bars on \the [src]..."),
-										span_notice("You start cutting the exposed bars on \the [src]"))
-				if(tool.use_tool(src, user, 20, volume = 50))
-					state = RWINDOW_BARS_CUT
-					to_chat(user, span_notice("The panels falls out of the way exposing the frame bolts."))
+				user.visible_message(span_notice("[user] snips away the exposed bars on \the [src]"),
+										span_notice("You snip away the exposed bars on \the [src], exposing the frame bolts"))
+				tool.play_tool_sound(src, 100)
+				state = RWINDOW_BARS_CUT
 			else if (tool.tool_behaviour)
 				to_chat(user, span_warning("The bars need to be cut first!"))
 
@@ -462,7 +452,7 @@
 			if(tool.tool_behaviour == TOOL_WRENCH)
 				user.visible_message(span_notice("[user] starts unfastening \the [src] from the frame..."),
 					span_notice("You start unfastening the bolts from the frame..."))
-				if(tool.use_tool(src, user, 40, volume = 50))
+				if(tool.use_tool(src, user, 6 SECONDS, volume = 50))
 					to_chat(user, span_notice("You unscrew the bolts from the frame and the window pops loose."))
 					state = WINDOW_OUT_OF_FRAME
 					set_anchored(FALSE)
@@ -488,9 +478,7 @@
 		if(RWINDOW_BOLTS_HEATED)
 			. += span_notice("The screws are glowing white hot, and you'll likely be able to <b>unscrew them</b> now.")
 		if(RWINDOW_BOLTS_OUT)
-			. += span_notice("The screws have been removed, revealing a small gap you could fit a <b>prying tool</b> in.")
-		if(RWINDOW_POPPED)
-			. += span_notice("The main plate of the window has popped out of the frame, exposing some bars that look like they can be <b>cut</b>.")
+			. += span_notice("The screws have been removed, exposing some bars that look like they can be <b>cut</b>.")
 		if(RWINDOW_BARS_CUT)
 			. += span_notice("The main pane can be easily moved out of the way to reveal some <b>bolts</b> holding the frame in.")
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -433,7 +433,7 @@
 			if(tool.tool_behaviour == TOOL_SCREWDRIVER)
 				user.visible_message(span_notice("[user] digs into the heated security screws and starts removing them..."),
 										span_notice("You dig into the heated screws hard and they start turning..."))
-				if(tool.use_tool(src, user, 6 SECONDS, volume = 50))
+				if(tool.use_tool(src, user, 4 SECONDS, volume = 50))
 					state = RWINDOW_BOLTS_OUT
 					to_chat(user, span_notice("The screws come out, and a gap forms around the edge of the pane."))
 			else if (tool.tool_behaviour)
@@ -452,7 +452,7 @@
 			if(tool.tool_behaviour == TOOL_WRENCH)
 				user.visible_message(span_notice("[user] starts unfastening \the [src] from the frame..."),
 					span_notice("You start unfastening the bolts from the frame..."))
-				if(tool.use_tool(src, user, 6 SECONDS, volume = 50))
+				if(tool.use_tool(src, user, 5 SECONDS, volume = 50))
 					to_chat(user, span_notice("You unscrew the bolts from the frame and the window pops loose."))
 					state = WINDOW_OUT_OF_FRAME
 					set_anchored(FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Its been three years since anyone has taken a swing at reinforced windows, so now its my turn to step up to the plate, and I'm hitting them hard. (Specifically approved by maintainers)
![P@](https://user-images.githubusercontent.com/55666666/165216393-18aa4981-984a-41f5-b16b-d6db7a436145.PNG)
![p2](https://user-images.githubusercontent.com/55666666/165216381-f1f7b377-dabc-4c86-946d-c9b941b599f9.PNG)

### THE CHANGES

Breaking:
80% Melee armor -> 20% Melee armor
11 Damage reflection -> 10 Damage Reflection (In practice, allows fire extinguishers, knives, and O2 tanks to be used effectively)
Health of 150 -> Unchanged!

Deconstructing
The welding step of deconstruction takes 33% less time
The wire cutter step is now instant (similar to r-walls)
Removed the crowbar step

Before:

https://user-images.githubusercontent.com/55666666/165217767-34c06470-c22d-414b-8724-81fd2cfca966.mp4

https://user-images.githubusercontent.com/55666666/165217965-3cceb2f5-a05a-45b1-916c-0069ed9339d4.mp4

After:


https://user-images.githubusercontent.com/55666666/165841178-0d3f9cf6-6197-4007-b983-f346dc891f21.mp4


https://user-images.githubusercontent.com/55666666/165841199-ab996113-8f9a-4540-bb91-4474c43072de.mp4



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Reinforced windows as they stand right now are incredibly robust, and incredibly prevalent. They very much outclass other security structures that they are around.
For example, walls take about 14 seconds to deconstruct with a welding tool and a wrench. Windows take about 40 seconds, and require a full tool belt.
An r-window takes a whopping 25 hits with an every sword to destroy, an airlock takes 15 hits and can be hacked in around 20 seconds, less if you have knowledge of the area's wires.
If the wall's weakness is deconstructing, and the airlock's weakness is hacking, then the window's weakness should be blunt force trauma.
A design document which I used to outline these changes: https://hackmd.io/ukaoe8rFRvCta-4ISR-SSg?view
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: itseasytosee

balance: Reinforced windows have been made quicker to deconstruct and easier to break

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
