### PR TITLE
Fixes Drones being charged for using the Lathe on/off station.

### DIFF
--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -43,7 +43,7 @@
 	if(!ismob(target))
 		return COMPONENT_OBJ_CANCEL_CHARGE
 	var/mob/living/user = target
-	if(issilicon(user)) //They have evolved beyond the need for mere credits
+	if(issilicon(user) || isdrone(user)) //They have evolved beyond the need for mere credits
 		return
 	var/obj/item/card/id/card
 	if(istype(user))


### PR DESCRIPTION

## About The Pull Request

So, I made a quick mistake in the economy PR, I implemented an `issilicon` check for determining if a silicon is trying to print something from the lathe as an attempt to exempt soviet and on-station drones from facing a lathe tax. HOWEVER, drones don't have a silicon path! They have robot flags, but they have the path `/mob/living/simple_animal/drone`. Oops.

This adds an `isdrone` check onto the production component for the same reason that the `issilicon` check was added to the payment component.

## Why It's Good For The Game

Helps fix an aspect of the current lathe tax issue floating around post-merge.

## Changelog

:cl:
fix: Drones are exempt from the lathe tax, off and on station.
/:cl:
