### PR TITLE
Fixes Cook CQC + job change config fixes

### DIFF
--- a/_maps/deltastation.json
+++ b/_maps/deltastation.json
@@ -10,7 +10,7 @@
 		"whiteship": "whiteship_delta"
 	},
 	"job_changes": {
-		"cook": {
+		"Cook": {
 			"additional_cqc_areas": ["/area/service/cafeteria"]
 		}
 	}

--- a/_maps/deltastation.json
+++ b/_maps/deltastation.json
@@ -11,7 +11,7 @@
 	},
 	"job_changes": {
 		"Cook": {
-			"additional_cqc_areas": ["/area/service/cafeteria"]
+			"additional_cqc_areas": ["/area/station/service/cafeteria"]
 		}
 	}
 }

--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -44,10 +44,10 @@
 	],
 	"minetype": "none",
 	"job_changes": {
-		"cook": {
-			"additional_cqc_areas": ["/area/service/kitchen/diner"]
+		"Cook": {
+			"additional_cqc_areas": ["/area/station/service/kitchen/diner"]
 		},
-		"captain": {
+		"Captain": {
 			"special_charter": "moon"
 		}
 	}

--- a/_maps/kilostation.json
+++ b/_maps/kilostation.json
@@ -16,10 +16,10 @@
 		}
 	],
 	"job_changes": {
-		"cook": {
-			"additional_cqc_areas": ["/area/service/bar/atrium"]
+		"Cook": {
+			"additional_cqc_areas": ["/area/station/service/bar/atrium"]
 		},
-		"captain": {
+		"Captain": {
 			"special_charter": "asteroid"
 		}
 	}

--- a/_maps/metastation.json
+++ b/_maps/metastation.json
@@ -11,7 +11,7 @@
 	},
 	"job_changes": {
 		"Cook": {
-			"additional_cqc_areas": ["/area/station/service/bar", "/area/station/service/kitchen/coldroom", "/area/station/commons/lounge"]
+			"additional_cqc_areas": ["/area/station/service/bar", "/area/station/commons/lounge"]
 		}
 	}
 }

--- a/_maps/metastation.json
+++ b/_maps/metastation.json
@@ -10,8 +10,8 @@
 		"emergency": "emergency_meta"
 	},
 	"job_changes": {
-		"cook": {
-			"additional_cqc_areas": ["/area/service/bar", "/area/service/kitchen/coldroom", "/area/commons/lounge"]
+		"Cook": {
+			"additional_cqc_areas": ["/area/station/service/bar", "/area/station/service/kitchen/coldroom", "/area/station/commons/lounge"]
 		}
 	}
 }

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -22,10 +22,10 @@
 		}
 	],
 	"job_changes": {
-		"cook": {
-			"additional_cqc_areas": ["/area/service/kitchen/diner"]
+		"Cook": {
+			"additional_cqc_areas": ["/area/station/service/kitchen/diner"]
 		},
-		"captain": {
+		"Captain": {
 			"special_charter": "asteroid"
 		}
 	}

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -118,7 +118,7 @@ SUBSYSTEM_DEF(job)
 		if(!job.config_check())
 			continue
 		if(!job.map_check()) //Even though we initialize before mapping, this is fine because the config is loaded at new
-			testing("Removed [job.type] due to map config")
+			log_job_debug("Removed [job.title] due to map config")
 			continue
 		new_all_occupations += job
 		name_occupations[job.title] = job

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -17,8 +17,6 @@
 	var/list/minimal_wildcard_access = list()
 	/// Static list. Cache of any mapping config job changes.
 	var/static/list/job_changes
-	/// What config entry relates to this job. Should be a lowercase job name with underscores for spaces, eg "prisoner" "research_director" "head_of_security"
-	var/config_job
 	/// An ID card with an access in this list can apply this trim to IDs or use it as a job template when adding access to a card. If the list is null, cannot be used as a template. Should be Head of Staff or ID Console accesses or it may do nothing.
 	var/list/template_access
 	/// The typepath to the job datum from the id_trim. This is converted to one of the job singletons in New().
@@ -31,11 +29,11 @@
 	if(isnull(job_changes))
 		job_changes = SSmapping.config.job_changes
 
-	if(!length(job_changes) || !config_job)
+	if(!length(job_changes))
 		refresh_trim_access()
 		return
 
-	var/list/access_changes = job_changes[config_job]
+	var/list/access_changes = job_changes[job.type]
 
 	if(!length(access_changes))
 		refresh_trim_access()
@@ -84,7 +82,6 @@
 	sechud_icon_state = SECHUD_ASSISTANT
 	extra_access = list(ACCESS_MAINT_TUNNELS)
 	minimal_access = list()
-	config_job = "assistant"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/assistant
 
@@ -105,7 +102,6 @@
 	extra_access = list(ACCESS_ENGINE_EQUIP, ACCESS_MINERAL_STOREROOM, ACCESS_TECH_STORAGE)
 	minimal_access = list(ACCESS_ENGINE, ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE, ACCESS_CONSTRUCTION, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_MAINT_TUNNELS, ACCESS_MECH_ENGINE,
 					ACCESS_MINERAL_STOREROOM)
-	config_job = "atmospheric_technician"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CE, ACCESS_CHANGE_IDS)
 	job = /datum/job/atmospheric_technician
 
@@ -115,7 +111,6 @@
 	sechud_icon_state = SECHUD_BARTENDER
 	extra_access = list(ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_MORGUE)
 	minimal_access = list(ACCESS_BAR, ACCESS_MINERAL_STOREROOM, ACCESS_THEATRE, ACCESS_WEAPONS, ACCESS_SERVICE)
-	config_job = "bartender"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/bartender
 
@@ -125,7 +120,6 @@
 	sechud_icon_state = SECHUD_BOTANIST
 	extra_access = list(ACCESS_BAR, ACCESS_KITCHEN)
 	minimal_access = list(ACCESS_HYDROPONICS, ACCESS_MINERAL_STOREROOM, ACCESS_MORGUE, ACCESS_SERVICE)
-	config_job = "botanist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/botanist
 
@@ -134,7 +128,6 @@
 	intern_alt_name = "Captain-in-Training"
 	trim_state = "trim_captain"
 	sechud_icon_state = SECHUD_CAPTAIN
-	config_job = "captain"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/captain
 
@@ -153,7 +146,6 @@
 	sechud_icon_state = SECHUD_CARGO_TECHNICIAN
 	extra_access = list(ACCESS_QM, ACCESS_MINING, ACCESS_MINING_STATION)
 	minimal_access = list(ACCESS_CARGO, ACCESS_MAILSORTING, ACCESS_MAINT_TUNNELS, ACCESS_MECH_MINING, ACCESS_MINERAL_STOREROOM)
-	config_job = "cargo_technician"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/cargo_technician
 
@@ -163,7 +155,6 @@
 	sechud_icon_state = SECHUD_CHAPLAIN
 	extra_access = list()
 	minimal_access = list(ACCESS_CHAPEL_OFFICE, ACCESS_CREMATORIUM, ACCESS_MORGUE, ACCESS_THEATRE, ACCESS_SERVICE)
-	config_job = "chaplain"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/chaplain
 
@@ -173,7 +164,6 @@
 	sechud_icon_state = SECHUD_CHEMIST
 	extra_access = list(ACCESS_SURGERY, ACCESS_VIROLOGY)
 	minimal_access = list(ACCESS_CHEMISTRY, ACCESS_MECH_MEDICAL, ACCESS_MEDICAL, ACCESS_MINERAL_STOREROOM, ACCESS_MORGUE, ACCESS_PHARMACY)
-	config_job = "chemist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CMO, ACCESS_CHANGE_IDS)
 	job = /datum/job/chemist
 
@@ -188,7 +178,6 @@
 					ACCESS_EXTERNAL_AIRLOCKS, ACCESS_HEADS, ACCESS_KEYCARD_AUTH, ACCESS_MAINT_TUNNELS, ACCESS_MECH_ENGINE,
 					ACCESS_MINERAL_STOREROOM, ACCESS_MINISAT, ACCESS_RC_ANNOUNCE, ACCESS_BRIG_ENTRANCE, ACCESS_TCOMSAT, ACCESS_TECH_STORAGE)
 	minimal_wildcard_access = list(ACCESS_CE)
-	config_job = "chief_engineer"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/chief_engineer
 
@@ -203,7 +192,6 @@
 					ACCESS_MEDICAL, ACCESS_MINERAL_STOREROOM, ACCESS_MORGUE, ACCESS_PHARMACY, ACCESS_PSYCHOLOGY, ACCESS_RC_ANNOUNCE,
 					ACCESS_BRIG_ENTRANCE, ACCESS_SURGERY, ACCESS_VIROLOGY)
 	minimal_wildcard_access = list(ACCESS_CMO)
-	config_job = "chief_medical_officer"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/chief_medical_officer
 
@@ -213,7 +201,6 @@
 	sechud_icon_state = SECHUD_CLOWN
 	extra_access = list()
 	minimal_access = list(ACCESS_THEATRE, ACCESS_SERVICE)
-	config_job = "clown"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/clown
 
@@ -223,7 +210,6 @@
 	sechud_icon_state = SECHUD_COOK
 	extra_access = list(ACCESS_BAR, ACCESS_HYDROPONICS)
 	minimal_access = list(ACCESS_KITCHEN, ACCESS_MINERAL_STOREROOM, ACCESS_MORGUE, ACCESS_SERVICE)
-	config_job = "cook"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/cook
 
@@ -237,7 +223,6 @@
 	sechud_icon_state = SECHUD_CURATOR
 	extra_access = list()
 	minimal_access = list(ACCESS_AUX_BASE, ACCESS_LIBRARY, ACCESS_MINING_STATION, ACCESS_SERVICE)
-	config_job = "curator"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/curator
 
@@ -248,7 +233,6 @@
 	extra_access = list()
 	minimal_access = list(ACCESS_BRIG, ACCESS_COURT, ACCESS_FORENSICS, ACCESS_BRIG_ENTRANCE,ACCESS_MAINT_TUNNELS, ACCESS_MORGUE,
 					ACCESS_MECH_SECURITY, ACCESS_MINERAL_STOREROOM, ACCESS_WEAPONS)
-	config_job = "detective"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOS, ACCESS_CHANGE_IDS)
 	job = /datum/job/detective
 
@@ -268,7 +252,6 @@
 	sechud_icon_state = SECHUD_GENETICIST
 	extra_access = list(ACCESS_ROBOTICS, ACCESS_TECH_STORAGE, ACCESS_XENOBIOLOGY)
 	minimal_access = list(ACCESS_GENETICS, ACCESS_MECH_SCIENCE, ACCESS_MINERAL_STOREROOM, ACCESS_MORGUE, ACCESS_RESEARCH, ACCESS_RND)
-	config_job = "geneticist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_RD, ACCESS_CHANGE_IDS)
 	job = /datum/job/geneticist
 
@@ -286,7 +269,6 @@
 					ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MORGUE, ACCESS_PSYCHOLOGY, ACCESS_QM, ACCESS_RC_ANNOUNCE,
 					ACCESS_RESEARCH, ACCESS_BRIG_ENTRANCE, ACCESS_TELEPORTER, ACCESS_THEATRE, ACCESS_VAULT, ACCESS_WEAPONS, ACCESS_SERVICE)
 	minimal_wildcard_access = list(ACCESS_HOP)
-	config_job = "head_of_personnel"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/head_of_personnel
 
@@ -302,7 +284,6 @@
 					ACCESS_MAILSORTING, ACCESS_MAINT_TUNNELS, ACCESS_MECH_SECURITY, ACCESS_MEDICAL, ACCESS_MINERAL_STOREROOM,
 					ACCESS_MINING, ACCESS_MORGUE, ACCESS_RC_ANNOUNCE, ACCESS_RESEARCH, ACCESS_SECURITY, ACCESS_BRIG_ENTRANCE, ACCESS_WEAPONS)
 	minimal_wildcard_access = list(ACCESS_HOS)
-	config_job = "head_of_security"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/head_of_security
 
@@ -322,7 +303,6 @@
 	sechud_icon_state = SECHUD_JANITOR
 	extra_access = list()
 	minimal_access = list(ACCESS_JANITOR, ACCESS_MAINT_TUNNELS, ACCESS_MINERAL_STOREROOM, ACCESS_SERVICE)
-	config_job = "janitor"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/janitor
 
@@ -332,7 +312,6 @@
 	sechud_icon_state = SECHUD_LAWYER
 	extra_access = list()
 	minimal_access = list(ACCESS_COURT, ACCESS_LAWYER, ACCESS_BRIG_ENTRANCE, ACCESS_SERVICE)
-	config_job = "lawyer"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_HOS, ACCESS_CHANGE_IDS)
 	job = /datum/job/lawyer
 
@@ -342,7 +321,6 @@
 	sechud_icon_state = SECHUD_MEDICAL_DOCTOR
 	extra_access = list(ACCESS_CHEMISTRY, ACCESS_VIROLOGY)
 	minimal_access = list(ACCESS_MECH_MEDICAL, ACCESS_MEDICAL, ACCESS_MINERAL_STOREROOM, ACCESS_MORGUE, ACCESS_PHARMACY, ACCESS_SURGERY)
-	config_job = "medical_doctor"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CMO, ACCESS_CHANGE_IDS)
 	job = /datum/job/doctor
 
@@ -352,7 +330,6 @@
 	sechud_icon_state = SECHUD_MIME
 	extra_access = list()
 	minimal_access = list(ACCESS_THEATRE, ACCESS_SERVICE)
-	config_job = "mime"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/mime
 
@@ -363,7 +340,6 @@
 	extra_access = list(ACCESS_SURGERY)
 	minimal_access = list(ACCESS_CONSTRUCTION, ACCESS_HYDROPONICS, ACCESS_MAINT_TUNNELS, ACCESS_MECH_MEDICAL,
 					ACCESS_MEDICAL, ACCESS_MINERAL_STOREROOM, ACCESS_MINING, ACCESS_MORGUE, ACCESS_RESEARCH)
-	config_job = "paramedic"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CMO, ACCESS_CHANGE_IDS)
 	job = /datum/job/paramedic
 
@@ -371,7 +347,6 @@
 	assignment = "Prisoner"
 	trim_state = "trim_prisoner"
 	sechud_icon_state = SECHUD_PRISONER
-	config_job = "prisoner"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_HOS, ACCESS_CHANGE_IDS)
 	job = /datum/job/prisoner
 
@@ -409,7 +384,6 @@
 	sechud_icon_state = SECHUD_PSYCHOLOGIST
 	extra_access = list()
 	minimal_access = list(ACCESS_MEDICAL, ACCESS_PSYCHOLOGY, ACCESS_SERVICE)
-	config_job = "psychologist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CMO, ACCESS_CHANGE_IDS)
 	job = /datum/job/psychologist
 
@@ -420,7 +394,6 @@
 	extra_access = list()
 	minimal_access = list(ACCESS_AUX_BASE, ACCESS_CARGO, ACCESS_MAILSORTING, ACCESS_MAINT_TUNNELS, ACCESS_MECH_MINING, ACCESS_MINING_STATION,
 					ACCESS_MINERAL_STOREROOM, ACCESS_MINING, ACCESS_QM, ACCESS_RC_ANNOUNCE, ACCESS_VAULT)
-	config_job = "quartermaster"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/quartermaster
 
@@ -437,7 +410,6 @@
 					ACCESS_ORDNANCE, ACCESS_ORDNANCE_STORAGE, ACCESS_RC_ANNOUNCE, ACCESS_RESEARCH, ACCESS_RND, ACCESS_ROBOTICS,
 					ACCESS_BRIG_ENTRANCE, ACCESS_TECH_STORAGE, ACCESS_TELEPORTER, ACCESS_XENOBIOLOGY)
 	minimal_wildcard_access = list(ACCESS_RD)
-	config_job = "research_director"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/research_director
 
@@ -448,7 +420,6 @@
 	extra_access = list(ACCESS_GENETICS, ACCESS_ORDNANCE, ACCESS_ORDNANCE_STORAGE, ACCESS_XENOBIOLOGY)
 	minimal_access = list(ACCESS_AUX_BASE, ACCESS_MECH_SCIENCE, ACCESS_MINERAL_STOREROOM, ACCESS_MORGUE, ACCESS_RESEARCH, ACCESS_RND,
 					ACCESS_ROBOTICS, ACCESS_TECH_STORAGE)
-	config_job = "roboticist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_RD, ACCESS_CHANGE_IDS)
 	job = /datum/job/roboticist
 
@@ -459,7 +430,6 @@
 	extra_access = list(ACCESS_GENETICS, ACCESS_ROBOTICS)
 	minimal_access = list(ACCESS_AUX_BASE, ACCESS_MECH_SCIENCE, ACCESS_MINERAL_STOREROOM, ACCESS_ORDNANCE, ACCESS_ORDNANCE_STORAGE,
 					ACCESS_RESEARCH, ACCESS_RND, ACCESS_XENOBIOLOGY)
-	config_job = "scientist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_RD, ACCESS_CHANGE_IDS)
 	job = /datum/job/scientist
 
@@ -471,11 +441,10 @@
 	extra_access = list(ACCESS_FORENSICS, ACCESS_MAINT_TUNNELS, ACCESS_MORGUE)
 	minimal_access = list(ACCESS_BRIG, ACCESS_COURT, ACCESS_SECURITY, ACCESS_BRIG_ENTRANCE, ACCESS_MECH_SECURITY,
 					ACCESS_MINERAL_STOREROOM, ACCESS_WEAPONS)
-	/// List of bonus departmental accesses that departmental sec officers get.
-	var/department_access = list()
-	config_job = "security_officer"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOS, ACCESS_CHANGE_IDS)
 	job = /datum/job/security_officer
+	/// List of bonus departmental accesses that departmental sec officers get.
+	var/department_access = list()
 
 /datum/id_trim/job/security_officer/refresh_trim_access()
 	. = ..()
@@ -516,7 +485,6 @@
 	extra_access = list(ACCESS_CARGO, ACCESS_MAINT_TUNNELS, ACCESS_QM)
 	minimal_access = list(ACCESS_AUX_BASE, ACCESS_MAILSORTING, ACCESS_MECH_MINING, ACCESS_MINERAL_STOREROOM, ACCESS_MINING,
 					ACCESS_MINING_STATION)
-	config_job = "shaft_miner"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/shaft_miner
 
@@ -533,7 +501,6 @@
 	extra_access = list(ACCESS_ATMOSPHERICS)
 	minimal_access = list(ACCESS_AUX_BASE, ACCESS_CONSTRUCTION, ACCESS_ENGINE, ACCESS_ENGINE_EQUIP, ACCESS_EXTERNAL_AIRLOCKS,
 					ACCESS_MAINT_TUNNELS, ACCESS_MECH_ENGINE, ACCESS_MINERAL_STOREROOM, ACCESS_TCOMSAT, ACCESS_TECH_STORAGE)
-	config_job = "station_engineer"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CE, ACCESS_CHANGE_IDS)
 	job = /datum/job/station_engineer
 
@@ -543,7 +510,6 @@
 	sechud_icon_state = SECHUD_VIROLOGIST
 	extra_access = list(ACCESS_CHEMISTRY, ACCESS_MORGUE, ACCESS_SURGERY)
 	minimal_access = list(ACCESS_MEDICAL, ACCESS_MECH_MEDICAL, ACCESS_MINERAL_STOREROOM, ACCESS_VIROLOGY)
-	config_job = "virologist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CMO, ACCESS_CHANGE_IDS)
 	job = /datum/job/virologist
 
@@ -554,7 +520,6 @@
 	extra_access = list(ACCESS_FORENSICS, ACCESS_MAINT_TUNNELS, ACCESS_MORGUE)
 	minimal_access = list(ACCESS_ARMORY, ACCESS_BRIG, ACCESS_COURT, ACCESS_MECH_SECURITY, ACCESS_MINERAL_STOREROOM,
 					ACCESS_SECURITY, ACCESS_BRIG_ENTRANCE, ACCESS_WEAPONS) // See /datum/job/warden/get_access()
-	config_job = "warden"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOS, ACCESS_CHANGE_IDS)
 	job = /datum/job/warden
 

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -33,7 +33,7 @@
 		refresh_trim_access()
 		return
 
-	var/list/access_changes = job_changes[job.type]
+	var/list/access_changes = job_changes[job.title]
 
 	if(!length(access_changes))
 		refresh_trim_access()

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -222,12 +222,37 @@
 ///Subtype of CQC. Only used for the chef.
 /datum/martial_art/cqc/under_siege
 	name = "Close Quarters Cooking"
-	var/list/kitchen_areas
+	///List of all areas that CQC will work in, defaults to Kitchen.
+	var/list/kitchen_areas = list(/area/station/service/kitchen)
 
-/// Refreshes the valid areas from the cook job singleton, otherwise uses the default kitchen area as a fallback option. See also [/datum/job/cook/New].
+/// Refreshes the valid areas from the cook's mapping config, adding areas in config to the list of possible areas.
 /datum/martial_art/cqc/under_siege/proc/refresh_valid_areas()
-	var/datum/job/cook/cook_job = SSjob.GetJobType(/datum/job/cook)
-	kitchen_areas = cook_job.kitchen_areas.Copy()
+	var/list/job_changes = SSmapping.config.job_changes
+
+	if(!length(job_changes))
+		return
+
+	var/list/cook_changes = job_changes[JOB_COOK]
+
+	if(!length(cook_changes))
+		return
+
+	var/list/additional_cqc_areas = cook_changes["additional_cqc_areas"]
+
+	if(!additional_cqc_areas)
+		return
+
+	if(!islist(additional_cqc_areas))
+		stack_trace("Incorrect CQC area format from mapping configs. Expected /list, got: \[[additional_cqc_areas.type]\]")
+		return
+
+	for(var/path_as_text in additional_cqc_areas)
+		var/path = text2path(path_as_text)
+		if(!ispath(path, /area))
+			stack_trace("Invalid path in mapping config for chef CQC: \[[path_as_text]\]")
+			continue
+
+		kitchen_areas |= path
 
 /// Limits where the chef's CQC can be used to only whitelisted areas.
 /datum/martial_art/cqc/under_siege/can_use(mob/living/owner)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -123,25 +123,18 @@
 
 /datum/job/New()
 	. = ..()
-	var/list/jobs_changes = get_map_changes()
-	if(!jobs_changes)
-		return
-	if(isnum(jobs_changes["spawn_positions"]))
-		spawn_positions = jobs_changes["spawn_positions"]
-	if(isnum(jobs_changes["total_positions"]))
-		total_positions = jobs_changes["total_positions"]
-
-/// Loads up map configs if necessary and returns job changes for this job.
-/datum/job/proc/get_map_changes()
-	var/string_type = "[type]"
-	var/list/splits = splittext(string_type, "/")
-	var/endpart = splits[splits.len]
-
 	var/list/job_changes = SSmapping.config.job_changes
-	if(!(endpart in job_changes))
-		return list()
+	if(!job_changes[title])
+		return TRUE
 
-	return job_changes[endpart]
+	var/list/job_positions_edits = job_changes[title]
+	if(!job_positions_edits)
+		return TRUE
+
+	if(isnum(job_positions_edits["spawn_positions"]))
+		spawn_positions = job_positions_edits["spawn_positions"]
+	if(isnum(job_positions_edits["total_positions"]))
+		total_positions = job_positions_edits["total_positions"]
 
 
 /// Executes after the mob has been spawned in the map. Client might not be yet in the mob, and is thus a separate variable.
@@ -230,10 +223,31 @@
 /datum/job/proc/config_check()
 	return TRUE
 
+/**
+ * # map_check
+ *
+ * Checks the map config for job changes
+ * If they have 0 spawn and total positions in the config, the job is entirely removed from occupations prefs for the round.
+ */
 /datum/job/proc/map_check()
-	var/list/job_changes = get_map_changes()
-	if(!job_changes)
+	var/list/job_changes = SSmapping.config.job_changes
+	if(!job_changes[title]) //no edits made
+		return TRUE
+
+	var/list/job_positions_edits = job_changes[title]
+	if(!job_positions_edits)
+		return TRUE
+
+	var/available_roundstart = TRUE
+	var/available_latejoin = TRUE
+	if(!isnull(job_positions_edits["spawn_positions"]) && (job_positions_edits["spawn_positions"] == 0))
+		available_roundstart = FALSE
+	if(!isnull(job_positions_edits["total_positions"]) && (job_positions_edits["total_positions"] == 0))
+		available_latejoin = FALSE
+
+	if(!available_roundstart && !available_latejoin) //map config disabled the job
 		return FALSE
+
 	return TRUE
 
 /datum/job/proc/radio_help_message(mob/M)

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -89,7 +89,7 @@
 	var/list/job_changes = SSmapping.config.job_changes
 	if(!length(job_changes))
 		return
-	var/list/captain_changes = job_changes["captain"]
+	var/list/captain_changes = job_changes[JOB_CAPTAIN]
 	if(!length(captain_changes))
 		return
 	special_charter = captain_changes["special_charter"]

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -9,8 +9,6 @@
 	selection_color = "#bbe291"
 	exp_granted_type = EXP_TYPE_CREW
 	var/cooks = 0 //Counts cooks amount
-	/// List of areas that are counted as the kitchen for the purposes of CQC. Defaults to just the kitchen. Mapping configs can and should override this.
-	var/list/kitchen_areas = list(/area/station/service/kitchen)
 
 	outfit = /datum/outfit/job/cook
 	plasmaman_outfit = /datum/outfit/plasmaman/chef
@@ -26,39 +24,11 @@
 		/datum/job_department/service,
 		)
 
-	family_heirlooms = list(/obj/item/reagent_containers/food/condiment/saltshaker, /obj/item/kitchen/rollingpin, /obj/item/clothing/head/chefhat)
-	rpg_title = "Tavern Chef"
-	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
-
-
-/datum/job/cook/New()
-	. = ..()
-	var/list/job_changes = SSmapping.config.job_changes
-
-	if(!length(job_changes))
-		return
-
-	var/list/cook_changes = job_changes[JOB_COOK]
-
-	if(!length(cook_changes))
-		return
-
-	var/list/additional_cqc_areas = cook_changes["additional_cqc_areas"]
-
-	if(!additional_cqc_areas)
-		return
-
-	if(!islist(additional_cqc_areas))
-		stack_trace("Incorrect CQC area format from mapping configs. Expected /list, got: \[[additional_cqc_areas.type]\]")
-		return
-
-	for(var/path_as_text in additional_cqc_areas)
-		var/path = text2path(path_as_text)
-		if(!ispath(path, /area))
-			stack_trace("Invalid path in mapping config for chef CQC: \[[path_as_text]\]")
-			continue
-
-		kitchen_areas |= path
+	family_heirlooms = list(
+		/obj/item/reagent_containers/food/condiment/saltshaker,
+		/obj/item/kitchen/rollingpin,
+		/obj/item/clothing/head/chefhat,
+	)
 
 	mail_goodies = list(
 		/obj/item/storage/box/ingredients/random = 80,
@@ -71,6 +41,8 @@
 		/obj/item/knife/butcher = 2
 	)
 
+	rpg_title = "Tavern Chef"
+	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
 
 /datum/job/cook/award_service(client/winner, award)
 	winner.give_award(award, winner.mob)
@@ -103,14 +75,14 @@
 
 /datum/outfit/job/cook/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
-	var/datum/job/cook/J = SSjob.GetJobType(jobtype)
-	if(J) // Fix for runtime caused by invalid job being passed
-		if(J.cooks>0)//Cooks
+	var/datum/job/cook/other_chefs = SSjob.GetJobType(jobtype)
+	if(other_chefs) // If there's other Chefs, you're a Cook
+		if(other_chefs.cooks > 0)//Cooks
 			id_trim = /datum/id_trim/job/cook
 			suit = /obj/item/clothing/suit/apron/chef
 			head = /obj/item/clothing/head/soft/mime
 		if(!visualsOnly)
-			J.cooks++
+			other_chefs.cooks++
 
 /datum/outfit/job/cook/get_types_to_preload()
 	. = ..()

--- a/code/modules/library/skill_learning/job_skillchips/chef.dm
+++ b/code/modules/library/skill_learning/job_skillchips/chef.dm
@@ -1,11 +1,12 @@
 /obj/item/skillchip/job/chef
-	name = "B0RK-X3 skillchip"  // bork bork bork
+	name = "B0RK-X3 skillchip" // bork bork bork
 	desc = "This biochip faintly smells of garlic, which is odd for something that is normally wedged inside a user's brain. Consult a dietician before use."
 	skill_name = "Close Quarters Cooking"
 	skill_description = "A specialised form of self defence, developed by skilled sous-chef de cuisines. No man fights harder than a chef to defend his kitchen."
 	skill_icon = "utensils"
 	activate_message = "<span class='notice'>You can visualize how to defend your kitchen with martial arts.</span>"
 	deactivate_message = "<span class='notice'>You forget how to control your muscles to execute kicks, slams and restraints while in a kitchen environment.</span>"
+	/// The Chef CQC given by the skillchip.
 	var/datum/martial_art/cqc/under_siege/style
 
 /obj/item/skillchip/job/chef/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

There's SEVERAL problems here:
1. configs used 'cook' and 'captain', but JOB_COOK is 'Cook', which is case sensitive so it didn't load
2. The area paths weren't updated, ``/area/service`` doesn't exist anymore
3. CQC areas were set on Cook's New, when mapping configs weren't loaded yet. It also felt weird to just have it BE there, so instead of moving it to the post_equip like the Captain, I just moved it to the CQC datum itself I guess it might help downstreams in some odd way if they disable Cook but still want the chip? Odd but I found this to be the better way to handle it.

Also, because Cook's mail is (for some reason) assigned in New, which used to early return due to no mapping config, Cooks just straight up did not have job-related mail. I have no idea why it was done this way, but I moved it to their datum to be consistent with literally every other job.


What I have done in this PR is tie config stuff to their title, while also fixing some other problems:
1. Mapping configs (the map's .json) now properly loads their overwrite job positions.
2. Mapping configs can now fully disable jobs, and doing so will actually remove the job from the occupations preferences page, so players will no longer be confused as to why they didn't load into a job on a map that doesn't support it (Currently, none of our maps do this, but Pubby USED to, so it being possible isn't out of the question)

## Why It's Good For The Game

I prefer when configs work as they are expected to.

## Changelog

:cl:
fix: Cook's CQC now properly works in the assigned areas outside the kitchen.
fix: Cooks now properly get their Cook mail instead of just money.
fix: Mapping configs can now once again set job position slots (and fully remove jobs from maps that don't support them).
/:cl: