### PR TITLE
Adds an Approved Balance/Rebalance tag to GBP that's worth 0 GBP, so that maintainers can replace the balance tag on PRs that are healthy improvements to the game

### DIFF
--- a/.github/gbp.toml
+++ b/.github/gbp.toml
@@ -4,6 +4,7 @@ reset_label = "GBP: Reset"
 [points]
 "Accessibility" = 3
 "Administration" = 2
+"Approved Balance/Rebalance" = 0
 "Atomic" = 2
 "Balance/Rebalance" = -5
 "Code Improvement" = 2
@@ -22,4 +23,3 @@ reset_label = "GBP: Reset"
 "Sound" = 3
 "Sprites" = 3
 "Unit Tests" = 6
-"Approved Balance/Rebalance" = 0

--- a/.github/gbp.toml
+++ b/.github/gbp.toml
@@ -22,3 +22,4 @@ reset_label = "GBP: Reset"
 "Sound" = 3
 "Sprites" = 3
 "Unit Tests" = 6
+"Approved Balance/Rebalance" = 0


### PR DESCRIPTION
## About The Pull Request
Adds an Approved Balance/Rebalance tag to GBP that's worth 0 GBP, so that maintainers can replace the balance tag on PRs that are healthy improvements to the game in their eyes.

## Why It's Good For The Game

We added the GBP system to punish people who add new shit constantly without actually fixing anything.

The problem is that this system pretends that balancing the game to not be an absolute dumpster fire is not fixing anything.

Someone can add a super broken overpowered thing, get charged GBP for it, and then if someone wants to make it not super broken and overpowered, they have to pay GBP for it.

We literally disincentivize developers from making an enjoyable gameplay experience this way. It's stupid. I'm tired of spending all my GBP fixing things that maintainers agree are negatively impacting the gameplay experience.

We're not just some random software library, we're a video game. We should really remember that **making the game not suck to play** is just as valuable as cool backend work.

We all like cool backend work, I know. It's clean, it's easy, you don't have to think about it, but man, at the end of the day someone has to buckle down and fix the game being shitty to play sometimes.

Yeah, people make stupid kneejerk balance PRs sometimes and they should probably be charged GBP for that, but when we've got real identified issues with something sucking absolute dogshit, we shouldn't have to spend GBP to fix it sucking absolute dogshit when Maintainers agree it sucks absolute dogshit.

### the TLDR is "backend work is just as important as making the game not suck to play, GBP currently pretends backend work is more important than making the game not suck to play, and that making the game not suck to play is a bad thing by penalizing developers who do so"

## "What about GBP: No Update?"
GBP: No Update negates *all* tags on a PR. If there's an important balance change, and I also do some code cleanup(fixing some var names to be not single letters, for example), now I don't get points for the code improvements. This lets maintainers make the balance change flagged as free while the code improvement points still go through.