### PR TITLE
Removes 2 tables on the same tile in Meta atmos

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -30403,7 +30403,6 @@
 	pixel_x = -4;
 	pixel_y = 8
 	},
-/obj/structure/table,
 /obj/item/stock_parts/cell/high{
 	pixel_y = -4
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the title says, removes 2 tables on the same tile in Meta atmos.

![image](https://user-images.githubusercontent.com/18170896/169879446-449aaa5f-68a6-43d4-89c6-f47b1db3b9d5.png)


## Why It's Good For The Game

Map optimization!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Removes an extra table in Meta atmos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
