### PR TITLE
Fixes Being Able To See Rock Out Of Nuke Ops Shuttle

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -38819,7 +38819,7 @@ WV
 Bz
 pw
 Es
-OL
+hh
 OL
 OL
 Zc
@@ -39076,8 +39076,8 @@ Bz
 pw
 Bz
 Es
+hh
 OL
-pJ
 pJ
 pJ
 pJ
@@ -39333,8 +39333,8 @@ Bz
 FR
 Bz
 Es
+hh
 OL
-hs
 pJ
 pJ
 pJ
@@ -39590,8 +39590,8 @@ Bz
 Bz
 Bz
 Es
+hh
 OL
-hs
 pJ
 aU
 pJ
@@ -39847,8 +39847,8 @@ Ff
 Ff
 Ff
 Es
+hh
 OL
-pJ
 pJ
 pJ
 pJ
@@ -40104,8 +40104,8 @@ Ff
 Ff
 Ff
 Es
+hh
 OL
-pJ
 Zc
 pJ
 pJ
@@ -40361,8 +40361,8 @@ Ff
 Ff
 Ff
 Es
+hh
 OL
-pJ
 pJ
 pJ
 pJ
@@ -40618,9 +40618,9 @@ Ff
 Ff
 Ff
 Es
+hh
 OL
 aU
-pJ
 pJ
 pJ
 pJ
@@ -40875,8 +40875,8 @@ Ff
 Ff
 Ff
 Es
+hh
 OL
-pJ
 pJ
 hs
 pJ
@@ -41132,8 +41132,8 @@ Ff
 Ff
 Ff
 Es
+hh
 OL
-pJ
 pJ
 pJ
 Zc
@@ -41389,8 +41389,8 @@ Ff
 Ff
 Ff
 Es
+hh
 OL
-pJ
 pJ
 aU
 pJ
@@ -41646,7 +41646,7 @@ Ff
 Ff
 Ff
 Es
-OL
+hh
 OL
 pJ
 pJ

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -39332,7 +39332,7 @@ WV
 Bz
 FR
 Bz
-Es
+Bz
 hh
 OL
 pJ
@@ -39589,7 +39589,7 @@ Bz
 Bz
 Bz
 Bz
-Es
+Bz
 hh
 OL
 pJ
@@ -39846,7 +39846,7 @@ Ff
 Ff
 Ff
 Ff
-Es
+Bz
 hh
 OL
 pJ
@@ -40103,7 +40103,7 @@ Ff
 Ff
 Ff
 Ff
-Es
+Bz
 hh
 OL
 Zc
@@ -40360,7 +40360,7 @@ Ff
 Ff
 Ff
 Ff
-Es
+Bz
 hh
 OL
 pJ
@@ -40617,7 +40617,7 @@ Ff
 Ff
 Ff
 Ff
-Es
+Bz
 hh
 OL
 aU
@@ -40874,7 +40874,7 @@ Ff
 Ff
 Ff
 Ff
-Es
+Bz
 hh
 OL
 pJ
@@ -41131,7 +41131,7 @@ Ff
 Ff
 Ff
 Ff
-Es
+Bz
 hh
 OL
 pJ
@@ -41388,7 +41388,7 @@ Ff
 Ff
 Ff
 Ff
-Es
+Bz
 hh
 OL
 pJ
@@ -41645,7 +41645,7 @@ Ff
 Ff
 Ff
 Ff
-Es
+Bz
 hh
 OL
 pJ
@@ -41902,7 +41902,7 @@ Bz
 Bz
 Bz
 Bz
-Es
+Bz
 hh
 OL
 hs
@@ -42159,7 +42159,7 @@ Bz
 Bz
 Bz
 Bz
-Es
+Bz
 hh
 OL
 OL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

![image](https://user-images.githubusercontent.com/34697715/170839403-57f628cd-4915-4bb0-94b1-37ba447b729b.png)

FUCK. Let's shift some walls around.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ruins immersion of the snow planet when you can see the walls that lead right into the Holding Facility.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The walls between the nuke ops base and the holding facility have been tweaked a bit to ensure that when you load in the nuke ops shuttle that you can't see the rocky walls of the holding facility. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
