### PR TITLE
Tesla coil upgrade nerf

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -45,7 +45,7 @@
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		power_multiplier += C.rating
 		zap_cooldown -= (C.rating * 20)
-	input_power_multiplier = (0.85 * (power_multiplier / 4)) //Max out at 85% efficency.
+	input_power_multiplier = max(1 * (power_multiplier / 8), 0.25) //Max out at 50% efficency.
 
 /obj/machinery/power/energy_accumulator/tesla_coil/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Slight nerf to the tesla coils stock parts upgrade going from a max 85% efficiency to a max 50% efficiency when converting power from the zaps with t4 parts. Roundstart setups remains untouched, but just upgrading the coils will yield 35% less power.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
With power becoming more prominent there is a need to upgrade your generation setup with more that just slap a couple of upgrades on 4 coils. Power generation will still be high (from ~2.2 MW to ~1.4 MW with t4 tesla coils), but it won't be enough for ultra consuming stations that demands 1.8-2.1 MW supply.
This change is to incentive engineers to upgrade not only the machines surrounding the SM (SMESes, coils, emitters) but also the SM itself, with better piping and better gases (try proto nitrate), without removing the needed powergen for the majority of the rounds/crew/needs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: lowered overall max tesla coil power conversion at all parts tiers (at t4 it went from 85% to 50%)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
