### PR TITLE
Fixes some wall objects and a doublewall in icebox engineering

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10608,7 +10608,8 @@
 	},
 /obj/machinery/computer/security/telescreen/ce{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = -1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -11238,10 +11239,11 @@
 /obj/machinery/disposal/bin,
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/item/radio/intercom/directional/south,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
 "dBY" = (
@@ -31547,6 +31549,7 @@
 /obj/machinery/atmospherics/components/binary/pressure_valve/on{
 	name = "Waste Release"
 	},
+/obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kgc" = (
@@ -37852,12 +37855,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -7
-	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/empty,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "miG" = (
@@ -51038,7 +51035,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qvW" = (
-/obj/machinery/firealarm/directional/south,
 /obj/structure/table,
 /obj/item/storage/belt/utility,
 /obj/item/t_scanner,
@@ -61978,7 +61974,7 @@
 	dir = 8
 	},
 /obj/structure/sign/poster/official/build{
-	pixel_x = 32
+	pixel_y = 32
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
@@ -71139,6 +71135,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"wUE" = (
+/obj/machinery/light_switch/directional/north{
+	pixel_x = -7
+	},
+/obj/structure/table,
+/obj/item/stock_parts/cell/high/empty,
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/engineering/lobby)
 "wUJ" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/tile/yellow{
@@ -74703,7 +74709,6 @@
 /area/station/cargo/storage)
 "ycX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ycY" = (
@@ -236023,7 +236028,7 @@ vvv
 tTV
 jtA
 bID
-bID
+wUE
 miw
 tSA
 cMd


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some wall objects meshing together in engineering on IceBox.
Tweaks a room a bit in the engineering foyer to avoid 2x2 walls
![image](https://user-images.githubusercontent.com/63861499/169635421-913b99d1-3596-444e-8876-3d48a9e18d47.png)


## Why It's Good For The Game

Aesthetics 😎 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Moved around some overlapping wall objects in engineering on IceBox
qol: Removed a 2x2 wall in engineering on IceBox
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
