### PR TITLE
Fixes ID access circuit components

### DIFF
--- a/code/modules/wiremod/components/id/access_checker.dm
+++ b/code/modules/wiremod/components/id/access_checker.dm
@@ -1,6 +1,6 @@
 /obj/item/circuit_component/compare/access
 	display_name = "Access Checker"
-	desc = "Performs a basic comparison between two numerical lists, with additional functions that help in using it to check access on IDs."
+	desc = "Performs a basic comparison between two lists of strings, with additional functions that help in using it to check access on IDs."
 	category = "ID"
 
 	input_port_amount = 0 //Uses custom ports for its comparisons
@@ -26,8 +26,8 @@
 	. += create_ui_notice("When \"Check Any\" is false, returns true only if \"Access To Check\" contains ALL values in \"Required Access\".", "orange", "info")
 
 /obj/item/circuit_component/compare/access/populate_custom_ports()
-	subject_accesses = add_input_port("Access To Check", PORT_TYPE_LIST(PORT_TYPE_NUMBER))
-	required_accesses = add_input_port("Required Access", PORT_TYPE_LIST(PORT_TYPE_NUMBER))
+	subject_accesses = add_input_port("Access To Check", PORT_TYPE_LIST(PORT_TYPE_STRING))
+	required_accesses = add_input_port("Required Access", PORT_TYPE_LIST(PORT_TYPE_STRING))
 	check_any = add_input_port("Check Any", PORT_TYPE_NUMBER)
 
 /obj/item/circuit_component/compare/access/save_data_to_list(list/component_data)

--- a/code/modules/wiremod/components/id/access_reader.dm
+++ b/code/modules/wiremod/components/id/access_reader.dm
@@ -19,7 +19,7 @@
 
 /obj/item/circuit_component/id_access_reader/populate_ports()
 	target = add_input_port("Target", PORT_TYPE_ATOM)
-	access_port = add_output_port("Access", PORT_TYPE_LIST(PORT_TYPE_NUMBER))
+	access_port = add_output_port("Access", PORT_TYPE_LIST(PORT_TYPE_STRING))
 
 
 /obj/item/circuit_component/id_access_reader/input_received(datum/port/input/port)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#67002 forgot about the circuit components that play with ID access, thus they were still trying to use numbers. Very simple fix since they were type agnostic outside of the actual i/o pin types.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Circuit components actually working.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The ID access reader and access checker circuit components now work again with the new string-based access system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
