### PR TITLE
Silver slime food is now toxic(causes disgust when eaten), as it's not real food.

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -452,6 +452,8 @@ Behavior that's still missing from this component that original food items had t
 			food_taste_reaction = FOOD_DISLIKED
 		else if(foodtypes & H.dna.species.liked_food)
 			food_taste_reaction = FOOD_LIKED
+	if(food_flags & FOOD_SILVER_SPAWNED) // it's not real food
+		food_taste_reaction = FOOD_TOXIC
 
 	switch(food_taste_reaction)
 		if(FOOD_TOXIC)


### PR DESCRIPTION
## About The Pull Request

Silver slime food is now toxic, as it's not real food. The food is now only good for using in projects and/or grinding down for cytology.

## Why It's Good For The Game

Xenobiology nullifying two entire jobs is dumb as shit. It's bad for jobs to be nullified by science, this is called bad game design, and if you don't understand what bad game design is maybe go back to playing roblox

xenobiology can now use the silver slime food for grinding down and using the actual food items, not for consumption, so that they can produce food items without stepping on the toes of the botanists and chefs.

## Changelog

:cl:
balance: Silver slime food is now toxic, as it's not real food.
/:cl:
