### PR TITLE
Sausage and eggs fix

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
@@ -17,7 +17,7 @@
 	name = "Egg with sausage"
 	reqs = list(
 		/obj/item/food/sausage = 1,
-		/obj/item/food/egg = 1,
+		/obj/item/food/friedegg = 1,
 	)
 	result = /obj/item/food/eggsausage
 	subcategory = CAT_EGG


### PR DESCRIPTION
## About The Pull Request

I would not like them here or there
I would not like them anywhere
I do not like raw egg and sausage. 
I do not like them, maintainer-the-complainer.

## Why It's Good For The Game

I think I was reaching it with the green eggs and ham joke. Anyway, it's weird that the sausage part of the recipe is cooked but the egg isn't, especially when the sprite shows a fried egg.

## Changelog


:cl:
fix: corrects pathway in sausage and eggs. Now cooked with fried eggs as intended.
/:cl:
