### PR TITLE
Reduces the chance of spawning a pants altar

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -340,7 +340,6 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 
 
 GLOBAL_LIST_INIT(oddity_loot, list(//oddity: strange or crazy items
-		/obj/structure/destructible/cult/pants_altar = 1,
 		/obj/effect/rune/teleport = 1,
 		/obj/item/clothing/head/helmet/abductor = 1,
 		/obj/item/clothing/shoes/jackboots/fast = 1,

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -340,6 +340,7 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 
 
 GLOBAL_LIST_INIT(oddity_loot, list(//oddity: strange or crazy items
+		/obj/structure/destructible/cult/pants_altar = 1,
 		/obj/effect/rune/teleport = 1,
 		/obj/item/clothing/head/helmet/abductor = 1,
 		/obj/item/clothing/shoes/jackboots/fast = 1,

--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -6,7 +6,7 @@
 	name = "crate spawner"
 	icon_state = "crate_secure"
 	loot = list(
-		/obj/effect/spawner/random/structure/crate_loot = 745,
+		/obj/effect/spawner/random/structure/crate_loot = 744,
 		/obj/structure/closet/crate/trashcart/filled = 75,
 		/obj/effect/spawner/random/trash/moisture_trap = 50,
 		/obj/effect/spawner/random/trash/hobo_squat = 30,
@@ -14,6 +14,7 @@
 		/obj/effect/spawner/random/trash/mess = 30,
 		/obj/item/kirbyplants/fern = 20,
 		/obj/structure/closet/crate/decorations = 15,
+		/obj/structure/destructible/cult/pants_altar = 1,
 	)
 
 /obj/effect/spawner/random/structure/crate_abandoned

--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -6,7 +6,7 @@
 	name = "crate spawner"
 	icon_state = "crate_secure"
 	loot = list(
-		/obj/effect/spawner/random/structure/crate_loot = 735,
+		/obj/effect/spawner/random/structure/crate_loot = 745,
 		/obj/structure/closet/crate/trashcart/filled = 75,
 		/obj/effect/spawner/random/trash/moisture_trap = 50,
 		/obj/effect/spawner/random/trash/hobo_squat = 30,
@@ -14,7 +14,6 @@
 		/obj/effect/spawner/random/trash/mess = 30,
 		/obj/item/kirbyplants/fern = 20,
 		/obj/structure/closet/crate/decorations = 15,
-		/obj/structure/destructible/cult/pants_altar = 10,
 	)
 
 /obj/effect/spawner/random/structure/crate_abandoned


### PR DESCRIPTION
## About The Pull Request

never thought i'd say this but athath was right

https://github.com/tgstation/tgstation/pull/66666/files/9fa8a1a0f3b16762b4d98b14e7b80714527d1ea3#diff-f42c068e330cbd8f3e8b5aa080fba8a1cd1abc9f9a9bcdcbe75f71b0c74b7094

## Why It's Good For The Game

currently the odds of spawning a pants alter in place of a crate is 1 in 100
on metastation, there are 25 crate spawners
meaning there's a 25% chance that a pants alter spawns **every round** on metastation

that's a bit too high for a goofy maint item, also makes it a lot less special to come across, especially if the map spawns multiple pants altars (which it very likely could)

## Changelog

:cl: Melbert
balance: Central Command's agency of supernatural structures have made it much less likely for you to come across ancient altars 
/:cl:
