### PR TITLE
IceBox Dorm wall crowding fixes

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -18475,7 +18475,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/bluespace_vendor/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "fVe" = (
@@ -56954,11 +56954,13 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "sof" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/requests_console/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "sot" = (
@@ -68809,7 +68811,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/requests_console/auto_name/directional/north,
+/obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "weK" = (
@@ -237915,7 +237917,7 @@ fbr
 mPF
 fvW
 fbr
-mPF
+sof
 mPF
 fbr
 fvW
@@ -238945,7 +238947,7 @@ jsX
 lLf
 asa
 kCu
-sof
+iXK
 uja
 ewd
 ehm


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Request console next to Cabin 1 moved to Dorm 2/3 wall to free up space
- Cabin 1 gas vendor moved to the opposite side of the door, moving it off of the inside's lock button for people who can see both sides
- Intercom opposite the room from Cabin 1 moved off its current wall (clipping the bathroom air alarm slightly) to where the gas vendor was, because it doesn't clip the lock button there.
![image](https://user-images.githubusercontent.com/101627558/171482019-a4948ca3-e348-459b-98a4-371efdbbdded.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

On-wall sprites that clip each other when you can see both sides of a wall (ghost, standing in line with the wall and vision to both sides) are bad, actually

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Shuffles objects to stop sprites from clipping or covering each other (with differing levels of severity) on IceBox's overcrowded dormitory walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
