### PR TITLE
blood barrage bolts can now bring constructs to full health instead of stopping <=5 points of damage away from full health

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -878,8 +878,8 @@ Striking a noncultist, however, will tear their flesh."}
 				H.reagents.add_reagent(/datum/reagent/fuel/unholywater, 4)
 		if(isshade(target) || isconstruct(target))
 			var/mob/living/simple_animal/M = target
-			if(M.health+5 < M.maxHealth)
-				M.adjustHealth(-5)
+			if(M.health < M.maxHealth)
+				M.adjustHealth(max(M.health - M.maxHealth, -5)) //heals 5 hp or all damage, whichever is less
 		new /obj/effect/temp_visual/cult/sparks(T)
 		qdel(src)
 	else


### PR DESCRIPTION
## About The Pull Request

Blood bolt barrage bolts (from the blood rites cult spell) will, when striking a cult-aligned construct or shade, heal either 5 HP of damage or all of the construct or shade's remaining damage, whichever is less.

## Why It's Good For The Game

Currently, due to some sloppy coding, blood bolt barrage bolts will stop healing constructs or shades once they have <=5 points or less of damage, which mildly triggers my OCD.

## Changelog

:cl: ATHATH
fix: Blood bolt barrage bolts (from the blood rites cult spell) will, when striking a cult-aligned construct or shade, heal either 5 HP of damage or all of the construct or shade's remaining damage, whichever is less. Previously, they would just refuse to heal constructs and shades if their health totals within 5 points of their maximum hp totals.
/:cl: