### PR TITLE
RCD can't deconstruct reinforced tiles.

### DIFF
--- a/code/game/turfs/open/floor/hull.dm
+++ b/code/game/turfs/open/floor/hull.dm
@@ -6,13 +6,6 @@
 	initial_gas_mix = AIRLESS_ATMOS
 	temperature = TCMB
 
-/turf/open/floor/engine/hull/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode) //no rcd destroying this flooring
-	if(passed_mode == RCD_DECONSTRUCT)
-		to_chat(user, span_warning("The flooring is too thick to be regularly deconstructed!"))
-		return FALSE
-	return ..()
-
-/// RCD-immune plating generated only by shuttle code for shuttle ceilings on multi-z maps, should not be mapped in or creatable in any other way
 /turf/open/floor/engine/hull/ceiling
 	name = "shuttle ceiling plating"
 	var/old_turf_type

--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -18,6 +18,12 @@
 	. += ..()
 	. += span_notice("The reinforcement rods are <b>wrenched</b> firmly in place.")
 
+/turf/open/floor/engine/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode) //no rcd destroying this flooring
+	if(passed_mode == RCD_DECONSTRUCT)
+		to_chat(user, span_warning("The flooring is too thick to be regularly deconstructed!"))
+		return FALSE
+	return ..()
+
 /turf/open/floor/engine/airless
 	initial_gas_mix = AIRLESS_ATMOS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just this, you need to deconstruct a reinforced tiles with the proper tools before you can RCD the plating out and make a hole to space.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's been 2 years since #53725 and making a hole into the SM still is the first step I see people do when the SM starts delaming, often before they check on other bigger issues like pipes being damaged/removed, filter's settings being changed or even turning the emitters off.

It's also a bigger issue if we keep pushing players to use more exotic mixes on the SM in exchange for power, having the rare coolant be spaced should be the last option, not the first.

You can still make a hole in the SM for the rare cases that you need it with minimal effort but if this change stops 10% of the new players falling for this noob trap, which often makes things worse, it is a win in my book.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
balance: RCDs can't deconstruct reinforced tiles directly anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
