### PR TITLE
Adds a condimaster to the Icebox kitchen + a lil extra space

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2259,9 +2259,8 @@
 /turf/open/floor/iron,
 /area/station/science/mixing)
 "aMO" = (
-/obj/machinery/vending/dinnerware,
 /obj/structure/sign/poster/random/directional/east,
-/turf/open/floor/iron/cafeteria,
+/turf/closed/wall,
 /area/station/service/kitchen)
 "aMP" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -21962,13 +21961,7 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "gZK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/chem_master/condimaster,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "gZO" = (
@@ -58650,13 +58643,7 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva/lower)
 "sWj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "sWl" = (
@@ -70685,6 +70672,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/commons/lounge)
+"wMx" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "wMz" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	color = "#0000ff";
@@ -179437,8 +179428,8 @@ fzK
 xqz
 ybm
 pXb
+ldY
 aMO
-cpY
 cpY
 tjo
 tjo
@@ -179694,7 +179685,7 @@ fzK
 kfG
 uZN
 pXb
-cpY
+gZK
 cpY
 tjo
 tjo
@@ -179950,9 +179941,9 @@ jFe
 fzK
 pqV
 pZE
+pXb
 sWj
 cpY
-xMq
 tjo
 tjo
 tjo
@@ -180207,9 +180198,9 @@ jre
 jre
 jre
 roc
-gZK
+pXb
+wMx
 cpY
-xMq
 xMq
 tjo
 tjo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Icebox kitchen has always lacked a condimaster for whatever reason. Time for it to actually have one like other kitchens do.
Also, the wall on the downstairs kitchen right in front of the stairs has been pushed out slightly to make room for it.

![image](https://user-images.githubusercontent.com/18170896/168417777-450f7d83-9c91-41b2-8240-927849c33070.png)

## Why It's Good For The Game

The condimaster is an invaluable tool for chefs who need to separate out specific ingredients from mixtures if they make an error, or who want to bottle ingredients for future use. All other stations have one, except for Icebox. 3 extra tiles have been added to the downstairs kitchen, pushing the wall back to allow for more room in the cramped area and a space for the condimaster.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The Icebox kitchen was slightly expanded, giving it 3 more tiles of space downstairs.
fix: Finally gave the Icebox kitchen a condimaster. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
