### PR TITLE
Makes heretic ghoul rituals are a bit more descriptive 

### DIFF
--- a/code/modules/antagonists/heretic/heretic_monsters.dm
+++ b/code/modules/antagonists/heretic/heretic_monsters.dm
@@ -21,7 +21,7 @@
 			to_chat(master.current, span_warning("The essence of [owner], your servant, fades from your mind."))
 		if(owner.current)
 			to_chat(owner.current, span_deconversion_message("Your mind begins to fill with haze - your master is no longer[master ? " [master]":""], you are free!"))
-			owner.current.visible_message("[owner.current] looks like [owner.current.p_theyve()] been freed from the chains of the Mansus!", ignored_mobs = owner.current)
+			owner.current.visible_message(span_deconversion_message("[owner.current] looks like [owner.current.p_theyve()] been freed from the chains of the Mansus!"), ignored_mobs = owner.current)
 
 	master = null
 	return ..()

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -148,7 +148,9 @@
 		return FALSE
 
 	for(var/mob/living/carbon/human/body in atoms)
-		if(body.stat != DEAD || !IS_VALID_GHOUL_MOB(body) || HAS_TRAIT(body, TRAIT_HUSK))
+		if(body.stat != DEAD)
+			continue
+		if(!IS_VALID_GHOUL_MOB(body) || HAS_TRAIT(body, TRAIT_HUSK))
 			to_chat(user, span_hierophant("[body] is not in a valid state to be made into a ghoul."))
 			continue
 

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -151,7 +151,7 @@
 		if(body.stat != DEAD)
 			continue
 		if(!IS_VALID_GHOUL_MOB(body) || HAS_TRAIT(body, TRAIT_HUSK))
-			to_chat(user, span_hierophant("[body] is not in a valid state to be made into a ghoul."))
+			to_chat(user, span_hierophant_warning("[body] is not in a valid state to be made into a ghoul."))
 			continue
 
 		// We'll select any valid bodies here. If they're clientless, we'll give them a new one.

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -84,19 +84,19 @@
 		target.balloon_alert(source, "at ghoul limit!")
 		return COMPONENT_BLOCK_CHARGE_USE
 
+	if(HAS_TRAIT(target, TRAIT_HUSK))
+		target.balloon_alert(source, "husked!")
+		return COMPONENT_BLOCK_CHARGE_USE
+
 	if(!IS_VALID_GHOUL_MOB(target))
 		target.balloon_alert(source, "invalid body!")
 		return COMPONENT_BLOCK_CHARGE_USE
 
-	// Get their ghost in here so we can raise them
 	target.grab_ghost()
 
+	// The grab failed, so they're mindless or playerless. We can't continue
 	if(!target.mind || !target.client)
 		target.balloon_alert(source, "no soul!")
-		return COMPONENT_BLOCK_CHARGE_USE
-
-	if(HAS_TRAIT(target, TRAIT_HUSK))
-		target.balloon_alert(source, "husked!")
 		return COMPONENT_BLOCK_CHARGE_USE
 
 	make_ghoul(source, target)
@@ -149,13 +149,15 @@
 
 	for(var/mob/living/carbon/human/body in atoms)
 		if(body.stat != DEAD || !IS_VALID_GHOUL_MOB(body) || HAS_TRAIT(body, TRAIT_HUSK))
-			atoms -= body
+			to_chat(user, span_hierophant("[body] is not in a valid state to be made into a ghoul."))
+			continue
 
-	if(!(locate(/mob/living/carbon/human) in atoms))
-		loc.balloon_alert(user, "ritual failed, no valid body!")
-		return FALSE
+		// We'll select any valid bodies here. If they're clientless, we'll give them a new one.
+		selected_atoms += body
+		return TRUE
 
-	return TRUE
+	loc.balloon_alert(user, "ritual failed, no valid body!")
+	return FALSE
 
 /datum/heretic_knowledge/limited_amount/flesh_ghoul/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/mob/living/carbon/human/soon_to_be_ghoul = locate() in selected_atoms
@@ -180,6 +182,7 @@
 
 	selected_atoms -= soon_to_be_ghoul
 	make_ghoul(user, soon_to_be_ghoul)
+	return TRUE
 
 /// Makes [victim] into a ghoul.
 /datum/heretic_knowledge/limited_amount/flesh_ghoul/proc/make_ghoul(mob/living/user, mob/living/carbon/human/victim)

--- a/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
@@ -35,8 +35,11 @@
 		if(!IS_VALID_GHOUL_MOB(body) || HAS_TRAIT(body, TRAIT_HUSK))
 			to_chat(user, span_hierophant("[body] is not in a valid state to be made into a ghoul."))
 			continue
-		if(!body.mind || (!body.client && !body.mind.get_ghost(ghosts_with_clients = TRUE)))
+		if(!body.mind)
 			to_chat(user, span_hierophant("[body] is mindless and cannot be made into a ghoul."))
+			continue
+		if(!body.client && !body.mind.get_ghost(ghosts_with_clients = TRUE))
+			to_chat(user, span_hierophant("[body] is soulless and cannot be made into a ghoul."))
 			continue
 
 		// We will only accept valid bodies with a mind, or with a ghost connected that used to control the body

--- a/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
@@ -33,13 +33,13 @@
 		if(body.stat != DEAD)
 			continue
 		if(!IS_VALID_GHOUL_MOB(body) || HAS_TRAIT(body, TRAIT_HUSK))
-			to_chat(user, span_hierophant("[body] is not in a valid state to be made into a ghoul."))
+			to_chat(user, span_hierophant_warning("[body] is not in a valid state to be made into a ghoul."))
 			continue
 		if(!body.mind)
-			to_chat(user, span_hierophant("[body] is mindless and cannot be made into a ghoul."))
+			to_chat(user, span_hierophant_warning("[body] is mindless and cannot be made into a ghoul."))
 			continue
 		if(!body.client && !body.mind.get_ghost(ghosts_with_clients = TRUE))
-			to_chat(user, span_hierophant("[body] is soulless and cannot be made into a ghoul."))
+			to_chat(user, span_hierophant_warning("[body] is soulless and cannot be made into a ghoul."))
 			continue
 
 		// We will only accept valid bodies with a mind, or with a ghost connected that used to control the body

--- a/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
@@ -31,11 +31,15 @@
 
 	for(var/mob/living/carbon/human/body in atoms)
 		if(body.stat != DEAD || !IS_VALID_GHOUL_MOB(body) || HAS_TRAIT(body, TRAIT_HUSK))
+			to_chat(user, span_hierophant("[body] is not in a valid state to be made into a ghoul."))
+			continue
+		if(!body.mind || (!body.client && !body.mind.get_ghost(ghosts_with_clients = TRUE)))
+			to_chat(user, span_hierophant("[body] is mindless and cannot be made into a ghoul."))
 			continue
 
-		if(body.mind?.get_ghost(ghosts_with_clients = TRUE))
-			selected_atoms += body
-			return TRUE
+		// We will only accept valid bodies with a mind, or with a ghost connected that used to control the body
+		selected_atoms += body
+		return TRUE
 
 	loc.balloon_alert(user, "ritual failed, no valid body!")
 	return FALSE
@@ -55,11 +59,12 @@
 
 	selected_atoms -= soon_to_be_ghoul
 	make_risen(user, soon_to_be_ghoul)
+	return TRUE
 
 /// Make [victim] into a shattered risen ghoul.
 /datum/heretic_knowledge/limited_amount/risen_corpse/proc/make_risen(mob/living/user, mob/living/carbon/human/victim)
 	log_game("[key_name(user)] created a shattered risen out of [key_name(victim)].")
-	message_admins("[ADMIN_LOOKUPFLW(user)] shattered risen out of [ADMIN_LOOKUPFLW(victim)].")
+	message_admins("[ADMIN_LOOKUPFLW(user)] created a shattered risen, [ADMIN_LOOKUPFLW(victim)].")
 
 	victim.apply_status_effect(
 		/datum/status_effect/ghoul,

--- a/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
@@ -30,7 +30,9 @@
 		return FALSE
 
 	for(var/mob/living/carbon/human/body in atoms)
-		if(body.stat != DEAD || !IS_VALID_GHOUL_MOB(body) || HAS_TRAIT(body, TRAIT_HUSK))
+		if(body.stat != DEAD)
+			continue
+		if(!IS_VALID_GHOUL_MOB(body) || HAS_TRAIT(body, TRAIT_HUSK))
 			to_chat(user, span_hierophant("[body] is not in a valid state to be made into a ghoul."))
 			continue
 		if(!body.mind || (!body.client && !body.mind.get_ghost(ghosts_with_clients = TRUE)))


### PR DESCRIPTION
## About The Pull Request

- Heretic Ghoul rituals are a bit more descriptive when they don't work. They'll say why skipped over bodies were invalid for selection. 
- Fixed a span in heretic ghoul deconversion 
- Consistency pass for the two ghoul recipes.
- Also moved a husk check to prior to a ghost grab because that would be annoying for players to experience.  

## Why It's Good For The Game

Someone had a tough time making a ghoul and couldn't figure out why. This should help a bit. 

## Changelog

:cl: Melbert
qol: Heretic ghoul recipes are more descriptive when failing
fix: Fixes a missing span on heretic ghoul deconversion
/:cl:
