### PR TITLE
Fixes pellet cloud wounding where I just broke it

### DIFF
--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -310,7 +310,7 @@
 				// technically this only checks armor worn the moment that all the pellets resolve rather than as each one hits you,
 				// but this isn't important enough to warrant all the extra loops of mostly redundant armor checks
 				var/mob/living/carbon/hit_carbon = target
-				var/armor_factor = hit_carbon.getarmor(hit_part, P.armor_flag)
+				var/armor_factor = hit_carbon.getarmor(hit_part, initial(P.armor_flag))
 				armor_factor = min(ARMOR_MAX_BLOCK, armor_factor) //cap damage reduction at 90%
 				if(armor_factor > 0)
 					if(P.weak_against_armour && armor_factor >= 0)

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -313,7 +313,7 @@
 				var/armor_factor = hit_carbon.getarmor(hit_part, initial(P.armor_flag))
 				armor_factor = min(ARMOR_MAX_BLOCK, armor_factor) //cap damage reduction at 90%
 				if(armor_factor > 0)
-					if(P.weak_against_armour && armor_factor >= 0)
+					if(initial(P.weak_against_armour) && armor_factor >= 0)
 						armor_factor *= ARMOR_WEAKENED_MULTIPLIER
 					damage_dealt *= armor_factor
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I was stupid in #67331 and forgot an initial() around an un-instantiated projectile var call. This puts it in so wounding checks don't runtime. I have actually tested that this works
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pellet clouds work properly
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ryll/Shaps
fix: Fixed pellet clouds not being able to wound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
