### PR TITLE
Remove data/ from /datum/asset/json url mapping

### DIFF
--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -482,10 +482,10 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	)
 
 /datum/asset/json/register()
-	var/filename = "[name].json"
+	var/filename = "data/[name].json"
 	fdel(filename)
 	text2file(json_encode(generate()), filename)
-	SSassets.transport.register_asset(filename, fcopy_rsc(filename))
+	SSassets.transport.register_asset("[name].json", fcopy_rsc(filename))
 	fdel(filename)
 
 /// Returns the data that will be JSON encoded

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -474,15 +474,15 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	var/name
 
 /datum/asset/json/send(client)
-	return SSassets.transport.send_assets(client, "data/[name].json")
+	return SSassets.transport.send_assets(client, "[name].json")
 
 /datum/asset/json/get_url_mappings()
 	return list(
-		"[name].json" = SSassets.transport.get_asset_url("data/[name].json"),
+		"[name].json" = SSassets.transport.get_asset_url("[name].json"),
 	)
 
 /datum/asset/json/register()
-	var/filename = "data/[name].json"
+	var/filename = "[name].json"
 	fdel(filename)
 	text2file(json_encode(generate()), filename)
 	SSassets.transport.register_asset(filename, fcopy_rsc(filename))


### PR DESCRIPTION
Closes #66535. Untested, let this TM first.

![image](https://user-images.githubusercontent.com/35135081/165415321-2d65e7a7-7d2e-420d-9874-332a7025e372.png)

Alt-text (from MSO):

i set the mutation system up to ensure local test would break if it wasn't cdn/fetch url ready. I was not expecting the reverse to be happen.

in old mode, the name of the asset is its filename, this is how assets used to work.

Naming the asset data/preferences.json means it is trying to save it to data/preferences.json and then byond saves it to preferences.json.

Using different asset names to register the asset in tgui (preferences.json) and in dm code (data/preferences.json) was also insanely unwise Mothblocks and i want to see you return parity there.

Because I do not want to make the asset system have to parse and clean up the asset filenames and play cat and mouse there, asset filenames must be valid filenames moving forward, in the most restrictive set this is /[-a-zA-Z0-9\._]+/. 