### PR TITLE
Removes cremator access from cremator buttons

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -85184,8 +85184,7 @@
 "wRV" = (
 /obj/machinery/button/crematorium{
 	id = "cremawheat";
-	pixel_x = -26;
-	req_access = list("crematorium")
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -22439,8 +22439,7 @@
 "ijP" = (
 /obj/machinery/button/crematorium{
 	id = "crematoriumChapel";
-	pixel_x = -26;
-	req_access = list("crematorium")
+	pixel_x = -26
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -319,8 +319,7 @@
 "ahv" = (
 /obj/machinery/button/crematorium{
 	id = "crematoriumChapel";
-	pixel_y = -26;
-	req_access = list("crematorium")
+	pixel_y = -26
 	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Civilian - Chapel Crematorium"


### PR DESCRIPTION
## About The Pull Request

Cremator access was added to cremator buttons in #35113

However, it was bugged and didn't work, because it used req access text and the button's default access overrided it 

But this was unintentionally fixed. #67002

Between then and now, it was decided the ccremator shouldn't have an access requirement. #44228

So, I'm removing cremator access from the cremator buttons. 

## Why It's Good For The Game

How are you supposed to cremate lings?

## Changelog

:cl: Melbert
balance: Cremator button has no access requirements
/:cl:
