### PR TITLE
fixes dizziness causing hard crashes

### DIFF
--- a/code/datums/status_effects/debuffs/dizziness.dm
+++ b/code/datums/status_effects/debuffs/dizziness.dm
@@ -53,9 +53,11 @@
 	var/pixel_y_diff = 0
 
 	// This shit is annoying at high strengthvar/pixel_x_diff = 0
+	var/list/view_range_list = getviewsize(owner.client.view)
+	var/view_range = view_range_list[1]
 	var/amplitude = amount * (sin(amount * (time)) + 1)
-	var/x_diff = amplitude * sin(amount * time)
-	var/y_diff = amplitude * cos(amount * time)
+	var/x_diff = clamp(amplitude * sin(amount * time), -view_range, view_range)
+	var/y_diff = clamp(amplitude * cos(amount * time), -view_range, view_range)
 	pixel_x_diff += x_diff
 	pixel_y_diff += y_diff
 	// Brief explanation. We're basically snapping between different pixel_x/ys instantly, with delays between


### PR DESCRIPTION

## About The Pull Request

this pr fixes dizziness causing hardcrashes and sending your view 50 tiles in both x and y

Fixes https://github.com/tgstation/tgstation/issues/66755

## Why It's Good For The Game

do you want people to get stuck in hardcrashes, also this is probably exploitable and usable to round remove people

## Changelog
:cl:
fix: fixed dizziness causing hard crashes
/:cl: