### PR TITLE
Off-station lathes now have no lathe tax instead of forcing everyone who uses them to pay lathe tax, regardless of department

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -172,8 +172,9 @@
 		if(!reagents.has_reagent(R, D.reagents_list[R]*print_quantity/coeff))
 			say("Not enough reagents to complete prototype[print_quantity > 1? "s" : ""].")
 			return FALSE
-	var/total_cost = LATHE_TAX
+	var/total_cost = 0
 	if(is_station_level(z) && isliving(usr)) //We don't block purchases off station Z.
+		total_cost = LATHE_TAX
 		var/mob/living/user = usr
 		var/obj/item/card/id/card = user.get_idcard(TRUE)
 		if(!card && istype(user.pulling, /obj/item/card/id))
@@ -182,10 +183,10 @@
 			var/datum/bank_account/our_acc = card.registered_account
 			if(our_acc.account_job && SSeconomy.get_dep_account(our_acc.account_job?.paycheck_department) == SSeconomy.get_dep_account(payment_department))
 				total_cost = 0 //We are not charging crew for printing their own supplies and equipment.
-	if(attempt_charge(src, usr, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE)
+	if(attempt_charge(src, usr, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE) //note that, as of the time of the writing of this comment, attempt_charge() returns false if you're a silicon, so even if a silicon is dragging a card, they (currently) can't make the card pay the tax instead of their cell. they can still get the departmental discount, though.
 		return FALSE
 
-	if(iscyborg(usr))
+	if(iscyborg(usr) && total_cost) //don't charge borgs for items that are supposed to be taxless
 		var/mob/living/silicon/robot/borg = usr
 		if(!borg.cell)
 			return


### PR DESCRIPTION
## About The Pull Request

A bit of weird logic in a block of code for off-station lathe taxes seems to have caused the opposite effect of the stated intent of said block of code. Instead of making off-station lathes not charge any lathe tax, it instead makes off-station lathes force EVERYONE who uses them to pay lathe tax, even if their ID's department aligns with that of the lathe. This PR corrects that logic and makes lathe tax only apply to on-station lathes, as the code's comments say it does.

This PR also makes lathes only drain cyborg cells upon being used if they actually have a nonzero lathe tax. As a side effect of this, cyborgs, like all other living creatures, can now use the departmental lathe tax exemption by dragging an ID of the appropriate department.

Due to jank in the code for attempt_charge() (which directly checks for and returns early for silicon users), borgs still won't be able to pay lathe taxes will the credits of a dragged ID instead of the charge of their cell, but out of fear of breaking everything, I ain't touching attempt_charge() with a 10 foot pole. Someone else can get the GBP for that.

## Why It's Good For The Game

unfucks charlie station, probably

If this isn't a part of the design intent of lathe taxes, edit the comments to reflect that, please.

## Changelog

:cl: ATHATH
fix: Off-station protolathes now have no lathe tax instead of forcing everyone who uses them to pay lathe tax, regardless of department.
fix: Cyborg cells are no longer charged lathe tax for tax-less lathe uses.
fix: Cyborgs, like all other living creatures, can now get the departmental lathe tax exemption if they're dragging an ID of the appropriate department. Any nonzero lathe tax payments will still be made from their cell, not their dragged ID, though.
/:cl: