### PR TITLE
Fixes some runtimes with ling stings

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -44,7 +44,6 @@
 /atom/movable/screen/ling/sting
 	name = "current sting"
 	screen_loc = ui_lingstingdisplay
-	invisibility = INVISIBILITY_ABSTRACT
 
 /atom/movable/screen/ling/sting/Click()
 	if(isobserver(usr))

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -139,10 +139,6 @@
 		lingchemdisplay.hud = hud_used
 		hud_used.infodisplay += lingchemdisplay
 
-		lingstingdisplay = new /atom/movable/screen/ling/sting()
-		lingstingdisplay.hud = hud_used
-		hud_used.infodisplay += lingstingdisplay
-
 		hud_used.show_hud(hud_used.hud_version)
 	else
 		RegisterSignal(living_mob, COMSIG_MOB_HUD_CREATED, .proc/on_hud_created)
@@ -162,10 +158,6 @@
 	lingchemdisplay.hud = ling_hud
 	ling_hud.infodisplay += lingchemdisplay
 
-	lingstingdisplay = new
-	lingstingdisplay.hud = ling_hud
-	ling_hud.infodisplay += lingstingdisplay
-
 	ling_hud.show_hud(ling_hud.hud_version)
 
 /datum/antagonist/changeling/remove_innate_effects(mob/living/mob_override)
@@ -176,8 +168,11 @@
 	if(living_mob.hud_used)
 		var/datum/hud/hud_used = living_mob.hud_used
 
-		hud_used.infodisplay -= lingchemdisplay
-		hud_used.infodisplay -= lingstingdisplay
+		if(lingchemdisplay)
+			hud_used.infodisplay -= lingchemdisplay
+		if(lingstingdisplay)
+			hud_used.infodisplay -= lingstingdisplay
+
 		QDEL_NULL(lingchemdisplay)
 		QDEL_NULL(lingstingdisplay)
 
@@ -270,7 +265,7 @@
 	var/cap_to = isnum(override_cap) ? override_cap : total_chem_storage
 	chem_charges = clamp(chem_charges + amount, 0, cap_to)
 
-	lingchemdisplay.maptext = FORMAT_CHEM_CHARGES_TEXT(chem_charges)
+	lingchemdisplay?.maptext = FORMAT_CHEM_CHARGES_TEXT(chem_charges)
 
 /*
  * Remove changeling powers from the current Changeling's purchased_powers list.

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -20,16 +20,24 @@
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	changeling.chosen_sting = src
 
-	changeling.lingstingdisplay.icon_state = button_icon_state
-	changeling.lingstingdisplay.invisibility = 0
+	if(user.hud_used)
+		var/datum/hud/hud_used = user.hud_used
+		changeling.lingstingdisplay = new /atom/movable/screen/ling/sting()
+		changeling.lingstingdisplay.hud = hud_used
+		hud_used.infodisplay += changeling.lingstingdisplay
+
+		hud_used.show_hud(hud_used.hud_version) //refresh
+		changeling.lingstingdisplay.icon_state = button_icon_state //set icon state
 
 /datum/action/changeling/sting/proc/unset_sting(mob/user)
 	to_chat(user, span_warning("We retract our sting, we can't sting anyone for now."))
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	changeling.chosen_sting = null
 
-	changeling.lingstingdisplay.icon_state = null
-	changeling.lingstingdisplay.invisibility = INVISIBILITY_ABSTRACT
+	if(user.hud_used)
+		var/datum/hud/hud_used = user.hud_used
+		hud_used.infodisplay -= changeling.lingstingdisplay
+		QDEL_NULL(changeling.lingstingdisplay)
 
 /mob/living/carbon/proc/unset_sting()
 	if(mind)


### PR DESCRIPTION
## About The Pull Request

Brought up in https://github.com/tgstation/tgstation/issues/66668
for some reason some people have changeling antag datums but don't have huds. I don't know whats causing this exactly, but I made the ling sting hud only show up when you actually are using a ling sting, rather than turning visible/invisible, and added a check for updating chemicals.
I'm not really a fan of the ? for updating chemicals and would rather figure out what's actually causing them to not have a hud, though, but I dunno if it's worth it. My initial assumption is client-less players are becoming changelings somehow.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/66668

## Changelog

Not needed, its just runtimes that don't affect gameplay.