### PR TITLE
Makes GAGS menu display time spent even without full preview

### DIFF
--- a/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
+++ b/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
@@ -221,7 +221,7 @@ const PreviewDisplay = (props, context) => {
         </Table.Row>
       </Table>
       {
-        !!data.generate_full_preview
+        !!data.unlocked
           && `Time Spent: ${data.sprites.time_spent}ms`
       }
       <Divider />


### PR DESCRIPTION
## About The Pull Request

Simply lets you see how much time was spent on generating a sprite as long as you're in the debug version of the menu instead of only if you have full preview enabled.