### PR TITLE
Greps to check for commonly misplaced structures in closed turfs

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_bughabitat.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_bughabitat.dmm
@@ -1,7 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "as" = (
 /obj/machinery/door/airlock/public,
-/turf/closed/mineral/random/snow,
 /area/icemoon/surface/outdoors/nospawn)
 "ax" = (
 /obj/effect/turf_decal/stripes/white/line{

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_bughabitat.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_bughabitat.dmm
@@ -1,6 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "as" = (
 /obj/machinery/door/airlock/public,
+/turf/open/misc/snow,
 /area/icemoon/surface/outdoors/nospawn)
 "ax" = (
 /obj/effect/turf_decal/stripes/white/line{

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -7179,10 +7179,6 @@
 	dir = 4
 	},
 /area/ruin/space/ancientstation/delta/biolab)
-"HZ" = (
-/obj/structure/lattice,
-/turf/closed/mineral/plasma,
-/area/space/nearstation)
 "Ia" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/l3closet/scientist,
@@ -7509,10 +7505,6 @@
 /obj/structure/sign/warning/test_chamber/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
-"Kz" = (
-/obj/structure/lattice,
-/turf/closed/mineral/random,
-/area/space/nearstation)
 "KG" = (
 /obj/machinery/light/directional/east,
 /obj/structure/table/reinforced,
@@ -10552,11 +10544,11 @@ oJ
 lW
 YH
 Jg
-Kz
-Kz
-Kz
-HZ
-HZ
+UP
+UP
+UP
+Uu
+Uu
 Yp
 nm
 nu
@@ -11198,7 +11190,7 @@ aa
 aa
 aa
 Jg
-Kz
+UP
 Jg
 kQ
 cr

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -2382,9 +2382,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/medbay)
-"ji" = (
-/obj/machinery/door/airlock/glass_large,
-/area/awaymission/research/exterior)
 "jj" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
@@ -34965,7 +34962,7 @@ ad
 ad
 ad
 ad
-ji
+ad
 ad
 ad
 ad

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -2384,7 +2384,6 @@
 /area/awaymission/research/interior/medbay)
 "ji" = (
 /obj/machinery/door/airlock/glass_large,
-/turf/closed/mineral,
 /area/awaymission/research/exterior)
 "jj" = (
 /obj/structure/dresser,

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -564,10 +564,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
-"io" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/shuttle/escape)
 "it" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -5313,7 +5309,7 @@ Ho
 Ho
 Ho
 Ho
-io
+Ho
 JG
 JG
 JG
@@ -5400,7 +5396,7 @@ JG
 JG
 JG
 Ho
-io
+Ho
 Ho
 Ho
 Ho
@@ -5473,9 +5469,9 @@ JG
 Ho
 Ho
 Ho
-io
 Ho
-io
+Ho
+Ho
 JG
 PB
 JG
@@ -5568,7 +5564,7 @@ PB
 JG
 Ho
 Ho
-io
+Ho
 Ho
 Ho
 Ho
@@ -6147,7 +6143,7 @@ zE
 PB
 PB
 PB
-io
+Ho
 Ho
 Ho
 JG
@@ -6556,7 +6552,7 @@ nr
 PB
 PB
 PB
-io
+Ho
 Ho
 Ho
 Pb
@@ -6800,7 +6796,7 @@ PB
 PB
 PB
 PB
-io
+Ho
 Ho
 Ho
 Ho
@@ -7036,7 +7032,7 @@ JG
 PB
 Ho
 Ho
-io
+Ho
 Ho
 PB
 JG
@@ -7115,14 +7111,14 @@ JG
 PB
 JG
 Ho
-io
 Ho
 Ho
 Ho
 Ho
-io
 Ho
-io
+Ho
+Ho
+Ho
 Ho
 Ho
 Ho
@@ -7194,7 +7190,7 @@ Ho
 JG
 JG
 JG
-io
+Ho
 Ho
 Ho
 Ho

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -2183,9 +2183,6 @@
 "ev" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/syndicate/hallway)
-"AO" = (
-/obj/machinery/door/airlock/hatch,
-/area/shuttle/syndicate/airlock)
 
 (1,1,1) = {"
 ad
@@ -2307,7 +2304,7 @@ ad
 ad
 ad
 ad
-AO
+aO
 aI
 aP
 bC

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -2185,7 +2185,6 @@
 /area/shuttle/syndicate/hallway)
 "AO" = (
 /obj/machinery/door/airlock/hatch,
-/turf/closed/wall/r_wall/syndicate,
 /area/shuttle/syndicate/airlock)
 
 (1,1,1) = {"

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -116,6 +116,21 @@ if grep -Pzo '"\w+" = \(\n[^)]*?/obj/structure/lattice[/\w]*?,\n[^)]*?/turf/clos
     echo "ERROR: found lattice stacked with a wall, please remove them."
     st=1
 fi;
+if grep -Pzo '"\w+" = \(\n[^)]*?/obj/structure/lattice[/\w]*?,\n[^)]*?/turf/closed[/\w]*?,\n[^)]*?/area/.+?\)' _maps/**/*.dmm;	then
+	echo
+    echo "ERROR: found lattice stacked within a wall, please remove them."
+    st=1
+fi;
+if grep -Pzo '"\w+" = \(\n[^)]*?/obj/structure/window[/\w]*?,\n[^)]*?/turf/closed[/\w]*?,\n[^)]*?/area/.+?\)' _maps/**/*.dmm;	then
+	echo
+    echo "ERROR: found a window stacked within a wall, please remove it."
+    st=1
+fi;
+if grep -Pzo '"\w+" = \(\n[^)]*?/obj/machinery/door/airlock[/\w]*?,\n[^)]*?/turf/closed[/\w]*?,\n[^)]*?/area/.+?\)' _maps/**/*.dmm;	then
+	echo
+    echo "ERROR: found an airlock stacked within a wall, please remove it."
+    st=1
+fi;
 if grep -Pzo '"\w+" = \(\n[^)]*?/obj/structure/stairs[/\w]*?,\n[^)]*?/turf/open/genturf[/\w]*?,\n[^)]*?/area/.+?\)' _maps/**/*.dmm;	then
 	echo
     echo "ERROR: found a staircase on top of a genturf. Please replace the genturf with a proper tile."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds some checks for structures that are commonly misplaced inside walls. One of the more recent updatepaths also replaced a bunch of posters with windoors in walls so this will help find all those.

I also edited the one that checks for lattices to look for closed turfs, because we really don't want the structures we're looking for to be in any closed turfs anyways.

We don't want to look for all structures like this because things like transit tubes exist.

## Why It's Good For The Game

Even more quality control for our maps. We'll catch a lot of things before players do this way. : )

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Adds some greps to check for commonly misplaced structures in closed turfs
fix: Some objects stacked within closed turfs have been removed from those turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
