### PR TITLE
access helpers for the centcom level

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -48,6 +48,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Workout Room"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -60,6 +61,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"as" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "at" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Backstage"
@@ -745,10 +758,10 @@
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "ck" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Thunderdome";
-	req_access = list("cent_general")
+	name = "Thunderdome"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/bar,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "cl" = (
@@ -796,10 +809,10 @@
 /area/centcom/central_command_areas/holding)
 "ct" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "cu" = (
@@ -1254,6 +1267,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Kitchen"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -1593,11 +1607,11 @@
 /area/centcom/syndicate_mothership/control)
 "eD" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Administrative Office";
-	req_access = list("cent_captain")
+	name = "Administrative Office"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
 "eE" = (
@@ -1979,6 +1993,7 @@
 	name = "Backup Emergency Escape Shuttle"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "fG" = (
@@ -1986,6 +2001,7 @@
 	name = "Bathroom"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/admin)
 "fH" = (
@@ -2111,6 +2127,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "War Room"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/textured_large,
 /area/centcom/syndicate_mothership/control)
 "gd" = (
@@ -2129,6 +2146,7 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "gh" = (
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
 	},
@@ -2444,6 +2462,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"hf" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Backstage"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/bar,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "hg" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 4
@@ -2658,6 +2686,7 @@
 /obj/effect/turf_decal/siding/wideplating,
 /obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -2749,8 +2778,7 @@
 /area/centcom/syndicate_mothership)
 "hN" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Thunderdome";
-	req_access = list("cent_general")
+	name = "Thunderdome"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -3326,12 +3354,12 @@
 /area/centcom/central_command_areas/supply)
 "jr" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "Supply Shuttle";
-	req_access = list("cent_storage")
+	name = "Supply Shuttle"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "js" = (
@@ -3867,6 +3895,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Medical Bay"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -3886,10 +3915,10 @@
 /area/centcom/central_command_areas/courtroom)
 "kZ" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "la" = (
@@ -4120,18 +4149,18 @@
 /area/space)
 "lJ" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Shuttle Control Office";
-	req_access = list("cent_captain")
+	name = "Shuttle Control Office"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "lK" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Supply";
-	req_access = list("cent_storage")
+	name = "CentCom Supply"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "lL" = (
@@ -4194,12 +4223,12 @@
 /area/centcom/central_command_areas/supplypod/supplypod_temp_holding)
 "lT" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "lU" = (
@@ -4594,6 +4623,7 @@
 	},
 /obj/machinery/door/puzzle/keycard/syndicate_bio,
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -4717,12 +4747,12 @@
 /area/centcom/central_command_areas/control)
 "nq" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "nr" = (
@@ -4778,11 +4808,11 @@
 /area/centcom/central_command_areas/ferry)
 "nC" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "nE" = (
@@ -5199,13 +5229,13 @@
 /area/centcom/tdome/observation)
 "oI" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Administration";
-	req_access = list("cent_thunder")
+	name = "Thunderdome Administration"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "oJ" = (
@@ -5273,6 +5303,7 @@
 /obj/machinery/door/airlock/glass_large{
 	name = "Disembarkents"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -5923,6 +5954,14 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
+"qL" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/prison)
 "qM" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -5939,11 +5978,11 @@
 /area/centcom/central_command_areas/ferry)
 "qS" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "qT" = (
@@ -6201,13 +6240,12 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "rR" = (
-/obj/machinery/door/airlock/external/ruin{
-	req_access = list("syndicate")
-	},
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
 "rS" = (
@@ -6282,9 +6320,9 @@
 /area/centcom/tdome/observation)
 "sd" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Orbital Drop Pod Loading";
-	req_access = list("cent_storage")
+	name = "Orbital Drop Pod Loading"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "sh" = (
@@ -6307,6 +6345,19 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/sepia,
 /area/centcom/central_command_areas/holding)
+"sn" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/medical,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "sq" = (
 /obj/machinery/computer/shuttle/white_ship{
 	dir = 4
@@ -6372,6 +6423,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"sy" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "sz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/status_display/evac/directional/west,
@@ -6435,12 +6496,12 @@
 /area/centcom/central_command_areas/control)
 "sL" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "sM" = (
@@ -6534,16 +6595,16 @@
 /area/centcom/wizard_station)
 "sY" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Supplypod Loading";
-	req_access = list("cent_storage")
+	name = "CentCom Supplypod Loading"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "sZ" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Supplypod Loading";
-	req_access = list("cent_storage")
+	name = "CentCom Supplypod Loading"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod)
 "ta" = (
@@ -6679,12 +6740,12 @@
 /area/centcom/central_command_areas/ferry)
 "tu" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Supply";
-	req_access = list("cent_storage")
+	name = "CentCom Supply"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "tx" = (
@@ -6709,6 +6770,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
 "tB" = (
@@ -6721,6 +6783,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "Sky Bridge"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/textured_large,
 /area/centcom/syndicate_mothership/control)
 "tC" = (
@@ -6746,8 +6809,7 @@
 /area/centcom/syndicate_mothership/control)
 "tF" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Locker Room";
-	req_access = list("cent_general")
+	name = "Thunderdome Locker Room"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -6761,11 +6823,11 @@
 /area/centcom/tdome/observation)
 "tH" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Administration";
-	req_access = list("cent_thunder")
+	name = "Thunderdome Administration"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "tI" = (
@@ -6869,6 +6931,20 @@
 /obj/effect/baseturf_helper/asteroid/snow,
 /turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_mothership/control)
+"ub" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "uc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -7062,10 +7138,10 @@
 /area/centcom/central_command_areas/courtroom)
 "uO" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Shuttle Control Office";
-	req_access = list("cent_captain")
+	name = "Shuttle Control Office"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "uP" = (
@@ -7266,6 +7342,17 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"vu" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/courtroom)
 "vz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -7319,11 +7406,11 @@
 /area/centcom/central_command_areas/ferry)
 "vF" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Administrative Office";
-	req_access = list("cent_captain")
+	name = "Administrative Office"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "vG" = (
@@ -7600,8 +7687,7 @@
 "wu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -7609,6 +7695,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "wv" = (
@@ -7665,12 +7752,12 @@
 /area/centcom/central_command_areas/ferry)
 "wC" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Customs";
-	req_access = list("cent_captain")
+	name = "CentCom Customs"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "wE" = (
@@ -7688,6 +7775,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/catwalk_floor/iron,
 /area/centcom/syndicate_mothership/control)
 "wG" = (
@@ -7859,6 +7947,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "xd" = (
@@ -8213,8 +8302,7 @@
 /area/centcom/central_command_areas/admin/storage)
 "yj" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8222,6 +8310,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "yn" = (
@@ -8246,10 +8335,10 @@
 /area/centcom/syndicate_mothership/control)
 "yr" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Briefing Room";
-	req_access = list("cent_general")
+	name = "Briefing Room"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "ys" = (
@@ -8480,6 +8569,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 8
 	},
@@ -8539,6 +8629,7 @@
 	name = "Infirmary"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/medical,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "zl" = (
@@ -9392,13 +9483,13 @@
 /area/centcom/syndicate_mothership)
 "BA" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "BB" = (
@@ -9522,10 +9613,10 @@
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
 "BM" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "BN" = (
@@ -9689,6 +9780,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/catwalk_floor/iron,
 /area/centcom/syndicate_mothership/control)
 "Cm" = (
@@ -9804,8 +9896,7 @@
 /area/centcom/central_command_areas/holding)
 "Cz" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Thunderdome";
-	req_access = list("cent_general")
+	name = "Thunderdome"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -9855,6 +9946,7 @@
 	name = "Sky Bridge"
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/textured_large,
 /area/centcom/syndicate_mothership/control)
 "CH" = (
@@ -10077,6 +10169,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "Dr" = (
@@ -10504,6 +10597,7 @@
 	},
 /obj/machinery/door/puzzle/keycard/syndicate_bomb,
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -10616,6 +10710,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/catwalk_floor/titanium,
 /area/centcom/syndicate_mothership/control)
 "EU" = (
@@ -10731,12 +10826,12 @@
 "Fj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Administration";
-	req_access = list("cent_thunder")
+	name = "Thunderdome Administration"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "Fk" = (
@@ -10893,6 +10988,7 @@
 	dir = 1
 	},
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -11122,6 +11218,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Security Checkpoint"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -11453,6 +11550,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "Hq" = (
@@ -11586,6 +11684,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -11597,6 +11696,7 @@
 	},
 /obj/machinery/door/puzzle/keycard/syndicate_chem,
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -11975,6 +12075,7 @@
 	},
 /obj/effect/turf_decal/siding/wideplating,
 /obj/machinery/door/puzzle/keycard/syndicate_fridge,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -12335,8 +12436,7 @@
 /area/centcom/central_command_areas/briefing)
 "Kf" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Administrative Storage";
-	req_access = list("cent_storage")
+	name = "Administrative Storage"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -12345,6 +12445,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
 "Kg" = (
@@ -12437,6 +12538,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Cafeteria"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -12604,6 +12706,7 @@
 	name = "Sky Bridge"
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/textured_large,
 /area/centcom/syndicate_mothership/control)
 "KY" = (
@@ -12922,6 +13025,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Closet"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_edge,
 /area/centcom/syndicate_mothership/control)
 "Mh" = (
@@ -13439,13 +13543,13 @@
 /area/centcom/central_command_areas/holding)
 "NG" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "NH" = (
@@ -13563,13 +13667,13 @@
 /area/centcom/central_command_areas/holding)
 "Oc" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Administrative Office";
-	req_access = list("cent_captain")
+	name = "Administrative Office"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "Od" = (
@@ -13782,11 +13886,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/dark/textured_half,
 /area/centcom/syndicate_mothership/control)
 "Oz" = (
 /obj/machinery/door/airlock/external/ruin,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "OB" = (
@@ -13854,9 +13960,7 @@
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
 "OJ" = (
-/obj/machinery/door/airlock/external/ruin{
-	req_access = list("syndicate")
-	},
+/obj/machinery/door/airlock/external/ruin,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
@@ -13864,6 +13968,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
 "OL" = (
@@ -13896,11 +14001,11 @@
 /area/centcom/central_command_areas/supplypod/loading/one)
 "OQ" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Briefing Room";
-	req_access = list("cent_general")
+	name = "Briefing Room"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "OR" = (
@@ -14682,10 +14787,10 @@
 /area/centcom/central_command_areas/admin/storage)
 "Ra" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "Rb" = (
@@ -16106,8 +16211,7 @@
 /area/centcom/central_command_areas/supplypod)
 "UO" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16115,6 +16219,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "UP" = (
@@ -16618,8 +16723,7 @@
 /area/centcom/central_command_areas/holding)
 "Wc" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16627,6 +16731,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Wd" = (
@@ -16708,6 +16813,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Tool Closet"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/mineral/titanium/yellow,
 /area/centcom/syndicate_mothership/control)
 "Ws" = (
@@ -16735,8 +16841,7 @@
 	id = "XCCFerry";
 	name = "Hanger Bay Shutters";
 	pixel_x = -8;
-	pixel_y = 24;
-	req_access = list("cent_general")
+	pixel_y = 24
 	},
 /obj/machinery/button/door/indestructible{
 	id = "XCCsec3";
@@ -16756,6 +16861,7 @@
 	pixel_x = -8;
 	pixel_y = 38
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
@@ -16931,8 +17037,7 @@
 "WQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16940,6 +17045,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "WR" = (
@@ -16969,12 +17075,12 @@
 /area/centcom/tdome/arena)
 "WU" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Administrative Office";
-	req_access = list("cent_captain")
+	name = "Administrative Office"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
 "WV" = (
@@ -17157,11 +17263,11 @@
 /area/centcom/central_command_areas/supplypod/loading/one)
 "Xt" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "Xu" = (
@@ -17198,6 +17304,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "Xz" = (
@@ -17542,6 +17649,7 @@
 	locked = 1;
 	name = "CentCom Auxiliary Announcement Closet"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "YB" = (
@@ -18062,13 +18170,13 @@
 /area/centcom/syndicate_mothership/control)
 "ZX" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access = list("cent_general")
+	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "ZY" = (
@@ -58369,7 +58477,7 @@ PT
 Nl
 QC
 QC
-at
+hf
 QC
 QC
 QC
@@ -59631,9 +59739,9 @@ iu
 iu
 io
 io
-Oj
+ub
 mk
-Oj
+ub
 io
 io
 iu
@@ -64240,7 +64348,7 @@ lL
 lL
 lL
 lL
-Ra
+qL
 lL
 lL
 Pq
@@ -64537,7 +64645,7 @@ Ad
 Nl
 QC
 QC
-at
+hf
 QC
 QC
 QC
@@ -65806,7 +65914,7 @@ cg
 cg
 cg
 cg
-UO
+sn
 cg
 cg
 fm
@@ -66087,12 +66195,12 @@ QC
 ei
 Ah
 pI
-tH
+sy
 Bp
 Tt
 Bj
 Bp
-oI
+as
 Bp
 Sz
 Sz
@@ -67062,11 +67170,11 @@ aa
 aa
 Hv
 Hv
-ja
+vu
 Hv
 Hv
 Hv
-ja
+vu
 Hv
 Hv
 Hv

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1993,7 +1993,6 @@
 	name = "Backup Emergency Escape Shuttle"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "fG" = (
@@ -2146,7 +2145,6 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "gh" = (
-/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
 	},
@@ -4623,7 +4621,6 @@
 	},
 /obj/machinery/door/puzzle/keycard/syndicate_bio,
 /obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -6056,6 +6053,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Gangway"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "rm" = (
@@ -6423,16 +6421,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
-"sy" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Administration"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
-/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
-/turf/open/floor/iron,
-/area/centcom/tdome/administration)
 "sz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/status_display/evac/directional/west,
@@ -9774,6 +9762,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
+"Cj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration"
+	},
+/turf/open/floor/plating,
+/area/centcom/tdome/administration)
 "Ck" = (
 /obj/machinery/door/airlock/maintenance/external{
 	name = "Bunk Room 1"
@@ -10597,7 +10592,6 @@
 	},
 /obj/machinery/door/puzzle/keycard/syndicate_bomb,
 /obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -11228,6 +11222,7 @@
 	name = "Gangway"
 	},
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "Gr" = (
@@ -11696,7 +11691,6 @@
 	},
 /obj/machinery/door/puzzle/keycard/syndicate_chem,
 /obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -12075,7 +12069,6 @@
 	},
 /obj/effect/turf_decal/siding/wideplating,
 /obj/machinery/door/puzzle/keycard/syndicate_fridge,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -16861,7 +16854,6 @@
 	pixel_x = -8;
 	pixel_y = 38
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
@@ -66195,7 +66187,7 @@ QC
 ei
 Ah
 pI
-sy
+tH
 Bp
 Tt
 Bj
@@ -66710,7 +66702,7 @@ pO
 HE
 Sl
 SU
-Wn
+Cj
 Vl
 bM
 Wn

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -61,18 +61,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
-"as" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Administration"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
-/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
-/turf/open/floor/iron,
-/area/centcom/tdome/administration)
 "at" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Backstage"
@@ -66192,7 +66180,7 @@ Bp
 Tt
 Bj
 Bp
-as
+oI
 Bp
 Sz
 Sz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds access helpers for the centcom level for both the syndicate base and centcom proper. Utilizes some of the other access helpers and makes the access a bit more consistent

## Why It's Good For The Game

Yay access helpers!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Access helpers were added to centcom
fix: Some accesses in centcomm were made more consistent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
