### PR TITLE
Removes adjustHealth procs from Icemoon Fauna (they no longer regenerate health)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
@@ -72,11 +72,6 @@
 	SLEEP_CHECK_DEATH(8, src)
 	return ..()
 
-/mob/living/simple_animal/hostile/asteroid/ice_demon/Life(delta_time = SSMOBS_DT, times_fired)
-	. = ..()
-	if(!. || target)
-		return
-
 /mob/living/simple_animal/hostile/asteroid/ice_demon/spawn_crusher_loot()
 	loot += crusher_loot
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
@@ -76,7 +76,6 @@
 	. = ..()
 	if(!. || target)
 		return
-	adjustHealth(-0.0125 * maxHealth * delta_time)
 
 /mob/living/simple_animal/hostile/asteroid/ice_demon/spawn_crusher_loot()
 	loot += crusher_loot

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_whelp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_whelp.dm
@@ -50,7 +50,6 @@
 	. = ..()
 	if(!. || target)
 		return
-	adjustHealth(-0.0125 * maxHealth * delta_time)
 
 /mob/living/simple_animal/hostile/asteroid/ice_whelp/death(gibbed)
 	move_force = MOVE_FORCE_DEFAULT

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_whelp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_whelp.dm
@@ -46,11 +46,6 @@
 	var/list/burn_turfs = get_line(src, target_fire_turf) - get_turf(src)
 	dragon_fire_line(src, burn_turfs, frozen = TRUE)
 
-/mob/living/simple_animal/hostile/asteroid/ice_whelp/Life(delta_time = SSMOBS_DT, times_fired)
-	. = ..()
-	if(!. || target)
-		return
-
 /mob/living/simple_animal/hostile/asteroid/ice_whelp/death(gibbed)
 	move_force = MOVE_FORCE_DEFAULT
 	move_resist = MOVE_RESIST_DEFAULT

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
@@ -50,7 +50,6 @@
 	. = ..()
 	if(!. || target)
 		return
-	adjustHealth(-0.0125 * maxHealth * delta_time)
 	aggressive_message_said = FALSE
 
 /mob/living/simple_animal/hostile/asteroid/polarbear/death(gibbed)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
@@ -57,7 +57,6 @@
 	. = ..()
 	if(!. || target)
 		return
-	adjustHealth(-0.0125 * maxHealth * delta_time)
 	retreat_message_said = FALSE
 
 /obj/item/crusher_trophy/wolf_ear


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

As described in Issue #67311, several ice waste fauna regenerate *1.25%* of their health every Life tick (presumably when they're not attacking). This was not explicit nor documented, so I will axe it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This was added back in 2020 at IceBox's first introduction, when the station was still in it's infancy and normal crew weren't really meant to explore the lower Z-Levels or even exist there. However, this design has been altered heavily over the last few years as the station has had a heavier focus on having crew be placed on these lower structures, so it should be easier for crew to not have to struggle with something non-explicit feature these mobs have as they try and merely exist in the wastes (or fight their way back up to the station). It's hard enough to kill them without mining tools, why make it _even more challenging?_

This is one of the larger complaints I've heard about icebox, how getting knocked down by a bomb isn't a silly "get pomfed in the snow", because you immediately get swarmed by three watchers that all aggro and teleport to you and kill you in seconds. Let's make it a bit more manageable. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: IceMoon Fauna no longer regenerate health. This should make it a bit easier to kill them in spots such as IceBoxStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
