### PR TITLE
tgui: Fix usage of computeBoxClassName

### DIFF
--- a/tgui/packages/tgui/layouts/Layout.js
+++ b/tgui/packages/tgui/layouts/Layout.js
@@ -21,7 +21,7 @@ export const Layout = props => {
         className={classes([
           'Layout',
           className,
-          ...computeBoxClassName(rest),
+          computeBoxClassName(rest),
         ])}
         {...computeBoxProps(rest)}>
         {children}
@@ -43,7 +43,7 @@ const LayoutContent = props => {
         'Layout__content',
         scrollable && 'Layout__content--scrollable',
         className,
-        ...computeBoxClassName(rest),
+        computeBoxClassName(rest),
       ])}
       {...computeBoxProps(rest)}>
       {children}


### PR DESCRIPTION
## About The Pull Request

It's a dumb error that I have sneaked into the code and it was unnoticed for god knows how long. If it was TypeScript, it'd be found before it was committed.

Yes, it's a web edit.

## Why It's Good For The Game

Fixes Box-like behavior on Layout tgui component, makes it more consistent. Makes certain properties, like `color`, that we unusable before, now usable.

