### PR TITLE
Moves APC Mapping Checks to Mapload rather than New (CI IS SAVED EDITION)

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -105,6 +105,9 @@
 	var/obj/machinery/computer/apc_control/remote_control = null
 	///Represents a signel source of power alarms for this apc
 	var/datum/alarm_handler/alarm_manager
+	// offset APC_PIXEL_OFFSET pixels in direction of dir
+	// this allows the APC to be embedded in a wall, yet still inside an area
+	var/offset_old
 
 /obj/machinery/power/apc/New(turf/loc, ndir, building=0)
 	if(!req_access)
@@ -126,9 +129,6 @@
 		addtimer(CALLBACK(src, .proc/update), 5)
 		dir = ndir
 
-	// offset APC_PIXEL_OFFSET pixels in direction of dir
-	// this allows the APC to be embedded in a wall, yet still inside an area
-	var/offset_old
 	switch(dir)
 		if(NORTH)
 			offset_old = pixel_y
@@ -142,8 +142,6 @@
 		if(WEST)
 			offset_old = pixel_x
 			pixel_x = -APC_PIXEL_OFFSET
-	if(abs(offset_old) != APC_PIXEL_OFFSET && !building)
-		log_mapping("APC: ([src]) at [AREACOORD(src)] with dir ([dir] | [uppertext(dir2text(dir))]) has pixel_[dir & (WEST|EAST) ? "x" : "y"] value [offset_old] - should be [dir & (SOUTH|EAST) ? "-" : ""][APC_PIXEL_OFFSET]. Use the directional/ helpers!")
 
 /obj/machinery/power/apc/Initialize(mapload)
 	. = ..()
@@ -182,6 +180,10 @@
 	make_terminal()
 
 	addtimer(CALLBACK(src, .proc/update), 5)
+
+	///This is how we test to ensure that mappers use the directional subtypes of APCs, rather than use the parent and pixel-shift it themselves.
+	if(abs(offset_old) != APC_PIXEL_OFFSET)
+		log_mapping("APC: ([src]) at [AREACOORD(src)] with dir ([dir] | [uppertext(dir2text(dir))]) has pixel_[dir & (WEST|EAST) ? "x" : "y"] value [offset_old] - should be [dir & (SOUTH|EAST) ? "-" : ""][APC_PIXEL_OFFSET]. Use the directional/ helpers!")
 
 /obj/machinery/power/apc/Destroy()
 	GLOB.apcs_list -= src

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -105,8 +105,7 @@
 	var/obj/machinery/computer/apc_control/remote_control = null
 	///Represents a signel source of power alarms for this apc
 	var/datum/alarm_handler/alarm_manager
-	// offset APC_PIXEL_OFFSET pixels in direction of dir
-	// this allows the APC to be embedded in a wall, yet still inside an area
+	/// Offsets the object by APC_PIXEL_OFFSET (defined in apc_defines.dm) pixels in the direction we want it placed in. This allows the APC to be embedded in a wall, yet still inside an area (like mapping).
 	var/offset_old
 
 /obj/machinery/power/apc/New(turf/loc, ndir, building=0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Everytime CI ran, we would get something like this:

```
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
APC: (the area power controller) at Test Room (126,126,6) with dir (2 | SOUTH) has pixel_y value 0 - should be -25. Use the directional/ helpers!
```

We've been dealing with this issue for a few months now, and I've grown tired of explaining the problem after I figured it out and decided to finally fix it today.

Basically, this check ran at _all_ times, rather than just on mapload (even though it logs to log_mapping). Not good, let's fix that by shuffling some stuff around. I tested this code and I was able to organically create an APC that wasn't shitted somehow, and all the APCs on load didn't appear to be absolutely fucked in some horrific way.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/169638863-529aecda-bea0-4cdf-816e-4dcf5dd01834.png)

Hey, no more mapping logging whenever create_and_destroy iterates the atom! Perfect!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: If you've been paying to the Continuous Integration logs since... the dawn of the creation of the "Create And Destroy" Unit Test, you may be pleased to know that we should now no longer have mapping errors logged as a result of that test running.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
