### PR TITLE
Janitorial Content: You can kick the bucket!

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -71,6 +71,20 @@
 				qdel(src)
 			return
 
+	for(var/turf_content in our_guy_pos)
+		if(istype(turf_content, /obj/item/reagent_containers/glass/bucket))
+			to_chat(living_guy, span_warning("A malevolent force pushes the bucket into your path..."))
+			var/obj/item/reagent_containers/glass/bucket/darth_bucket = turf_content
+			INVOKE_ASYNC(darth_bucket, /obj/item/reagent_containers/glass/bucket/.proc/bucket_got_kicked, TRUE)
+			living_guy.apply_status_effect(/datum/status_effect/incapacitating/paralyzed, 10)
+			if(prob(13))
+				living_guy.adjustBruteLoss(666)
+				to_chat(living_guy, span_danger("Pain rushes through all your body..."))
+				living_guy.visible_message(span_danger("[living_guy] kicks \the bucket for real this time!!"))
+			if(!permanent)
+				qdel(src)
+			return
+
 	for(var/turf/the_turf as anything in get_adjacent_open_turfs(living_guy))
 		if(the_turf.zPassOut(living_guy, DOWN) && living_guy.can_z_move(DOWN, the_turf, z_move_flags = ZMOVE_FALL_FLAGS))
 			to_chat(living_guy, span_warning("A malevolent force guides you towards the edge..."))

--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -82,7 +82,7 @@
 			continue
 		living_guy.adjustBruteLoss(666)
 		to_chat(living_guy, span_danger("Pain rushes through all your body..."))
-		living_guy.visible_message(span_danger("[living_guy] kicks \the bucket for real this time!!"))
+		living_guy.visible_message(span_danger("[living_guy] kicks the bucket for real this time!!"))
 		if(!permanent)
 			qdel(src)
 		return

--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -73,17 +73,19 @@
 
 	for(var/turf_content in our_guy_pos)
 		if(istype(turf_content, /obj/item/reagent_containers/glass/bucket))
-			to_chat(living_guy, span_warning("A malevolent force pushes the bucket into your path..."))
-			var/obj/item/reagent_containers/glass/bucket/darth_bucket = turf_content
-			INVOKE_ASYNC(darth_bucket, /obj/item/reagent_containers/glass/bucket/.proc/bucket_got_kicked, TRUE)
-			living_guy.apply_status_effect(/datum/status_effect/incapacitating/paralyzed, 10)
-			if(prob(13))
-				living_guy.adjustBruteLoss(666)
-				to_chat(living_guy, span_danger("Pain rushes through all your body..."))
-				living_guy.visible_message(span_danger("[living_guy] kicks \the bucket for real this time!!"))
-			if(!permanent)
-				qdel(src)
-			return
+			continue
+		to_chat(living_guy, span_warning("A malevolent force pushes the bucket into your path..."))
+		var/obj/item/reagent_containers/glass/bucket/darth_bucket = turf_content
+		INVOKE_ASYNC(darth_bucket, /obj/item/reagent_containers/glass/bucket/.proc/bucket_got_kicked, TRUE)
+		living_guy.apply_status_effect(/datum/status_effect/incapacitating/paralyzed, 10)
+		if(prob(13))
+			continue
+		living_guy.adjustBruteLoss(666)
+		to_chat(living_guy, span_danger("Pain rushes through all your body..."))
+		living_guy.visible_message(span_danger("[living_guy] kicks \the bucket for real this time!!"))
+		if(!permanent)
+			qdel(src)
+		return
 
 	for(var/turf/the_turf as anything in get_adjacent_open_turfs(living_guy))
 		if(the_turf.zPassOut(living_guy, DOWN) && living_guy.can_z_move(DOWN, the_turf, z_move_flags = ZMOVE_FALL_FLAGS))

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -18,7 +18,7 @@
 
 /obj/structure/janitorialcart/Initialize(mapload)
 	. = ..()
-	create_reagents(100, OPENCONTAINER)
+	create_reagents(200, OPENCONTAINER)
 	GLOB.janitor_devices += src
 
 /obj/structure/janitorialcart/Destroy()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -18,7 +18,7 @@
 
 /obj/structure/janitorialcart/Initialize(mapload)
 	. = ..()
-	create_reagents(200, OPENCONTAINER)
+	create_reagents(150, OPENCONTAINER)
 	GLOB.janitor_devices += src
 
 /obj/structure/janitorialcart/Destroy()

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -9,7 +9,7 @@
 
 /obj/structure/mopbucket/Initialize(mapload)
 	. = ..()
-	create_reagents(100, OPENCONTAINER)
+	create_reagents(200, OPENCONTAINER)
 
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/mop))

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -9,7 +9,7 @@
 
 /obj/structure/mopbucket/Initialize(mapload)
 	. = ..()
-	create_reagents(200, OPENCONTAINER)
+	create_reagents(150, OPENCONTAINER)
 
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/mop))

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -292,7 +292,6 @@
 		/obj/item/grenade/clusterbuster/cleaner = 1,
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/mop/advanced = 1,
-		/obj/item/reagent_containers/glass/bucket = 1,
 		/obj/item/storage/box/lights/mixed = 1,
 		/obj/item/storage/box/survival/engineer = 1,
 	)
@@ -416,7 +415,6 @@
 	back = /obj/item/storage/backpack/ert/janitor
 	backpack_contents = list(
 		/obj/item/mop/advanced = 1,
-		/obj/item/reagent_containers/glass/bucket = 1,
 		/obj/item/storage/box/lights/mixed = 1,
 		/obj/item/storage/box/survival/engineer = 1,
 	)

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -20,7 +20,7 @@
 		/datum/job_department/service,
 		)
 
-	family_heirlooms = list(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket, /obj/item/toy/plush/beeplushie)
+	family_heirlooms = list(/obj/item/cultivator, /obj/item/toy/plush/beeplushie)
 
 	mail_goodies = list(
 		/obj/item/reagent_containers/glass/bottle/mutagen = 20,

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -20,7 +20,7 @@
 		/datum/job_department/service,
 		)
 
-	family_heirlooms = list(/obj/item/mop, /obj/item/clothing/suit/caution, /obj/item/reagent_containers/glass/bucket, /obj/item/paper/fluff/stations/soap)
+	family_heirlooms = list(/obj/item/mop, /obj/item/clothing/suit/caution, /obj/item/paper/fluff/stations/soap)
 
 	mail_goodies = list(
 		/obj/item/grenade/chem_grenade/cleaner = 30,

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -351,7 +351,7 @@
 		/obj/item/melee/flyswatter,
 		/obj/item/extinguisher/mini,
 		/obj/item/mop/cyborg,
-		/obj/item/reagent_containers/glass/bucket,
+		/obj/item/reagent_containers/glass/bucket/cyborg,
 		/obj/item/paint/paint_remover,
 		/obj/item/lightreplacer/cyborg,
 		/obj/item/holosign_creator,

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -292,6 +292,9 @@
 	SIGNAL_HANDLER
 
 	var/mob/living/kicker = AM
+	if(!isturf(loc) || !isliving(AM))
+		return
+
 	if(istype(kicker.buckled, /obj/vehicle))
 		var/obj/vehicle/ridden_vehicle = kicker.buckled
 		bucket_got_kicked()
@@ -305,9 +308,6 @@
 		return
 
 	if(reagents?.total_volume < 100) //this is to add some cost to this trap and prevent 1u bucket spam
-		return
-
-	if(!isturf(loc) || !isliving(AM))
 		return
 
 	if(isanimal(kicker))

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -273,7 +273,6 @@
 		ITEM_SLOT_LPOCKET, ITEM_SLOT_RPOCKET,\
 		ITEM_SLOT_DEX_STORAGE
 	)
-	var/kicked_over = FALSE
 
 /obj/item/reagent_containers/glass/bucket/Initialize(mapload)
 	. = ..()
@@ -283,11 +282,13 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
+///Gets called when someone sucessfuly kicks a bucket, splashing it's reagents.
 /obj/item/reagent_containers/glass/bucket/proc/bucket_got_kicked()
 	SpinAnimation(7,1)
 	playsound(src, 'sound/effects/slosh.ogg', 50, TRUE)
 	chem_splash(loc, null, 2, list(reagents))
 
+///Checks when something has crossed the bucket and if the bucket will get kicked or not based on a few parameters
 /obj/item/reagent_containers/glass/bucket/proc/kicking_the_bucket(datum/source, atom/movable/AM, thrown_at = FALSE)
 	SIGNAL_HANDLER
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -301,7 +301,7 @@
 		pile_of_buckets += total_of_buckets
 		if(pile_of_buckets.len > 1)
 			kicker.visible_message(span_danger("[kicker] avoids the multiple buckets on the floor."), \
-			span_userdanger("You avoid the multiple buckets!"))
+				span_userdanger("You avoid the multiple buckets!"))
 			return
 
 	if(!isturf(loc) || !isliving(AM))
@@ -331,7 +331,7 @@
 	kicker.Paralyze(30)
 	bucket_got_kicked()
 	kicker.visible_message(span_danger("[kicker] kicks \the [src]."), \
-	span_userdanger("You kicked \the [src]!"))
+		span_userdanger("You kicked \the [src]!"))
 
 /obj/item/reagent_containers/glass/bucket/attackby(obj/O, mob/user, params)
 	if(istype(O, /obj/item/mop))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I was cleaning the house today and heard a noise coming from the kitchen, turns out my 5 year old decided that it was the best time for her to run around the house, kicked the bucket I had just finished using and splashed dirty water all over the kitchen.
So this pushed me to do this dumb PR.

If a singular bucket (if more than 1 bucket is on a tile they won't be kicked, this is to avoid insta kill bucket stack) with more than 50u is on the floor and you run through it will be kicked, splashing water all around it and ending with whoever kicked the bucket likely slipping on the mess. (Remember to walk when you see the warning signs!) 
Now which janitor puts their bucket on the floor? None! Backpack bucket is the meta so to make that work buckets are bulky now.
Since they are bulky they shouldn't be that worse than pocket sized beakers so I raised their volume to 100 units. Janicart and mopbucket also went from 100 to 150.
(Janiborgs don't need to manage their bucket placement + carry weight so they keep the old 70 value)

And if you have the bad luck/bad omen effect and kick the bucket, you might die!

Had to remove buckets from the ERTs' bag but they have advanced mops so they don't need it, also had to remove heirloom buckets.

Reminder that you use 1 unit of water to clean a tile, so you can clean 100 tiles before you need to refill your bucket.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![kick_the_bucket](https://user-images.githubusercontent.com/55374212/169639859-02bd992d-6a5a-4e87-b225-6a90693f18c2.png)

Janitor has a lot of effective ways to clean(mop, soap, spray, backpack, etc) but the Janitor gameplay that is more engaging for the crew is mop + bucket as the wet tiles become a small hazard that can have an effect on combat or just create crew conflict.
This expand on that side of janitors by letting them carry more water for their mop while having to take care of their bucket by placing it in a corner where it won't be easily kicked by the coworkers that NEED to run everywhere. (Or leave in their way so they learn to respect the walk signs!)


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
add: You can now kick the bucket! (If they have 50u+ of reagents) It will splash the reagents all around it. If you want to be respectful to the best NT employee just remember that walking prevents 9/10 Janitorial accidents.
balance: To push Janitors to put their buckets on the floor and be in their kickable state, buckets have been made bulky and their volume got increased from 70 to 100. Janicart and mopbucket went from 100 to 150.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
