### PR TITLE
Access Helpers Pt. 5.5/6 - Tram Station Modules

### DIFF
--- a/_maps/map_files/tramstation/modular_pieces/maintenance_bar_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_bar_1.dmm
@@ -49,11 +49,14 @@
 "x" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Bar Excess Storage";
-	req_one_access_txt = "12;25"
+	name = "Bar Excess Storage"
 	},
 /obj/machinery/duct,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/central/greater)
 "D" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_bar_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_bar_2.dmm
@@ -106,10 +106,13 @@
 "M" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Bar Excess Storage";
-	req_one_access_txt = "12;25"
+	name = "Bar Excess Storage"
 	},
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/central/greater)
 "O" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_1.dmm
@@ -1,11 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "d" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "e" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_2.dmm
@@ -22,11 +22,11 @@
 /turf/template_noop,
 /area/template_noop)
 "q" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "r" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_3.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_3.dmm
@@ -56,13 +56,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "z" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/aft)
 "E" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_attachment1_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_attachment1_1.dmm
@@ -22,9 +22,9 @@
 "H" = (
 /obj/modular_map_connector,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "I" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_attachment2_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_attachment2_1.dmm
@@ -38,11 +38,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "S" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/modular_map_connector,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "X" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_attachment2_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_civilian_south_attachment2_2.dmm
@@ -16,10 +16,12 @@
 "x" = (
 /obj/modular_map_connector,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "G" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_engine_5x6_east_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_engine_5x6_east_1.dmm
@@ -16,11 +16,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
 "i" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
 "n" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_engine_5x6_east_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_engine_5x6_east_2.dmm
@@ -17,12 +17,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "i" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
 "k" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_engine_5x6_extension_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_engine_5x6_extension_2.dmm
@@ -37,11 +37,11 @@
 /area/station/maintenance/starboard/lesser)
 "X" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
 

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_engine_east_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_engine_east_1.dmm
@@ -47,6 +47,10 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
 "U" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_enginelong_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_enginelong_1.dmm
@@ -53,6 +53,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"G" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lesser)
 "K" = (
 /turf/closed/wall/rock/porous,
 /area/station/maintenance/starboard/lesser)
@@ -72,10 +79,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "U" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "X" = (
@@ -108,7 +117,7 @@
 
 (1,1,1) = {"
 X
-U
+G
 b
 s
 b

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_enginelong_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_enginelong_2.dmm
@@ -41,10 +41,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
 "P" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
 "V" = (
@@ -52,10 +54,17 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
+"W" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/starboard/lesser)
 
 (1,1,1) = {"
 g
-P
+W
 E
 E
 I

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_laundry_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_laundry_1.dmm
@@ -42,11 +42,14 @@
 /area/station/maintenance/port/aft)
 "t" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Storage";
-	req_one_access_txt = "12"
+	name = "Maintenance Storage"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "N" = (
@@ -58,11 +61,11 @@
 /turf/template_noop,
 /area/template_noop)
 "R" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "T" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_laundry_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_laundry_2.dmm
@@ -15,11 +15,14 @@
 /area/station/maintenance/port/aft)
 "x" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Clothing Storage";
-	req_one_access_txt = "12"
+	name = "Clothing Storage"
 	},
 /obj/modular_map_connector,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "y" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_1.dmm
@@ -82,12 +82,14 @@
 /turf/template_noop,
 /area/template_noop)
 "N" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
 "Q" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_2.dmm
@@ -38,12 +38,14 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
 "z" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
 "B" = (
@@ -81,9 +83,12 @@
 "M" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Water Closet";
-	req_one_access_txt = "12"
+	name = "Water Closet"
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
 "N" = (
@@ -98,9 +103,11 @@
 /area/station/maintenance/port/fore)
 "S" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance/glass{
-	req_access_txt = "12"
+/obj/machinery/door/airlock/maintenance/glass,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
 "Y" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_attachment_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_attachment_1.dmm
@@ -36,11 +36,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "Y" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_attachment_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_attachment_2.dmm
@@ -3,11 +3,13 @@
 /turf/template_noop,
 /area/template_noop)
 "i" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
 "m" = (
@@ -27,10 +29,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
 "G" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
 "H" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_attachment_3.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_attachment_3.dmm
@@ -77,11 +77,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
 "H" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/fore)
 "L" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_midladder_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_midladder_2.dmm
@@ -42,6 +42,7 @@
 	cycle_id = "ladder-external"
 	},
 /obj/effect/turf_decal/sand/plating,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/tram/mid)
 "q" = (
@@ -81,6 +82,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/tram/mid)
 "B" = (
@@ -111,6 +116,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/tram/mid)
 "N" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_midladder_upper_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_midladder_upper_1.dmm
@@ -67,9 +67,9 @@
 /area/station/maintenance/department/cargo)
 "F" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "H" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_midladder_upper_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_midladder_upper_2.dmm
@@ -29,8 +29,19 @@
 /area/station/maintenance/department/cargo)
 "l" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
+"m" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
@@ -60,8 +71,10 @@
 /area/station/maintenance/department/cargo)
 "q" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance/glass{
-	req_access_txt = "12"
+/obj/machinery/door/airlock/maintenance/glass,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/cargo)
@@ -234,7 +247,7 @@ u
 (9,1,1) = {"
 a
 a
-l
+m
 a
 a
 a

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_midladder_upper_attachment_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_midladder_upper_attachment_1.dmm
@@ -30,11 +30,11 @@
 /area/station/maintenance/department/cargo)
 "K" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/cargo)
 "M" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_midladder_upper_attachment_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_midladder_upper_attachment_2.dmm
@@ -35,10 +35,10 @@
 /area/station/maintenance/department/cargo)
 "y" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/cargo)
 "A" = (
@@ -60,9 +60,9 @@
 /area/station/maintenance/department/cargo)
 "G" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance/glass{
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance/glass,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/cargo)
 "H" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_miningsolar_cavetunnel_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_miningsolar_cavetunnel_1.dmm
@@ -82,11 +82,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/greater)
 "R" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/template_noop)
 "S" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_miningsolar_cavetunnel_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_miningsolar_cavetunnel_2.dmm
@@ -20,6 +20,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "o" = (
@@ -27,11 +28,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/greater)
 "q" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/modular_map_connector,
-/turf/template_noop,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/template_noop)
 "r" = (
 /turf/closed/wall,
@@ -59,6 +62,7 @@
 	name = "External Access"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "E" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_science_west_attachment_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_science_west_attachment_1.dmm
@@ -59,8 +59,10 @@
 "U" = (
 /obj/modular_map_connector,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical)

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_science_west_attachment_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_science_west_attachment_2.dmm
@@ -26,10 +26,12 @@
 /area/station/maintenance/department/medical)
 "r" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical)
 "v" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_security_long_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_security_long_1.dmm
@@ -37,12 +37,14 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security)
 "x" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security)
 "y" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_security_long_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_security_long_2.dmm
@@ -108,11 +108,13 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security)
 "J" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security)
 "M" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_security_long_attachment_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_security_long_attachment_1.dmm
@@ -3,11 +3,13 @@
 /turf/closed/wall,
 /area/station/maintenance/department/security)
 "d" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "f" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_security_long_attachment_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_security_long_attachment_2.dmm
@@ -3,12 +3,14 @@
 /turf/closed/wall,
 /area/station/maintenance/department/security)
 "c" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/security)
 "e" = (
@@ -56,10 +58,12 @@
 /area/station/maintenance/department/security)
 "U" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance/glass{
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance/glass,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/security)
 "Y" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_storagebig_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_storagebig_1.dmm
@@ -22,11 +22,11 @@
 "o" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Mining Construction Storage";
-	req_one_access_txt = "12"
+	name = "Mining Construction Storage"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/central)
 "r" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_storagebig_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_storagebig_2.dmm
@@ -36,12 +36,13 @@
 "n" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "General Storage Access";
-	req_one_access_txt = "12"
+	name = "General Storage Access"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/central)
 "p" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_storagebig_3.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_storagebig_3.dmm
@@ -37,10 +37,10 @@
 "D" = (
 /obj/modular_map_connector,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "I" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_storagemid_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_storagemid_1.dmm
@@ -102,12 +102,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "V" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
 /obj/modular_map_connector,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/central/greater)
 "X" = (

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_storagemid_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_storagemid_2.dmm
@@ -44,9 +44,9 @@
 "Y" = (
 /obj/modular_map_connector,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR audits the door accesses for the **55** modular maps associated with Tram station and updates them, with mapping helpers, to the same standards as #66877 

## Why It's Good For The Game
Standardizes access requirements for the map and reduces changes for inconsistent mapping to happen by use of mapping helpers. Makes access requirements easier to audit.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed several inconsistent or niche access requirements on TramStation's modular pieces
qol: Replaced all access requirement vars on doors with mapping helpers on TramStation's modular pieces
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
