### PR TITLE
Revert "You can now emag tram crossing signals to disable their motion sensors (#67123)"

### DIFF
--- a/code/game/machinery/crossing_signal.dm
+++ b/code/game/machinery/crossing_signal.dm
@@ -53,14 +53,6 @@
 	if(tram_part)
 		UnregisterSignal(tram_part, COMSIG_TRAM_SET_TRAVELLING)
 
-/obj/machinery/crossing_signal/emag_act(mob/living/user)
-	if(obj_flags & EMAGGED)
-		return
-	balloon_alert(user, "disabled motion sensors")
-	if(signal_state != XING_STATE_GREEN)
-		set_signal_state(XING_STATE_GREEN)
-	obj_flags |= EMAGGED
-
 /**
  * Finds the tram, just like the tram computer
  *
@@ -92,9 +84,6 @@
  * Returns whether we are still processing.
  */
 /obj/machinery/crossing_signal/proc/update_operating()
-	//emagged crossing signals dont update
-	if(obj_flags & EMAGGED)
-		return
 	// Immediately process for snappy feedback
 	var/should_process = process() != PROCESS_KILL
 	if(should_process)


### PR DESCRIPTION
## About The Pull Request

You can no longer emag crossing signals.

## Why It's Good For The Game

People are just going to ignore the crossing signals because people are going to emag them every single round they can get an emag. It turns the crossing signals into something people ignore for tricking them instead of something they fall for. SS13 players fall for something exactly once, and then after that they assume it's trapped every single round.

In short, letting people emag the crossing signals defeats the point of having the crossing signals in the first place.

## Changelog
:cl:
del: Crossing signals can no longer be emagged.
/:cl: