### PR TITLE
Small refactor to how analyzer's last atmos gasmix data is made

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_tools.dm
+++ b/code/__DEFINES/dcs/signals/signals_tools.dm
@@ -1,0 +1,7 @@
+// Notifies tools that something is happening.
+
+// Sucessful actions against an atom.
+///Called from /atom/proc/tool_act (atom)
+#define COMSIG_TOOL_ATOM_ACTED_PRIMARY(tooltype) "tool_atom_acted_[tooltype]"
+///Called from /atom/proc/tool_act (atom)
+#define COMSIG_TOOL_ATOM_ACTED_SECONDARY(tooltype) "tool_atom_acted_[tooltype]"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1418,10 +1418,10 @@
 	// A tooltype_act has completed successfully
 	if(is_left_clicking)
 		log_tool("[key_name(user)] used [tool] on [src] at [AREACOORD(src)]")
-		SEND_SIGNAL(tool,  COMSIG_TOOL_ATOM_ACTED_PRIMARY(tooltype), src)
+		SEND_SIGNAL(tool,  COMSIG_TOOL_ATOM_ACTED_PRIMARY(tool_type), src)
 	else
 		log_tool("[key_name(user)] used [tool] on [src] (right click) at [AREACOORD(src)]")
-		SEND_SIGNAL(tool,  COMSIG_TOOL_ATOM_ACTED_SECONDARY(tooltype), src)
+		SEND_SIGNAL(tool,  COMSIG_TOOL_ATOM_ACTED_SECONDARY(tool_type), src)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1424,7 +1424,12 @@
 			if(TOOL_ANALYZER)
 				act_result = analyzer_act_secondary(user, tool)
 	if(act_result) // A tooltype_act has completed successfully
-		log_tool("[key_name(user)] used [tool] on [src][is_right_clicking ? "(right click)" : ""] at [AREACOORD(src)]")
+		if(!is_right_clicking)
+			log_tool("[key_name(user)] used [tool] on [src] at [AREACOORD(src)]")
+			SEND_SIGNAL(tool,  COMSIG_TOOL_ATOM_ACTED_PRIMARY(tooltype), src)
+		else
+			log_tool("[key_name(user)] used [tool] on [src] (right click) at [AREACOORD(src)]")
+			SEND_SIGNAL(tool,  COMSIG_TOOL_ATOM_ACTED_SECONDARY(tooltype), src)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1380,7 +1380,10 @@
 /atom/proc/tool_act(mob/living/user, obj/item/tool, tool_type, is_right_clicking)
 	var/act_result
 	var/signal_result
-	if(!is_right_clicking) // Left click first for sensibility
+
+	var/is_left_clicking = !is_right_clicking
+
+	if(is_left_clicking) // Left click first for sensibility
 		var/list/processing_recipes = list() //List of recipes that can be mutated by sending the signal
 		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, tool, processing_recipes)
 		if(signal_result & COMPONENT_BLOCK_TOOL_ATTACK) // The COMSIG_ATOM_TOOL_ACT signal is blocking the act
@@ -1389,48 +1392,37 @@
 			process_recipes(user, tool, processing_recipes)
 		if(QDELETED(tool))
 			return TRUE
-		switch(tool_type)
-			if(TOOL_CROWBAR)
-				act_result = crowbar_act(user, tool)
-			if(TOOL_MULTITOOL)
-				act_result = multitool_act(user, tool)
-			if(TOOL_SCREWDRIVER)
-				act_result = screwdriver_act(user, tool)
-			if(TOOL_WRENCH)
-				act_result = wrench_act(user, tool)
-			if(TOOL_WIRECUTTER)
-				act_result = wirecutter_act(user, tool)
-			if(TOOL_WELDER)
-				act_result = welder_act(user, tool)
-			if(TOOL_ANALYZER)
-				act_result = analyzer_act(user, tool)
 	else
 		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_SECONDARY_TOOL_ACT(tool_type), user, tool)
 		if(signal_result & COMPONENT_BLOCK_TOOL_ATTACK) // The COMSIG_ATOM_TOOL_ACT signal is blocking the act
 			return TOOL_ACT_SIGNAL_BLOCKING
-		switch(tool_type)
-			if(TOOL_CROWBAR)
-				act_result = crowbar_act_secondary(user, tool)
-			if(TOOL_MULTITOOL)
-				act_result = multitool_act_secondary(user, tool)
-			if(TOOL_SCREWDRIVER)
-				act_result = screwdriver_act_secondary(user, tool)
-			if(TOOL_WRENCH)
-				act_result = wrench_act_secondary(user, tool)
-			if(TOOL_WIRECUTTER)
-				act_result = wirecutter_act_secondary(user, tool)
-			if(TOOL_WELDER)
-				act_result = welder_act_secondary(user, tool)
-			if(TOOL_ANALYZER)
-				act_result = analyzer_act_secondary(user, tool)
-	if(act_result) // A tooltype_act has completed successfully
-		if(!is_right_clicking)
-			log_tool("[key_name(user)] used [tool] on [src] at [AREACOORD(src)]")
-			SEND_SIGNAL(tool,  COMSIG_TOOL_ATOM_ACTED_PRIMARY(tooltype), src)
-		else
-			log_tool("[key_name(user)] used [tool] on [src] (right click) at [AREACOORD(src)]")
-			SEND_SIGNAL(tool,  COMSIG_TOOL_ATOM_ACTED_SECONDARY(tooltype), src)
-		return TOOL_ACT_TOOLTYPE_SUCCESS
+
+	switch(tool_type)
+		if(TOOL_CROWBAR)
+			act_result = is_left_clicking ? crowbar_act(user, tool) : crowbar_act_secondary(user, tool)
+		if(TOOL_MULTITOOL)
+			act_result = is_left_clicking ? multitool_act(user, tool) : multitool_act_secondary(user, tool)
+		if(TOOL_SCREWDRIVER)
+			act_result = is_left_clicking ? screwdriver_act(user, tool) : screwdriver_act_secondary(user, tool)
+		if(TOOL_WRENCH)
+			act_result = is_left_clicking ? wrench_act(user, tool) : wrench_act_secondary(user, tool)
+		if(TOOL_WIRECUTTER)
+			act_result = is_left_clicking ? wirecutter_act(user, tool) : wirecutter_act_secondary(user, tool)
+		if(TOOL_WELDER)
+			act_result = is_left_clicking ? welder_act(user, tool) : welder_act_secondary(user, tool)
+		if(TOOL_ANALYZER)
+			act_result = is_left_clicking ? analyzer_act(user, tool) : analyzer_act_secondary(user, tool)
+	if(!act_result)
+		return
+
+	// A tooltype_act has completed successfully
+	if(is_left_clicking)
+		log_tool("[key_name(user)] used [tool] on [src] at [AREACOORD(src)]")
+		SEND_SIGNAL(tool,  COMSIG_TOOL_ATOM_ACTED_PRIMARY(tooltype), src)
+	else
+		log_tool("[key_name(user)] used [tool] on [src] (right click) at [AREACOORD(src)]")
+		SEND_SIGNAL(tool,  COMSIG_TOOL_ATOM_ACTED_SECONDARY(tooltype), src)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 
 /atom/proc/process_recipes(mob/living/user, obj/item/processed_object, list/processing_recipes)

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -24,7 +24,7 @@
 
 /obj/item/analyzer/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_TOOL_ATOM_ACTED_PRIMARY, .proc/on_analyze)
+	RegisterSignal(src, COMSIG_TOOL_ATOM_ACTED_PRIMARY(tool_behaviour), .proc/on_analyze)
 
 /obj/item/analyzer/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -128,7 +128,7 @@
 	ui_interact(user)
 
 /// Called when our analyzer is used on something
-/obj/item/analyzer/proc/on_analyze(atom/target)
+/obj/item/analyzer/proc/on_analyze(datum/source, atom/target)
 	var/mixture = target.return_analyzable_air()
 	if(!mixture)
 		return FALSE

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -22,6 +22,10 @@
 	var/barometer_accuracy // 0 is the best accuracy.
 	var/list/last_gasmix_data
 
+/obj/item/analyzer/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_TOOL_ATOM_ACTED_PRIMARY, .proc/on_analyze)
+
 /obj/item/analyzer/examine(mob/user)
 	. = ..()
 	. += span_notice("Right-click [src] to open the gas reference.")
@@ -123,13 +127,27 @@
 
 	ui_interact(user)
 
+/// Called when our analyzer is used on something
+/obj/item/analyzer/proc/on_analyze(atom/target)
+	var/mixture = target.return_analyzable_air()
+	if(!mixture)
+		return FALSE
+	var/list/airs = islist(mixture) ? mixture : list(mixture)
+	var/list/new_gasmix_data = list()
+	for(var/datum/gas_mixture/air as anything in airs)
+		var/mix_name = capitalize(lowertext(target.name))
+		if(airs.len != 1) //not a unary gas mixture
+			mix_name += " - Node [airs.Find(air)]"
+		new_gasmix_data += list(gas_mixture_parser(air, mix_name))
+	old_gasmix_data = new_gasmix_data
+
 /**
  * Outputs a message to the user describing the target's gasmixes.
  *
  * Gets called by analyzer_act, which in turn is called by tool_act.
  * Also used in other chat-based gas scans.
  */
-/proc/atmos_scan(mob/user, atom/target, obj/item/analyzer/tool, silent=FALSE)
+/proc/atmos_scan(mob/user, atom/target, obj/tool, silent=FALSE)
 	var/mixture = target.return_analyzable_air()
 	if(!mixture)
 		return FALSE
@@ -139,8 +157,6 @@
 	if(!silent && isliving(user))
 		user.visible_message(span_notice("[user] uses the analyzer on [icon2html(icon, viewers(user))] [target]."), span_notice("You use the analyzer on [icon2html(icon, user)] [target]."))
 	message += span_boldnotice("Results of analysis of [icon2html(icon, user)] [target].")
-
-	var/list/gasmix_data = list()
 
 	var/list/airs = islist(mixture) ? mixture : list(mixture)
 	for(var/datum/gas_mixture/air as anything in airs)
@@ -172,11 +188,6 @@
 		else
 			message += airs.len > 1 ? span_notice("This node is empty!") : span_notice("[target] is empty!")
 			message += span_notice("Volume: [volume] L") // don't want to change the order volume appears in, suck it
-		
-		gasmix_data += list(gas_mixture_parser(air, mix_name))
-
-	if(istype(tool))
-		tool.last_gasmix_data = gasmix_data
 
 	// we let the join apply newlines so we do need handholding
 	to_chat(user, jointext(message, "\n"), type = MESSAGE_TYPE_INFO)

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -139,7 +139,7 @@
 		if(airs.len != 1) //not a unary gas mixture
 			mix_name += " - Node [airs.Find(air)]"
 		new_gasmix_data += list(gas_mixture_parser(air, mix_name))
-	old_gasmix_data = new_gasmix_data
+	last_gasmix_data = new_gasmix_data
 
 /**
  * Outputs a message to the user describing the target's gasmixes.

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -116,8 +116,8 @@
 	if (user.stat != CONSCIOUS || user.is_blind())
 		to_chat(user, span_warning("You're unable to see [src]'s results!"))
 		return
-
 	atmos_scan(user=user, target=get_turf(src), tool=src, silent=FALSE)
+	on_analyze(source=src, target=get_turf(src))
 
 /obj/item/analyzer/attack_self_secondary(mob/user, modifiers)
 	// Check if it requires visibility and if the user is you know, blind.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -245,6 +245,7 @@
 #include "code\__DEFINES\dcs\signals\signals_subsystem.dm"
 #include "code\__DEFINES\dcs\signals\signals_swab.dm"
 #include "code\__DEFINES\dcs\signals\signals_techweb.dm"
+#include "code\__DEFINES\dcs\signals\signals_tools.dm"
 #include "code\__DEFINES\dcs\signals\signals_traitor.dm"
 #include "code\__DEFINES\dcs\signals\signals_tram.dm"
 #include "code\__DEFINES\dcs\signals\signals_transform.dm"


### PR DESCRIPTION
## About The Pull Request
Initially wanted to reimplement breathedeep to pda hence the branch name, but pda is in flux and i see differing opinions on hardwares and such. I think ill sit those out for a while and let folks hash things first before readding stuffs

havent tested this will do tomorrow so drafting

## Why It's Good For The Game
Analyzer's last gasmix data is now fully handled by the analyzer now. This will sacrifice a tiny bit of performance for the sake of code though, so lmk if it isn't worth it.

Same with the tool act rewriting thing, added two more is left click checks while the old one doesn't. But it contains less copypasted code and is shorter and thus easier to read. Also a bit subjective so lmk if this wont fly.

## Changelog
:cl:
refactor: Refactored how the analyzer's last gasmix ui thing works. No gameplay changes expected.
code: Reorganized tool usage code a bit. Also no gameplay changes expected. 
/:cl: