### PR TITLE
Security now has One-Hit Hard-Stun tasers again, with the Hybrid Taser. With a catch.

### DIFF
--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -5,6 +5,9 @@
 	e_cost = 200
 	harmful = FALSE
 
+/obj/item/ammo_casing/energy/electrode/assistant
+	projectile_type = /obj/projectile/energy/electrode/assistant
+
 /obj/item/ammo_casing/energy/electrode/spec
 	e_cost = 100
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -24,13 +24,14 @@
 	return
 
 /obj/item/gun/energy/disabler
-	name = "disabler"
-	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."
-	icon_state = "disabler"
+	name = "hybrid taser"
+	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse. Comes with a taser mode that only effects assistants. Use it in-hand to switch between modes."
+	icon_state = "advtaser"
 	inhand_icon_state = null
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
-	ammo_x_offset = 2
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode/assistant, /obj/item/ammo_casing/energy/disabler)
+	modifystate = TRUE
 	can_flashlight = TRUE
+	ammo_x_offset = 2
 	flight_x_offset = 15
 	flight_y_offset = 10
 

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -3,20 +3,23 @@
 	icon_state = "spark"
 	color = "#FFFF00"
 	nodamage = FALSE
-	paralyze = 100
+	paralyze = 10 SECONDS
 	stutter = 10 SECONDS
-	jitter = 20
+	jitter = 2 SECONDS
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 7
 	tracer_type = /obj/effect/projectile/tracer/stun
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	impact_type = /obj/effect/projectile/impact/stun
 
+/obj/projectile/energy/electrode/proc/tase_checks()
+	return TRUE
+
 /obj/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
 		do_sparks(1, TRUE, src)
-	else if(iscarbon(target))
+	else if(iscarbon(target) && tase_checks(target))
 		var/mob/living/carbon/C = target
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "tased", /datum/mood_event/tased)
 		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK)
@@ -24,7 +27,23 @@
 			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
 		else if((C.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(C, TRAIT_STUNIMMUNE))
 			addtimer(CALLBACK(C, /mob/living/carbon.proc/do_jitter_animation, jitter), 5)
+		C.Paralyze(10 SECONDS)
+		C.Jitter(10 SECONDS)
+		C.set_timed_status_effect(10 SECONDS, /datum/status_effect/speech/stutter)
 
 /obj/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	do_sparks(1, TRUE, src)
 	..()
+
+/obj/projectile/energy/electrode/assistant
+	name = "assistant electrode"
+
+// We only want to activate on Assistants.
+/obj/projectile/energy/electrode/assistant/tase_checks(mob/target)
+	if(!ishuman(target))
+		return FALSE
+	var/mob/living/carbon/human/human_target = target
+	if(istype(human_target.mind.assigned_role, /datum/job/assistant))
+		return TRUE
+	human_target.balloon_alert_to_viewers("not an assistant, can't tase!")
+	return FALSE

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -3,9 +3,6 @@
 	icon_state = "spark"
 	color = "#FFFF00"
 	nodamage = FALSE
-	paralyze = 10 SECONDS
-	stutter = 10 SECONDS
-	jitter = 2 SECONDS
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 7
 	tracer_type = /obj/effect/projectile/tracer/stun


### PR DESCRIPTION
It only tases Assistants.

## About The Pull Request

Security now has one hit stun tasers again, with the Hybrid Taser. With a catch. It only tases Assistants.

https://user-images.githubusercontent.com/4081722/167747715-5b4d2a4d-0dd2-4ebd-9964-ef82ed94d262.mp4

## Why It's Good For The Game

Assistants have not had to fear the golden bolt in decades. Security isn't able to oppress assistants without playing the CQC game with stun batons anymore, and Assistants win that game because they have the e-lance. It's time for a reckoning against assistant players, and so giving Security a way to tase assistant greytiders again is the way to go.

This should also discourage playing Assistant, which is a design goal of the entire SS13 project.

## Changelog

:cl:
balance: Security now has one hit stun tasers again, with the Hybrid Taser. With a catch. It only tases Assistants.
/:cl: