### PR TITLE
Fixes double light fixture on tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7836,7 +7836,6 @@
 	},
 /obj/machinery/newscaster/directional/east,
 /obj/effect/landmark/start/lawyer,
-/obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "byD" = (


### PR DESCRIPTION
## About The Pull Request

Removes a double-light fixture from Tramstation's Law office.

please pretend i have a verified signature commit

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/53777086/165409057-d15d654e-8cf3-42c9-8d2a-334f67263866.png)

## Changelog

:cl:
fix: A double light fixture in the law office has been fixed. Enjoy your lights.
/:cl: