### PR TITLE
Makes pride ruin front door friendly

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -16,7 +16,6 @@
 /turf/open/lava/smooth,
 /area/ruin/powered/pride)
 "j" = (
-/obj/structure/mirror/magic/pride,
 /turf/closed/wall/mineral/silver,
 /area/ruin/powered/pride)
 "k" = (
@@ -90,6 +89,12 @@
 "G" = (
 /turf/closed/wall/mineral/cult,
 /area/ruin/powered/pride)
+"H" = (
+/obj/structure/mirror/magic/pride{
+	pixel_y = 26
+	},
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
 "J" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -112,7 +117,7 @@
 "N" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding/burnt,
-/obj/machinery/door/airlock/cult/unruned,
+/obj/machinery/door/airlock/cult/unruned/friendly,
 /turf/open/lava/smooth,
 /area/ruin/powered/pride)
 "O" = (
@@ -225,7 +230,7 @@ c
 c
 G
 j
-r
+H
 S
 y
 z


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the front door of the pride ruin from a real cult door (non-cultists can't enter it) to an aesthetic cult door.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #66879
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: non-cultists can now enter the pride ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
