### PR TITLE
Fixes initial floating action buttons failing to properly position

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -345,6 +345,11 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	return
 
 /datum/hud/proc/position_action(atom/movable/screen/movable/action_button/button, position)
+	// This is kinda a hack, I'm sorry.
+	// Basically, FLOATING is never a valid position to pass into this proc. It exists as a generic marker for manually positioned buttons
+	// Not as a position to target
+	if(position == SCRN_OBJ_FLOATING)
+		return
 	if(button.location != SCRN_OBJ_DEFAULT)
 		hide_action(button)
 	switch(position)
@@ -433,8 +438,8 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 		var/atom/movable/screen/movable/action_button/button = action.viewers[src]
 		if(!button)
 			action.ShowTo(mymob)
-			button = action.viewers[src]
-		position_action(button, button.location)
+		else
+			position_action(button, button.location)
 
 /datum/action_group
 	/// The hud we're owned by

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -63,6 +63,8 @@
 		spellnum++
 	if(runetype)
 		var/pos = 2+spellnum*31
+		if(construct_spells.len >= 4)
+			pos -= 31*(construct_spells.len - 4)
 		our_rune = new runetype(src)
 		our_rune.default_button_position = "6:[pos],4:-2" // Set the default position to this random position
 		our_rune.Grant(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #66120

Also cleans up artificer stuff a bit, their rune button should align with their spells.

Basically, when we grant someone a button, it gets positioned in its default location. 
If the button's floating, their location var becomes an invalid arg to position_action. 
Then we called position action with their location var.

Big fucky.

I've cleaned up the logic a bit, and ensured that you can never position to FLOATING directly, since it's a marker rather then a real position on the screen

## Why It's Good For The Game

Fixes a bug, makes artificer buttons a bit nicer

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Artificers can see their action buttons again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
