### PR TITLE
Fixes examination room signs and fixes sign UpdatePath

### DIFF
--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1120,7 +1120,7 @@
 /turf/open/floor/iron,
 /area/awaymission/caves/bmp_asteroid)
 "fL" = (
-/obj/structure/sign/departments/maint{
+/obj/structure/sign/departments/exam_room{
 	pixel_y = 32
 	},
 /turf/open/floor/iron,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4224,7 +4224,7 @@
 /turf/open/space/basic,
 /area/space)
 "bhd" = (
-/obj/structure/sign/departments/maint,
+/obj/structure/sign/departments/exam_room,
 /turf/closed/wall,
 /area/station/medical/treatment_center)
 "bhh" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48497,7 +48497,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/structure/sign/departments/maint{
+/obj/structure/sign/departments/exam_room{
 	color = "#52B4E9";
 	pixel_y = -32
 	},

--- a/tools/UpdatePaths/replace_sign_names.txt
+++ b/tools/UpdatePaths/replace_sign_names.txt
@@ -12,6 +12,6 @@
 /obj/structure/sign/warning/chemdiamond : /obj/structure/sign/warning/chem_diamond {@OLD}
 /obj/structure/sign/warning/radshelter : /obj/structure/sign/warning/rad_shelter {@OLD}
 
-/obj/structure/sign/departments/examroom : /obj/structure/sign/departments/maint {@OLD}
-/obj/structure/sign/departments/mait : /obj/machinery/door/window/right/directional/east {@OLD}
+/obj/structure/sign/departments/examroom : /obj/structure/sign/departments/exam_room {@OLD}
+/obj/structure/sign/departments/mait : /obj/structure/sign/departments/maint {@OLD}
 /obj/structure/sign/departments/mait/alt : /obj/structure/sign/departments/maint/alt {@OLD}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#66754 added an UpdatePath for the pathing changes it brought to signs but forgot to replace a bit when I assume they copypasted from the windoor UpdatePath.

![image](https://user-images.githubusercontent.com/25415050/169697359-3e96d38e-9468-4970-bf1f-34196bf105c6.png)

All our exam room signs turned into maintenance signs and our maintenance signs turned into wall windoors one of which was adressed in #67122. I lazily tried looking for more wall windoors but didn't find any so this PR focuses mostly on bringing back the exam room signs and fixing the UpdatePath to prevent downstreams from having to deal with more busy work. 

## Why It's Good For The Game

Signs are neat which is why I'm bringing them back, UpdatePaths not causing issues is also good for the game.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed incorrect departmental signs on Delta and Meta, as well as the Caves Gateway mission.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
