### PR TITLE
Stun batons now deactivate when put into a bag/storage, and take 5 seconds to turn on.

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -414,7 +414,15 @@
 		else
 			cell = new preload_cell_type(src)
 	RegisterSignal(src, COMSIG_PARENT_ATTACKBY, .proc/convert)
+	RegisterSignal(src, list(COMSIG_ITEM_DROPPED, COMSIG_STORAGE_EXITED, COMSIG_ITEM_EQUIPPED, COMSIG_STORAGE_ENTERED), .proc/turn_off_baton)
 	update_appearance()
+
+/obj/item/melee/baton/security/proc/turn_off_baton()
+	SIGNAL_HANDLER
+	if(active)
+		active = FALSE
+		playsound(src, SFX_SPARKS, 75, TRUE, -1)
+		update_appearance()
 
 /obj/item/melee/baton/security/get_cell()
 	return cell
@@ -504,9 +512,10 @@
 
 /obj/item/melee/baton/security/attack_self(mob/user)
 	if(cell?.charge >= cell_hit_cost)
-		active = !active
-		balloon_alert(user, "turned [active ? "on" : "off"]")
-		playsound(src, SFX_SPARKS, 75, TRUE, -1)
+		if(do_after(user, 5 SECONDS, src, IGNORE_USER_LOC_CHANGE))
+			active = !active
+			balloon_alert(user, "turned [active ? "on" : "off"]")
+			playsound(src, SFX_SPARKS, 75, TRUE, -1)
 	else
 		active = FALSE
 		if(!cell)


### PR DESCRIPTION
## About The Pull Request
Stun batons now deactivate when dropped, placed into storage, taken out of storage, or put into an inventory slot, and take 5 seconds to turn on.

## Why It's Good For The Game

Made after Watermelon suggested some form of mechanic for this instead of making stun batons bulky.

We want people to talk more and RP more, and that's simply impossible to get players to do when they're worried about surprise stun batons, since you only need to hit someone with a stun baton once to win the fight. This gives people being chased by a stun baton an opportunity to react and see it coming, rather than being completely blindsided by someone who's hotkey game is on point instantly equips, activates, and batons them.

## Changelog
:cl:
balance: Stun batons now deactivate when dropped, placed into storage, taken out of storage, or put into an inventory slot, and take 5 seconds to turn on.
/:cl:
