### PR TITLE
Allows modsuits to be used in outfit manager

### DIFF
--- a/code/modules/admin/outfit_editor.dm
+++ b/code/modules/admin/outfit_editor.dm
@@ -178,7 +178,11 @@
 		if("l_hand")
 			choose_any_item(slot)
 		if("back")
-			options = typesof(/obj/item/storage/backpack) + typesof(/obj/item/mod/control/pre_equipped)
+			options = typesof(/obj/item/storage/backpack)
+			for(var/obj/item/mod/control/pre_equipped/potential_mod as anything in typesof(/obj/item/mod/control/pre_equipped))
+				if(!(potential_mod.slot_flags == ITEM_SLOT_BACK))
+					continue
+				options |= potential_mod
 		if("r_hand")
 			choose_any_item(slot)
 

--- a/code/modules/admin/outfit_editor.dm
+++ b/code/modules/admin/outfit_editor.dm
@@ -180,7 +180,7 @@
 		if("back")
 			options = typesof(/obj/item/storage/backpack)
 			for(var/obj/item/mod/control/pre_equipped/potential_mod as anything in typesof(/obj/item/mod/control/pre_equipped))
-				if(!(potential_mod.slot_flags == ITEM_SLOT_BACK))
+				if(!(initial(potential_mod.slot_flags) == ITEM_SLOT_BACK))
 					continue
 				options |= potential_mod
 		if("r_hand")

--- a/code/modules/admin/outfit_editor.dm
+++ b/code/modules/admin/outfit_editor.dm
@@ -178,7 +178,7 @@
 		if("l_hand")
 			choose_any_item(slot)
 		if("back")
-			options = typesof(/obj/item/storage/backpack)
+			options = typesof(/obj/item/storage/backpack) + typesof(/obj/item/mod/control/pre_equipped)
 		if("r_hand")
 			choose_any_item(slot)
 

--- a/code/modules/admin/outfit_editor.dm
+++ b/code/modules/admin/outfit_editor.dm
@@ -179,7 +179,7 @@
 			choose_any_item(slot)
 		if("back")
 			options = typesof(/obj/item/storage/backpack)
-			for(var/obj/item/mod/control/pre_equipped/potential_mod as anything in typesof(/obj/item/mod/control/pre_equipped))
+			for(var/obj/item/mod/control/pre_equipped/potential_mod as anything in subtypesof(/obj/item/mod/control/pre_equipped))
 				if(!(initial(potential_mod.slot_flags) == ITEM_SLOT_BACK))
 					continue
 				options |= potential_mod


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The admin outfit manager just checked for /obj/item/storage/backpack subtypes, and as such excluded modsuits, this corrects that

## Why It's Good For The Game
Better for making custom outfits

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: MODsuits can now be picked through the outfit manager
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
