### PR TITLE
Simple animal Destroy edge case fix

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -214,8 +214,7 @@
 
 /mob/living/simple_animal/Destroy()
 	GLOB.simple_animals[AIStatus] -= src
-	if (SSnpcpool.state == SS_PAUSED && LAZYLEN(SSnpcpool.currentrun))
-		SSnpcpool.currentrun -= src
+	SSnpcpool.currentrun -= src
 
 	if(nest)
 		nest.spawned_mobs -= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm not sure if this is the main reason for the simple_animal npcpool problem.. But I'm pretty sure it at least is the cause a non-zero number of times.

Actually looked at it in response to runtimes from  #67273

In the case of `SSnpcpool.state == SS_PAUSING`, simple animals currently do not remove themselves from `SSnpcpool.currentrun` when destroyed. However, on the next run of `npcpool/fire()`, `resumed` will be `TRUE` so it will use the old currentlist, where that simple_animal will still be there.

Also there's no reason for those checks in `simple_animal/Destroy()` anyway as far as I can tell.

Please correct me if I misunderstand how subsystems work. Pretty sure the above will happen during `SS_PAUSING` before this PR change though. Do we have a test that was reliably causing the simple_animals active list error on master?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Maybe fix some cases of that issue happening?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

No player-facing change.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
