### PR TITLE
Deadchat control alerts ghosts when they can input another command

### DIFF
--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -63,13 +63,16 @@
 		return
 
 	if(deadchat_mode & ANARCHY_MODE)
+		if(!source || !source.ckey)
+			return
 		var/cooldown = ckey_to_cooldown[source.ckey] - world.time
 		if(cooldown > 0)
-			to_chat(source, span_warning("Your deadchat control inputs are still on cooldown for another [cooldown * 0.1] seconds."))
+			to_chat(source, span_warning("Your deadchat control inputs are still on cooldown for another [CEILING(cooldown * 0.1, 1)] second\s."))
 			return MOB_DEADSAY_SIGNAL_INTERCEPT
-		inputs[message].Invoke()
 		ckey_to_cooldown[source.ckey] = world.time + input_cooldown
-		to_chat(source, span_notice("\"[message]\" input accepted. You are now on cooldown for [input_cooldown * 0.1] seconds."))
+		addtimer(CALLBACK(src, .proc/end_cooldown, source.ckey), input_cooldown)
+		inputs[message].Invoke()
+		to_chat(source, span_notice("\"[message]\" input accepted. You are now on cooldown for [CEILING(input_cooldown * 0.1, 1)] second\s."))
 		return MOB_DEADSAY_SIGNAL_INTERCEPT
 
 	if(deadchat_mode & DEMOCRACY_MODE)
@@ -85,7 +88,7 @@
 	if(!isnull(result))
 		inputs[result].Invoke()
 		if(!(deadchat_mode & MUTE_DEMOCRACY_MESSAGES))
-			var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [input_cooldown * 0.1] seconds.</span>"
+			var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [CEILING(input_cooldown * 0.1, 1)] second\s.</span>"
 			for(var/M in orbiters)
 				to_chat(M, message)
 	else if(!(deadchat_mode & MUTE_DEMOCRACY_MESSAGES))
@@ -191,9 +194,9 @@
 	examine_list += span_notice("[A.p_theyre(TRUE)] currently under deadchat control using the [(deadchat_mode & DEMOCRACY_MODE) ? "democracy" : "anarchy"] ruleset!")
 
 	if(deadchat_mode & DEMOCRACY_MODE)
-		examine_list += span_notice("Type a command into chat to vote on an action. This happens once every [input_cooldown * 0.1] seconds.")
+		examine_list += span_notice("Type a command into chat to vote on an action. This happens once every [CEILING(input_cooldown * 0.1, 1)] second\s.")
 	else if(deadchat_mode & ANARCHY_MODE)
-		examine_list += span_notice("Type a command into chat to perform. You may do this once every [input_cooldown * 0.1] seconds.")
+		examine_list += span_notice("Type a command into chat to perform. You may do this once every [CEILING(input_cooldown * 0.1, 1)] second\s.")
 
 	var/extended_examine = "<span class='notice'>Command list:"
 
@@ -203,6 +206,14 @@
 	extended_examine += ".</span>"
 
 	examine_list += extended_examine
+
+///Removes the ghost from the ckey_to_cooldown list and lets them know they are free to submit a command for the parent again.
+/datum/component/deadchat_control/proc/end_cooldown(ghost_ckey)
+	ckey_to_cooldown -= ghost_ckey
+	var/mob/ghost = get_mob_by_ckey(ghost_ckey)
+	if(!ghost || isliving(ghost))
+		return
+	to_chat(ghost, "[FOLLOW_LINK(ghost, parent)] <span class='nicegreen'>Your deadchat control inputs for [parent] are no longer on cooldown.</span>")
 
 /**
  * Deadchat Moves Things

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -72,7 +72,7 @@
 		ckey_to_cooldown[source.ckey] = world.time + input_cooldown
 		addtimer(CALLBACK(src, .proc/end_cooldown, source.ckey), input_cooldown)
 		inputs[message].Invoke()
-		to_chat(source, span_notice("\"[message]\" input accepted. You are now on cooldown for [CEILING(input_cooldown * 0.1, 1)] second\s."))
+		to_chat(source, span_notice("\"[message]\" input accepted. You are now on cooldown for [input_cooldown * 0.1] second\s."))
 		return MOB_DEADSAY_SIGNAL_INTERCEPT
 
 	if(deadchat_mode & DEMOCRACY_MODE)
@@ -88,7 +88,7 @@
 	if(!isnull(result))
 		inputs[result].Invoke()
 		if(!(deadchat_mode & MUTE_DEMOCRACY_MESSAGES))
-			var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [CEILING(input_cooldown * 0.1, 1)] second\s.</span>"
+			var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [input_cooldown * 0.1] second\s.</span>"
 			for(var/M in orbiters)
 				to_chat(M, message)
 	else if(!(deadchat_mode & MUTE_DEMOCRACY_MESSAGES))
@@ -194,9 +194,9 @@
 	examine_list += span_notice("[A.p_theyre(TRUE)] currently under deadchat control using the [(deadchat_mode & DEMOCRACY_MODE) ? "democracy" : "anarchy"] ruleset!")
 
 	if(deadchat_mode & DEMOCRACY_MODE)
-		examine_list += span_notice("Type a command into chat to vote on an action. This happens once every [CEILING(input_cooldown * 0.1, 1)] second\s.")
+		examine_list += span_notice("Type a command into chat to vote on an action. This happens once every [input_cooldown * 0.1] second\s.")
 	else if(deadchat_mode & ANARCHY_MODE)
-		examine_list += span_notice("Type a command into chat to perform. You may do this once every [CEILING(input_cooldown * 0.1, 1)] second\s.")
+		examine_list += span_notice("Type a command into chat to perform. You may do this once every [input_cooldown * 0.1] second\s.")
 
 	var/extended_examine = "<span class='notice'>Command list:"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so deadchat control alerts ghosts when they can input another command. Also rounds the seconds values in the to_chat messages for deadchat control up, so they don't have a decimal point.

![dreamseeker_nPhiyvxl7a](https://user-images.githubusercontent.com/25089914/166119600-d6b32e02-90d5-4f6f-8429-2adbaf645fb0.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You don't have to keep trying to input something to see if the cooldown has expired yet. Removing the decimal point looks cleaner.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Deadchat control on anarchy mode will now alert you when you can enter another command
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
