### PR TITLE
Fixes plants not taking proximity into account

### DIFF
--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -66,6 +66,8 @@
  * our_plant - our plant, that we're attacking with
  * user - the person who is attacking with the plant
  * target - the atom which is attacked by the plant
+ *
+ * return TRUE if plant attack is acceptable, otherwise FALSE to early return subtypes.
  */
 /datum/plant_gene/trait/attack/proc/after_plant_attack(obj/item/our_plant, atom/target, mob/user, proximity_flag, click_parameters)
 	SIGNAL_HANDLER

--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -67,8 +67,12 @@
  * user - the person who is attacking with the plant
  * target - the atom which is attacked by the plant
  */
-/datum/plant_gene/trait/attack/proc/after_plant_attack(obj/item/our_plant, atom/target, mob/user)
+/datum/plant_gene/trait/attack/proc/after_plant_attack(obj/item/our_plant, atom/target, mob/user, proximity_flag, click_parameters)
 	SIGNAL_HANDLER
+
+	if(!proximity_flag)
+		return FALSE
+	return TRUE
 
 /// Novaflower's attack effects (sets people on fire) + degradation on attack
 /datum/plant_gene/trait/attack/novaflower_attack
@@ -77,6 +81,8 @@
 
 /datum/plant_gene/trait/attack/novaflower_attack/on_plant_attack(obj/item/our_plant, mob/living/target, mob/living/user)
 	. = ..()
+	if(!.)
+		return
 
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
 	to_chat(target, "<span class='danger'>You are lit on fire from the intense heat of [our_plant]!</span>")
@@ -86,8 +92,10 @@
 		log_game("[key_name(user)] set [key_name(target)] on fire with [our_plant] at [AREACOORD(user)]")
 	our_plant.investigate_log("was used by [key_name(user)] to burn [key_name(target)] at [AREACOORD(user)]", INVESTIGATE_BOTANY)
 
-/datum/plant_gene/trait/attack/novaflower_attack/after_plant_attack(obj/item/our_plant, atom/target, mob/user)
+/datum/plant_gene/trait/attack/novaflower_attack/after_plant_attack(obj/item/our_plant, atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
+	if(!.)
+		return
 
 	if(!ismovable(target))
 		return
@@ -101,8 +109,10 @@
 /datum/plant_gene/trait/attack/sunflower_attack
 	name = "Bright Petals"
 
-/datum/plant_gene/trait/attack/sunflower_attack/after_plant_attack(obj/item/our_plant, atom/target, mob/living/user)
+/datum/plant_gene/trait/attack/sunflower_attack/after_plant_attack(obj/item/our_plant, atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
+	if(!.)
+		return
 
 	if(!ismob(target))
 		return
@@ -117,8 +127,10 @@
 	name = "Sharpened Leaves"
 	force_multiplier = 0.2
 
-/datum/plant_gene/trait/attack/nettle_attack/after_plant_attack(obj/item/our_plant, atom/target, mob/user)
+/datum/plant_gene/trait/attack/nettle_attack/after_plant_attack(obj/item/our_plant, atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
+	if(!.)
+		return
 
 	if(!ismovable(target))
 		return


### PR DESCRIPTION
## About The Pull Request

Plants that use after_plant_attack() now take being in proximity into account when using durability.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/66631
Fixes a bug.

## Changelog

:cl:
fix: Plants like Deathnettle will no longer use durability when clicking on someone from a distance.
/:cl: