### PR TITLE
Fixes toy mecha not having the proper say args

### DIFF
--- a/code/game/objects/items/toy_mechs.dm
+++ b/code/game/objects/items/toy_mechs.dm
@@ -266,7 +266,7 @@
 /**
  * Override the say proc if they're mute
  */
-/obj/item/toy/mecha/say()
+/obj/item/toy/mecha/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null, filterproof = null)
 	if(!quiet)
 		. = ..()
 


### PR DESCRIPTION
This was causing linter failures because someone forgot to include the
proper args for this override