### PR TITLE
Fixes departmental revolts

### DIFF
--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -19,7 +19,7 @@
 	var/list/options = list()
 	var/list/pickable_departments = subtypesof(/datum/job_department)
 	for(var/datum/job_department/dep as anything in pickable_departments)
-		options[dep.department_name] = dep
+		options[initial(dep.department_name)] = dep
 	picked_department = options[(input(usr,"Which department should revolt? Select none for a random department.","Select a department") as null|anything in options)]
 	if(!picked_department)
 		return //eh just random they dont care


### PR DESCRIPTION
## About The Pull Request

Trying to start a revolt using Trigger Event didn't work, because it would runtime error when trying to check a typepath's department_name

![image](https://user-images.githubusercontent.com/53777086/166842749-a41e659d-a8ea-42ae-81dd-8a6568d9cd23.png)

## Why It's Good For The Game

Bug fix, event works again!

## Changelog

:cl:
fix: Admin Nation-creating event can now properly trigger and work.
/:cl:
