### PR TITLE
[NO GBP] changes the turf tab update speed

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -16,8 +16,6 @@ SUBSYSTEM_DEF(statpanels)
 	var/status_wait = 6
 	///how many subsystem fires between updates of the MC tab
 	var/mc_wait = 5
-	/// how many subsystem fires between updates of the turf examine tab
-	var/turf_wait = 2
 	///how many full runs this subsystem has completed. used for variable rate refreshes.
 	var/num_fires = 0
 
@@ -80,7 +78,7 @@ SUBSYSTEM_DEF(statpanels)
 					set_spells_tab(target, target_mob)
 
 
-			if(target_mob?.listed_turf && num_fires % turf_wait == 0)
+			if(target_mob?.listed_turf && num_fires % default_wait == 0)
 				if(!target_mob.TurfAdjacent(target_mob.listed_turf) || isnull(target_mob.listed_turf))
 					target.stat_panel.send_message("remove_listedturf")
 					target_mob.listed_turf = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

i originally changed the refresh rate of the turf tab in the stat panel from 10, to 2, because i felt like it wouldn't be that intensive on clients. apparently it is. now we know!

i think it's because icons don't get cached across updates, maybe? most likely. not sure why i didn't think of that

## Why It's Good For The Game

lag bad
