### PR TITLE
expands gas analyzer functionality to include heat capacity and thermal energy readings

### DIFF
--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -154,6 +154,8 @@
 		var/pressure = air.return_pressure()
 		var/volume = air.return_volume() //could just do mixture.volume... but safety, I guess?
 		var/temperature = air.return_temperature()
+		var/heat_capacity = air.heat_capacity()
+		var/thermal_energy = air.thermal_energy()
 
 		if(total_moles > 0)
 			message += span_notice("Moles: [round(total_moles, 0.01)] mol")
@@ -165,8 +167,11 @@
 			message += span_notice("Temperature: [round(temperature - T0C,0.01)] &deg;C ([round(temperature, 0.01)] K)")
 			message += span_notice("Volume: [volume] L")
 			message += span_notice("Pressure: [round(pressure, 0.01)] kPa")
+			message += span_notice("Heat Capacity: [display_joules(heat_capacity)] / K")
+			message += span_notice("Thermal Energy: [display_joules(thermal_energy)]")
 		else
 			message += airs.len > 1 ? span_notice("This node is empty!") : span_notice("[target] is empty!")
+			message += span_notice("Volume: [volume] L") // don't want to change the order volume appears in, suck it
 		
 		gasmix_data += list(gas_mixture_parser(air, mix_name))
 


### PR DESCRIPTION


## About The Pull Request

This PR expands the readings that the gas analyzer gives to include the heat capacity and thermal energy of a gas mixture. It also allows the volume of empty pipe networks to be shown.

## Why It's Good For The Game

This change would allow for atmos technicians to better understand what is going with their reactions and pipe networks. This works towards the goal of demystifying atmos and making it easier for people to understand. This change would work in conjunction with the information in the reactions guide to explain what reactions do.

## Changelog

:cl:
qol: the gas analyzer now shows the heat capacity and thermal energy of a mix
qol: the gas analyzer now shows the volume of empty pipe networks
/:cl:

