### PR TITLE
Fixes map votes not happening when the ALLOW_MAP_VOTING config flag was disabled

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -392,7 +392,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	if(SSvote.current_vote) //Theres already a vote running, default to rotation.
 		maprotate()
 		return
-	SSvote.initiate_vote(/datum/vote/map_vote, "automatic map rotation")
+	SSvote.initiate_vote(/datum/vote/map_vote, "automatic map rotation", forced = TRUE)
 
 /datum/controller/subsystem/mapping/proc/changemap(datum/map_config/change_to)
 	if(!change_to.MakeNextMap())


### PR DESCRIPTION
## About The Pull Request
It was an oversight from Melbert, it was intended to be forced, but it somehow wasn't. This resulted in servers that had those votes not available to be started by everyone being locked out of automatic map votes, because it was accidentally now tied in with the config.

## Why It's Good For The Game
Round-end map votes should still happen, even if you disable the option for everyone to start a map vote themselves.

## Changelog

:cl: GoldenAlpharex
fix: Map votes will now happen again once the shuttle departs, regardless of whether your server allows everyone to start a map vote or not, as intended.
/:cl: