### PR TITLE
Drones can't give themselves access to machines/wires

### DIFF
--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -144,6 +144,9 @@
 			if(!computer || !card_slot || !id_card)
 				to_chat(current_user, span_notice("No ID found, authorization failed."))
 				return
+			if(isdrone(current_user))
+				to_chat(current_user, span_notice("You can't free yourself."))
+				return
 			if(!(ACCESS_CE in id_card.access))
 				to_chat(current_user, span_notice("Required access not found on ID."))
 				return


### PR DESCRIPTION
## About The Pull Request

Removes drone ability to give themselves access to blacklisted drone stuff using Botkeeper

## Why It's Good For The Game

Fixes an exploit, this should be limited to the CE, but sadly Drones are given Captain IDs.

## Changelog

:cl:
fix: Drones can no longer give themselves access to machines/wires through consoles.
/:cl: