### PR TITLE
Lets the engilathe print plasma cutters.

### DIFF
--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -50,7 +50,7 @@
 	materials = list(/datum/material/iron = 1500, /datum/material/glass = 500, /datum/material/plasma = 400)
 	build_path = /obj/item/gun/energy/plasmacutter
 	category = list("Mining Designs")
-	departmental_flags = DEPARTMENT_BITFLAG_CARGO
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_ENGINEERING
 
 /datum/design/plasmacutter_adv
 	name = "Advanced Plasma Cutter"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The engilathe can print plasma cutters like the cargolathe. Only the standard ones, as advanced cutters only make it better for the purposes of damage, range and ammo spent on shooting.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
With RCDs and Experimental Welders being more limited, I think the plasma cutter will be nice for them, as it's a slightly faster welder that can be refilled with more exotic stuff (plasma).
It acts as a nice deconstruction tool, as it can also slice girders apart, letting engineers do faster room refurbishing.
The mining functions seem neat if engineers want to do something cool on Kilo/Tram which are surrounded by asteroid, while not being overly strong since you know, it's just the standard cutter.
It also looks really cool.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The engilathe can now print plasma cutters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
