### PR TITLE
Refactors warp whistle

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -766,8 +766,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// trait associated to not having fine manipulation appendages such as hands
 #define LACKING_MANIPULATION_APPENDAGES_TRAIT "lacking-manipulation-appengades"
 #define HANDCUFFED_TRAIT "handcuffed"
-/// Trait granted by [/obj/item/warpwhistle]
-#define WARPWHISTLE_TRAIT "warpwhistle"
 ///Turf trait for when a turf is transparent
 #define TURF_Z_TRANSPARENT_TRAIT "turf_z_transparent"
 /// Trait applied by [/datum/component/soulstoned]

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -766,6 +766,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// trait associated to not having fine manipulation appendages such as hands
 #define LACKING_MANIPULATION_APPENDAGES_TRAIT "lacking-manipulation-appengades"
 #define HANDCUFFED_TRAIT "handcuffed"
+/// Trait granted by [/obj/item/warpwhistle]
+#define WARPWHISTLE_TRAIT "warpwhistle"
 ///Turf trait for when a turf is transparent
 #define TURF_Z_TRANSPARENT_TRAIT "turf_z_transparent"
 /// Trait applied by [/datum/component/soulstoned]

--- a/code/_globalvars/phobias.dm
+++ b/code/_globalvars/phobias.dm
@@ -325,7 +325,7 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 		/obj/item/storage/toolbox/haunted,
 		/obj/item/tome,
 		/obj/item/toy/eightball/haunted,
-		/obj/item/warpwhistle,
+		/obj/item/warp_whistle,
 		/obj/machinery/door/airlock/cult,
 		/obj/narsie,
 		/obj/structure/destructible/cult,

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -348,6 +348,7 @@
 	src.whistle = whistle
 	if(!whistle)
 		qdel(src)
+		return
 	RegisterSignal(src, COMSIG_MOVABLE_CROSS_OVER, .proc/check_teleport)
 	SSmove_manager.move_towards(src, get_turf(whistle.whistler))
 

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -346,6 +346,8 @@
 /obj/effect/temp_visual/teleporting_tornado/Initialize(mapload, obj/item/warp_whistle/whistle)
 	. = ..()
 	src.whistle = whistle
+	if(!whistle)
+		qdel(src)
 	RegisterSignal(src, COMSIG_MOVABLE_CROSS_OVER, .proc/check_teleport)
 	SSmove_manager.move_towards(src, get_turf(whistle.whistler))
 
@@ -369,5 +371,6 @@
 			animate(stored_mobs, pixel_y = null, time = 1 SECONDS)
 			stored_mobs.log_message("warped with [whistle].", LOG_ATTACK, color="red")
 
-	whistle.whistler = null
+	if(whistle)
+		whistle.whistler = null
 	return ..()

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -373,4 +373,5 @@
 
 	if(whistle)
 		whistle.whistler = null
+		whistle = null
 	return ..()

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -335,7 +335,7 @@
 	layer = FLY_LAYER
 	plane = ABOVE_GAME_PLANE
 	randomdir = FALSE
-	duration = 3 SECONDS
+	duration = 10 SECONDS
 	movement_type = PHASING
 
 	/// Reference to the whistle
@@ -362,16 +362,17 @@
 	buckle_mob(crossed, TRUE, FALSE)
 	animate(src, alpha = 20, pixel_y = 400, time = 3 SECONDS)
 	animate(crossed, pixel_y = 400, time = 3 SECONDS)
+	addtimer(CALLBACK(src, .proc/send_away), 2 SECONDS)
+
+/obj/effect/temp_visual/teleporting_tornado/proc/send_away()
+	var/turf/ending_turfs = find_safe_turf()
+	for(var/mob/stored_mobs as anything in pickedup_mobs)
+		do_teleport(stored_mobs, ending_turfs, channel = TELEPORT_CHANNEL_MAGIC)
+		animate(stored_mobs, pixel_y = null, time = 1 SECONDS)
+		stored_mobs.log_message("warped with [whistle].", LOG_ATTACK, color = "red")
 
 /// Destroy the tornado and teleport everyone on it away.
 /obj/effect/temp_visual/teleporting_tornado/Destroy()
-	if(!isnull(pickedup_mobs))
-		var/turf/ending_turfs = find_safe_turf()
-		for(var/mob/stored_mobs as anything in pickedup_mobs)
-			do_teleport(stored_mobs, ending_turfs, channel = TELEPORT_CHANNEL_MAGIC)
-			animate(stored_mobs, pixel_y = null, time = 1 SECONDS)
-			stored_mobs.log_message("warped with [whistle].", LOG_ATTACK, color = "red")
-
 	if(whistle)
 		whistle.whistler = null
 		whistle = null

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -370,7 +370,7 @@
 		for(var/mob/stored_mobs as anything in pickedup_mobs)
 			do_teleport(stored_mobs, ending_turfs, channel = TELEPORT_CHANNEL_MAGIC)
 			animate(stored_mobs, pixel_y = null, time = 1 SECONDS)
-			stored_mobs.log_message("warped with [whistle].", LOG_ATTACK, color="red")
+			stored_mobs.log_message("warped with [whistle].", LOG_ATTACK, color = "red")
 
 	if(whistle)
 		whistle.whistler = null

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -323,7 +323,7 @@
 	var/turf/current_turf = get_turf(user)
 	var/turf/spawn_location = locate(user.x + pick(-7, 7), user.y, user.z)
 	playsound(current_turf,'sound/magic/warpwhistle.ogg', 200, TRUE)
-	new /obj/effect/temp_visual/teleporting_tornado(spawn_location, spawn_location, src)
+	new /obj/effect/temp_visual/teleporting_tornado(spawn_location, src)
 	COOLDOWN_START(src, whistle_cooldown, 4 SECONDS)
 
 ///Teleporting tornado, spawned by warp whistle, teleports the user if they manage to pick them up.
@@ -336,13 +336,14 @@
 	plane = ABOVE_GAME_PLANE
 	randomdir = FALSE
 	duration = 3 SECONDS
+	movement_type = PHASING
 
 	/// Reference to the whistle
 	var/obj/item/warp_whistle/whistle
 	/// List of all mobs currently held by the tornado.
 	var/list/pickedup_mobs = list()
 
-/obj/effect/temp_visual/teleporting_tornado/Initialize(mapload, turf/spawn_loc, obj/item/warp_whistle/whistle)
+/obj/effect/temp_visual/teleporting_tornado/Initialize(mapload, obj/item/warp_whistle/whistle)
 	. = ..()
 	src.whistle = whistle
 	RegisterSignal(src, COMSIG_MOVABLE_CROSS_OVER, .proc/check_teleport)
@@ -361,11 +362,12 @@
 
 /// Destroy the tornado and teleport everyone on it away.
 /obj/effect/temp_visual/teleporting_tornado/Destroy()
-	var/turf/ending_turfs = find_safe_turf()
-	for(var/mob/stored_mobs as anything in pickedup_mobs)
-		do_teleport(stored_mobs, ending_turfs, channel = TELEPORT_CHANNEL_MAGIC)
-		animate(stored_mobs, pixel_y = null, time = 2 SECONDS)
-		stored_mobs.log_message("warped with [whistle].", LOG_ATTACK, color="red")
+	if(!isnull(pickedup_mobs))
+		var/turf/ending_turfs = find_safe_turf()
+		for(var/mob/stored_mobs as anything in pickedup_mobs)
+			do_teleport(stored_mobs, ending_turfs, channel = TELEPORT_CHANNEL_MAGIC)
+			animate(stored_mobs, pixel_y = null, time = 1 SECONDS)
+			stored_mobs.log_message("warped with [whistle].", LOG_ATTACK, color="red")
 
 	whistle.whistler = null
 	return ..()

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -299,78 +299,73 @@
 	heal_burn = 25
 	heal_oxy = 25
 
-//Warp Whistle: Provides uncontrolled long distance teleportation.
-/obj/item/warpwhistle
+///Warp whistle, spawns a tornado that teleports you
+/obj/item/warp_whistle
 	name = "warp whistle"
-	desc = "One toot on this whistle will send you to a far away land!"
+	desc = "Calls a cloud to come pick you up and drop you at a random location on the station."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "whistle"
-	var/on_cooldown = 0 //0: usable, 1: in use, 2: on cooldown
-	var/mob/living/carbon/last_user
 
-/obj/item/warpwhistle/proc/interrupted(mob/living/carbon/user)
-	if(!user || QDELETED(src) || user.notransform)
-		on_cooldown = FALSE
-		return TRUE
-	return FALSE
+	/// Cooldown between whistle uses.
+	COOLDOWN_DECLARE(whistle_cooldown)
+	/// Person using the warp whistle
+	var/mob/living/whistler
 
-/obj/item/warpwhistle/proc/end_effect(mob/living/carbon/user)
-	user.invisibility = initial(user.invisibility)
-	user.status_flags &= ~GODMODE
-	REMOVE_TRAIT(user, TRAIT_IMMOBILIZED, WARPWHISTLE_TRAIT)
-
-
-/obj/item/warpwhistle/attack_self(mob/living/carbon/user)
-	if(!istype(user) || on_cooldown)
+/obj/item/warp_whistle/attack_self(mob/user)
+	if(!COOLDOWN_FINISHED(src, whistle_cooldown))
+		to_chat(user, span_warning("[src] is still on cooldown!"))
 		return
-	on_cooldown = TRUE
-	last_user = user
-	var/turf/T = get_turf(user)
-	playsound(T,'sound/magic/warpwhistle.ogg', 200, TRUE)
-	ADD_TRAIT(user, TRAIT_IMMOBILIZED, WARPWHISTLE_TRAIT)
-	new /obj/effect/temp_visual/tornado(T)
-	sleep(20)
-	if(interrupted(user))
-		REMOVE_TRAIT(user, TRAIT_IMMOBILIZED, WARPWHISTLE_TRAIT)
+	if(whistler)
+		to_chat(user, span_warning("[src] is already warping."))
 		return
-	user.invisibility = INVISIBILITY_MAXIMUM
-	user.status_flags |= GODMODE
-	sleep(20)
-	if(interrupted(user))
-		end_effect(user)
-		return
-	var/breakout = 0
-	while(breakout < 50)
-		var/turf/potential_T = find_safe_turf()
-		if(T.z != potential_T.z || abs(get_dist_euclidian(potential_T,T)) > 50 - breakout)
-			do_teleport(user, potential_T, channel = TELEPORT_CHANNEL_MAGIC)
-			T = potential_T
-			break
-		breakout += 1
-	new /obj/effect/temp_visual/tornado(T)
-	sleep(20)
-	end_effect(user)
-	if(interrupted(user))
-		return
-	on_cooldown = 2
-	addtimer(VARSET_CALLBACK(src, on_cooldown, 0), 4 SECONDS)
 
-/obj/item/warpwhistle/Destroy()
-	if(on_cooldown == 1 && last_user) //Flute got dunked somewhere in the teleport
-		end_effect(last_user)
-	return ..()
+	whistler = user
+	var/turf/current_turf = get_turf(user)
+	var/turf/spawn_location = locate(user.x + pick(-7, 7), user.y, user.z)
+	playsound(current_turf,'sound/magic/warpwhistle.ogg', 200, TRUE)
+	new /obj/effect/temp_visual/teleporting_tornado(spawn_location, spawn_location, src)
+	COOLDOWN_START(src, whistle_cooldown, 4 SECONDS)
 
-/obj/effect/temp_visual/tornado
-	icon = 'icons/obj/wizard.dmi'
-	icon_state = "tornado"
+///Teleporting tornado, spawned by warp whistle, teleports the user if they manage to pick them up.
+/obj/effect/temp_visual/teleporting_tornado
 	name = "tornado"
 	desc = "This thing sucks!"
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "tornado"
 	layer = FLY_LAYER
 	plane = ABOVE_GAME_PLANE
-	randomdir = 0
-	duration = 40
-	pixel_x = 500
+	randomdir = FALSE
+	duration = 3 SECONDS
 
-/obj/effect/temp_visual/tornado/Initialize(mapload)
+	/// Reference to the whistle
+	var/obj/item/warp_whistle/whistle
+	/// List of all mobs currently held by the tornado.
+	var/list/pickedup_mobs = list()
+
+/obj/effect/temp_visual/teleporting_tornado/Initialize(mapload, turf/spawn_loc, obj/item/warp_whistle/whistle)
 	. = ..()
-	animate(src, pixel_x = -500, time = 40)
+	src.whistle = whistle
+	RegisterSignal(src, COMSIG_MOVABLE_CROSS_OVER, .proc/check_teleport)
+	SSmove_manager.move_towards(src, get_turf(whistle.whistler))
+
+/// Check if anything the tornado crosses is the creator.
+/obj/effect/temp_visual/teleporting_tornado/proc/check_teleport(datum/source, atom/movable/crossed)
+	SIGNAL_HANDLER
+	if(crossed != whistle.whistler)
+		return
+
+	pickedup_mobs += crossed
+	buckle_mob(crossed, TRUE, FALSE)
+	animate(src, alpha = 20, pixel_y = 400, time = 3 SECONDS)
+	animate(crossed, pixel_y = 400, time = 3 SECONDS)
+
+/// Destroy the tornado and teleport everyone on it away.
+/obj/effect/temp_visual/teleporting_tornado/Destroy()
+	var/turf/ending_turfs = find_safe_turf()
+	for(var/mob/stored_mobs as anything in pickedup_mobs)
+		do_teleport(stored_mobs, ending_turfs, channel = TELEPORT_CHANNEL_MAGIC)
+		animate(stored_mobs, pixel_y = null, time = 2 SECONDS)
+		stored_mobs.log_message("warped with [whistle].", LOG_ATTACK, color="red")
+
+	whistle.whistler = null
+	return ..()

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -355,11 +355,12 @@
 /// Check if anything the tornado crosses is the creator.
 /obj/effect/temp_visual/teleporting_tornado/proc/check_teleport(datum/source, atom/movable/crossed)
 	SIGNAL_HANDLER
-	if(crossed != whistle.whistler)
+	if(crossed != whistle.whistler || (crossed in pickedup_mobs))
 		return
 
 	pickedup_mobs += crossed
 	buckle_mob(crossed, TRUE, FALSE)
+	ADD_TRAIT(crossed, TRAIT_INCAPACITATED, WARPWHISTLE_TRAIT)
 	animate(src, alpha = 20, pixel_y = 400, time = 3 SECONDS)
 	animate(crossed, pixel_y = 400, time = 3 SECONDS)
 	addtimer(CALLBACK(src, .proc/send_away), 2 SECONDS)
@@ -370,10 +371,10 @@
 		do_teleport(stored_mobs, ending_turfs, channel = TELEPORT_CHANNEL_MAGIC)
 		animate(stored_mobs, pixel_y = null, time = 1 SECONDS)
 		stored_mobs.log_message("warped with [whistle].", LOG_ATTACK, color = "red")
+		REMOVE_TRAIT(stored_mobs, TRAIT_INCAPACITATED, WARPWHISTLE_TRAIT)
 
 /// Destroy the tornado and teleport everyone on it away.
 /obj/effect/temp_visual/teleporting_tornado/Destroy()
 	if(whistle)
-		whistle.whistler = null
 		whistle = null
 	return ..()

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -495,7 +495,7 @@
 /datum/spellbook_entry/item/warpwhistle
 	name = "Warp Whistle"
 	desc = "A strange whistle that will transport you to a distant safe place on the station. There is a window of vulnerability at the beginning of every use."
-	item_path = /obj/item/warpwhistle
+	item_path = /obj/item/warp_whistle
 	category = "Mobility"
 	cost = 1
 

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(summoned_magic, list(
 	/obj/item/gun/magic/staff/healing,
 	/obj/item/gun/magic/staff/door,
 	/obj/item/scrying,
-	/obj/item/warpwhistle,
+	/obj/item/warp_whistle,
 	/obj/item/immortality_talisman,
 	/obj/item/melee/ghost_sword))
 
@@ -98,7 +98,7 @@ GLOBAL_LIST_INIT(summoned_magic_objectives, list(
 	/obj/item/scrying,
 	/obj/item/spellbook,
 	/obj/item/storage/belt/wands/full,
-	/obj/item/warpwhistle))
+	/obj/item/warp_whistle))
 
 /*
  * Gives [to_equip] a random gun from a list.


### PR DESCRIPTION
## About The Pull Request

Warp whistle is now a status effect that walks towards you.
If it hits the person that summoned it, it picks them up and starts floating away, then teleports them to a random space place on the station once it's complete. Said person will fals from the sky onto their destination.

Example video:
https://user-images.githubusercontent.com/53777086/168730074-4a5017ea-3f3b-4cf6-aef5-76da7faa0cc4.mp4

TO DO:
- [x] Make the tornado ignore walls

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/67054 (my own issue that I made earlier today)
Makes warp whistle's code less bad (like not giving godmode) while also making it worth the 1 spellbook point it was.

## Changelog

:cl:
refactor: Wizard's warp whistle is now an effect that charges at the summoner to pick them up, and will drop them down.
/:cl: