### PR TITLE
[NO GBP] Fix mapped cardhands not initializing

### DIFF
--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -9,10 +9,13 @@
 /obj/item/toy/cards/cardhand/Initialize(mapload, list/cards_to_combine = list())
 	. = ..()
 
-	if(!LAZYLEN(cards_to_combine) && (mapload && !LAZYLEN(cards)))
+	var/has_runtime_spawned_cards = length(cards_to_combine)
+	var/has_mapped_spawned_cards = mapload && length(cards)
+
+	if(!has_runtime_spawned_cards && !has_mapped_spawned_cards)
 		CRASH("[src] is being made into a cardhand without a list of cards to combine")
 
-	if(mapload && LAZYLEN(cards)) // these cards have not been initialized
+	if(has_mapped_spawned_cards) // these cards have not been initialized
 		for(var/card_name in cards)
 			var/obj/item/toy/singlecard/new_card = new (loc, card_name)
 			new_card.update_appearance()

--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -6,7 +6,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	worn_icon_state = "card"
 
-/obj/item/toy/cards/cardhand/Initialize(mapload, list/cards_to_combine)
+/obj/item/toy/cards/cardhand/Initialize(mapload, list/cards_to_combine = list())
 	. = ..()
 
 	if(!LAZYLEN(cards_to_combine) && (mapload && !LAZYLEN(cards)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes this:

![chrome_PRyr8fg8JB](https://user-images.githubusercontent.com/5195984/166489717-2ce44480-9895-40c4-a1aa-33fc9f3bb3ba.png)

There is a mapped cardhand on the whiteship that doesn't initialize properly.  When we were doing our testing we were running the code on runtime station so the whiteship never spawned.  The problem was that the list arg was never properly declared, it needed the `list()` added. 

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Fixes a minor bug.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix mapped in cardhands not initializing properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
