### PR TITLE
Rearranges some wall objects in science and downstairs medical on icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -407,7 +407,6 @@
 "aiH" = (
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/rd)
 "aiT" = (
@@ -10348,6 +10347,7 @@
 	c_tag = "Research Directors Observation Deck";
 	network = list("ss13","rd")
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/rd)
 "dnk" = (
@@ -32941,7 +32941,6 @@
 "kBT" = (
 /obj/structure/table,
 /obj/item/retractor,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "kBV" = (
@@ -35531,10 +35530,8 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
-/obj/machinery/requests_console/directional/south{
-	department = "Virology";
-	name = "Virology Requests Console";
-	receive_ore_updates = 1
+/obj/structure/sign/warning/electric_shock{
+	pixel_y = -32
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -40896,6 +40893,9 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/obj/structure/sign/warning/electric_shock{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "nmg" = (
@@ -41272,12 +41272,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/smooth_half,
 /area/station/security/brig/upper)
-"nrZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/sign/warning/electric_shock,
-/turf/open/floor/plating,
-/area/station/medical/virology)
 "nsc" = (
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
@@ -41459,6 +41453,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"nvX" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "nwd" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable,
@@ -49224,7 +49226,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12;
@@ -49234,6 +49235,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/dark,
+/obj/machinery/requests_console/directional/west{
+	department = "Virology";
+	name = "Virology Requests Console";
+	receive_ore_updates = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "pQG" = (
@@ -52753,7 +52759,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "qXz" = (
@@ -55363,7 +55368,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/lapvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -57300,6 +57304,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "syh" = (
@@ -65206,6 +65211,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "vey" = (
@@ -67509,6 +67515,7 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/surgical_drapes,
 /obj/item/razor,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "vPF" = (
@@ -178692,7 +178699,7 @@ tMk
 xDb
 pGS
 xEh
-nrZ
+pGS
 ceE
 pGS
 xDb
@@ -179715,7 +179722,7 @@ eqB
 ako
 fDH
 jeI
-nrZ
+pGS
 cDb
 dYn
 jWd
@@ -181260,7 +181267,7 @@ xDb
 huH
 qWD
 oQY
-dRz
+nvX
 jUB
 rOH
 lPC
@@ -189453,7 +189460,7 @@ lvt
 lvt
 lvt
 lvt
-lvt
+wrX
 wrX
 wrX
 daj


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the rest of the overlapping wall objects on IceBox. I audited the rest of the map and these are the last that I could find. Also fixed some posters that were on shocked windows.

## Why It's Good For The Game

We want the game to look good for ghosts and AIs as well as players.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The rest of the overlapping wall objects on IceBox are no longer overlapping.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
