### PR TITLE
Fix biogenerator using 10 times more power than it should

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -167,20 +167,20 @@
 	if(processing)
 		to_chat(user, span_warning("The biogenerator is in the process of working."))
 		return
-	var/S = 0
+	var/processing_time = 0
 	for(var/obj/item/food/grown/I in contents)
-		S += 5
+		processing_time += 5
 		if(I.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) < 0.1)
 			points += 1 * productivity
 		else
 			points += I.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 10 * productivity
 		qdel(I)
-	if(S)
+	if(processing_time)
 		processing = TRUE
 		update_appearance()
 		playsound(loc, 'sound/machines/blender.ogg', 50, TRUE)
-		use_power(S * active_power_usage)
-		sleep(S + 15 / productivity)
+		use_power(processing_time * active_power_usage * 0.1) // .1 needed here to convert time (in deciseconds) to seconds such that watts * seconds = joules
+		sleep(processing_time + 15 / productivity)
 		processing = FALSE
 		update_appearance()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title, exact same cause as #66453, also renames the `S` variable to `processing_time`
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #66919 , makes `S` something more understandable
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Biogenerators don't take 1% of a power cell to grind a single melon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
