### PR TITLE
Ensures cinematics really go away when they're done. 

### DIFF
--- a/code/datums/cinematics/_cinematic.dm
+++ b/code/datums/cinematics/_cinematic.dm
@@ -80,12 +80,11 @@
 
 	//Actually play it
 	play_cinematic()
+	addtimer(CALLBACK(src, .proc/clean_up_cinematic, ooc_toggled), cleanup_time)
 
-	//Cleanup
-	sleep(cleanup_time)
-
-	//Restore OOC
-	if(ooc_toggled)
+/// Cleans up the cinematic after a set timer of it sticking on the end screen.
+/datum/cinematic/proc/clean_up_cinematic(was_ooc_toggled = FALSE)
+	if(was_ooc_toggled)
 		toggle_ooc(TRUE)
 
 	stop_cinematic()
@@ -136,8 +135,10 @@
 /// Stops the cinematic and removes it from all the viewers.
 /datum/cinematic/proc/stop_cinematic()
 	for(var/client/viewing_client as anything in watching)
-		viewing_client.mob.clear_fullscreen("cinematic")
-		viewing_client.screen -= screen
+		// byond client volatility strikes back.
+		// We really don't wanna runtime here or else everyone'll be stuck with a cinematic in the way.
+		viewing_client?.mob?.clear_fullscreen("cinematic")
+		viewing_client?.screen -= screen
 
 	for(var/datum/weakref/locked_ref as anything in locked)
 		var/mob/locked_mob = locked_ref.resolve()

--- a/code/datums/cinematics/_cinematic.dm
+++ b/code/datums/cinematics/_cinematic.dm
@@ -115,7 +115,7 @@
 		watching_mob.notransform = TRUE
 
 	// Only show the actual cinematic to cliented mobs.
-	if(!watching_client || watching_client in watching)
+	if(!watching_client || (watching_client in watching))
 		return
 
 	watching += watching_client
@@ -158,7 +158,7 @@
 	SIGNAL_HANDLER
 
 	if(!(no_longer_watching in watching))
-		return
+		CRASH("cinematic remove_watcher was passed a client which wasn't watching.")
 
 	UnregisterSignal(no_longer_watching, COMSIG_PARENT_QDELETING)
 	if(no_longer_watching.mob)

--- a/code/datums/cinematics/_cinematic.dm
+++ b/code/datums/cinematics/_cinematic.dm
@@ -104,9 +104,15 @@
 /datum/cinematic/proc/show_to(mob/watching_mob, client/watching_client)
 	SIGNAL_HANDLER
 
-	locked += WEAKREF(watching_mob)
-	watching_mob.notransform = TRUE
+	// We could technically rip people out of notransform who shouldn't be,
+	// so we'll only lock down all viewing mobs who don't have it already set.
+	// This does potentially mean some mobs could lose their notrasnform and
+	// not be locked down by cinematics, but that should be very unlikely.
+	if(!watching_mob.notransform)
+		locked += WEAKREF(watching_mob)
+		watching_mob.notransform = TRUE
 
+	// Only show the actual cinematic to cliented mobs.
 	if(!watching_client)
 		return
 

--- a/code/datums/cinematics/_cinematic.dm
+++ b/code/datums/cinematics/_cinematic.dm
@@ -150,6 +150,7 @@
 		if(QDELETED(locked_mob))
 			continue
 		locked_mob.notransform = FALSE
+		UnregisterSignal(locked_mob, COMSIG_MOB_CLIENT_LOGIN)
 
 	qdel(src)
 
@@ -161,12 +162,9 @@
 		CRASH("cinematic remove_watcher was passed a client which wasn't watching.")
 
 	UnregisterSignal(no_longer_watching, COMSIG_PARENT_QDELETING)
-	if(no_longer_watching.mob)
-		UnregisterSignal(no_longer_watching.mob, COMSIG_MOB_CLIENT_LOGIN)
-		// We'll clear the cinematic if they have a mob which has one,
-		// but we won't remove notransform. Wait for the cinematic end to do that.
-		no_longer_watching.mob.clear_fullscreen("cinematic")
-
+	// We'll clear the cinematic if they have a mob which has one,
+	// but we won't remove notransform. Wait for the cinematic end to do that.
+	no_longer_watching.mob?.clear_fullscreen("cinematic")
 	no_longer_watching.screen -= screen
 
 	watching -= no_longer_watching

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -560,12 +560,6 @@ GLOBAL_VAR(station_nuke_source)
 	else
 		detonation_status = DETONATION_MISSED_STATION
 
-	/*
-	if(detonation_status < NUKE_MISS_STATION)
-		SSshuttle.registerHostileEnvironment(src)
-		SSshuttle.lockdown = TRUE
-	*/
-
 	// Missing the station will register a hostile environment, until it actually explodes
 	if(detonation_status == DETONATION_MISSED_STATION)
 		SSshuttle.registerHostileEnvironment(src)


### PR DESCRIPTION
## About The Pull Request

Fixes #67210

There were some occasions where the clients within the watching list of cinematics would `null` out and cause them to stick around. This caused unfortunate issues during `stop_cinematic()`, as we'd end up runtiming while trying to clear it from everyone's face, leaving it stuck there. 

Also axes some commented out code I may have accidentally had in my original PR

## Why It's Good For The Game

Ensures cinematics properly depart when done. 

## Changelog

:cl: Melbert
fix: Fixes some cinematics sticking around for longer than comfortable 
/:cl:

