### PR TITLE
[NO GBP] Fixes zombie powder again

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -247,8 +247,8 @@
 	zombiepowder.data["method"] |= INGEST
 
 /datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/M, delta_time, times_fired)
-	..()
 	if(HAS_TRAIT(M, TRAIT_FAKEDEATH) && HAS_TRAIT(M, TRAIT_DEATHCOMA))
+		..()
 		return TRUE
 	switch(current_cycle)
 		if(1 to 5)
@@ -259,6 +259,8 @@
 			M.adjustStaminaLoss(40 * REM * delta_time, 0)
 		if(9 to INFINITY)
 			M.fakedeath(type)
+	..()
+	return TRUE
 
 /datum/reagent/toxin/ghoulpowder
 	name = "Ghoul Powder"


### PR DESCRIPTION
## About The Pull Request
My fault this time.

Fixes https://github.com/tgstation/tgstation/issues/67501

https://github.com/tgstation/tgstation/blob/a7070d7ee3942c103047024aaf56f74e1a7f866c/code/modules/reagents/chemistry/reagents/toxin_reagents.dm#L250
Was the fatal flaw. End metabolization is handled by `on_mob_life`'s parent. The switch check runs after that, mucking you over after fakedeath has been cured.

## Why It's Good For The Game
Yeah...

## Changelog
:cl:
fix: fixed a bigger dose of zombie powder permasleeping you
/:cl: