### PR TITLE
fixes airlock ai cut wires runtiming

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -147,7 +147,7 @@
 			if(24 to 30)
 				airlock.panel_open = TRUE
 	if(airlock.cutAiWire)
-		wires.cut(WIRE_AI)
+		airlock.aiControlDisabled = AI_WIRE_DISABLED
 	if(airlock.autoname)
 		name = get_area_name(src, TRUE)
 	update_appearance()

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -147,9 +147,9 @@
 			if(24 to 30)
 				airlock.panel_open = TRUE
 	if(airlock.cutAiWire)
-		airlock.aiControlDisabled = AI_WIRE_DISABLED
+		airlock.wires.cut(WIRE_AI)
 	if(airlock.autoname)
-		name = get_area_name(src, TRUE)
+		airlock.name = get_area_name(src, TRUE)
 	update_appearance()
 	qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

these cut the ai wire of the mapping helper. not of the airlock, this runtimes and never deletes the mapping helper.
fixes #66664 

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
sopa the macaco

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes airlock ai mapping helpers not working
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
