### PR TITLE
Puts Wags-His-Tail and Eats-The-Roaches back in Delta's janitor closet (extremely important)

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -51044,6 +51044,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/janitor,
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "nUz" = (
@@ -78375,7 +78376,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/landmark/start/janitor,
+/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "veu" = (
@@ -83953,6 +83954,7 @@
 	dir = 9;
 	name = "service camera"
 	},
+/mob/living/simple_animal/hostile/lizard/eats_the_roaches,
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "wzD" = (

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -25,7 +25,7 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
-	can_be_held = TRUE 
+	can_be_held = TRUE
 	var/static/list/edibles = typecacheof(list(/mob/living/simple_animal/butterfly, /mob/living/basic/cockroach)) //list of atoms, however turfs won't affect AI, but will affect consumption.
 
 /mob/living/simple_animal/hostile/lizard/Initialize(mapload)
@@ -61,3 +61,7 @@
 /mob/living/simple_animal/hostile/lizard/wags_his_tail
 	name = "Wags-His-Tail"
 	desc = "The janitorial department's trusty pet lizard."
+
+/mob/living/simple_animal/hostile/lizard/eats_the_roaches
+	name = "Eats-The-Roaches"
+	desc = "The janitorial department's less trusty pet lizard."


### PR DESCRIPTION
## About The Pull Request

Apparently I removed BOTH by accident and didn't notice

## Why It's Good For The Game

Missing lizards :(

## Changelog

:cl: Melbert
fix: Wags-His-Tail and Eats-The-Roaches have wiggled their way back from a deep space expedition to the janitorial closet of Deltastation.
/:cl:

