### PR TITLE
The supermatter cascade now triggers the round end when it activates instead of taking 5 entire minutes to show the round end report, since it ends the round.

### DIFF
--- a/code/modules/power/supermatter/supermatter_delamination.dm
+++ b/code/modules/power/supermatter/supermatter_delamination.dm
@@ -202,28 +202,5 @@
 		You are hereby directed to enter the rift using all means necessary, quite possibly as the last humans alive. \
 		Five minutes before the universe collapses. Good l\[\[###!!!-")
 
-	addtimer(CALLBACK(src, .proc/delta), 10 SECONDS)
-
-	addtimer(CALLBACK(src, .proc/last_message), 4 MINUTES)
-
-	addtimer(CALLBACK(src, .proc/the_end), 5 MINUTES)
-
-/**
- * Increases the security level to the highest level
- */
-/datum/supermatter_delamination/proc/delta()
-	set_security_level("delta")
-	sound_to_playing_players('sound/misc/notice1.ogg')
-
-/**
- * Announces the last message to the station
- */
-/datum/supermatter_delamination/proc/last_message()
-	priority_announce("To the remaining humans alive, I hope it was worth it.", " ", 'sound/misc/bloop.ogg')
-
-/**
- * Ends the round
- */
-/datum/supermatter_delamination/proc/the_end()
 	SSticker.news_report = SUPERMATTER_CASCADE
 	SSticker.force_ending = 1


### PR DESCRIPTION
## About The Pull Request

The supermatter cascade now triggers the round end when it activates instead of taking 5 entire minutes to show the round end report, since it ends the round.

## Why It's Good For The Game

we don't make the crew watch the station slowly be eaten by the blob after the blob reaches critical mass, nor do we force the crew to watch nar'sie for 5 entire minutes, we rapidly end the round after the game over condition has been hit

to not rapidly end the round is poor design, the round is over and there is nothing anyone can do to stop it, so we will should be ending the round when the SM cascade goes off and players will be happier for it, otherwise they will whine about how long the cascade takes and you're going to be in here all "boo hoo why dont people like my supermatter cascade 😢" and none the wiser

at the very least if the SM cascade is eating the station people can discuss the round in OOC and deadchat while watching the cascade eat the station, instead of having to sit around in silence for 5 minutes as quoted while it slowly eats the station and nobody can do anything

## Changelog

:cl:
qol: The supermatter cascade now triggers the round end when it activates instead of taking 5 entire minutes to show the round end report, since it ends the round.
/:cl:
