### PR TITLE
Useful mapping log error for when turret control panel has a bad control_area

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -894,9 +894,10 @@ DEFINE_BITFIELD(turret_flags, list(
 
 	if(control_area)
 		control_area_instance = get_area_instance_from_text(control_area)
+		if(!control_area_instance)
+			log_mapping("Bad control_area path for [src] at [AREACOORD(src)]: [control_area]")
 	if(!control_area_instance)
 		control_area_instance = get_area(src)
-		log_mapping("Bad control_area path for [src] at [AREACOORD(src)]: [control_area]")
 
 	for(var/obj/machinery/porta_turret/T in control_area_instance)
 		turrets |= WEAKREF(T)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -889,15 +889,16 @@ DEFINE_BITFIELD(turret_flags, list(
 	if(!mapload)
 		return
 
-	if(control_area)
-		control_area = get_area_instance_from_text(control_area)
-		if(control_area == null)
-			control_area = get_area(src)
-			stack_trace("Bad control_area path for [src], [src.control_area]")
-	else if(!control_area)
-		control_area = get_area(src)
+	// The actual area that control_area refers to
+	var/area/control_area_instance
 
-	for(var/obj/machinery/porta_turret/T in control_area)
+	if(control_area)
+		control_area_instance = get_area_instance_from_text(control_area)
+	if(!control_area_instance)
+		control_area_instance = get_area(src)
+		log_mapping("Bad control_area path for [src] at [AREACOORD(src)]: [control_area]")
+
+	for(var/obj/machinery/porta_turret/T in control_area_instance)
 		turrets |= WEAKREF(T)
 
 /obj/machinery/turretid/examine(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, if a turret control panel has a bad `control_area`, it throws a stack trace where it doesn't even tell you what the incorrect value is, or where the turret control panel actually is beyond the area name.

- Changes it to a log_mapping with the full AREACOORD and the bad value listed to be more CI friendly.
- Also refactors the offending proc slightly to not be confusing as hell or as redundant.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

CI

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
