### PR TITLE
Makes constable helmet not block hair

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -450,7 +450,7 @@
 	cost = CARGO_CRATE_VALUE * 2.2
 	contraband = TRUE
 	contains = list(/obj/item/clothing/under/rank/security/constable,
-					/obj/item/clothing/head/helmet/constable,
+					/obj/item/clothing/head/constable,
 					/obj/item/clothing/gloves/color/white,
 					/obj/item/clothing/mask/whistle,
 					/obj/item/conversion_kit)

--- a/code/modules/clothing/head/hat.dm
+++ b/code/modules/clothing/head/hat.dm
@@ -7,6 +7,14 @@
 	armor = list(MELEE = 30, BULLET = 15, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50)
 	strip_delay = 80
 
+/obj/item/clothing/head/constable
+	name = "constable helmet"
+	desc = "A british looking helmet."
+	icon_state = "constable"
+	inhand_icon_state = "constable"
+	custom_price = PAYCHECK_COMMAND * 1.5
+	worn_y_offset = 4
+
 /obj/item/clothing/head/spacepolice
 	name = "space police cap"
 	desc = "A blue cap for patrolling the daily beat."

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -229,14 +229,6 @@
 	icon_state = "policehelm"
 
 
-/obj/item/clothing/head/helmet/constable
-	name = "constable helmet"
-	desc = "A british looking helmet."
-	icon_state = "constable"
-	inhand_icon_state = "constable"
-	custom_price = PAYCHECK_COMMAND * 1.5
-	worn_y_offset = 4
-
 /obj/item/clothing/head/helmet/swat/nanotrasen
 	name = "\improper SWAT helmet"
 	desc = "An extremely robust helmet with the Nanotrasen logo emblazoned on the top."


### PR DESCRIPTION
## About The Pull Request

Moves constable hats to be a subtype of /head directly, rather than /head/helmet, because they aren't helmets.
Helmets block your hair, which looks odd for something like constable hats that don't actually cover said hair, so you look bald instead.

## Why It's Good For The Game

It isn't covering your hair, why should it vanish from wearing this?

## Changelog

:cl:
fix: Constable helmets no longer cause your hair to mysteriously disappear when wearing one.
/:cl: