### PR TITLE
the reagent effect multiplier is no longer mistakenly applied twice to unholy water

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -369,8 +369,8 @@
 
 /datum/reagent/fuel/unholywater/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	if(IS_CULTIST(M))
-		M.adjust_drowsyness(-5* REM * delta_time)
-		M.AdjustAllImmobility(-40 *REM* REM * delta_time)
+		M.adjust_drowsyness(-5 * REM * delta_time)
+		M.AdjustAllImmobility(-40 * REM * delta_time)
 		M.adjustStaminaLoss(-10 * REM * delta_time, 0)
 		M.adjustToxLoss(-2 * REM * delta_time, 0)
 		M.adjustOxyLoss(-2 * REM * delta_time, 0)


### PR DESCRIPTION
## About The Pull Request

Unholy water's stun length reduction effect accidentally applies the reagent effect multiplier (aka REM, which is usually 0.5) twice. This PR makes REM only apply once to that effect, as it does to most other chem effects (including the other effects of unholy water).

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/42606352/171177943-a2ff7c56-872e-4f6a-9d62-f3e1d05d4cca.png)
![image](https://user-images.githubusercontent.com/42606352/171177991-912cd19a-a2b7-4c94-9cac-517b4e7108dd.png)

## Changelog

:cl: ATHATH
fix: Unholy water's stun length reduction effect is now as potent as it was intended to be. Its strength was previously half as strong as it was intended to be due to a copy+paste error.
/:cl:

