### PR TITLE
Applying templates now changes a job's payment department.

### DIFF
--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -465,6 +465,9 @@ SUBSYSTEM_DEF(id_access)
 
 	id_card.add_access(trim.access, mode = TRY_ADD_ALL_NO_WILDCARD)
 	id_card.add_wildcards(trim.wildcard_access, mode = TRY_ADD_ALL)
+	if(istype(trim, /datum/id_trim/job))
+		var/datum/id_trim/job/job_trim = trim // Here is where we update a player's paycheck department for the purposes of discounts/paychecks.
+		id_card.registered_account.account_job.paycheck_department = job_trim.job.paycheck_department
 
 /**
  * Tallies up all accesses the card has that have flags greater than or equal to the access_flag supplied.


### PR DESCRIPTION
This one took a hot second to figure out what was going on in the background.

## About The Pull Request

So, unbeknownst to me, the refactor to ID cards and trims from a few months ago also changed how setting your payment department is handled. In that it doesn't, you COULDN'T change your payment department. Now, this made sense at the time because it wasn't a player facing change and I don't imagine that specific circumstance mattered to anyone whose played the game in the last few months. However, as a direct consequence of the changes to paychecks and economy, it made it so that going and getting a new job DIDN'T change your paycheck department, and prevented you from being able to meaningfully avoid the lathe tax by changing jobs, which was a clear part of the previous PR's intent.

The best way I could imagine to handle this was to have it compare against the job of the trim/id set and change that value on the job stored within the account on the ID, since we can now count on IDs always having a registered account.

## Why It's Good For The Game

Having a job change should ideally change the department that is paying you, and by making you a formal member of your department you can change who you get discounts from in the future.

Ideally, we should probably make this work on making your payment department adjusted within the card program and computer, but for the moment this is a serviceable middle ground since I'm already a bit out of my depth with regard to IDs/Trims/Cards.

## Changelog
:cl:
fix: Id cards, when having their job template changed, will change that job's payment department as they used to.
/:cl:
