### PR TITLE
Moves an intercom in Metastation captain's office to prevent overlapping. 

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -20919,6 +20919,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "grN" = (
@@ -31827,10 +31828,6 @@
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"kBm" = (
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/carpet,
-/area/command/heads_quarters/captain/private)
 "kBv" = (
 /obj/machinery/exodrone_launcher,
 /turf/open/floor/plating,
@@ -99221,7 +99218,7 @@ any
 fxE
 qPQ
 idt
-kBm
+gWx
 hbO
 xqZ
 cKh


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Howdy, this looks bad...
![image](https://user-images.githubusercontent.com/42174630/165554861-c553b33b-046b-4f46-8266-b37fc94b1a1f.png)

I moved the intercom, so it no longer looks bad!
![image](https://user-images.githubusercontent.com/42174630/165554892-df1eb1cd-3ff9-4ca6-8d65-84452c061fe3.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Closes #66555 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Moved an intercom in Metastation's captain's office to prevent overlapping visible to ghosts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
