### PR TITLE
Adds a teeny bit of sanity to the Heretic Lionhunter Rifle

### DIFF
--- a/code/modules/antagonists/heretic/items/hunter_rifle.dm
+++ b/code/modules/antagonists/heretic/items/hunter_rifle.dm
@@ -1,3 +1,6 @@
+/// The max range we can zoom in on people from.
+#define MAX_LIONHUNTER_RANGE 16
+
 // The Lionhunter, a gun for heretics
 // The ammo it uses takes time to "charge" before firing,
 // releasing a homing, very damaging projectile
@@ -50,6 +53,9 @@
 		return FALSE
 
 	var/distance = get_dist(user, target)
+	if(target.z != user.z || distance > MAX_LIONHUNTER_RANGE)
+		return FALSE
+
 	var/fire_time = min(distance * seconds_per_distance, 10 SECONDS)
 
 	if(distance <= min_distance || !isliving(target))
@@ -142,3 +148,5 @@
 	layer = BELOW_MOB_LAYER
 	plane = GAME_PLANE
 	light_range = 2
+
+#undef MAX_LIONHUNTER_RANGE


### PR DESCRIPTION
## About The Pull Request

Adds a max range and z-check to targets aquired by the lionhunter rifle. 

## Why It's Good For The Game

Just in case. Numbers past this shouldn't be valid. 

## Changelog

:cl: Melbert
fix: Adds some minor sanity to the Lionhunter Rifle. 
/:cl:
