### PR TITLE
fixes cayenne nuke interaction

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -176,7 +176,7 @@ GLOBAL_VAR(station_nuke_source)
 
 /obj/machinery/nuclearbomb/ui_state(mob/user)
 	if(HAS_TRAIT(user, TRAIT_CAN_USE_NUKE))
-		return GLOB.conscious_state
+		return GLOB.physical_state
 	return ..()
 
 /obj/machinery/nuclearbomb/proc/get_nuke_state()


### PR DESCRIPTION
## About The Pull Request

Cayenne can now only interact with the nuke if they are next to it, so they cant just open the UI and walk away to use it from wherever.

## Why It's Good For The Game

bug fix

![image](https://user-images.githubusercontent.com/53777086/166086560-0d9654f4-5ccb-4b8d-8326-cc1c27be05d6.png)
![image](https://user-images.githubusercontent.com/53777086/166086557-c671fe5a-c936-4e12-a275-4deb878327b9.png)

## Changelog

:cl:
fix: Cayenne can no longer use the nuke from anywhere.
/:cl: