### PR TITLE
Fixes the captain's PDA

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -490,7 +490,7 @@
 	/obj/item/modular_computer/tablet/pda/heads/cmo = list(REGION_COMMAND), \
 	/obj/item/modular_computer/tablet/pda/heads/ce = list(REGION_COMMAND), \
 	/obj/item/modular_computer/tablet/pda/heads/rd = list(REGION_COMMAND), \
-	/obj/item/modular_computer/tablet/pda/captain = list(REGION_COMMAND), \
+	/obj/item/modular_computer/tablet/pda/heads/captain = list(REGION_COMMAND), \
 	/obj/item/modular_computer/tablet/pda/cargo = list(REGION_SUPPLY), \
 	/obj/item/modular_computer/tablet/pda/quartermaster = list(REGION_SUPPLY), \
 	/obj/item/modular_computer/tablet/pda/shaftminer = list(REGION_SUPPLY), \

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -12,6 +12,7 @@
 	new /obj/item/clothing/neck/petcollar(src)
 	new /obj/item/pet_carrier(src)
 	new /obj/item/storage/bag/garment/captain(src)
+	new /obj/item/computer_hardware/hard_drive/portable/command/captain(src)
 	new /obj/item/storage/box/silver_ids(src)
 	new /obj/item/radio/headset/heads/captain/alt(src)
 	new /obj/item/radio/headset/heads/captain(src)

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -62,7 +62,7 @@
 		/obj/item/melee/baton/telescopic = 1,
 		/obj/item/station_charter = 1,
 		)
-	belt = /obj/item/modular_computer/tablet/pda/captain
+	belt = /obj/item/modular_computer/tablet/pda/heads/captain
 	ears = /obj/item/radio/headset/heads/captain/alt
 	glasses = /obj/item/clothing/glasses/sunglasses
 	gloves = /obj/item/clothing/gloves/color/captain

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -23,7 +23,7 @@
 	greyscale_colors = "#2C7CB2#FF0000#FFFFFF#FFD55B"
 	insert_type = /obj/item/pen/fountain
 
-/obj/item/modular_computer/tablet/pda/captain/Initialize(mapload)
+/obj/item/modular_computer/tablet/pda/heads/captain/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_TABLET_CHECK_DETONATE, .proc/tab_no_detonate)
 


### PR DESCRIPTION
## About The Pull Request

I screwed it up and didn't make the Captain's PDA a subtype of heads, so captain was spawning with the wrong PDA, and forgot to put their new cartridge in their locker.

## Why It's Good For The Game

Bug fix, tested the captain's PDA in-game and it works now.

## Changelog

:cl:
fix: The Captain's PDA now works, and their cartridge now spawns in their locker.
/:cl: