### PR TITLE
adds the replace_html proc to tgwindow instances

### DIFF
--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -312,6 +312,18 @@
 	message_queue = null
 
 /**
+ * public
+ *
+ * Replaces the inline HTML content.
+ *
+ * required inline_html string HTML to inject
+ */
+/datum/tgui_window/proc/replace_html(inline_html)
+	if(!inline_html)
+		return
+	send_message("replace_html", inline_html)
+
+/**
  * private
  *
  * Callback for handling incoming tgui messages.

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -319,7 +319,7 @@
  * required inline_html string HTML to inject
  */
 /datum/tgui_window/proc/replace_html(inline_html = "")
-	client << output(url_encode(inline_html), "statbrowser:replaceHtml")
+	client << output(url_encode(inline_html), "[window_id]:replaceHtml")
 
 /**
  * private

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -319,7 +319,7 @@
  * required inline_html string HTML to inject
  */
 /datum/tgui_window/proc/replace_html(inline_html = "")
-	send_message("replace_html", inline_html)
+	client << output(url_encode(inline_html), "statbrowser:replaceHtml")
 
 /**
  * private

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -319,7 +319,7 @@
  * required inline_html string HTML to inject
  */
 /datum/tgui_window/proc/replace_html(inline_html = "")
-	client << output(url_encode(inline_html), "[window_id]:replaceHtml")
+	client << output(url_encode(inline_html), "[id].browser:replaceHtml")
 
 /**
  * private

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -318,9 +318,7 @@
  *
  * required inline_html string HTML to inject
  */
-/datum/tgui_window/proc/replace_html(inline_html)
-	if(!inline_html)
-		return
+/datum/tgui_window/proc/replace_html(inline_html = "")
 	send_message("replace_html", inline_html)
 
 /**

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -487,11 +487,11 @@ window.update.flushQueue = function (listener) {
   }
 };
 
-Byond.subscribeTo("replace_html", function(inline_html) {
-  let children = document.body.childNodes;
+Byond.subscribeTo("replace_html", function (inline_html) {
+  var children = document.body.childNodes;
 
-  for (let i = 0; i < children.length; i++) {
-    if (children[i].nodeValue == " tgui:inline-html-start ") {;
+  for (var i = 0; i < children.length; i++) {
+    if (children[i].nodeValue == " tgui:inline-html-start ") {
       while (children[i].nodeValue != " tgui:inline-html-end ") {
         children[i].remove();
       }
@@ -499,7 +499,12 @@ Byond.subscribeTo("replace_html", function(inline_html) {
     }
   }
 
-  document.body.insertAdjacentHTML("afterbegin", "<!-- tgui:inline-html-start -->" + inline_html + "<!-- tgui:inline-html-end -->");
+  document.body.insertAdjacentHTML(
+    "afterbegin",
+    "<!-- tgui:inline-html-start -->"
+      + inline_html
+      + "<!-- tgui:inline-html-end -->"
+  );
 });
 
 // Signal tgui that we're ready to receive updates

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -487,6 +487,21 @@ window.update.flushQueue = function (listener) {
   }
 };
 
+Byond.subscribeTo("replace_html", function(inline_html) {
+  let children = document.body.childNodes;
+
+  for (let i = 0; i < children.length; i++) {
+    if (children[i].nodeValue == " tgui:inline-html-start ") {;
+      while (children[i].nodeValue != " tgui:inline-html-end ") {
+        children[i].remove();
+      }
+      children[i].remove();
+    }
+  }
+
+  document.body.insertAdjacentHTML("afterbegin", "<!-- tgui:inline-html-start -->" + inline_html + "<!-- tgui:inline-html-end -->");
+});
+
 // Signal tgui that we're ready to receive updates
 Byond.sendMessage('ready');
 </script>
@@ -594,7 +609,9 @@ blink {
 
 <!-- tgui:inline-polyfill -->
 <!-- tgui:assets -->
+<!-- tgui:inline-html-start -->
 <!-- tgui:inline-html -->
+<!-- tgui:inline-html-end -->
 <!-- tgui:inline-js -->
 
 <!-- Root element for tgui interfaces -->

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -487,7 +487,7 @@ window.update.flushQueue = function (listener) {
   }
 };
 
-Byond.subscribeTo("replace_html", function (inline_html) {
+window.replaceHtml = function (inline_html) {
   var children = document.body.childNodes;
 
   for (var i = 0; i < children.length; i++) {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds the ability to realtime inject HTML into TGWindow instances, just as you can create TGWindow instances with inline_html at initialization. 

the proc itself (`replace_html(inline_html as string)`) simply checks if the `inline_html` value actually has a value, and then sends a message with type `replace_html` and payload `inline_html`. `tgui.html` proceeds to do some wacky adjacent HTML and node shenanigans to entirely replace the inline HTML content. 

## Why It's Good For The Game

future usage with tgwindow instances