### PR TITLE
Fix androids looking dumb and stupid and ugly

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -44,21 +44,3 @@
 	. = ..()
 	// Androids don't eat, hunger or metabolise foods. Let's do some cleanup.
 	C.set_safe_hunger_level()
-
-/datum/species/android/replace_body(mob/living/carbon/target, datum/species/new_species)
-	. = ..()
-	var/skintone
-	if(ishuman(target))
-		var/mob/living/carbon/human/human_target = target
-		skintone = human_target.skin_tone
-
-	for(var/obj/item/bodypart/limb as anything in target.bodyparts)
-		if(limb.body_zone == BODY_ZONE_HEAD || limb.body_zone == BODY_ZONE_CHEST)
-			limb.is_dimorphic = TRUE
-		limb.skin_tone ||= skintone
-		limb.limb_id = SPECIES_HUMAN
-		limb.should_draw_greyscale = TRUE
-		limb.name = "human [limb.plaintext_zone]"
-		limb.update_limb()
-		limb.brute_reduction = 5
-		limb.burn_reduction = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #65913, in which androids look really ugly, by removing some code that I'm assuming was leftover from when @Kapu1178  was putting together Kapulimbs. The code removed here seems to functionally do nothing other than break the sprites, but I've tagged Kapu juuuuust in case.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Androids aren't synths and shouldn't look human. Not that they particularly look human right now...

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: androids no longer look like they were in the tanning bed for way too long
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
