### PR TITLE
Gives the Detective back his Thermals he lost in 2012

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -164,6 +164,7 @@
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/binoculars(src)
 	new /obj/item/storage/box/rxglasses/spyglasskit(src)
+	new /obj/item/clothing/glasses/thermal(src)
 
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections"


### PR DESCRIPTION
## About The Pull Request

The Detective's Locker now contains a pair of Thermal Goggles.

## Why It's Good For The Game

Ten years ago, we removed the Detective's thermals. This was a controversial move. I think Detective has gotten stale recently, and this should spice things back up in the Detective game. 

The Detective doesn't really strike the fear of God into people as much anymore, so this should really improve the experience for Detectives and make people try to be a little more stealthy when they think nobody's watching.

## Changelog

:cl:
balance: After ten years, the Detective has been given back his Thermals in his locker.
/:cl:
