### PR TITLE
Belts are now Bulky and do not fit in bags.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -12,6 +12,7 @@
 	attack_verb_simple = list("whip", "lash", "discipline")
 	max_integrity = 300
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
+	w_class = WEIGHT_CLASS_BULKY
 	var/content_overlays = FALSE //If this is true, the belt will gain overlays based on what it's holding
 
 /obj/item/storage/belt/suicide_act(mob/living/carbon/user)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -96,7 +96,6 @@
 	l_hand = /obj/item/gun/energy/pulse/carbine/loyalpin
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded = 1,
-		/obj/item/storage/belt/security/full = 1,
 		/obj/item/storage/box/handcuffs = 1,
 		/obj/item/storage/box/survival/engineer = 1,
 	)


### PR DESCRIPTION
## About The Pull Request

Fixes an obvious oversight resulting in stacking inventory items to violate the laws of physics. Belts are now Bulky and do not fit in bags.

## Why It's Good For The Game

We already have problems with too much inventory space on the average spaceman, this is just pushing it into egregious territory with this obvious oversight.

## Changelog

:cl:
fix: Fixes an obvious oversight resulting in stacking inventory items to violate the laws of physics. Belts are now Bulky and do not fit in bags.
/:cl:
