### PR TITLE
Fixes a semi-rare bee hard delete

### DIFF
--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -165,16 +165,16 @@
 			to_chat(user, span_warning("This hive already has a queen!"))
 			return
 
-		var/obj/item/queen_bee/qb = I
-		user.temporarilyRemoveItemFromInventory(qb)
+		var/obj/item/queen_bee/new_queen = I
+		user.temporarilyRemoveItemFromInventory(new_queen)
 
-		qb.queen.forceMove(src)
-		bees += qb.queen
-		queen_bee = qb.queen
-		qb.queen = null
+		bees += new_queen.queen
+		queen_bee = new_queen.queen
+
+		new_queen.queen.forceMove(src)
 
 		if(queen_bee)
-			visible_message(span_notice("[user] sets [qb] down inside the apiary, making it their new home."))
+			visible_message(span_notice("[user] sets [queen_bee] down inside the apiary, making it their new home."))
 			var/relocated = 0
 			for(var/b in bees)
 				var/mob/living/simple_animal/hostile/bee/B = b
@@ -190,7 +190,6 @@
 		else
 			to_chat(user, span_warning("The queen bee disappeared! Disappearing bees have been in the news lately..."))
 
-		qdel(qb)
 		return
 
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -295,7 +295,7 @@
 	if (!beehome || loc == beehome)
 		return ..()
 
-	idle = min(100, ++idle)
+	idle = min(100, idle + 1)
 	if(idle >= BEE_IDLE_ROAMING && prob(BEE_PROB_GOROAM))
 		toggle_ai(AI_ON)
 		forceMove(beehome.drop_location())

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -320,6 +320,7 @@
 	. = ..()
 	if(gone == queen)
 		queen = null
+		qdel(src)
 
 /obj/item/queen_bee/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/syringe))

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -321,7 +321,9 @@
 	. = ..()
 	if(gone == queen)
 		queen = null
-		qdel(src)
+		// the bee should not exist without a bee.
+		if(!QDELETED(src))
+			qdel(src)
 
 /obj/item/queen_bee/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/syringe))

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -291,13 +291,14 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/bee/consider_wakeup()
-	if (beehome && loc == beehome) // If bees are chilling in their nest, they're not actively looking for targets
-		idle = min(100, ++idle)
-		if(idle >= BEE_IDLE_ROAMING && prob(BEE_PROB_GOROAM))
-			toggle_ai(AI_ON)
-			forceMove(beehome.drop_location())
-	else
+	// If bees are chilling in their nest, they're not actively looking for targets.
+	if (!beehome || loc == beehome)
 		return ..()
+
+	idle = min(100, ++idle)
+	if(idle >= BEE_IDLE_ROAMING && prob(BEE_PROB_GOROAM))
+		toggle_ai(AI_ON)
+		forceMove(beehome.drop_location())
 
 /obj/item/queen_bee
 	name = "queen bee"

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -290,14 +290,36 @@
 		return TRUE
 	return FALSE
 
+/mob/living/simple_animal/hostile/bee/consider_wakeup()
+	if (beehome && loc == beehome) // If bees are chilling in their nest, they're not actively looking for targets
+		idle = min(100, ++idle)
+		if(idle >= BEE_IDLE_ROAMING && prob(BEE_PROB_GOROAM))
+			toggle_ai(AI_ON)
+			forceMove(beehome.drop_location())
+	else
+		return ..()
+
 /obj/item/queen_bee
 	name = "queen bee"
 	desc = "She's the queen of bees, BZZ BZZ!"
 	icon_state = "queen_item"
 	inhand_icon_state = ""
 	icon = 'icons/mob/bees.dmi'
+	/// The actual mob that our bee item corresponds to
 	var/mob/living/simple_animal/hostile/bee/queen/queen
 
+/obj/item/queen_bee/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_QUEEN_BEE, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
+
+/obj/item/queen_bee/Destroy()
+	QDEL_NULL(queen)
+	return ..()
+
+/obj/item/queen_bee/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(gone == queen)
+		queen = null
 
 /obj/item/queen_bee/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/syringe))
@@ -330,26 +352,11 @@
 	qdel(src)
 	return TOXLOSS
 
-/obj/item/queen_bee/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/swabable, CELL_LINE_TABLE_QUEEN_BEE, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
+/obj/item/queen_bee/bought
 
 /obj/item/queen_bee/bought/Initialize(mapload)
 	. = ..()
 	queen = new(src)
-
-/obj/item/queen_bee/Destroy()
-	QDEL_NULL(queen)
-	return ..()
-
-/mob/living/simple_animal/hostile/bee/consider_wakeup()
-	if (beehome && loc == beehome) // If bees are chilling in their nest, they're not actively looking for targets
-		idle = min(100, ++idle)
-		if(idle >= BEE_IDLE_ROAMING && prob(BEE_PROB_GOROAM))
-			toggle_ai(AI_ON)
-			forceMove(beehome.drop_location())
-	else
-		..()
 
 /mob/living/simple_animal/hostile/bee/short
 	desc = "These bees seem unstable and won't survive for long."


### PR DESCRIPTION
## About The Pull Request

While unit-testing the nuke with #67144, I discovered that maps with roundstart bees will occasionally hard delete with my setup. So I investigated... 

Queen bees are held within in an item.
The nuke, when detonating, gibs and deletes all mobs on the z-level. 
Bees are on the z-level.
The bee within the bee item is deleted and hard deletes because it lacks reference handling if it were to be deleted. 

So, by adding some extra criteria to ensure "if the bee is deleted, get rid of the item", the hard deletes should stop too.

## Why It's Good For The Game

Stops hard deletes. 

## Changelog

:cl: Melbert
fix: Fixes a rare hard-delete with queen bees. 
/:cl:

