### PR TITLE
Explosive lances now move you onto the same tile as the person you're lancing, or explodes in your hands if this isn't possible.

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -153,8 +153,14 @@
 	if(iseffect(AM)) //and no accidentally wasting your moment of glory on graffiti
 		return
 	user.say("[war_cry]", forced="spear warcry")
-	explosive.forceMove(AM)
-	explosive.detonate(lanced_by=user)
+	if(isliving(user))
+		var/mob/living/living_user = user
+		living_user.set_resting(TRUE, TRUE, TRUE)
+		living_user.Move(get_turf(AM))
+		explosive.forceMove(get_turf(living_user))
+		explosive.detonate(lanced_by=user)
+		if(!QDELETED(living_user))
+			living_user.set_resting(FALSE, TRUE, TRUE)
 	qdel(src)
 
 //GREY TIDE

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -155,12 +155,12 @@
 	user.say("[war_cry]", forced="spear warcry")
 	if(isliving(user))
 		var/mob/living/living_user = user
-		living_user.set_resting(TRUE, TRUE, TRUE)
+		living_user.set_resting(new_resting = TRUE, silent = TRUE, instant = TRUE)
 		living_user.Move(get_turf(AM))
 		explosive.forceMove(get_turf(living_user))
 		explosive.detonate(lanced_by=user)
 		if(!QDELETED(living_user))
-			living_user.set_resting(FALSE, TRUE, TRUE)
+			living_user.set_resting(new_resting = FALSE, silent = TRUE, instant = TRUE)
 	qdel(src)
 
 //GREY TIDE


### PR DESCRIPTION
## About The Pull Request
Hitting someone in melee with the explosive lance now moves you to the same tile as them before it sets off the spear.

## Why It's Good For The Game

It's possible to make an explosive mix that completely vaporizes the target while leaving all the tiles next to it relatively unharmed or at least in a revivable state. This is working as intended for explosion code. However, when applied to the concept for the explosive lance, it doesn't really mesh with the concept as Kor envisioned it when adding them:

![chrome_Vq5APFuVq9](https://user-images.githubusercontent.com/4081722/155187536-cd7f174f-cb58-4d00-a18d-0dffb97b0fa5.png)

As you can see, Kor very much intended for this to be a "if I'm dying you're coming with me" style weapon. It used to be this in the past, and the natural content churn of the game means it isn't anymore. This change should restore the weapon to it's former intended (non-meta) functionality rather than being a powergame weapon.

## Changelog

:cl:
balance: Hitting someone in melee with the explosive lance now moves you to the same tile as them before it sets off the grenade.
/:cl: