### PR TITLE
Makes Playing Lobby Music A Config

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -391,7 +391,7 @@
 
 /datum/config_entry/flag/native_fov
 
-/datum/config_entry/flag/allow_title_music
+/datum/config_entry/flag/disallow_title_music
 
 /datum/config_entry/number/station_goal_budget
 	default = 1

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -391,7 +391,10 @@
 
 /datum/config_entry/flag/native_fov
 
+/datum/config_entry/flag/allow_title_music
+
 /datum/config_entry/number/station_goal_budget
 	default = 1
 	min_val = 0
 	integer = FALSE
+

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -199,7 +199,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	set waitfor = FALSE
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
-	if(prefs && (prefs.toggles & SOUND_LOBBY) && (!CONFIG_GET(flag/disallow_title_music)))
+	if(prefs && (prefs.toggles & SOUND_LOBBY) && !CONFIG_GET(flag/disallow_title_music))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
 /proc/get_rand_frequency()

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -199,7 +199,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	set waitfor = FALSE
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
-	if(prefs && (prefs.toggles & SOUND_LOBBY) && (CONFIG_GET(flag/disallow_title_music)))
+	if(prefs && (prefs.toggles & SOUND_LOBBY) && (!CONFIG_GET(flag/disallow_title_music)))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
 /proc/get_rand_frequency()

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -199,7 +199,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	set waitfor = FALSE
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
-	if(prefs && (prefs.toggles & SOUND_LOBBY))
+	if(prefs && (prefs.toggles & SOUND_LOBBY) && (CONFIG_GET(flag/allow_title_music)))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
 /proc/get_rand_frequency()

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -199,7 +199,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	set waitfor = FALSE
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
-	if(prefs && (prefs.toggles & SOUND_LOBBY) && (CONFIG_GET(flag/allow_title_music)))
+	if(prefs && (prefs.toggles & SOUND_LOBBY) && (CONFIG_GET(flag/disallow_title_music)))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
 /proc/get_rand_frequency()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -467,5 +467,6 @@ MAXFINE 2000
 ## Whether native FoV is enabled for all people.
 #NATIVE_FOV
 
-## Uncomment if you wish to disable title music from playing at the lobby screen.
-#DISALLOW_TITLE_MUSIC
+## Comment if you wish to enable title music playing at the lobby screen. This flag is disabled by default to facilitate better code testing on local machines.
+## Do keep in mind that this flag will not affect individual player's preferences: if they opt-out on your server, it will never play for them.
+DISALLOW_TITLE_MUSIC

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -467,5 +467,5 @@ MAXFINE 2000
 ## Whether native FoV is enabled for all people.
 #NATIVE_FOV
 
-## Comment if you wish to disable title music from playing at the lobby screen.
-ALLOW_TITLE_MUSIC
+## Uncomment if you wish to disable title music from playing at the lobby screen.
+#DISALLOW_TITLE_MUSIC

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -466,3 +466,6 @@ MAXFINE 2000
 
 ## Whether native FoV is enabled for all people.
 #NATIVE_FOV
+
+## Comment if you wish to disable title music from playing at the lobby screen.
+ALLOW_TITLE_MUSIC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Apparently some people don't like listening to the soulful lobby music we have to offer. How unfortunate. This adds a config flag to disable said title screen music. I've heard people who like debugging a lot don't want to get their ears-bleeding via flipflap, but I find it hard to agree.

I will not lie to you, my heart honestly sunk to the bowels of my gut when I finally got this to work. If you toggle this, you are ludicrous.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Some people don't like being bugged by the title screen music (even though it's such a helpful reminder for when your compile successfully goes through while you're scrolling Twitter or something). You can enable this config on your local fork whenever it gets annoying and you aren't logged into BYOND since your preferences aren't set. If you are a server host and do not like having our free lobby music play, you can also do this. Just one flag to set (and to never commit).

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
config: Hey, server operators! Title music playing at the lobby screen is now DISABLED by default in the config settings (game_options.txt). If you are not hearing any title music, be sure to adjust your config. If you're a player reading this and are sorely missing out on those soulful tunes, please notify your server's administration team of this change so they can diagnose it properly from there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
