### PR TITLE
Removes Cyborg's PDA app

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -85,13 +85,13 @@
 	modularInterface.saved_identification = real_name || name
 	if(istype(src, /mob/living/silicon/robot))
 		modularInterface.saved_job = "Cyborg"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated/borg)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/robot)
 	if(istype(src, /mob/living/silicon/ai))
 		modularInterface.saved_job = "AI"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/ai)
 	if(istype(src, /mob/living/silicon/pai))
 		modularInterface.saved_job = "pAI Messenger"
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/integrated)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/ai)
 
 /mob/living/silicon/robot/model/syndicate/create_modularInterface()
 	if(!modularInterface)

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -177,18 +177,15 @@
 	store_file(new /datum/computer_file/program/notepad(src))
 
 // For borg integrated tablets. No downloader.
-/obj/item/computer_hardware/hard_drive/small/integrated/install_default_programs()
+/obj/item/computer_hardware/hard_drive/small/ai/install_default_programs()
 	var/datum/computer_file/program/messenger/messenger = new(src)
 	messenger.is_silicon = TRUE
 	store_file(messenger)
 
-/obj/item/computer_hardware/hard_drive/small/integrated/borg/install_default_programs()
+/obj/item/computer_hardware/hard_drive/small/robot/install_default_programs()
 	store_file(new /datum/computer_file/program/computerconfig(src)) // Computer configuration utility, allows hardware control and displays more info than status bar
 	store_file(new /datum/computer_file/program/filemanager(src)) // File manager, allows text editor functions and basic file manipulation.
 	store_file(new /datum/computer_file/program/robotact(src))
-	var/datum/computer_file/program/messenger/messenger = new(src)
-	messenger.is_silicon = TRUE
-	store_file(messenger)
 
 // Syndicate variant - very slight better
 /obj/item/computer_hardware/hard_drive/portable/syndicate


### PR DESCRIPTION
## About The Pull Request

I got rid of the 'integrated' subtype because it was useless.

When PDA functionality was ported over to Tablets, one of the biggest deals was complete 'feature parity'. Borgs did not have PDA's before this, so them being given it now was breaking this rule, bringing in undocumented changes. Because of this, I'm assuming that this change was accidental, so I am reverting it.

## Why It's Good For The Game

The Roboticist SiliConnect app lets them send messages to Cyborgs, their master AI can see messages sent to them, and can help reply if needed.
I do not see any reason for this app to be made irrelevant, by giving Cyborgs the ability to send PDA messages directly instead. Cyborgs are limited in their abilities to act like crewmembers, because they aren't crewmembers.

For a reason as to why Cyborgs shouldn't have PDA's in general, is because they are meant to be an extension of the AI, rather than their own thing. Siliconnect can message them but not get a response back, which I find is more interesting than direct communication via PDA's like any other crewmember. 

## Changelog

:cl:
fix: Cyborgs once again can't PDA people anymore.
/:cl: