### PR TITLE
Fixes mind restoration causing dizziness

### DIFF
--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -43,7 +43,7 @@
 
 
 	if(A.stage >= 3)
-		M.adjust_timed_status_effect(4 SECONDS, /datum/status_effect/dizziness)
+		M.adjust_timed_status_effect(-4 SECONDS, /datum/status_effect/dizziness)
 		M.adjust_drowsyness(-2)
 		M.adjust_timed_status_effect(-1 SECONDS, /datum/status_effect/speech/slurring/drunk)
 		M.adjust_timed_status_effect(-2 SECONDS, /datum/status_effect/confusion)


### PR DESCRIPTION
## About The Pull Request

Adds a negative.

## Why It's Good For The Game

Mind restoration should heal dizziness, not cause it. 

## Changelog
:cl: Melbert
fix: Fixes mind restoration causing dizziness instead of healing it
/:cl:

