### PR TITLE
Fixes succumb blank text (again)

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -415,10 +415,10 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 	var/mob/living/living_owner = owner
 	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Final Words")
-	if (!last_whisper || !CAN_SUCCUMB(living_owner))
+	if(isnull(last_whisper) || !CAN_SUCCUMB(living_owner))
 		return
 
-	if (length(last_whisper))
+	if(length(last_whisper))
 		living_owner.say("#[last_whisper]")
 
 	living_owner.succumb(whispered = length(last_whisper) > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I'm not sure who tested #65379 or if this was only a downstream issue,
But it is not true that TGUI inputs can't return null. It returns null if you cancel or hit X. 
By changing the isnull check to only look for a falsy value, you can no longer enter a blank text to succumb without last words.
Meaning you MUST enter something to succumb.
This is unintended.

### Falsy check (current): 
https://user-images.githubusercontent.com/42397676/166188730-8bcf0d8e-b1e9-42f9-a25f-88e8373dd956.mp4
### With this PR:
https://user-images.githubusercontent.com/42397676/166189169-1268c95f-bbeb-4aba-8c0c-69460fdd12d1.mp4

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a bug again. Please allow blank text last words, some people would rather the silent treatment.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You no longer have to enter text to succumb. A blank value works.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
