### PR TITLE
[s] Removes protected variable exploit

### DIFF
--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -29,6 +29,11 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 	msg = "Edit"
 	return msg
 
+/datum/controller/global_vars/can_vv_get(var_name)
+	if(var_name == "gvars_datum_protected_varlist" || var_name == "gvars_datum_in_built_vars")
+		return FALSE
+	. = ..()
+
 /datum/controller/global_vars/vv_edit_var(var_name, var_value)
 	if(gvars_datum_protected_varlist[var_name])
 		return FALSE

--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -32,7 +32,7 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 /datum/controller/global_vars/can_vv_get(var_name)
 	if(var_name == "gvars_datum_protected_varlist" || var_name == "gvars_datum_in_built_vars")
 		return FALSE
-	. = ..()
+	return ..()
 
 /datum/controller/global_vars/vv_edit_var(var_name, var_value)
 	if(gvars_datum_protected_varlist[var_name])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
From BeeStation/BeeStation-Hornet#6896
Some global variables are protected by a macro that adds them to a list of protected variables, however the list itself is not protected and can be edited. This results in the ability for any admin with VV to unprotect any variable protected by this list.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The following is a small selection of the variables protected by this list:
admin_log
admins
admin_ranks
href_token
admin_datums
VVlocked
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Admins can no longer unprotect globals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
