### PR TITLE
[NO GBP] Fixes hierophant trophy damage

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -438,5 +438,5 @@
 /obj/item/crusher_trophy/vortex_talisman/on_mark_detonation(mob/living/target, mob/living/user)
 	if(isliving(target))
 		var/obj/effect/temp_visual/hierophant/chaser/chaser = new(get_turf(user), user, target, 3, TRUE)
-		chaser.monster_damage_boost = FALSE // Weaker cuz no cooldown
+		chaser.damage = 20
 		log_combat(user, target, "fired a chaser at", src)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -438,5 +438,6 @@
 /obj/item/crusher_trophy/vortex_talisman/on_mark_detonation(mob/living/target, mob/living/user)
 	if(isliving(target))
 		var/obj/effect/temp_visual/hierophant/chaser/chaser = new(get_turf(user), user, target, 3, TRUE)
+		chaser.monster_damage_boost = FALSE // Weaker cuz no cooldown
 		chaser.damage = 20
 		log_combat(user, target, "fired a chaser at", src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So somebody(not calling out names because then this PR will get closed instantly due to sheer hatred towards that person) in manuel discord pointed out that my math is wrong in two places:
A) Due to how their AI works, hierophant chasers actually hit targets every 1.2 seconds(in best scenario), not 0.6
B) Hierophant blasts don't have any armor penetration against simplemobs which causes them to deal x0.5 damage to lavaland fauna due to burn resist.
So instead of 16.(6) DPS you got 4.1(6) which is 4 times lower than intended. 

OOOPS
![image](https://user-images.githubusercontent.com/44720187/167831340-ca615d37-623f-4b51-a63e-aecbe6c5fe72.png)


## Why It's Good For The Game

5 damage every 1.2 seconds is hilarious compared to crusher's default DPS.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Hierophant trophy now deals damage that it was supposed to deal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
