### PR TITLE
removes metastation (disposal pipe)

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -67946,9 +67946,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "ydu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/gambling,
 /obj/effect/spawner/random/entertainment/gambling,


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/53777086/166306171-9d459aff-2a29-44e0-9179-23e83b132b4f.png)

## Why It's Good For The Game

its not attached to anything and it confused me when i tried to fix a blown-up bar.

## Changelog

:cl:
fix: A lone disposal pipe segment under a table in the bar on Metastation has been removed.
/:cl: