### PR TITLE
Makes cult's objectives load before their antag ui

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -58,9 +58,9 @@
 	owner.announce_objectives()
 
 /datum/antagonist/cult/on_gain()
+	add_objectives()
 	. = ..()
 	var/mob/living/current = owner.current
-	add_objectives()
 	if(give_equipment)
 		equip_cultist(TRUE)
 	current.log_message("has been converted to the cult of Nar'Sie!", LOG_ATTACK, color="#960000")


### PR DESCRIPTION
Hope you guys like more one-line fixes...

## About The Pull Request

Makes Cultists get their objectives from their team BEFORE their parent's on_gain runs, giving and triggering their antag UI. This means players no longer have to close and reopen the page to see their actual objectives.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/66893

Makes Cult antag UI work from the start.

## Changelog

:cl:
fix: Cult's antag UI now works from the start, rather than having to close and reopen the tab to see your objectives.
/:cl: