### PR TITLE
fixes darkened blades saying they only need 1 silver to make

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -28,7 +28,7 @@
 /datum/heretic_knowledge/limited_amount/starting/base_blade
 	name = "The Cutting Edge"
 	desc = "Opens up the path of blades to you. \
-		Allows you to transmute a knife with a bar of silver to create a Darkened Blade. \
+		Allows you to transmute a knife with two bars of silver to create a Darkened Blade. \
 		You can create up to five at a time."
 	gain_text = "Our great ancestors forged swords and practiced sparring on the even of great battles."
 	next_knowledge = list(/datum/heretic_knowledge/blade_grasp)


### PR DESCRIPTION

## About The Pull Request

fixes #67305 
## Why It's Good For The Game

having the descriptions be accurate is good
## Changelog



:cl:
spellcheck: blade heretic lore for how much silver it takes to make a blade is now correct
/:cl:


