### PR TITLE
Projectile Dampener Module is now printable

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -123,7 +123,7 @@
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/megaphone,
 		/obj/item/mod/module/projectile_dampener,
-		/obj/item/mod/module/criminalcapture,
+		/obj/item/mod/module/pepper_shoulders,
 	)
 
 /obj/item/mod/control/pre_equipped/magnate

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -123,7 +123,7 @@
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/megaphone,
 		/obj/item/mod/module/projectile_dampener,
-		/obj/item/mod/module/pepper_shoulders,
+		/obj/item/mod/module/criminalcapture,
 	)
 
 /obj/item/mod/control/pre_equipped/magnate

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1389,13 +1389,6 @@
 	build_path = /obj/item/mod/module/anomaly_locked/kinesis
 	department_type = MODULE_ENGINEERING
 
-/datum/design/module/criminal_capture
-	name = "MOD Module: Criminal Capture"
-	id = "mod_criminal_capture"
-	materials = list(/datum/material/iron = 1000, /datum/material/gold = 500)
-	build_path = /obj/item/mod/module/criminalcapture
-	department_type = MODULE_SECURITY
-
 /datum/design/module/projectile_dampener
 	name = "MOD Module: Projectile Dampener"
 	id = "mod_projectile_dampener"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1388,3 +1388,17 @@
 	materials = list(/datum/material/iron = 2500, /datum/material/glass = 2000, /datum/material/uranium = 1000, /datum/material/bluespace = 1000)
 	build_path = /obj/item/mod/module/anomaly_locked/kinesis
 	department_type = MODULE_ENGINEERING
+
+/datum/design/module/criminal_capture
+	name = "MOD Module: Criminal Capture"
+	id = "mod_criminal_capture"
+	materials = list(/datum/material/iron = 1000, /datum/material/gold = 500)
+	build_path = /obj/item/mod/module/criminalcapture
+	department_type = MODULE_SECURITY
+
+/datum/design/module/projectile_dampener
+	name = "MOD Module: Projectile Dampener"
+	id = "mod_projectile_dampener"
+	materials = list(/datum/material/iron = 1000, /datum/material/bluespace = 500)
+	build_path = /obj/item/mod/module/projectile_dampener
+	department_type = MODULE_SECURITY

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1532,7 +1532,6 @@
 		"mod_mag_harness",
 		"mod_pathfinder",
 		"mod_holster",
-		"mod_criminal_capture",
 		"mod_projectile_dampener"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1533,7 +1533,7 @@
 		"mod_pathfinder",
 		"mod_holster",
 		"mod_criminal_capture",
-		"mod_project_dampener"
+		"mod_projectile_dampener"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1532,6 +1532,8 @@
 		"mod_mag_harness",
 		"mod_pathfinder",
 		"mod_holster",
+		"mod_criminal_capture",
+		"mod_project_dampener"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 


### PR DESCRIPTION
## About The Pull Request

Adds projectile dampener and criminal capture to security MOD techweb node and mech printer.

## Why It's Good For The Game

These mod currently can't be printed and HOS modsuit "Safeguard" is not pre-equipped with them. Considering it's wide usage for other MODsuits and talking to fikou, I have changed the previous pr idea into adding these to the exofab. Users can now choose between their regular security MOD or take the defensive one.

## Changelog
:cl: SpaceLove
add: Projectile Dampener(1000 metal, 500 bluespace) can be researched and printed like other modules.
:cl: