### PR TITLE
Fixes strange runtime with restart votes

### DIFF
--- a/code/datums/votes/restart_vote.dm
+++ b/code/datums/votes/restart_vote.dm
@@ -44,7 +44,7 @@
 		return
 
 	if(winning_option == CHOICE_RESTART)
-		for(var/client/online_admin as anything in GLOB.admins | GLOB.deadmins)
+		for(var/client/online_admin as anything in GLOB.admins)
 			if(online_admin.is_afk() || !check_rights_for(online_admin, R_SERVER))
 				continue
 


### PR DESCRIPTION
## About The Pull Request

So, I refactored votes a little bit ago.
This line was present in the result process for restart votes. 
```dm
for(var/client/C in GLOB.admins + GLOB.deadmins)
	if(!C.is_afk() && check_rights_for(C, R_SERVER))
		active_admins = TRUE
		break
```
So, I converted it to this.
```dm
for(var/client/online_admin as anything in GLOB.admins | GLOB.deadmins)
	if(online_admin.is_afk() || !check_rights_for(online_admin, R_SERVER))
		continue
```
Seems fine, right?
Unfortunately, no. 

`GLOB.deadmins` is a global list of deadminned **ckeys**. Not deadminned **clients**.
So, the original loop iterated over a combined list of clients AND ckeys, but ONLY typechecked for clients. 

Why were we adding in ckeys in the first place, if it didn't even check them?
No idea. But it seems like, since no one noticed restart votes weren't checking for deadminned admins in the first place, there isn't a reason to continue to consider them. Admins can re-admin to cancel restart votes or address the server's concerns if they're online, I suppose. 

## Why It's Good For The Game

Restart votes work. 

## Changelog

:cl: Melbert
fix: Restart Votes work once more
/:cl:
