### PR TITLE
[NO GBP] Fixes a window without plating underneath in DeltaStation rec

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -30590,10 +30590,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"iwr" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/space/basic,
-/area/station/commons/dorms)
 "iwy" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Central Hallway - Aft Port";
@@ -143506,7 +143502,7 @@ yaI
 yaI
 unm
 ijp
-iwr
+ijp
 tKi
 yaI
 yaI


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There was a lack of hull underneath a window in deltastation rec that I seem to have missed when I tweaked the layout of that area in a previous PR. This one patches the hull back.

## Why It's Good For The Game

Breaking a window shouldn't space the area.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: A severe lack of plating under a window in the DeltaStation rec room was remedied
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
