### PR TITLE
Move more silicon-relevant logs to silicon logs

### DIFF
--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -42,7 +42,7 @@
 				R.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
 				if(new_ai && (new_ai != R.connected_ai))
 					R.set_connected_ai(new_ai)
-					log_combat(usr, R, "synced cyborg [R.connected_ai ? "from [ADMIN_LOOKUP(R.connected_ai)]": ""] to [ADMIN_LOOKUP(new_ai)]")
+					log_silicon("[key_name(usr)] synced [key_name(R)] [R.connected_ai ? "from [ADMIN_LOOKUP(R.connected_ai)]": ""] to [ADMIN_LOOKUP(new_ai)]")
 					if(R.shell)
 						R.undeploy() //If this borg is an AI shell, disconnect the controlling AI and assign ti to a new AI
 						R.notify_ai(AI_NOTIFICATION_AI_SHELL)
@@ -52,17 +52,17 @@
 			if(!QDELETED(R.builtInCamera) && !R.scrambledcodes)
 				R.builtInCamera.toggle_cam(usr, FALSE)
 				R.visible_message(span_notice("[R]'s camera lens focuses loudly."), span_notice("Your camera lens focuses loudly."))
-				log_combat(usr, R, "toggled cyborg camera to [R.builtInCamera.status ? "on" : "off"] via pulse")
+				log_silicon("[key_name(usr)] toggled [key_name(R)]'s camera to [R.builtInCamera.status ? "on" : "off"] via pulse")
 		if(WIRE_LAWSYNC) // Forces a law update if possible.
 			if(R.lawupdate)
 				R.visible_message(span_notice("[R] gently chimes."), span_notice("LawSync protocol engaged."))
-				log_combat(usr, R, "forcibly synced cyborg laws via pulse")
+				log_silicon("[key_name(usr)] forcibly synced [key_name(R)]'s laws via pulse")
 				// TODO, log the laws they gained here
 				R.lawsync()
 				R.show_laws()
 		if(WIRE_LOCKDOWN)
 			R.SetLockdown(!R.lockcharge) // Toggle
-			log_combat(usr, R, "[!R.lockcharge ? "locked down" : "released"] via pulse")
+			log_silicon("[key_name(usr)] [!R.lockcharge ? "locked down" : "released"] [key_name(R)] via pulse")
 
 		if(WIRE_RESET_MODEL)
 			if(R.has_model())
@@ -74,7 +74,7 @@
 		if(WIRE_AI) // Cut the AI wire to reset AI control.
 			if(!mend)
 				R.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
-				log_combat(usr, R, "cut AI wire on cyborg[R.connected_ai ? " and disconnected from [ADMIN_LOOKUP(R.connected_ai)]": ""]")
+				log_silicon("[key_name(usr)] cut AI wire on [key_name(R)][R.connected_ai ? " and disconnected from [ADMIN_LOOKUP(R.connected_ai)]": ""]")
 				if(R.shell)
 					R.undeploy()
 				R.set_connected_ai(null)
@@ -83,26 +83,26 @@
 			if(mend)
 				if(!R.emagged)
 					R.lawupdate = TRUE
-					log_combat(usr, R, "enabled lawsync via wire")
+					log_silicon("[key_name(usr)] enabled [key_name(R)]'s lawsync via wire")
 			else if(!R.deployed) //AI shells must always have the same laws as the AI
 				R.lawupdate = FALSE
-				log_combat(usr, R, "disabled lawsync via wire")
-			R.logevent("Lawsync Module fault [mend?"cleared":"detected"]")
+				log_silicon("[key_name(usr)] disabled [key_name(R)]'s lawsync via wire")
+			R.logevent("Lawsync Module fault [mend ? "cleared" : "detected"]")
 		if (WIRE_CAMERA) // Disable the camera.
 			if(!QDELETED(R.builtInCamera) && !R.scrambledcodes)
 				R.builtInCamera.status = mend
 				R.builtInCamera.toggle_cam(usr, 0)
 				R.visible_message(span_notice("[R]'s camera lens focuses loudly."), span_notice("Your camera lens focuses loudly."))
 				R.logevent("Camera Module fault [mend?"cleared":"detected"]")
-				log_combat(usr, R, "[mend ? "enabled" : "disabled"] cyborg camera via wire")
+				log_silicon("[key_name(usr)] [mend ? "enabled" : "disabled"] [key_name(R)]'s camera via wire")
 		if(WIRE_LOCKDOWN) // Simple lockdown.
 			R.SetLockdown(!mend)
 			R.logevent("Motor Controller fault [mend?"cleared":"detected"]")
-			log_combat(usr, R, "[!R.lockcharge ? "locked down" : "released"] via wire")
+			log_silicon("[key_name(usr)] [!R.lockcharge ? "locked down" : "released"] [key_name(R)] via wire")
 		if(WIRE_RESET_MODEL)
 			if(R.has_model() && !mend)
 				R.ResetModel()
-				log_combat(usr, R, "reset the cyborg module via wire")
+				log_silicon("[key_name(usr)] reset [key_name(R)]'s module via wire")
 
 /datum/wires/robot/can_reveal_wires(mob/user)
 	if(HAS_TRAIT(user, TRAIT_KNOW_CYBORG_WIRES))

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -56,7 +56,7 @@ AI MODULES
 		if(tot_laws > CONFIG_GET(number/silicon_max_law_amount) && !bypass_law_amt_check)//allows certain boards to avoid this check, eg: reset
 			to_chat(user, span_alert("Not enough memory allocated to [law_datum.owner ? law_datum.owner : "the AI core"]'s law processor to handle this amount of laws."))
 			message_admins("[ADMIN_LOOKUPFLW(user)] tried to upload laws to [law_datum.owner ? ADMIN_LOOKUPFLW(law_datum.owner) : "an AI core"] that would exceed the law cap.")
-			log_game("[ADMIN_LOOKUP(user)] tried to upload laws to [law_datum.owner ? ADMIN_LOOKUP(law_datum.owner) : "an AI core"] that would exceed the law cap.")
+			log_silicon("[key_name(user)] tried to upload laws to [law_datum.owner ? key_name(law_datum.owner) : "an AI core"] that would exceed the law cap.")
 			overflow = TRUE
 
 	var/law2log = transmitInstructions(law_datum, user, overflow) //Freeforms return something extra we need to log

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -38,7 +38,7 @@
 	else //No AI on the card, therefore the user wants to download one.
 		target.transfer_ai(AI_TRANS_TO_CARD, user, null, src)
 		if(AI)
-			log_combat(user, AI, "carded", src)
+			log_silicon("[key_name(user)] carded [key_name(AI)]", src)
 			update_appearance()
 			return TRUE
 	return ..()

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -24,6 +24,7 @@
 		AI.add_malf_picker()
 		AI.hack_software = TRUE
 		log_game("[key_name(user)] has upgraded [key_name(AI)] with a [src].")
+		log_silicon("[key_name(user)] has upgraded [key_name(AI)] with a [src].")
 		message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
 	to_chat(user, span_notice("You upgrade [AI]. [src] is consumed in the process."))
 	qdel(src)

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -23,7 +23,6 @@
 		to_chat(AI, span_userdanger("Your current laws and objectives remain unchanged.")) //this unlocks malf powers, but does not give the license to plasma flood
 		AI.add_malf_picker()
 		AI.hack_software = TRUE
-		log_game("[key_name(user)] has upgraded [key_name(AI)] with a [src].")
 		log_silicon("[key_name(user)] has upgraded [key_name(AI)] with a [src].")
 		message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
 	to_chat(user, span_notice("You upgrade [AI]. [src] is consumed in the process."))

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -145,9 +145,9 @@
 	to_chat(user, span_notice("You [chest.cell ? "replace [src]'s [chest.cell.name] with [temp_cell]" : "insert [temp_cell] into [src]"]."))
 	chest.cell = temp_cell
 	return TRUE
+
 //ADD
 /obj/item/robot_suit/attackby(obj/item/W, mob/user, params)
-
 	if(istype(W, /obj/item/stack/sheet/iron))
 		var/obj/item/stack/sheet/iron/M = W
 		if(!l_arm && !r_arm && !l_leg && !r_leg && !chest && !head)
@@ -324,7 +324,7 @@
 		var/obj/item/borg/upgrade/ai/M = W
 		if(check_completion())
 			if(!isturf(loc))
-				to_chat(user, span_warning("You cannot install[M], the frame has to be standing on the ground to be perfectly precise!"))
+				to_chat(user, span_warning("You cannot install [M], the frame has to be standing on the ground to be perfectly precise!"))
 				return
 			if(!user.temporarilyRemoveItemFromInventory(M))
 				to_chat(user, span_warning("[M] is stuck to your hand!"))
@@ -401,16 +401,19 @@
 				created_name = ""
 				return
 			created_name = new_name
-			log_game("[key_name(user)] have set \"[new_name]\" as a cyborg shell name at [loc_name(user)]")
+			log_silicon("[key_name(user)] has set \"[new_name]\" as a cyborg shell name at [loc_name(user)]")
 			return TRUE
 		if("locomotion")
 			locomotion = !locomotion
+			log_silicon("[key_name(user)] has [locomotion ? "enabled" : "disabled"] movement on a cyborg shell at [loc_name(user)]")
 			return TRUE
 		if("panel")
 			panel_locked = !panel_locked
+			log_silicon("[key_name(user)] has [panel_locked ? "locked" : "unlocked"] the panel on a cyborg shell at [loc_name(user)]")
 			return TRUE
 		if("aisync")
 			aisync = !aisync
+			log_silicon("[key_name(user)] has [aisync ? "enabled" : "disabled"] the AI sync for a cyborg shell at [loc_name(user)]")
 			return TRUE
 		if("set_ai")
 			var/selected_ai = select_active_ai(user, z)
@@ -420,7 +423,9 @@
 				to_chat(user, span_alert("No active AIs detected."))
 				return
 			forced_ai = selected_ai
+			log_silicon("[key_name(user)] set the default AI for a cyborg shell to [key_name(selected_ai)] at [log_name(user)]")
 			return TRUE
 		if("lawsync")
 			lawsync = !lawsync
+			log_silicon("[key_name(user)] has [lawsync ? "enabled" : "disabled"] the law sync for a cyborg shell at [loc_name(user)]")
 			return TRUE

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -423,7 +423,7 @@
 				to_chat(user, span_alert("No active AIs detected."))
 				return
 			forced_ai = selected_ai
-			log_silicon("[key_name(user)] set the default AI for a cyborg shell to [key_name(selected_ai)] at [log_name(user)]")
+			log_silicon("[key_name(user)] set the default AI for a cyborg shell to [key_name(selected_ai)] at [loc_name(user)]")
 			return TRUE
 		if("lawsync")
 			lawsync = !lawsync

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -47,7 +47,7 @@
 			if(prob(shuffleLawsChance))
 				M.shuffle_laws(list(LAW_INHERENT, LAW_SUPPLIED, LAW_ION))
 
-			log_game("Ion storm changed laws of [key_name(M)] to [english_list(M.laws.get_law_list(TRUE, TRUE))]")
+			log_silicon("Ion storm changed laws of [key_name(M)] to [english_list(M.laws.get_law_list(TRUE, TRUE))]")
 			M.post_lawchange()
 
 	if(botEmagChance)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -363,7 +363,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	lawupdate = FALSE
 	set_connected_ai(null)
 	message_admins("[ADMIN_LOOKUPFLW(user)] emagged cyborg [ADMIN_LOOKUPFLW(src)].  Laws overridden.")
-	log_silicon("EMAG: [key_name(user)] emagged cyborg [key_name(src)].  Laws overridden.")
+	log_silicon("EMAG: [key_name(user)] emagged cyborg [key_name(src)]. Laws overridden.")
 	var/time = time2text(world.realtime,"hh:mm:ss")
 	if(user)
 		GLOB.lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")


### PR DESCRIPTION
## About The Pull Request
Moves a bunch of logs that were silicon-related but logged to game.log to silicon.log.

## Why It's Good For The Game
Logs for silicon-specific actions should all be in one place, not split between attack logs and silicon logs.

## Changelog
:cl:
admin: cyborg wire pulses/cuts are now logged in silicon.log
admin: AIs being carded is now logged in silicon.log
admin: giving an AI a combat module is now logged in silicon.log
admin: trying to upload over the maximum number of laws is now logged in silicon.log
admin: ion storm law changes are now logged in silicon.log
admin: changing settings on a borg shell is now logged in silicon.log
/:cl: