### PR TITLE
Remove organs from delimber anomaly 

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -442,7 +442,6 @@
 	var/static/list/r_arms
 	var/static/list/l_legs
 	var/static/list/r_legs
-	var/static/list/organs
 
 /obj/effect/anomaly/delimber/Initialize(mapload, new_lifespan, drops_core)
 	. = ..()
@@ -458,8 +457,6 @@
 		l_legs = typesof(/obj/item/bodypart/l_leg)
 	if(!r_legs)
 		r_legs = typesof(/obj/item/bodypart/r_leg)
-	if(!organs)
-		organs = subtypesof(/obj/item/organ)
 
 /obj/effect/anomaly/delimber/anomalyEffect(delta_time)
 	. = ..()
@@ -495,9 +492,6 @@
 		new_part.replace_limb(nearby, TRUE)
 		if(picked_user_part)
 			qdel(picked_user_part)
-		var/obj/item/organ/picked_organ = pick(organs)
-		var/obj/item/organ/new_organ = new picked_organ
-		new_organ.Insert(nearby, TRUE, FALSE)
 		nearby.update_body(TRUE)
 		balloon_alert(nearby, "something has changed about you")
 

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -392,7 +392,6 @@
 	var/static/list/r_arms
 	var/static/list/l_legs
 	var/static/list/r_legs
-	var/static/list/organs
 
 /obj/item/clothing/suit/armor/reactive/delimbering/Initialize(mapload)
 	. = ..()
@@ -408,8 +407,6 @@
 		l_legs = typesof(/obj/item/bodypart/l_leg)
 	if(!r_legs)
 		r_legs = typesof(/obj/item/bodypart/r_leg)
-	if(!organs)
-		organs = subtypesof(/obj/item/organ)
 
 /obj/item/clothing/suit/armor/reactive/delimbering/cooldown_activation(mob/living/carbon/human/owner)
 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
@@ -452,8 +449,5 @@
 		var/obj/item/bodypart/new_part = new picked_part()
 		new_part.replace_limb(nearby, TRUE)
 		qdel(picked_user_part)
-		var/obj/item/organ/picked_organ = pick(organs)
-		var/obj/item/organ/new_organ = new picked_organ
-		new_organ.Insert(nearby, TRUE, FALSE)
 		nearby.update_body(TRUE)
 		balloon_alert(nearby, "something has changed about you")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix #66840 plus other issues that were encountered when changing organs 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix a bunch of issues that can come up with the anomaly, mainly instant round removal and admin organs 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fix delimber anomaly from round removing you and other griefs
remove: delimber anomaly doesn't change your organs anymore 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
