### PR TITLE
Fixes Duplicate APC on IceBoxStation's Prison Wing

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16226,7 +16226,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/safe)
 "fkZ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -33302,12 +33302,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"kHH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/security/prison)
 "kHJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -34928,11 +34922,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"lgB" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
-/turf/open/floor/plating,
-/area/station/security/prison)
 "lgD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44840,11 +44829,11 @@
 /area/station/hallway/primary/central)
 "oua" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/safe)
 "ouc" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas,
@@ -45150,7 +45139,7 @@
 "oyH" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/safe)
 "ozn" = (
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
@@ -45256,7 +45245,7 @@
 "oAP" = (
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/safe)
 "oBi" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -50294,7 +50283,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/safe)
 "qfu" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/machinery/camera/directional/south{
@@ -53504,10 +53493,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage)
-"rke" = (
-/obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating,
-/area/station/security/prison)
 "rki" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -167594,10 +167579,10 @@ tjo
 tjo
 cek
 iDt
-mMM
-rke
+xhK
+taV
 qfs
-tVf
+vVH
 sFu
 oVY
 vHU
@@ -167851,10 +167836,10 @@ gjq
 gjq
 cek
 iDt
-mMM
-lgB
-kHH
-tVf
+xhK
+nCQ
+swf
+vVH
 xtz
 oVY
 pez
@@ -168108,10 +168093,10 @@ gjq
 gjq
 kSw
 iDt
-mMM
+xhK
 oAP
 oua
-tVf
+vVH
 kqn
 oVY
 tjC
@@ -168365,10 +168350,10 @@ gjq
 gjq
 gjq
 gjq
-mMM
+xhK
 oyH
-kHH
-tVf
+swf
+vVH
 kqn
 oVY
 rwu
@@ -168622,10 +168607,10 @@ gjq
 gjq
 gjq
 gjq
-mMM
-tVf
+xhK
+vVH
 fkV
-tVf
+vVH
 kqn
 oVY
 sMs


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there, it's on the tin.

I believe the original intent was to have one APC for the Prison Wing, and then another APC for the Prison Wing cells, but I believe an oversight occurred to the point where this APC was not located in the "Safe Prison" area. To rectify this, I put that whole room in that aforementioned area.

This should be a good prerequisite to #66864.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less errors, the better.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nanotrasen will no longer install two separate APCs in the prison wing of IceBoxStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
