### PR TITLE
Fixes Openspace and Space Usage Errors on TramStation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -44887,10 +44887,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
-"oKU" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/solars/port/aft)
 "oKW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -64714,11 +64710,6 @@
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
-"weB" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/solars/port/aft)
 "weC" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Secure - Telecomms Server Room";
@@ -155404,7 +155395,7 @@ sub
 sub
 sub
 sub
-jwD
+gNY
 uwO
 aYr
 aYr
@@ -156929,14 +156920,14 @@ dDG
 dDG
 unm
 gNY
-jwD
-jwD
-jwD
-jwD
-jwD
-jwD
-jwD
-jwD
+gNY
+gNY
+gNY
+gNY
+gNY
+gNY
+gNY
+gNY
 jKT
 uaT
 jKT
@@ -157445,12 +157436,12 @@ dDG
 dDG
 dDG
 unm
-jwD
-jwD
-jwD
-jwD
-jwD
-jwD
+gNY
+gNY
+gNY
+gNY
+gNY
+gNY
 jKT
 uaT
 jKT
@@ -157702,12 +157693,12 @@ dDG
 dDG
 wgT
 wgT
-weB
-weB
-weB
-weB
-weB
-oKU
+mxQ
+mxQ
+mxQ
+mxQ
+mxQ
+uaT
 uaT
 uaT
 mxQ
@@ -157962,9 +157953,9 @@ dDG
 dDG
 dDG
 unm
-jwD
-jwD
-jwD
+gNY
+gNY
+gNY
 jKT
 uaT
 jKT
@@ -158476,9 +158467,9 @@ dDG
 dDG
 dDG
 unm
-jwD
-jwD
-jwD
+gNY
+gNY
+gNY
 jKT
 uaT
 jKT
@@ -158736,7 +158727,7 @@ dDG
 dDG
 aYr
 aYr
-jwD
+gNY
 aYr
 aYr
 mxQ
@@ -159250,7 +159241,7 @@ dDG
 dDG
 aYr
 aYr
-jwD
+gNY
 aYr
 aYr
 mxQ
@@ -159505,10 +159496,10 @@ dDG
 dDG
 dDG
 unm
-jwD
-jwD
+gNY
+gNY
 jKT
-oKU
+uaT
 jKT
 mxQ
 jKT
@@ -159765,7 +159756,7 @@ dDG
 aYr
 aYr
 jKT
-oKU
+uaT
 jKT
 uaT
 jKT
@@ -160022,7 +160013,7 @@ dDG
 aYr
 aYr
 jKT
-oKU
+uaT
 jKT
 uaT
 jKT
@@ -160277,10 +160268,10 @@ aRN
 wgT
 wgT
 wgT
-oKU
-oKU
-weB
-oKU
+uaT
+uaT
+mxQ
+uaT
 mxQ
 mxQ
 mxQ
@@ -161049,10 +161040,10 @@ dDG
 dDG
 dDG
 unm
-jwD
-jwD
+gNY
+gNY
 jKT
-oKU
+uaT
 jKT
 uaT
 jKT
@@ -161308,7 +161299,7 @@ dDG
 dDG
 dDG
 aYr
-jwD
+gNY
 aYr
 aYr
 aYr
@@ -161564,9 +161555,9 @@ dDG
 dDG
 dDG
 unm
-hnE
-hnE
-hnE
+sub
+sub
+sub
 sub
 sub
 sub


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

There was a few of these lurking around, which probably didn't cause anything weird in game, but they certainly had some weird properties in map editors. This just fixes all turfs on the second z-level of TramStation to be openspace rather than actual space. The difference is nearly completely imperceptible, so a photograph will not be of much help.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Prevents weird visibility/technical glitches happening on TramStation.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nanotrasen's Department of "Reality Fixing" has corrected an issue regarding the space on the tiles of the southern solars on TramStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
