### PR TITLE
Roundstart engineering SMESes start with ROUGHLY 4-5 more minutes of power

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -408,7 +408,7 @@
 	log_smes()
 
 /obj/machinery/power/smes/engineering
-	charge = 2e6 // Engineering starts with some charge for singulo //sorry little one, singulo as engine is gone
+	charge = 2.5e6 // Engineering starts with some charge for singulo //sorry little one, singulo as engine is gone
 	output_level = 90000
 
 /obj/machinery/power/smes/magical


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Here was my math for eyeballing. Yes it is very rough

Current amount of power engie starts with: 2,000,000
Usually runs out at the 15 minute mark if nothing is done to setup SM, making each minute cost 133,333
Adding 4 "minutes" of power puts us at ROUGHLY 2.5e6
![image](https://user-images.githubusercontent.com/40974010/170884363-e1fb48d3-a65c-4721-9751-576cd6a2775e.png)
Assume that I undershot how fast the station runs out of power and this should make sense

## Why It's Good For The Game

Newer players need time to read wiki, go slow, etc. If the station runs out of power, the SM suddenly becomes a LOT harder due to pacmen now being required for bootup, on top of that the pacmen are now timed too to how much mats you have... you can see how it gets out of control, so let's give just a bit more time for newer players to approach the engine.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Engineering SMESes now start with a bit more juice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
