### PR TITLE
Makes departmental budget accounts visible on command IDs, makes departmental budget mechanic more obvious in general

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -684,7 +684,8 @@
 	if(registered_account)
 		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [registered_account.account_balance] cr."
 		if(ACCESS_HEADS in access)
-			. += "The '[registered_account.account_job.paycheck_department]' department budget linked to the ID reports a balance of [SSeconomy.get_dep_account(registered_account.account_job.paycheck_department).account_balance] cr."
+			var/datum/bank_account/linked_dept = SSeconomy.get_dep_account(registered_account.account_job.paycheck_department)
+			. += "The [linked_dept.account_holder] linked to the ID reports a balance of [linked_dept.account_balance] cr."
 
 	if(HAS_TRAIT(user, TRAIT_ID_APPRAISER))
 		. += HAS_TRAIT(src, TRAIT_JOB_FIRST_ID_CARD) ? span_boldnotice("Hmm... yes, this ID was issued from Central Command!") : span_boldnotice("This ID was created in this sector, not by Central Command.")

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -683,7 +683,7 @@
 	. = ..()
 	if(registered_account)
 		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [registered_account.account_balance] cr."
-		if(ACCESS_HEADS in access)
+		if((ACCESS_HEADS in access)  || (ACCESS_QM in access))
 			var/datum/bank_account/linked_dept = SSeconomy.get_dep_account(registered_account.account_job.paycheck_department)
 			. += "The [linked_dept.account_holder] linked to the ID reports a balance of [linked_dept.account_balance] cr."
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -683,6 +683,9 @@
 	. = ..()
 	if(registered_account)
 		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [registered_account.account_balance] cr."
+		if(ACCESS_HEADS in access)
+			. += "The department budget linked to the ID reports a balance of [SSeconomy.get_dep_account(registered_account.account_job.paycheck_department).account_balance] cr."
+
 	if(HAS_TRAIT(user, TRAIT_ID_APPRAISER))
 		. += HAS_TRAIT(src, TRAIT_JOB_FIRST_ID_CARD) ? span_boldnotice("Hmm... yes, this ID was issued from Central Command!") : span_boldnotice("This ID was created in this sector, not by Central Command.")
 	. += span_notice("<i>There's more information below, you can look again to take a closer look...</i>")

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -684,7 +684,7 @@
 	if(registered_account)
 		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [registered_account.account_balance] cr."
 		if(ACCESS_HEADS in access)
-			. += "The department budget linked to the ID reports a balance of [SSeconomy.get_dep_account(registered_account.account_job.paycheck_department).account_balance] cr."
+			. += "The '[registered_account.account_job.paycheck_department]' department budget linked to the ID reports a balance of [SSeconomy.get_dep_account(registered_account.account_job.paycheck_department).account_balance] cr."
 
 	if(HAS_TRAIT(user, TRAIT_ID_APPRAISER))
 		. += HAS_TRAIT(src, TRAIT_JOB_FIRST_ID_CARD) ? span_boldnotice("Hmm... yes, this ID was issued from Central Command!") : span_boldnotice("This ID was created in this sector, not by Central Command.")

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -683,7 +683,7 @@
 	. = ..()
 	if(registered_account)
 		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [registered_account.account_balance] cr."
-		if((ACCESS_HEADS in access)  || (ACCESS_QM in access))
+		if((ACCESS_HEADS in access) || (ACCESS_QM in access))
 			var/datum/bank_account/linked_dept = SSeconomy.get_dep_account(registered_account.account_job.paycheck_department)
 			. += "The [linked_dept.account_holder] linked to the ID reports a balance of [linked_dept.account_balance] cr."
 

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -98,6 +98,7 @@
 
 /obj/machinery/computer/cargo/ui_data()
 	var/list/data = list()
+	data["department"] = "Cargo" // Hardcoded here, for customization in budgetordering.dm AKA NT IRN
 	data["location"] = SSshuttle.supply.getStatusText()
 	var/datum/bank_account/D = SSeconomy.get_dep_account(cargo_account)
 	if(D)

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -68,6 +68,7 @@
 	. = ..()
 	var/list/data = get_header_data()
 	data["location"] = SSshuttle.supply.getStatusText()
+	data["department"] = "Cargo"
 	var/datum/bank_account/buyer = SSeconomy.get_dep_account(cargo_account)
 	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
 	var/obj/item/card/id/id_card = card_slot?.GetID()
@@ -82,11 +83,8 @@
 		if(ACCESS_HEADS in id_card.access)
 			// If buyer is a departmental budget, replaces "Cargo" with that budget - we're not using the cargo budget here
 			data["department"] = addtext(buyer.account_holder, " Requisitions")
-		else
-			data["department"] = "Cargo"
 	else
 		requestonly = TRUE
-		data["department"] = "Cargo"
 	if(buyer)
 		data["points"] = buyer.account_balance
 

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -79,8 +79,14 @@
 		else
 			requestonly = TRUE
 			can_approve_requests = FALSE
+		if(ACCESS_HEADS in id_card.access)
+			// If buyer is a departmental budget, replaces "Cargo" with that budget - we're not using the cargo budget here
+			data["department"] = addtext(buyer.account_holder, " Requisitions")
+		else
+			data["department"] = "Cargo"
 	else
 		requestonly = TRUE
+		data["department"] = "Cargo"
 	if(buyer)
 		data["points"] = buyer.account_balance
 

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -85,6 +85,7 @@ export const CargoContent = (props, context) => {
 const CargoStatus = (props, context) => {
   const { act, data } = useBackend(context);
   const {
+    department,
     grocery,
     away,
     docked,
@@ -98,7 +99,7 @@ const CargoStatus = (props, context) => {
   } = data;
   return (
     <Section
-      title="Cargo"
+      title={department}
       buttons={(
         <Box inline bold>
           <AnimatedNumber


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds more examine text to Command Staff IDs which now report the department budget's balance the ID's linked to.

![168511709-1cbece1c-5f30-4088-828f-87fe4d3361ee](https://user-images.githubusercontent.com/16405947/168521717-1af29f6c-3cbf-4e5a-9c0c-1e9afa4baf28.png)

Also changes up Cargo.js such that the title is now modifiable. This is made use of in IRN as shown below - when a department head's ID is in a tablet/computer with IRN, the header changes to make it more clear you're using the department's budget, not Cargo's:

![image](https://user-images.githubusercontent.com/16405947/168511748-18d7f969-ee1d-4661-b22f-2be0eb8d3a0d.png)

The behavior of standard cargo consoles and IRN when non-heads use it is unchanged, as far as tests have shown.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This will make a somewhat lesser known mechanic more visible to the player base, and to newer command staff players - it seemed during the previous coderbus meeting people were not aware of what departmental budgets/IRN were or that they existed, and from general conversation folks don't seem to be aware of budgets, so hopefully this brings something that's relatively unknown to the fore.

This is also a QOL change for those already in the know - you can now tell what your department's budget is at a glance as a department head, and when using IRN it should be more clear in general that you're using your department's budget as opposed to using the station budget.

Overall this ideally has the effect of making department heads aware that there's another way to improve/affect the situation for their departments by purchasing crates to help folks do their jobs...or that they can squander the budget for their own ends.  

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Department heads are now able to check their department budgets when examining their ID. NT IRN has also been updated for clarity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
