### PR TITLE
Fixes bluespace bodybags runtiming when xenomorphs are put in

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -141,7 +141,7 @@
 		content.forceMove(B)
 		if(isliving(content))
 			to_chat(content, span_userdanger("You're suddenly forced into a tiny, compressed space!"))
-		if(iscarbon(content))
+		if(ishuman(content))
 			var/mob/living/carbon/mob = content
 			if (mob.dna.get_mutation(/datum/mutation/human/dwarfism))
 				max_weight_of_contents = max(WEIGHT_CLASS_NORMAL, max_weight_of_contents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previous check for carbons included xenos which are don't have actual DNA. This meant checking for mutations on their DNA runtimed, since they don't have DNA, and it wouldn't finish putting the bodybag in-hand, so it just deleted the bag and everything inside. Now it checks for humanity instead, because humans have DNA.

Fixes #66634 

## Why It's Good For The Game

Stops xenos in a bluespace bodybag from getting everything in the bodybag deleted.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Folding a bluespace bodybag with a xenomorph in it no longer annihilates the bodybag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
