### PR TITLE
Makes smoke react to opening airlocks.

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -218,6 +218,9 @@
 			process_results(checked_turf)
 
 /obj/machinery/door/firedoor/proc/register_adjacent_turfs(atom/loc)
+	if(!loc)
+		return
+
 	for(var/dir in GLOB.cardinals)
 		var/turf/checked_turf = get_step(get_turf(loc), dir)
 
@@ -225,10 +228,14 @@
 			continue
 		process_results(checked_turf)
 		RegisterSignal(checked_turf, COMSIG_TURF_EXPOSE, .proc/process_results)
-		RegisterSignal(checked_turf, COMSIG_TURF_CALCULATED_ADJACENT_ATMOS, .proc/process_results)
+	RegisterSignal(loc, COMSIG_TURF_CALCULATED_ADJACENT_ATMOS, .proc/process_results)
 
 
 /obj/machinery/door/firedoor/proc/unregister_adjacent_turfs(atom/loc)
+	if(!loc)
+		return
+
+	UnregisterSignal(loc, COMSIG_TURF_CALCULATED_ADJACENT_ATMOS)
 	for(var/dir in GLOB.cardinals)
 		var/turf/checked_turf = get_step(get_turf(loc), dir)
 
@@ -236,7 +243,6 @@
 			continue
 
 		UnregisterSignal(checked_turf, COMSIG_TURF_EXPOSE)
-		UnregisterSignal(checked_turf, COMSIG_TURF_CALCULATED_ADJACENT_ATMOS)
 
 /obj/machinery/door/firedoor/proc/check_atmos(turf/checked_turf)
 	var/datum/gas_mixture/environment = checked_turf.return_air()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -221,6 +221,7 @@
 	if(!loc)
 		return
 
+	RegisterSignal(loc, COMSIG_TURF_CALCULATED_ADJACENT_ATMOS, .proc/process_results)
 	for(var/dir in GLOB.cardinals)
 		var/turf/checked_turf = get_step(get_turf(loc), dir)
 
@@ -228,7 +229,6 @@
 			continue
 		process_results(checked_turf)
 		RegisterSignal(checked_turf, COMSIG_TURF_EXPOSE, .proc/process_results)
-	RegisterSignal(loc, COMSIG_TURF_CALCULATED_ADJACENT_ATMOS, .proc/process_results)
 
 
 /obj/machinery/door/firedoor/proc/unregister_adjacent_turfs(atom/loc)

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -15,11 +15,16 @@
 	animate_movement = FALSE
 	/// How long the smoke sticks around before it dissipates.
 	var/lifetime = 10 SECONDS
+	/// Makes the smoke react to changes on/of its turf.
+	var/static/loc_connections = list(
+		COMSIG_TURF_CALCULATED_ADJACENT_ATMOS = .proc/react_to_atmos_adjacency_changes
+	)
 
 /obj/effect/particle_effect/fluid/smoke/Initialize(mapload, datum/fluid_group/group, ...)
 	. = ..()
 	create_reagents(1000)
 	setDir(pick(GLOB.cardinals))
+	AddElement(/datum/element/connect_loc, loc_connections)
 	SSsmoke.start_processing(src)
 
 /obj/effect/particle_effect/fluid/smoke/Destroy()
@@ -120,6 +125,21 @@
 	smoker.smoke_delay = TRUE
 	addtimer(VARSET_CALLBACK(smoker, smoke_delay, FALSE), 1 SECONDS)
 	return TRUE
+
+/**
+ * Makes the smoke react to nearby opening/closing airlocks and the like.
+ * Makes it possible for smoke to spread through airlocks that open after the edge of the smoke cloud has already spread past them.
+ *
+ * Arguments:
+ * - [source][/turf]: The turf that has been touched by an atmos adjacency change.
+ */
+/obj/effect/particle_effect/fluid/smoke/proc/react_to_atmos_adjacency_changes(turf/source)
+	SIGNAL_HANDLER
+	if(!group)
+		return NONE
+	if (spread_bucket)
+		return NONE
+	SSsmoke.queue_spread(src)
 
 /// A factory which produces clouds of smoke.
 /datum/effect_system/fluid_spread/smoke

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -73,6 +73,7 @@
 			if (current_turf.atmos_adjacent_turfs)
 				current_turf.atmos_adjacent_turfs -= src
 			UNSETEMPTY(current_turf.atmos_adjacent_turfs)
+		SEND_SIGNAL(current_turf, COMSIG_TURF_CALCULATED_ADJACENT_ATMOS)
 	UNSETEMPTY(atmos_adjacent_turfs)
 	src.atmos_adjacent_turfs = atmos_adjacent_turfs
 	SEND_SIGNAL(src, COMSIG_TURF_CALCULATED_ADJACENT_ATMOS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes smoke spread through newly opened airlocks if the cloud has spread past the airlock, but has not completely finished spreading.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More intuitive smoke behavior.
As funny as it is to open an airlock and see nothing but a wall of smoke it's even funnier to open an airlock and suddenly be inside a wall of smoke.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Smoke expands through newly opened airlocks if it hasn't finished spreading.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
