### PR TITLE
Durand shield now shows correctly on top of the mech.

### DIFF
--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -158,20 +158,20 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 	light_power = 5
 	light_color = LIGHT_COLOR_ELECTRIC_CYAN
 	light_on = FALSE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF //The shield should not take damage from fire,  lava, or acid; that's the mech's job.
 	///Our link back to the durand
 	var/obj/vehicle/sealed/mecha/combat/durand/chassis
 	///To keep track of things during the animation
 	var/switching = FALSE
-	var/currentuser
-	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF //The shield should not take damage from fire,  lava, or acid; that's the mech's job.
-
 
 /obj/durand_shield/Initialize(mapload, _chassis, _layer, _dir)
 	. = ..()
 	chassis = _chassis
 	layer = _layer
+	plane = chassis.plane
 	setDir(_dir)
 	RegisterSignal(src, COMSIG_MECHA_ACTION_TRIGGER, .proc/activate)
+	RegisterSignal(chassis, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, .proc/shield_glide_size_update)
 
 
 /obj/durand_shield/Destroy()
@@ -179,6 +179,10 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 		chassis.shield = null
 		chassis = null
 	return ..()
+
+obj/durand_shield/proc/shield_glide_size_update(datum/source, target)
+	SIGNAL_HANDLER
+	glide_size = target
 
 /**
  * Handles activating and deactivating the shield.
@@ -195,7 +199,6 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
  */
 /obj/durand_shield/proc/activate(datum/source, mob/owner, list/signal_args)
 	SIGNAL_HANDLER
-	currentuser = owner
 	if(!LAZYLEN(chassis?.occupants))
 		return
 	if(switching && !signal_args[1])
@@ -229,9 +232,20 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 		playsound(src, 'sound/mecha/mech_shield_drop.ogg', 50, FALSE)
 		set_light(0)
 		icon_state = "shield_null"
-		invisibility = INVISIBILITY_MAXIMUM //no showing on right-click
+		addtimer(CALLBACK(src, .proc/make_invisible), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 		UnregisterSignal(chassis, COMSIG_ATOM_DIR_CHANGE)
 	switching = FALSE
+
+/**
+ * Sets invisibility to INVISIBILITY_MAXIMUM if defense mode is disabled
+ *
+ * We need invisibility set to higher than 25 for the shield to not appear
+ * in the right-click context menu, but if we do it too early, we miss the
+ * deactivate animation. Hense, timer and this proc.
+ */
+/obj/durand_shield/proc/make_invisible()
+	if(!chassis.defense_mode)
+		invisibility = INVISIBILITY_MAXIMUM
 
 /obj/durand_shield/proc/resetdir(datum/source, olddir, newdir)
 	SIGNAL_HANDLER

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -21,7 +21,7 @@
 
 /obj/vehicle/sealed/mecha/combat/durand/Initialize(mapload)
 	. = ..()
-	shield = new /obj/durand_shield(loc, src, layer, dir)
+	shield = new /obj/durand_shield(loc, src, plane, layer, dir)
 	RegisterSignal(src, COMSIG_MECHA_ACTION_TRIGGER, .proc/relay)
 	RegisterSignal(src, COMSIG_PROJECTILE_PREHIT, .proc/prehit)
 
@@ -164,11 +164,11 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 	///To keep track of things during the animation
 	var/switching = FALSE
 
-/obj/durand_shield/Initialize(mapload, _chassis, _layer, _dir)
+/obj/durand_shield/Initialize(mapload, _chassis, _plane, _layer, _dir)
 	. = ..()
 	chassis = _chassis
 	layer = _layer
-	plane = chassis.plane
+	plane = _plane
 	setDir(_dir)
 	RegisterSignal(src, COMSIG_MECHA_ACTION_TRIGGER, .proc/activate)
 	RegisterSignal(chassis, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, .proc/shield_glide_size_update)

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -180,7 +180,7 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 		chassis = null
 	return ..()
 
-obj/durand_shield/proc/shield_glide_size_update(datum/source, target)
+/obj/durand_shield/proc/shield_glide_size_update(datum/source, target)
 	SIGNAL_HANDLER
 	glide_size = target
 

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -164,18 +164,20 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 	///To keep track of things during the animation
 	var/switching = FALSE
 
-/obj/durand_shield/Initialize(mapload, _chassis, _plane, _layer, _dir)
+/obj/durand_shield/Initialize(mapload, chassis, plane, layer, dir)
 	. = ..()
-	chassis = _chassis
-	layer = _layer
-	plane = _plane
-	setDir(_dir)
+	src.chassis = chassis
+	src.layer = layer
+	src.plane = plane
+	setDir(dir)
 	RegisterSignal(src, COMSIG_MECHA_ACTION_TRIGGER, .proc/activate)
 	RegisterSignal(chassis, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, .proc/shield_glide_size_update)
 
 
 /obj/durand_shield/Destroy()
+	UnregisterSignal(src, COMSIG_MECHA_ACTION_TRIGGER)
 	if(chassis)
+		UnregisterSignal(chassis, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE)
 		chassis.shield = null
 		chassis = null
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Fixes the shield being on the wrong plane.

- Fixes the shield undeploy animation being hidden due to invisibility being set too early.

- Fixes the shield having the wrong glide_size and having its movement desync from the Durand.

- Removes unused `currentuser` var.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Durand shields no longer layer incorrectly or visually decouple from the mech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
