### PR TITLE
moves a poster literally one tile down

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -61493,7 +61493,6 @@
 /area/engineering/atmos/storage/gas)
 "pNe" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "pNm" = (
@@ -78690,6 +78689,7 @@
 	},
 /obj/item/rack_parts,
 /obj/effect/spawner/random/engineering/tool,
+/obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/fore)
 "uOD" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the deltastation cargo warehouse poster one tile down
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Looks bad for ghosts/AI when they pan over it
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:xyc

fix: DeltaStation cargo warehouse poster has been moved one tile down

/:cl:
![fix](https://user-images.githubusercontent.com/76170211/165660615-b8c83c5b-272c-4ad4-9706-705eb984058b.PNG)


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
