### PR TITLE
Makes Pixel Perfect 2x the default pixel scaling method

### DIFF
--- a/code/modules/client/preferences/pixel_size.dm
+++ b/code/modules/client/preferences/pixel_size.dm
@@ -1,3 +1,10 @@
+/// All the possible values for the pixel size, left here for convenience.
+#define STRETCH_TO_FIT 0
+#define PIXEL_PERFECT_1X 1
+#define PIXEL_PERFECT_1_5X 1.5
+#define PIXEL_PERFECT_2X 2
+#define PIXEL_PERFECT_3X 3
+
 /datum/preference/numeric/pixel_size
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "pixel_size"
@@ -9,7 +16,13 @@
 	step = 0.5
 
 /datum/preference/numeric/pixel_size/create_default_value()
-	return 0
+	return PIXEL_PERFECT_2X
 
 /datum/preference/numeric/pixel_size/apply_to_client(client/client, value)
 	client?.view_size?.resetFormat()
+
+#undef STRETCH_TO_FIT
+#undef PIXEL_PERFECT_1X
+#undef PIXEL_PERFECT_1_5X
+#undef PIXEL_PERFECT_2X
+#undef PIXEL_PERFECT_3X


### PR DESCRIPTION
## About The Pull Request
For whatever reason, Stretch to fit was the default value for the pixel scaling method preference. That means that, by default, unless you were extremely lucky with your screen resolution, and/or fought a while with the width of your chat window, your game would oftentimes look disproportionate, and would lose a lot of pixel fidelity, rendering many things uglier than they should be.

**What's the difference between the two?**
Stretch to fit will stretch the width and height of the pixels displayed on your screen to match the entire window they're contained in. That means that, unless you have a perfect ratio for that window, you'll have certain rows or columns of pixels that are wider or narrower than others.
Pixel Perfect, on the other hand, will use the exact amount of pixels on your screen to match the size of an in-game pixel. That means that Pixel Perfect 2x will take a 2 by 2 square of pixels on your screen to display a game pixel, ensuring that every pixel has the same size.

**Why does it matter?**
/tg/ has been moving forward with massive improvements to its sprites in the past year or two, and it's a shame that new players don't get to fully enjoy that beauty because the resolution of the game doesn't do them justice.

## Why It's Good For The Game
New players should be able to choose to change their setting to Stretch to fit if they feel like that'd be an improvement for them, rather than making it the default. I think that pixel fidelity (and therefor, sprite fidelity) is more important than avoiding some black bars at both ends of your screen. It becomes a conscious decision to make things look unlike what they're intended to look like.

<details><summary>I mean, look at these:</summary>

Stretch to fit:
![image](https://user-images.githubusercontent.com/58045821/170888773-3ecbd6d4-3c2e-46e7-a49f-384f0cd10ec9.png)

Pixel Perfect 2x:
![image](https://user-images.githubusercontent.com/58045821/170888791-40d9dd57-10fe-42a5-a36b-a215a49b2eea.png)
</details>

<details><summary>Or these</summary>

Stretch to fit:
![image](https://user-images.githubusercontent.com/58045821/170889861-ec773fb5-72f8-4dc0-833b-f282bd04c3a3.png)
(notice the deformed right leg of the captain, that wider split on that one tile and that guy with one eye wider than the other)

Pixel Perfect 2x:
![image](https://user-images.githubusercontent.com/58045821/170889868-965b7a37-51e8-4b03-8430-b905465b9820.png)
(all is uniform)
</details>


## Changelog

:cl: GoldenAlpharex
qol: Pixel Perfect 2x is now the default pixel scaling method, rather than Stretch to fit, so that new players will be able to enjoy the game's visuals as they're meant to look like, rather than oftentimes distorted.
/:cl: