### PR TITLE
Advanced tools are medium sized, toolboxes can carry medium sized items.

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -37,6 +37,10 @@
 	if(has_latches)
 		. += latches
 
+/obj/item/storage/toolbox/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/toolbox/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] robusts [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -96,6 +100,11 @@
 	desc = "It's seen better days."
 	force = 5
 	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/storage/toolbox/mechanical/old/heirloom/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/toolbox/mechanical/old/heirloom/PopulateContents()
 	return

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -112,7 +112,7 @@
 
 /obj/item/crowbar/power/syndicate
 	name = "Syndicate jaws of life"
-	desc = "A re-engineered copy of Nanotrasen's standard jaws of life. Can be used to force open airlocks in its crowbar configuration."
+	desc = "A pocket sized re-engineered copy of Nanotrasen's standard jaws of life. Can be used to force open airlocks in its crowbar configuration."
 	icon_state = "jaws_syndie"
 	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -83,6 +83,7 @@
 	custom_materials = list(/datum/material/iron = 4500, /datum/material/silver = 2500, /datum/material/titanium = 3500)
 	usesound = 'sound/items/jaws_pry.ogg'
 	force = 15
+	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7
 	force_opens = TRUE
 

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -114,6 +114,7 @@
 	name = "Syndicate jaws of life"
 	desc = "A re-engineered copy of Nanotrasen's standard jaws of life. Can be used to force open airlocks in its crowbar configuration."
 	icon_state = "jaws_syndie"
+	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5
 	force_opens = TRUE
 

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -81,7 +81,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	custom_materials = list(/datum/material/iron=3500, /datum/material/silver=1500, /datum/material/titanium=2500) //what research value?
 	force = 8 //might or might not be too high, subject to change
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 8
 	throw_speed = 2
 	throw_range = 3//it's heavier than a screw driver/wrench, so it does more damage, but can't be thrown as far

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -82,13 +82,13 @@
 	custom_materials = list(/datum/material/iron=3500, /datum/material/silver=1500, /datum/material/titanium=2500) //what research value?
 	force = 8 //might or might not be too high, subject to change
 	throwforce = 8
-	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 2
 	throw_range = 3//it's heavier than a screw driver/wrench, so it does more damage, but can't be thrown as far
 	attack_verb_continuous = list("drills", "screws", "jabs", "whacks")
 	attack_verb_simple = list("drill", "screw", "jab", "whack")
 	hitsound = 'sound/items/drill_hit.ogg'
 	usesound = 'sound/items/drill_use.ogg'
+	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7
 	random_color = FALSE
 	greyscale_config = null

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -81,8 +81,8 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	custom_materials = list(/datum/material/iron=3500, /datum/material/silver=1500, /datum/material/titanium=2500) //what research value?
 	force = 8 //might or might not be too high, subject to change
-	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 8
+	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 2
 	throw_range = 3//it's heavier than a screw driver/wrench, so it does more damage, but can't be thrown as far
 	attack_verb_continuous = list("drills", "screws", "jabs", "whacks")

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -381,6 +381,7 @@
 	change_icons = FALSE
 	can_off_process = TRUE
 	light_range = 1
+	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.5
 	var/last_gen = 0
 	var/nextrefueltick = 0

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -71,6 +71,7 @@
 	icon_state = "e_cautery"
 	custom_materials = list(/datum/material/iron = 4000, /datum/material/glass = 2000, /datum/material/plasma = 2000, /datum/material/uranium = 3000, /datum/material/titanium = 3000)
 	hitsound = 'sound/items/welder.ogg'
+	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7
 	light_system = MOVABLE_LIGHT
 	light_range = 1
@@ -267,6 +268,7 @@
 	custom_materials = list(/datum/material/iron = 6000, /datum/material/glass = 1500, /datum/material/silver = 2000, /datum/material/gold = 1500, /datum/material/diamond = 200, /datum/material/titanium = 4000)
 	hitsound = 'sound/weapons/blade1.ogg'
 	force = 16
+	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7
 	light_system = MOVABLE_LIGHT
 	light_range = 1
@@ -314,6 +316,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	custom_materials = list(/datum/material/iron = 12000, /datum/material/glass = 4000, /datum/material/silver = 4000, /datum/material/titanium = 5000)
 	icon_state = "adv_retractor"
+	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7
 
 /obj/item/retractor/advanced/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the tier 2 tools be Medium sized instead of Small.
To be clear, this doesn't affect them being carried inside belts in any way.

The toolboxes were literally a reskinned box that did more damage while being bulky.
A box was better at carrying tools than a toolbox... letting them carry medium sized items should shift that around cleanly.

Heirloom toolbox doesn't get the buff to carry size since they can be carried inside a bag.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Oh boye here comes a long Item Economy talk sponsored by "Being sick and doing something "meaningful" as distraction"!

We have multiple ways to balance an Item "desirability" and I feel the advanced tools score too high on that field.
But lets explain that "desirability" properly first, it would be some weird equation between intended use/effectiveness, cost to acquire and cost to use.

- 1: Intended use/effectiveness is a giant can of worms and different for each item but I'm sure you get it's core.
- 2: Cost of acquiring on SS13 is a few things, material cost, research cost, credit cost to purchase, time to acquire AKA asking/stealing/just walking to a vending machine, etc.
- 3: Cost to use would be energy/ammo, cooldowns, limited use/replacing, weight to carry, etc.

Now let's look at the Tier 2 tools and... Most of them don't have a cost that the end user actually cares about, so they are meaningless to them...

- Intended use... they score high on that, print 30 jaws of life/laser saws and put them outside the bar, see how quickly they get grabbed by people. It's pseudo AA or a 17 force sharp weapon that goes into your pocket.
- Material cost is something that miners deal with, research is with science, lathe tax to print is too small.
- They don't use energy/ammo, have no cooldown, don't degrade...

So what the end user has to deal with is their weight... Which is basically nothing since you can carry 49 of them in a bag at the moment. No one is making the hard decision of "To carry or not to carry?" a Jaws of Life in a round, they just do it.

With this change, going for an upgraded tier 2 tool won't be an 100% improvement for everyone at every time and instead a choice that you have to make and will change from round to round. You might have room to keep a laser saw for self defense in a shift and opt to throw it away for a baton in another instead of just keeping the baton **AND** the laser saw inside your box.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Why It's Good For The Game not a wall of text edition:

The current version of these items is something that 99% of the players would opt in to grab every shift if they can.

All upsides with no downsides is bad design, encouraging the players to make the choice of grabbing tools or not makes more interesting rounds when something go wrong and they think: "I'm glad I sacrificed some inventory space for this jaw, it saved my life." or "I should have grabbed a Jaw, I wouldn't have died if I did." instead of every round being "Hahaha Jaws go brrrrr!"


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
balance: Tier 2 tools (Jaws of life/Laser scalpel/Experimental welder) are changed from Small to Medium sized so now you can't carry 49 Jaws of life in your backpack. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
