### PR TITLE
Add logging for malf upgrades

### DIFF
--- a/code/__HELPERS/logging/antagonists.dm
+++ b/code/__HELPERS/logging/antagonists.dm
@@ -8,6 +8,11 @@
 	if (CONFIG_GET(flag/log_uplink))
 		WRITE_LOG(GLOB.world_uplink_log, "UPLINK: [text]")
 
+/// Logging for upgrades purchased by a malfunctioning (or combat upgraded) AI
+/proc/log_malf_upgrades(text)
+	if (CONFIG_GET(flag/log_uplink))
+		WRITE_LOG(GLOB.world_uplink_log, "MALF UPGRADE: [text]")
+
 /// Logging for changeling powers purchased
 /proc/log_changeling_power(text)
 	if (CONFIG_GET(flag/log_uplink))

--- a/code/modules/antagonists/traitor/equipment/module_picker.dm
+++ b/code/modules/antagonists/traitor/equipment/module_picker.dm
@@ -122,4 +122,5 @@
 				action.desc = "[initial(action.desc)] It has [action.uses] use\s remaining."
 				action.UpdateButtons()
 	processing_time -= AM.cost
+	log_malf_upgrades("[key_name(AI)] purchased [AM.name]")
 	SSblackbox.record_feedback("nested tally", "malfunction_modules_bought", 1, list("[initial(AM.name)]", "[AM.cost]"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title

## Why It's Good For The Game
Mostly consistency; turns out that malf upgrades aren't logged except in the blackbox. You could probably find them in TGUI logs but this is easier at a glance.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: AI malf/combat purchases are now logged in uplink.log
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
