### PR TITLE
Fixes inspect bounties not generating for most areas and giving invalid areas to scan

### DIFF
--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -50,16 +50,23 @@
 	var/area/demanded_area
 
 /datum/bounty/item/security/paperwork/New()
-	///list of areas for security to choose from to perform an inspection.
-	var/static/list/possible_areas = list(\
-		/area/station/maintenance,\
-		/area/station/commons,\
-		/area/station/service,\
-		/area/station/hallway/primary,\
-		/area/station/security/office,\
-		/area/station/security/prison,\
-		/area/station/security/checkpoint,\
-		/area/station/security/interrogation)
+	///list of areas for security to choose from to perform an inspection. Pulls the list and cross references it to the map to make sure the area is on the map before assigning.
+	var/static/list/possible_areas
+	if(!possible_areas)
+		possible_areas = list(\
+			/area/station/maintenance,\
+			/area/station/commons,\
+			/area/station/service,\
+			/area/station/hallway/primary,\
+			/area/station/security/office,\
+			/area/station/security/prison,\
+			/area/station/security/range,\
+			/area/station/security/checkpoint,\
+			/area/station/security/interrogation)
+		for (var/area_type in possible_areas)
+			if(GLOB.areas_by_type[area_type])
+				continue
+			possible_areas -= area_type
 	demanded_area = pick(possible_areas)
 	name = name + ": [initial(demanded_area.name)]"
 	description = initial(description) + " [initial(demanded_area.name)]"

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -53,7 +53,7 @@
 	///list of areas for security to choose from to perform an inspection. Pulls the list and cross references it to the map to make sure the area is on the map before assigning.
 	var/static/list/possible_areas
 	if(!possible_areas)
-		possible_areas = list(\
+		possible_areas = typecacheof(list(\
 			/area/station/maintenance,\
 			/area/station/commons,\
 			/area/station/service,\
@@ -62,7 +62,7 @@
 			/area/station/security/prison,\
 			/area/station/security/range,\
 			/area/station/security/checkpoint,\
-			/area/station/security/interrogation)
+			/area/station/security/interrogation))
 		for (var/area_type in possible_areas)
 			if(GLOB.areas_by_type[area_type])
 				continue

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -58,7 +58,6 @@
 		/area/station/hallway/primary,\
 		/area/station/security/office,\
 		/area/station/security/prison,\
-		/area/station/security/range,\
 		/area/station/security/checkpoint,\
 		/area/station/security/interrogation)
 	demanded_area = pick(possible_areas)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
EDIT:
Instead of removing the firing range as an option to scan, Melbert helped me set it up so that the code now scans the map to see if that area is on the map. If it isn't, it removes it from the list.

In the process of testing that, we found out that only the security department entries were valid because the list didn't properly pull the children of the service, maintenance, commons, etc. paths. We turned the list into a typecacheof in order to properly validate all of those areas. I believe we also made it so that list only runs once and then assigns bounties off the validated list.

## Why It's Good For The Game

EDIT:
Makes the range of inspection bounties available much larger and work as intended. Validates that none of the unused areas are being used so it will only assign areas that are actually on the map.

Fixes #67382 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Inspect bounties no longer give you invalid areas to scan for bounties
fix: Inspect bounties now properly choose from a broader range of assignments in service, maintenance, commons, etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
