### PR TITLE
Fixes the exploit allowing you to stack up absurd mood bonuses using the Holodeck pet garden. Petting 10 animals no longer counts as individual mood bonuses, and will instead replace eachother.

### DIFF
--- a/code/datums/elements/pet_bonus.dm
+++ b/code/datums/elements/pet_bonus.dm
@@ -35,4 +35,4 @@
 	new /obj/effect/temp_visual/heart(pet.loc)
 	if(emote_message && prob(33))
 		pet.manual_emote(emote_message)
-	SEND_SIGNAL(petter, COMSIG_ADD_MOOD_EVENT, pet, moodlet, pet)
+	SEND_SIGNAL(petter, COMSIG_ADD_MOOD_EVENT, "petting_bonus", moodlet, pet)


### PR DESCRIPTION
## About The Pull Request
Fixes the exploit allowing you to stack up absurd mood bonuses using the Holodeck pet garden.
Petting 10 animals no longer counts as individual mood bonuses, and will instead replace eachother.

## Why It's Good For The Game
Exploit abuse bad.

## Changelog

:cl:
fix: Petting 10 animals no longer counts as individual mood bonuses, and will instead replace eachother.
/:cl: