### PR TITLE
Slime Stasis state gas changed to Nitrous from Bz

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -52892,7 +52892,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/south,
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "otS" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -22682,7 +22682,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "hnB" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -64650,7 +64650,7 @@
 	pixel_x = -24;
 	req_access = list("xenobiology")
 	},
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "smR" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -64398,7 +64398,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/box,
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "wGR" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -42200,7 +42200,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "omS" = (

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -143,15 +143,15 @@
 		REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, SLIME_COLD)
 
 	if(stat != DEAD)
-		var/bz_percentage =0
-		if(environment.gases[/datum/gas/bz])
-			bz_percentage = environment.gases[/datum/gas/bz][MOLES] / environment.total_moles()
-		var/stasis = (bz_percentage >= 0.05 && bodytemperature < (T0C + 100)) || force_stasis
+		var/nitrous_oxide_percentage =0
+		if(environment.gases[/datum/gas/nitrous_oxide])
+			nitrous_oxide_percentage = environment.gases[/datum/gas/nitrous_oxide][MOLES] / environment.total_moles()
+		var/stasis = (nitrous_oxide_percentage >= 0.05 && bodytemperature < (T0C + 100)) || force_stasis
 
 		switch(stat)
 			if(CONSCIOUS)
 				if(stasis)
-					to_chat(src, span_danger("Nerve gas in the air has put you in stasis!"))
+					to_chat(src, span_danger("Sleeping gas in the air has put you in stasis!"))
 					set_stat(UNCONSCIOUS)
 					powerlevel = 0
 					rabid = FALSE

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -236,7 +236,7 @@
 
 	switch(stat)
 		if(HARD_CRIT, UNCONSCIOUS)
-			. += "You are knocked out by high levels of BZ!"
+			. += "You are knocked out by high levels of Nitrous Oxide!"
 		else
 			. += "Power Level: [powerlevel]"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Slimes will now enter their sleep state by Nitrous Oxide rather then Bz, Maps have been updated to include Nitrous Cans in Xenobio where old Bz cans were.
This also effects Anomaly Red Slimes and other Sentient Slimes. Very minor edits to alert messages.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Prior to #66738 Xenobio would always receive a Bz canaster to be used for slime stasis. After Toxins to Ordinance changes were made these canasters were often taken to complete Bz Shell experiments and Noblium formation whether those doing Xenobio  wanted them or not to quote the one of the comments in #66738 which really summed it up well.

> Years of Atmosian Culture die today, our younglings will never know the joy of speedrunning that BZ can and bashing a Xenobiologist's skull in for getting in the way... Memery aside, this is a good change. 

I also don’t believe that Ordinance will provide Xenobio with Bz as there is no advantage for Ordinance to do and will just add more work for them when they could be making bombs or core compressions. Ordinance is not Atmospherics and Atmospherics won't do it for the same reason as Ordinance won't.

If Bz is supplied to Xenobio from Ordinance it will have been too late in the round for it to matter due to it being slow to produce with t3 or better lasers needed and slow formation speed. It will also be even later if its used in Nobilium formation first.

Why Nitrous..

Cheaper and easier to acquire than BZ with it being one of the starting Atmospheric gasses. 
It already has a similar reaction with Carbon Mobs.
Makes Xenobio sabotage/malpractice much more interesting and effective.
Slime persons already have this reaction and ethereals which are from the same planet as Slimes also do.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

balance: Slimes will now enter their sleep state by Nitrous Oxide rather then Bz. Xenobio on maps changed to reflect this.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
