### PR TITLE
Fixes some randomly mistyped prisoner computers.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1267,10 +1267,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard)
 "apK" = (
-/obj/machinery/computer/prisoner{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "apL" = (
@@ -86947,6 +86945,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/port)
+"xsm" = (
+/obj/machinery/computer/prisoner/management{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/misc/space)
 "xsp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -138697,7 +138701,7 @@ aad
 aaa
 aaa
 aaa
-aaa
+xsm
 aaa
 aaa
 aaa

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -21859,12 +21859,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hah" = (
-/obj/machinery/computer/prisoner,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/cable,
+/obj/machinery/computer/prisoner/management,
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "hal" = (

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2824,12 +2824,12 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "zo" = (
-/obj/machinery/computer/prisoner,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/cable,
+/obj/machinery/computer/prisoner/management,
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "zA" = (


### PR DESCRIPTION

## About The Pull Request

So, we have a parent type called `/obj/machinery/computer/prisoner`, which is a parent to the prisoner management console and the gulag teleporter. The parent literally only handles card operations, while the subtypes actually interact with the player in a meaningful way.

We have several of these parent computers spawned throughout player facing maps, including the HOS office on delta, all maps on lavaland gulag, and on icebox. This corrects the path for some of those, and removes those where the correct computer already existed a room away seriously delta what the heck.

We left one on SnowCabin, which is in a secret location but also replacing it with one of the subtypes wouldn't have made much sense there anyway.

## Why It's Good For The Game

Having broken non-functional consoles mapped into high traffic maps is a bad look and should be fixed.

## Changelog

:cl:
fix: Several non-functional prison management computers have been replaced by functional computers.
/:cl:

