### PR TITLE
Fixes computers being unusable and runtiming to hell

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -250,7 +250,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		update_appearance()
 		update_slot_icon()
 
-	return FALSE
+	return TRUE
 
 /obj/item/modular_computer/MouseDrop(obj/over_object, src_location, over_location)
 	var/mob/M = usr


### PR DESCRIPTION
## About The Pull Request

Currently, it returns FALSE regardless of what happens on the proc on the first breakpoint, which means it goes on to the second breakpoint, where it adds the ID to both card slots, the first slot holder will early return since it already has a card, but it will add the card to the second, meaning the card is technically in both, but is only in the second since that was last to be moved to. This caused programs that required the ID in the first slot, to runtime since it lacks one and only has in the second.
![image](https://user-images.githubusercontent.com/53777086/167071600-0fe90954-3e9d-4158-8094-afde511e5079.png)

Because InsertID just calls try_insert
![image](https://user-images.githubusercontent.com/53777086/167071576-c5b8b662-8a67-4372-a032-4d7bf7b98c7c.png)

## Why It's Good For The Game

Computers actually work, you can download apps and use ID-locked programs, and it doesnt cause a fuck-ton of runtime errors.

## Changelog

:cl:
fix: Modular computers work again, allowing you to put your ID in to download/use programs.
/:cl: