### PR TITLE
Adds the Tider taser

### DIFF
--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -24,3 +24,6 @@
 
 /obj/item/ammo_casing/energy/disabler/hos
 	e_cost = 60
+
+/obj/item/ammo_casing/energy/electrode/tider
+	projectile_type = /obj/projectile/energy/electrode/tider

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -11,6 +11,13 @@
 	desc = "A low-capacity, energy-based stun gun used by security teams to subdue targets at range. This model only works on assistants."
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/tider)
 
+/obj/item/gun/energy/taser/tider/process_fire(atom/target, mob/living/user)
+	. = ..()
+	if (!user.mind)
+		return
+	if(istype(user.mind.assigned_role, /datum/job/assistant))
+		user.gib()
+
 /obj/item/gun/energy/e_gun/advtaser
 	name = "hybrid taser"
 	desc = "A dual-mode taser designed to fire both short-range high-power electrodes and long-range disabler beams."

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -6,6 +6,11 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
 	ammo_x_offset = 3
 
+/obj/item/gun/energy/taser/tider // admin only. fun.
+	name = "tider taser"
+	desc = "A low-capacity, energy-based stun gun used by security teams to subdue targets at range. This model only works on assistants."
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode/tider)
+
 /obj/item/gun/energy/e_gun/advtaser
 	name = "hybrid taser"
 	desc = "A dual-mode taser designed to fire both short-range high-power electrodes and long-range disabler beams."

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -42,15 +42,15 @@
 	if(!tase_checks(target))
 		return
 	. = ..()
-	var/mob/living/carbon/C = target
-	var/area/Location = get_area(C)
+	var/mob/living/carbon/victim = target
+	var/area/Location = get_area(victim)
 	var/list/gibbable_areas = list(/area/station/command/bridge, /area/station/command/heads_quarters/captain)
-	for(var/area/A as anything in gibbable_areas)
-		if (istype(Location, A))
-			C.gib()
+	for(var/area/area_to_check as anything in gibbable_areas)
+		if (istype(Location, area_to_check))
+			victim.gib()
 			return
-	C.Paralyze(10 SECONDS)
-	C.set_timed_status_effect(10 SECONDS, /datum/status_effect/speech/stutter)
+	victim.Paralyze(10 SECONDS)
+	victim.set_timed_status_effect(10 SECONDS, /datum/status_effect/speech/stutter)
 
 
 /obj/projectile/energy/electrode/tider

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -12,6 +12,9 @@
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	impact_type = /obj/effect/projectile/impact/stun
 
+/obj/projectile/energy/electrode/proc/tase_checks()
+	return TRUE
+
 /obj/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
@@ -28,3 +31,23 @@
 /obj/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	do_sparks(1, TRUE, src)
 	..()
+
+/obj/projectile/energy/electrode/tider/on_hit(atom/target)
+	. = ..()
+	if (tase_checks(target))
+		var/mob/living/carbon/C = target
+		C.Paralyze(10 SECONDS)
+		C.set_timed_status_effect(10 SECONDS, /datum/status_effect/speech/stutter)
+
+/obj/projectile/energy/electrode/tider
+	name = "tider taser"
+
+// We only want to activate on Assistants.
+/obj/projectile/energy/electrode/tider/tase_checks(mob/target)
+	if(!ishuman(target))
+		return FALSE
+	var/mob/living/carbon/human/human_target = target
+	if(istype(human_target.mind.assigned_role, /datum/job/assistant))
+		return TRUE
+	human_target.balloon_alert_to_viewers("not an assistant, can't tase!")
+	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds an admin-only taser that only works on assistants.
Oh, and if they're hit in the bridge or the Captain's office they'll be gibbed.
Also also, if you try and use it as an assistant, that's a gibbin'
Based off goof's PR: https://github.com/tgstation/tgstation/pull/66873
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If the tide is being particularly annoying, gives admins a way to ICly tip the balance in security's favour.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: WineAllWine
admin: admins can give out the tider taser
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
