### PR TITLE
Blocks changing AI laws via upload console for the first 5 minutes

### DIFF
--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -17,6 +17,9 @@
 		if(!current)
 			to_chat(user, span_alert("You haven't selected anything to transmit laws to!"))
 			return
+		if(world.time - SSticker.round_start_time <= 5 MINUTES)
+			to_chat(user, span_alert("Upload failed! Central Command has disabled uploading right away to prevent severe NT policy breaks."))
+			return
 		if(!can_upload_to(current))
 			to_chat(user, span_alert("Upload failed! Check to make sure [current.name] is functioning properly."))
 			current = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The upload console now rejects law changes if it hasn't been at least 5 minutes since roundstart.

## Why It's Good For The Game

The "alternate ai laws" config and station trait get really mogged by the fact that every captain immediately switches the AI back to asimov. This is bannable, as confirmed by the community meeting I'm in right now, but admins miss it really often and we have the code ability to block an action you'd only do in a context that would get you banned... so why not?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: AI Uploads block law changes until at least 5 minutes pass past roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
