### PR TITLE
Fixes some overlapping wall objects on the IceBox Minisat

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5139,7 +5139,6 @@
 /area/station/maintenance/department/chapel)
 "bET" = (
 /obj/machinery/light/small/directional/east,
-/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -10222,6 +10221,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "dlr" = (
@@ -19232,6 +19232,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/stripes/line,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "ghJ" = (
@@ -40451,7 +40452,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "ndM" = (
-/obj/machinery/light/small/directional/east,
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/service";
 	name = "Service Bay Turret Control";
@@ -65001,11 +65001,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "vdr" = (
-/obj/machinery/light/small/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "MiniSat Antechamber";
 	network = list("minisat");
 	start_active = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/atmos";
@@ -65013,9 +65015,6 @@
 	pixel_x = -27;
 	req_access = null;
 	req_access_txt = "65"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -71432,7 +71431,6 @@
 /area/station/cargo/storage)
 "xdF" = (
 /obj/machinery/light/small/directional/west,
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -71889,6 +71887,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xlq" = (
@@ -74531,6 +74530,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/stripes/line,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service)
 "yep" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

 Some of the AI turret controls on the minisat were overlapping with intercomms making it impossible to tell the state of the turrets as an AI or someone is watching cameras.
 
 Fixed to this:
 
![image](https://user-images.githubusercontent.com/63861499/167332027-546d472b-5449-4a43-a6b6-d8d6e79fd8ab.png)


## Why It's Good For The Game

Properly conveying item states is awesome. Not overcrowding walls is also cool.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed overlapping objecs on the AI minisat on IceBoxStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
