### PR TITLE
Removes power monitor from tablets

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -69,7 +69,6 @@
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/alarm_monitor,
-		/datum/computer_file/program/power_monitor,
 		/datum/computer_file/program/supermatter_monitor,
 	)
 
@@ -144,7 +143,6 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#D99A2E#69DBF3#E3DF3D"
 	default_applications = list(
-		/datum/computer_file/program/power_monitor,
 		/datum/computer_file/program/supermatter_monitor,
 	)
 

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -9,7 +9,7 @@
 	ui_header = "power_norm.gif"
 	transfer_access = list(ACCESS_ENGINEERING)
 	usage_flags = PROGRAM_CONSOLE
-	requires_ntnet = 0
+	requires_ntnet = FALSE
 	size = 8
 	tgui_id = "NtosPowerMonitor"
 	program_icon = "plug"

--- a/code/modules/modular_computers/hardware/program_disks.dm
+++ b/code/modules/modular_computers/hardware/program_disks.dm
@@ -64,7 +64,6 @@
 
 /obj/item/computer_hardware/hard_drive/portable/command/ce/install_default_programs()
 	. = ..()
-	store_file(new /datum/computer_file/program/power_monitor(src))
 	store_file(new /datum/computer_file/program/supermatter_monitor(src))
 	store_file(new /datum/computer_file/program/atmosscan(src))
 	store_file(new /datum/computer_file/program/alarm_monitor(src))
@@ -139,7 +138,6 @@
 
 /obj/item/computer_hardware/hard_drive/portable/engineering/install_default_programs()
 	. = ..()
-	store_file(new /datum/computer_file/program/power_monitor(src))
 	store_file(new /datum/computer_file/program/supermatter_monitor(src))
 
 /obj/item/computer_hardware/hard_drive/portable/atmos


### PR DESCRIPTION
## About The Pull Request

These apps are restricted for computers, and weren't meant to be added to tablets.
They were added as a job disk, ported from cartridges, but this was a mistake as it wasn't intended for PDAs to have this app.

This worked when it was a job disk because job disks would snowflake all apps on them to let anything be able to run them, which is completely stupid and ruins the whole point of apps being limited to what can run them, since it removes the barriers we set up meant to prevent shit from breaking in ways we haven't checked.

## Why It's Good For The Game

They aren't supposed to have this app in the first place, they can't even run it though at the moment.

## Changelog

:cl:
fix: The Chief Engineer and Station Engineers no longer spawn with a broken app- AmpCheck. You can still use said app from your Engineering consoles.
/:cl: