### PR TITLE
[s] Revert "[s] Removes protected variable exploit"

### DIFF
--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -29,11 +29,6 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 	msg = "Edit"
 	return msg
 
-/datum/controller/global_vars/can_vv_get(var_name)
-	if(var_name == "gvars_datum_protected_varlist" || var_name == "gvars_datum_in_built_vars")
-		return FALSE
-	return ..()
-
 /datum/controller/global_vars/vv_edit_var(var_name, var_value)
 	if(gvars_datum_protected_varlist[var_name])
 		return FALSE


### PR DESCRIPTION
Reverts tgstation/tgstation#67071

It doesn't actually fix the issue of protected lists themselves being editable, it just solves them in one particular case.
Not a good fix. I don't think it's worth the human time to fix it better, since this has seemingly never been an issue, but if you're going to waste your time it should at least be done correctly.