### PR TITLE
Makes minifridges able to hold more stuff

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -117,7 +117,7 @@
 	icon_state = "mini_fridge"
 	icon_welded = "welded_small"
 	max_mob_size = MOB_SIZE_SMALL
-	storage_capacity = 7
+	storage_capacity = 10
 
 /obj/structure/closet/mini_fridge/PopulateContents()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Due to mini-fridges being in the pool for spawning instead of crates/lockers, if there's too many things meant to spawn in said fridge (like maintenance loot x4), unit tests will fail because it just can't hold it.

I went the easy way out and just added more storage space to fridges, because I don't think the alternative (removing a lot of maint loot from lockers/crates) would be wanted over it

## Why It's Good For The Game

Integration tests are randomly failing please help.

## Changelog

:cl:
balance: Mini-fridges can now hold slightly more things.
/:cl: