### PR TITLE
Fixes being able to ride dead space carp

### DIFF
--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -30,9 +30,11 @@
 	RegisterSignal(target, COMSIG_MOVABLE_PREBUCKLE, .proc/check_mounting)
 	if(isvehicle(target))
 		RegisterSignal(target, COMSIG_SPEED_POTION_APPLIED, .proc/check_potion)
+	if(ismob(target))
+		RegisterSignal(target, COMSIG_LIVING_DEATH, .proc/handle_removal)
 
 /datum/element/ridable/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_MOVABLE_PREBUCKLE, COMSIG_SPEED_POTION_APPLIED))
+	UnregisterSignal(target, list(COMSIG_MOVABLE_PREBUCKLE, COMSIG_SPEED_POTION_APPLIED, COMSIG_LIVING_DEATH))
 	return ..()
 
 /// Someone is buckling to this movable, which is literally the only thing we care about (other than speed potions)
@@ -143,8 +145,10 @@
 			qdel(O)
 	return TRUE
 
+/datum/element/ridable/proc/handle_removal(datum/source)
+	SIGNAL_HANDLER
 
-
+	Detach(source)
 
 /obj/item/riding_offhand
 	name = "offhand"

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -149,7 +149,6 @@
 	SIGNAL_HANDLER
 
 	var/atom/movable/ridden = source
-	ridden.can_buckle = FALSE
 	ridden.unbuckle_all_mobs()
 
 	Detach(source)

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -148,6 +148,10 @@
 /datum/element/ridable/proc/handle_removal(datum/source)
 	SIGNAL_HANDLER
 
+	var/atom/movable/ridden = source
+	ridden.can_buckle = FALSE
+	ridden.unbuckle_all_mobs()
+
 	Detach(source)
 
 /obj/item/riding_offhand

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -91,12 +91,6 @@
 		tamed(friendref.resolve())
 	return ..()
 
-/mob/living/simple_animal/hostile/carp/death(gibbed)
-	if (tamed)
-		can_buckle = FALSE
-		unbuckle_all_mobs()
-	return ..()
-
 /mob/living/simple_animal/hostile/carp/proc/make_tameable()
 	AddComponent(/datum/component/tameable, food_types = list(/obj/item/food/meat), tame_chance = 10, bonus_tame_chance = 5, after_tame = CALLBACK(src, .proc/tamed))
 

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -88,7 +88,9 @@
 /mob/living/simple_animal/hostile/carp/revive(full_heal, admin_revive)
 	if (tamed)
 		var/datum/weakref/friendref = ai_controller.blackboard[BB_HOSTILE_FRIEND]
-		tamed(friendref.resolve())
+		var/mob/living/friend = friendref?.resolve()
+		if(friend)
+			tamed(friend)
 	return ..()
 
 /mob/living/simple_animal/hostile/carp/death(gibbed)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -91,6 +91,11 @@
 		tamed(friendref.resolve())
 	return ..()
 
+/mob/living/simple_animal/hostile/carp/death(gibbed)
+	if (tamed)
+		can_buckle = FALSE
+	return ..()
+
 /mob/living/simple_animal/hostile/carp/proc/make_tameable()
 	AddComponent(/datum/component/tameable, food_types = list(/obj/item/food/meat), tame_chance = 10, bonus_tame_chance = 5, after_tame = CALLBACK(src, .proc/tamed))
 

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -66,6 +66,8 @@
 	var/static/list/carp_colors_rare = list(
 		"silver" = "#fdfbf3"
 	)
+	/// Is the carp tamed?
+	var/tamed = FALSE
 
 /mob/living/simple_animal/hostile/carp/Initialize(mapload, mob/tamer)
 	AddElement(/datum/element/simple_flying)
@@ -83,9 +85,14 @@
 		else
 			make_tameable()
 
+/mob/living/simple_animal/hostile/carp/revive(full_heal, admin_revive)
+	if (tamed)
+		var/datum/weakref/friendref = ai_controller.blackboard[BB_HOSTILE_FRIEND]
+		tamed(friendref.resolve())
+	return ..()
+
 /mob/living/simple_animal/hostile/carp/death(gibbed)
-	if (can_buckle)
-		RemoveElement(/datum/element/ridable)
+	if (tamed)
 		can_buckle = FALSE
 		unbuckle_all_mobs()
 	return ..()
@@ -94,6 +101,7 @@
 	AddComponent(/datum/component/tameable, food_types = list(/obj/item/food/meat), tame_chance = 10, bonus_tame_chance = 5, after_tame = CALLBACK(src, .proc/tamed))
 
 /mob/living/simple_animal/hostile/carp/proc/tamed(mob/living/tamer)
+	tamed = TRUE
 	can_buckle = TRUE
 	buckle_lying = 0
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/carp)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -83,6 +83,13 @@
 		else
 			make_tameable()
 
+/mob/living/simple_animal/hostile/carp/death(gibbed)
+	if (can_buckle)
+		RemoveElement(/datum/element/ridable)
+		can_buckle = FALSE
+		unbuckle_all_mobs()
+	return ..()
+
 /mob/living/simple_animal/hostile/carp/proc/make_tameable()
 	AddComponent(/datum/component/tameable, food_types = list(/obj/item/food/meat), tame_chance = 10, bonus_tame_chance = 5, after_tame = CALLBACK(src, .proc/tamed))
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
just removes the ridable element, and unbuckles all the mobs, otherwise
they'll be able to ride it still if they don't get off
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Exploits are bad
Fixes https://github.com/tgstation/tgstation/issues/66438

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed being able to ride dead space carp.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
