### PR TITLE
Makes the Messenger program baked into PDAs, fixing heads not getting all of their roundstart programs

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -5,10 +5,11 @@
 	program_icon_state = "command"
 	program_state = PROGRAM_STATE_BACKGROUND
 	extended_desc = "This program allows old-school communication with other modular devices."
-	size = 8
+	size = 0
+	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
+	available_on_ntnet = FALSE
 	usage_flags = PROGRAM_TABLET
 	ui_header = "ntnrc_idle.gif"
-	available_on_ntnet = TRUE
 	tgui_id = "NtosMessenger"
 	program_icon = "comment-alt"
 	alert_able = TRUE


### PR DESCRIPTION
## About The Pull Request
Basically, the messaging app was taking 8 "GQ" of storage, which meant that, once cartridges were removed, heads of staff were sometimes unable to receive all of their roundstart programs, which obviously is an issue.

After discussing it with John, it was decided to make it take up no space, be undeletable and undownloadable (apparently having it be downloadable by cyborgs is a sin, go figure), as a fix for this issue.

So here's just that. Simple enough.

Fixes https://github.com/tgstation/tgstation/issues/66996.

## Why It's Good For The Game
People should get the programs they're meant to have at roundstart, at roundstart, and shouldn't have to delete other programs they spawned with, and don't care about (talking about you, experi_track), to be able to have the ones that are genuinely useful for their job.

## Changelog

:cl: GoldenAlpharex
fix: The PDA Messenger app is now undeletable, unavailable for download and also no longer takes space on the hardware, something something bluespace cloud storage. As a result, everyone should once again be spawning with the programs they were meant to spawn with in the first place.
/:cl: