### PR TITLE
Fix "destroy machinery" objective runtime

### DIFF
--- a/code/modules/antagonists/traitor/objectives/destroy_machinery.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_machinery.dm
@@ -49,7 +49,7 @@
 	if(!length(applicable_jobs))
 		return FALSE
 	var/list/obj/machinery/possible_machines = list()
-	while(length(possible_machines) <= 0)
+	while(length(possible_machines) <= 0 && length(applicable_jobs) > 0)
 		var/target_head = pick(applicable_jobs)
 		var/obj/machinery/machine_to_find = applicable_jobs[target_head]
 		applicable_jobs -= target_head


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If the map has no protolathes or an ORM, `/datum/traitor_objective/destroy_machinery` was runtiming after running out of `applicable_jobs`.

- Added a check for if the `applicable_jobs` list got completely eliminated. The `if(!length(possible_machines))` check immediately after this while loop with then cause the objective generation to cleanly fail.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fix runtime

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
