### PR TITLE
Nanotrasen has moved the radiation shielding from Maintenance to the Bar, so as to encourage workers to patronize their service department occasionally.

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -3,21 +3,21 @@
 	name = "radiation storm"
 	desc = "A cloud of intense radiation passes through the area dealing rad damage to those who are unprotected."
 
-	telegraph_duration = 400
+	telegraph_duration = 600
 	telegraph_message = "<span class='danger'>The air begins to grow warm.</span>"
 
-	weather_message = "<span class='userdanger'><i>You feel waves of heat wash over you! Find shelter!</i></span>"
+	weather_message = "<span class='userdanger'><i>You feel waves of heat wash over you! Find shelter at the bar!</i></span>"
 	weather_overlay = "ash_storm"
-	weather_duration_lower = 600
-	weather_duration_upper = 1500
+	weather_duration_lower = 1000
+	weather_duration_upper = 2000
 	weather_color = "green"
 	weather_sound = 'sound/misc/bloblarm.ogg'
 
-	end_duration = 100
+	end_duration = 200
 	end_message = "<span class='notice'>The air seems to be cooling off again.</span>"
 
 	area_type = /area
-	protected_areas = list(/area/station/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer, /area/ai_monitored/turret_protected/aisat/maint, /area/ai_monitored/command/storage/satellite,
+	protected_areas = list(/area/station/service/kitchen, /area/station/service/cafeteria, /area/station/service/bar, /area/station/service/theater, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer, /area/ai_monitored/turret_protected/aisat/maint, /area/ai_monitored/command/storage/satellite,
 	/area/ai_monitored/turret_protected/ai, /area/station/commons/storage/emergency/starboard, /area/station/commons/storage/emergency/port, /area/shuttle, /area/station/security/prison/safe, /area/station/security/prison/toilet, /area/icemoon/underground)
 	target_trait = ZTRAIT_STATION
 

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -12,7 +12,7 @@
 	announceWhen = 1
 
 /datum/round_event/radiation_storm/announce(fake)
-	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", ANNOUNCER_RADIATION)
+	priority_announce("High levels of radiation detected near the station, you have 60 seconds to take shelter at the Bar and Kitchen, and enjoy the wonderful food and drink the staff have made!", "Anomaly Alert", ANNOUNCER_RADIATION)
 	//sound not longer matches the text, but an audible warning is probably good
 
 /datum/round_event/radiation_storm/start()


### PR DESCRIPTION
## About The Pull Request

Nanotrasen has moved the radiation shielding from Maintenance to the Bar, so as to encourage workers to patronize their service department occasionally.

## Why It's Good For The Game

Saw someone suggest this and thought it was a great idea. Sitting in maintenance is boring as shit and it's way, way funnier to cram the entire crew into the bar for an extended duration. This also gives chefs and bartenders a lot to do.

I also upped the telegraph duration since it might take longer to get to the bar as a result, and upped the actual radstorm duration to encourage people to actually sit in the bar for a bit rather than just vibing at the exit to be ready to go right out.

## Changelog

:cl:
balance: Nanotrasen has moved the radiation shielding from Maintenance to the Bar, so as to encourage workers to patronize their service department occasionally.
/:cl:
