### PR TITLE
Refactors the Charge wizard spell

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -118,12 +118,6 @@
 #define COMSIG_ITEM_PICKUP "item_pickup"
 ///from base of mob/living/carbon/attacked_by(): (mob/living/carbon/target, mob/living/user, hit_zone)
 #define COMSIG_ITEM_ATTACK_ZONE "item_attack_zone"
-///return a truthy value to prevent ensouling, checked in /obj/effect/proc_holder/spell/targeted/lichdom/cast(): (mob/user)
-#define COMSIG_ITEM_IMBUE_SOUL "item_imbue_soul"
-	#define COMPONENT_BLOCK_IMBUE (1 << 0)
-///called before marking an object for retrieval, checked in /obj/effect/proc_holder/spell/targeted/summonitem/cast() : (mob/user)
-#define COMSIG_ITEM_MARK_RETRIEVAL "item_mark_retrieval"
-	#define COMPONENT_BLOCK_MARK_RETRIEVAL (1<<0)
 ///from base of obj/item/hit_reaction(): (list/args)
 #define COMSIG_ITEM_HIT_REACT "item_hit_react"
 	#define COMPONENT_HIT_REACTION_BLOCK (1<<0)
@@ -306,6 +300,22 @@
 ///called from /obj/effect/proc_holder/spell/perform (src)
 #define COMSIG_MOB_CAST_SPELL "mob_cast_spell"
 
+/// Sent from /obj/effect/proc_holder/spell/targeted/lichdom/cast(), to the item being imbued: (mob/user)
+#define COMSIG_ITEM_IMBUE_SOUL "item_imbue_soul"
+	/// Returns to block this item from being imbued into a phylactery
+	#define COMPONENT_BLOCK_IMBUE (1 << 0)
+/// Sent from /obj/effect/proc_holder/spell/targeted/summonitem/cast(), to the item being marked : ()
+#define COMSIG_ITEM_MARK_RETRIEVAL "item_mark_retrieval"
+	/// Returns to block this item from being marked for instant summons
+	#define COMPONENT_BLOCK_MARK_RETRIEVAL (1<<0)
+
+/// Sent from /obj/effect/proc_holder/spell/targeted/charge/cast(), to the item in hand being charged: (obj/effect/proc_holder/spell/targeted/charge/spell, mob/living/caster)
+#define COMSIG_ITEM_MAGICALLY_CHARGED "item_magic_charged"
+	/// Returns if an item was successfuly recharged
+	#define COMPONENT_ITEM_CHARGED (1 << 0)
+	/// Returns if the item had a negative side effect occur while recharging
+	#define COMPONENT_ITEM_BURNT_OUT (1 << 1)
+
 // /obj/item/camera signals
 
 ///from /obj/item/camera/captureimage(): (atom/target, mob/user)
@@ -398,10 +408,3 @@
 /// from base of /obj/item/slimepotion/speed/afterattack(): (obj/target, /obj/src, mob/user)
 #define COMSIG_SPEED_POTION_APPLIED "speed_potion"
 	#define SPEED_POTION_STOP (1<<0)
-
-/// Sent from /obj/effect/proc_holder/spell/targeted/charge/cast(), to the item in hand being charged: (obj/effect/proc_holder/spell/targeted/charge/spell, mob/living/caster)
-#define COMSIG_ITEM_MAGICALLY_CHARGED "item_magic_charged"
-	/// Returns if an item was successfuly recharged
-	#define COMPONENT_ITEM_CHARGED (1 << 0)
-	/// Returns if the item had a negative side effect occur while recharging
-	#define COMPONENT_ITEM_BURNT_OUT (1 << 1)

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -399,3 +399,9 @@
 #define COMSIG_SPEED_POTION_APPLIED "speed_potion"
 	#define SPEED_POTION_STOP (1<<0)
 
+/// Sent from /obj/effect/proc_holder/spell/targeted/charge/cast(), to the item in hand being charged: (obj/effect/proc_holder/spell/targeted/charge/spell, mob/living/caster)
+#define COMSIG_ITEM_MAGICALLY_CHARGED "item_magic_charged"
+	/// Returns if an item was successfuly recharged
+	#define COMPONENT_ITEM_CHARGED (1 << 0)
+	/// Returns if the item had a negative side effect occur while recharging
+	#define COMPONENT_ITEM_BURNT_OUT (1 << 1)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -119,6 +119,35 @@
 	var/spell
 	var/spellname = "conjure bugs"
 
+
+/obj/item/book/granter/spell/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_ITEM_MAGICALLY_CHARGED, .proc/on_magic_charge)
+
+/**
+ * Signal proc for [COMSIG_ITEM_MAGICALLY_CHARGED]
+ *
+ * Refreshes uses on our spell granter, or make it quicker to read if it's already infinite use
+ */
+/obj/item/book/granter/spell/proc/on_magic_charge(datum/source, obj/effect/proc_holder/spell/targeted/charge/spell, mob/living/caster)
+	SIGNAL_HANDLER
+
+	if(!oneuse)
+		to_chat(caster, span_notice("This book is infinite use and can't be recharged, \
+			yet the magic has improved it somehow..."))
+		pages_to_mastery = max(pages_to_mastery - 1, 1)
+		return COMPONENT_ITEM_CHARGED|COMPONENT_ITEM_BURNT_OUT
+
+	if(prob(80))
+		caster.dropItemToGround(src, TRUE)
+		visible_message(span_warning("[src] catches fire and burns to ash!"))
+		new /obj/effect/decal/cleanable/ash(drop_location())
+		qdel(src)
+		return COMPONENT_ITEM_BURNT_OUT
+
+	used = FALSE
+	return COMPONENT_ITEM_CHARGED
+
 /obj/item/book/granter/spell/already_known(mob/user)
 	if(!spell)
 		return TRUE

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -668,6 +668,28 @@
 /obj/item/spellbook/Initialize(mapload)
 	. = ..()
 	prepare_spells()
+	RegisterSignal(src, COMSIG_ITEM_MAGICALLY_CHARGED, .proc/on_magic_charge)
+
+/**
+ * Signal proc for [COMSIG_ITEM_MAGICALLY_CHARGED]
+ *
+ * Has no effect on charge, but gives a funny message to people who think they're clever.
+ */
+/obj/item/spellbook/proc/on_magic_charge(datum/source, obj/effect/proc_holder/spell/targeted/charge/spell, mob/living/caster)
+	SIGNAL_HANDLER
+
+	var/static/list/clever_girl = list(
+		"NICE TRY BUT NO!",
+		"CLEVER BUT NOT CLEVER ENOUGH!",
+		"SUCH FLAGRANT CHEESING IS WHY WE ACCEPTED YOUR APPLICATION!",
+		"CUTE! VERY CUTE!",
+		"YOU DIDN'T THINK IT'D BE THAT EASY, DID YOU?",
+	)
+
+	to_chat(caster, span_warning("Glowing red letters appear on the front cover..."))
+	to_chat(caster, span_red(pick(clever_girl)))
+
+	return COMPONENT_ITEM_BURNT_OUT
 
 /obj/item/spellbook/attack_self(mob/user)
 	if(!owner)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -60,6 +60,49 @@
 		desc += " This one has a rating of [display_energy(maxcharge)][prob(10) ? ", and you should not swallow it" : ""]." //joke works better if it's not on every cell
 	update_appearance()
 
+	RegisterSignal(src, COMSIG_ITEM_MAGICALLY_CHARGED, .proc/on_magic_charge)
+	var/static/list/loc_connections = list(
+		COMSIG_ITEM_MAGICALLY_CHARGED = .proc/on_magic_charge,
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+
+/**
+ * Signal proc for [COMSIG_ITEM_MAGICALLY_CHARGED]
+ *
+ * If we, or the item we're located in, is subject to the charge spell, gain some charge back
+ */
+/obj/item/stock_parts/cell/proc/on_magic_charge(datum/source, obj/effect/proc_holder/spell/targeted/charge/spell, mob/living/caster)
+	SIGNAL_HANDLER
+
+	// This shouldn't be runnable if we're not being held by a mob,
+	// or if we're not within an objecting being held by a mob,
+	// but just in case.
+	if(!ismovable(loc))
+		return
+
+	. = COMPONENT_ITEM_CHARGED
+
+	if(prob(80))
+		maxcharge -= 200
+
+	if(maxcharge <= 1) // Div by 0 protection
+		maxcharge = 1
+		. |= COMPONENT_ITEM_BURNT_OUT
+
+	charge = maxcharge
+	update_appearance()
+
+	// Guns need to process their chamber when we've been charged
+	if(isgun(loc))
+		var/obj/item/gun/gun_loc = loc
+		gun_loc.process_chamber()
+
+	// The thing we're in might have overlays or icon states for whether the cell is charged
+	if(!ismob(loc))
+		loc.update_appearance()
+
+	return .
+
 /obj/item/stock_parts/cell/create_reagents(max_vol, flags)
 	. = ..()
 	RegisterSignal(reagents, list(COMSIG_REAGENTS_NEW_REAGENT, COMSIG_REAGENTS_ADD_REAGENT, COMSIG_REAGENTS_DEL_REAGENT, COMSIG_REAGENTS_REM_REAGENT), .proc/on_reagent_change)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -74,9 +74,8 @@
 /obj/item/stock_parts/cell/proc/on_magic_charge(datum/source, obj/effect/proc_holder/spell/targeted/charge/spell, mob/living/caster)
 	SIGNAL_HANDLER
 
-	// This shouldn't be runnable if we're not being held by a mob,
-	// or if we're not within an objecting being held by a mob,
-	// but just in case.
+	// This shouldn't be running if we're not being held by a mob,
+	// or if we're not within an object being held by a mob, but just in case...
 	if(!ismovable(loc))
 		return
 


### PR DESCRIPTION
## About The Pull Request

This PR refactors the "charge" spell to be signal based instead of looping over held items + istype checks. 
This was atomized out of my proc holder removal PR. Figured it was small enough to handle on its own. 

## Why It's Good For The Game

Cleaner code, better behavior

## Changelog

:cl: Melbert
refactor: Refactored the wizard spell Charge
/:cl:
