### PR TITLE
Material holding machines can't connect to ore silos on different z levels

### DIFF
--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -28,6 +28,7 @@ handles linking back and forth.
 
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/OnAttackBy)
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), .proc/OnMultitool)
+	RegisterSignal(parent, COMSIG_MOVABLE_Z_CHANGED, .proc/check_z_level)
 
 	var/turf/T = get_turf(parent)
 	if (force_connect || (mapload && is_station_level(T.z)))
@@ -38,14 +39,14 @@ handles linking back and forth.
 /datum/component/remote_materials/proc/LateInitialize()
 	silo = GLOB.ore_silo_default
 	if (silo)
-		silo.connected += src
+		silo.ore_connected_machines += src
 		mat_container = silo.GetComponent(/datum/component/material_container)
 	else
 		_MakeLocal()
 
 /datum/component/remote_materials/Destroy()
 	if (silo)
-		silo.connected -= src
+		silo.ore_connected_machines -= src
 		silo.updateUsrDialog()
 		silo = null
 		mat_container = null
@@ -105,18 +106,30 @@ handles linking back and forth.
 		if (silo == M.buffer)
 			to_chat(user, span_warning("[parent] is already connected to [silo]!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
+		var/turf/user_loc = get_turf(user)
+		if(GLOB.ore_silo_default == M.buffer && !is_station_level(user_loc.z))
+			to_chat(user, span_warning("[parent] is too far away to get a connection signal!"))
+			return COMPONENT_BLOCK_TOOL_ATTACK
 		if (silo)
-			silo.connected -= src
+			silo.ore_connected_machines -= src
 			silo.updateUsrDialog()
 		else if (mat_container)
 			mat_container.retrieve_all()
 			qdel(mat_container)
 		silo = M.buffer
-		silo.connected += src
+		silo.ore_connected_machines += src
 		silo.updateUsrDialog()
 		mat_container = silo.GetComponent(/datum/component/material_container)
 		to_chat(user, span_notice("You connect [parent] to [silo] from the multitool's buffer."))
 		return COMPONENT_BLOCK_TOOL_ATTACK
+
+/datum/component/remote_materials/proc/check_z_level(datum/source, turf/old_turf, turf/new_turf)
+	SIGNAL_HANDLER
+
+	if(!silo || !(GLOB.ore_silo_default == silo))
+		return
+	if(!is_station_level(new_turf.z))
+		disconnect_from(silo)
 
 /datum/component/remote_materials/proc/on_hold()
 	return silo?.holds["[get_area(parent)]/[category]"]

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -130,8 +130,11 @@ handles linking back and forth.
 		return
 
 	var/turf/silo_turf = get_turf(silo)
-	if(silo_turf.z != new_turf.z)
-		disconnect_from(silo)
+	if(is_station_level(silo_turf.z) && is_station_level(new_turf.z)) // if we're both on "station", regardless of multi-z, we'll pass by.
+		return
+	if(silo_turf.z == new_turf.z)
+		return
+	disconnect_from(silo)
 
 /datum/component/remote_materials/proc/on_hold()
 	return silo?.holds["[get_area(parent)]/[category]"]

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -106,8 +106,9 @@ handles linking back and forth.
 		if (silo == M.buffer)
 			to_chat(user, span_warning("[parent] is already connected to [silo]!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
+		var/turf/silo_turf = get_turf(M.buffer)
 		var/turf/user_loc = get_turf(user)
-		if(GLOB.ore_silo_default == M.buffer && !is_station_level(user_loc.z))
+		if(user_loc.z != silo_turf.z)
 			to_chat(user, span_warning("[parent] is too far away to get a connection signal!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
 		if (silo)
@@ -125,10 +126,11 @@ handles linking back and forth.
 
 /datum/component/remote_materials/proc/check_z_level(datum/source, turf/old_turf, turf/new_turf)
 	SIGNAL_HANDLER
-
-	if(!silo || !(GLOB.ore_silo_default == silo))
+	if(!silo)
 		return
-	if(!is_station_level(new_turf.z))
+
+	var/turf/silo_turf = get_turf(silo)
+	if(silo_turf.z != new_turf.z)
 		disconnect_from(silo)
 
 /datum/component/remote_materials/proc/on_hold()

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -9,9 +9,12 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/ore_silo
 
-	var/list/holds = list()
-	var/list/datum/component/remote_materials/connected = list()
+	/// The machine UI's page of logs showing ore history.
 	var/log_page = 1
+	/// List of all connected components that are on hold from accessing materials.
+	var/list/holds = list()
+	/// List of all components that are sharing ores with this silo.
+	var/list/datum/component/remote_materials/ore_connected_machines = list()
 
 /obj/machinery/ore_silo/Initialize(mapload)
 	. = ..()
@@ -36,11 +39,10 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	if (GLOB.ore_silo_default == src)
 		GLOB.ore_silo_default = null
 
-	for(var/C in connected)
-		var/datum/component/remote_materials/mats = C
+	for(var/datum/component/remote_materials/mats as anything in ore_connected_machines)
 		mats.disconnect_from(src)
 
-	connected = null
+	ore_connected_machines = null
 
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	materials.retrieve_all()
@@ -112,14 +114,13 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		ui += "Nothing!"
 
 	ui += "</div><div class='statusDisplay'><h2>Connected Machines:</h2>"
-	for(var/C in connected)
-		var/datum/component/remote_materials/mats = C
+	for(var/datum/component/remote_materials/mats as anything in ore_connected_machines)
 		var/atom/parent = mats.parent
 		var/hold_key = "[get_area(parent)]/[mats.category]"
 		ui += "<a href='?src=[REF(src)];remove=[REF(mats)]'>Remove</a>"
 		ui += "<a href='?src=[REF(src)];hold[!holds[hold_key]]=[url_encode(hold_key)]'>[holds[hold_key] ? "Allow" : "Hold"]</a>"
 		ui += " <b>[parent.name]</b> in [get_area_name(parent, TRUE)]<br>"
-	if(!connected.len)
+	if(!ore_connected_machines.len)
 		ui += "Nothing!"
 
 	ui += "</div><div class='statusDisplay'><h2>Access Logs:</h2>"
@@ -153,10 +154,10 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	usr.set_machine(src)
 
 	if(href_list["remove"])
-		var/datum/component/remote_materials/mats = locate(href_list["remove"]) in connected
+		var/datum/component/remote_materials/mats = locate(href_list["remove"]) in ore_connected_machines
 		if (mats)
 			mats.disconnect_from(src)
-			connected -= mats
+			ore_connected_machines -= mats
 			updateUsrDialog()
 			return TRUE
 	else if(href_list["hold1"])


### PR DESCRIPTION
## About The Pull Request

The station's ore silo can't connect to machines that are off the station z-level anymore. This doesn't affect multi-z stations.
Also includes ore silo code improvement because I was unhappy with it.

https://cdn.discordapp.com/attachments/279359975250198528/974701591137509456/2022-05-13_11-55-20.mp4

## Why It's Good For The Game

When we removed part upgrades, we also removed the main reason Miners kept the ORM on the station. There's a specific access for jobs to access the ORM - ACCESS_MINERAL_STOREROOM - but they can't take advantage of it, because Miners always bring the ORM down to Lavaland to never interact with the station, literally ever.

I tied this to the station's ore silo, because I didn't want to limit ghost roles from using ore silos for their own stuff.

## Changelog

:cl:
balance: Station equipment that holds materials (techfabs, ORMs) can't connect to ore silo's on a different Z level.
/:cl: