### PR TITLE
Adds more instructions on finding Active Turfs in Map Errors Logging

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -543,7 +543,11 @@ SUBSYSTEM_DEF(air)
 		var/starting_ats = active_turfs.len
 		sleep(world.tick_lag)
 		var/timer = world.timeofday
-		log_mapping("There are [starting_ats] active turfs at roundstart caused by a difference of the air between the adjacent turfs. You can see its coordinates using \"Mapping -> Show roundstart AT list\" verb (debug verbs required).")
+
+		log_mapping("There are [starting_ats] active turfs at roundstart caused by a difference of the air between the adjacent turfs. \
+		To locate these active turfs, go into the \"Debug\" tab of your stat-panel. Then hit the verb that says \"Mapping Verbs - Enable\". \
+		Now, you can see all of the associated coordinates using \"Mapping -> Show roundstart AT list\" verb.")
+
 		for(var/turf/T in active_turfs)
 			GLOB.active_turfs_startlist += T
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

![image](https://user-images.githubusercontent.com/34697715/168393690-4f85fd29-a9c7-4a49-918a-f9b74dca9cdd.png)

That little portion that says (debug verbs required) is not helpful at all to anyone who isn't already familiar with the aforementioned debug verbs. It's a pretty buried feature in the codebase as of this PR, so I think it's best to add some more verbosity on actually getting these debug verbs enabled.

Escaping newlines seems to work with logging without any noted downsides, helps readability if it's not all smashed on that one line.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mappers who want to diagnose and fix the issues they create don't need to scratch their head over not having "debug verbs".

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: If you're looking into patching out Active Turfs, the logging message that alerts you to said Active Turfs is now a bit more verbose to getting you put on the right track.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
