### PR TITLE
Scipaper rebalancing: Nitrium and halon shell removal. Nitrous added. Emphasis on BZ.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -52884,13 +52884,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "otQ" = (
-/obj/machinery/portable_atmospherics/canister/bz,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "otS" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -22575,12 +22575,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
 "hny" = (
-/obj/machinery/portable_atmospherics/canister/bz,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "hnB" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -64640,7 +64640,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -64651,6 +64650,7 @@
 	pixel_x = -24;
 	req_access = list("xenobiology")
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "smR" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -64400,9 +64400,9 @@
 /area/station/science/research)
 "wGQ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/bz,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/box,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "wGR" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -42215,7 +42215,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/bz,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "omS" = (

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -98,24 +98,24 @@
 	name = "Reactionless Explosives"
 	description = "Gases with high specific heat can heat up those with a low one and produce a lot of pressure. Perform research and publish papers on this field. No gas reactions are allowed."
 	gain = list(10,50,100)
-	target_amount = list(20,75,200)
+	target_amount = list(20,50,100)
 	experiment_proper = TRUE
 	sanitized_misc = FALSE
 	sanitized_reactions = TRUE
 
-/datum/experiment/ordnance/gaseous/nitrium
-	name = "Nitrium Gas Shells"
-	description = "The delivery of Nitrium gas into an area of operation might prove useful. Perform research and publish papers on this field."
-	gain = list(20,60,120)
-	target_amount = list(20,120,500)
+/datum/experiment/ordnance/gaseous/nitrous_oxide
+	name = "Nitrous Oxide Gas Shells"
+	description = "The delivery of N2O into an area of operation might prove useful. Perform research and publish papers on this field."
+	gain = list(10,40)
+	target_amount = list(200,600)
 	experiment_proper = TRUE
-	required_gas = /datum/gas/nitrium
+	required_gas = /datum/gas/nitrous_oxide
 
 /datum/experiment/ordnance/gaseous/bz
 	name = "BZ Gas Shells"
 	description = "The delivery of BZ gas into an area of operation might prove useful. Perform research and publish papers on this field."
-	gain = list(25,50)
-	target_amount = list(200,600)
+	gain = list(10,30,60)
+	target_amount = list(50,125,400)
 	experiment_proper = TRUE
 	required_gas = /datum/gas/bz
 
@@ -126,14 +126,6 @@
 	target_amount = list(15,55,250)
 	experiment_proper = TRUE
 	required_gas = /datum/gas/hypernoblium
-
-/datum/experiment/ordnance/gaseous/halon
-	name = "Halon Gas Shells"
-	description = "The delivery of Halon gas into an area of operation might prove useful. Perform research and publish papers on this field."
-	gain = list(10,30,60)
-	target_amount = list(15,55,250)
-	experiment_proper = TRUE
-	required_gas = /datum/gas/halon
 
 /datum/experiment/scanning/random/material/meat
 	name = "Biological Material Scanning Experiment"

--- a/code/modules/research/ordnance/scipaper_partner.dm
+++ b/code/modules/research/ordnance/scipaper_partner.dm
@@ -1,47 +1,74 @@
-/datum/scientific_partner/spinward_science
-	name="Spinward Science"
-	flufftext="A local scientific community started by the diverse inhabitants of the Spinward Sector. Not generally advanced, but they will gladly work with us."
-	multipliers=list(SCIPAPER_COOPERATION_INDEX = 1, SCIPAPER_FUNDING_INDEX=0.75)
-	boosted_nodes=list("emp_basic" = 500, "NVGtech" = 1500, "integrated_HUDs" = 500)
+/datum/scientific_partner/mining
+	name = "Mining Corps"
+	flufftext = "A local group of miners are looking for ways to improve their mining output. They are interested in smaller scale explosives."
+	accepted_experiments = list(/datum/experiment/ordnance/explosive/lowyieldbomb)
+	multipliers = list(SCIPAPER_COOPERATION_INDEX = 0.75, SCIPAPER_FUNDING_INDEX = 0.75)
+	boosted_nodes = list(
+		"bluespace_basic" = 2000,
+		"NVGtech" = 1500,
+		"practical_bluespace" = 2500,
+		"basic_plasma" = 2000,
+		"basic_mining" = 2000,
+		"adv_mining" = 2000,
+	)
 
 /datum/scientific_partner/baron
 	name = "Ghost Writing"
-	flufftext="A nearby research station ran by a very wealthy captain seems to be struggling with their scientific output. They might reward us handsomely if we ghostwrite for them."
-	multipliers = list(SCIPAPER_COOPERATION_INDEX = 0.25, SCIPAPER_FUNDING_INDEX=5)
-	boosted_nodes = list("comp_recordkeeping" = 500, "computer_hardware_basic"=500)
+	flufftext = "A nearby research station ran by a very wealthy captain seems to be struggling with their scientific output. They might reward us handsomely if we ghostwrite for them."
+	multipliers = list(SCIPAPER_COOPERATION_INDEX = 0.25, SCIPAPER_FUNDING_INDEX = 5)
+	boosted_nodes = list(
+		"comp_recordkeeping" = 500, 
+		"computer_hardware_basic" = 500,
+	)
 
 /datum/scientific_partner/defense
-	name="Defense Partnership"
-	flufftext="We can work directly for Nanotrasen's \[REDACTED\] division, potentially providing us access with advanced defensive gadgets."
-	accepted_experiments=list(/datum/experiment/ordnance/explosive/lowyieldbomb, /datum/experiment/ordnance/explosive/highyieldbomb, /datum/experiment/ordnance/explosive/pressurebomb)
-	boosted_nodes = list("adv_weaponry" = 5000, "weaponry" = 2500, "sec_basic" = 1250, "explosive_weapons"=1250)
-
-/datum/scientific_partner/energy
-	name="High-Energy Research"
-	flufftext="A recently established high-energy research concern started by Nanotrasen. They might be able to assist our energy-based research."
-	accepted_experiments=list(/datum/experiment/ordnance/explosive/hydrogenbomb, /datum/experiment/ordnance/explosive/nobliumbomb)
-	boosted_nodes = list("adv_beam_weapons" = 1250, "beam_weapons" = 1250, "electronic_weapons"=1250, "mech_laser"=1250, "mech_laser_heavy"=1250)
-
-/datum/scientific_partner/engineering
-	name="Corps of Engineers"
-	flufftext = "Many engineers are interested in the application of exotic gases in their day-to-day work. They might be able to offer us information on some their gadgets in return."
-	accepted_experiments=list(/datum/experiment/ordnance/gaseous/halon, /datum/experiment/ordnance/gaseous/noblium, /datum/experiment/ordnance/explosive/lowyieldbomb)
-	boosted_nodes=list(/datum/techweb_node/adv_engi=2500, /datum/techweb_node/adv_power=1500, /datum/techweb_node/bluespace_power=2000, /datum/techweb_node/high_efficiency=2500, /datum/techweb_node/micro_bluespace=2500)
+	name = "Defense Partnership"
+	flufftext = "We can work directly for Nanotrasen's \[REDACTED\] division, potentially providing us access with advanced defensive gadgets."
+	accepted_experiments = list(
+		/datum/experiment/ordnance/explosive/highyieldbomb, 
+		/datum/experiment/ordnance/explosive/pressurebomb,
+		/datum/experiment/ordnance/explosive/hydrogenbomb,
+	)
+	boosted_nodes = list(
+		"adv_weaponry" = 5000, 
+		"weaponry" = 2500,
+		"sec_basic" = 1250, 
+		"explosive_weapons" = 1250,
+		"electronic_weapons" = 1250,
+		"radioactive_weapons" = 1250,
+		"beam_weapons" = 1250,
+		"explosive_weapons" = 1250,
+	)
 
 /datum/scientific_partner/medical
-	name="Biological Research Division"
-	flufftext="A collegiate of the best medical researchers Nanotrason employs. They seem to be interested in the biological effects of some more exotic gases."
-	accepted_experiments=list(/datum/experiment/ordnance/gaseous/nitrium, /datum/experiment/ordnance/gaseous/bz)
-	boosted_nodes=list("cyber_organs"=750, "cyber_organs_upgraded"=1000, "genetics"=500, "subdermal_implants"=1250, "adv_biotech"=1000)
+	name = "Biological Research Division"
+	flufftext = "A collegiate of the best medical researchers Nanotrason employs. They seem to be interested in the biological effects of some more exotic gases. Especially stimulants and neurosupressants."
+	accepted_experiments = list(
+		/datum/experiment/ordnance/gaseous/nitrous_oxide, 
+		/datum/experiment/ordnance/gaseous/bz,
+	)
+	boosted_nodes = list(
+		"cyber_organs" = 750, 
+		"cyber_organs_upgraded" = 1000, 
+		"genetics" = 500, 
+		"subdermal_implants" = 1250, 
+		"adv_biotech" = 1000,
+		"biotech" = 1000,
+	)
 
-/datum/scientific_partner/ordnance
-	name="Ordnance Partners"
-	flufftext="There are other stations tasked with researching the more esoteric reactions. We might be able to exchange some information with them."
-	accepted_experiments=list(/datum/experiment/ordnance/explosive/pressurebomb, /datum/experiment/ordnance/explosive/nobliumbomb)
-	boosted_nodes=list("gravity_gun"=1250, "mecha_phazon"=1500, "mech_wormhole_gen"=1250, "bluespace_travel"=1000, "micro_bluespace"=3000, "basic_plasma"=1000, "adv_plasma"=1000)
-
-/datum/scientific_partner/cold_physics
-	name="Low Temperature Research"
-	flufftext="A Nanotrasen division researching matter interactions at very low temperatures. Very interested in our hyper-noblium research."
-	accepted_experiments=list(/datum/experiment/ordnance/gaseous/noblium, /datum/experiment/ordnance/explosive/nobliumbomb)
-	boosted_nodes=list("emp_super" = 3000, "emp_adv"=1250, "cryotech"=1500)
+/datum/scientific_partner/physics
+	name = "NT Physics Quarterly"
+	flufftext = "A prestigious physics journal managed by Nanotrasen. The main journal for publishing cutting-edge physics research conducted by Nanotrasen, given that they aren't classified."
+	accepted_experiments = list(
+		/datum/experiment/ordnance/gaseous/noblium,
+		/datum/experiment/ordnance/explosive/nobliumbomb,
+	)
+	boosted_nodes = list(
+		"engineering" = 5000,
+		"adv_engi" = 5000,
+		"emp_super" = 3000, 
+		"emp_adv" = 1250,
+		"high_efficiency" = 5000,
+		"micro_bluespace" = 5000,
+		"adv_power" = 1500,
+	)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -549,6 +549,7 @@
 		"weldingmask",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	required_experiments = list(/datum/experiment/ordnance/gaseous/bz)
 	discount_experiments = list(/datum/experiment/scanning/random/material/medium/one = 4000)
 
 /datum/techweb_node/anomaly
@@ -1168,6 +1169,7 @@
 		"cybernetic_stomach_tier2",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
+	
 
 /datum/techweb_node/cyber_organs_upgraded
 	id = "cyber_organs_upgraded"
@@ -1182,7 +1184,6 @@
 		"cybernetic_stomach_tier3",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
-	required_experiments = list(/datum/experiment/ordnance/gaseous/bz)
 
 /datum/techweb_node/cyber_implants
 	id = "cyber_implants"
@@ -1212,7 +1213,6 @@
 		"ci-toolset",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	required_experiments = list(/datum/experiment/ordnance/gaseous/nitrium)
 
 /datum/techweb_node/combat_cyber_implants
 	id = "combat_cyber_implants"
@@ -1254,7 +1254,7 @@
 	id = "adv_mining"
 	display_name = "Advanced Mining Technology"
 	description = "Efficiency Level 127" //dumb mc references
-	prereq_ids = list("basic_mining", "adv_engi", "adv_power", "adv_plasma")
+	prereq_ids = list("basic_mining", "adv_power", "adv_plasma")
 	design_ids = list(
 		"drill_diamond",
 		"hypermod",
@@ -1368,6 +1368,7 @@
 		"tele_shield",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	required_experiments = list(/datum/experiment/ordnance/explosive/pressurebomb)
 
 /datum/techweb_node/adv_weaponry
 	id = "adv_weaponry"
@@ -1378,7 +1379,6 @@
 		"pin_loyalty",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	required_experiments = list(/datum/experiment/ordnance/explosive/highyieldbomb)
 
 /datum/techweb_node/electric_weapons
 	id = "electronic_weapons"


### PR DESCRIPTION
## About The Pull Request
Similar in spirit to #65707, with some more changes.

Restructured the gaseous experiments to:
1. Nitrous (practice experiment)
2. BZ (mainstay experiment)
3. Hyper-Nob (lategame/once-in-a-while experiment)

Added a mining partner.

Moved adv weaponry lock to normal weaponry under reactionless. Toned down t3 reactionless.

BZ locks adv engi. Medbay unbridled by toxin gasses now.

Removed Xenobio's BZ Can.

## Why It's Good For The Game
My original intent with papers was expanding the difficulty range of toxins. Both to things harder than tritium (nob, nitrium, etc) and also to things easier than tritium (bz, reactionless, etc). 

In that process, I feel that i strayed a bit to the harder side, this PR is an attempt to tone down the overall difficulty of some of the gaseous experiments a notch. 

Nitrous now takes place of the old BZ, BZ takes place of old nitrium/halon, and noblium stays because it's difficulty is in a pretty good spot for a relatively unimportant but nice to have tech.

While we're at it, I also added more emphasis to BZ production to toxins instead of tritium. This will hopefully incentivize people to try the department out. There is a risk of this being a bit of a chore, but I believe that the relevant atmos gameplay loop is strong enough to have it be fun. You need to check on the chamber, turn on pipes, adjust the input rate, and many more that makes it significantly more fun to do.

We do this by:
1) Locking advanced engineering with BZ (organs and implants lock lifted). Depending on feedback i wont mind changing this around if you want to suggest another node as long as it's of similar or very slightly less importance.

2) Getting rid of xeno's BZ can. Some xeno players need it for making slimes sleep, with their roundstart supply removed there should be a significant demand for the BZ production in toxins to go online asap.

If you have been paying attention to our PRs, i have been working to make BZ production as seamless and quick as possible in toxins. My five map prs #66454 #66198 #66064 #66010 #65857 have been building up to this. You can make BZ relatively quickly with the new freezer chamber in place. Probably even faster than ordering it in cargo, which is a fine ballpark to use if you want to make changes to it.

If you want to know how to operate it, here is a wiki guide in place https://tgstation13.org/wiki/User:Vincentius_vin/Sandbox#BZ_Synthesis. We will move it to the main toxins page once the rest of the page is finished, pictures are added, code things are finalized etc etc.

Refer to the linked PR above for justification on the mining partner and also the reactionless explosion.

## Changelog
:cl:
balance: Made adv engi tech node require bz shells as an experiment, organs no longer need it.
balance: Adv mining no longer requires adv engi.
balance: Removed nitrium and halon shell, implant experiment lock lifted because of the former.
balance: Relocked sec 1 tech node to need pressure bombs, sec 2 no longer needs tritium bomb.
balance: Made advanced pressure bombs easier to do without funny fusion gases.
balance: Added a new mining partner that accepts smaller (even non-atmos/non-ordnance related) bombs
balance: Added more options to purchase nodes in the paper partners. Your point gain stays the same though.
balance: Removed roundstart BZ can from xenobio.
/:cl: