### PR TITLE
Adds the HoP to Cargo's department

### DIFF
--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -21,6 +21,7 @@
 	plasmaman_outfit = /datum/outfit/plasmaman/head_of_personnel
 	departments_list = list(
 		/datum/job_department/service,
+		/datum/job_department/cargo,
 		/datum/job_department/command,
 		)
 


### PR DESCRIPTION
## About The Pull Request

Makes HoP part of Cargo in their department list

Here's a video proving that Cargo banning people doesn't actually ban from HoP, meaning you can still play HoP to bypass a department ban (video is on a Fulp server because I don't have database locally and this is the only place I do have perms and a functional DB, but it is the same as on TG).

https://user-images.githubusercontent.com/53777086/166843084-04ed6ab6-5101-4b50-a519-e94bfe4aaaaa.mp4

## Why It's Good For The Game

The HoP is part of Supply and should be treated like such, especially since this is what is used for Departmental bans.

This doesn't break department revolts, since they don't work on people that are in more than 1 department (so basically all command members can't break away lol).

## Changelog

:cl:
fix: The HoP is now considered part of Supply (Supply bans apply to HoP, they get Supply deathrattle, cannot get smuggle objective, ect).
/:cl: