### PR TITLE
Fix asteroid parallax layering issue

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -324,6 +324,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 
 /atom/movable/screen/parallax_layer/random/asteroids
 	icon_state = "asteroids"
+	layer = 4
 
 /atom/movable/screen/parallax_layer/planet
 	icon_state = "planet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
on insane level of parallax detail blue stars are rendered. This PR fixes a layering issue where the blue stars would render on top of the asteroids.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Looks bad.

**BEFORE:**
![dreamseeker_rlZ4e2T8zn](https://user-images.githubusercontent.com/16618648/170806343-c1b31369-dd04-4b27-9776-1edaa65003e0.gif)

**AFTER:**
![dreamseeker_Rpol1Tcbm6](https://user-images.githubusercontent.com/16618648/170806370-88f49c3e-d3cf-47e6-ada2-618ac9f0c450.gif)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed parallax blue stars showing through parallax asteroids.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
