### PR TITLE
Standardizes ID cases and fixes cell charger/APC module

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -171,7 +171,7 @@
 
 /datum/design/apc_board
 	name = "APC Module"
-	id = "power control"
+	id = "power_control"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 100, /datum/material/glass = 100)
 	build_path = /obj/item/electronics/apc

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -250,7 +250,7 @@
 /datum/design/subspace_ansible
 	name = "Subspace Ansible"
 	desc = "A compact module capable of sensing extradimensional activity."
-	id = "s-ansible"
+	id = "s_ansible"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 100, /datum/material/silver = 100)
 	build_path = /obj/item/stock_parts/subspace/ansible
@@ -260,7 +260,7 @@
 /datum/design/hyperwave_filter
 	name = "Hyperwave Filter"
 	desc = "A tiny device capable of filtering and converting super-intense radiowaves."
-	id = "s-filter"
+	id = "s_filter"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 100, /datum/material/silver = 100)
 	build_path = /obj/item/stock_parts/subspace/filter
@@ -270,7 +270,7 @@
 /datum/design/subspace_amplifier
 	name = "Subspace Amplifier"
 	desc = "A compact micro-machine capable of amplifying weak subspace transmissions."
-	id = "s-amplifier"
+	id = "s_amplifier"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 100, /datum/material/gold = 100, /datum/material/uranium = 100)
 	build_path = /obj/item/stock_parts/subspace/amplifier
@@ -280,7 +280,7 @@
 /datum/design/subspace_treatment
 	name = "Subspace Treatment Disk"
 	desc = "A compact micro-machine capable of stretching out hyper-compressed radio waves."
-	id = "s-treatment"
+	id = "s_treatment"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 100, /datum/material/silver = 200)
 	build_path = /obj/item/stock_parts/subspace/treatment
@@ -290,7 +290,7 @@
 /datum/design/subspace_analyzer
 	name = "Subspace Analyzer"
 	desc = "A sophisticated analyzer capable of analyzing cryptic subspace wavelengths."
-	id = "s-analyzer"
+	id = "s_analyzer"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 100, /datum/material/gold = 100)
 	build_path = /obj/item/stock_parts/subspace/analyzer
@@ -300,7 +300,7 @@
 /datum/design/subspace_crystal
 	name = "Ansible Crystal"
 	desc = "A sophisticated analyzer capable of analyzing cryptic subspace wavelengths."
-	id = "s-crystal"
+	id = "s_crystal"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/glass = 800, /datum/material/silver = 100, /datum/material/gold = 100)
 	build_path = /obj/item/stock_parts/subspace/crystal
@@ -310,7 +310,7 @@
 /datum/design/subspace_transmitter
 	name = "Subspace Transmitter"
 	desc = "A large piece of equipment used to open a window into the subspace dimension."
-	id = "s-transmitter"
+	id = "s_transmitter"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/glass = 100, /datum/material/silver = 100, /datum/material/uranium = 100)
 	build_path = /obj/item/stock_parts/subspace/transmitter

--- a/code/modules/research/designs/telecomms_designs.dm
+++ b/code/modules/research/designs/telecomms_designs.dm
@@ -5,7 +5,7 @@
 /datum/design/board/subspace_receiver
 	name = "Machine Design (Subspace Receiver)"
 	desc = "Allows for the construction of Subspace Receiver equipment."
-	id = "s-receiver"
+	id = "s_receiver"
 	build_path = /obj/item/circuitboard/machine/telecomms/receiver
 	category = list("Subspace Telecomms")
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
@@ -13,7 +13,7 @@
 /datum/design/board/telecomms_bus
 	name = "Machine Design (Bus Mainframe)"
 	desc = "Allows for the construction of Telecommunications Bus Mainframes."
-	id = "s-bus"
+	id = "s_bus"
 	build_path = /obj/item/circuitboard/machine/telecomms/bus
 	category = list("Subspace Telecomms")
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
@@ -21,7 +21,7 @@
 /datum/design/board/telecomms_hub
 	name = "Machine Design (Hub Mainframe)"
 	desc = "Allows for the construction of Telecommunications Hub Mainframes."
-	id = "s-hub"
+	id = "s_hub"
 	build_path = /obj/item/circuitboard/machine/telecomms/hub
 	category = list("Subspace Telecomms")
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
@@ -29,7 +29,7 @@
 /datum/design/board/telecomms_relay
 	name = "Machine Design (Relay Mainframe)"
 	desc = "Allows for the construction of Telecommunications Relay Mainframes."
-	id = "s-relay"
+	id = "s_relay"
 	build_path = /obj/item/circuitboard/machine/telecomms/relay
 	category = list("Subspace Telecomms")
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
@@ -37,7 +37,7 @@
 /datum/design/board/telecomms_processor
 	name = "Machine Design (Processor Unit)"
 	desc = "Allows for the construction of Telecommunications Processor equipment."
-	id = "s-processor"
+	id = "s_processor"
 	build_path = /obj/item/circuitboard/machine/telecomms/processor
 	category = list("Subspace Telecomms")
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
@@ -45,7 +45,7 @@
 /datum/design/board/telecomms_server
 	name = "Machine Design (Server Mainframe)"
 	desc = "Allows for the construction of Telecommunications Servers."
-	id = "s-server"
+	id = "s_server"
 	build_path = /obj/item/circuitboard/machine/telecomms/server
 	category = list("Subspace Telecomms")
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
@@ -53,7 +53,7 @@
 /datum/design/board/telecomms_messaging
 	name = "Machine Design (Messaging Server)"
 	desc = "Allows for the construction of Telecommunications Messaging Servers."
-	id = "s-messaging"
+	id = "s_messaging"
 	build_path = /obj/item/circuitboard/machine/telecomms/message_server
 	category = list("Subspace Telecomms")
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
@@ -61,7 +61,7 @@
 /datum/design/board/subspace_broadcaster
 	name = "Machine Design (Subspace Broadcaster)"
 	desc = "Allows for the construction of Subspace Broadcasting equipment."
-	id = "s-broadcaster"
+	id = "s_broadcaster"
 	build_path = /obj/item/circuitboard/machine/telecomms/broadcaster
 	category = list("Subspace Telecomms")
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -196,7 +196,7 @@
 /datum/design/large_grenade
 	name = "Large Grenade"
 	desc = "A grenade that affects a larger area and use larger containers."
-	id = "large_Grenade"
+	id = "large_grenade"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 3000)
 	build_path = /obj/item/grenade/chem_grenade/large
@@ -206,7 +206,7 @@
 /datum/design/pyro_grenade
 	name = "Pyro Grenade"
 	desc = "An advanced grenade that is able to self ignite its mixture."
-	id = "pyro_Grenade"
+	id = "pyro_grenade"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 2000, /datum/material/plasma = 500)
 	build_path = /obj/item/grenade/chem_grenade/pyro
@@ -216,7 +216,7 @@
 /datum/design/cryo_grenade
 	name = "Cryo Grenade"
 	desc = "An advanced grenade that rapidly cools its contents upon detonation."
-	id = "cryo_Grenade"
+	id = "cryo_grenade"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 2000, /datum/material/silver = 500)
 	build_path = /obj/item/grenade/chem_grenade/cryo
@@ -226,7 +226,7 @@
 /datum/design/adv_grenade
 	name = "Advanced Release Grenade"
 	desc = "An advanced grenade that can be detonated several times, best used with a repeating igniter."
-	id = "adv_Grenade"
+	id = "adv_grenade"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 3000, /datum/material/glass = 500)
 	build_path = /obj/item/grenade/chem_grenade/adv_release

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -492,7 +492,6 @@
 		"atmosalerts",
 		"autolathe",
 		"cell_charger",
-		"cell_charger",
 		"crystallizer",
 		"electrolyzer",
 		"emergency_oxygen",
@@ -509,7 +508,7 @@
 		"plasma_tank",
 		"plasmaman_tank_belt",
 		"pneumatic_seal",
-		"power control",
+		"power_control",
 		"powermonitor",
 		"recharger",
 		"recycler",
@@ -1069,21 +1068,21 @@
 		"comm_monitor",
 		"comm_server",
 		"ntnet_relay",
-		"s-amplifier",
-		"s-analyzer",
-		"s-ansible",
-		"s-broadcaster",
-		"s-bus",
-		"s-crystal",
-		"s-filter",
-		"s-hub",
-		"s-messaging",
-		"s-processor",
-		"s-receiver",
-		"s-relay",
-		"s-server",
-		"s-transmitter",
-		"s-treatment",
+		"s_amplifier",
+		"s_analyzer",
+		"s_ansible",
+		"s_broadcaster",
+		"s_bus",
+		"s_crystal",
+		"s_filter",
+		"s_hub",
+		"s_messaging",
+		"s_processor",
+		"s_receiver",
+		"s_relay",
+		"s_server",
+		"s_transmitter",
+		"s_treatment",
 	)
 
 /datum/techweb_node/integrated_hud
@@ -1133,7 +1132,7 @@
 	description = "Smart freezing of objects to preserve them!"
 	prereq_ids = list("adv_engi", "biotech")
 	design_ids = list(
-		"cryo_Grenade",
+		"cryo_grenade",
 		"cryotube",
 		"splitbeaker",
 		"stasis",
@@ -1348,7 +1347,9 @@
 	id = "adv_rcd_upgrade"
 	display_name = "Advanced RCD Designs Upgrade"
 	description = "Unlocks new RCD designs."
-	design_ids = list("rcd_upgrade_silo_link")
+	design_ids = list(
+		"rcd_upgrade_silo_link",
+	)
 	prereq_ids = list(
 		"bluespace_travel",
 		"rcd_upgrade",
@@ -1427,9 +1428,9 @@
 	description = "If the light stuff just won't do it."
 	prereq_ids = list("adv_weaponry")
 	design_ids = list(
-		"adv_Grenade",
-		"large_Grenade",
-		"pyro_Grenade",
+		"adv_grenade",
+		"large_grenade",
+		"pyro_grenade",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 


### PR DESCRIPTION
## About The Pull Request

Removes cell chargers showing up twice in Industrial Engineering, and fixes the APC module's sprite.
To prevent more bugs like this, I standardized other IDs to all use snake_case.

![image](https://user-images.githubusercontent.com/53777086/169604257-17d3891e-b581-4579-8260-bd51b1883b50.png)

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/67163

## Changelog

:cl:
fix: Cell chargers no longer show up twice in Industrial Engineering's research node, and APC modules don't look like a Golem shell.
/:cl: