### PR TITLE
Adds Ceilings To IceMoon Ruins

### DIFF
--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -8,6 +8,7 @@
 	default_area = /area/icemoon/surface/outdoors/unexplored
 	has_ceiling = TRUE
 	ceiling_turf = /turf/closed/mineral/random/snow
+	ceiling_baseturfs = list(/turf/open/misc/asteroid/snow/icemoon)
 
 // above ground only
 

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -6,6 +6,8 @@
 	cost = 5
 	ruin_type = ZTRAIT_ICE_RUINS
 	default_area = /area/icemoon/surface/outdoors/unexplored
+	has_ceiling = TRUE
+	ceiling_turf = /turf/closed/mineral/random/snow
 
 // above ground only
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

On IceBox, sometimes, ruins could spawn below chasms that we had, or below a ruin that spawned in more openspace chasms. This would cause numerous Active Turfs on initialization, and I've seen the number go up to 150 active turfs. This change should reduce the number by a good margin.

I decided to make the ceiling mineral-rich snow to ensure it had that "buried" appearance, and would hopefully look nice to have that odd chance for a underground ice ruin create a natural bridge that just needs to be excavated.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Let's show some pictures to illustrate my point:

![image](https://user-images.githubusercontent.com/34697715/167485529-a9e81671-3050-4dde-8f0a-83ff59520cb2.png)

That's what this given section of IceBox looks like in StrongDMM. Now, let's compile in game with the changes in this PR.

![image](https://user-images.githubusercontent.com/34697715/167485650-60580367-6d78-4537-84d1-da959218d7fb.png)

The "Last Ash Drake" ruin happened to spawn underneath this, and currently in production, this would simply vent all the atmospherics up and out through the openspace chasm above, being a nuisance to adventurers and people-who-like-short-compiles. This change does "eat" the mapping done for the bridge to cross the chasm, but I think it's an interesting level of flavor for the map to have these conformational changes depending on how the Ruin Generator operates (I like the concept of infrastructure being decimated by avalanches such as these).

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: On IceBoxStation, Ice Moon Ruins will no longer vent out all their atmospherics out the top of the map, since they magically now have ceilings.
add: However, this dark magick to give Ice Moon Ruins ceilings come at a cost: avalanches over certain chasms are now much more likely, and can decimate certain infrastructure. Nanotrasen has ensured that anything vital shouldn't be impacted by this, but do expect to see certain "unmaintained" catwalk sections be swept up in an avalanche of sorts.
/:cl:

This should definitely be done for multi-Z planetary ruins going forward.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
