### PR TITLE
fixes inconsistent lighting ci failure in icebox

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -229,8 +229,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 	var/turf/atom_turf = get_turf(checked_atom) //use checked_atom's turfs, as it's coords are the same as checked_atom's AND checked_atom's coords are lost if it is inside another atom
 	if(!atom_turf)
 		return null
-	var/final_x = atom_turf.x + rough_x
-	var/final_y = atom_turf.y + rough_y
+	var/final_x = clamp(atom_turf.x + rough_x, 1, world.maxx)
+	var/final_y = clamp(atom_turf.y + rough_y, 1, world.maxy)
 
 	if(final_x || final_y)
 		return locate(final_x, final_y, atom_turf.z)

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -229,8 +229,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 	var/turf/atom_turf = get_turf(checked_atom) //use checked_atom's turfs, as it's coords are the same as checked_atom's AND checked_atom's coords are lost if it is inside another atom
 	if(!atom_turf)
 		return null
-	var/final_x = clamp(atom_turf.x + rough_x, 1, world.maxx)
-	var/final_y = clamp(atom_turf.y + rough_y, 1, world.maxy)
+	var/final_x = atom_turf.x + rough_x
+	var/final_y = atom_turf.y + rough_y
 
 	if(final_x || final_y)
 		return locate(final_x, final_y, atom_turf.z)

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -49,7 +49,7 @@
 #define GC_FAILURE_HARD_LOOKUP
 #endif // REFERENCE_DOING_IT_LIVE
 
-#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
+//#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 /// If this is uncommented, Autowiki will generate edits and shut down the server.
 /// Prefer the autowiki build target instead.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -49,7 +49,7 @@
 #define GC_FAILURE_HARD_LOOKUP
 #endif // REFERENCE_DOING_IT_LIVE
 
-//#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
+#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 /// If this is uncommented, Autowiki will generate edits and shut down the server.
 /// Prefer the autowiki build target instead.

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -92,6 +92,7 @@
 #include "emoting.dm"
 #include "food_edibility_check.dm"
 #include "gas_transfer.dm"
+#include "get_turf_pixel.dm"
 #include "greyscale_config.dm"
 #include "heretic_knowledge.dm"
 #include "heretic_rituals.dm"

--- a/code/modules/unit_tests/get_turf_pixel.dm
+++ b/code/modules/unit_tests/get_turf_pixel.dm
@@ -3,8 +3,6 @@
 	//we need long larry to peek over the top edge of the earth
 	var/turf/north = locate(1, world.maxy, run_loc_floor_bottom_left.z)
 	var/turf/east = locate(world.maxx, world.maxy, run_loc_floor_bottom_left.z)
-	var/turf/south = locate(world.maxx, 1, run_loc_floor_bottom_left.z)
-	var/turf/west = locate(1, 1, run_loc_floor_bottom_left.z)
 
 	///long larry is long indeed
 	var/long_larry_coefficient = 30
@@ -12,8 +10,6 @@
 
 	var/matrix/north_transform = identity_matrix.Scale(1,long_larry_coefficient)
 	var/matrix/east_transform = identity_matrix.Scale(long_larry_coefficient, 1)
-	var/matrix/south_transform = identity_matrix.Scale(1, -long_larry_coefficient)
-	var/matrix/west_transform = identity_matrix.Scale(-long_larry_coefficient, 1)
 
 	///hes really long, so hes really good at peaking over the edge of the map
 	var/mob/living/simple_animal/hostile/megafauna/colossus/long_larry = allocate(/mob/living/simple_animal/hostile/megafauna/colossus, north)
@@ -23,14 +19,6 @@
 	long_larry.loc = east
 	long_larry.transform = east_transform
 	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite extends east of the bounds of the world inside of the map.")
-
-	long_larry.loc = south
-	long_larry.transform = south_transform
-	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite extends south of the bounds of the world inside of the map.")
-
-	long_larry.loc = west
-	long_larry.transform = west_transform
-	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite extends west of the bounds of the world inside of the map.")
 
 
 

--- a/code/modules/unit_tests/get_turf_pixel.dm
+++ b/code/modules/unit_tests/get_turf_pixel.dm
@@ -1,0 +1,37 @@
+///ensures that get_turf_pixel() returns turfs within the bounds of the map, even when called on a movable with its sprite out of bounds
+/datum/unit_test/get_turf_pixel/Run()
+	//we need long larry to peek over the top edge of the earth
+	var/turf/north = locate(1, world.maxy, run_loc_floor_bottom_left.z)
+	var/turf/east = locate(world.maxx, world.maxy, run_loc_floor_bottom_left.z)
+	var/turf/south = locate(world.maxx, 1, run_loc_floor_bottom_left.z)
+	var/turf/west = locate(1, 1, run_loc_floor_bottom_left.z)
+
+	///long larry is long indeed
+	var/long_larry_coefficient = 30
+	var/matrix/identity_matrix = matrix()
+
+	var/matrix/north_transform = identity_matrix.Scale(1,long_larry_coefficient)
+	var/matrix/east_transform = identity_matrix.Scale(long_larry_coefficient, 1)
+	var/matrix/south_transform = identity_matrix.Scale(1, -long_larry_coefficient)
+	var/matrix/west_transform = identity_matrix.Scale(-long_larry_coefficient, 1)
+
+	///hes really long, so hes really good at peaking over the edge of the map
+	var/mob/living/simple_animal/hostile/megafauna/colossus/long_larry = allocate(/mob/living/simple_animal/hostile/megafauna/colossus, north)
+	long_larry.transform = north_transform
+	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite is above the bounds of the world inside of the map.")
+
+	long_larry.loc = east
+	long_larry.transform = east_transform
+	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite extends east of the bounds of the world inside of the map.")
+
+	long_larry.loc = south
+	long_larry.transform = south_transform
+	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite extends south of the bounds of the world inside of the map.")
+
+	long_larry.loc = west
+	long_larry.transform = west_transform
+	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite extends west of the bounds of the world inside of the map.")
+
+
+
+

--- a/code/modules/unit_tests/get_turf_pixel.dm
+++ b/code/modules/unit_tests/get_turf_pixel.dm
@@ -8,4 +8,4 @@
 
 	//hes really long, so hes really good at peaking over the edge of the map
 	var/mob/living/simple_animal/hostile/megafauna/colossus/long_larry = allocate(/mob/living/simple_animal/hostile/megafauna/colossus, north)
-	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite is above the bounds of the world inside of the map.")
+	TEST_ASSERT(istype(get_turf_pixel(long_larry), /turf), "get_turf_pixel() isnt clamping a mob whos sprite is above the bounds of the world inside of the map.")

--- a/code/modules/unit_tests/get_turf_pixel.dm
+++ b/code/modules/unit_tests/get_turf_pixel.dm
@@ -2,23 +2,11 @@
 /datum/unit_test/get_turf_pixel/Run()
 	//we need long larry to peek over the top edge of the earth
 	var/turf/north = locate(1, world.maxy, run_loc_floor_bottom_left.z)
-	var/turf/east = locate(world.maxx, world.maxy, run_loc_floor_bottom_left.z)
-
-	///long larry is long indeed
-	var/long_larry_coefficient = 30
-	var/matrix/identity_matrix = matrix()
-
-	var/matrix/north_transform = identity_matrix.Scale(1,long_larry_coefficient)
-	var/matrix/east_transform = identity_matrix.Scale(long_larry_coefficient, 1)
 
 	///hes really long, so hes really good at peaking over the edge of the map
 	var/mob/living/simple_animal/hostile/megafauna/colossus/long_larry = allocate(/mob/living/simple_animal/hostile/megafauna/colossus, north)
-	long_larry.transform = north_transform
 	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite is above the bounds of the world inside of the map.")
 
-	long_larry.loc = east
-	long_larry.transform = east_transform
-	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite extends east of the bounds of the world inside of the map.")
 
 
 

--- a/code/modules/unit_tests/get_turf_pixel.dm
+++ b/code/modules/unit_tests/get_turf_pixel.dm
@@ -1,3 +1,5 @@
+/datum/unit_test/get_turf_pixel
+
 ///ensures that get_turf_pixel() returns turfs within the bounds of the map, even when called on a movable with its sprite out of bounds
 /datum/unit_test/get_turf_pixel/Run()
 	//we need long larry to peek over the top edge of the earth

--- a/code/modules/unit_tests/get_turf_pixel.dm
+++ b/code/modules/unit_tests/get_turf_pixel.dm
@@ -1,6 +1,7 @@
+///ensures that get_turf_pixel() returns turfs within the bounds of the map,
+///even when called on a movable with its sprite out of bounds
 /datum/unit_test/get_turf_pixel
 
-///ensures that get_turf_pixel() returns turfs within the bounds of the map, even when called on a movable with its sprite out of bounds
 /datum/unit_test/get_turf_pixel/Run()
 	//we need long larry to peek over the top edge of the earth
 	var/turf/north = locate(1, world.maxy, run_loc_floor_bottom_left.z)
@@ -8,8 +9,3 @@
 	///hes really long, so hes really good at peaking over the edge of the map
 	var/mob/living/simple_animal/hostile/megafauna/colossus/long_larry = allocate(/mob/living/simple_animal/hostile/megafauna/colossus, north)
 	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite is above the bounds of the world inside of the map.")
-
-
-
-
-

--- a/code/modules/unit_tests/get_turf_pixel.dm
+++ b/code/modules/unit_tests/get_turf_pixel.dm
@@ -6,6 +6,6 @@
 	//we need long larry to peek over the top edge of the earth
 	var/turf/north = locate(1, world.maxy, run_loc_floor_bottom_left.z)
 
-	///hes really long, so hes really good at peaking over the edge of the map
+	//hes really long, so hes really good at peaking over the edge of the map
 	var/mob/living/simple_animal/hostile/megafauna/colossus/long_larry = allocate(/mob/living/simple_animal/hostile/megafauna/colossus, north)
 	TEST_ASSERT(get_turf_pixel(long_larry) != null, "get_turf_pixel() isnt clamping a mob whos sprite is above the bounds of the world inside of the map.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![Screenshot_2045](https://user-images.githubusercontent.com/15794172/171071869-9f74bdb5-be35-4dae-8ca5-5a0e3586c5b6.png)
happened across this error when testing icebox, remembered something about this being a ci failure. turns out it was because `pixel_turf` was null, which happens get_turf_pixel() returns null here in light_source/proc/update_corners():
```
if (isturf(top_atom))
		if (source_turf != top_atom)
			source_turf = top_atom
			pixel_turf = source_turf
			update = TRUE
	else if (top_atom.loc != source_turf)
		source_turf = top_atom.loc
		pixel_turf = get_turf_pixel(top_atom)
		update = TRUE
	else
		var/pixel_loc = get_turf_pixel(top_atom)
		if (pixel_loc != pixel_turf)
			pixel_turf = pixel_loc
			update = TRUE
```

when does get_turf_pixel() return null? turns out, top_atom in this case was a colossus mob which is taller than a tile, and it happened to spawn at y = 255. so get_turf_pixel(colossus at the top of the map) was trying to find the turf at locate(colossus.x, colossus.y + top of his tall ass sprite, colossus.z), which is > 255, so it returned null and made lighting objects runtime. now it clamps the values to the bounds of the map and doesnt runtime in the same way

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes ci
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
