### PR TITLE
SM cascade is viable with gas and more visually interesting

### DIFF
--- a/code/__DEFINES/supermatter.dm
+++ b/code/__DEFINES/supermatter.dm
@@ -11,8 +11,8 @@
 #define HEALIUM_HEAT_PENALTY 4
 #define PROTO_NITRATE_HEAT_PENALTY -3
 #define ZAUKER_HEAT_PENALTY 8
-#define HYPERNOBLIUM_HEAT_PENALTY -5
-#define ANTINOBLIUM_HEAT_PENALTY 20
+#define HYPERNOBLIUM_HEAT_PENALTY -13
+#define ANTINOBLIUM_HEAT_PENALTY 15
 
 //All of these get divided by 10-bzcomp * 5 before having 1 added and being multiplied with power to determine rads
 //Keep the negative values here above -10 and we won't get negative rads
@@ -26,6 +26,8 @@
 #define HEALIUM_TRANSMIT_MODIFIER 2.4
 #define PROTO_NITRATE_TRANSMIT_MODIFIER 15
 #define ZAUKER_TRANSMIT_MODIFIER 20
+#define ANTINOBLIUM_TRANSMIT_MODIFIER -5
+#define HYPERNOBLIUM_TRANSMIT_MODIFIER 3
 
 #define BZ_RADIOACTIVITY_MODIFIER 5 //Improves the effect of transmit modifiers
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -118,6 +118,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		/datum/gas/healium = HEALIUM_TRANSMIT_MODIFIER,
 		/datum/gas/proto_nitrate = PROTO_NITRATE_TRANSMIT_MODIFIER,
 		/datum/gas/zauker = ZAUKER_TRANSMIT_MODIFIER,
+		/datum/gas/hypernoblium = HYPERNOBLIUM_TRANSMIT_MODIFIER,
+		/datum/gas/antinoblium = ANTINOBLIUM_TRANSMIT_MODIFIER,
 	)
 	///The list of gases mapped against their heat penaltys. We use it to determin molar and heat output
 	var/list/gas_heat = list(
@@ -159,9 +161,13 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		/datum/gas/proto_nitrate = 1,
 		/datum/gas/zauker = 1,
 		/datum/gas/miasma = 0.5,
+		/datum/gas/antinoblium = 1,
+		/datum/gas/hypernoblium = -1,
 	)
 	///The last air sample's total molar count, will always be above or equal to 0
 	var/combined_gas = 0
+	///Total mole count of the environment we are in
+	var/environment_total_moles = 0
 	///Affects the power gain the sm experiances from heat
 	var/gasmix_power_ratio = 0
 	///Affects the amount of o2 and plasma the sm outputs, along with the heat it makes.
@@ -485,7 +491,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	for(var/gas_path in required_gases)
 		if(has_destabilizing_crystal)
 			break // We have a destabilizing crystal, we're good
-		if(gas_comp[gas_path] < 0.4 || combined_gas < MOLE_PENALTY_THRESHOLD)
+		if(gas_comp[gas_path] < 0.4 || environment_total_moles < MOLE_PENALTY_THRESHOLD)
 			supermatter_cascade = FALSE
 			break
 

--- a/code/modules/power/supermatter/supermatter_delamination.dm
+++ b/code/modules/power/supermatter/supermatter_delamination.dm
@@ -182,7 +182,7 @@
 		crystal_cascade_location.ChangeTurf(/turf/closed/indestructible/supermatter_wall)
 
 /**
- * Adds a bit of spicyness to the cascade by breaking lights and turning emergency maint access on
+ * Adds a bit of spiciness to the cascade by breaking lights and turning emergency maint access on
  */
 /datum/supermatter_delamination/proc/create_cascade_ambience()
 	break_lights_on_station()

--- a/code/modules/power/supermatter/supermatter_delamination.dm
+++ b/code/modules/power/supermatter/supermatter_delamination.dm
@@ -173,12 +173,20 @@
 	SSshuttle.registerHostileEnvironment(src)
 	SSshuttle.supermatter_cascade = TRUE
 	call_explosion()
+	create_cascade_ambience()
 	pick_rift_location()
 	warn_crew()
 	supermatter_turf.ChangeTurf(/turf/closed/indestructible/supermatter_wall)
-	for(var/i in 1 to rand(1,3))
+	for(var/i in 1 to rand(2,5))
 		var/turf/crystal_cascade_location = get_turf(pick(GLOB.generic_event_spawns))
 		crystal_cascade_location.ChangeTurf(/turf/closed/indestructible/supermatter_wall)
+
+/**
+ * Adds a bit of spicyness to the cascade by breaking lights and turning emergency maint access on
+ */
+/datum/supermatter_delamination/proc/create_cascade_ambience()
+	break_lights_on_station()
+	make_maint_all_access()
 
 /**
  * Picks a random location for the rift
@@ -227,3 +235,14 @@
 /datum/supermatter_delamination/proc/the_end()
 	SSticker.news_report = SUPERMATTER_CASCADE
 	SSticker.force_ending = 1
+
+/**
+ * Break the lights on the station, have 35% of them be set to emergency
+ */
+/datum/supermatter_delamination/proc/break_lights_on_station()
+	for(var/obj/machinery/light/light_to_break in GLOB.machines)
+		if(prob(35))
+			light_to_break.emergency_mode = TRUE
+			light_to_break.update_appearance()
+			continue
+		light_to_break.break_light_tube()

--- a/code/modules/power/supermatter/supermatter_process.dm
+++ b/code/modules/power/supermatter/supermatter_process.dm
@@ -19,6 +19,7 @@
 
 	//Ok, get the air from the turf
 	var/datum/gas_mixture/env = local_turf.return_air()
+	environment_total_moles = env.total_moles()
 	var/datum/gas_mixture/removed
 	if(produces_gas)
 		//Remove gas from surrounding area
@@ -135,15 +136,17 @@
 			has_holes = TRUE
 			break
 
+	var/cascade_multiplier = cascade_initiated ? 0.25 : 1
+
 	//Due to DAMAGE_INCREASE_MULTIPLIER, we only deal one 4th of the damage the statements otherwise would cause
 	//((((some value between 0.5 and 1 * temp - ((273.15 + 40) * some values between 1 and 10)) * some number between 0.25 and knock your socks off / 150) * 0.25
 	//Heat and mols account for each other, a lot of hot mols are more damaging then a few
 	//Mols start to have a positive effect on damage after 350
 	damage = max(damage + (max(clamp(removed.total_moles() / 200, 0.5, 1) * removed.temperature - ((T0C + HEAT_PENALTY_THRESHOLD)*dynamic_heat_resistance), 0) * mole_heat_penalty / 150 ) * DAMAGE_INCREASE_MULTIPLIER, 0)
-	//Power only starts affecting damage when it is above 5000
-	damage = max(damage + (max(power - POWER_PENALTY_THRESHOLD, 0)/500) * DAMAGE_INCREASE_MULTIPLIER, 0)
-	//Molar count only starts affecting damage when it is above 1800
-	damage = max(damage + (max(combined_gas - MOLE_PENALTY_THRESHOLD, 0)/80) * DAMAGE_INCREASE_MULTIPLIER, 0)
+	//Power only starts affecting damage when it is above 5000 (1250 when a cascade is occurring)
+	damage = max(damage + (max(power - (POWER_PENALTY_THRESHOLD * cascade_multiplier), 0)/500) * DAMAGE_INCREASE_MULTIPLIER, 0)
+	//Molar count only starts affecting damage when it is above 1800 (450 when a cascade is occurring)
+	damage = max(damage + (max(combined_gas - (MOLE_PENALTY_THRESHOLD * cascade_multiplier), 0)/80) * DAMAGE_INCREASE_MULTIPLIER, 0)
 
 	//There might be a way to integrate healing and hurting via heat
 	//healing damage


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the check for antinob+hypernob cascade for the total amount of gases from the combined_gas to the environmental one.
Allows more damage to the crystal while the cascade is going
Made the antinob and hypernob heat penalty in similar but opposite amounts (15 anti, -13 hyper)
Added transmit modifiers to both gases (-5 anti, 3 hyper)
Increased the amount of crystal shards that spawns from the explosion to a max of 5 and min 2
Added light breaking and random light on emergency mode + maint emergency access when the cascade occurs 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Due to a miscalculation i didn't consider that the combined_gas var refers to the amount of gases that are removed from the environment (that are later used to do all types of calculations). The issue here is that it removes the 15% of the total environment, so this caused a big issue, instead of being able to "just" need around 20k moles of gas (10k hyper and nob) to achieve a cascade delamination, you would have needed 200k Moles of total gas, which is impossible to gather.

The other changes were made to make the cascade viable in terms of SM heat and gas production plus to make the two gases useful in case of normal use.

The light addition is to have a darker station or red lights all around

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: supermatter cascade gas needed amount was broken and you'd needed around 200k Moles of antinob+hypernob (40% each at least) instead of "just" 20k Moles.
balance: changed how hypernob and antinob interact with the SM: heat capacity made similar (15 anti, -13 hyper), transmit modifier added (-5 anti, 3 hyper)
add: lights now break or set to emergency when the cascade starts, maintenance is set to emergency access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
