### PR TITLE
fixes all access helpers

### DIFF
--- a/code/modules/mapping/access_helpers.dm
+++ b/code/modules/mapping/access_helpers.dm
@@ -8,21 +8,14 @@
 		log_mapping("[src] at [AREACOORD(src)] tried to set req_one_access, but req_access was already set!")
 	else
 		var/list/access_list = get_access()
-		// Overwrite if there is no access set, otherwise add onto existing access
-		if(airlock.req_one_access == null)
-			airlock.req_one_access = access_list
-		else
-			airlock.req_one_access += access_list
+		airlock.req_one_access += access_list
 
 /obj/effect/mapping_helpers/airlock/access/all/payload(obj/machinery/door/airlock/airlock)
 	if(airlock.req_one_access != null)
 		log_mapping("[src] at [AREACOORD(src)] tried to set req_one_access, but req_access was already set!")
 	else
 		var/list/access_list = get_access()
-		if(airlock.req_access == null)
-			airlock.req_access = access_list
-		else
-			airlock.req_access_txt += access_list
+		airlock.req_access += access_list
 
 /obj/effect/mapping_helpers/airlock/access/proc/get_access()
 	var/list/access = list()


### PR DESCRIPTION
## About The Pull Request

All access helpers added their access to req_access_txt instead of req_access, that fixes that by just adding it to req_access instead.

I also removed unneeded code, there's no reason to check for null to set it as access, instead of just adding access onto it.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/53777086/171836633-613113cd-659e-4b54-bbbe-c6be0a2a0554.png)

## Changelog

Because we don't actually use several of these 'all' helpers on maps (yet, engineers have access to secure tech storage as we speak), this isn't player-facing.