### PR TITLE
Mindshock/mindshield modifications

### DIFF
--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -11,20 +11,20 @@
 /obj/item/organ/heart/gland/mindshock/activate()
 	to_chat(owner, span_notice("You get a headache."))
 
-	var/turf/T = get_turf(owner)
-	for(var/mob/living/carbon/H in orange(4,T))
-		if(H == owner)
+	var/turf/owner_turf = get_turf(owner)
+	for(var/mob/living/carbon/target in orange(4,owner_turf))
+		if(target == owner)
 			continue
-		if(HAS_TRAIT(H, TRAIT_MINDSHIELD))
-			to_chat(H, span_notice("You hear a faint hum fill your ears, which quickly dies down."))
+		if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+			to_chat(target, span_notice("You hear a faint hum fill your ears, which quickly dies down."))
 			continue
 
 		switch(pick(1,3))
 			if(1)
-				to_chat(H, span_userdanger("You hear a loud buzz in your head, silencing your thoughts!"))
+				to_chat(target, span_userdanger("You hear a loud buzz in your head, silencing your thoughts!"))
 				H.Stun(50)
 			if(2)
-				to_chat(H, span_warning("You hear an annoying buzz in your head."))
+				to_chat(target, span_warning("You hear an annoying buzz in your head."))
 				H.add_confusion(15)
 				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 160)
 			if(3)
@@ -34,25 +34,25 @@
 	if(!ownerCheck() || !mind_control_uses || active_mind_control)
 		return FALSE
 	mind_control_uses--
-	for(var/mob/M in oview(7, owner))
-		if(!ishuman(M))
+	for(var/mob/target_mob in oview(7, owner))
+		if(!ishuman(target_mob))
 			continue
-		var/mob/living/carbon/human/H = M
-		if(H.stat)
-			continue
-
-		if(HAS_TRAIT(H, TRAIT_MINDSHIELD))
-			to_chat(H, span_notice("You hear a low drone as something foreign attempts to enter your mind, but the noise fades after a few moments."))
+		var/mob/living/carbon/human/target_human = target_mob
+		if(target_human.stat)
 			continue
 
-		broadcasted_mobs += H
-		to_chat(H, span_userdanger("You suddenly feel an irresistible compulsion to follow an order..."))
-		to_chat(H, span_mind_control("[command]"))
+		if(HAS_TRAIT(target_human, TRAIT_MINDSHIELD))
+			to_chat(target_human, span_notice("You hear a low drone as something foreign attempts to enter your mind, but the noise fades after a few moments."))
+			continue
 
-		message_admins("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(H)]: [command]")
-		log_game("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(H)]: [command]")
+		broadcasted_mobs += target_human
+		to_chat(target_human, span_userdanger("You suddenly feel an irresistible compulsion to follow an order..."))
+		to_chat(target_human, span_mind_control("[command]"))
 
-		var/atom/movable/screen/alert/mind_control/mind_alert = H.throw_alert(ALERT_MIND_CONTROL, /atom/movable/screen/alert/mind_control)
+		message_admins("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(target_human)]: [command]")
+		log_game("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(target_human)]: [command]")
+
+		var/atom/movable/screen/alert/mind_control/mind_alert = target_human.throw_alert(ALERT_MIND_CONTROL, /atom/movable/screen/alert/mind_control)
 		mind_alert.command = command
 
 	if(LAZYLEN(broadcasted_mobs))
@@ -65,9 +65,9 @@
 /obj/item/organ/heart/gland/mindshock/clear_mind_control()
 	if(!active_mind_control || !LAZYLEN(broadcasted_mobs))
 		return FALSE
-	for(var/M in broadcasted_mobs)
-		var/mob/living/carbon/human/H = M
-		to_chat(H, span_userdanger("You feel the compulsion fade, and you <i>completely forget</i> about your previous orders."))
-		H.clear_alert(ALERT_MIND_CONTROL)
+	for(var/target_mob in broadcasted_mobs)
+		var/mob/living/carbon/human/target_human = target_mob
+		to_chat(target_human, span_userdanger("You feel the compulsion fade, and you <i>completely forget</i> about your previous orders."))
+		target_human.clear_alert(ALERT_MIND_CONTROL)
 	active_mind_control = FALSE
 	return TRUE

--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -22,13 +22,13 @@
 		switch(pick(1,3))
 			if(1)
 				to_chat(target, span_userdanger("You hear a loud buzz in your head, silencing your thoughts!"))
-				H.Stun(50)
+				target.Stun(50)
 			if(2)
 				to_chat(target, span_warning("You hear an annoying buzz in your head."))
-				H.add_confusion(15)
-				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 160)
+				target.add_confusion(15)
+				target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 160)
 			if(3)
-				H.hallucination += 60
+				target.hallucination += 60
 
 /obj/item/organ/heart/gland/mindshock/mind_control(command, mob/living/user)
 	if(!ownerCheck() || !mind_control_uses || active_mind_control)

--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -4,7 +4,7 @@
 	cooldown_high = 700
 	uses = -1
 	icon_state = "mindshock"
-	mind_control_uses = 1
+	mind_control_uses = 2
 	mind_control_duration = 1200
 	var/list/mob/living/carbon/human/broadcasted_mobs = list()
 

--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -15,16 +15,19 @@
 	for(var/mob/living/carbon/H in orange(4,T))
 		if(H == owner)
 			continue
-		switch(pick(1,3))
-			if(1)
-				to_chat(H, span_userdanger("You hear a loud buzz in your head, silencing your thoughts!"))
-				H.Stun(50)
-			if(2)
-				to_chat(H, span_warning("You hear an annoying buzz in your head."))
-				H.add_confusion(15)
-				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 160)
-			if(3)
-				H.hallucination += 60
+		if(!HAS_TRAIT(H, TRAIT_MINDSHIELD))
+			switch(pick(1,3))
+				if(1)
+					to_chat(H, span_userdanger("You hear a loud buzz in your head, silencing your thoughts!"))
+					H.Stun(50)
+				if(2)
+					to_chat(H, span_warning("You hear an annoying buzz in your head."))
+					H.add_confusion(15)
+					H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 160)
+				if(3)
+					H.hallucination += 60
+		else
+			to_chat(H, span_notice("You hear a faint hum behind you, for just a moment."))
 
 /obj/item/organ/heart/gland/mindshock/mind_control(command, mob/living/user)
 	if(!ownerCheck() || !mind_control_uses || active_mind_control)
@@ -47,6 +50,8 @@
 
 			var/atom/movable/screen/alert/mind_control/mind_alert = H.throw_alert(ALERT_MIND_CONTROL, /atom/movable/screen/alert/mind_control)
 			mind_alert.command = command
+		else
+			to_chat(H, span_notice("You hear a low drone as something foreign attempts to enter your mind, but the noise fades after a few moments."))
 
 	if(LAZYLEN(broadcasted_mobs))
 		active_mind_control = TRUE

--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -1,11 +1,11 @@
 /obj/item/organ/heart/gland/mindshock
 	abductor_hint = "neural crosstalk uninhibitor. The abductee emits a disrupting psychic wave every so often. This will either stun, cause hallucinations or deal random brain damage to people nearby."
-	cooldown_low = 400
-	cooldown_high = 700
+	cooldown_low = 40 SECONDS
+	cooldown_high = 70 SECONDS
 	uses = -1
 	icon_state = "mindshock"
 	mind_control_uses = 2
-	mind_control_duration = 1200
+	mind_control_duration = 120 SECONDS
 	var/list/mob/living/carbon/human/broadcasted_mobs = list()
 
 /obj/item/organ/heart/gland/mindshock/activate()
@@ -15,19 +15,20 @@
 	for(var/mob/living/carbon/H in orange(4,T))
 		if(H == owner)
 			continue
-		if(!HAS_TRAIT(H, TRAIT_MINDSHIELD))
-			switch(pick(1,3))
-				if(1)
-					to_chat(H, span_userdanger("You hear a loud buzz in your head, silencing your thoughts!"))
-					H.Stun(50)
-				if(2)
-					to_chat(H, span_warning("You hear an annoying buzz in your head."))
-					H.add_confusion(15)
-					H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 160)
-				if(3)
-					H.hallucination += 60
-		else
+		if(HAS_TRAIT(H, TRAIT_MINDSHIELD))
 			to_chat(H, span_notice("You hear a faint hum fill your ears, which quickly dies down."))
+			continue
+
+		switch(pick(1,3))
+			if(1)
+				to_chat(H, span_userdanger("You hear a loud buzz in your head, silencing your thoughts!"))
+				H.Stun(50)
+			if(2)
+				to_chat(H, span_warning("You hear an annoying buzz in your head."))
+				H.add_confusion(15)
+				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 160)
+			if(3)
+				H.hallucination += 60
 
 /obj/item/organ/heart/gland/mindshock/mind_control(command, mob/living/user)
 	if(!ownerCheck() || !mind_control_uses || active_mind_control)
@@ -40,18 +41,19 @@
 		if(H.stat)
 			continue
 
-		if(!HAS_TRAIT(H, TRAIT_MINDSHIELD))
-			broadcasted_mobs += H
-			to_chat(H, span_userdanger("You suddenly feel an irresistible compulsion to follow an order..."))
-			to_chat(H, span_mind_control("[command]"))
-
-			message_admins("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(H)]: [command]")
-			log_game("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(H)]: [command]")
-
-			var/atom/movable/screen/alert/mind_control/mind_alert = H.throw_alert(ALERT_MIND_CONTROL, /atom/movable/screen/alert/mind_control)
-			mind_alert.command = command
-		else
+		if(HAS_TRAIT(H, TRAIT_MINDSHIELD))
 			to_chat(H, span_notice("You hear a low drone as something foreign attempts to enter your mind, but the noise fades after a few moments."))
+			continue
+
+		broadcasted_mobs += H
+		to_chat(H, span_userdanger("You suddenly feel an irresistible compulsion to follow an order..."))
+		to_chat(H, span_mind_control("[command]"))
+
+		message_admins("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(H)]: [command]")
+		log_game("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(H)]: [command]")
+
+		var/atom/movable/screen/alert/mind_control/mind_alert = H.throw_alert(ALERT_MIND_CONTROL, /atom/movable/screen/alert/mind_control)
+		mind_alert.command = command
 
 	if(LAZYLEN(broadcasted_mobs))
 		active_mind_control = TRUE

--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -27,7 +27,7 @@
 				if(3)
 					H.hallucination += 60
 		else
-			to_chat(H, span_notice("You hear a faint hum behind you, for just a moment."))
+			to_chat(H, span_notice("You hear a faint hum fill your ears, which quickly dies down."))
 
 /obj/item/organ/heart/gland/mindshock/mind_control(command, mob/living/user)
 	if(!ownerCheck() || !mind_control_uses || active_mind_control)

--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -5,7 +5,7 @@
 	uses = -1
 	icon_state = "mindshock"
 	mind_control_uses = 1
-	mind_control_duration = 600
+	mind_control_duration = 1200
 	var/list/mob/living/carbon/human/broadcasted_mobs = list()
 
 /obj/item/organ/heart/gland/mindshock/activate()

--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -5,7 +5,7 @@
 	uses = -1
 	icon_state = "mindshock"
 	mind_control_uses = 1
-	mind_control_duration = 6000
+	mind_control_duration = 600
 	var/list/mob/living/carbon/human/broadcasted_mobs = list()
 
 /obj/item/organ/heart/gland/mindshock/activate()
@@ -37,15 +37,16 @@
 		if(H.stat)
 			continue
 
-		broadcasted_mobs += H
-		to_chat(H, span_userdanger("You suddenly feel an irresistible compulsion to follow an order..."))
-		to_chat(H, span_mind_control("[command]"))
+		if(!HAS_TRAIT(H, TRAIT_MINDSHIELD))
+			broadcasted_mobs += H
+			to_chat(H, span_userdanger("You suddenly feel an irresistible compulsion to follow an order..."))
+			to_chat(H, span_mind_control("[command]"))
 
-		message_admins("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(H)]: [command]")
-		log_game("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(H)]: [command]")
+			message_admins("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(H)]: [command]")
+			log_game("[key_name(user)] broadcasted an abductor mind control message from [key_name(owner)] to [key_name(H)]: [command]")
 
-		var/atom/movable/screen/alert/mind_control/mind_alert = H.throw_alert(ALERT_MIND_CONTROL, /atom/movable/screen/alert/mind_control)
-		mind_alert.command = command
+			var/atom/movable/screen/alert/mind_control/mind_alert = H.throw_alert(ALERT_MIND_CONTROL, /atom/movable/screen/alert/mind_control)
+			mind_alert.command = command
 
 	if(LAZYLEN(broadcasted_mobs))
 		active_mind_control = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the length of the brainwashing from six minutes to two. Adds a second charge to the mindshock gland to compensate.

Makes it so that having a mindshield will protect you from the effects of a mindshock gland. The includes the passive effects that mindshock glands have on people near them, as well as the brainwash command from the mental interface device.

Since the implant itself is handling the brainwash broadcast, it will still succeed in broadcasting the message even if the gland holder is mindshielded.  Mindshields only prevent you from _receiving_ the brainwash message. Tinfoil hat functionality is untouched and remains the only way to block the message from being broadcast.

Very open to feedback on this one, please let me know what you think.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The entire purpose of mindshields are to protect from brainwashing. If it can shield you from mutineer flashes, traitor hypnoflashes, and the eldritch influence of Nar'Sie herself, it should be able to protect you from alien brainwashing. You already have very little way of seeing it coming, and it can control an entire room of people (like a packed medbay trying to remove abductor glands), so there should be some form of counterplay if the crew knows what the abductors are up to.

As for the length of the hypnosis being shortened, six minutes really starts to drag on when you're at the receiving end of the brainwashing. Abductors still have brainwash surgery for their long-term bits, and with the second charge the mindshock brainwash is a bit more flexible in its short-term comedy potential.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The mindshock gland mind control has been changed from a single, six-minute command to two, two-minute long commands. Also, those who are mindshielded will resist the brainwashing effects and the brain-melting waves the gland passively emits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
