### PR TITLE
Fixes extraneous null access reqs on several external airlocks

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1496,8 +1496,7 @@
 /area/mine/living_quarters)
 "iE" = (
 /obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp External Airlock";
-	req_access = null
+	name = "Labor Camp External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -2748,8 +2747,7 @@
 /area/mine/laborcamp)
 "wK" = (
 /obj/machinery/door/airlock/external/glass{
-	name = "Mining External Airlock";
-	req_access = null
+	name = "Mining External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
@@ -2780,8 +2778,7 @@
 /area/mine/laborcamp)
 "xU" = (
 /obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp External Airlock";
-	req_access = null
+	name = "Labor Camp External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -3057,7 +3054,6 @@
 "Dt" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock";
-	req_access = null;
 	space_dir = 2
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -377,7 +377,6 @@
 
 /// Access free external airlock
 /obj/machinery/door/airlock/external/ruin
-	req_access = null
 
 /obj/machinery/door/airlock/external/glass
 	opacity = FALSE
@@ -385,7 +384,6 @@
 
 /// Access free external glass airlock
 /obj/machinery/door/airlock/external/glass/ruin
-	req_access = null
 
 //////////////////////////////////
 /*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since we no longer have null access built into external airlocks, it's time to cut from some doors that have an override built into them. It wasn't necessary in the first place, actually, since the access req was built in incorrectly to these airlocks, but regardless...

## Why It's Good For The Game
Gets rid of incorrect code from the airlocks so nobody goes stumbling through them in the future and thinks that it's required or does anything.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: removed some unnecessary varedits from some external airlocks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
