### PR TITLE
Re-adds the Concealed Weapon Bay

### DIFF
--- a/code/__DEFINES/exosuit_fab.dm
+++ b/code/__DEFINES/exosuit_fab.dm
@@ -15,21 +15,23 @@
 #define EXOSUIT_MODULE_ODYSSEUS (1<<1)
 /// Module is compatible with Clarke Exosuit models
 #define EXOSUIT_MODULE_CLARKE (1<<2)
+/// Module is compatible with a mech carrying the Concealed Weapon Bay
+#define EXOSUIT_MODULE_CONCEALED_WEP_BAY (1<<3)
 /// Module is compatible with Gygax Exosuit models
-#define EXOSUIT_MODULE_GYGAX (1<<3)
+#define EXOSUIT_MODULE_GYGAX (1<<4)
 /// Module is compatible with Durand Exosuit models
-#define EXOSUIT_MODULE_DURAND (1<<4)
+#define EXOSUIT_MODULE_DURAND (1<<5)
 /// Module is compatible with H.O.N.K Exosuit models
-#define EXOSUIT_MODULE_HONK (1<<5)
+#define EXOSUIT_MODULE_HONK (1<<6)
 /// Module is compatible with Phazon Exosuit models
-#define EXOSUIT_MODULE_PHAZON (1<<6)
+#define EXOSUIT_MODULE_PHAZON (1<<7)
 /// Module is compatible with Savannah Exosuit models
-#define EXOSUIT_MODULE_SAVANNAH (1<<7)
+#define EXOSUIT_MODULE_SAVANNAH (1<<8)
 
 /// Module is compatible with "Working" Exosuit models - Ripley and Clarke
 #define EXOSUIT_MODULE_WORKING EXOSUIT_MODULE_RIPLEY | EXOSUIT_MODULE_CLARKE
 /// Module is compatible with "Combat" Exosuit models - Gygax, H.O.N.K, Durand and Phazon
-#define EXOSUIT_MODULE_COMBAT EXOSUIT_MODULE_GYGAX | EXOSUIT_MODULE_HONK | EXOSUIT_MODULE_DURAND | EXOSUIT_MODULE_PHAZON | EXOSUIT_MODULE_SAVANNAH
+#define EXOSUIT_MODULE_COMBAT EXOSUIT_MODULE_GYGAX | EXOSUIT_MODULE_HONK | EXOSUIT_MODULE_DURAND | EXOSUIT_MODULE_PHAZON | EXOSUIT_MODULE_SAVANNAH | EXOSUIT_MODULE_CONCEALED_WEP_BAY
 /// Module is compatible with "Medical" Exosuit modelsm - Odysseus
 #define EXOSUIT_MODULE_MEDICAL EXOSUIT_MODULE_ODYSSEUS
 

--- a/code/__DEFINES/exosuit_fab.dm
+++ b/code/__DEFINES/exosuit_fab.dm
@@ -15,7 +15,7 @@
 #define EXOSUIT_MODULE_ODYSSEUS (1<<1)
 /// Module is compatible with Clarke Exosuit models
 #define EXOSUIT_MODULE_CLARKE (1<<2)
-/// Module is compatible with a mech carrying the Concealed Weapon Bay
+/// Module is compatible with a mech carrying an empty Concealed Weapon Bay
 #define EXOSUIT_MODULE_CONCEALED_WEP_BAY (1<<3)
 /// Module is compatible with Gygax Exosuit models
 #define EXOSUIT_MODULE_GYGAX (1<<4)
@@ -30,7 +30,7 @@
 
 /// Module is compatible with "Working" Exosuit models - Ripley and Clarke
 #define EXOSUIT_MODULE_WORKING EXOSUIT_MODULE_RIPLEY | EXOSUIT_MODULE_CLARKE
-/// Module is compatible with "Combat" Exosuit models - Gygax, H.O.N.K, Durand and Phazon
+/// Module is compatible with "Combat" Exosuit models - Gygax, H.O.N.K, Durand and Phazon, or any Exosuit with an empty Concealed Weapon Bay
 #define EXOSUIT_MODULE_COMBAT EXOSUIT_MODULE_GYGAX | EXOSUIT_MODULE_HONK | EXOSUIT_MODULE_DURAND | EXOSUIT_MODULE_PHAZON | EXOSUIT_MODULE_SAVANNAH | EXOSUIT_MODULE_CONCEALED_WEP_BAY
 /// Module is compatible with "Medical" Exosuit modelsm - Odysseus
 #define EXOSUIT_MODULE_MEDICAL EXOSUIT_MODULE_ODYSSEUS

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -254,6 +254,17 @@
 	cost = 20
 	restricted_roles = list(JOB_CLOWN)
 
+/datum/uplink_item/role_restricted/concealed_weapon_bay
+	name = "Concealed Weapon Bay"
+	desc = "A modification for non-combat exosuits that allows them to equip one piece of equipment designed for combat units. \
+			Attach to an exosuit with an existing equipment to disguise the bay as that equipment. The sacrificed equipment will be lost.\
+			Alternatively, you can attach the bay to an empty equipment slot, but the bay will not be concealed. Once the bay is \
+			attached, an exosuit weapon can be fitted inside."
+	progression_minimum = 30 MINUTES
+	item = /obj/item/mecha_parts/mecha_equipment/concealed_weapon_bay
+	cost = 3
+	restricted_roles = list(JOB_ROBOTICIST, JOB_RESEARCH_DIRECTOR)
+
 /datum/uplink_item/role_restricted/his_grace
 	name = "His Grace"
 	desc = "An incredibly dangerous weapon recovered from a station overcome by the grey tide. Once activated, He will thirst for blood and must be used to kill to sate that thirst. \

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -43,6 +43,8 @@
 	if(can_attach(M, attach_right))
 		if(!user.temporarilyRemoveItemFromInventory(src))
 			return FALSE
+		if(special_attaching_interaction(attach_right, M, user))
+			return TRUE //The rest is handled in the special interactions proc
 		attach(M, attach_right)
 		user.visible_message(span_notice("[user] attaches [src] to [M]."), span_notice("You attach [src] to [M]."))
 		return TRUE
@@ -126,13 +128,27 @@
 		return FALSE
 	if(equipment_slot == MECHA_WEAPON)
 		if(attach_right)
-			if(mech.equip_by_category[MECHA_R_ARM])
+			if(mech.equip_by_category[MECHA_R_ARM] && (!special_attaching_interaction(attach_right, mech, checkonly = TRUE)))
 				return FALSE
 		else
-			if(mech.equip_by_category[MECHA_L_ARM])
+			if(mech.equip_by_category[MECHA_L_ARM] && (!special_attaching_interaction(attach_right, mech, checkonly = TRUE)))
 				return FALSE
 		return TRUE
 	return length(mech.equip_by_category[equipment_slot]) < mech.max_equip_by_category[equipment_slot]
+
+/**
+ * Special Attaching Interaction, used to bypass normal attachment procs.
+ *
+ * If an equipment needs to bypass the regular chain of events, this proc can be used to allow for that. If used, it
+ * must handle actually calling attach(), as well as any feedback to the user.
+ * Args:
+ * * attach_right: True if attaching the the right-hand equipment slot, false otherwise.
+ * * mech: ref to the mecha that we're attaching onto.
+ * * user: ref to the mob doing the attaching
+ * * checkonly: check if we are able to handle the attach procedure ourselves, but don't actually do it yet.
+ */
+/obj/item/mecha_parts/mecha_equipment/proc/special_attaching_interaction(attach_right = FALSE, obj/vehicle/sealed/mecha/mech, mob/user, checkonly = FALSE)
+	return FALSE
 
 /obj/item/mecha_parts/mecha_equipment/proc/attach(obj/vehicle/sealed/mecha/M, attach_right = FALSE)
 	LAZYADD(M.flat_equipment, src)

--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -468,3 +468,46 @@
 		generate_effect(movement_dir)
 		return TRUE
 	return FALSE
+
+///////////////////////////////////// CONCEALED WEAPON BAY ////////////////////////////////////////
+
+/obj/item/mecha_parts/mecha_equipment/concealed_weapon_bay
+	name = "concealed weapon bay"
+	desc = "A compartment that allows a non-combat mecha to equip one weapon while hiding the weapon from plain sight."
+	icon_state = "mecha_weapon_bay"
+
+/obj/item/mecha_parts/mecha_equipment/concealed_weapon_bay/try_attach_part(mob/user, obj/vehicle/sealed/mecha/M)
+	if(istype(M, /obj/vehicle/sealed/mecha/combat))
+		to_chat(user, span_warning("[M] does not have the correct bolt configuration!"))
+		return
+	return ..()
+
+/obj/item/mecha_parts/mecha_equipment/concealed_weapon_bay/special_attaching_interaction(attach_right = FALSE, obj/vehicle/sealed/mecha/mech, mob/user, checkonly = FALSE)
+	if(checkonly)
+		return TRUE
+	var/obj/item/mecha_parts/mecha_equipment/existing_equip
+	if(attach_right)
+		existing_equip = mech.equip_by_category[MECHA_R_ARM]
+	else
+		existing_equip = mech.equip_by_category[MECHA_L_ARM]
+	if(existing_equip)
+		name = existing_equip.name
+		icon = existing_equip.icon
+		icon_state = existing_equip.icon_state
+		existing_equip.detach()
+		existing_equip.Destroy()
+		user.visible_message(span_notice("[user] hollows out [src] and puts something in."), span_notice("You attach the concealed weapon bay to [mech] within the shell of [src]."))
+	else
+		user.visible_message(span_notice("[user] attaches [src] to [mech]."), span_notice("You attach [src] to [mech]."))
+	attach(mech, attach_right)
+	mech.mech_type |= EXOSUIT_MODULE_CONCEALED_WEP_BAY
+	return TRUE
+
+/obj/item/mecha_parts/mecha_equipment/concealed_weapon_bay/detach(atom/moveto)
+	var/obj/vehicle/sealed/mecha/mech = chassis
+	. = ..()
+	name = initial(name)
+	icon = initial(icon)
+	icon_state = initial(icon_state)
+	if(!locate(/obj/item/mecha_parts/mecha_equipment/concealed_weapon_bay) in mech.contents) //if no others exist
+		mech.mech_type &= ~EXOSUIT_MODULE_CONCEALED_WEP_BAY

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -16,9 +16,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/can_attach(obj/vehicle/sealed/mecha/mech, attach_right = FALSE)
 	if(!..())
 		return FALSE
-	if(mech.mech_type & EXOSUIT_MODULE_CONCEALED_WEP_BAY)
-		return TRUE
-	if(istype(mech, /obj/vehicle/sealed/mecha/combat))
+	if(mech.mech_type & EXOSUIT_MODULE_COMBAT)
 		return TRUE
 	return FALSE
 

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -13,12 +13,41 @@
 	var/firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect //the visual effect appearing when the weapon is fired.
 	var/kickback = TRUE //Will using this weapon in no grav push mecha back.
 
-/obj/item/mecha_parts/mecha_equipment/weapon/can_attach(obj/vehicle/sealed/mecha/M, attach_right = FALSE)
+/obj/item/mecha_parts/mecha_equipment/weapon/can_attach(obj/vehicle/sealed/mecha/mech, attach_right = FALSE)
 	if(!..())
 		return FALSE
-	if(istype(M, /obj/vehicle/sealed/mecha/combat))
+	if(mech.mech_type & EXOSUIT_MODULE_CONCEALED_WEP_BAY)
+		return TRUE
+	if(istype(mech, /obj/vehicle/sealed/mecha/combat))
 		return TRUE
 	return FALSE
+
+/obj/item/mecha_parts/mecha_equipment/weapon/special_attaching_interaction(attach_right = FALSE, obj/vehicle/sealed/mecha/mech, mob/user, checkonly = FALSE)
+	var/obj/item/mecha_parts/mecha_equipment/concealed_weapon_bay/bay
+	if(attach_right)
+		bay = mech.equip_by_category[MECHA_R_ARM]
+	else
+		bay = mech.equip_by_category[MECHA_L_ARM]
+	if(!istype(bay))
+		return FALSE //No bay, use normal attach procs
+	if(checkonly)
+		return TRUE
+	name = bay.name
+	icon = bay.icon
+	icon_state = bay.icon_state
+	bay.detach()
+	bay.forceMove(src) //for later detaching
+	attach(mech, attach_right)
+	user.visible_message(span_notice("[user] inserts something into [src]."), span_notice("You attach the [initial(name)] into the concealed weapon bay."))
+	return TRUE
+
+/obj/item/mecha_parts/mecha_equipment/weapon/detach(atom/moveto)
+	for(var/obj/item/mecha_parts/mecha_equipment/concealed_weapon_bay/bay in contents)
+		bay.forceMove(get_turf(chassis))
+	name = initial(name)
+	icon = initial(icon)
+	icon_state = initial(icon_state)
+	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/weapon/action(mob/source, atom/target, list/modifiers)
 	if(!action_checks(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Concealed Weapon Bay was a robo traitor item allowing the attachment of combat equipment to non-combat mechs. It was removed when with the recent mech rework (#65375) due to a change in how equipment was handled, requiring a rework of the Bay itself.

The Weapon Bay now is added over top an existing equipment. It takes on the name and sprite of the existing equipment, before removing it (as if it was being installed within the case of the old equipment). An exosuit weapon can then be installed over top the Weapon Bay (as if it was installed within the bay). The Weapon Bay can alternatively be added without an existing equipment in place, but the Bay will not be concealed in that case. If an equipment is used to disguise the Weapon Bay, the equipment functionality is lost, and the equipment will not be recovered even if the Weapon Bay is detached later.

Unlike before, there is not a one-weapon limit. However, two Weapon Bays would need to be purchased to install two weapons.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Concealed Weapon Bay was a neat traitor item, and was only removed due to the mechanics changing underneath it. The ability to hide mech weapons allows for some stealthier ambush tactics that are hard to get away with in a full combat mech.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The Concealed Weapon Bay is available again for traitor Roboticists and Research Directors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
