### PR TITLE
PACMAN buff to make it usable as backup generator again

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -195,13 +195,13 @@
 
 /obj/item/circuitboard/machine/pacman/examine(mob/user)
 	. = ..()
-	var/message = high_production_profile ? "high production - high consumption" : "low production - low consumption"
+	var/message = high_production_profile ? "high-power uranium mode" : "medium-power plasma mode"
 	. += span_notice("It's set to [message].")
 	. += span_notice("You can switch the mode by using a screwdriver on [src].")
 
 /obj/item/circuitboard/machine/pacman/screwdriver_act(mob/living/user, obj/item/tool)
 	high_production_profile = !high_production_profile
-	var/message = high_production_profile ? "high production - high consumption" : "low production - low consumption"
+	var/message = high_production_profile ? "high-power uranium mode" : "medium-power plasma mode"
 	to_chat(user, span_notice("You set the board for [message]"))
 
 /obj/item/circuitboard/machine/turbine_compressor

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -81,13 +81,13 @@
 /obj/machinery/power/port_gen/pacman
 	name = "\improper P.A.C.M.A.N.-type portable generator"
 	circuit = /obj/item/circuitboard/machine/pacman
-	power_gen = 2500
+	power_gen = 5000
 	var/sheets = 0
-	var/max_sheets = 10
+	var/max_sheets = 50
 	var/sheet_name = ""
 	var/sheet_path = /obj/item/stack/sheet/mineral/plasma
 	var/sheet_left = 0 // How much is left of the sheet
-	var/time_per_sheet = 50
+	var/time_per_sheet = 60
 	var/current_heat = 0
 
 /obj/machinery/power/port_gen/pacman/Initialize(mapload)
@@ -107,7 +107,7 @@
 	if(our_board.high_production_profile)
 		icon_state = "portgen1_0"
 		base_icon = "portgen1"
-		max_sheets = 5
+		max_sheets = 20
 		time_per_sheet = 20
 		power_gen = 15000
 		sheet_path = /obj/item/stack/sheet/mineral/uranium
@@ -272,10 +272,10 @@
 /obj/machinery/power/port_gen/pacman/super
 	icon_state = "portgen1_0"
 	base_icon = "portgen1"
-	max_sheets = 5
+	max_sheets = 20
 	time_per_sheet = 20
 	power_gen = 15000
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/pre_loaded
-	sheets = 10
+	sheets = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
We discussed the matter briefly with Ghilker and there was somewhat of a too large step done with the previous change to the PACMAN generators. They're intended to be usable as a backup power source for 1-3 rooms in a department, especially the ones that spawn on the map pre-filled, and after the power changes they were unreasonably largely hit and weren't quite able to do even that.

As such, this PR buffs the PACMAN portable generators to a more reasonable level.
- PACMAN sheet capacity up to 50 from 10 (same as pre-nerf)
- PACMAN sheet base usage to 60 seconds from 50 (just a rounder number and easier to track, previously 260)
- PACMAN power generation to 5-20 kW from 2.5-10kW (pre-nerf 10-40kW)
- PACMAN high-power mode (previously SUPERPACMAN) max sheets to 20 from 5

This gives you 50 minutes of 5kW, or about 12 minutes of 20kW power, which is a more likely use-case considering the power draw of most of the rooms (5-20kW in robotics, 10kW in medbay with sleepers, etc.).

Before the changes, the values were 10-40kW and 260 seconds per sheet at 10kW. This was quite long-lasting and I might suggest bringing the duration-per-sheet up, but since the pre-map generators spawn full, just increasing the sheet storage may also be an idea if this change isn't enough. This does mean that the previous nerf decreased the amount of power PACMAN makes by about 50 times, which is a bit of an overkill.

Additionally, the high power / low power mode switch on the circuit board was changed to call it a "high-power uranium mode" and "medium-power plasma mode" instead of just high production and low production mode, as it didn't really communicate that the PACMAN would use uranium in the high power mode otherwise.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
PACMAN gens should be usable as portable backup generators. In their current state, they don't really do that - especially in rooms that use more than pittance of electricity. This change should bring them back to being useful. They still consume a lot of plasma/uranium, so they're not going to be usable as a primary power source. I left the uranium mode (previously SUPERPACMAN) mostly unchanged, just now usable for more than a few seconds.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Buffed PACMAN generators to make the map-spawned gens more usable as backup sources of power.
qol: PACMAN now tells you if it will use uranium or plasma when you screwdriver the board
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
