### PR TITLE
[Tram] Access Helpers for Engine room external airlocks

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -48777,6 +48777,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "qws" = (
@@ -50841,6 +50842,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "riK" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds missing(?) access helpers to a pair of external airlocks next to the engine room
I'm honestly not sure if this is right since access helpers are new to me, but I was having trouble using these doors as an engineer downstream so I hope this'll get updated down the line (the map doesn't have access helpers yet but the access reqs are the same, I dunno)

There's a pair of unpowered doors lower down lower I'm not sure if that's intended or not but tram is just kind of messy in general still.

I'm sure sans will check this PR and let me know.

## Why It's Good For The Game
Seems consistent, makes the door work if it didn't already.

## Changelog

:cl:
fix: Tram: Engine room external airlock access corrected.
/:cl:
