### PR TITLE
You can now emag tram crossing signals to disable their motion sensors

### DIFF
--- a/code/game/machinery/crossing_signal.dm
+++ b/code/game/machinery/crossing_signal.dm
@@ -56,7 +56,7 @@
 /obj/machinery/crossing_signal/emag_act(mob/living/user)
 	if(obj_flags & EMAGGED)
 		return
-	to_chat(user, span_notice("You disable the [src]'s motion sensors."))
+	balloon_alert(user, "disabled motion sensors")
 	if(signal_state != XING_STATE_GREEN)
 		set_signal_state(XING_STATE_GREEN)
 	obj_flags |= EMAGGED

--- a/code/game/machinery/crossing_signal.dm
+++ b/code/game/machinery/crossing_signal.dm
@@ -53,6 +53,14 @@
 	if(tram_part)
 		UnregisterSignal(tram_part, COMSIG_TRAM_SET_TRAVELLING)
 
+/obj/machinery/crossing_signal/emag_act(mob/living/user)
+	if(obj_flags & EMAGGED)
+		return
+	to_chat(user, span_notice("You disable the [src]'s motion sensors."))
+	if(signal_state != XING_STATE_GREEN)
+		set_signal_state(XING_STATE_GREEN)
+	obj_flags |= EMAGGED
+
 /**
  * Finds the tram, just like the tram computer
  *
@@ -84,6 +92,9 @@
  * Returns whether we are still processing.
  */
 /obj/machinery/crossing_signal/proc/update_operating()
+	//emagged crossing signals dont update
+	if(obj_flags & EMAGGED)
+		return
 	// Immediately process for snappy feedback
 	var/should_process = process() != PROCESS_KILL
 	if(should_process)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title, basically they always appear green regardless of where the tram is.

credit to qfmysterman for the idea

## Why It's Good For The Game

Minor, neat emag interaction.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now emag tram crossing signals to disable their motion sensors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
