### PR TITLE
Set steel_sheet_cost for tablets (PDAs) to 2

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -11,7 +11,7 @@
 	max_hardware_size = 1
 	w_class = WEIGHT_CLASS_SMALL
 	max_bays = 3
-	steel_sheet_cost = 1
+	steel_sheet_cost = 2
 	slot_flags = ITEM_SLOT_ID | ITEM_SLOT_BELT
 	has_light = TRUE //LED flashlight!
 	comp_light_luminosity = 2.3 //Same as the PDA


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Destroyed player PDA / tablet drops half of the steel_sheet_cost as a stack on destruction.  Having this set to 1 creates zero sized stacks of iron.  Rather than fix the code that drops, I just upped this to make it drop 1 sheet on destruction, which is probably the intended effect.

## Why It's Good For The Game

Zero sized stacks of items . . . are actually kinda funny, but maybe shouldn't exist.

## Changelog

Looks like when destroyed the item drops half the steel_sheet_cost as a stack of metal (as in I set it to 10 to test and it dropped 5 iron).

Thus, when a new PDA/tablet thing was destroyed, it would drop half a sheet of metal which nicely rounds down to zero metal.

The alternative is to make the code that drops the metal check if the rounded value is greater than zero.  Your choice, but you'll have to code the other option.

Stops the following from existing

>  That's some iron.
> Sheets made out of iron.
> It is made out of iron.
> It appears to have an ever-updating bluespace warning label.
> They are a tiny item.
> The iron is made of fire-retardant materials.
> There is 0 iron sheet in the stack.
> Right-click with an empty hand to take a custom amount.
> You can build a wall girder (unanchored) by right clicking on an empty floor.



:cl:iain0
fix: PDA/Tablets are now made from a realistic amount of iron.
/:cl:
