### PR TITLE
Refactors cyborg drink refilling into a component

### DIFF
--- a/code/datums/components/reagent_refiller.dm
+++ b/code/datums/components/reagent_refiller.dm
@@ -13,9 +13,9 @@
 	var/list/whitelisted_reagents
 
 /datum/component/reagent_refiller/Initialize(
-	time_to_refill = 5 SECONDS,
+	time_to_refill = 60 SECONDS,
 	datum/callback/power_draw_callback,
-	power_to_draw = 300,
+	power_to_draw = 30,
 	whitelisted_reagents = list(/datum/reagent/consumable)
 )
 	if(!istype(parent, /obj/item/reagent_containers))

--- a/code/datums/components/reagent_refiller.dm
+++ b/code/datums/components/reagent_refiller.dm
@@ -1,0 +1,68 @@
+/**
+ * ## Reagent refiller
+ * Refills any drinks poured out of the reagent container (and is allowed within the whitelisted reagents).
+ */
+/datum/component/reagent_refiller
+	/// Time to refill
+	var/time_to_refill
+	/// Callback to consume power
+	var/datum/callback/power_draw_callback
+	/// Amount of power to use from the cell
+	var/power_to_draw
+	/// Whitelist of reagents allowed to be synthesized
+	var/list/whitelisted_reagents
+
+/datum/component/reagent_refiller/Initialize(
+	time_to_refill = 5 SECONDS,
+	datum/callback/power_draw_callback,
+	power_to_draw = 300,
+	whitelisted_reagents = list(/datum/reagent/consumable)
+)
+	if(!istype(parent, /obj/item/reagent_containers))
+		return COMPONENT_INCOMPATIBLE
+
+	src.time_to_refill = time_to_refill
+	src.power_draw_callback = power_draw_callback
+	src.power_to_draw = power_to_draw
+	src.whitelisted_reagents = whitelisted_reagents
+
+	return ..()
+
+/datum/component/reagent_refiller/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ITEM_AFTERATTACK, .proc/refill)
+	RegisterSignal(parent, COMSIG_ATOM_EXITED, .proc/delete_self)
+
+/datum/component/reagent_refiller/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_ITEM_AFTERATTACK, COMSIG_ATOM_EXITED))
+
+/datum/component/reagent_refiller/proc/delete_self()
+	SIGNAL_HANDLER
+
+	qdel(src)
+
+/// Preps the reagent container for being refilled
+/datum/component/reagent_refiller/proc/refill()
+	SIGNAL_HANDLER
+
+	var/obj/item/reagent_containers/container = parent
+	var/refill = container.reagents.get_master_reagent_id()
+	var/amount = min((container.amount_per_transfer_from_this + container.reagents.total_volume), container.reagents.total_volume)
+
+	if (amount == 0)
+		return
+	if (!is_path_in_list(refill, whitelisted_reagents))
+		return
+
+	addtimer(CALLBACK(src, .proc/add_reagents, container, container.loc, refill, amount), time_to_refill)
+
+/// Refills the reagent container, and uses cell power if applicable
+/datum/component/reagent_refiller/proc/add_reagents(obj/item/reagent_containers/target, oldloc, reagent_to_refill, amount)
+	if (QDELETED(src) || QDELETED(target))
+		return
+	if (target.loc != oldloc)
+		return
+
+	target.reagents.add_reagent(reagent_to_refill, amount)
+
+	if (!isnull(power_draw_callback))
+		power_draw_callback.Invoke(power_to_draw)

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -165,8 +165,24 @@
 	storable = list(/obj/item/reagent_containers/food/drinks,
 					/obj/item/reagent_containers/food/condiment)
 
-/obj/item/borg/apparatus/beaker/servive/add_glass()
+/obj/item/borg/apparatus/beaker/service/add_glass()
 	stored = new /obj/item/reagent_containers/food/drinks/drinkingglass(src)
+	handle_reflling(stored, loc.loc, force = TRUE)
+
+/obj/item/borg/apparatus/beaker/service/proc/handle_reflling(obj/item/reagent_containers/glass, mob/living/silicon/robot/bro, force = FALSE)
+	if (isnull(bro))
+		bro = loc
+	if (!iscyborg(bro))
+		return
+
+	if (!stored || force)
+		glass.AddComponent(/datum/component/reagent_refiller, power_draw_callback = CALLBACK(bro, /mob/living/silicon/robot.proc/draw_power))
+
+/obj/item/borg/apparatus/beaker/service/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	if (!istype(arrived, /obj/item/reagent_containers/food/drinks))
+		return
+	handle_reflling(arrived)
+	return ..()
 
 /// allows medical cyborgs to manipulate organs without hands
 /obj/item/borg/apparatus/organ_storage

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -81,21 +81,13 @@
 		if(!reagents.total_volume)
 			to_chat(user, span_warning("[src] is empty."))
 			return
-
 		if(target.reagents.holder_full())
 			to_chat(user, span_warning("[target] is full."))
 			return
 
-		var/refill = reagents.get_master_reagent_id()
 		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
 		to_chat(user, span_notice("You transfer [trans] units of the solution to [target]."))
 
-		if(iscyborg(user)) //Cyborg modules that include drinks automatically refill themselves (and only with consumable drinks), but drain the borg's cell
-			if (!ispath(refill, /datum/reagent/consumable))
-				return
-			var/mob/living/silicon/robot/bro = user
-			bro.cell.use(30)
-			addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent, refill, trans), 600)
 
 	else if(target.is_drainable()) //A dispenser. Transfer FROM it TO us.
 		if (!is_refillable())

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1003,3 +1003,7 @@
 
 	cut_overlay(GLOB.fire_appearances[fire_icon])
 	return null
+
+/// Draw power from the robot
+/mob/living/silicon/robot/proc/draw_power(power_to_draw)
+	cell?.use(power_to_draw)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -761,6 +761,7 @@
 #include "code\datums\components\pricetag.dm"
 #include "code\datums\components\punchcooldown.dm"
 #include "code\datums\components\radiation_countdown.dm"
+#include "code\datums\components\reagent_refiller.dm"
 #include "code\datums\components\religious_tool.dm"
 #include "code\datums\components\remote_materials.dm"
 #include "code\datums\components\rename.dm"


### PR DESCRIPTION
Reopen of https://github.com/tgstation/tgstation/pull/65859 with the code improvements atomized out, and the reviews addressed 

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turned the cyborg drink refilling feature into a component to clean up
the code since it was pretty snowflakey. and had some bugs


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better code + Fixes https://github.com/tgstation/tgstation/issues/65798
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Cyborg drink glasses will nolonger automagically refill themselves when not actually being held by the cyborg.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
