### PR TITLE
Removes native_fov from the config for lacking documentation as to what the fuck it is.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -393,8 +393,6 @@
 
 /datum/config_entry/flag/sdql_spells
 
-/datum/config_entry/flag/native_fov
-
 /datum/config_entry/number/station_goal_budget
 	default = 1
 	min_val = 0

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -473,6 +473,3 @@ MAXFINE 2000
 ## Warning: SDQL is a powerful tool and can break many things or expose security sensitive information.
 ## Giving players access to it has major security concerns, be careful and deliberate when using this feature.
 #SDQL_SPELLS
-
-## Whether native FoV is enabled for all people.
-#NATIVE_FOV


### PR DESCRIPTION
I do not know, or understand this config, what it is, what enabling it does, what the fuck a native fov is, how it differentiates from what the fuck is used when the config is not enabled, etc.

This pr is good for the game because it removes confusing configs from the config file server operators have to use to setup a downstream server.

Catering to downstream servers is good for the game because downstream servers are good for the game.

Downstream servers are good for the game because downstream servers existing keeps us in check via capitalism/competition.

todo:remove config controller entry and then find out via the errors what the fuck this config actually does.