### PR TITLE
Reworks the BZ reaction slightly

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -139,8 +139,8 @@
 // BZ:
 /// The maximum temperature BZ can form at. Deliberately set lower than the minimum burn temperature for most combustible gases in an attempt to prevent long fuse singlecaps.
 #define BZ_FORMATION_MAX_TEMPERATURE (FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 60) // Yes, someone used this as a bomb timer. I hate players.
-/// The amount of energy ~2.5 moles of BZ forming from N2O and plasma releases.
-#define BZ_FORMATION_ENERGY FIRE_CARBON_ENERGY_RELEASED
+/// The amount of energy 1 mole of BZ forming from N2O and plasma releases.
+#define BZ_FORMATION_ENERGY 40000
 
 // Pluoxium:
 /// The minimum temperature pluoxium can form from carbon dioxide, oxygen, and tritium at.

--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -140,7 +140,7 @@
 /// The maximum temperature BZ can form at. Deliberately set lower than the minimum burn temperature for most combustible gases in an attempt to prevent long fuse singlecaps.
 #define BZ_FORMATION_MAX_TEMPERATURE (FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 60) // Yes, someone used this as a bomb timer. I hate players.
 /// The amount of energy 1 mole of BZ forming from N2O and plasma releases.
-#define BZ_FORMATION_ENERGY 40000
+#define BZ_FORMATION_ENERGY 80000
 
 // Pluoxium:
 /// The minimum temperature pluoxium can form from carbon dioxide, oxygen, and tritium at.

--- a/code/modules/atmospherics/gasmixtures/reaction_factors.dm
+++ b/code/modules/atmospherics/gasmixtures/reaction_factors.dm
@@ -75,12 +75,10 @@
 
 /datum/gas_reaction/bzformation/init_factors()
 	factor = list(
-		/datum/gas/plasma = "Plasma is consumed at 2 reaction rate. If there is more plasma than nitrous oxide reaction rate is slowed down.",
-		/datum/gas/nitrous_oxide = "Nitrous oxide is consumed at 1 reaction rate. If there is less nitrous oxide than plasma the reaction rate is slowed down.",
-		/datum/gas/bz = "BZ is formed at 2.5 reaction rate. A small malus up to half a mole per tick is applied if the reaction rate is constricted by nitrous oxide.",
-		/datum/gas/oxygen = "Oxygen is produced from the BZ malus. This only happens when the reaction rate is being constricted by the amount of nitrous oxide present. I.E. amount of nitrous oxide is less than the reaction rate.", // Less than the reaction rate AND half the plasma, but suppose that's not necessary to mention.
-		"Pressure" = "The lower the pressure the faster the reaction rate goes.",
-		"Energy" = "[FIRE_CARBON_ENERGY_RELEASED] joules of energy is released per reaction rate",
+		/datum/gas/plasma = "Each mole of BZ made consumes 0.8 moles of plasma. If there is more plasma than nitrous oxide reaction rate is slowed down.",
+		/datum/gas/nitrous_oxide = "Each mole of bz made consumes 0.4 moles of Nitrous oxide. If there is less nitrous oxide than plasma the reaction rate is slowed down.",
+		/datum/gas/bz = "The lower the pressure and larger the volume the more bz gets made. Less nitrous oxide than plasma will slow down the reaction.",
+		"Energy" = "[BZ_FORMATION_ENERGY] joules of energy is released per mol of BZ made",
 	)
 
 /datum/gas_reaction/pluox_formation/init_factors()

--- a/code/modules/atmospherics/gasmixtures/reaction_factors.dm
+++ b/code/modules/atmospherics/gasmixtures/reaction_factors.dm
@@ -76,9 +76,11 @@
 /datum/gas_reaction/bzformation/init_factors()
 	factor = list(
 		/datum/gas/plasma = "Each mole of BZ made consumes 0.8 moles of plasma. If there is more plasma than nitrous oxide reaction rate is slowed down.",
-		/datum/gas/nitrous_oxide = "Each mole of bz made consumes 0.4 moles of Nitrous oxide. If there is less nitrous oxide than plasma the reaction rate is slowed down.",
+		/datum/gas/nitrous_oxide = "Each mole of bz made consumes 0.4 moles of Nitrous oxide. If there is less nitrous oxide than plasma the reaction rate is slowed down. At three times the amount of plasma to Nitrous oxide it will start breaking down into Nitrogen and Oxygen, the lower the ratio the more Nitrous oxide decomposes.
 		/datum/gas/bz = "The lower the pressure and larger the volume the more bz gets made. Less nitrous oxide than plasma will slow down the reaction.",
-		"Energy" = "[BZ_FORMATION_ENERGY] joules of energy is released per mol of BZ made",
+		/datum/gas/nitrogen = "Each mole Nitrous oxide decomposed makes 1 mol Nitrogen. Lower ratio of Nitrous oxide to Plasma means a higher ratio of decomposition to BZ production."
+		/datum/gas/oxygen = "Each mole Nitrous oxide decomposed makes 0.5 moles Oxygen. Lower ratio of Nitrous oxide to Plasma means a higher ratio of decomposition to BZ production."
+		"Energy" = "[BZ_FORMATION_ENERGY] joules of energy is released per mol of BZ made. Nitrous oxide decomposition releases [N2O_DECOMPOSITION_ENERGY] per mol decomposed",
 	)
 
 /datum/gas_reaction/pluox_formation/init_factors()

--- a/code/modules/atmospherics/gasmixtures/reaction_factors.dm
+++ b/code/modules/atmospherics/gasmixtures/reaction_factors.dm
@@ -76,10 +76,10 @@
 /datum/gas_reaction/bzformation/init_factors()
 	factor = list(
 		/datum/gas/plasma = "Each mole of BZ made consumes 0.8 moles of plasma. If there is more plasma than nitrous oxide reaction rate is slowed down.",
-		/datum/gas/nitrous_oxide = "Each mole of bz made consumes 0.4 moles of Nitrous oxide. If there is less nitrous oxide than plasma the reaction rate is slowed down. At three times the amount of plasma to Nitrous oxide it will start breaking down into Nitrogen and Oxygen, the lower the ratio the more Nitrous oxide decomposes.
+		/datum/gas/nitrous_oxide = "Each mole of bz made consumes 0.4 moles of Nitrous oxide. If there is less nitrous oxide than plasma the reaction rate is slowed down. At three times the amount of plasma to Nitrous oxide it will start breaking down into Nitrogen and Oxygen, the lower the ratio the more Nitrous oxide decomposes.",
 		/datum/gas/bz = "The lower the pressure and larger the volume the more bz gets made. Less nitrous oxide than plasma will slow down the reaction.",
-		/datum/gas/nitrogen = "Each mole Nitrous oxide decomposed makes 1 mol Nitrogen. Lower ratio of Nitrous oxide to Plasma means a higher ratio of decomposition to BZ production."
-		/datum/gas/oxygen = "Each mole Nitrous oxide decomposed makes 0.5 moles Oxygen. Lower ratio of Nitrous oxide to Plasma means a higher ratio of decomposition to BZ production."
+		/datum/gas/nitrogen = "Each mole Nitrous oxide decomposed makes 1 mol Nitrogen. Lower ratio of Nitrous oxide to Plasma means a higher ratio of decomposition to BZ production.",
+		/datum/gas/oxygen = "Each mole Nitrous oxide decomposed makes 0.5 moles Oxygen. Lower ratio of Nitrous oxide to Plasma means a higher ratio of decomposition to BZ production.",
 		"Energy" = "[BZ_FORMATION_ENERGY] joules of energy is released per mol of BZ made. Nitrous oxide decomposition releases [N2O_DECOMPOSITION_ENERGY] per mol decomposed",
 	)
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -557,7 +557,7 @@
 	var/ratio_efficency = min(cached_gases[/datum/gas/nitrous_oxide][MOLES]/cached_gases[/datum/gas/plasma][MOLES], 1)
 	var/bz_formed = min(0.01 * ratio_efficency * environment_effciency, cached_gases[/datum/gas/nitrous_oxide][MOLES] * INVERSE(0.4), cached_gases[/datum/gas/plasma][MOLES] * INVERSE(0.8))
 
-	if (cached_gases[/datum/gas/nitrous_oxide][MOLES] - bz_formed*0.4 < 0  || cached_gases[/datum/gas/plasma][MOLES] - (0.8 * bz_formed) < 0 || bz_formed <= 0)
+	if (cached_gases[/datum/gas/nitrous_oxide][MOLES] - bz_formed * 0.4 < 0  || cached_gases[/datum/gas/plasma][MOLES] - (0.8 * bz_formed) < 0 || bz_formed <= 0)
 		return NO_REACTION
 
 	var/old_heat_capacity = air.heat_capacity()

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -572,7 +572,7 @@
 	if (nitrous_oxide_decomposed_factor>0)
 		ASSERT_GAS(/datum/gas/nitrogen, air)
 		ASSERT_GAS(/datum/gas/oxygen, air)
-		var/amount_decomposed = 0.4 * bzformed * nitrous_oxide_decomposed_factor
+		var/amount_decomposed = 0.4 * bz_formed * nitrous_oxide_decomposed_factor
 		cached_gases[/datum/gas/nitrogen] += amount_decomposed
 		cached_gases[/datum/gas/oxygen] += 0.5 * amount_decomposed
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -553,17 +553,17 @@
 	var/list/cached_gases = air.gases
 	var/pressure = air.return_pressure()
 	var/volume = air.return_volume()
-	var/pressure_effciency = 1/pressure
-	var/ratio_efficency = min(cached_gases[/datum/gas/nitrous_oxide][MOLES]/cached_gases[/datum/gas/plasma][MOLES],1)
-	var/bz_formed = min(pressure_effciency*ratio_efficency*volume/100, cached_gases[/datum/gas/nitrous_oxide][MOLES], cached_gases[/datum/gas/plasma][MOLES]*INVERSE(2))
+	var/environment_effciency = volume/pressure
+	var/ratio_efficency = min(cached_gases[/datum/gas/nitrous_oxide][MOLES]/cached_gases[/datum/gas/plasma][MOLES], 1)
+	var/bz_formed = min(0.01 * ratio_efficency * environment_effciency, cached_gases[/datum/gas/nitrous_oxide][MOLES] * INVERSE(0.4), cached_gases[/datum/gas/plasma][MOLES] * INVERSE(0.8))
 
-	if ((cached_gases[/datum/gas/nitrous_oxide][MOLES] - bz_formed < 0 )|| (cached_gases[/datum/gas/plasma][MOLES] - (2 * bz_formed) < 0) || bz_formed <= 0)
+	if (cached_gases[/datum/gas/nitrous_oxide][MOLES] - bz_formed < 0  || cached_gases[/datum/gas/plasma][MOLES] - (2 * bz_formed) < 0 || bz_formed <= 0)
 		return NO_REACTION
 
 	var/old_heat_capacity = air.heat_capacity()
 	ASSERT_GAS(/datum/gas/bz, air)
 	cached_gases[/datum/gas/bz][MOLES] += bz_formed
-	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= 0.4 bz_formed
+	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= 0.4 * bz_formed
 	cached_gases[/datum/gas/plasma][MOLES] -= 0.8 * bz_formed
 
 	SET_REACTION_RESULTS(bz_formed)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -557,7 +557,7 @@
 	var/ratio_efficency = min(cached_gases[/datum/gas/nitrous_oxide][MOLES]/cached_gases[/datum/gas/plasma][MOLES], 1)
 	var/bz_formed = min(0.01 * ratio_efficency * environment_effciency, cached_gases[/datum/gas/nitrous_oxide][MOLES] * INVERSE(0.4), cached_gases[/datum/gas/plasma][MOLES] * INVERSE(0.8))
 
-	if (cached_gases[/datum/gas/nitrous_oxide][MOLES] - bz_formed < 0  || cached_gases[/datum/gas/plasma][MOLES] - (2 * bz_formed) < 0 || bz_formed <= 0)
+	if (cached_gases[/datum/gas/nitrous_oxide][MOLES] - bz_formed*0.4 < 0  || cached_gases[/datum/gas/plasma][MOLES] - (0.8 * bz_formed) < 0 || bz_formed <= 0)
 		return NO_REACTION
 
 	var/old_heat_capacity = air.heat_capacity()

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -552,31 +552,22 @@
 /datum/gas_reaction/bzformation/react(datum/gas_mixture/air)
 	var/list/cached_gases = air.gases
 	var/pressure = air.return_pressure()
-	// This slows down in relation to pressure, very quickly. Please don't expect it to be anything more then a snail
+	var/volume = air.return_volume()
+	var/pressure_effciency = 1/pressure
+	var/ratio_efficency = min(cached_gases[/datum/gas/nitrous_oxide][MOLES]/cached_gases[/datum/gas/plasma][MOLES],1)
+	var/bz_formed = min(pressure_effciency*ratio_efficency*volume/100, cached_gases[/datum/gas/nitrous_oxide][MOLES], cached_gases[/datum/gas/plasma][MOLES]*INVERSE(2))
 
-	// Bigger is better for these two values.
-	var/pressure_efficiency = (0.1 * ONE_ATMOSPHERE) / pressure // More pressure = more bad
-	var/ratio_efficiency = min(cached_gases[/datum/gas/nitrous_oxide][MOLES] / cached_gases[/datum/gas/plasma][MOLES], 1) // Malus to production if more plasma than n2o.
-
-	var/reaction_efficency = min(pressure_efficiency * ratio_efficiency, cached_gases[/datum/gas/nitrous_oxide][MOLES], cached_gases[/datum/gas/plasma][MOLES] * INVERSE(2))
-
-	if ((cached_gases[/datum/gas/nitrous_oxide][MOLES] - reaction_efficency < 0 )|| (cached_gases[/datum/gas/plasma][MOLES] - (2 * reaction_efficency) < 0) || reaction_efficency <= 0) //Shouldn't produce gas from nothing.
+	if ((cached_gases[/datum/gas/nitrous_oxide][MOLES] - bz_formed < 0 )|| (cached_gases[/datum/gas/plasma][MOLES] - (2 * bz_formed) < 0) || bz_formed <= 0)
 		return NO_REACTION
 
 	var/old_heat_capacity = air.heat_capacity()
 	ASSERT_GAS(/datum/gas/bz, air)
-	if (reaction_efficency == cached_gases[/datum/gas/nitrous_oxide][MOLES])
-		ASSERT_GAS(/datum/gas/oxygen, air)
-		cached_gases[/datum/gas/bz][MOLES] += (reaction_efficency * 2.5) - min(pressure, 0.5)
-		cached_gases[/datum/gas/oxygen][MOLES] += min(pressure, 0.5)
-	else
-		cached_gases[/datum/gas/bz][MOLES] += reaction_efficency * 2.5
+	cached_gases[/datum/gas/bz][MOLES] += bz_formed
+	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= 0.4 bz_formed
+	cached_gases[/datum/gas/plasma][MOLES] -= 0.8 * bz_formed
 
-	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= reaction_efficency
-	cached_gases[/datum/gas/plasma][MOLES] -= 2 * reaction_efficency
-
-	SET_REACTION_RESULTS(reaction_efficency)
-	var/energy_released = 2 * reaction_efficency * FIRE_CARBON_ENERGY_RELEASED
+	SET_REACTION_RESULTS(bz_formed)
+	var/energy_released = bz_formed * BZ_FORMATION_ENERGY
 	var/new_heat_capacity = air.heat_capacity()
 	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
 		air.temperature = max(((air.temperature * old_heat_capacity + energy_released) / new_heat_capacity), TCMB)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -563,7 +563,7 @@
 	var/old_heat_capacity = air.heat_capacity()
 	ASSERT_GAS(/datum/gas/bz, air)
 	cached_gases[/datum/gas/bz][MOLES] += bz_formed
-	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= 0.4 bz_formed
+	cached_gases[/datum/gas/nitrous_oxide][MOLES] -= 0.4 * bz_formed
 	cached_gases[/datum/gas/plasma][MOLES] -= 0.8 * bz_formed
 
 	SET_REACTION_RESULTS(bz_formed)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -582,7 +582,7 @@
 	cached_gases[/datum/gas/plasma][MOLES] -= 0.8 * bz_formed * (1-nitrous_oxide_decomposed_factor)
 
 	SET_REACTION_RESULTS(bz_formed)
-	var/energy_released = bz_formed * (BZ_FORMATION_ENERGY + nitrous_oxide_decomposed_factor * (N2O_DECOMPOSITION_ENERGY-BZ_FORMATION_ENERGY))
+	var/energy_released = bz_formed * (BZ_FORMATION_ENERGY + nitrous_oxide_decomposed_factor * (N2O_DECOMPOSITION_ENERGY - BZ_FORMATION_ENERGY))
 	var/new_heat_capacity = air.heat_capacity()
 	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
 		air.temperature = max(((air.temperature * old_heat_capacity + energy_released) / new_heat_capacity), TCMB)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes BZ reaction rates between pipes and turfs consistent. Removes O2 production from the BZ reaction. Also fixes rate multiplication by splitting pipenets using valves or similar.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes BZ rates consistent and makes pipebased BZ setups actually produce gas in significant amounts. Makes multiplying reaction rates for BZ by splitting pipenets impossible. Simplifies the reaction by removing a largely unused, mostly unknown way of making o2.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: BZ production rates between pipes and turfs are now consistent. O2 production removed.
fix: Multiplying production rates by splitting pipenets no longer possible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
