### PR TITLE
Improves the readability of attack logs for stripping

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -111,9 +111,8 @@
 
 	to_chat(user, span_notice("You try to put [equipping] on [source]..."))
 
-	var/log = "[key_name(source)] is having [equipping] put on them by [key_name(user)]"
-	user.log_message(log, LOG_ATTACK, color="red")
-	source.log_message(log, LOG_VICTIM, color="red", log_globally=FALSE)
+	user.log_message("is putting [equipping] on [key_name(source)]", LOG_ATTACK, color="red")
+	source.log_message("is having [equipping] put on them by [key_name(user)]", LOG_VICTIM, color="orange", log_globally=FALSE)
 
 	return TRUE
 
@@ -158,8 +157,8 @@
 	)
 
 	to_chat(user, span_danger("You try to remove [source]'s [item]..."))
-	user.log_message("[key_name(source)] is being stripped of [item] by [key_name(user)]", LOG_ATTACK, color="red")
-	source.log_message("[key_name(source)] is being stripped of [item] by [key_name(user)]", LOG_VICTIM, color="red", log_globally=FALSE)
+	user.log_message("is stripping [key_name(source)] of [item]", LOG_ATTACK, color="red")
+	source.log_message("is being stripped of [item] by [key_name(user)]", LOG_VICTIM, color="orange", log_globally=FALSE)
 	item.add_fingerprint(src)
 
 	if(ishuman(source))
@@ -262,6 +261,8 @@
 	var/mob/mob_source = source
 	mob_source.equip_to_slot(equipping, item_slot)
 
+	return finish_equip_mob(equipping, source, user)
+
 /datum/strippable_item/mob_item_slot/get_obscuring(atom/source)
 	if (iscarbon(source))
 		var/mob/living/carbon/carbon_source = source
@@ -292,6 +293,11 @@
 /datum/strippable_item/mob_item_slot/proc/get_equip_delay(obj/item/equipping)
 	return equipping.equip_delay_other
 
+/// A utility function for `/datum/strippable_item`s to finish equipping an item to a mob.
+/proc/finish_equip_mob(obj/item/item, mob/source, mob/user)
+	user.log_message("has put [item] on [key_name(source)]", LOG_ATTACK, color="red")
+	source.log_message("had [item] put on them by [key_name(user)]", LOG_VICTIM, color="orange", log_globally=FALSE)
+
 /// A utility function for `/datum/strippable_item`s to start unequipping an item from a mob.
 /proc/start_unequip_mob(obj/item/item, mob/source, mob/user, strip_delay)
 	if (!do_mob(user, source, strip_delay || item.strip_delay, interaction_key = REF(item)))
@@ -304,8 +310,8 @@
 	if (!item.doStrip(user, source))
 		return FALSE
 
-	user.log_message("[key_name(source)] has been stripped of [item] by [key_name(user)]", LOG_ATTACK, color="red")
-	source.log_message("[key_name(source)] has been stripped of [item] by [key_name(user)]", LOG_VICTIM, color="red", log_globally=FALSE)
+	user.log_message("has stripped [key_name(source)] of [item]", LOG_ATTACK, color="red")
+	source.log_message("has been stripped of [item] by [key_name(user)]", LOG_VICTIM, color="orange", log_globally=FALSE)
 
 	// Updates speed in case stripped speed affecting item
 	source.update_equipment_speed_mods()

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -156,9 +156,8 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 
 	to_chat(user, span_notice("You try to empty [source]'s [pocket_side] pocket."))
 
-	var/log_message = "[key_name(source)] is being pickpocketed of [item] by [key_name(user)] ([pocket_side])"
-	user.log_message(log_message, LOG_ATTACK, color="red")
-	source.log_message(log_message, LOG_VICTIM, color="red", log_globally=FALSE)
+	user.log_message("is pickpocketing [key_name(source)] of [item] ([pocket_side])", LOG_ATTACK, color="red")
+	source.log_message("is being pickpocketed of [item] by [key_name(user)] ([pocket_side])", LOG_VICTIM, color="orange", log_globally=FALSE)
 	item.add_fingerprint(src)
 
 	var/result = start_unequip_mob(item, source, user, POCKET_STRIP_DELAY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks stripping related attack logs to use the standard format "has [done thing] to [person]" and "had [thing done] by [person]", with red for the perpetrator and orange for the victim, instead of the current "[person] has [done thing] to [person]" in red for both parties. Additionally adds a missing log for finishing equipping an item only a mob, currently only starting to equip it logged and whether that was finished is left dubious.

![image](https://user-images.githubusercontent.com/5479091/167894246-48fcc39c-f8ea-4069-aba0-7436bb9942ba.png)

fixes #55489

## Why It's Good For The Game

Improves log readability for admins, as stripping logs now look the way they would be expected to based on the surrounding logs, making it much easier to see at a glance who was responsible.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Attack logs for stripping people and equipping items to them have been reformatted to match all other attack logs, improving readability.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
