### PR TITLE
Reimplements breathedeep's scan into atmozphere.

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -54,7 +54,7 @@
 	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_GHOST, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
 	if(user.client)
-		if(user.gas_scan && atmos_scan(user=user, target=src, tool=null, silent=TRUE))
+		if(user.gas_scan && atmos_scan(user=user, target=src, silent=TRUE))
 			return TRUE
 		else if(isAdminGhostAI(user))
 			attack_ai(user)

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -127,6 +127,7 @@
 
 /// Called when our analyzer is used on something
 /obj/item/analyzer/proc/on_analyze(datum/source, atom/target)
+	SIGNAL_HANDLER
 	var/mixture = target.return_analyzable_air()
 	if(!mixture)
 		return FALSE

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -116,7 +116,7 @@
 /obj/item/analyzer/attack_self(mob/user, modifiers)
 	if(user.stat != CONSCIOUS || !user.can_read(src) || user.is_blind())
 		return
-	atmos_scan(user=user, target=get_turf(src), tool=src, silent=FALSE)
+	atmos_scan(user=user, target=get_turf(src), silent=FALSE)
 	on_analyze(source=src, target=get_turf(src))
 
 /obj/item/analyzer/attack_self_secondary(mob/user, modifiers)
@@ -145,7 +145,7 @@
  * Gets called by analyzer_act, which in turn is called by tool_act.
  * Also used in other chat-based gas scans.
  */
-/proc/atmos_scan(mob/user, atom/target, obj/tool, silent=FALSE)
+/proc/atmos_scan(mob/user, atom/target, silent=FALSE)
 	var/mixture = target.return_analyzable_air()
 	if(!mixture)
 		return FALSE

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -341,7 +341,7 @@
 	return TRUE
 
 /obj/analyzer_act(mob/living/user, obj/item/analyzer/tool)
-	if(atmos_scan(user=user, target=src, tool=tool, silent=FALSE))
+	if(atmos_scan(user=user, target=src, silent=FALSE))
 		return TRUE
 	return ..()
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -23,7 +23,7 @@
 	var/turf/T = get_turf(mob)
 	if(!isturf(T))
 		return
-	atmos_scan(user=usr, target=T, tool=null, silent=TRUE)
+	atmos_scan(user=usr, target=T, silent=TRUE)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Air Status In Location") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_robotize(mob/M in GLOB.mob_list)

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -4,7 +4,7 @@
 
 	if(!isturf(target))
 		return
-	atmos_scan(user=usr, target=target, tool=null, silent=TRUE)
+	atmos_scan(user=usr, target=target, silent=TRUE)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Show Air Status") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/fix_next_move()

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -77,7 +77,7 @@
 	return 0
 
 /**
- *Runs when the device is used to attack an atom in non-combat mode.
+ *Runs when the device is used to attack an atom in non-combat mode using right click (secondary).
  *
  *Simulates using the device to read or scan something. Tap is called by the computer during pre_attack
  *and sends us all of the related info. If we return TRUE, the computer will stop the attack process

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -1,5 +1,5 @@
 /// Scan the turf where the computer is on.
-#define ATMOZPHERE_SCAN_ENV "self"
+#define ATMOZPHERE_SCAN_ENV "env"
 /// Scan the objects that the tablet clicks.
 #define ATMOZPHERE_SCAN_CLICK "click"
 
@@ -17,9 +17,9 @@
 	var/list/last_gasmix_data
 
 /// Secondary attack self.
-/datum/computer_file/program/atmosscan/proc/turf_analyze(mob/user)
+/datum/computer_file/program/atmosscan/proc/turf_analyze(datum/source, mob/user)
 	atmos_scan(user=user, target=get_turf(computer), silent=FALSE)
-	on_analyze(source=src, target=get_turf(src))
+	on_analyze(source=src, target=get_turf(computer))
 
 /// Updates our gasmix data if on click mode.
 /datum/computer_file/program/atmosscan/proc/on_analyze(datum/source, atom/target)
@@ -63,12 +63,14 @@
 				if(computer.tool_behaviour == TOOL_ANALYZER)
 					computer.tool_behaviour = NONE
 					UnregisterSignal(computer, COMSIG_TOOL_ATOM_ACTED_PRIMARY(TOOL_ANALYZER))
+					UnregisterSignal(computer, COMSIG_ITEM_ATTACK_SELF_SECONDARY)
 				return TRUE
 			if(computer.hardware_flag != PROGRAM_TABLET)
 				computer.say("Device incompatible for scanning objects!")
 				return FALSE
-			var/turf/turf = get_turf(computer)
-			last_gasmix_data = list(gas_mixture_parser(turf?.return_air(), "Location Reading"))
+			atmozphere_mode = ATMOZPHERE_SCAN_CLICK
 			computer.tool_behaviour = TOOL_ANALYZER
 			RegisterSignal(computer, COMSIG_TOOL_ATOM_ACTED_PRIMARY(TOOL_ANALYZER), .proc/on_analyze)
 			RegisterSignal(computer, COMSIG_ITEM_ATTACK_SELF_SECONDARY, .proc/turf_analyze)
+			var/turf/turf = get_turf(computer)
+			last_gasmix_data = list(gas_mixture_parser(turf?.return_air(), "Location Reading"))

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -25,6 +25,8 @@
 
 /// Keep this in sync with it's tool based counterpart [/obj/proc/analyzer_act] and [/atom/proc/tool_act]
 /datum/computer_file/program/atmosscan/tap(atom/A, mob/living/user, params)
+	if(atmozphere_mode != ATMOZPHERE_SCAN_CLICK)
+		return FALSE
 	atmos_scan(user=user, target=A, silent=FALSE)
 	on_analyze(source=computer, target=A)
 	return TRUE

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -19,6 +19,8 @@
 /// Secondary attack self.
 /datum/computer_file/program/atmosscan/proc/turf_analyze(datum/source, mob/user)
 	SIGNAL_HANDLER
+	if(atmozphere_mode != ATMOZPHERE_SCAN_CLICK)
+		return
 	atmos_scan(user=user, target=get_turf(computer), silent=FALSE)
 	on_analyze(source=source, target=get_turf(computer))
 	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -13,7 +13,9 @@
 	tgui_id = "NtosGasAnalyzer"
 	program_icon = "thermometer-half"
 
+	/// Whether we scan the current turf automatically (env) or scan tapped objects manually (click).
 	var/atmozphere_mode = ATMOZPHERE_SCAN_ENV
+	/// Saved [GasmixParser][/proc/gas_mixture_parser] data of the last thing we scanned.
 	var/list/last_gasmix_data
 
 /// Secondary attack self.
@@ -29,7 +31,8 @@
 /datum/computer_file/program/atmosscan/tap(atom/A, mob/living/user, params)
 	if(atmozphere_mode != ATMOZPHERE_SCAN_CLICK)
 		return FALSE
-	atmos_scan(user=user, target=A, silent=FALSE)
+	if(!atmos_scan(user=user, target=A, silent=FALSE))
+		return FALSE
 	on_analyze(source=computer, target=A)
 	return TRUE
 

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -42,6 +42,7 @@
 	var/list/data = get_header_data()
 	var/turf/turf = get_turf(computer)
 	data["atmozphereMode"] = atmozphere_mode
+	data["clickAtmozphereCompatible"] = computer.hardware_flag == PROGRAM_TABLET
 	switch (atmozphere_mode) //Null air wont cause errors, don't worry.
 		if(ATMOZPHERE_SCAN_ENV)
 			var/datum/gas_mixture/air = turf?.return_air()

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -18,11 +18,14 @@
 
 /// Secondary attack self.
 /datum/computer_file/program/atmosscan/proc/turf_analyze(datum/source, mob/user)
+	SIGNAL_HANDLER
 	atmos_scan(user=user, target=get_turf(computer), silent=FALSE)
-	on_analyze(source=src, target=get_turf(computer))
+	on_analyze(source=source, target=get_turf(computer))
+	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /// Updates our gasmix data if on click mode.
 /datum/computer_file/program/atmosscan/proc/on_analyze(datum/source, atom/target)
+	SIGNAL_HANDLER
 	var/mixture = target.return_analyzable_air()
 	if(!mixture)
 		return FALSE

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -23,9 +23,14 @@
 	on_analyze(source=source, target=get_turf(computer))
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
+/// Keep this in sync with it's tool based counterpart [/obj/proc/analyzer_act] and [/atom/proc/tool_act]
+/datum/computer_file/program/atmosscan/tap(atom/A, mob/living/user, params)
+	atmos_scan(user=user, target=A, silent=FALSE)
+	on_analyze(source=computer, target=A)
+	return TRUE
+
 /// Updates our gasmix data if on click mode.
 /datum/computer_file/program/atmosscan/proc/on_analyze(datum/source, atom/target)
-	SIGNAL_HANDLER
 	var/mixture = target.return_analyzable_air()
 	if(!mixture)
 		return FALSE
@@ -63,17 +68,12 @@
 		if("scantoggle")
 			if(atmozphere_mode == ATMOZPHERE_SCAN_CLICK)
 				atmozphere_mode = ATMOZPHERE_SCAN_ENV
-				if(computer.tool_behaviour == TOOL_ANALYZER)
-					computer.tool_behaviour = NONE
-					UnregisterSignal(computer, COMSIG_TOOL_ATOM_ACTED_PRIMARY(TOOL_ANALYZER))
-					UnregisterSignal(computer, COMSIG_ITEM_ATTACK_SELF_SECONDARY)
+				UnregisterSignal(computer, COMSIG_ITEM_ATTACK_SELF_SECONDARY)
 				return TRUE
 			if(computer.hardware_flag != PROGRAM_TABLET)
 				computer.say("Device incompatible for scanning objects!")
 				return FALSE
 			atmozphere_mode = ATMOZPHERE_SCAN_CLICK
-			computer.tool_behaviour = TOOL_ANALYZER
-			RegisterSignal(computer, COMSIG_TOOL_ATOM_ACTED_PRIMARY(TOOL_ANALYZER), .proc/on_analyze)
 			RegisterSignal(computer, COMSIG_ITEM_ATTACK_SELF_SECONDARY, .proc/turf_analyze)
 			var/turf/turf = get_turf(computer)
 			last_gasmix_data = list(gas_mixture_parser(turf?.return_air(), "Location Reading"))

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -77,3 +77,4 @@
 			RegisterSignal(computer, COMSIG_ITEM_ATTACK_SELF_SECONDARY, .proc/turf_analyze)
 			var/turf/turf = get_turf(computer)
 			last_gasmix_data = list(gas_mixture_parser(turf?.return_air(), "Location Reading"))
+			return TRUE

--- a/tgui/packages/tgui/interfaces/GasAnalyzer.tsx
+++ b/tgui/packages/tgui/interfaces/GasAnalyzer.tsx
@@ -8,8 +8,12 @@ import {
 import { Window } from '../layouts';
 import { Section } from '../components';
 
+export type GasAnalyzerData = {
+	gasmixes: Gasmix[]
+}
+
 export const GasAnalyzerContent = (props, context) => {
-  const { act, data } = useBackend<{ gasmixes: Gasmix[] }>(context);
+  const { act, data } = useBackend<GasAnalyzerData>(context);
   const { gasmixes } = data;
   const [setActiveGasId, setActiveReactionId] = atmosHandbookHooks(context);
   return (

--- a/tgui/packages/tgui/interfaces/NtosGasAnalyzer.tsx
+++ b/tgui/packages/tgui/interfaces/NtosGasAnalyzer.tsx
@@ -1,27 +1,32 @@
+import { BooleanLike } from 'common/react';
 import { useBackend } from '../backend';
 import { Button } from '../components';
 import { NtosWindow } from '../layouts';
 import { GasAnalyzerContent, GasAnalyzerData } from './GasAnalyzer';
 
 type NtosGasAnalyzerData = GasAnalyzerData & {
-  atmozphereMode: "click" | "env";
+  atmozphereMode: 'click' | 'env';
+  clickAtmozphereCompatible: BooleanLike;
 };
 
 export const NtosGasAnalyzer = (props, context) => {
   const { act, data } = useBackend<NtosGasAnalyzerData>(context);
+  const { atmozphereMode, clickAtmozphereCompatible } = data;
   return (
     <NtosWindow width={500} height={450}>
       <NtosWindow.Content scrollable>
-        <Button
-          title={
-            data.atmozphereMode === "click"
-              ? 'Scanning tapped objects. Click to switch.'
-              : 'Scanning current location. Click to switch.'
-          }
-          icon={"sync"}
-          onClick={() => act('scantoggle')}
-          fluid
-        />
+        {clickAtmozphereCompatible && (
+          <Button
+            title={
+              atmozphereMode === 'click'
+                ? 'Scanning tapped objects. Click to switch.'
+                : 'Scanning current location. Click to switch.'
+            }
+            icon={'sync'}
+            onClick={() => act('scantoggle')}
+            fluid
+          />
+        )}
         <GasAnalyzerContent />
       </NtosWindow.Content>
     </NtosWindow>

--- a/tgui/packages/tgui/interfaces/NtosGasAnalyzer.tsx
+++ b/tgui/packages/tgui/interfaces/NtosGasAnalyzer.tsx
@@ -16,7 +16,17 @@ export const NtosGasAnalyzer = (props, context) => {
     <NtosWindow width={500} height={450}>
       <NtosWindow.Content scrollable>
         {!!clickAtmozphereCompatible && (
-          <Button icon={'sync'} onClick={() => act('scantoggle')} fluid textAlign="center">
+          <Button
+            icon={'sync'}
+            onClick={() => act('scantoggle')}
+            fluid
+            textAlign="center"
+            tooltip={
+              atmozphereMode === 'click'
+                ? 'Right-click on objects while holding the tablet to scan them. Right-click on the tablet to scan the current location.'
+                : "The app will update it's gas mixture reading automatically."
+            }
+            tooltipPosition="bottom">
             {atmozphereMode === 'click'
               ? 'Scanning tapped objects. Click to switch.'
               : 'Scanning current location. Click to switch.'}

--- a/tgui/packages/tgui/interfaces/NtosGasAnalyzer.tsx
+++ b/tgui/packages/tgui/interfaces/NtosGasAnalyzer.tsx
@@ -1,10 +1,27 @@
+import { useBackend } from '../backend';
+import { Button } from '../components';
 import { NtosWindow } from '../layouts';
-import { GasAnalyzerContent } from './GasAnalyzer';
+import { GasAnalyzerContent, GasAnalyzerData } from './GasAnalyzer';
+
+type NtosGasAnalyzerData = GasAnalyzerData & {
+  atmozphereMode: "click" | "env";
+};
 
 export const NtosGasAnalyzer = (props, context) => {
+  const { act, data } = useBackend<NtosGasAnalyzerData>(context);
   return (
     <NtosWindow width={500} height={450}>
       <NtosWindow.Content scrollable>
+        <Button
+          title={
+            data.atmozphereMode === "click"
+              ? 'Scanning tapped objects. Click to switch.'
+              : 'Scanning current location. Click to switch.'
+          }
+          icon={"sync"}
+          onClick={() => act('scantoggle')}
+          fluid
+        />
         <GasAnalyzerContent />
       </NtosWindow.Content>
     </NtosWindow>

--- a/tgui/packages/tgui/interfaces/NtosGasAnalyzer.tsx
+++ b/tgui/packages/tgui/interfaces/NtosGasAnalyzer.tsx
@@ -15,17 +15,12 @@ export const NtosGasAnalyzer = (props, context) => {
   return (
     <NtosWindow width={500} height={450}>
       <NtosWindow.Content scrollable>
-        {clickAtmozphereCompatible && (
-          <Button
-            title={
-              atmozphereMode === 'click'
-                ? 'Scanning tapped objects. Click to switch.'
-                : 'Scanning current location. Click to switch.'
-            }
-            icon={'sync'}
-            onClick={() => act('scantoggle')}
-            fluid
-          />
+        {!!clickAtmozphereCompatible && (
+          <Button icon={'sync'} onClick={() => act('scantoggle')} fluid textAlign="center">
+            {atmozphereMode === 'click'
+              ? 'Scanning tapped objects. Click to switch.'
+              : 'Scanning current location. Click to switch.'}
+          </Button>
         )}
         <GasAnalyzerContent />
       </NtosWindow.Content>


### PR DESCRIPTION
## About The Pull Request
It was missed during the pda->tablet conversion, this brings it back.

Also removed the unused tool arg that i forgot to get rid of during the refactor.

Oh, and er, borgs have the scan button show on their tablet ui but they cant take the tablet out. Ideally it should be removed but even more ideally there should be a variable communicating that certain tablets cant be equipped. Ill call it out of scope i suppose. let me know if i need to clean that up in this pr because i'd rather not.

## Why It's Good For The Game
Some people liked it and its pretty seamless to implement.

## Changelog
:cl:
qol: breathedeep makes a return in the atmozphere tablet app. Right click to scan things, right self click (on the tablet) to scan current turf.
/:cl: