### PR TITLE
readds the chameleon gun

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -476,6 +476,7 @@
 	new /obj/item/radio/headset/chameleon(src)
 	new /obj/item/stamp/chameleon(src)
 	new /obj/item/modular_computer/tablet/pda/chameleon(src)
+	new /obj/item/gun/energy/laser/chameleon(src)
 
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -776,7 +776,7 @@
 	var/list/chameleon_projectile_vars
 
 	/// The badmin mode. Makes your projectiles act like the real deal.
-	var/real_hits
+	var/real_hits = FALSE
 
 /obj/item/gun/energy/laser/chameleon/New()
 	..()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -782,7 +782,7 @@
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/gun
-	chameleon_action.chameleon_name = "gun"
+	chameleon_action.chameleon_name = "Gun"
 	chameleon_action.chameleon_blacklist = typesof(/obj/item/gun/magic, /obj/item/gun/energy/minigun)
 	chameleon_action.initialize_disguises()
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -870,56 +870,56 @@
 		stack_trace("[cartridge] is not a valid ammo casing.")
 		return FALSE
 
-	var/obj/projectile/proj = cartridge.loaded_projectile
-	set_chameleon_projectile(proj)
+	var/obj/projectile/projectile = cartridge.loaded_projectile
+	set_chameleon_projectile(projectile)
 
 /**
  * Description: Sets the current projectile variables for our chameleon gun.
- * Arguments: [obj/projectile/cham_projectile (the projectile we're trying to copy)]
+ * Arguments: [obj/projectile/template_projectile (the projectile we're trying to copy)]
  */
-/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_projectile(obj/projectile/cham_projectile)
-	if(!istype(cham_projectile))
-		stack_trace("[cham_projectile] is not a valid typepath.")
+/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_projectile(obj/projectile/template_projectile)
+	if(!istype(template_projectile))
+		stack_trace("[template_projectile] is not a valid typepath.")
 		return FALSE
 
 	chameleon_projectile_vars = list("name" = "practice laser", "icon" = 'icons/obj/guns/projectiles.dmi', "icon_state" = "laser")
 
-	var/default_state = isnull(cham_projectile.icon_state) ? "laser" : cham_projectile.icon_state
+	var/default_state = isnull(template_projectile.icon_state) ? "laser" : template_projectile.icon_state
 
-	chameleon_projectile_vars["name"] = cham_projectile.name
-	chameleon_projectile_vars["icon"] = cham_projectile.icon
+	chameleon_projectile_vars["name"] = template_projectile.name
+	chameleon_projectile_vars["icon"] = template_projectile.icon
 	chameleon_projectile_vars["icon_state"] = default_state
-	chameleon_projectile_vars["speed"] = cham_projectile.speed
-	chameleon_projectile_vars["color"] = cham_projectile.color
-	chameleon_projectile_vars["hitsound"] = cham_projectile.hitsound
-	chameleon_projectile_vars["impact_effect_type"] = cham_projectile.impact_effect_type
-	chameleon_projectile_vars["range"] = cham_projectile.range
-	chameleon_projectile_vars["suppressed"] = cham_projectile.suppressed
-	chameleon_projectile_vars["hitsound_wall"] = cham_projectile.hitsound_wall
-	chameleon_projectile_vars["pass_flags"] = cham_projectile.pass_flags
+	chameleon_projectile_vars["speed"] = template_projectile.speed
+	chameleon_projectile_vars["color"] = template_projectile.color
+	chameleon_projectile_vars["hitsound"] = template_projectile.hitsound
+	chameleon_projectile_vars["impact_effect_type"] = template_projectile.impact_effect_type
+	chameleon_projectile_vars["range"] = template_projectile.range
+	chameleon_projectile_vars["suppressed"] = template_projectile.suppressed
+	chameleon_projectile_vars["hitsound_wall"] = template_projectile.hitsound_wall
+	chameleon_projectile_vars["pass_flags"] = template_projectile.pass_flags
 
 	if(istype(chambered, /obj/item/ammo_casing/energy/chameleon))
 		var/obj/item/ammo_casing/energy/chameleon/cartridge = chambered
 
-		cartridge.loaded_projectile.name = cham_projectile.name
-		cartridge.loaded_projectile.icon = cham_projectile.icon
+		cartridge.loaded_projectile.name = template_projectile.name
+		cartridge.loaded_projectile.icon = template_projectile.icon
 		cartridge.loaded_projectile.icon_state = default_state
-		cartridge.loaded_projectile.speed = cham_projectile.speed
-		cartridge.loaded_projectile.color = cham_projectile.color
-		cartridge.loaded_projectile.hitsound = cham_projectile.hitsound
-		cartridge.loaded_projectile.impact_effect_type = cham_projectile.impact_effect_type
-		cartridge.loaded_projectile.range = cham_projectile.range
-		cartridge.loaded_projectile.suppressed = cham_projectile.suppressed
-		cartridge.loaded_projectile.hitsound_wall =	cham_projectile.hitsound_wall
-		cartridge.loaded_projectile.pass_flags = cham_projectile.pass_flags
+		cartridge.loaded_projectile.speed = template_projectile.speed
+		cartridge.loaded_projectile.color = template_projectile.color
+		cartridge.loaded_projectile.hitsound = template_projectile.hitsound
+		cartridge.loaded_projectile.impact_effect_type = template_projectile.impact_effect_type
+		cartridge.loaded_projectile.range = template_projectile.range
+		cartridge.loaded_projectile.suppressed = template_projectile.suppressed
+		cartridge.loaded_projectile.hitsound_wall =	template_projectile.hitsound_wall
+		cartridge.loaded_projectile.pass_flags = template_projectile.pass_flags
 
 		cartridge.projectile_vars = chameleon_projectile_vars.Copy()
 
 	if(real_hits)
 		qdel(chambered.loaded_projectile)
-		chambered.projectile_type = cham_projectile.type
+		chambered.projectile_type = template_projectile.type
 
-	qdel(cham_projectile)
+	qdel(template_projectile)
 
 
 /**

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -204,7 +204,7 @@
 /datum/action/item_action/chameleon/change/proc/update_look(mob/user, obj/item/picked_item)
 	if(istype(target, /obj/item/gun/energy/laser/chameleon))
 		var/obj/item/gun/energy/laser/chameleon/chameleon_gun = target
-		chameleon_gun.get_chameleon_projectile(picked_item)
+		chameleon_gun.set_chameleon_disguise(picked_item)
 	if(isliving(user))
 		var/mob/living/C = user
 		if(C.stat != CONSCIOUS)
@@ -787,7 +787,7 @@
 	chameleon_action.initialize_disguises()
 
 	recharge_newshot()
-	get_chameleon_projectile(/obj/item/gun/energy/laser)
+	set_chameleon_disguise(/obj/item/gun/energy/laser)
 
 /obj/item/gun/energy/laser/chameleon/Destroy()
 	. = ..()
@@ -821,7 +821,7 @@
  */
 /obj/item/gun/energy/laser/chameleon/proc/set_chameleon_gun(obj/item/gun/gun_to_set)
 	if(!istype(gun_to_set))
-		stack_trace("[gun_to_set] is not a valid typepath.")
+		stack_trace("[gun_to_set] is not a valid gun.")
 		return FALSE
 
 	fire_sound = gun_to_set.fire_sound
@@ -879,7 +879,7 @@
  */
 /obj/item/gun/energy/laser/chameleon/proc/set_chameleon_projectile(obj/projectile/template_projectile)
 	if(!istype(template_projectile))
-		stack_trace("[template_projectile] is not a valid typepath.")
+		stack_trace("[template_projectile] is not a valid projectile.")
 		return FALSE
 
 	chameleon_projectile_vars = list("name" = "practice laser", "icon" = 'icons/obj/guns/projectiles.dmi', "icon_state" = "laser")
@@ -926,7 +926,7 @@
  * Description: Resets our chameleon variables, then resets the entire gun to mimic the given guntype.
  * Arguments: [guntype (the gun we're copying, pathtyped to obj/item/gun)]
  */
-/obj/item/gun/energy/laser/chameleon/proc/get_chameleon_projectile(guntype)
+/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_disguise(guntype)
 	reset_chameleon_vars()
 	var/obj/item/gun/new_gun = new guntype(src)
 	set_chameleon_gun(new_gun)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -203,8 +203,8 @@
 
 /datum/action/item_action/chameleon/change/proc/update_look(mob/user, obj/item/picked_item)
 	if(istype(target, /obj/item/gun/energy/laser/chameleon))
-		var/obj/item/gun/energy/laser/chameleon/cham_gun = target
-		cham_gun.get_chameleon_projectile(picked_item)
+		var/obj/item/gun/energy/laser/chameleon/chameleon_gun = target
+		chameleon_gun.get_chameleon_projectile(picked_item)
 	if(isliving(user))
 		var/mob/living/C = user
 		if(C.stat != CONSCIOUS)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -783,7 +783,7 @@
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/gun
 	chameleon_action.chameleon_name = "Gun"
-	chameleon_action.chameleon_blacklist = typesof(/obj/item/gun/magic, /obj/item/gun/energy/minigun)
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/gun/energy/minigun)
 	chameleon_action.initialize_disguises()
 
 	recharge_newshot()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -789,6 +789,10 @@
 	recharge_newshot()
 	get_chameleon_projectile(/obj/item/gun/energy/laser)
 
+/obj/item/gun/energy/laser/chameleon/Destroy()
+	. = ..()
+	chameleon_projectile_vars.Cut()
+
 /obj/item/gun/energy/laser/chameleon/emp_act(severity)
 	return
 
@@ -815,7 +819,7 @@
  * Description: Sets what gun we should be mimicking.
  * Arguments: [obj/item/gun/gun_to_set (the gun we're trying to mimic), passthrough (whether or not we're setting ammo too)]
  */
-/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_gun(obj/item/gun/gun_to_set, passthrough = TRUE)
+/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_gun(obj/item/gun/gun_to_set)
 	if(!istype(gun_to_set))
 		stack_trace("[gun_to_set] is not a valid typepath.")
 		return FALSE
@@ -826,46 +830,44 @@
 	inhand_x_dimension = gun_to_set.inhand_x_dimension
 	inhand_y_dimension = gun_to_set.inhand_y_dimension
 
-	if(passthrough)
-		if(istype(gun_to_set, /obj/item/gun/ballistic))
-			var/obj/item/gun/ballistic/ball_gun = gun_to_set
-			var/obj/item/ammo_box/ball_ammo = new ball_gun.mag_type(gun_to_set)
-			qdel(ball_gun)
+	if(istype(gun_to_set, /obj/item/gun/ballistic))
+		var/obj/item/gun/ballistic/ball_gun = gun_to_set
+		var/obj/item/ammo_box/ball_ammo = new ball_gun.mag_type(gun_to_set)
+		qdel(ball_gun)
 
-			if(!istype(ball_ammo) || !ball_ammo.ammo_type)
-				qdel(ball_ammo)
-				return FALSE
+		if(!istype(ball_ammo) || !ball_ammo.ammo_type)
+			qdel(ball_ammo)
+			return FALSE
 
-			var/obj/item/ammo_casing/ball_cartridge = new ball_ammo.ammo_type(gun_to_set)
-			set_chameleon_ammo(ball_cartridge)
+		var/obj/item/ammo_casing/ball_cartridge = new ball_ammo.ammo_type(gun_to_set)
+		set_chameleon_ammo(ball_cartridge)
 
-		else if(istype(gun_to_set, /obj/item/gun/magic))
-			var/obj/item/gun/magic/magic_gun = gun_to_set
-			var/obj/item/ammo_casing/magic_cartridge = new magic_gun.ammo_type(gun_to_set)
-			set_chameleon_ammo(magic_cartridge)
+	else if(istype(gun_to_set, /obj/item/gun/magic))
+		var/obj/item/gun/magic/magic_gun = gun_to_set
+		var/obj/item/ammo_casing/magic_cartridge = new magic_gun.ammo_type(gun_to_set)
+		set_chameleon_ammo(magic_cartridge)
 
-		else if(istype(gun_to_set, /obj/item/gun/energy))
-			var/obj/item/gun/energy/energy_gun = gun_to_set
-			if(islist(energy_gun.ammo_type) && energy_gun.ammo_type.len)
-				var/obj/item/ammo_casing/energy_cartridge = energy_gun.ammo_type[1]
-				set_chameleon_ammo(energy_cartridge)
+	else if(istype(gun_to_set, /obj/item/gun/energy))
+		var/obj/item/gun/energy/energy_gun = gun_to_set
+		if(islist(energy_gun.ammo_type) && energy_gun.ammo_type.len)
+			var/obj/item/ammo_casing/energy_cartridge = energy_gun.ammo_type[1]
+			set_chameleon_ammo(energy_cartridge)
 
-		else if(istype(gun_to_set, /obj/item/gun/syringe))
-			var/obj/item/ammo_casing/syringe_cartridge = new /obj/item/ammo_casing/syringegun(src)
-			set_chameleon_ammo(syringe_cartridge)
+	else if(istype(gun_to_set, /obj/item/gun/syringe))
+		var/obj/item/ammo_casing/syringe_cartridge = new /obj/item/ammo_casing/syringegun(src)
+		set_chameleon_ammo(syringe_cartridge)
 
 /**
  * Description: Sets the ammo type our gun should have.
  * Arguments: [obj/item/ammo_casing/cartridge (the ammo_casing we're trying to copy), passthrough (whether or not we're the loaded projectile too)]
  */
-/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_ammo(obj/item/ammo_casing/cartridge, passthrough = TRUE)
+/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_ammo(obj/item/ammo_casing/cartridge)
 	if(!istype(cartridge))
 		stack_trace("[cartridge] is not a valid typepath.")
 		return FALSE
 
-	if(passthrough)
-		var/obj/projectile/proj = cartridge.loaded_projectile
-		set_chameleon_projectile(proj)
+	var/obj/projectile/proj = cartridge.loaded_projectile
+	set_chameleon_projectile(proj)
 
 /**
  * Description: Sets the current projectile variables for our chameleon gun.

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -782,7 +782,7 @@
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/gun
-	chameleon_action.chameleon_name = "Gun"
+	chameleon_action.chameleon_name = "gun"
 	chameleon_action.chameleon_blacklist = typesof(/obj/item/gun/magic, /obj/item/gun/energy/minigun)
 	chameleon_action.initialize_disguises()
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -857,6 +857,10 @@
 		var/obj/item/ammo_casing/syringe_cartridge = new /obj/item/ammo_casing/syringegun(src)
 		set_chameleon_ammo(syringe_cartridge)
 
+	else
+		var/obj/item/ammo_casing/default_cartridge = new /obj/item/ammo_casing(src)
+		set_chameleon_ammo(default_cartridge)
+
 /**
  * Description: Sets the ammo type our gun should have.
  * Arguments: [obj/item/ammo_casing/cartridge (the ammo_casing we're trying to copy), passthrough (whether or not we're the loaded projectile too)]

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -796,7 +796,7 @@
 
 /**
  * Description: Resets the currently loaded chameleon variables, essentially resetting it to brand new.
- * Arguements: []
+ * Arguments: []
  */
 /obj/item/gun/energy/laser/chameleon/proc/reset_chameleon_vars()
 	chameleon_projectile_vars = list()
@@ -815,7 +815,7 @@
 
 /**
  * Description: Sets what gun we should be mimicking.
- * Arguements: [obj/item/gun/gun_to_set (the gun we're trying to mimic), passthrough (whether or not we're setting ammo too)]
+ * Arguments: [obj/item/gun/gun_to_set (the gun we're trying to mimic), passthrough (whether or not we're setting ammo too)]
  */
 /obj/item/gun/energy/laser/chameleon/proc/set_chameleon_gun(obj/item/gun/gun_to_set, passthrough = TRUE)
 	if(!istype(gun_to_set))
@@ -858,7 +858,7 @@
 
 /**
  * Description: Sets the ammo type our gun should have.
- * Arguements: [obj/item/ammo_casing/cartridge (the ammo_casing we're trying to copy), passthrough (whether or not we're the loaded projectile too)]
+ * Arguments: [obj/item/ammo_casing/cartridge (the ammo_casing we're trying to copy), passthrough (whether or not we're the loaded projectile too)]
  */
 /obj/item/gun/energy/laser/chameleon/proc/set_chameleon_ammo(obj/item/ammo_casing/cartridge, passthrough = TRUE)
 	if(!istype(cartridge))
@@ -871,7 +871,7 @@
 
 /**
  * Description: Sets the current projectile variables for our chameleon gun.
- * Arguements: [obj/projectile/cham_projectile (the projectile we're trying to copy)]
+ * Arguments: [obj/projectile/cham_projectile (the projectile we're trying to copy)]
  */
 /obj/item/gun/energy/laser/chameleon/proc/set_chameleon_projectile(obj/projectile/cham_projectile)
 	if(!istype(cham_projectile))
@@ -920,7 +920,7 @@
 
 /**
  * Description: Resets our chameleon variables, then resets the entire gun to mimic the given guntype.
- * Arguements: [guntype (the gun we're copying, pathtyped to obj/item/gun)]
+ * Arguments: [guntype (the gun we're copying, pathtyped to obj/item/gun)]
  */
 /obj/item/gun/energy/laser/chameleon/proc/get_chameleon_projectile(guntype)
 	reset_chameleon_vars()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -884,7 +884,7 @@
 
 	chameleon_projectile_vars = list("name" = "practice laser", "icon" = 'icons/obj/guns/projectiles.dmi', "icon_state" = "laser")
 
-	var/default_state = !isnull(cham_projectile.icon_state) ? cham_projectile.icon_state : "laser"
+	var/default_state = isnull(cham_projectile.icon_state) ? "laser" : cham_projectile.icon_state
 
 	chameleon_projectile_vars["name"] = cham_projectile.name
 	chameleon_projectile_vars["icon"] = cham_projectile.icon

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -817,7 +817,7 @@
 
 /**
  * Description: Sets what gun we should be mimicking.
- * Arguments: [obj/item/gun/gun_to_set (the gun we're trying to mimic), passthrough (whether or not we're setting ammo too)]
+ * Arguments: [obj/item/gun/gun_to_set (the gun we're trying to mimic)]
  */
 /obj/item/gun/energy/laser/chameleon/proc/set_chameleon_gun(obj/item/gun/gun_to_set)
 	if(!istype(gun_to_set))
@@ -863,7 +863,7 @@
 
 /**
  * Description: Sets the ammo type our gun should have.
- * Arguments: [obj/item/ammo_casing/cartridge (the ammo_casing we're trying to copy), passthrough (whether or not we're the loaded projectile too)]
+ * Arguments: [obj/item/ammo_casing/cartridge (the ammo_casing we're trying to copy)]
  */
 /obj/item/gun/energy/laser/chameleon/proc/set_chameleon_ammo(obj/item/ammo_casing/cartridge)
 	if(!istype(cartridge))

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -778,16 +778,14 @@
 	/// The badmin mode. Makes your projectiles act like the real deal.
 	var/real_hits
 
-/obj/item/gun/energy/laser/chameleon/New()
-	..()
+/obj/item/gun/energy/laser/chameleon/Initialize()
+	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/gun
 	chameleon_action.chameleon_name = "Gun"
 	chameleon_action.chameleon_blacklist = typesof(/obj/item/gun/magic, /obj/item/gun/energy/minigun)
 	chameleon_action.initialize_disguises()
 
-/obj/item/gun/energy/laser/chameleon/Initialize(mapload)
-	. = ..()
 	recharge_newshot()
 	get_chameleon_projectile(/obj/item/gun/energy/laser)
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -867,7 +867,7 @@
  */
 /obj/item/gun/energy/laser/chameleon/proc/set_chameleon_ammo(obj/item/ammo_casing/cartridge)
 	if(!istype(cartridge))
-		stack_trace("[cartridge] is not a valid typepath.")
+		stack_trace("[cartridge] is not a valid ammo casing.")
 		return FALSE
 
 	var/obj/projectile/proj = cartridge.loaded_projectile

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -32,15 +32,25 @@
 /obj/item/ammo_casing/energy/chameleon
 	projectile_type = /obj/projectile/energy/chameleon
 	e_cost = 0
-	var/list/projectile_vars = list()
+	var/projectile_vars = list()
 
 /obj/item/ammo_casing/energy/chameleon/ready_proj()
 	. = ..()
+
+	loaded_projectile.name = projectile_vars["name"]
+	loaded_projectile.icon = projectile_vars["icon"]
+	loaded_projectile.icon_state = projectile_vars["icon_state"]
+	loaded_projectile.speed = projectile_vars["speed"]
+	loaded_projectile.color = projectile_vars["color"]
+	loaded_projectile.hitsound = projectile_vars["hitsound"]
+	loaded_projectile.impact_effect_type = projectile_vars["impact_effect_type"]
+	loaded_projectile.range = projectile_vars["range"]
+	loaded_projectile.suppressed = projectile_vars["suppressed"]
+	loaded_projectile.hitsound_wall =	projectile_vars["hitsound_wall"]
+	loaded_projectile.pass_flags = projectile_vars["pass_flags"]
+
 	if(!loaded_projectile)
 		newshot()
-	for(var/cham_variable in projectile_vars)
-		if(loaded_projectile.vars.Find(cham_variable))
-			loaded_projectile.vars[cham_variable] = projectile_vars[cham_variable] // Here, we're basically checking for any chameleon variables about the ammo passed, then setting them here.
 
 /obj/item/ammo_casing/energy/laser/scatter
 	projectile_type = /obj/projectile/beam/scatter

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -29,6 +29,19 @@
 	select_name = "practice"
 	harmful = FALSE
 
+/obj/item/ammo_casing/energy/chameleon
+	projectile_type = /obj/projectile/energy/chameleon
+	e_cost = 0
+	var/list/projectile_vars = list()
+
+/obj/item/ammo_casing/energy/chameleon/ready_proj()
+	. = ..()
+	if(!loaded_projectile)
+		newshot()
+	for(var/cham_variable in projectile_vars)
+		if(loaded_projectile.vars.Find(cham_variable))
+			loaded_projectile.vars[cham_variable] = projectile_vars[cham_variable] // Here, we're basically checking for any chameleon variables about the ammo passed, then setting them here.
+
 /obj/item/ammo_casing/energy/laser/scatter
 	projectile_type = /obj/projectile/beam/scatter
 	pellets = 5

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -39,7 +39,7 @@
 	name = "antique laser gun"
 	icon_state = "caplaser"
 	w_class = WEIGHT_CLASS_NORMAL
-	inhand_icon_state = "laser"
+	inhand_icon_state = null
 	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding."
 	force = 10
 	ammo_x_offset = 3
@@ -87,7 +87,7 @@
 	desc = "An advanced laser cannon that does more damage the farther away the target is."
 	icon_state = "lasercannon"
 	inhand_icon_state = "laser"
-	worn_icon_state = "laser"
+	worn_icon_state = null
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
 	flags_1 = CONDUCT_1
@@ -119,7 +119,7 @@
 	desc = "A high-power laser gun capable of expelling concentrated X-ray blasts that pass through multiple soft targets and heavier materials."
 	icon_state = "xray"
 	w_class = WEIGHT_CLASS_BULKY
-	inhand_icon_state = "laser"
+	inhand_icon_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/xray)
 	ammo_x_offset = 3
 
@@ -159,7 +159,7 @@
 	name = "nanite pistol"
 	desc = "A modified handcannon with a self-replicating reserve of decommissioned weaponized nanites. Spit globs of angry robots into the bad guys."
 	icon_state = "infernopistol"
-	inhand_icon_state = "laser"
+	inhand_icon_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/nanite)
 	shaded_charge = TRUE
 	ammo_x_offset = 1

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -39,7 +39,7 @@
 	name = "antique laser gun"
 	icon_state = "caplaser"
 	w_class = WEIGHT_CLASS_NORMAL
-	inhand_icon_state = null
+	inhand_icon_state = "laser"
 	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding."
 	force = 10
 	ammo_x_offset = 3
@@ -87,7 +87,7 @@
 	desc = "An advanced laser cannon that does more damage the farther away the target is."
 	icon_state = "lasercannon"
 	inhand_icon_state = "laser"
-	worn_icon_state = null
+	worn_icon_state = "laser"
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
 	flags_1 = CONDUCT_1
@@ -119,7 +119,7 @@
 	desc = "A high-power laser gun capable of expelling concentrated X-ray blasts that pass through multiple soft targets and heavier materials."
 	icon_state = "xray"
 	w_class = WEIGHT_CLASS_BULKY
-	inhand_icon_state = null
+	inhand_icon_state = "laser"
 	ammo_type = list(/obj/item/ammo_casing/energy/xray)
 	ammo_x_offset = 3
 
@@ -159,7 +159,7 @@
 	name = "nanite pistol"
 	desc = "A modified handcannon with a self-replicating reserve of decommissioned weaponized nanites. Spit globs of angry robots into the bad guys."
 	icon_state = "infernopistol"
-	inhand_icon_state = null
+	inhand_icon_state = "laser"
 	ammo_type = list(/obj/item/ammo_casing/energy/nanite)
 	shaded_charge = TRUE
 	ammo_x_offset = 1

--- a/code/modules/projectiles/projectile/energy/chameleon.dm
+++ b/code/modules/projectiles/projectile/energy/chameleon.dm
@@ -1,0 +1,2 @@
+/obj/projectile/energy/chameleon
+	nodamage = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3828,6 +3828,7 @@
 #include "code\modules\projectiles\projectile\bullets\sniper.dm"
 #include "code\modules\projectiles\projectile\bullets\special.dm"
 #include "code\modules\projectiles\projectile\energy\_energy.dm"
+#include "code\modules\projectiles\projectile\energy\chameleon.dm"
 #include "code\modules\projectiles\projectile\energy\decloner.dm"
 #include "code\modules\projectiles\projectile\energy\ebow.dm"
 #include "code\modules\projectiles\projectile\energy\net_snare.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

readds the chameleon gun way back from good ol' 2018. testing proved that the gun no longer crashes the server when spamming types and shooting over and over. comes with all the features you know and love:

- select any gun from the game
- all guns correspond to their respective ammo types
- (almost) indistinguishable to the average assistant!
- badmins have access to `real_hit` mode, which makes all the projectiles act realistically!

## Why It's Good For The Game

chameleon guns were super awesome and quite frankly a globally missed feature, just needed some love and nurturing (and porting)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Back by popular demand, the Syndicate has re-included their state-of-the-art Chameleon Gun into their chameleon kits, capable of disguising itself as any gun known to man-kind! Lethal rounds not included.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
