### PR TITLE
Fixes pants altars being spammable

### DIFF
--- a/code/game/objects/structures/maintenance.dm
+++ b/code/game/objects/structures/maintenance.dm
@@ -148,7 +148,7 @@ at the cost of risking a vicious bite.**/
 			if(!isnull(chosen_color) && user.canUseTopic(src, BE_CLOSE))
 				pants_color = chosen_color
 		if("Create Artefact")
-			if(!COOLDOWN_FINISHED(src, use_cooldown_duration))
+			if(!COOLDOWN_FINISHED(src, use_cooldown) || status != ALTAR_INACTIVE)
 				to_chat(user, span_warning("[src] is not ready to create something new yet..."))
 				return
 			pants_stageone()


### PR DESCRIPTION
## About The Pull Request

The cooldown doesn't start until the pants is finished being made, so while its still making the pants, you can spam the shit out of it

## Why It's Good For The Game

Holy shit please stop spamming the altar.

## Changelog

:cl:
fix: The new cult altar can't be spammed anymore.
/:cl: