### PR TITLE
Fixes the stasis ripple not playing in a loop and the unusually-slow stasis bed lying down animation

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -264,8 +264,8 @@
 	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, TRAIT_STATUS_EFFECT(id))
 	owner.add_filter("stasis_status_ripple", 2, list("type" = "ripple", "flags" = WAVE_BOUNDED, "radius" = 0, "size" = 2))
 	var/filter = owner.get_filter("stasis_status_ripple")
-	animate(filter, radius = 32, time = 1.5 SECONDS, size = 0, loop = -1, flags = ANIMATION_PARALLEL)
-	animate(radius = 0, time = 0.5 SECONDS, size = 2, easing = JUMP_EASING)
+	animate(filter, radius = 0, time = 0.2 SECONDS, size = 2, easing = JUMP_EASING, loop = -1, flags = ANIMATION_PARALLEL)
+	animate(radius = 32, time = 1.5 SECONDS, size = 0)
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
 		carbon_owner.update_bodypart_bleed_overlays()

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -264,7 +264,8 @@
 	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, TRAIT_STATUS_EFFECT(id))
 	owner.add_filter("stasis_status_ripple", 2, list("type" = "ripple", "flags" = WAVE_BOUNDED, "radius" = 0, "size" = 2))
 	var/filter = owner.get_filter("stasis_status_ripple")
-	animate(filter, radius = 32, time = 15, size = 0, loop = -1)
+	animate(filter, radius = 32, time = 1.5 SECONDS, size = 0, loop = -1, flags = ANIMATION_PARALLEL)
+	animate(radius = 0, time = 0.5 SECONDS, size = 2, easing = JUMP_EASING)
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
 		carbon_owner.update_bodypart_bleed_overlays()


### PR DESCRIPTION
## About The Pull Request
For a while now, the stasis ripple animation (introduced by Timberpoes in #54609) was only going once, and then it stopped. But why, you might ask? As it turns out, according to [Lummox](http://www.byond.com/forum/post/2749725#comment26049980), self-looping animations in a singular step were a bug that he fixed. That means that we *need* to have two steps to the animation to actually get it to loop, even if it's a step that has a `time = 0`, just to reset the value that's being changed by the `animate` to the initial values.

Now, as for the weird bug which causes you to occasionally lie down *very* slowly on the table? That's because both animations were fighting one-another, and for reasons unknown, the lying down `transform` animation was inheriting the time of the ripple animation. I solved that by making the ripple animation be started asynchronously, which means that it runs at the same time the ripple and the lying down animation, instead of just doing one or the other. I also made the ripple start after the lying animation is over, which should be a nice touch.

Fixes https://github.com/tgstation/tgstation/issues/61197.

## Why It's Good For The Game
Return to the intended behavior, while squashing another bug along the way. Hell yeah.

## Changelog

:cl: GoldenAlpharex
fix: The stasis ripple effect will now play in a loop as intended, rather than only playing once.
fix: Buckling down someone to a stasis bed should no longer occasionally make them lie down veeeeery slowly.
/:cl: