### PR TITLE
Titan's Final Lament - Colossus and hierophant crusher trophy rework

### DIFF
--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -16,8 +16,6 @@
 	var/default_projectile_spread = 0
 	/// The multiplier to the projectiles speed (a value of 2 makes it twice as slow, 0.5 makes it twice as fast)
 	var/projectile_speed_multiplier = 1
-	/// How long is pre-attack cooldown
-	var/pre_attack_cooldown = 10 SECONDS
 
 /datum/action/cooldown/mob_cooldown/projectile_attack/New(Target, projectile, homing, spread)
 	. = ..()
@@ -29,7 +27,7 @@
 		default_projectile_spread = spread
 
 /datum/action/cooldown/mob_cooldown/projectile_attack/Activate(atom/target_atom)
-	StartCooldown(pre_attack_cooldown)
+	StartCooldown(10 SECONDS)
 	attack_sequence(owner, target_atom)
 	StartCooldown()
 
@@ -286,10 +284,11 @@
 	name = "Titan's Finale"
 	desc = "A single-use ability that shoots a large amount of projectiles around you."
 	cooldown_time = 2.5 SECONDS
-	pre_attack_cooldown = 30 SECONDS
 
 /datum/action/cooldown/mob_cooldown/projectile_attack/colossus_final/Activate(atom/target_atom)
-	. = ..()
+	StartCooldown(30 SECONDS)
+	attack_sequence(owner, target_atom)
+	StartCooldown()
 	Remove(owner)
 
 /datum/action/cooldown/mob_cooldown/projectile_attack/colossus_final/attack_sequence(mob/living/firer, atom/target)
@@ -298,7 +297,7 @@
 		colossus = firer
 
 	var/finale_counter = 10
-	for(var/i = 1 to 20)
+	for(var/i in 1 to 20)
 		if(finale_counter > 4 && colossus)
 			colossus.say("Die!!", spans = list("colossus", "yell"))
 			colossus.telegraph()

--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -320,7 +320,7 @@
 		finale_counter += 6
 		SLEEP_CHECK_DEATH(finale_counter, firer)
 
-	for(var/i = 1 to 3)
+	for(var/i in 1 to 3)
 		if(colossus)
 			colossus.telegraph()
 			colossus.dir_shots.attack_sequence(firer, target)

--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -313,7 +313,7 @@
 
 		SLEEP_CHECK_DEATH(finale_counter + 1, firer)
 
-	for(var/i = 1 to 3)
+	for(var/i in 1 to 3)
 		if(colossus)
 			colossus.telegraph()
 			colossus.random_shots.attack_sequence(firer, target)

--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -295,11 +295,11 @@
 	var/mob/living/simple_animal/hostile/megafauna/colossus/colossus
 	if(istype(firer, /mob/living/simple_animal/hostile/megafauna/colossus))
 		colossus = firer
-
+		colossus.say("Perish.", spans = list("colossus", "yell"))
+	
 	var/finale_counter = 10
 	for(var/i in 1 to 20)
 		if(finale_counter > 4 && colossus)
-			colossus.say("Die!!", spans = list("colossus", "yell"))
 			colossus.telegraph()
 			colossus.shotgun_blast.attack_sequence(firer, target)
 
@@ -315,7 +315,6 @@
 
 	for(var/i = 1 to 3)
 		if(colossus)
-			colossus.say("Die.", spans = list("colossus", "yell"))
 			colossus.telegraph()
 			colossus.random_shots.attack_sequence(firer, target)
 		finale_counter += 6
@@ -323,7 +322,6 @@
 
 	for(var/i = 1 to 3)
 		if(colossus)
-			colossus.say("Die...", spans = list("colossus", "yell"))
 			colossus.telegraph()
 			colossus.dir_shots.attack_sequence(firer, target)
 		SLEEP_CHECK_DEATH(1 SECONDS, firer)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -449,17 +449,10 @@
 	denied_type = /obj/item/crusher_trophy/vortex_talisman
 
 /obj/item/crusher_trophy/vortex_talisman/effect_desc()
-	return "mark detonation to create a barrier you can pass"
+	return "mark detonation to create a homing hierophant chaser"
 
 /obj/item/crusher_trophy/vortex_talisman/on_mark_detonation(mob/living/target, mob/living/user)
-	var/turf/T = get_turf(user)
-	new /obj/effect/temp_visual/hierophant/wall/crusher(T, user) //a wall only you can pass!
-	var/turf/otherT = get_step(T, turn(user.dir, 90))
-	if(otherT)
-		new /obj/effect/temp_visual/hierophant/wall/crusher(otherT, user)
-	otherT = get_step(T, turn(user.dir, -90))
-	if(otherT)
-		new /obj/effect/temp_visual/hierophant/wall/crusher(otherT, user)
-
-/obj/effect/temp_visual/hierophant/wall/crusher
-	duration = 75
+	if(isliving(target))
+		var/obj/effect/temp_visual/hierophant/chaser/chaser = new(get_turf(user), user, target, 3, TRUE)
+		chaser.monster_damage_boost = FALSE // Weaker cuz no cooldown
+		log_combat(user, target, "fired a chaser at", src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -1,4 +1,4 @@
-#define COLOSSUS_ENRAGED (health < maxHealth/3)
+#define COLOSSUS_ENRAGED (health <= maxHealth / 3)
 
 /**
  * COLOSSUS
@@ -57,25 +57,31 @@
 	deathsound = 'sound/magic/demon_dies.ogg'
 	small_sprite_type = /datum/action/small_sprite/megafauna/colossus
 	/// Spiral shots ability
-	var/datum/action/cooldown/mob_cooldown/projectile_attack/spiral_shots/spiral_shots
+	var/datum/action/cooldown/mob_cooldown/projectile_attack/spiral_shots/colossus/spiral_shots
 	/// Random shots ablity
-	var/datum/action/cooldown/mob_cooldown/projectile_attack/random_aoe/random_shots
+	var/datum/action/cooldown/mob_cooldown/projectile_attack/random_aoe/colossus/random_shots
 	/// Shotgun blast ability
-	var/datum/action/cooldown/mob_cooldown/projectile_attack/shotgun_blast/shotgun_blast
+	var/datum/action/cooldown/mob_cooldown/projectile_attack/shotgun_blast/colossus/shotgun_blast
 	/// Directional shots ability
-	var/datum/action/cooldown/mob_cooldown/projectile_attack/dir_shots/alternating/dir_shots
+	var/datum/action/cooldown/mob_cooldown/projectile_attack/dir_shots/alternating/colossus/dir_shots
+	/// Final attack ability
+	var/datum/action/cooldown/mob_cooldown/projectile_attack/colossus_final/colossus_final
+	/// Have we used DIE yet?
+	var/final_availible = TRUE
 
 /mob/living/simple_animal/hostile/megafauna/colossus/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NO_FLOATING_ANIM, INNATE_TRAIT) //we don't want this guy to float, messes up his animations.
-	spiral_shots = new /datum/action/cooldown/mob_cooldown/projectile_attack/spiral_shots()
-	random_shots = new /datum/action/cooldown/mob_cooldown/projectile_attack/random_aoe()
-	shotgun_blast = new /datum/action/cooldown/mob_cooldown/projectile_attack/shotgun_blast()
-	dir_shots = new /datum/action/cooldown/mob_cooldown/projectile_attack/dir_shots/alternating()
+	spiral_shots = new /datum/action/cooldown/mob_cooldown/projectile_attack/spiral_shots/colossus()
+	random_shots = new /datum/action/cooldown/mob_cooldown/projectile_attack/random_aoe/colossus()
+	shotgun_blast = new /datum/action/cooldown/mob_cooldown/projectile_attack/shotgun_blast/colossus()
+	dir_shots = new /datum/action/cooldown/mob_cooldown/projectile_attack/dir_shots/alternating/colossus()
+	colossus_final = new /datum/action/cooldown/mob_cooldown/projectile_attack/colossus_final()
 	spiral_shots.Grant(src)
 	random_shots.Grant(src)
 	shotgun_blast.Grant(src)
 	dir_shots.Grant(src)
+	colossus_final.Grant(src)
 	RegisterSignal(src, COMSIG_ABILITY_STARTED, .proc/start_attack)
 	RegisterSignal(src, COMSIG_ABILITY_FINISHED, .proc/finished_attack)
 	AddElement(/datum/element/projectile_shield)
@@ -89,7 +95,7 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/megafauna/colossus/OpenFire()
-	anger_modifier = clamp(((maxHealth - health)/50),0,20)
+	anger_modifier = clamp(((maxHealth - health) / 40), 0, 20)
 
 	if(client)
 		return
@@ -97,7 +103,7 @@
 	if(enrage(target))
 		if(move_to_delay == initial(move_to_delay))
 			visible_message(span_colossus("\"<b>You can't dodge.</b>\""))
-		ranged_cooldown = world.time + 30
+		ranged_cooldown = world.time + 3 SECONDS
 		telegraph()
 		dir_shots.fire_in_directions(src, target, GLOB.alldirs)
 		move_to_delay = 3
@@ -105,21 +111,24 @@
 	else
 		move_to_delay = initial(move_to_delay)
 
-	if(prob(20+anger_modifier)) //Major attack
+	if(health <= maxHealth / 10 && !final_availible)
+		final_availible = FALSE
+		colossus_final.Trigger(target = target)
+	else if(prob(20 + anger_modifier)) //Major attack
 		spiral_shots.Trigger(target = target)
 	else if(prob(20))
 		random_shots.Trigger(target = target)
 	else
-		if(prob(70))
+		if(prob(60 + anger_modifier))
 			shotgun_blast.Trigger(target = target)
 		else
 			dir_shots.Trigger(target = target)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/telegraph()
-	for(var/mob/M in range(10,src))
-		if(M.client)
-			flash_color(M.client, "#C80000", 1)
-			shake_camera(M, 4, 3)
+	for(var/mob/viewer in range(10,src))
+		if(viewer.client)
+			flash_color(viewer.client, "#C80000", 1)
+			shake_camera(viewer, 4, 3)
 	playsound(src, 'sound/magic/clockwork/narsie_attack.ogg', 200, TRUE)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/start_attack(mob/living/owner, datum/action/cooldown/activated)
@@ -128,25 +137,31 @@
 		spiral_shots.enraged = COLOSSUS_ENRAGED
 		telegraph()
 		icon_state = "eva_attack"
-		visible_message(COLOSSUS_ENRAGED ? span_colossus("\"<b>Die.</b>\"") : span_colossus("\"<b>Judgement.</b>\""))
+		say("Judgement.", spans = list("colossus", "yell"))
+	else if(activated == random_shots)
+		say("Wrath.", spans = list("colossus", "yell"))
+	else if(activated == shotgun_blast)
+		say("Retribution.", spans = list("colossus", "yell"))
+	else if(activated == dir_shots)
+		say("Lament.", spans = list("colossus", "yell"))
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/finished_attack(mob/living/owner, datum/action/cooldown/finished)
 	SIGNAL_HANDLER
 	if(finished == spiral_shots)
 		icon_state = initial(icon_state)
 
-/mob/living/simple_animal/hostile/megafauna/colossus/proc/enrage(mob/living/L)
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		if(H.mind)
-			if(istype(H.mind.martial_art, /datum/martial_art/the_sleeping_carp))
+/mob/living/simple_animal/hostile/megafauna/colossus/proc/enrage(mob/living/victim)
+	if(ishuman(victim))
+		var/mob/living/carbon/human/human_victim = victim
+		if(human_victim.mind)
+			if(istype(human_victim.mind.martial_art, /datum/martial_art/the_sleeping_carp))
 				. = TRUE
-		if (is_species(H, /datum/species/golem/sand))
+		if (is_species(human_victim, /datum/species/golem/sand))
 			. = TRUE
 
-/mob/living/simple_animal/hostile/megafauna/colossus/devour(mob/living/L)
-	visible_message(span_colossus("[src] disintegrates [L]!"))
-	L.dust()
+/mob/living/simple_animal/hostile/megafauna/colossus/devour(mob/living/victim)
+	visible_message(span_colossus("[src] disintegrates [victim]!"))
+	victim.dust()
 
 /obj/effect/temp_visual/at_shield
 	name = "anti-toolbox field"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -125,7 +125,7 @@
 			dir_shots.Trigger(target = target)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/telegraph()
-	for(var/mob/viewer in range(10,src))
+	for(var/mob/viewer in viewers(src))
 		if(viewer.client)
 			flash_color(viewer.client, "#C80000", 1)
 			shake_camera(viewer, 4, 3)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -125,7 +125,7 @@
 			dir_shots.Trigger(target = target)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/telegraph()
-	for(var/mob/viewer in viewers(src))
+	for(var/mob/viewer as anything in viewers(10, src))
 		if(viewer.client)
 			flash_color(viewer.client, "#C80000", 1)
 			shake_camera(viewer, 4, 3)
@@ -137,13 +137,13 @@
 		spiral_shots.enraged = COLOSSUS_ENRAGED
 		telegraph()
 		icon_state = "eva_attack"
-		say("Judgement.", spans = list("colossus", "yell"))
+		INVOKE_ASYNC(src, /atom/movable.proc/say, "Judgement.", null, list("colossus", "yell"))
 	else if(activated == random_shots)
-		say("Wrath.", spans = list("colossus", "yell"))
+		INVOKE_ASYNC(src, /atom/movable.proc/say, "Wrath.", null, list("colossus", "yell"))
 	else if(activated == shotgun_blast)
-		say("Retribution.", spans = list("colossus", "yell"))
+		INVOKE_ASYNC(src, /atom/movable.proc/say, "Retribution.", null, list("colossus", "yell"))
 	else if(activated == dir_shots)
-		say("Lament.", spans = list("colossus", "yell"))
+		INVOKE_ASYNC(src, /atom/movable.proc/say, "Lament.", null, list("colossus", "yell"))
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/finished_attack(mob/living/owner, datum/action/cooldown/finished)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is somewhat a port of https://github.com/BeeStation/BeeStation-Hornet/pull/6805 with slight changes, credits to [Rukofamicom](https://github.com/Rukofamicom) for the original PR.

Kinetic crusher is supposed to be a high risk high reward weapon, but with current hiero wall trophy it just ends up with the player cheesing mob and boss AIs. To fix this, here we change hiero trophy to spawn a hierophant chaser instead of a wall, which will increase player's DPS without offering them any protection. 

However, this creates another issue: right now colossus is unbeatable with crusher without cheesing it with the wall due to it's shotgun attack which kills and dusts you point blank or 1 tile away, which is extremely unfair and unfun. To fix this, I add what should've been done from the start - make colossus telegraph it's attacks before starting them. Player has 1.5 seconds to react(unlike 3 seconds in the original PR which made the fight much easier) and dodge the attack or at least get away from the colossus to have a chance to survive.

Since this does make the fight significantly easier, colossus gets a special final attack during which it shouts "Perish" and uses different attacks. Unlike in the original PR, he can only use it once, so it's not as deadly and bullshit. This should make the fight more epic and similar to other bossfights which get cool attacks near the end of the battle.

Goodbye 4 GBP, you served me well.

## Why It's Good For The Game

Hierophant wall completely breaks mob AI and allows players to softlock them and kill them without taking any damage if they're good enough at it.

Colossus is absolutely bullshit and can instantly oneshot you with the shotgun attack close-range and is extremely unfun to play against. It's impossible to kill with crusher without the hierophant wall which is now removed, so it required changes as well.

It also is one of the most epic bosses and deserves to go out with a bang just like others which get cool attack near the end of the fight.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SmArtKar, Rukofamicom
balance: Hierophant crusher trophy now creates a hierophant chaser instead of a wall
add: Colossus now has a final attack which he can use once at 10% health.
balance: Colossus now telegraphs his attacks through speech 1.5 seconds before they happen - "Judgement" (Spiral or Double Spiral), "Wrath" (Ring), "Retribution" (Shotgun), "Lament" (Alternating cardinal and diagonal shots) and "Perish" (Final attack)
code: Improved colossus' variable names and added spaces where required
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
