### PR TITLE
Adds a link to the Guide To Mapping in Maps_and_Away_Missions.md

### DIFF
--- a/.github/guides/MAPS_AND_AWAY_MISSIONS.md
+++ b/.github/guides/MAPS_AND_AWAY_MISSIONS.md
@@ -19,6 +19,8 @@ If you are hosting a server, and want randomly picked maps to be played each rou
 
 ## EDITING MAPS
 
+### [Click here for a Quick-Start Guide To Mapping.](https://hackmd.io/@tgstation/SyVma0dS5)
+
 <b>It is absolutely inadvisable to <i>ever</i> use the mapping utility offered by Dream Maker</b>. It is clunky and dated software that will steal your time, patience, and creative desires.
 
 Instead, /tg/station map maintainers will always recommend using one of two modern and actively maintained programs.


### PR DESCRIPTION
We already have a sort of excerpt section in here, but I'm throwing a link to the HackMD guide we now have in this guide that directly involves Maps and Away Missions to help new mapping contributors or people who simply want to get a jump on mapping stuff.