### PR TITLE
Allows slimes to buckle to monkeys again

### DIFF
--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -44,7 +44,7 @@
 	if(HAS_TRAIT(potential_rider, TRAIT_CANT_RIDE))
 		//Do not prevent buckle, but stop any riding, do not block buckle here
 		//There are things that are supposed to buckle (like slimes) but not ride the creature
-		return FALSE
+		return NONE
 
 	var/arms_needed = 0
 	if(ride_check_flags & RIDER_NEEDS_ARMS)

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -42,7 +42,9 @@
 	SIGNAL_HANDLER
 
 	if(HAS_TRAIT(potential_rider, TRAIT_CANT_RIDE))
-		return COMPONENT_BLOCK_BUCKLE
+		//Do not prevent buckle, but stop any riding, do not block buckle here
+		//There are things that are supposed to buckle (like slimes) but not ride the creature
+		return FALSE
 
 	var/arms_needed = 0
 	if(ride_check_flags & RIDER_NEEDS_ARMS)


### PR DESCRIPTION
Just because they are not able to ride things doens't mean they should
not be able to buckle to anything

:cl: oranges
fix: Slimes will once again feed on monkeys
/:cl:
