### PR TITLE
patches a hole in the fatness immunity of podpeople

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -48,12 +48,13 @@
 		var/turf/T = H.loc
 		light_amount = min(1, T.get_lumcount()) - 0.5
 		H.adjust_nutrition(5 * light_amount * delta_time)
-		if(H.nutrition > NUTRITION_LEVEL_ALMOST_FULL)
-			H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
 		if(light_amount > 0.2) //if there's enough light, heal
 			H.heal_overall_damage(0.5 * delta_time, 0.5 * delta_time, 0, BODYTYPE_ORGANIC)
 			H.adjustToxLoss(-0.5 * delta_time)
 			H.adjustOxyLoss(-0.5 * delta_time)
+
+	if(H.nutrition > NUTRITION_LEVEL_ALMOST_FULL) //don't make podpeople fat because they stood in the sun for too long
+			H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
 		H.take_overall_damage(1 * delta_time, 0)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -54,7 +54,7 @@
 			H.adjustOxyLoss(-0.5 * delta_time)
 
 	if(H.nutrition > NUTRITION_LEVEL_ALMOST_FULL) //don't make podpeople fat because they stood in the sun for too long
-			H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
+		H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
 		H.take_overall_damage(1 * delta_time, 0)


### PR DESCRIPTION
## About The Pull Request

The check that makes podpeople immune to becoming fat (as otherwise, they'd near-instantly become fat simply from being in brightly lit areas) is only run if they're in a turf and not inside of something. Thus, if a podperson chows down on some food, then hides in a locker, they will be able to become fat.

This PR moves the anti-fatness check to be outside of that isturf() check (and next to the check that makes podpeople take damage if their hunger level is too low).

## Why It's Good For The Game

I don't want to feel obligated to mention this loophole every time I tell someone that podpeople are immune to getting fat, and it doesn't really have an in-universe explanation.

## Changelog

:cl: ATHATH
fix: Podpeople can no longer circumvent their immunity to becoming fat by chowing down on some food and then hiding in a locker.
/:cl: