### PR TITLE
Moves a telescreen in Deltastation's rec room

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1832,8 +1832,8 @@
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/camera/directional/west{
 	c_tag = "Library Backroom 1";
-	name = "library camera";
-	dir = 2
+	dir = 2;
+	name = "library camera"
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
@@ -62494,7 +62494,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/pen,
 /obj/item/storage/dice,
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "qaR" = (
@@ -75069,6 +75068,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/fancy/candle_box,
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "tHl" = (
@@ -81286,8 +81286,8 @@
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/camera/directional/west{
 	c_tag = "Library Backroom 2";
-	name = "library camera";
-	dir = 1
+	dir = 1;
+	name = "library camera"
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves a telescreen that would cover up a painting when viewed by observers. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Now the ghosts can properly admire the art in the library.

Closes #66715

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Moves a telescreen in Deltastation's library area
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
