### PR TITLE
Powerfist code improvement

### DIFF
--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -2,6 +2,9 @@
 #define LOW_PRESSURE 1
 #define MID_PRESSURE 2
 #define HIGH_PRESSURE 3
+///Defines for the tank change action
+#define TANK_INSERTING 0
+#define TANK_REMOVING 1
 
 /obj/item/melee/powerfist
 	name = "power-fist"
@@ -42,14 +45,14 @@
 /obj/item/melee/powerfist/wrench_act(mob/living/user, obj/item/tool)
 	fist_pressure_setting = fist_pressure_setting >= HIGH_PRESSURE ? LOW_PRESSURE : fist_pressure_setting + 1
 	tool.play_tool_sound(src)
-	balloon_alert(user, "you tweak \the [src]'s piston valve to [fist_pressure_setting]")
+	balloon_alert(user, "piston strength set to [fist_pressure_setting]")
 	return TRUE
 
 /obj/item/melee/powerfist/screwdriver_act(mob/living/user, obj/item/tool)
 	if(!tank)
 		balloon_alert(user, "no tank present")
 		return
-	update_tank(tank, TRUE, user)
+	update_tank(tank, TANK_REMOVING, user)
 	return TRUE
 
 /obj/item/melee/powerfist/attackby(obj/item/item_to_insert, mob/user, params)
@@ -62,9 +65,9 @@
 	if(tank_to_insert.volume <= 3)
 		to_chat(user, span_warning("\The [tank_to_insert] is too small for \the [src]."))
 		return
-	update_tank(item_to_insert, FALSE, user)
+	update_tank(item_to_insert, TANK_INSERTING, user)
 
-/obj/item/melee/powerfist/proc/update_tank(obj/item/tank/internals/the_tank, removing = 0, mob/living/carbon/human/user)
+/obj/item/melee/powerfist/proc/update_tank(obj/item/tank/internals/the_tank, removing = TANK_INSERTING, mob/living/carbon/human/user)
 	if(removing)
 		if(!tank)
 			to_chat(user, span_notice("\The [src] currently has no tank attached to it."))
@@ -132,3 +135,5 @@
 #undef LOW_PRESSURE
 #undef MID_PRESSURE
 #undef HIGH_PRESSURE
+#undef TANK_INSERTING
+#undef TANK_REMOVING

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -1,3 +1,8 @@
+///Defines for the pressure strength of the fist
+#define LOW_PRESSURE 1
+#define MID_PRESSURE 2
+#define HIGH_PRESSURE 3
+
 /obj/item/melee/powerfist
 	name = "power-fist"
 	desc = "A metal gauntlet with a piston-powered ram ontop for that extra 'ompfh' in your punch."
@@ -14,11 +19,14 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 100, ACID = 40)
 	resistance_flags = FIRE_PROOF
-	var/click_delay = 1.5
-	var/fisto_setting = 1
-	var/gasperfist = 3
-	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
-
+	/// Delay between attacks
+	var/click_delay = 0.15 SECONDS
+	/// Pressure level on the fist
+	var/fist_pressure_setting = LOW_PRESSURE
+	/// Amount of moles per punch
+	var/gas_per_fist = 3
+	/// Tank used for the gauntlet's piston-ram.
+	var/obj/item/tank/internals/tank
 
 /obj/item/melee/powerfist/examine(mob/user)
 	. = ..()
@@ -27,51 +35,53 @@
 		return
 	if(tank)
 		. += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it.")
+		. += span_notice("Can be removed with a screwdriver.")
+
+	. += span_notice("Use a wrench to change the valve strength. Current strength at [fist_pressure_setting].")
 
 /obj/item/melee/powerfist/wrench_act(mob/living/user, obj/item/tool)
-	switch(fisto_setting)
-		if(1)
-			fisto_setting = 2
-		if(2)
-			fisto_setting = 3
-		if(3)
-			fisto_setting = 1
+	fist_pressure_setting = fist_pressure_setting >= HIGH_PRESSURE ? LOW_PRESSURE : fist_pressure_setting + 1
 	tool.play_tool_sound(src)
-	to_chat(user, span_notice("You tweak \the [src]'s piston valve to [fisto_setting]."))
+	balloon_alert(user, "you tweak \the [src]'s piston valve to [fist_pressure_setting]")
 	return TRUE
 
 /obj/item/melee/powerfist/screwdriver_act(mob/living/user, obj/item/tool)
+	if(!tank)
+		balloon_alert(user, "no tank present")
+		return
+	update_tank(tank, TRUE, user)
+	return TRUE
+
+/obj/item/melee/powerfist/attackby(obj/item/item_to_insert, mob/user, params)
+	if(!istype(item_to_insert, /obj/item/tank/internals))
+		return ..()
 	if(tank)
-		updateTank(tank, 1, user)
-		return TRUE
+		to_chat(user, span_notice("A tank is already present, remove it with a screwdriver first."))
+		return
+	var/obj/item/tank/internals/tank_to_insert = item_to_insert
+	if(tank_to_insert.volume <= 3)
+		to_chat(user, span_warning("\The [tank_to_insert] is too small for \the [src]."))
+		return
+	update_tank(item_to_insert, FALSE, user)
 
-/obj/item/melee/powerfist/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/tank/internals))
-		if(!tank)
-			var/obj/item/tank/internals/IT = W
-			if(IT.volume <= 3)
-				to_chat(user, span_warning("\The [IT] is too small for \the [src]."))
-				return
-			updateTank(W, 0, user)
-
-/obj/item/melee/powerfist/proc/updateTank(obj/item/tank/internals/thetank, removing = 0, mob/living/carbon/human/user)
+/obj/item/melee/powerfist/proc/update_tank(obj/item/tank/internals/the_tank, removing = 0, mob/living/carbon/human/user)
 	if(removing)
 		if(!tank)
 			to_chat(user, span_notice("\The [src] currently has no tank attached to it."))
 			return
-		to_chat(user, span_notice("You detach \the [thetank] from \the [src]."))
+		to_chat(user, span_notice("You detach \the [the_tank] from \the [src]."))
 		tank.forceMove(get_turf(user))
 		user.put_in_hands(tank)
 		tank = null
-	if(!removing)
-		if(tank)
-			to_chat(user, span_warning("\The [src] already has a tank."))
-			return
-		if(!user.transferItemToLoc(thetank, src))
-			return
-		to_chat(user, span_notice("You hook \the [thetank] up to \the [src]."))
-		tank = thetank
+		return
 
+	if(tank)
+		to_chat(user, span_warning("\The [src] already has a tank."))
+		return
+	if(!user.transferItemToLoc(the_tank, src))
+		return
+	to_chat(user, span_notice("You hook \the [the_tank] up to \the [src]."))
+	tank = the_tank
 
 /obj/item/melee/powerfist/attack(mob/living/target, mob/living/user)
 	if(!tank)
@@ -80,19 +90,21 @@
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("You don't want to harm other living beings!"))
 		return
-	var/datum/gas_mixture/gasused = tank.remove_air(gasperfist * fisto_setting)
-	var/turf/T = get_turf(src)
-	if(!T)
+	var/turf/our_turf = get_turf(src)
+	if(!our_turf)
 		return
-	T.assume_air(gasused)
-	if(!gasused)
+
+	var/datum/gas_mixture/gas_used = tank.remove_air(gas_per_fist * fist_pressure_setting)
+	if(!gas_used)
 		to_chat(user, span_warning("\The [src]'s tank is empty!"))
 		target.apply_damage((force / 5), BRUTE)
 		playsound(loc, 'sound/weapons/punch1.ogg', 50, TRUE)
 		target.visible_message(span_danger("[user]'s powerfist lets out a dull thunk as [user.p_they()] punch[user.p_es()] [target.name]!"), \
 			span_userdanger("[user]'s punches you!"))
 		return
-	if(!molar_cmp_equals(gasused.total_moles(), gasperfist * fisto_setting))
+
+	if(!molar_cmp_equals(gas_used.total_moles(), gas_per_fist * fist_pressure_setting))
+		our_turf.assume_air(gas_used)
 		to_chat(user, span_warning("\The [src]'s piston-ram lets out a weak hiss, it needs more gas!"))
 		playsound(loc, 'sound/weapons/punch4.ogg', 50, TRUE)
 		target.apply_damage((force / 2), BRUTE)
@@ -100,7 +112,7 @@
 			span_userdanger("[user]'s punch strikes with force!"))
 		return
 
-	target.apply_damage(force * fisto_setting, BRUTE, wound_bonus = CANT_WOUND)
+	target.apply_damage(force * fist_pressure_setting, BRUTE, wound_bonus = CANT_WOUND)
 	target.visible_message(span_danger("[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!"), \
 		span_userdanger("You cry out in pain as [user]'s punch flings you backwards!"))
 	new /obj/effect/temp_visual/kinetic_blast(target.loc)
@@ -109,10 +121,14 @@
 
 	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 
-	target.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
+	target.throw_at(throw_target, 5 * fist_pressure_setting, 0.5 + (fist_pressure_setting / 2))
 
 	log_combat(user, target, "power fisted", src)
 
 	user.changeNext_move(CLICK_CD_MELEE * click_delay)
 
-	return
+	our_turf.assume_air(gas_used)
+
+#undef LOW_PRESSURE
+#undef MID_PRESSURE
+#undef HIGH_PRESSURE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I wanted to add some nuance to the used gasmix in the powerfist but i want to do some cleanups first so here we are, i've also added some more text in examine and item use for a bit of quality of life
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
cleaner code, better examine for players
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: cleaned and brought up to date the powerfist code
qol: added some more examine text on the powerfist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
