### PR TITLE
Submitting blank last words while succumbing doesn't stop you from dying 

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -419,8 +419,14 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return
 
 	var/mob/living/living_owner = owner
+	var/confirm = tgui_alert(usr,"Are you sure you want to succumb to death?", "Goodnight, Sweet Prince", list("Yes", "No"))
+
+	if(!confirm)
+		return
+
 	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Final Words")
-	if (!last_whisper || !CAN_SUCCUMB(living_owner))
+
+	if (!CAN_SUCCUMB(living_owner))
 		return
 
 	if (length(last_whisper))

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -421,7 +421,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	var/mob/living/living_owner = owner
 	var/confirm = tgui_alert(usr ,"Are you sure you want to succumb to death?", "Goodnight, Sweet Prince", list("Yes", "No"))
 
-	if(!confirm || !CAN_SUCCUMB(living_owner))
+	if(confirm != "Yes" || !CAN_SUCCUMB(living_owner))
 		return
 
 	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Final Words")

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -419,7 +419,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return
 
 	var/mob/living/living_owner = owner
-	var/confirm = tgui_alert(usr ,"Are you sure you want to succumb to death?", "Goodnight, Sweet Prince", list("Yes", "No"))
+	var/confirm = tgui_alert(usr, "Are you sure you want to succumb to death?", "Goodnight, Sweet Prince", list("Yes", "No"))
 
 	if(confirm != "Yes" || !CAN_SUCCUMB(living_owner))
 		return

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -419,9 +419,9 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return
 
 	var/mob/living/living_owner = owner
-	var/confirm = tgui_alert(usr,"Are you sure you want to succumb to death?", "Goodnight, Sweet Prince", list("Yes", "No"))
+	var/confirm = tgui_alert(usr ,"Are you sure you want to succumb to death?", "Goodnight, Sweet Prince", list("Yes", "No"))
 
-	if(!confirm)
+	if(!confirm || !CAN_SUCCUMB(living_owner))
 		return
 
 	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Final Words")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Prefaces the succumb prompt with a "Are you sure you want to succumb?" After you click yes on this you will die no matter how the last words box is finished (Summited black, canceled, or closed with the X)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its annoying to type out some meaningless last words when you are just sat there alone and dying.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: itseasytosee
fix: Leaving the last words box empty in the succumb prompt will not stop you from dying.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
