### PR TITLE
adds crowbars to fire-safety closets without gutting red toolboxes

### DIFF
--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -43,7 +43,7 @@
 
 
 /obj/item/crowbar/large
-	name = "crowbar"
+	name = "large crowbar"
 	desc = "It's a big crowbar. It doesn't fit in your pockets, because it's big."
 	force = 12
 	w_class = WEIGHT_CLASS_NORMAL
@@ -54,6 +54,11 @@
 	inhand_icon_state = "crowbar"
 	worn_icon_state = "crowbar"
 	toolspeed = 0.7
+
+/obj/item/crowbar/large/emergency
+	name = "emergency crowbar"
+	desc = "It's a huge crowbar. It almost seems deliberately designed to not be able to fit inside of a backpack."
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/crowbar/large/heavy //from space ruin
 	name = "heavy crowbar"

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -57,7 +57,7 @@
 
 /obj/item/crowbar/large/emergency
 	name = "emergency crowbar"
-	desc = "It's a huge crowbar. It almost seems deliberately designed to not be able to fit inside of a backpack."
+	desc = "It's a bulky crowbar. It almost seems deliberately designed to not be able to fit inside of a backpack."
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/crowbar/large/heavy //from space ruin

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -69,6 +69,7 @@
 	new /obj/item/tank/internals/oxygen/red(src)
 	new /obj/item/extinguisher(src)
 	new /obj/item/clothing/head/hardhat/red(src)
+	new /obj/item/crowbar/large/emergency(src)
 
 /obj/structure/closet/firecloset/full/PopulateContents()
 	new /obj/item/clothing/suit/fire/firefighter(src)
@@ -77,6 +78,7 @@
 	new /obj/item/tank/internals/oxygen/red(src)
 	new /obj/item/extinguisher(src)
 	new /obj/item/clothing/head/hardhat/red(src)
+	new /obj/item/crowbar/large/emergency(src)
 
 /*
  * Tool Closet


### PR DESCRIPTION
## About The Pull Request

Alternative to https://github.com/tgstation/tgstation/pull/67459.

Adds emergency crowbars to all roundstart fire-safety closets. Emergency crowbars are like large crowbars, except they're bulky and have a different name/description.

Changes the name of the large crowbar item from "crowbar" to "large crowbar", since I liked that change from Guill's PR.

## Why It's Good For The Game

This is a change I suggested in Guill's PR that he ended up incorporating (except with normal-sized crowbars instead of bulky ones) into his PR. His PR still removes red crowbars and mini-extinguishers from red toolboxes, though, which I think is entirely unnecessary and quite tragic.

The stated reason for the creation of Guill's PR is that players often loot crowbars from the red toolboxes of emergency closets early in the round, leaving none for opening firelocks/unpowered doors with during actual emergencies. This is an understandable grievance!

**I believe that adding a bulky crowbar to each fire-safety locker will fix this issue- because most players don't want to hold a crowbar in their hands all shift, most of these bulky crowbars will be left in their lockers until an emergency arises that actually warrants their usage (and ideally will be returned there once the emergency passes, as they can't be absent-mindedly hoarded).**

It also makes sense for fire-safety closets to contain crowbars- where there's fire, there are incredibly annoying firelocks. Because these bulky crowbars are a 100% consistent spawn, unlike red toolboxes, this should make fire-safety closets a far more consistent source of crowbars in an emergency than red toolboxes ever were. Think of them like wall-mounted fire extinguishers.

Unlike Guillarme, however, I believe that the addition of these bulky crowbars to fire-safety closets does not warrant the removal of miniature fire extinguishers from and the replacement of red crowbars with upsized ones in red toolboxes. **With this PR, the roundstart looting of red toolboxes no longer has an impact on the availability of crowbars during emergencies that require them, so I see no (good) reason to nerf their contents to make them less appealing**- especially since Guill's attempt to do so seems to have received some public pushback. Yeah, yeah, populism isn't a valid argument in this codebase, but in the absence of better ones, I think it's relevant.

If your problem is with the widespread availability/hoardability of tools, I'd recommend ripping the band-aid off by hitting many things at once, not by hitting random sources of tools one at a time whenever you remember they exist.

## Changelog

:cl: ATHATH
add: Bulky crowbars have been added to all fire-safety lockers.
spellcheck: Large crowbars are now named "large crowbars" instead of just "crowbars".
/:cl: