### PR TITLE
Tweaks Icebox botany machine placements

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -14817,13 +14817,8 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "eLT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	dir = 8;
-	name = "Hydroponics Desk";
-	req_access = list("hydroponics")
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/biogenerator,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "eMa" = (
@@ -25895,7 +25890,6 @@
 /turf/open/openspace,
 /area/station/cargo/storage)
 "irF" = (
-/obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -25909,6 +25903,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
+/obj/machinery/smartfridge,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "irO" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR will move the Icebox botany biogenerator upstairs below the smartfridge, and give botany another fridge downstairs.
![image](https://user-images.githubusercontent.com/18170896/169639973-2b130589-5568-4c89-9f72-067e42aa28ac.png)


## Why It's Good For The Game

On Icebox, the biogenerator is for some reason downstairs and only accessible by the chef who has to take a long trip to the hallway doors to get to it. Nice botanists typically move it to the spot shown, but some do not which can be really frustrating if you are the chef and depend on its products or are someone in need of cloth, leather, or monkey cubes.

Where the biogenerator was downstairs is instead replaced by another smartfridge. This is so that the botanists have a place to store the chef's crops and general crew things, and another place to store things they would prefer the crew not to have, such as toxic plants. I got this idea from Delta station, which has two different fridges.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Moved around a few of the Icebox botany machines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
