### PR TITLE
Fix medical doctors to have full surgery kit at roundstart

### DIFF
--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -123,15 +123,16 @@
 		return
 	var/static/items_inside = list(
 		/obj/item/healthanalyzer = 1,
-		/obj/item/stack/medical/gauze/twelve = 1,
-		/obj/item/stack/medical/suture = 2,
-		/obj/item/stack/medical/mesh = 2,
-		/obj/item/reagent_containers/hypospray/medipen = 1,
+		/obj/item/clothing/mask/surgical = 1,
 		/obj/item/surgical_drapes = 1,
 		/obj/item/scalpel = 1,
 		/obj/item/hemostat = 1,
-		/obj/item/cautery = 1)
-	generate_items_inside(items_inside,src)
+		/obj/item/cautery = 1,
+		/obj/item/circular_saw = 1,
+		/obj/item/bonesetter = 1,
+		/obj/item/retractor = 1,
+	)
+	generate_items_inside(items_inside, src)
 
 /obj/item/storage/medkit/ancient
 	icon_state = "oldfirstaid"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This lets medical doctors spawn with a full surgery kit in their surgical medkit.  It's one of the oversights from #66414.

The surgical medkit now spawns with:

```
/obj/item/healthanalyzer = 1,
/obj/item/clothing/mask/surgical = 1,
/obj/item/surgical_drapes = 1,
/obj/item/scalpel = 1,
/obj/item/hemostat = 1,
/obj/item/cautery = 1,
/obj/item/circular_saw = 1,
/obj/item/bonesetter = 1,
/obj/item/retractor = 1,
```

I did consider adding bone gel or surgical tape, but I think the bonesetter is fine and all that is really needed.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Doctors don't have to steal surgery tools at roundstart anymore.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Fix medical doctors not spawning with full surgery tools at roundstart. Removed some basic items from the surgery medkit as a result.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
