### PR TITLE
Fixes DeltaStation Holodeck placement

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -955,6 +955,11 @@
 	pixel_y = -32
 	},
 /obj/machinery/camera/directional/south,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/box,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -5221,8 +5226,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bsJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "bsR" = (
@@ -6175,6 +6181,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"bEU" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "bFa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -6405,6 +6418,27 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
+"bGX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/aft)
 "bGY" = (
 /obj/structure/cable,
 /obj/machinery/requests_console/directional/north{
@@ -6764,6 +6798,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
+"bMs" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/station/commons/fitness/recreation)
 "bMH" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -8134,6 +8172,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"ceo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "ces" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -8403,20 +8445,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/mix)
-"ciE" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Dormitories - Center";
-	name = "dormitories camera"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
-/area/station/commons/dorms)
 "ciG" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
@@ -11098,7 +11126,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
@@ -11796,13 +11824,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dks" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/neutral/half{
 	dir = 8
 	},
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/commons/dorms)
 "dkz" = (
 /obj/structure/disposalpipe/segment,
@@ -12925,7 +12950,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "dEz" = (
-/obj/machinery/washing_machine,
+/obj/structure/table,
+/obj/structure/bedsheetbin,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -13514,6 +13540,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"dOL" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "dOP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -13778,14 +13809,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "dTK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron,
 /area/station/commons/dorms)
 "dTV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -13926,6 +13953,17 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"dVY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "dWf" = (
 /obj/structure/cable,
 /obj/structure/filingcabinet/chestdrawer,
@@ -15499,6 +15537,10 @@
 "evq" = (
 /turf/open/floor/iron/dark,
 /area/station/service/electronic_marketing_den)
+"evs" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "evM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -15929,12 +15971,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
 /area/station/security/prison)
-"eBL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "eBZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
@@ -16588,8 +16624,8 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/bar)
 "eMp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/half{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -17038,6 +17074,10 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
+"eSy" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "eSJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 6
@@ -17202,6 +17242,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/theater/abandoned)
+"eVD" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "eVG" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -17496,6 +17545,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"eYW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "eYZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
@@ -18457,6 +18515,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"flc" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "fli" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21544,6 +21605,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"gci" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/aft)
 "gcl" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
@@ -23758,17 +23830,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"gGz" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/station/commons/dorms)
 "gGO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -24795,8 +24856,7 @@
 /area/station/security/prison)
 "gVQ" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced,
 /area/station/commons/dorms)
 "gVU" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
@@ -24866,6 +24926,12 @@
 	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/greater)
+"gXE" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "gXF" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Distribution Loop";
@@ -25168,6 +25234,18 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/checker,
 /area/station/engineering/atmos/pumproom)
+"hbU" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "hbV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25798,14 +25876,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "hms" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "hmx" = (
@@ -25917,6 +25988,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs/aft)
+"hov" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "hoz" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/decal/cleanable/dirt,
@@ -27586,11 +27662,6 @@
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore)
-"hNT" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "hOa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor{
@@ -28197,13 +28268,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "hWc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/catwalk_floor/iron,
 /area/station/commons/dorms)
 "hWh" = (
 /obj/machinery/meter,
@@ -28333,6 +28400,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/closet,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "hXB" = (
@@ -28923,9 +28992,7 @@
 /area/station/cargo/drone_bay)
 "ieT" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ieW" = (
@@ -29536,6 +29603,15 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/medical/storage)
+"ilW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "img" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -30792,7 +30868,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/commons/dorms)
+/area/station/maintenance/starboard)
 "iBO" = (
 /obj/machinery/power/turbine/inlet_compressor,
 /turf/open/floor/engine,
@@ -31357,6 +31433,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"iKe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "iKl" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
@@ -31385,11 +31470,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
-"iKQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "iKX" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
@@ -31932,13 +32012,6 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/service/janitor)
-"iSO" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "iSR" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Quarters"
@@ -32888,27 +32961,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"jeR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "jfe" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular,
@@ -33846,10 +33898,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"jsU" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "jta" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -38945,20 +38993,18 @@
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
 "kKo" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "kKr" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/catwalk_floor/iron,
 /area/station/commons/dorms)
 "kKx" = (
 /obj/effect/turf_decal/loading_area{
@@ -39170,16 +39216,7 @@
 /area/station/hallway/primary/central/fore)
 "kOr" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/iron,
 /area/station/commons/dorms)
 "kOv" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -39700,15 +39737,6 @@
 "kVP" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
-"kVV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "kVZ" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/effect/decal/cleanable/dirt,
@@ -40406,16 +40434,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/misc_lab/range)
-"ldL" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "ldM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -41852,6 +41870,23 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
+"lyZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Recreational Area"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "lzp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42650,12 +42685,6 @@
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
-"lKB" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "lKI" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -44310,13 +44339,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/lobby)
-"mhY" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "mig" = (
 /obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/tile/purple{
@@ -46429,11 +46451,11 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "mMU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/iron,
 /area/station/commons/dorms)
 "mMX" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -49519,6 +49541,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -50609,6 +50632,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "nUc" = (
@@ -51726,6 +51750,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"ogW" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "ogZ" = (
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -53076,12 +53109,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/command)
-"oCt" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "oCy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -53778,11 +53805,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"oMF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "oMM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -54511,6 +54533,16 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
+"oWO" = (
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "oWR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -56270,14 +56302,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"puW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/power/port_gen/pacman/pre_loaded,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "puX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
@@ -56357,13 +56381,7 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "pwb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/glass/reinforced,
 /area/station/commons/dorms)
 "pwk" = (
 /obj/machinery/camera/directional/east{
@@ -57897,10 +57915,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "pQw" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/catwalk_floor/iron,
 /area/station/commons/dorms)
 "pQF" = (
 /obj/effect/landmark/start/lawyer,
@@ -58100,13 +58118,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
-"pTP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "pTU" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Science - Port";
@@ -59284,6 +59295,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"qln" = (
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/commons/dorms)
 "qlr" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
@@ -60593,6 +60616,10 @@
 /obj/item/circuitboard/machine/chem_master,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/port/fore)
+"qDG" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "qDT" = (
 /obj/structure/bookcase/manuals/engineering,
 /turf/open/floor/wood,
@@ -60646,6 +60673,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
+"qFd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "qFe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60697,6 +60732,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"qGt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/station/maintenance/starboard/aft)
 "qGz" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb,
@@ -60802,6 +60841,17 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"qIn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "qIx" = (
 /obj/structure/table,
 /obj/item/crowbar/red,
@@ -61649,9 +61699,10 @@
 /turf/open/floor/plating,
 /area/station/medical/morgue)
 "qVJ" = (
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "qVO" = (
@@ -61691,14 +61742,6 @@
 "qWk" = (
 /turf/closed/wall,
 /area/station/science/xenobiology)
-"qWq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "qWr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63303,6 +63346,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"rtB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "rtH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65172,11 +65224,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"rTn" = (
-/obj/structure/girder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "rTo" = (
 /turf/closed/wall,
 /area/station/maintenance/aft)
@@ -66160,12 +66207,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"sfB" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "sfC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66214,15 +66255,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"sfV" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
-"sgc" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "sgZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -66632,13 +66664,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
-"slk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "slp" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -68083,6 +68108,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"sEE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
+/area/holodeck/rec_center)
 "sEM" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Quarter Solar Access";
@@ -68313,14 +68342,6 @@
 "sHC" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
-"sHD" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "sHL" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/blue{
@@ -69018,12 +69039,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"sPQ" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "sPT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69033,6 +69048,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
+"sPU" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "sPV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -69426,12 +69447,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
-"sVF" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "sVI" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -70113,13 +70128,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/engineering/atmos)
-"tdk" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "tdt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70485,6 +70493,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"tkf" = (
+/turf/open/space/basic,
+/area/station/commons/fitness/recreation)
 "tki" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70638,15 +70649,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"tma" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "tmc" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/wood,
@@ -75285,6 +75287,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"utT" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "uuf" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -78470,6 +78477,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/storage)
+"viN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "viO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
@@ -78714,6 +78728,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"vnr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
 "vnu" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/rack,
@@ -79586,9 +79604,10 @@
 /turf/closed/wall,
 /area/station/service/kitchen)
 "vza" = (
-/turf/open/floor/iron{
-	heat_capacity = 1e+006
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "vze" = (
 /obj/structure/bookcase/random,
@@ -82022,8 +82041,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/storage/gas)
 "wef" = (
-/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /obj/machinery/vending/games,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "weh" = (
@@ -82602,6 +82624,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"wlN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/holodeck/rec_center)
 "wlS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -83225,14 +83252,11 @@
 /area/station/science/storage)
 "wuY" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -84125,14 +84149,6 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
-"wFQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "wFR" = (
 /obj/structure/lattice,
 /obj/structure/sign/nanotrasen{
@@ -84523,6 +84539,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"wMB" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Dormitories - Center";
+	name = "dormitories camera"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/station/commons/dorms)
 "wNa" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -85079,6 +85109,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
+"wVh" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/space/basic,
+/area/station/commons/dorms)
 "wVj" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -88643,6 +88677,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"xQX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "xQY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -138477,7 +138520,7 @@ hPZ
 frW
 aFD
 jxM
-amm
+viN
 nXH
 oib
 lvZ
@@ -138733,8 +138776,8 @@ nXH
 nXH
 nXH
 nXH
+nXH
 sqY
-wFQ
 uRS
 kQs
 nUO
@@ -138987,11 +139030,11 @@ tqt
 dVF
 oCP
 nGQ
-gGz
 dEz
+dEz
+qln
 nXH
 jUb
-eBL
 nXH
 pIA
 lvZ
@@ -139244,11 +139287,11 @@ kaG
 lPS
 gCP
 ieT
-tma
 dks
+dks
+eVD
 nXH
-jeR
-nXH
+bGX
 nXH
 nXH
 nXH
@@ -139503,9 +139546,9 @@ xsS
 kOr
 mMU
 kKo
+utT
 nXH
 vuV
-qWq
 avh
 avh
 gzn
@@ -139757,12 +139800,12 @@ tqt
 tqt
 mbO
 suy
-elU
+ilW
 eMp
 bsJ
+dOL
 nXH
 mQM
-hqH
 hqH
 uKb
 hYQ
@@ -140016,6 +140059,7 @@ kOY
 oCP
 qga
 ijp
+ijp
 kGx
 nXH
 nXH
@@ -140023,7 +140067,6 @@ nXH
 nXH
 nXH
 nXH
-ckP
 akD
 ckP
 nXH
@@ -140272,15 +140315,15 @@ yaI
 yaI
 yaI
 xlJ
-ldL
 pwb
+pwb
+ogW
 yaI
 sOA
 lsg
 jJZ
 vPH
 nXH
-rqb
 oMS
 sij
 nXH
@@ -140529,15 +140572,15 @@ lpI
 rQJ
 hJg
 xlJ
-oCt
 dTK
+dTK
+dVY
 dua
 mkb
 vdD
 jtu
 lbr
 nXH
-iSO
 ulF
 ckP
 nXH
@@ -140786,15 +140829,15 @@ axK
 iEV
 yaI
 jiF
-sfV
-mhY
+pwb
+pwb
+oWO
 yaI
 oqp
 cOi
 qzF
 kPU
 nXH
-ckP
 ulF
 ekN
 nXH
@@ -141043,15 +141086,15 @@ yaI
 yaI
 yaI
 oOU
-hNT
-ciE
+pwb
+pwb
+wMB
 yaI
 yaI
 yaI
 yaI
 yaI
 nXH
-lKB
 bOY
 vRg
 nXH
@@ -141301,6 +141344,7 @@ sra
 yaI
 xlJ
 gVQ
+pwb
 tKM
 yaI
 fBd
@@ -141308,9 +141352,8 @@ cwf
 nPP
 iyE
 nXH
-oMF
 bOY
-ckP
+evs
 nXH
 aGS
 aDV
@@ -141557,15 +141600,15 @@ qzF
 mkb
 oyA
 wuY
-oCt
 hWc
+hWc
+qFd
 qAC
 eiF
 baO
 eAS
 ouA
 nXH
-lKB
 bOY
 sij
 nXH
@@ -141814,15 +141857,15 @@ gyj
 pPx
 yaI
 elU
-sfV
-jsU
+pwb
+pwb
+gXE
 yaI
 tVb
 vOj
 eAS
 wxt
 nXH
-kVV
 ulF
 amm
 nXH
@@ -142071,22 +142114,22 @@ yaI
 yaI
 yaI
 ffQ
-sfV
-jsU
+pwb
+pwb
+gXE
 yaI
 yaI
 yaI
 yaI
 yaI
 nXH
-rTn
 rFJ
 jcd
 hXA
 aVD
 bKG
-amm
-ckP
+rUU
+eSy
 dMJ
 nXH
 nXH
@@ -142328,15 +142371,15 @@ clB
 fLG
 yaI
 elU
-sfV
-sgc
+pwb
+pwb
+bEU
 yaI
 cNT
 laO
 owR
 eyy
 nXH
-tdk
 oyW
 wpb
 vRg
@@ -142584,18 +142627,18 @@ eAS
 baO
 eiF
 ygP
-elU
+hbU
 kKr
 pQw
+qIn
 mbu
 dAc
 tza
 owR
 qhi
 nXH
-puW
-oyW
-aFD
+iKe
+xQX
 rES
 hqH
 ssI
@@ -142842,19 +142885,19 @@ vOj
 oKk
 yaI
 cXA
-sPQ
-pTP
+pwb
+pwb
+eYW
 yaI
 iRJ
 fsz
 ybg
 igG
 nXH
-slk
 hms
+gci
 dWG
-iKQ
-nXH
+qGt
 bBd
 nXH
 nXH
@@ -143100,7 +143143,8 @@ yaI
 yaI
 unm
 ijp
-unm
+wVh
+lyZ
 yaI
 yaI
 yaI
@@ -143109,7 +143153,6 @@ yaI
 nXH
 nXH
 aqJ
-nXH
 nXH
 nXH
 aad
@@ -143357,6 +143400,7 @@ bAu
 lrM
 oYd
 mgY
+mgY
 vEb
 dZF
 bAu
@@ -143366,7 +143410,6 @@ yge
 hjd
 rsv
 jie
-sHD
 wef
 uKw
 aaa
@@ -143614,6 +143657,7 @@ cwA
 baK
 pRZ
 mgY
+mgY
 dNw
 baK
 bjr
@@ -143623,7 +143667,6 @@ rjM
 pnO
 aGR
 esB
-baK
 vza
 mfC
 aad
@@ -143872,6 +143915,7 @@ wbF
 mgY
 mgY
 mgY
+mgY
 aeI
 sIK
 jgM
@@ -143880,7 +143924,6 @@ enr
 ekl
 uql
 eEr
-baK
 vza
 mfC
 aaa
@@ -144128,6 +144171,7 @@ hJG
 mdD
 kZn
 pji
+mgY
 hiM
 vZw
 sIK
@@ -144137,8 +144181,7 @@ pKN
 leN
 uql
 eEr
-aBG
-vza
+rtB
 mfC
 aad
 aad
@@ -144385,6 +144428,7 @@ hJG
 mEi
 pRZ
 eFS
+mgY
 dNw
 lPT
 sIK
@@ -144394,8 +144438,7 @@ cZU
 leN
 uql
 fzB
-baK
-baK
+vza
 mfC
 aad
 aaa
@@ -144643,6 +144686,7 @@ hFM
 mgY
 mgY
 mgY
+mgY
 tkl
 sIK
 sMP
@@ -144651,8 +144695,7 @@ oYg
 dKE
 uql
 fzB
-baK
-baK
+vza
 mfC
 qYo
 qYo
@@ -144899,6 +144942,7 @@ aek
 baK
 kZn
 mgY
+mgY
 hiM
 qAF
 xLL
@@ -144908,8 +144952,7 @@ klz
 nZf
 oSk
 qAF
-baK
-baK
+vza
 mfC
 qYo
 xTK
@@ -145156,6 +145199,7 @@ wZT
 wZT
 baK
 mgY
+mgY
 baK
 qAF
 baK
@@ -145163,7 +145207,6 @@ uIN
 baK
 baK
 bJH
-pxj
 vii
 vii
 akC
@@ -145413,6 +145456,7 @@ mfC
 mNC
 fBy
 mfC
+mfC
 fBy
 fIQ
 mfC
@@ -145420,7 +145464,6 @@ mfC
 mfC
 mfC
 uKw
-mfC
 kuM
 ria
 aci
@@ -145667,17 +145710,17 @@ aaa
 aaa
 aad
 aaa
-mNC
-sfB
-uKw
+lAY
 ezf
-fIQ
+baK
+baK
+sPU
+qOn
 aaa
 qYo
 eqU
-qYo
-aaa
-mfC
+flc
+vnr
 pEx
 lfb
 dFi
@@ -145927,14 +145970,14 @@ mNC
 mNC
 pHx
 mfC
+mfC
 wIk
 fIQ
 kYk
 fIQ
 fIQ
-fIQ
-aad
-mfC
+bMs
+ceo
 swS
 aXN
 ooD
@@ -146189,9 +146232,9 @@ cFF
 cFF
 cFF
 cFF
-fIQ
-aaa
-mfC
+wlN
+tkf
+vnr
 mfC
 mfC
 mfC
@@ -146442,14 +146485,14 @@ cFF
 cFF
 cFF
 cFF
+cFF
 sHM
 cFF
 cFF
-cFF
-fIQ
-aaa
-mfC
-aad
+wlN
+tkf
+vnr
+tkf
 aad
 aad
 aad
@@ -146703,13 +146746,13 @@ cFF
 cFF
 cFF
 cTi
-qOn
-aad
-uKw
+sEE
+bMs
+aJD
+tkf
 aad
 aaa
 aaa
-xTK
 aaa
 aaa
 aaa
@@ -146956,17 +146999,17 @@ cFF
 cFF
 cFF
 cFF
+cFF
 sHM
 cFF
 cFF
-cFF
-fIQ
-aaa
-mfC
+wlN
+tkf
+vnr
+tkf
 aad
 aaa
 aaa
-xTK
 aaa
 aaa
 aaa
@@ -147217,13 +147260,13 @@ cFF
 cFF
 cFF
 cFF
-fIQ
-aaa
-mfC
+wlN
+tkf
+vnr
+tkf
 aad
 aaa
 aaa
-xTK
 aaa
 aaa
 aaa
@@ -147474,13 +147517,13 @@ cFF
 cFF
 cFF
 cFF
-fIQ
-aad
-mfC
+wlN
+bMs
+ceo
+tkf
 aad
 xTK
 aaa
-qYo
 aaa
 qYo
 aaa
@@ -147731,13 +147774,13 @@ cFF
 cFF
 cFF
 xVV
-qOn
-aaa
-mfC
+sEE
+tkf
+vnr
+tkf
 aad
 xTK
 qYo
-xTK
 xTK
 xTK
 qYo
@@ -147988,11 +148031,11 @@ cFF
 cFF
 cFF
 cFF
-fIQ
-aaa
-mfC
+wlN
+tkf
+vnr
+tkf
 aad
-aaa
 aaa
 aaa
 aaa
@@ -148245,12 +148288,12 @@ cFF
 cFF
 cFF
 cFF
-fIQ
-aad
-uKw
+wlN
+bMs
+aJD
+tkf
 aad
 xTK
-aaa
 aaa
 aaa
 aaa
@@ -148497,17 +148540,17 @@ mNC
 mNC
 oVy
 mfC
+mfC
 hGu
 fIQ
 fIQ
 fIQ
 fIQ
-fIQ
-aaa
-mfC
+tkf
+vnr
+tkf
 aad
 xTK
-aaa
 aaa
 aaa
 aaa
@@ -148751,20 +148794,20 @@ aaa
 aaa
 aad
 aaa
-mfC
-qVJ
 uKw
-sVF
-fIQ
+qVJ
+baK
+baK
+hov
+qOn
 aaa
 qYo
 eqU
-qYo
-aaa
-mfC
+flc
+vnr
+tkf
 aad
 xTK
-aaa
 aaa
 aaa
 aaa
@@ -149011,6 +149054,7 @@ mfC
 mfC
 vfP
 mfC
+mfC
 tAu
 fIQ
 mfC
@@ -149018,9 +149062,8 @@ mfC
 uKw
 mfC
 mfC
-mfC
+tkf
 aad
-aaa
 aaa
 aaa
 aaa
@@ -149268,6 +149311,7 @@ aad
 mfC
 gHb
 fpD
+mEi
 yjp
 fIQ
 qYo
@@ -149277,7 +149321,6 @@ qYo
 qYo
 qYo
 aad
-aaa
 aaa
 aaa
 aaa
@@ -149525,6 +149568,7 @@ qYo
 uKw
 aRM
 mMK
+baK
 wyD
 uKw
 qYo
@@ -149534,7 +149578,6 @@ xTK
 xTK
 aaa
 qYo
-aaa
 aaa
 aaa
 aaa
@@ -149782,11 +149825,11 @@ aaa
 mfC
 ryG
 tuI
+qDG
 uwt
 mfC
 qYo
 efQ
-aaa
 aaa
 aaa
 aaa
@@ -150041,8 +150084,8 @@ mfC
 mfC
 mfC
 mfC
+mfC
 qYo
-aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes the alignment of the DeltaStation holodeck so that holodeck templates spawn properly. Alignment was changed to best adhere to the recent changes done to the space:
![image](https://user-images.githubusercontent.com/63861499/167965992-e5f2abfb-5f6e-479f-8221-9fe4c6d721d9.png)


## Why It's Good For The Game

Allows holodeck templates to function properly on all maps and adhere to the same restrictions. Fixes #66884 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Realigns the DeltaStation holodeck to fit universal templates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
