### PR TITLE
Makes traitor reputation display consistent

### DIFF
--- a/code/__DEFINES/uplink.dm
+++ b/code/__DEFINES/uplink.dm
@@ -10,5 +10,5 @@
 #define UPLINK_CLOWN_OPS (1 << 2)
 
 /// Progression gets turned into a user-friendly form. This is just an abstract equation that makes progression not too large.
-#define DISPLAY_PROGRESSION(time) round(time/600, 0.01)
+#define DISPLAY_PROGRESSION(time) round(time/60, 0.01)
 

--- a/tgui/packages/tgui/interfaces/Uplink/calculateReputationLevel.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/calculateReputationLevel.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex } from '../../components';
 
 export const calculateProgression = (progression_points: number) => {
-  return Math.round(progression_points / 6) / 10;
+  return Math.round(progression_points / 6) / 100;
 };
 
 const badGradient = "reputation-bad";

--- a/tgui/packages/tgui/interfaces/Uplink/calculateReputationLevel.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/calculateReputationLevel.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex } from '../../components';
 
 export const calculateProgression = (progression_points: number) => {
-  return Math.round(progression_points / 6) / 100;
+  return Math.round(progression_points / 6) / 10;
 };
 
 const badGradient = "reputation-bad";


### PR DESCRIPTION
## About The Pull Request

This pull requests converts the Uplink UI's progression point to reputation calculation to use the same calculation as DISPLAY_PROGRESSION does, so the reputation values you see in the Uplink, are not ten times the actual reputation your objective talk about.

Of course, the decimal values are a bit ugly according to some, so alternatively we could make DISPLAY_PROGRESSION  show ten times the value.

## Why It's Good For The Game

Having the uplink's display values be 10 times larger than the values displayed on your antaginfo panels can lead to people think they have gathered enough reputation, when they are actually way, way behind.

## Changelog

:cl:
fix: Player-facing Traitor reputation numbers are now consistent when you view how much you have.
/:cl:

