### PR TITLE
Keep mutating filenames when the cdn is disabled midround.

### DIFF
--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -106,6 +106,5 @@
 		admin_disabled_cdn_transport = current_transport
 		CONFIG_SET(string/asset_transport, "simple")
 		SSassets.OnConfigLoad()
-		SSassets.transport.dont_mutate_filenames = TRUE
 		message_admins("[key_name_admin(usr)] disabled the CDN asset transport")
 		log_admin("[key_name(usr)] disabled the CDN asset transport")


### PR DESCRIPTION
Fix issues with disabling the CDN because it also disables md5 based filenames but some things assumed the asset name could contain non-filename-valid characters not knowing that the string used to identify and regster an asset (asset name) has to be a valid filename to work properly in the oldschool case where it is also the client side filename.


![image](https://user-images.githubusercontent.com/7069733/165416657-b12593f8-8716-4b1c-bc9e-fe773a8fc6f9.png)
