### PR TITLE
cascade rift is a proper portal now

### DIFF
--- a/code/modules/power/supermatter/supermatter_cascade_components.dm
+++ b/code/modules/power/supermatter/supermatter_cascade_components.dm
@@ -116,8 +116,8 @@
 		var/mob/living/consumed_mob = consumed_object
 		if(consumed_mob.status_flags & GODMODE)
 			return
-		message_admins("[src] has consumed [key_name_admin(consumed_mob)] [ADMIN_JMP(src)].")
-		investigate_log("has consumed [key_name(consumed_mob)].", INVESTIGATE_ENGINE)
+		message_admins("[key_name_admin(consumed_mob)] has entered [src] [ADMIN_JMP(src)].")
+		investigate_log("was entered by [key_name(consumed_mob)].", INVESTIGATE_ENGINE)
 		consumed_mob.forceMove(arrival_turf)
 		consumed_mob.Paralyze(100)
 		consumed_mob.adjustBruteLoss(30)

--- a/code/modules/power/supermatter/supermatter_cascade_components.dm
+++ b/code/modules/power/supermatter/supermatter_cascade_components.dm
@@ -32,7 +32,7 @@
 		light_range = 0
 		return PROCESS_KILL
 
-	COOLDOWN_START(src, sm_wall_cooldown, rand(0, 5 SECONDS))
+	COOLDOWN_START(src, sm_wall_cooldown, rand(0, 3 SECONDS))
 
 	var/picked_dir = pick_n_take(available_dirs)
 	var/turf/next_turf = get_step_multiz(src, picked_dir)
@@ -45,8 +45,6 @@
 		if(isliving(checked_atom))
 			qdel(checked_atom)
 		else if(ismob(checked_atom)) // Observers, AI cameras.
-			continue
-		else if(istype(checked_atom, /obj/cascade_portal))
 			continue
 		else
 			qdel(checked_atom)
@@ -113,12 +111,16 @@
  */
 /obj/cascade_portal/proc/consume(atom/movable/consumed_object)
 	if(isliving(consumed_object))
+		var/list/arrival_turfs = get_area_turfs(/area/centcom/evacuation)
+		var/turf/arrival_turf = pick(arrival_turfs)
 		var/mob/living/consumed_mob = consumed_object
 		if(consumed_mob.status_flags & GODMODE)
 			return
 		message_admins("[src] has consumed [key_name_admin(consumed_mob)] [ADMIN_JMP(src)].")
 		investigate_log("has consumed [key_name(consumed_mob)].", INVESTIGATE_ENGINE)
-		consumed_mob.dust(force = TRUE)
+		consumed_mob.forceMove(arrival_turf)
+		consumed_mob.Paralyze(100)
+		consumed_mob.adjustBruteLoss(30)
 	else if(consumed_object.flags_1 & SUPERMATTER_IGNORES_1)
 		return
 	else if(isobj(consumed_object))

--- a/code/modules/power/supermatter/supermatter_delamination.dm
+++ b/code/modules/power/supermatter/supermatter_delamination.dm
@@ -177,7 +177,7 @@
 	pick_rift_location()
 	warn_crew()
 	supermatter_turf.ChangeTurf(/turf/closed/indestructible/supermatter_wall)
-	for(var/i in 1 to rand(2,5))
+	for(var/i in 1 to rand(4,6))
 		var/turf/crystal_cascade_location = get_turf(pick(GLOB.generic_event_spawns))
 		crystal_cascade_location.ChangeTurf(/turf/closed/indestructible/supermatter_wall)
 
@@ -194,6 +194,7 @@
 /datum/supermatter_delamination/proc/pick_rift_location()
 	var/turf/rift_location = get_turf(pick(GLOB.generic_event_spawns))
 	cascade_rift = new /obj/cascade_portal(rift_location)
+	RegisterSignal(cascade_rift, COMSIG_PARENT_QDELETING, .proc/deleted_portal)
 
 /**
  * Warns the crew about the cascade start and the rift location
@@ -205,12 +206,17 @@
 	priority_announce("Unknown harmonance affecting local spatial substructure, all nearby matter is starting to crystallize.", "Central Command Higher Dimensional Affairs", 'sound/misc/bloblarm.ogg')
 	priority_announce("There's been a sector-wide electromagnetic pulse. All of our systems are heavily damaged, including those required for emergency shuttle navigation. \
 		We can only reasonably conclude that a supermatter cascade has been initiated on or near your station. \
-		Evacuation is no longer possible by conventional means; however, a bluespace rift of unkown origin has appeared near the [get_area_name(cascade_rift)]. \
+		Evacuation is no longer possible by conventional means; however, we managed to open a rift near the [span_boldannounce(get_area_name(cascade_rift))]. \
 		All personnel are hereby advised to enter the rift using all means available. Retrieval of survivors will be conducted upon recovery of necessary facilities. \
-		One minute before total loss of the station and nearby space. Good l\[\[###!!!-")
+		Good l\[\[###!!!-")
 
 
 	addtimer(CALLBACK(src, .proc/delta), 10 SECONDS)
+
+/datum/supermatter_delamination/proc/deleted_portal()
+	SIGNAL_HANDLER
+
+	priority_announce("The rift has been destroyed, we can no longer help you...", "Warning", 'sound/misc/bloblarm.ogg')
 
 	addtimer(CALLBACK(src, .proc/last_message), 50 SECONDS)
 
@@ -227,7 +233,7 @@
  * Announces the last message to the station
  */
 /datum/supermatter_delamination/proc/last_message()
-	priority_announce("To the remaining survivors of [station_name()], I hope it was worth it.", " ", 'sound/misc/bloop.ogg')
+	priority_announce("To the remaining survivors of [station_name()], We're sorry.", " ", 'sound/misc/bloop.ogg')
 
 /**
  * Ends the round


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Centcom managed to open the rift during a cascade to bring you to safety, now it will teleport you there instead of dusting you. The cascade duration has been changed to make it so that people can still reach the portal in time. Once the portal gets eaten, the one minute countdown starts.
To try and prevent the rounds from going too long, the number of walls spawned has been increased to a random between 4 and 6 all around the station.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The portal was still missing a proper way to save yourself from the crystal doom, now you can run to the portal and get teleported back to centcom. Team antags can cooperate to stop anyone from going inside the portal till the last minutes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Cascade rift is now a portal that teleports you to centcom evac instead of dusting you. 
balance: There are more crystal walls spawned around the station and the timing of the cascade has been changed to start the one minute countdown after the portal has been eaten.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
