### PR TITLE
Remove Meta's medbay central light switch

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12182,7 +12182,6 @@
 /obj/structure/sign/warning/chem_diamond{
 	pixel_y = 32
 	},
-/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the out of place and unnecessary light switch in Meta station's medbay, is a continuation of #67091 as requested by san since I kinda dinked that one

## Why It's Good For The Game

Since Meta station's medbay central is just a hallway, it doesn't make sense for it to have a light switch like other hallways. Plus, this one's is really out of place.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Removes the unnecessary light switch in Meta Station medbay central.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
