### PR TITLE
Fix a source of undeleted query spamming admin chat when gathering admin feedback threads from the database.

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -181,9 +181,13 @@ GLOBAL_PROTECT(href_token)
 
 	if(!feedback_query.Execute())
 		log_sql("Error retrieving feedback link for [src]")
+		qdel(feedback_query);
 		return cached_forum_link
 	if(!feedback_query.NextRow())
+		qdel(feedback_query);
 		return FALSE // no feedback link exists
+
+	qdel(feedback_query);
 
 	cached_forum_link = feedback_query.item[1]
 	return cached_forum_link

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -181,13 +181,13 @@ GLOBAL_PROTECT(href_token)
 
 	if(!feedback_query.Execute())
 		log_sql("Error retrieving feedback link for [src]")
-		qdel(feedback_query);
+		qdel(feedback_query)
 		return cached_forum_link
 	if(!feedback_query.NextRow())
-		qdel(feedback_query);
+		qdel(feedback_query)
 		return FALSE // no feedback link exists
 
-	qdel(feedback_query);
+	qdel(feedback_query)
 
 	cached_forum_link = feedback_query.item[1]
 	return cached_forum_link


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/24975989/170077725-1ca7e6a6-45b0-4d89-a15f-d11161ac7b33.png)

#66909 never deleted the queries it made. On the one hand it's cool because admins now know when someone pushed adminwho, even if we don't know who did it. /s On the other hand it's really, really annoying to be spammed by the undeleted query notifications in chat.

Not that admins ever notify coders about it anyway.

I believe that is the source of the undeleted query notifications, and I have added qdels across all code paths to handle this. This appears to match how `/datum/db_query`s are handled across all other parts of the code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Feex bug.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The DB query retrieving the feedback thread link for adminwho properly deletes the DB query across all code paths, stopping error spam in admin chat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
