### PR TITLE
Changes stripped_input to behave like tgui_text

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -101,23 +101,45 @@
 	return text
 
 
-/// Used to get a properly sanitized input, of max_length
-/// no_trim is self explanatory but it prevents the input from being trimed if you intend to parse newlines or whitespace.
-/proc/stripped_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE)
-	var/name = input(user, message, title, default) as text|null
-
+/**
+ * Used to get a properly sanitized input
+ *
+ * Arguments
+ ** user - Target of the input prompt.
+ ** message - The text inside of the prompt.
+ ** title - The window title of the prompt.
+ ** max_length - If you intend to impose a length limit - default is 1024.
+ ** no_trim - Prevents the input from being trimmed if you intend to parse newlines or whitespace.
+ ** null_return - Allows you to return a null value in case the user cancels or hits X. Default is false, which returns an empty string.
+*/
+/proc/stripped_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE, null_return=FALSE)
+	var/user_input = input(user, message, title, default) as text|null
+	if(null_return && isnull(user_input))
+		return
 	if(no_trim)
-		return copytext(html_encode(name), 1, max_length)
+		return copytext(html_encode(user_input), 1, max_length)
 	else
-		return trim(html_encode(name), max_length) //trim is "outside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
+		return trim(html_encode(user_input), max_length) //trim is "outside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
 
-// Used to get a properly sanitized multiline input, of max_length
-/proc/stripped_multiline_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE)
-	var/name = input(user, message, title, default) as message|null
+/**
+ * Used to get a properly sanitized input in a larger box. Works very similarly to stripped_input.
+ *
+ * Arguments
+ ** user - Target of the input prompt.
+ ** message - The text inside of the prompt.
+ ** title - The window title of the prompt.
+ ** max_length - If you intend to impose a length limit - default is 1024.
+ ** no_trim - Prevents the input from being trimmed if you intend to parse newlines or whitespace.
+ ** null_return - Allows you to return a null value in case the user cancels or hits X. Default is false, which returns an empty string.
+*/
+/proc/stripped_multiline_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE, null_return=FALSE)
+	var/user_input = input(user, message, title, default) as message|null
+	if(null_return && isnull(user_input))
+		return
 	if(no_trim)
-		return copytext(html_encode(name), 1, max_length)
+		return copytext(html_encode(user_input), 1, max_length)
 	else
-		return trim(html_encode(name), max_length)
+		return trim(html_encode(user_input), max_length)
 
 #define NO_CHARS_DETECTED 0
 #define SPACES_DETECTED 1

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -102,7 +102,7 @@
 
 
 /**
- * Used to get a properly sanitized input
+ * Used to get a properly sanitized input. Returns null if cancel is pressed.
  *
  * Arguments
  ** user - Target of the input prompt.
@@ -110,11 +110,10 @@
  ** title - The window title of the prompt.
  ** max_length - If you intend to impose a length limit - default is 1024.
  ** no_trim - Prevents the input from being trimmed if you intend to parse newlines or whitespace.
- ** null_return - Allows you to return a null value in case the user cancels or hits X. Default is false, which returns an empty string.
 */
-/proc/stripped_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE, null_return=FALSE)
+/proc/stripped_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE)
 	var/user_input = input(user, message, title, default) as text|null
-	if(null_return && isnull(user_input))
+	if(isnull(user_input)) // User pressed cancel
 		return
 	if(no_trim)
 		return copytext(html_encode(user_input), 1, max_length)
@@ -130,11 +129,10 @@
  ** title - The window title of the prompt.
  ** max_length - If you intend to impose a length limit - default is 1024.
  ** no_trim - Prevents the input from being trimmed if you intend to parse newlines or whitespace.
- ** null_return - Allows you to return a null value in case the user cancels or hits X. Default is false, which returns an empty string.
 */
-/proc/stripped_multiline_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE, null_return=FALSE)
+/proc/stripped_multiline_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE)
 	var/user_input = input(user, message, title, default) as message|null
-	if(null_return && isnull(user_input))
+	if(isnull(user_input)) // User pressed cancel
 		return
 	if(no_trim)
 		return copytext(html_encode(user_input), 1, max_length)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -408,7 +408,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	if(!.)
 		return
 	var/mob/living/living_owner = owner
-	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Final Words")
+	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Goodnight, Sweet Prince")
 	if(isnull(last_whisper) || !CAN_SUCCUMB(living_owner))
 		return
 	if(length(last_whisper))

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -407,15 +407,15 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	. = ..()
 	if(!.)
 		return
-
 	var/mob/living/living_owner = owner
-	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Final Words")
-	if(isnull(last_whisper) || !CAN_SUCCUMB(living_owner))
+	var/confirm = tgui_alert(usr, "Are you sure you wish to succumb to death?", "Goodnight, Sweet Prince", list("Yes", "No"))
+	if(confirm != "Yes" || !CAN_SUCCUMB(living_owner))
 		return
-
+	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Final Words")
+	if(!CAN_SUCCUMB(living_owner))
+		return
 	if(length(last_whisper))
 		living_owner.say("#[last_whisper]")
-
 	living_owner.succumb(whispered = length(last_whisper) > 0)
 
 //ALIENS

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -408,11 +408,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	if(!.)
 		return
 	var/mob/living/living_owner = owner
-	var/confirm = tgui_alert(usr, "Are you sure you wish to succumb to death?", "Goodnight, Sweet Prince", list("Yes", "No"))
-	if(confirm != "Yes" || !CAN_SUCCUMB(living_owner))
-		return
 	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Final Words")
-	if(!CAN_SUCCUMB(living_owner))
+	if(isnull(last_whisper) || !CAN_SUCCUMB(living_owner))
 		return
 	if(length(last_whisper))
 		living_owner.say("#[last_whisper]")

--- a/code/modules/tgui/tgui_input_text.dm
+++ b/code/modules/tgui/tgui_input_text.dm
@@ -28,9 +28,9 @@
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		if(encode)
 			if(multiline)
-				return stripped_multiline_input(user, message, title, default, max_length, null_return = TRUE)
+				return stripped_multiline_input(user, message, title, default, max_length)
 			else
-				return stripped_input(user, message, title, default, max_length, null_return = TRUE)
+				return stripped_input(user, message, title, default, max_length)
 		else
 			if(multiline)
 				return input(user, message, title, default) as message|null
@@ -70,9 +70,9 @@
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		if(encode)
 			if(multiline)
-				return stripped_multiline_input(user, message, title, default, max_length, null_return = TRUE)
+				return stripped_multiline_input(user, message, title, default, max_length)
 			else
-				return stripped_input(user, message, title, default, max_length, null_return = TRUE)
+				return stripped_input(user, message, title, default, max_length)
 		else
 			if(multiline)
 				return input(user, message, title, default) as message|null

--- a/code/modules/tgui/tgui_input_text.dm
+++ b/code/modules/tgui/tgui_input_text.dm
@@ -117,6 +117,7 @@
 	src.message = message
 	src.multiline = multiline
 	src.title = title
+	src.entry = ""
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time
@@ -183,11 +184,9 @@
 			return TRUE
 
 /datum/tgui_input_text/proc/set_entry(entry)
-	if(length(entry))
+	if(entry)
 		var/converted_entry = encode ? html_encode(entry) : entry
 		src.entry = trim(converted_entry, max_length)
-	else
-		src.entry = ""
 
 /**
  * # async tgui_input_text

--- a/code/modules/tgui/tgui_input_text.dm
+++ b/code/modules/tgui/tgui_input_text.dm
@@ -28,9 +28,9 @@
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		if(encode)
 			if(multiline)
-				return stripped_multiline_input(user, message, title, default, max_length)
+				return stripped_multiline_input(user, message, title, default, max_length, null_return = TRUE)
 			else
-				return stripped_input(user, message, title, default, max_length)
+				return stripped_input(user, message, title, default, max_length, null_return = TRUE)
 		else
 			if(multiline)
 				return input(user, message, title, default) as message|null
@@ -70,9 +70,9 @@
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		if(encode)
 			if(multiline)
-				return stripped_multiline_input(user, message, title, default, max_length)
+				return stripped_multiline_input(user, message, title, default, max_length, null_return = TRUE)
 			else
-				return stripped_input(user, message, title, default, max_length)
+				return stripped_input(user, message, title, default, max_length, null_return = TRUE)
 		else
 			if(multiline)
 				return input(user, message, title, default) as message|null
@@ -117,7 +117,6 @@
 	src.message = message
 	src.multiline = multiline
 	src.title = title
-	src.entry = ""
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time
@@ -184,7 +183,7 @@
 			return TRUE
 
 /datum/tgui_input_text/proc/set_entry(entry)
-	if(entry)
+	if(!isnull(entry))
 		var/converted_entry = encode ? html_encode(entry) : entry
 		src.entry = trim(converted_entry, max_length)
 

--- a/code/modules/tgui/tgui_input_text.dm
+++ b/code/modules/tgui/tgui_input_text.dm
@@ -183,9 +183,11 @@
 			return TRUE
 
 /datum/tgui_input_text/proc/set_entry(entry)
-	if(!isnull(entry))
+	if(length(entry))
 		var/converted_entry = encode ? html_encode(entry) : entry
 		src.entry = trim(converted_entry, max_length)
+	else
+		src.entry = ""
 
 /**
  * # async tgui_input_text


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After ~~a little bit of~~ EVEN MORE misunderstanding, it's apparent that tgui text handles null differently, which meant fixing last whisper for tgui inputs users (chads) would mean that it would be broken for byond input users (lizards).

All jokes aside, this changes it so that text inputs will return null when you hit cancel or X for BOTH tgui and stripped_input.

tgui text:
https://user-images.githubusercontent.com/42397676/167283042-5f4c7ea7-3982-43e2-aa3e-0f52101ee56c.mp4
standard input:
https://user-images.githubusercontent.com/42397676/167283046-786f3540-62b9-461c-b5d8-f6d5ee7117b5.mp4

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Matches input functionality, fixes a bug for the umpteenth time, gives succumb the funny text "goodnight sweet prince"
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
@nevimer @itseasytosee @lemoninthedark
:cl:
fix: Changes the succumb screen to work for both tgui and standard inputs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
