### PR TITLE
Reduces the point reduction on traitor objectives significantly

### DIFF
--- a/code/modules/antagonists/traitor/traitor_objective.dm
+++ b/code/modules/antagonists/traitor/traitor_objective.dm
@@ -30,7 +30,7 @@
 	var/skipped = FALSE
 
 	/// Determines how influential global progression will affect this objective. Set to 0 to disable.
-	var/global_progression_influence_intensity = 0.5
+	var/global_progression_influence_intensity = 0
 	/// Determines how great the deviance has to be before progression starts to get reduced.
 	var/global_progression_deviance_required = 0.5
 	/// Determines the minimum and maximum progression this objective can be worth as a result of being influenced by global progression

--- a/code/modules/antagonists/traitor/traitor_objective.dm
+++ b/code/modules/antagonists/traitor/traitor_objective.dm
@@ -30,12 +30,12 @@
 	var/skipped = FALSE
 
 	/// Determines how influential global progression will affect this objective. Set to 0 to disable.
-	var/global_progression_influence_intensity = 0
+	var/global_progression_influence_intensity = 0.1
 	/// Determines how great the deviance has to be before progression starts to get reduced.
-	var/global_progression_deviance_required = 0.5
+	var/global_progression_deviance_required = 1
 	/// Determines the minimum and maximum progression this objective can be worth as a result of being influenced by global progression
 	/// Should only be smaller than or equal to 1
-	var/global_progression_limit_coeff = 0.1
+	var/global_progression_limit_coeff = 0.6
 	/// The deviance coefficient used to determine the randomness of the progression rewards.
 	var/progression_cost_coeff_deviance = 0.05
 	/// This gets added onto the coeff when calculating the updated progression cost. Used for variability and a slight bit of randomness


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR reduces the point reduction on traitor objectives significantly.

The maximum point reduction that can be achieved now is 40% and only appears if you are around 90 minutes ahead of progression (very unlikely)

10% point reduction is achieved if you are 40 minutes ahead of progression. Around 20% point reduction is achieved if you are 60 minutes ahead of progression and 35% point reduction is at 80 minutes ahead of progression.

If you are below 20 minutes ahead of progression, there is no reduction on progression points at all.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
The test with no progression point on objectives was tested and I found it alright, but there were cases where people seemingly got final objectives somewhat easy. There is also no reductions for low crew populations, making it easy to get final objectives on lowpop, which this'll help mitigate.

With this change, it will not make it impossible to reach final objectives but it'll make it somewhat harder as progression points will still be reduced in some capacity, but not as much as before.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Traitor objectives have a significantly reduced reputation reduction, making it more viable to gain reputation beyond the expected reputation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
