### PR TITLE
Fixes accidental nerfs to rust and blade heretic ascension 

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -369,7 +369,7 @@
 	. = ..()
 	priority_announce("[generate_heretic_text()] Master of blades, the Colonel's disciple, [user.real_name] has ascended! Their steel is that which will cut reality in a maelstom of silver! [generate_heretic_text()]","[generate_heretic_text()]", ANNOUNCER_SPANOMALIES)
 	user.client?.give_award(/datum/award/achievement/misc/blade_ascension, user)
-	ADD_TRAIT(user, TRAIT_BATON_RESISTANCE, name)
+	ADD_TRAIT(user, TRAIT_STUNIMMUNE, name)
 	ADD_TRAIT(user, TRAIT_NEVER_WOUNDED, name)
 	RegisterSignal(user, COMSIG_HERETIC_BLADE_ATTACK, .proc/on_eldritch_blade)
 	user.apply_status_effect(/datum/status_effect/protective_blades/recharging, null, 8, 30, 0.25 SECONDS, 1 MINUTES)

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -201,7 +201,7 @@
 	var/area/ritual_location = /area/station/command/bridge
 	/// A static list of traits we give to the heretic when on rust.
 	var/static/list/conditional_immunities = list(
-		TRAIT_BATON_RESISTANCE,
+		TRAIT_STUNIMMUNE,
 		TRAIT_SLEEPIMMUNE,
 		TRAIT_PUSHIMMUNE,
 		TRAIT_SHOCKIMMUNE,


### PR DESCRIPTION
## About The Pull Request

#66788 accidentally replaced `stunimmune` with `baton_resistance` in two places. 
![image](https://user-images.githubusercontent.com/51863163/169605592-7d69a1bb-345d-47ef-85d3-96e268310c22.png)
![image](https://user-images.githubusercontent.com/51863163/169605620-b6e8d0f7-74c6-4779-8a65-d056e80154b3.png)
This PR undoes that. 
Fixes #67169

## Why It's Good For The Game

Accidental major nerf to some heretic ascensions. 

## Changelog

:cl: Melbert
fix: Rust and Blade ascension make you stun immune again
/:cl:
