### PR TITLE
Fat Armsky no longer deletes people by standing on boxes.

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -552,8 +552,8 @@
 		return FALSE
 	if(istype(owner.loc, /obj/structure/closet/cardboard/agent))
 		var/obj/structure/closet/cardboard/agent/box = owner.loc
-		owner.playsound_local(box, 'sound/misc/box_deploy.ogg', 50, TRUE)
-		box.open()
+		if(box.open())
+			owner.playsound_local(box, 'sound/misc/box_deploy.ogg', 50, TRUE)
 		return
 	//Box closing from here on out.
 	if(!isturf(owner.loc)) //Don't let the player use this to escape mechs/welded closets.

--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -26,6 +26,10 @@
 
 /obj/structure/closet/cardboard/agent/open(mob/living/user, force = FALSE)
 	. = ..()
+
+	if(!.)
+		return
+
 	qdel(src)
 
 /obj/structure/closet/cardboard/agent/process()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -251,11 +251,11 @@
 
 /obj/structure/closet/proc/open(mob/living/user, force = FALSE)
 	if(!can_open(user, force))
-		return
+		return FALSE
 	if(opened)
-		return
+		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_CLOSET_PRE_OPEN, user, force) & BLOCK_OPEN)
-		return
+		return FALSE
 	welded = FALSE
 	locked = FALSE
 	playsound(loc, open_sound, open_sound_volume, TRUE, -3)

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -95,4 +95,3 @@
 	open_sound_volume = 35
 	close_sound_volume = 50
 	material_drop = /obj/item/stack/sheet/plasteel
-#undef SNAKE_SPAM_TICKS

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -20,7 +20,6 @@
 	door_anim_time = 0 // no animation
 	var/move_speed_multiplier = 1
 	var/move_delay = FALSE
-
 	can_install_electronics = FALSE
 
 	/// Cooldown controlling when the box can trigger the Metal Gear Solid-style '!' alert.

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -48,7 +48,7 @@
 			break
 		if(Snake)
 			alerted = viewers(7,src)
-	..()
+	. = ..()
 	if(LAZYLEN(alerted))
 		egged = world.time + SNAKE_SPAM_TICKS
 		for(var/mob/living/L in alerted)

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -1,4 +1,3 @@
-#define SNAKE_SPAM_TICKS 600 //how long between cardboard box openings that trigger the '!'
 /obj/structure/closet/cardboard
 	name = "large cardboard box"
 	desc = "Just a box..."

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -70,8 +70,6 @@
 
 	playsound(loc, 'sound/machines/chime.ogg', 50, FALSE, -5)
 
-	return
-
 /// Does the MGS ! animation
 /atom/proc/do_alert_animation()
 	var/image/alert_image = image('icons/obj/closet.dmi', src, "cardboard_special", layer+1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Total clickbait title that misrepresents the actual bug.

https://tgstation13.org/parsed-logs/sybil/data/logs/2022/05/25/round-183770/runtime.txt
```
[2022-05-25 17:47:30.597] runtime error: Cannot read null.damage_resistance
 - proc name: apply damage (/datum/species/proc/apply_damage)
 -   source file: species.dm,1340
 -   usr: Alice Heart (/mob/living/carbon/human)
 -   src: Felinid (/datum/species/human/felinid)
 -   usr.loc: the inconspicious box (/obj/structure/closet/cardboard/agent)
 -   call stack:
 - Felinid (/datum/species/human/felinid): apply damage(20, "brute", "chest", 0, Alice Heart (/mob/living/carbon/human), 0, 0, 0, 0, 0, null)
 - Alice Heart (/mob/living/carbon/human): apply damage(20, "brute", "chest", 0, 0, 0, 0, 0, 0, null)
 - the storage implant (/obj/item/implant/storage): removed(Alice Heart (/mob/living/carbon/human), 0, 0)
 - the storage implant (/obj/item/implant/storage): Destroy(0)
 - qdel(the storage implant (/obj/item/implant/storage), 0)
 - Alice Heart (/mob/living/carbon/human): Destroy(0)
 - Alice Heart (/mob/living/carbon/human): Destroy(0)
 - Alice Heart (/mob/living/carbon/human): Destroy(0)
 - Alice Heart (/mob/living/carbon/human): Destroy(0)
 - Alice Heart (/mob/living/carbon/human): Destroy(0)
 - qdel(Alice Heart (/mob/living/carbon/human), 0)
 - the inconspicious box (/obj/structure/closet/cardboard/agent): Destroy(0)
 - the inconspicious box (/obj/structure/closet/cardboard/agent): Destroy(0)
 - the inconspicious box (/obj/structure/closet/cardboard/agent): Destroy(0)
 - the inconspicious box (/obj/structure/closet/cardboard/agent): Destroy(0)
 - qdel(the inconspicious box (/obj/structure/closet/cardboard/agent), 0)
 - the inconspicious box (/obj/structure/closet/cardboard/agent): open(null, 0)
 - Deploy Box (/datum/action/item_action/agent_box): Trigger(null)
 - Deploy Box (/atom/movable/screen/movable/action_button): Click(null, "mapwindow.map", "icon-x=16;icon-y=22;left=1;scr...")
 - Typhnox (/client): Click(Deploy Box (/atom/movable/screen/movable/action_button), null, "mapwindow.map", "icon-x=16;icon-y=22;left=1;scr...")
```

In the recent Sybil 183770 a player's mob got qdel'd because of the stealth implant's box deleting them. Let's go through it!

![zOzabSE6nN](https://user-images.githubusercontent.com/24975989/170352770-1c577a93-229d-45d7-95e9-3eae74ca487a.gif)

When Armsky starts stunning people, it sets itself to `anchored = TRUE`.

![image](https://user-images.githubusercontent.com/24975989/170350311-f5824e41-85dd-48b4-aaf1-adc11c40b159.png)

If you attempt to de-equip your stealth implant, it runs a suite of generic `/obj/structure/closet/proc/can_open(mob/living/user, force = FALSE)` checks to see if the box you're in can be opened. One of the checks it does is whether there are any anchored mobs stood on the box.

![image](https://user-images.githubusercontent.com/24975989/170350865-6ba724f4-a54b-4754-9ede-0b3e4a154116.png)

This causes can_open() to return false, early returns out of the open() proc and doesn't reach the parent-most call to open() which does a dump_contents().

The stealth box then goes "you can't tell me what to do I'm my own boss I'm a strong independent young box I don't need no man" and qdeletes itself regardless of whether it was successfully opened or not.

This deletes its contents. This kills the Alice Heart.

I think this behaviour is funny and don't want to pass force = TRUE to solve everything because it could have unforeseen consequences. I want ~~fat~~ anchored mobs to trap operatives in boxes.

So instead I've made some adjustments to make the code actually care if the box opened or not.

The action trigger doesn't play a sound if the box doesn't open.

The box itself checks the return of the parent call on open and doesn't qdelete itself if it didn't open.

The call stack preserves the return value where appropriate.

You now have to wait for Armsky to ~~lose some weight~~ stop trying to arrest you before you can break out of your box if he's stood on you and don't get ~~shipped to Brazil~~ literally deleted instead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes a weird edge case where anything that would prevent a storage closet or locker from opening would instead cause stealth implant boxes to delete the player inside them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
