### PR TITLE
Fixes "high blood pressure" status effect, and corrects the spelling of "opioid" (fixing another bug)

### DIFF
--- a/code/datums/status_effects/drug_effects.dm
+++ b/code/datums/status_effects/drug_effects.dm
@@ -4,15 +4,13 @@
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/woozy
 
-
 /datum/status_effect/woozy/nextmove_modifier()
 	return 1.5
 
 /atom/movable/screen/alert/status_effect/woozy
 	name = "Woozy"
-	desc = "You feel a bit slower than usual, it seems doing things with your hands takes longer than it usually does"
+	desc = "You feel a bit slower than usual, it seems doing things with your hands takes longer than it usually does."
 	icon_state = "woozy"
-
 
 /datum/status_effect/high_blood_pressure
 	id = "high_blood_pressure"
@@ -21,21 +19,24 @@
 	alert_type = /atom/movable/screen/alert/status_effect/high_blood_pressure
 
 /datum/status_effect/high_blood_pressure/on_apply()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/human_owner = owner
-		human_owner.physiology.bleed_mod *= 1.25
+	if(!ishuman(owner))
+		return FALSE
+
+	var/mob/living/carbon/human/human_owner = owner
+	human_owner.physiology.bleed_mod *= 1.25
+	return TRUE
 
 /datum/status_effect/high_blood_pressure/on_remove()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/human_owner = owner
-		human_owner.physiology.bleed_mod /= 1.25
+	if(!ishuman(owner))
+		return
+
+	var/mob/living/carbon/human/human_owner = owner
+	human_owner.physiology.bleed_mod /= 1.25
 
 /atom/movable/screen/alert/status_effect/high_blood_pressure
 	name = "High blood pressure"
 	desc = "Your blood pressure is real high right now ... You'd probably bleed like a stuck pig."
 	icon_state = "highbloodpressure"
-
-
 
 /datum/status_effect/seizure
 	id = "seizure"

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -107,7 +107,7 @@
 	overdose_threshold = 20
 	ph = 9
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	addiction_types = list(/datum/addiction/opiods = 18) //7.2 per 2 seconds
+	addiction_types = list(/datum/addiction/opioids = 18) //7.2 per 2 seconds
 
 
 /datum/reagent/drug/krokodil/on_mob_life(mob/living/carbon/M, delta_time, times_fired)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -603,7 +603,7 @@
 	overdose_threshold = 30
 	ph = 8.96
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	addiction_types = list(/datum/addiction/opiods = 10)
+	addiction_types = list(/datum/addiction/opioids = 10)
 
 /datum/reagent/medicine/morphine/on_mob_metabolize(mob/living/L)
 	..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1240,7 +1240,7 @@
 	taste_description = "numbness"
 	ph = 9.1
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	addiction_types = list(/datum/addiction/opiods = 10)
+	addiction_types = list(/datum/addiction/opioids = 10)
 
 /datum/reagent/impedrezene/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.jitteriness = max(M.jitteriness - (2.5*delta_time),0)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -652,7 +652,7 @@
 	toxpwr = 0
 	ph = 9
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	addiction_types = list(/datum/addiction/opiods = 25)
+	addiction_types = list(/datum/addiction/opioids = 25)
 
 /datum/reagent/toxin/fentanyl/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3 * REM * normalise_creation_purity() * delta_time, 150)

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -1,24 +1,23 @@
 ///Opiods
-/datum/addiction/opiods
-	name = "opiod"
-	withdrawal_stage_messages = list("I feel aches in my bodies..", "I need some pain relief...", "It aches all over...I need some opiods!")
+/datum/addiction/opioids
+	name = "opioid"
+	withdrawal_stage_messages = list("I feel aches in my bodies..", "I need some pain relief...", "It aches all over...I need some opioids!")
 
-/datum/addiction/opiods/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/opioids/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	if(DT_PROB(10, delta_time))
 		affected_carbon.emote("yawn")
 
-/datum/addiction/opiods/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
+/datum/addiction/opioids/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
 	. = ..()
 	affected_carbon.apply_status_effect(/datum/status_effect/high_blood_pressure)
 
-/datum/addiction/opiods/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
+/datum/addiction/opioids/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	if(affected_carbon.disgust < DISGUST_LEVEL_DISGUSTED && DT_PROB(7.5, delta_time))
 		affected_carbon.adjust_disgust(12.5 * delta_time)
 
-
-/datum/addiction/opiods/end_withdrawal(mob/living/carbon/affected_carbon)
+/datum/addiction/opioids/end_withdrawal(mob/living/carbon/affected_carbon)
 	. = ..()
 	affected_carbon.remove_status_effect(/datum/status_effect/high_blood_pressure)
 	affected_carbon.set_disgust(affected_carbon.disgust * 0.5) //half their disgust to help

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -1,4 +1,4 @@
-///Opiods
+///Opioids
 /datum/addiction/opioids
 	name = "opioid"
 	withdrawal_stage_messages = list("I feel aches in my bodies..", "I need some pain relief...", "It aches all over...I need some opioids!")


### PR DESCRIPTION
## About The Pull Request

- Corrects the spelling of opioid
- Status effects have to return "TRUE" in on_apply, or else they are self-deleted. 
- Adds a missing period.

## Why It's Good For The Game

Status effects that are intended to be added, are actually added.
Opioid is now spelled correctly, consistently. 

This actually caused a bug: Opioid `end_withdrawal` was never called because it's path was spelled correctly and the others weren't. 

## Changelog

:cl: Melbert
fix: High blood pressure effect is now applied correctly by opioid addiction
spellcheck: opioid is now also spelled correctly
/:cl:
