### PR TITLE
atmos layers update

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -67,7 +67,7 @@
 #define PIPING_LAYER_DEFAULT 3
 #define PIPING_LAYER_P_X 5
 #define PIPING_LAYER_P_Y 5
-#define PIPING_LAYER_LCHANGE 0.05
+#define PIPING_LAYER_LCHANGE 0.005
 
 /// intended to connect with all layers, check for all instead of just one.
 #define PIPING_ALL_LAYER (1<<0)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -208,8 +208,8 @@
 	update_appearance()
 
 /obj/machinery/atmospherics/update_icon()
-	layer = initial(layer) + piping_layer / 1000
-	return ..()
+	. = ..()
+	update_layer()
 
 /**
  * Check if a node can actually exists by connecting to another machine
@@ -579,7 +579,7 @@
  * Update the layer in which the pipe/device is in, that way pipes have consistent layer depending on piping_layer
  */
 /obj/machinery/atmospherics/proc/update_layer()
-	layer = initial(layer) + (piping_layer - PIPING_LAYER_DEFAULT) * PIPING_LAYER_LCHANGE + (GLOB.pipe_colors_ordered[pipe_color] * 0.01)
+	return
 
 /**
  * Called by the RPD.dm pre_attack(), overriden by pipes.dm

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -3,6 +3,7 @@
 
 /obj/machinery/atmospherics/components
 	hide = FALSE
+	layer = GAS_PUMP_LAYER
 	///Is the component welded?
 	var/welded = FALSE
 	///Should the component should show the pipe underneath it?
@@ -284,3 +285,6 @@
 		disconnect_nodes()
 		return
 	connect_nodes()
+
+/obj/machinery/atmospherics/components/update_layer()
+	layer = initial(layer) + (piping_layer - PIPING_LAYER_DEFAULT) * PIPING_LAYER_LCHANGE + (GLOB.pipe_colors_ordered[pipe_color] * 0.001)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -90,6 +90,9 @@
 	crack.dir = dir
 	. += crack
 
+/obj/machinery/atmospherics/components/unary/hypertorus/update_layer()
+	return
+
 /obj/machinery/atmospherics/components/unary/hypertorus/fuel_input
 	name = "HFR fuel input port"
 	desc = "Input port for the Hypertorus Fusion Reactor, designed to take in only Hydrogen and Tritium in gas forms."

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -332,6 +332,9 @@
 			gas_input = clamp(_gas_input, 0, 250)
 	update_icon()
 
+/obj/machinery/atmospherics/components/binary/crystallizer/update_layer()
+	return
+
 #undef MIN_PROGRESS_AMOUNT
 #undef MIN_DEVIATION_RATE
 #undef MAX_DEVIATION_RATE

--- a/code/modules/atmospherics/machinery/components/unary_devices/bluespace_sender.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/bluespace_sender.dm
@@ -176,3 +176,6 @@
 				update_parents()
 				bluespace_network.garbage_collect()
 			. = TRUE
+
+/obj/machinery/atmospherics/components/unary/bluespace_sender/update_layer()
+	return

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -565,6 +565,9 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 			node.add_member(src)
 		SSair.add_to_rebuild_queue(src)
 
+/obj/machinery/atmospherics/components/unary/cryo_cell/update_layer()
+	return
+
 #undef MAX_TEMPERATURE
 #undef CRYO_MULTIPLY_FACTOR
 #undef CRYO_TX_QTY

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -312,6 +312,9 @@
 		return
 	. = ..()
 
+/obj/machinery/atmospherics/components/unary/thermomachine/update_layer()
+	return
+
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer
 
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -127,3 +127,6 @@
 		pipe_color = paint_color
 		update_node_icon()
 	return paintable
+
+/obj/machinery/atmospherics/pipe/update_layer()
+	layer = initial(layer) + (piping_layer - PIPING_LAYER_DEFAULT) * PIPING_LAYER_LCHANGE + (GLOB.pipe_colors_ordered[pipe_color] * 0.0001)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Updates atmosmachines layering in a way that they keep the same layer in all piping_layer and colors. dense machines have a static OBJ_LAYER that doesn't change regardless of color/layer
![image](https://user-images.githubusercontent.com/42839747/167435488-42f154cd-3e7e-4f35-95e2-bdc065964a35.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
better visual clarity for pipes and fix the issue where some machines (like the thermomachine) was always under every pipes
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: thermomachine no longer is under every pipe but is now above them
qol: pipes and atmos components have better visual clarity and consistency between them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
