### PR TITLE
Changes Admin DSAY rank display to a tooltip

### DIFF
--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -24,7 +24,8 @@
 	if(holder.fakekey)
 		rank_name = pick(strings("admin_nicknames.json", "ranks", "config"))
 		admin_name = pick(strings("admin_nicknames.json", "names", "config"))
-	var/rendered = "<span class='game deadsay'>[span_prefix("DEAD:")] [span_name("[rank_name]([admin_name])")] says, <span class='message'>\"[emoji_parse(msg)]\"</span></span>"
+	var/name_and_rank = "[span_tooltip(rank_name, "STAFF")]([admin_name])"
+	var/rendered = "<span class='game deadsay'> [span_prefix("DEAD:")] [name_and_rank] says, <span class='message'>\"[emoji_parse(msg)]\"</span></span>"
 
 	for (var/mob/M in GLOB.player_list)
 		var/admin_holder = M.client?.holder


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Granular Admin Perms (#66368) was a good change and improvement to our admin tools, but damn the rank display when admins use the dsay verb sucks now.
[![dreamseeker_2022-05-17_20-37-11.png](https://i.imgur.com/Qudmhpel.jpg)](https://i.imgur.com/Qudmhpe.png)

This PR changes the rank display to a simple tooltip that says `STAFF`, which can be hovered over for the person's rank(s). Observe:

[![dreamseeker_2022-05-17_20-31-44.png](https://i.imgur.com/vcGxYccl.jpg)](https://i.imgur.com/vcGxYcc.png)

[![dreamseeker_2022-05-17_20-32-00.png](https://i.imgur.com/2apQYTzl.jpg)](https://i.imgur.com/2apQYTz.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Easier way to show multiple ranks in dsay without looking like you're showing off your massive rank display
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ryll/Shaps
admin: Admins using the dsay verb will now have their rank(s) shown in a hoverable tooltip
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
