### PR TITLE
Makes ridable not work if you cant hold the offhand

### DIFF
--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -42,7 +42,7 @@
 	SIGNAL_HANDLER
 
 	if(HAS_TRAIT(potential_rider, TRAIT_CANT_RIDE))
-		return
+		return COMPONENT_BLOCK_BUCKLE
 
 	var/arms_needed = 0
 	if(ride_check_flags & RIDER_NEEDS_ARMS)

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -101,7 +101,7 @@
 			amount_equipped++
 		else
 			qdel(inhand)
-			break
+			return FALSE
 
 	if(amount_equipped >= amount_required)
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

Because amount_equipped is 0, and because not being able to insert the riding_offhand does break instead returns FALSE, it goes on to fireman carry people you're not supposed to, leading to situations where people are fireman carrying others and is completely unable to drop them due to the lack of a riding_offhand.

I can't test this locally since I can't reproduce it, no matter how long I tried, but I see this happening consistently for the past few days on live.

## Why It's Good For The Game

Bug fix

## Changelog

:cl:
fix: Trying to fireman carry someone you can't fireman carry now properly makes you not carry them permanently
/:cl: