### PR TITLE
The word filter now verbosely describes config failure + backwards support on rust proc

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -154,7 +154,7 @@
 #define rustg_read_toml_file_result(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
 
 /proc/rustg_read_toml_file(path)
-var/list/result = rustg_read_toml_file_result(path)
+	var/list/result = rustg_read_toml_file_result(path)
 	if (result["success"])
 		return result["content"]
 	else

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -151,7 +151,14 @@
 #define rustg_time_milliseconds(id) text2num(call(RUST_G, "time_milliseconds")(id))
 #define rustg_time_reset(id) call(RUST_G, "time_reset")(id)
 
-#define rustg_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+#define rustg_read_toml_file_result(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+
+/proc/rustg_read_toml_file(path)
+    var/list/result = rustg_read_toml_file_result(path)
+    if (result["success"])
+        return result["content"]
+    else
+        CRASH(result["content"])
 
 #define rustg_url_encode(text) call(RUST_G, "url_encode")("[text]")
 #define rustg_url_decode(text) call(RUST_G, "url_decode")(text)

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -154,11 +154,11 @@
 #define rustg_read_toml_file_result(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
 
 /proc/rustg_read_toml_file(path)
-    var/list/result = rustg_read_toml_file_result(path)
-    if (result["success"])
-        return result["content"]
-    else
-        CRASH(result["content"])
+var/list/result = rustg_read_toml_file_result(path)
+	if (result["success"])
+		return result["content"]
+	else
+		CRASH(result["content"])
 
 #define rustg_url_encode(text) call(RUST_G, "url_encode")("[text]")
 #define rustg_url_decode(text) call(RUST_G, "url_decode")(text)

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -380,12 +380,13 @@ Example config:
 
 	log_config("Loading config file word_filter.toml...")
 
-	var/list/word_filter = rustg_read_toml_file("[directory]/word_filter.toml")
-	if (!islist(word_filter))
-		var/message = "The word filter configuration did not output a list, contact someone with configuration access to make sure it's setup properly."
+	var/list/result = rustg_read_toml_file_result("[directory]/word_filter.toml")
+	if(!result["success"])
+		var/message = "The word filter is not configured correctly! [result["content"]]"
 		log_config(message)
 		DelayedMessageAdmins(message)
 		return
+	var/list/word_filter = result["content"]
 
 	ic_filter_reasons = try_extract_from_word_filter(word_filter, "ic")
 	ic_outside_pda_filter_reasons = try_extract_from_word_filter(word_filter, "ic_outside_pda")


### PR DESCRIPTION
rustg_read_toml_file has backwards dependency to support older cases that checked for lack of list (the old sign the rust fn went wrong).



<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #67446

Sister pr (This needs the rust pr or else it breaks): https://github.com/tgstation/rust-g/pull/98

The configuration for the word filter now verbosely describes the error from the bad toml to the logs, allowing problems with it to be identified quicker and resolved.

## Why It's Good For The Game

![BLAZING](https://forthebadge.com/images/badges/made-with-rust.svg)

<details>
  <summary>Ferris warning</summary>
  
  ![image](https://user-images.githubusercontent.com/40974010/171547882-054185eb-f0b4-4c54-b44b-ca152f933c6f.png)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Word filters incorrectly set up will now have their errors actually described. Please, tell your server ops when you see it so they may fix the configuration
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
