### PR TITLE
removes double-tom from Delta brig

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -78138,10 +78138,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"vaX" = (
-/mob/living/simple_animal/mouse/brown/tom,
-/turf/open/floor/iron,
-/area/station/security/prison)
 "vbf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -146180,7 +146176,7 @@ aaa
 aaa
 hLe
 fPP
-vaX
+vxr
 oQD
 vxr
 fZl


### PR DESCRIPTION
## About The Pull Request

There's 2 Toms in Deltastation's permabrig, this removes one.

## Why It's Good For The Game

Didn't we remove cloning?

## Changelog

:cl:
fix: There is now only one Tom in Deltastation permabrig.
/:cl:
