### PR TITLE
fixes infinite loops when a projectile pierces a bumped object

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -464,7 +464,7 @@
  */
 /obj/projectile/proc/select_target(turf/our_turf, atom/target, atom/bumped)
 	// 1. special bumped border object check
-	if(bumped?.flags_1 & ON_BORDER_1)
+	if((bumped?.flags_1 & ON_BORDER_1) && can_hit_target(bumped, original == bumped, FALSE, TRUE))
 		return bumped
 	// 2. original
 	if(can_hit_target(original, TRUE, FALSE, original == bumped))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

so
looking at this, this is bad end of the day for performance but it's too late in the day for me to rewrite projectile select target **again**

tl;dr

the bumped prioritization was not checking can hit target. this is bad because impacted[] check is in there.
impacted[] is how projectiles that shouldn't hit something/is piercing through knows to not hit it again
failure to check it is how process_hit turns into an infinite loop

## Why It's Good For The Game

bugfixing

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
:cl:
fix: infinite loop on process_hit in projectiles when hitting ON_BORDER objects, like windoors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
