### PR TITLE
fixes action lockout due to notepad

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosNotepad.js
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.js
@@ -23,7 +23,7 @@ export const NtosNotepad = (props, context) => {
               <Input
                 value={note}
                 fluid
-                onInput={(e, value) => act('UpdateNote', {
+                onEnter={(e, value) => act('UpdateNote', {
                   newnote: value,
                 })}
               />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

changes the tgui input box function to be `onEnter`, rather than `onInput`, which was causing people to get an action cooldown lockout

![image](https://user-images.githubusercontent.com/88991542/165446755-b1b34796-ffc5-4c1d-82fe-488b080e19a6.png)


## Why It's Good For The Game

quality of life and i also imagine this does not look very pretty performance-wise

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: notepad app no longer causes a barrage of action cooldown messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
