### PR TITLE
adds prisoner landmarks to Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -3893,6 +3893,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/aft/lesser)
+"kr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison)
 "ks" = (
 /turf/open/floor/wood,
 /area/service/lawoffice)
@@ -5123,9 +5130,10 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/east{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Library Reading Room"
+	c_tag = "Security - Permabrig Library Reading Room";
+	network = list("ss13","prison")
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/carpet/blue,
 /area/security/prison/work)
 "nL" = (
@@ -6255,6 +6263,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/work)
 "qJ" = (
@@ -8885,8 +8894,8 @@
 /area/mine/storage)
 "xQ" = (
 /obj/machinery/camera/directional/east{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Upper Hallway East"
+	c_tag = "Security - Permabrig Upper Hallway East";
+	network = list("ss13","prison")
 	},
 /turf/open/openspace,
 /area/security/prison)
@@ -9650,6 +9659,10 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/security/prison)
+"zV" = (
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/carpet/red,
+/area/security/prison/work)
 "zW" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
@@ -12035,8 +12048,8 @@
 /area/maintenance/aft/lesser)
 "GK" = (
 /obj/machinery/door/window/brigdoor/left/directional/north{
-	req_access_txt = "3";
-	name = "Secure Weapons Storage"
+	name = "Secure Weapons Storage";
+	req_access_txt = "3"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/ai_monitored/security/armory)
@@ -12075,8 +12088,8 @@
 /obj/item/reagent_containers/glass/bottle/welding_fuel,
 /obj/item/reagent_containers/glass/bottle/welding_fuel,
 /obj/machinery/camera/directional/west{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Cytology"
+	c_tag = "Security - Permabrig Cytology";
+	network = list("ss13","prison")
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/grimy,
@@ -13447,6 +13460,7 @@
 "Kt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison/work)
 "Ku" = (
@@ -14726,8 +14740,8 @@
 /area/icemoon/underground/explored)
 "NV" = (
 /obj/machinery/button/door/directional/east{
-	name = "Privacy Shutters";
-	id = "kanyewest"
+	id = "kanyewest";
+	name = "Privacy Shutters"
 	},
 /obj/structure/chair/office{
 	dir = 8
@@ -16478,8 +16492,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/west{
-	network = list("ss13","prison");
-	c_tag = "Security - Upper Permabrig Hallway West"
+	c_tag = "Security - Upper Permabrig Hallway West";
+	network = list("ss13","prison")
 	},
 /turf/open/floor/iron/dark/textured,
 /area/security/prison)
@@ -17715,8 +17729,8 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_y = 32;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 32
 	},
 /obj/machinery/button/door/incinerator_vent_ordmix{
 	pixel_x = -8;
@@ -43618,7 +43632,7 @@ dq
 vu
 hw
 gt
-Jo
+zV
 gt
 GZ
 UG
@@ -47732,7 +47746,7 @@ mO
 mO
 tI
 kQ
-DZ
+kr
 DZ
 wP
 LJ

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
@@ -429,8 +429,8 @@
 /area/security/prison/rec)
 "et" = (
 /obj/structure/toilet/greyscale{
-	dir = 1;
-	cistern = 1
+	cistern = 1;
+	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/showroomfloor,
@@ -603,8 +603,8 @@
 /area/icemoon/underground/explored)
 "fL" = (
 /obj/machinery/camera/directional/west{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Recreation"
+	c_tag = "Security - Permabrig Recreation";
+	network = list("ss13","prison")
 	},
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -679,6 +679,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"gJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "gN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/food/pie_smudge,
@@ -944,8 +950,8 @@
 "jf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/west{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Chapel"
+	c_tag = "Security - Permabrig Chapel";
+	network = list("ss13","prison")
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
@@ -1891,6 +1897,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"th" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
+/area/security/prison/workout)
 "ti" = (
 /obj/item/storage/box/donkpockets{
 	pixel_y = 5
@@ -2019,6 +2031,12 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/mine/mechbay)
+"uO" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
+/area/security/prison/workout)
 "uV" = (
 /obj/structure/fluff/tram_rail,
 /obj/structure/fluff/tram_rail{
@@ -2110,6 +2128,7 @@
 "vJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/vault,
 /area/security/prison/rec)
 "wc" = (
@@ -3083,6 +3102,13 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
 /area/security/prison/rec)
+"FR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron/dark/side,
+/area/security/prison)
 "FS" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3408,6 +3434,16 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/mine/eva/lower)
+"Jb" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/wood,
+/area/security/prison/rec)
 "Jf" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -3996,8 +4032,8 @@
 /area/mine/mechbay)
 "Od" = (
 /obj/machinery/camera/directional/west{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Lower Hallway Stairwell"
+	c_tag = "Security - Permabrig Lower Hallway Stairwell";
+	network = list("ss13","prison")
 	},
 /turf/open/floor/iron/dark/textured,
 /area/security/prison)
@@ -4209,12 +4245,12 @@
 	pixel_x = 8
 	},
 /obj/item/clothing/head/soft/blue{
-	pixel_y = 3;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 3
 	},
 /obj/item/clothing/head/soft/blue{
-	pixel_y = 6;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 6
 	},
 /obj/item/clothing/head/soft/red{
 	pixel_x = -5
@@ -4541,8 +4577,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/west{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Lower Hallway East"
+	c_tag = "Security - Permabrig Lower Hallway East";
+	network = list("ss13","prison")
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -4592,8 +4628,8 @@
 /area/mine/eva/lower)
 "TT" = (
 /obj/machinery/camera/directional/west{
-	network = list("ss13","prison");
-	c_tag = "Security - Permabrig Observation Prep"
+	c_tag = "Security - Permabrig Observation Prep";
+	network = list("ss13","prison")
 	},
 /obj/structure/sign/poster/official/safety_internals{
 	pixel_x = -32
@@ -4943,8 +4979,8 @@
 /area/mine/laborcamp)
 "WZ" = (
 /obj/structure/toilet/greyscale{
-	dir = 1;
-	cistern = 1
+	cistern = 1;
+	dir = 1
 	},
 /obj/effect/spawner/random/entertainment/cigar,
 /obj/machinery/light/small/directional/south,
@@ -29712,7 +29748,7 @@ Yr
 gs
 Sa
 Fc
-ap
+Jb
 ap
 pa
 KT
@@ -32282,7 +32318,7 @@ BO
 QT
 zW
 RS
-bG
+FR
 FI
 he
 Em
@@ -33322,7 +33358,7 @@ CL
 CL
 cp
 Tk
-Tk
+gJ
 Tk
 hT
 Fq
@@ -34592,11 +34628,11 @@ zt
 OH
 hn
 tF
-Mr
+uO
 XB
 VO
 XW
-XW
+th
 BM
 Sq
 Gk


### PR DESCRIPTION
## About The Pull Request

Adds landmarks for Prisoners to spawn on Icebox.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/66669
Prisoners don't spawn out of permabrig anymore.

## Changelog

:cl:
fix: Icebox no longer spawns Prisoners outside of Permabrig.
/:cl:
