### PR TITLE
Unit tests for default hydroponic seed gene setups 

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -98,6 +98,7 @@
 #include "holidays.dm"
 #include "hydroponics_harvest.dm"
 #include "hydroponics_self_mutations.dm"
+#include "hydroponics_validate_genes.dm"
 #include "keybinding_init.dm"
 #include "load_map_security.dm"
 #include "machine_disassembly.dm"

--- a/code/modules/unit_tests/hydroponics_validate_genes.dm
+++ b/code/modules/unit_tests/hydroponics_validate_genes.dm
@@ -27,6 +27,5 @@
 				if(trait_gene.type != other_trait_gene.type)
 					continue
 				TEST_FAIL("[instantiated_seed] - [instantiated_seed.type] has a duplicate gene. (Duped gene: [trait_gene] - [trait_gene.type])")
-				break
 
 		qdel(instantiated_seed)

--- a/code/modules/unit_tests/hydroponics_validate_genes.dm
+++ b/code/modules/unit_tests/hydroponics_validate_genes.dm
@@ -1,4 +1,4 @@
-/// Unit test to ensure plants don't have multiple of a plant type at once by default..
+/// Unit test to ensure plants don't have multiple of a plant type at once by default.
 /datum/unit_test/hydroponics_validate_genes
 
 /datum/unit_test/hydroponics_validate_genes/Run()

--- a/code/modules/unit_tests/hydroponics_validate_genes.dm
+++ b/code/modules/unit_tests/hydroponics_validate_genes.dm
@@ -1,0 +1,32 @@
+/// Unit test to ensure plants don't have multiple of a plant type at once by default..
+/datum/unit_test/hydroponics_validate_genes
+
+/datum/unit_test/hydroponics_validate_genes/Run()
+	var/list/all_seeds = subtypesof(/obj/item/seeds)
+
+	for(var/seed in all_seeds)
+		var/obj/item/seeds/instantiated_seed = new seed()
+
+		var/all_trait_ids_we_have = NONE
+		for(var/datum/plant_gene/trait/trait_gene in instantiated_seed.genes)
+			// Check if our seed is blacklisted from this trait.
+			for(var/blacklisted_type in trait_gene.seed_blacklist)
+				if(!istype(instantiated_seed, blacklisted_type))
+					continue
+				TEST_FAIL("[instantiated_seed] - [instantiated_seed.type] has a gene which blacklists its type. (Bad gene: [trait_gene] - [trait_gene.type])")
+
+			// Check if we already have a trait id from another trait.
+			if(all_trait_ids_we_have & trait_gene.trait_ids)
+				TEST_FAIL("[instantiated_seed] - [instantiated_seed.type] has an invalid default gene configuration. (Found on: [trait_gene] - [trait_gene.type])")
+
+			all_trait_ids_we_have |= trait_gene.trait_ids
+
+			// Check if we have duplicate traits.
+			for(var/datum/plant_gene/trait/other_trait_gene in instantiated_seed.genes - trait_gene)
+				// Have to check for type exact, since subtypes may be valid with one another.
+				if(trait_gene.type != other_trait_gene.type)
+					continue
+				TEST_FAIL("[instantiated_seed] - [instantiated_seed.type] has a duplicate gene. (Duped gene: [trait_gene] - [trait_gene.type])")
+				break
+
+		qdel(instantiated_seed)


### PR DESCRIPTION
## About The Pull Request

Adds a unit test that ensures the default list of genes for all plants is a valid setup. 
I meant to do this like a year ago but never did. 

## Why It's Good For The Game

Ensures that seeds are in a valid initial state when they're added or modified in code. 

## Changelog

Not necessary. 