### PR TITLE
Add lint to validate tgstation.dme is in the proper order

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -39,6 +39,7 @@ jobs:
           bash tools/ci/check_changelogs.sh
           bash tools/ci/check_grep.sh
           bash tools/ci/check_misc.sh
+          tools/bootstrap/python tools/validate_dme.py <tgstation.dme
           tools/build/build --ci lint tgui-test
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test

--- a/tools/validate_dme.py
+++ b/tools/validate_dme.py
@@ -48,4 +48,5 @@ sorted_lines = sorted(lines, key = functools.cmp_to_key(compare_lines))
 for (index, line) in enumerate(lines):
     if sorted_lines[index] != line:
         print(f"The include at line {index + 1} is out of order ({line})")
+        print(f"::error file=tgstation.dme,line={index+1},title=DME Validator::The include at line {index + 1} is out of order ({line})")
         sys.exit(1)

--- a/tools/validate_dme.py
+++ b/tools/validate_dme.py
@@ -1,0 +1,51 @@
+import functools
+import sys
+
+reading = False
+
+lines = []
+
+for line in sys.stdin:
+    line = line.strip()
+
+    if line == "// BEGIN_INCLUDE":
+        reading = True
+        continue
+    elif line == "// END_INCLUDE":
+        break
+    elif not reading:
+        continue
+
+    lines.append(line)
+
+def compare_lines(a, b):
+    # Remove initial include as well as the final quotation mark
+    a = a[len("#include \""):-1].lower()
+    b = b[len("#include \""):-1].lower()
+
+    a_segments = a.split('\\')
+    b_segments = b.split('\\')
+
+    for (a_segment, b_segment) in zip(a_segments, b_segments):
+        a_is_file = a_segment.endswith(".dm")
+        b_is_file = b_segment.endswith(".dm")
+
+        # code\something.dm will ALWAYS come before code\directory\something.dm
+        if a_is_file and not b_is_file:
+            return -1
+
+        if b_is_file and not a_is_file:
+            return 1
+
+        # interface\something.dm will ALWAYS come after code\something.dm
+        if a_segment != b_segment:
+            return (a_segment > b_segment) - (a_segment < b_segment)
+
+    raise f"Two lines were exactly the same ({a} vs. {b})"
+
+sorted_lines = sorted(lines, key = functools.cmp_to_key(compare_lines))
+
+for (index, line) in enumerate(lines):
+    if sorted_lines[index] != line:
+        print(f"The include at line {index + 1} is out of order ({line})")
+        sys.exit(1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds `validate_dme.py` to the CI suite to verify that tgstation.dme is in proper alphabetical order

And by alphabetical order I mean the ass-backwards specific rules that Dream Maker enforces