### PR TITLE
Disables the tax on off-station lathes

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -89,7 +89,7 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "aA" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/machinery/rnd/production/protolathe/department/engineering/no_tax,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 9
 	},

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -3116,7 +3116,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "hD" = (
-/obj/machinery/rnd/production/protolathe,
+/obj/machinery/rnd/production/protolathe/offstation,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -227,6 +227,9 @@
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/rnd/production/protolathe/department/engineering
 
+/obj/item/circuitboard/machine/protolathe/department/engineering/no_tax
+	build_path = /obj/machinery/rnd/production/protolathe/department/engineering/no_tax
+
 /obj/item/circuitboard/machine/rtg
 	name = "RTG (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -21,6 +21,8 @@
 
 	/// What color is this machine's stripe? Leave null to not have a stripe.
 	var/stripe_color = null
+	/// Does this charge the user's ID on fabrication?
+	var/charges_tax = TRUE
 
 /obj/machinery/rnd/production/Initialize(mapload)
 	. = ..()
@@ -173,7 +175,9 @@
 			say("Not enough reagents to complete prototype[print_quantity > 1? "s" : ""].")
 			return FALSE
 	var/total_cost = LATHE_TAX
-	if(is_station_level(z) && isliving(usr)) //We don't block purchases off station Z.
+	if(!charges_tax)
+		total_cost = 0
+	if(isliving(usr))
 		var/mob/living/user = usr
 		var/obj/item/card/id/card = user.get_idcard(TRUE)
 		if(!card && istype(user.pulling, /obj/item/card/id))
@@ -182,8 +186,6 @@
 			var/datum/bank_account/our_acc = card.registered_account
 			if(our_acc.account_job && SSeconomy.get_dep_account(our_acc.account_job?.paycheck_department) == SSeconomy.get_dep_account(payment_department))
 				total_cost = 0 //We are not charging crew for printing their own supplies and equipment.
-	if(!is_station_level(z) || is_mining_level(z))
-		total_cost = 0
 	if(attempt_charge(src, usr, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE)
 		return FALSE
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -182,6 +182,8 @@
 			var/datum/bank_account/our_acc = card.registered_account
 			if(our_acc.account_job && SSeconomy.get_dep_account(our_acc.account_job?.paycheck_department) == SSeconomy.get_dep_account(payment_department))
 				total_cost = 0 //We are not charging crew for printing their own supplies and equipment.
+	if(!is_station_level(z) || is_mining_level(z))
+		total_cost = 0
 	if(attempt_charge(src, usr, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE)
 		return FALSE
 

--- a/code/modules/research/machinery/circuit_imprinter.dm
+++ b/code/modules/research/machinery/circuit_imprinter.dm
@@ -33,3 +33,4 @@
 	desc = "Manufactures circuit boards for the construction of machines. Its ancient construction may limit its ability to print all known technology."
 	allowed_buildtypes = AWAY_IMPRINTER
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/offstation
+	charges_tax = FALSE

--- a/code/modules/research/machinery/departmental_protolathe.dm
+++ b/code/modules/research/machinery/departmental_protolathe.dm
@@ -12,6 +12,10 @@
 	stripe_color = "#EFB341"
 	payment_department = ACCOUNT_ENG
 
+/obj/machinery/rnd/production/protolathe/department/engineering/no_tax
+	circuit = /obj/item/circuitboard/machine/protolathe/department/engineering/no_tax
+	charges_tax = FALSE
+
 /obj/machinery/rnd/production/protolathe/department/service
 	name = "department protolathe (Service)"
 	allowed_department_flags = DEPARTMENTAL_FLAG_SERVICE

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -38,3 +38,4 @@
 	desc = "Converts raw materials into useful objects. Its ancient construction may limit its ability to print all known technology."
 	circuit = /obj/item/circuitboard/machine/protolathe/offstation
 	allowed_buildtypes = AWAY_LATHE
+	charges_tax = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Disables the tax from lathes off-station or on-mining-level lathes.

## Why It's Good For The Game
Probably shouldn't be charging for off-station lathes, they aren't connected to the station. Also a downstream PR kicked upstream, where some ghost roles have lathes but no bank account, making them unable to use lathes.
on-mining check is for icebox

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Off-station lathes no longer you pay a tax.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
