### PR TITLE
TRAIT_BATON_RESISTANCE and pepperspray buff

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -219,7 +219,7 @@
 	return OXYLOSS
 
 /obj/item/reagent_containers/spray/pepper/get_waitstep(range)
-	return 1 //Fast and furious
+	return 2 //Fast and furious
 
 // Fix pepperspraying yourself
 /obj/item/reagent_containers/spray/pepper/afterattack(atom/A as mob|obj, mob/user)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -68,7 +68,6 @@
 	else
 		reagents.trans_to(reagent_puff, amount_per_transfer_from_this, 1/range)
 	reagent_puff.color = mix_color_from_reagents(reagent_puff.reagents.reagent_list)
-	var/wait_step = max(round(2+3/range), 2)
 
 	var/puff_reagent_string = reagent_puff.reagents.get_reagent_log_string()
 	var/turf/src_turf = get_turf(src)
@@ -77,7 +76,10 @@
 	log_game("[key_name(user)] fired a puff of reagents from \a [src] with a range of \[[range]\] and containing [puff_reagent_string] at [AREACOORD(src_turf)].")
 
 	// do_spray includes a series of step_towards and sleeps. As a result, it will handle deletion of the chempuff.
-	do_spray(target, wait_step, reagent_puff, range, puff_reagent_left, user)
+	do_spray(target, get_waitstep(range), reagent_puff, range, puff_reagent_left, user)
+
+/obj/item/reagent_containers/spray/proc/get_waitstep(range)
+	return max(round(2+3/range), 2)
 
 /// Handles exposing atoms to the reagents contained in a spray's chempuff. Deletes the chempuff when it's completed.
 /obj/item/reagent_containers/spray/proc/do_spray(atom/target, wait_step, obj/effect/decal/chempuff/reagent_puff, range, puff_reagent_left, mob/user)
@@ -215,6 +217,9 @@
 /obj/item/reagent_containers/spray/pepper/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins huffing \the [src]! It looks like [user.p_theyre()] getting a dirty high!"))
 	return OXYLOSS
+
+/obj/item/reagent_containers/spray/pepper/get_waitstep(range)
+	return 1 //Fast and furious
 
 // Fix pepperspraying yourself
 /obj/item/reagent_containers/spray/pepper/afterattack(atom/A as mob|obj, mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stimulants, some heretic rituals and changeling adrenaline(TRAIT_BATON_RESISTANCE) now lower baton stamina damage by 30%, making it into a 3-hit weapon. They also lower jittering and stuttering duration by 50% and confusion duration by 90%, as well as increasing the delay before second knockdown after getting batonged by 1 second from 2 to 3 seconds. Also makles clumsy use of batons check for TRAIT_BATON_RESISTACE for consistency.
To make peppersprays more reliable, their spray speed has been increased, making spraying targets further than 1 tile away from you much easier.

## Why It's Good For The Game

This allows you to somewhat fight against batons even after you get hit instead of getting hit the second time no matter what because of the afterstun and stamina damage slowdown. Right now batons have no actual counter at all, which makes them the best weapon that ends any fight in 1 hit. My changes won't make them useless, but will make fighting against someone with a baton without having one actually possible.

Regarding peppersprays, those are extremely underpowered and probably the worst item in security belts. I hope raising spray's speed improves the situation.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Stimulants, some heretic rituals and changeling adrenaline now lower baton stamina damage by 30%, making it into a 3-hit weapon. They also lower jittering and stuttering duration by 50% and confusion duration by 90%, as well as increasing the delay before second knockdown after getting batonged by 1 second from 2 to 3 seconds. Clumsy people batoning themselves also are affected by these changes.
balance: Peppersprays are now much faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
