### PR TITLE
improves SM cascade performances and fixes announcement text

### DIFF
--- a/code/controllers/subsystem/processing/supermatter_cascade.dm
+++ b/code/controllers/subsystem/processing/supermatter_cascade.dm
@@ -1,4 +1,4 @@
 PROCESSING_SUBSYSTEM_DEF(supermatter_cascade)
 	name = "Supermatter Cascade"
-	wait = 1 SECONDS
+	wait = 0.5 SECONDS
 	stat_tag = "SC"

--- a/code/modules/power/supermatter/supermatter_delamination.dm
+++ b/code/modules/power/supermatter/supermatter_delamination.dm
@@ -176,10 +176,9 @@
 	create_cascade_ambience()
 	pick_rift_location()
 	warn_crew()
-	supermatter_turf.ChangeTurf(/turf/closed/indestructible/supermatter_wall)
+	new /obj/crystal_mass(supermatter_turf)
 	for(var/i in 1 to rand(4,6))
-		var/turf/crystal_cascade_location = get_turf(pick(GLOB.generic_event_spawns))
-		crystal_cascade_location.ChangeTurf(/turf/closed/indestructible/supermatter_wall)
+		new /obj/crystal_mass(get_turf(pick(GLOB.generic_event_spawns)))
 
 /**
  * Adds a bit of spiciness to the cascade by breaking lights and turning emergency maint access on
@@ -206,7 +205,7 @@
 	priority_announce("Unknown harmonance affecting local spatial substructure, all nearby matter is starting to crystallize.", "Central Command Higher Dimensional Affairs", 'sound/misc/bloblarm.ogg')
 	priority_announce("There's been a sector-wide electromagnetic pulse. All of our systems are heavily damaged, including those required for emergency shuttle navigation. \
 		We can only reasonably conclude that a supermatter cascade has been initiated on or near your station. \
-		Evacuation is no longer possible by conventional means; however, we managed to open a rift near the [span_boldannounce(get_area_name(cascade_rift))]. \
+		Evacuation is no longer possible by conventional means; however, we managed to open a rift near the [get_area_name(cascade_rift)]. \
 		All personnel are hereby advised to enter the rift using all means available. Retrieval of survivors will be conducted upon recovery of necessary facilities. \
 		Good l\[\[###!!!-")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the cascade walls from turfs to objects to improve the performances of the roundending cascade.
The issue was that ChangeTurf() was a pretty expensive proc to be called that many times so i moved the cascade wall into an object. It doesn't delete anything other than living mobs and the portal to prevent edge case runtimes.
Plus remove a span_bold() from the announcement text since it wasn't making the text bold but was leaving behind <bold></bold>
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
better end game performances
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: sm cascade walls are no longer turfs, but are object, no player facing changes
fix: fixed announcement text and removed <bold></bold> texts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
