### PR TITLE
ports moveloop comparison from bee(and fixes goliaths not chasing people)

### DIFF
--- a/code/controllers/subsystem/movement/move_handler.dm
+++ b/code/controllers/subsystem/movement/move_handler.dm
@@ -76,9 +76,13 @@ SUBSYSTEM_DEF(move_manager)
 ///Adds a loop to our parent. Returns the created loop if a success, null otherwise
 /datum/movement_packet/proc/add_loop(datum/controller/subsystem/movement/subsystem, datum/move_loop/loop_type, priority, flags, datum/extra_info)
 	var/datum/move_loop/existing_loop = existing_loops[subsystem]
+
 	if(existing_loop && existing_loop.priority > priority)
 		if(!(existing_loop.flags & MOVEMENT_LOOP_IGNORE_PRIORITY) && !(flags & MOVEMENT_LOOP_IGNORE_PRIORITY))
 			return //Give up
+
+	if(existing_loop?.compare_loops(arglist(args.Copy(2))))
+		return //it already exists stop trying to make the same moveloop
 
 	var/datum/move_loop/new_loop = new loop_type(src, subsystem, parent, priority, flags, extra_info) //Pass the mob to move and ourselves in via new
 	var/list/arguments = args.Copy(6) //Just send the args we've not already dealt with

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -44,7 +44,7 @@
 	src.lifetime = timeout
 	return TRUE
 
-///proc that exists so we can check if this exact moveloop datum already exists (in terms of vars) and so we can stop it from needlessly create a new one to overwrite the old one
+///check if this exact moveloop datum already exists (in terms of vars) so we can avoid creating a new one to overwrite the old duplicate
 /datum/move_loop/proc/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay = 1, timeout = INFINITY)
 	SHOULD_CALL_PARENT(TRUE)
 	if(loop_type == type && priority == src.priority && flags == src.flags && delay == src.delay && timeout == lifetime)

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -49,6 +49,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if(loop_type == type && priority == src.priority && flags == src.flags && delay == src.delay && timeout == lifetime)
 		return TRUE
+	return FALSE
 
 /datum/move_loop/proc/start_loop()
 	SHOULD_CALL_PARENT(TRUE)
@@ -151,6 +152,7 @@
 /datum/move_loop/move/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, dir)
 	if(..() && direction == dir)
 		return TRUE
+	return FALSE
 
 /datum/move_loop/move/move()
 	var/atom/old_loc = moving.loc
@@ -231,6 +233,7 @@
 /datum/move_loop/has_target/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing)
 	if(..() && chasing == target)
 		return TRUE
+	return FALSE
 
 /datum/move_loop/has_target/Destroy()
 	target = null
@@ -359,6 +362,7 @@
 /datum/move_loop/has_target/jps/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, repath_delay, max_path_length, minimum_distance, obj/item/card/id/id, simulated_only, turf/avoid, skip_first)
 	if(..() && repath_delay == src.repath_delay && max_path_length == src.max_path_length && minimum_distance == src.minimum_distance && id == src.id && simulated_only == src.simulated_only && avoid == src.avoid)
 		return TRUE
+	return FALSE
 
 /datum/move_loop/has_target/jps/start_loop()
 	. = ..()
@@ -414,6 +418,7 @@
 /datum/move_loop/has_target/dist_bound/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, dist = 0)
 	if(..() && distance == dist)
 		return TRUE
+	return FALSE
 
 ///Returns FALSE if the movement should pause, TRUE otherwise
 /datum/move_loop/has_target/dist_bound/proc/check_dist()
@@ -562,6 +567,7 @@
 /datum/move_loop/has_target/move_towards/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, home = FALSE)
 	if(..() && home == src.home)
 		return TRUE
+	return FALSE
 
 /datum/move_loop/has_target/move_towards/Destroy()
 	if(home)
@@ -712,8 +718,9 @@
 	potential_directions = directions
 
 /datum/move_loop/move_rand/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, list/directions)
-	if(..() && (length(potential_directions | directions) == length(potential_directions))) //i guess this could be usefull if actually it really has yet to move
+	if(..() && (length(potential_directions | directions) == length(potential_directions))) //i guess this could be useful if actually it really has yet to move
 		return TRUE
+	return FALSE
 
 /datum/move_loop/move_rand/move()
 	var/list/potential_dirs = potential_directions.Copy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a port of my PR from the beestation downstream https://github.com/BeeStation/BeeStation-Hornet/pull/6845.
This basically adds a proc that will check if the arguments forwarded to generate the new moveloop are identical with the ones on maybe an old loop before it allows it to overwrite it that way we won't endlessly make new loops and destroy old ones even trough there is no reason to.
closes https://github.com/tgstation/tgstation/issues/64510
alternative solution to https://github.com/tgstation/tgstation/pull/67040

Now the reason why this fixes goliaths chasing others is because goliaths have a movement delay of like 4 seconds enough time for the proc adding the moveloop to chase the target to fire again and add a new moveloop with the same arguments basically overwriting the old moveloop before that one could move the goliath even once this then basically resets the timer for the goliath to move and this goes on pretty much forever the only times the goliath can move is if lag somehow allows the moveloop to move the parent atom before it can get overwritten again (very rare but happened like once during testing).
Now my PR simply stops new identical moveloops  (identical in terms of arguments) to get created and to overwrite old moveloops and thus allows the moveloop to continue normally and actually fire for goliaths.

## Why It's Good For The Game

stops unnecessary moveloop datums from beeing created and also fixes a bug as a bonus

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes goliath not chasing people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
