### PR TITLE
Departmental Officers now have access to most of their department

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -476,7 +476,7 @@
 /datum/id_trim/job/security_officer/science
 	assignment = "Security Officer (Science)"
 	trim_state = "trim_securityofficer_sci"
-	department_access = list(ACCESS_AUX_BASE, ACCESS_GENETICS, ACCESS_ORDNANCE, ACCESS_ORDNANCE_STORAGE, ACCESS_RESEARCH, ACCESS_ROBOTICS, ACCESS_SCIENCE, ACCESS_XENOBIOLOGY, ACCESS_ROBOTICS)
+	department_access = list(ACCESS_AUX_BASE, ACCESS_GENETICS, ACCESS_ORDNANCE, ACCESS_ORDNANCE_STORAGE, ACCESS_RESEARCH, ACCESS_ROBOTICS, ACCESS_SCIENCE, ACCESS_XENOBIOLOGY)
 
 /datum/id_trim/job/shaft_miner
 	assignment = "Shaft Miner"

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -466,17 +466,17 @@
 /datum/id_trim/job/security_officer/engineering
 	assignment = "Security Officer (Engineering)"
 	trim_state = "trim_securityofficer_engi"
-	department_access = list(ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE, ACCESS_CONSTRUCTION, ACCESS_ENGINEERING)
+	department_access = list(ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE, ACCESS_CONSTRUCTION, ACCESS_ENGINEERING, ACCESS_ENGINE_EQUIP, ACCESS_TCOMMS, ACCESS_TECH_STORAGE)
 
 /datum/id_trim/job/security_officer/medical
 	assignment = "Security Officer (Medical)"
 	trim_state = "trim_securityofficer_med"
-	department_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_SURGERY)
+	department_access = list(ACCESS_PHARMACY, ACCESS_PLUMBING, ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_SURGERY, ACCESS_VIROLOGY)
 
 /datum/id_trim/job/security_officer/science
 	assignment = "Security Officer (Science)"
 	trim_state = "trim_securityofficer_sci"
-	department_access = list(ACCESS_AUX_BASE, ACCESS_RESEARCH, ACCESS_SCIENCE)
+	department_access = list(ACCESS_AUX_BASE, ACCESS_GENETICS ACCESS_ORDNANCE, ACCESS_ORDNANCE_STORAGE, ACCESS_RESEARCH, ACCESS_ROBOTICS, ACCESS_SCIENCE, ACCESS_XENOBIOLOGY, ACCESS_ROBOTICS)
 
 /datum/id_trim/job/shaft_miner
 	assignment = "Shaft Miner"

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -466,7 +466,7 @@
 /datum/id_trim/job/security_officer/engineering
 	assignment = "Security Officer (Engineering)"
 	trim_state = "trim_securityofficer_engi"
-	department_access = list(ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE, ACCESS_CONSTRUCTION, ACCESS_ENGINEERING, ACCESS_TCOMMS, ACCESS_TECH_STORAGE)
+	department_access = list(ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE, ACCESS_CONSTRUCTION, ACCESS_ENGINEERING, ACCESS_ENGINE_EQUIP, ACCESS_TCOMMS)
 
 /datum/id_trim/job/security_officer/medical
 	assignment = "Security Officer (Medical)"

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -466,7 +466,7 @@
 /datum/id_trim/job/security_officer/engineering
 	assignment = "Security Officer (Engineering)"
 	trim_state = "trim_securityofficer_engi"
-	department_access = list(ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE, ACCESS_CONSTRUCTION, ACCESS_ENGINEERING, ACCESS_ENGINE_EQUIP, ACCESS_TCOMMS, ACCESS_TECH_STORAGE)
+	department_access = list(ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE, ACCESS_CONSTRUCTION, ACCESS_ENGINEERING, ACCESS_TCOMMS, ACCESS_TECH_STORAGE)
 
 /datum/id_trim/job/security_officer/medical
 	assignment = "Security Officer (Medical)"
@@ -476,7 +476,7 @@
 /datum/id_trim/job/security_officer/science
 	assignment = "Security Officer (Science)"
 	trim_state = "trim_securityofficer_sci"
-	department_access = list(ACCESS_AUX_BASE, ACCESS_GENETICS ACCESS_ORDNANCE, ACCESS_ORDNANCE_STORAGE, ACCESS_RESEARCH, ACCESS_ROBOTICS, ACCESS_SCIENCE, ACCESS_XENOBIOLOGY, ACCESS_ROBOTICS)
+	department_access = list(ACCESS_AUX_BASE, ACCESS_GENETICS, ACCESS_ORDNANCE, ACCESS_ORDNANCE_STORAGE, ACCESS_RESEARCH, ACCESS_ROBOTICS, ACCESS_SCIENCE, ACCESS_XENOBIOLOGY, ACCESS_ROBOTICS)
 
 /datum/id_trim/job/shaft_miner
 	assignment = "Shaft Miner"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request equalizes the access that departmental security is given for their department, giving departmental security officers access to all areas in the department which aren't head-specific. For example, the engineering security officer wouldn't have access to the tech storage room or the ce's office, but does have access to tcomms, engine equipment etc.

This is done so that all departmental security officers are equally enabled to respond to issues in their department and have the access that a basic member of the department would have. Currently, cargo officers are able to respond to any issue not in the vault or QMs office, but officers in science could only respond to issues in the science hallway, research room, or circuit room, and are unable to respond to issues in any other place in the department.

I believe that the reason for the above is that when new accesses have been added to departments, they neglected to add these areas for departmental security officers.

Upon further research, for things like virology or xenobio, it feels like keeping security officers out was intended, so I'll label this both a fix and a balance change.

## Why It's Good For The Game

Departmental security officers should be able to reliably respond to security issues in the department. While some areas like virology and xenobiology were deliberately separated from being accessible by security officers previously, I believe it is an antiquated design crutch that does not properly reflect the modern ways that antagonists work, and certainly doesn't reflect the standards that are currently set for officers.

Giving officers these accesses make departmental assignments something with genuine utility instead of something that gives you an armband and enables officers to feel/be felt like a part of their designated department.

These changes also make sure that departmental assignments are treated equally and have equal utility, making it easier to collectively change the feel of departmental security in the future.

## Changelog

:cl:
fix: departmental officers' access across departments has been standardized, and previously lost accesses were added back
balance: Departmental security officers have access to more areas in their departments, including xenobiology or virology
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
