### PR TITLE
adds the kinesis+ module

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -327,6 +327,7 @@
 		/obj/item/mod/module/timestopper,
 		/obj/item/mod/module/rewinder,
 		/obj/item/mod/module/tem,
+		/obj/item/mod/module/anomaly_locked/kinesis/plus,
 	)
 
 /obj/item/mod/control/pre_equipped/debug
@@ -352,6 +353,7 @@
 		/obj/item/mod/module/quick_carry/advanced,
 		/obj/item/mod/module/magboot/advanced,
 		/obj/item/mod/module/jetpack,
+		/obj/item/mod/module/anomaly_locked/kinesis/plus,
 	)
 
 //these exist for the prefs menu

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -15,14 +15,25 @@
 	overlay_state_inactive = "module_kinesis"
 	overlay_state_active = "module_kinesis_on"
 	accepted_anomalies = list(/obj/item/assembly/signaler/anomaly/grav)
+	/// Range of the knesis grab.
 	var/grab_range = 5
+	/// Time between us hitting objects with kinesis.
 	var/hit_cooldown_time = 1 SECONDS
-	var/movement_animation
+	/// Stat required for us to grab a mob.
+	var/stat_required = DEAD
+	/// How long we stun a mob for.
+	var/mob_stun_time = 5 SECONDS
+	/// Atom we grabbed with kinesis.
 	var/atom/movable/grabbed_atom
+	/// Ref of the beam following the grabbed atom.
 	var/datum/beam/kinesis_beam
+	/// Overlay we add to each grabbed atom.
 	var/mutable_appearance/kinesis_icon
+	/// Our mouse movement catcher.
 	var/atom/movable/screen/fullscreen/kinesis/kinesis_catcher
+	/// The sounds playing while we grabbed an object.
 	var/datum/looping_sound/gravgen/kinesis/soundloop
+	/// The cooldown between us hitting objects with kinesis.
 	COOLDOWN_DECLARE(hit_cooldown)
 
 /obj/item/mod/module/anomaly_locked/kinesis/Initialize(mapload)
@@ -30,12 +41,6 @@
 	soundloop = new(src)
 
 /obj/item/mod/module/anomaly_locked/kinesis/Destroy()
-	if(grabbed_atom)
-		kinesis_catcher = null
-		mod.wearer.clear_fullscreen("kinesis")
-		grabbed_atom.cut_overlay(kinesis_icon)
-		QDEL_NULL(kinesis_beam)
-		grabbed_atom.animate_movement = movement_animation
 	QDEL_NULL(soundloop)
 	return ..()
 
@@ -143,7 +148,7 @@
 		if(!isliving(movable_target))
 			return FALSE
 		var/mob/living/living_target = movable_target
-		if(living_target.stat != DEAD)
+		if(living_target.stat < stat_required)
 			return FALSE
 	else if(isitem(movable_target))
 		var/obj/item/item_target = movable_target

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -60,6 +60,9 @@
 		return
 	drain_power(use_power_cost)
 	grabbed_atom = target
+	if(isliving(grabbed_atom))
+		var/mob/living/grabbed_mob = grabbed_atom
+		grabbed_mob.Stun(mob_stun_time)
 	playsound(grabbed_atom, 'sound/effects/contractorbatonhit.ogg', 75, TRUE)
 	START_PROCESSING(SSfastprocess, src)
 	kinesis_icon = mutable_appearance(icon='icons/effects/effects.dmi', icon_state="kinesis", layer=grabbed_atom.layer-0.1)
@@ -256,3 +259,14 @@
 	given_turf = locate(mob_x+our_x-round(view[1]/2),mob_y+our_y-round(view[2]/2),mob_z)
 	given_x = round(icon_x - world.icon_size * our_x, 1)
 	given_y = round(icon_y - world.icon_size * our_y, 1)
+
+/obj/item/mod/module/anomaly_locked/kinesis/plus
+	name = "MOD kinesis+ module"
+	desc = "A modular plug-in to the forearm, this module was recently redeveloped in secret. \
+		The bane of all ne'er-do-wells, the kinesis+ module is a powerful tool that allows the user \
+		to manipulate the world around them. Like it's older counterpart, it's capable of manipulating \
+		structures, machinery, vehicles, and, thanks to the fruitful efforts of it's creators - living  \
+		beings. They can, however, still struggle after an initial burst of inertia."
+	complexity = 0
+	prebuilt = TRUE
+	stat_required = CONSCIOUS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
original pr: https://github.com/tgstation/tgstation/pull/65823
documents, cleans up some code in kinesis code and adds the ability for it to grab mobs through a var edit
adds a kinesis+ module that can grab mobs, gives it to chrono legionnaires and admin modsuits

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
![image](https://user-images.githubusercontent.com/23585223/169489632-ab33c8f6-dea5-459e-9528-bd2c1ee65b17.png)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Fikou, unit0016
add: Chrono Legionnaire and Admin MODsuits now have the ability to hold mobs with kinesis.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
