### PR TITLE
Fixes href exploit to use rwall with any pda.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -133,7 +133,7 @@
 				to_chat(usr, span_notice("ERROR: Device has sending disabled."))
 				return
 			if(!spam_mode)
-				to_char(usr, span_notice("ERROR: Device does not have mass-messaging perms."))
+				to_chat(usr, span_notice("ERROR: Device does not have mass-messaging perms."))
 				return
 
 			var/list/targets = list()

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -132,6 +132,9 @@
 			if(!sending_and_receiving)
 				to_chat(usr, span_notice("ERROR: Device has sending disabled."))
 				return
+			if(!spam_mode)
+				to_char(usr, span_notice("ERROR: Device does not have mass-messaging perms."))
+				return
 
 			var/list/targets = list()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a server-side check to make sure a PDA should be able to message every other PDA at once before messaging every other PDA at once.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The lawyers gimmick should stay the lawyers gimmick. Or the gimmick of whomever stole their PDA. Either works.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can no longer forge hrefs to message everyone from any PDA.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
