### PR TITLE
The transition between the cubic powerloss and linear powerloss for the supermatter is now smooth.

### DIFF
--- a/code/__DEFINES/supermatter.dm
+++ b/code/__DEFINES/supermatter.dm
@@ -119,3 +119,14 @@
 #define MAX_SPACE_EXPOSURE_DAMAGE 10
 
 #define SUPERMATTER_CASCADE_PERCENT 80
+
+/// The divisor scaling value for cubic power loss.
+#define POWERLOSS_CUBIC_DIVISOR 500
+/// The power threshold required to transform power loss into a linear function. It is the power needed for the derivative of the cubic power loss to be equal to POWERLOSS_LINEAR_RATE.
+#define POWERLOSS_LINEAR_THRESHOLD 5880.76
+/// The offset for the linear power loss function. It is the power loss when power is at POWERLOSS_LINEAR_THRESHOLD.
+#define POWERLOSS_LINEAR_OFFSET 1627.01
+/// The rate at which the linear power loss function scales with power.
+#define POWERLOSS_LINEAR_RATE 0.83
+/// How much a psychologist can reduce power loss.
+#define PSYCHOLOGIST_POWERLOSS_REDUCTION 0.2

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -266,8 +266,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/cascade_initiated = FALSE
 	///Reference to the warp effect
 	var/atom/movable/supermatter_warp_effect/warp
-	///How much power the supermatter is losing.
-	var/power_loss = 0
 
 /obj/machinery/power/supermatter_crystal/Initialize(mapload)
 	. = ..()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -266,6 +266,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/cascade_initiated = FALSE
 	///Reference to the warp effect
 	var/atom/movable/supermatter_warp_effect/warp
+	///How much power the supermatter is losing.
+	var/power_loss = 0
 
 /obj/machinery/power/supermatter_crystal/Initialize(mapload)
 	. = ..()

--- a/code/modules/power/supermatter/supermatter_process.dm
+++ b/code/modules/power/supermatter/supermatter_process.dm
@@ -88,7 +88,9 @@
 	//Transitions between one function and another, one we use for the fast inital startup, the other is used to prevent errors with fusion temperatures.
 	//Use of the second function improves the power gain imparted by using co2
 	if(power_changes)
-		power = max(power - min(((power/500)**3) * powerloss_inhibitor, power * 0.83 * powerloss_inhibitor) * (1 - (0.2 * psyCoeff)),0)
+		power_loss = power < POWERLOSS_LINEAR_THRESHOLD ? ((power / POWERLOSS_CUBIC_DIVISOR) ** 3) : (POWERLOSS_LINEAR_OFFSET + POWERLOSS_LINEAR_RATE * (power - POWERLOSS_LINEAR_THRESHOLD))
+		power_loss *= powerloss_inhibitor * (1 - (PSYCHOLOGIST_POWERLOSS_REDUCTION * psyCoeff))
+		power = max(power - power_loss, 0)
 	//After this point power is lowered
 	//This wraps around to the begining of the function
 	//Handle high power zaps/anomaly generation

--- a/code/modules/power/supermatter/supermatter_process.dm
+++ b/code/modules/power/supermatter/supermatter_process.dm
@@ -88,7 +88,8 @@
 	//Transitions between one function and another, one we use for the fast inital startup, the other is used to prevent errors with fusion temperatures.
 	//Use of the second function improves the power gain imparted by using co2
 	if(power_changes)
-		power_loss = power < POWERLOSS_LINEAR_THRESHOLD ? ((power / POWERLOSS_CUBIC_DIVISOR) ** 3) : (POWERLOSS_LINEAR_OFFSET + POWERLOSS_LINEAR_RATE * (power - POWERLOSS_LINEAR_THRESHOLD))
+		///The power that is getting lost this tick.
+		var/power_loss = power < POWERLOSS_LINEAR_THRESHOLD ? ((power / POWERLOSS_CUBIC_DIVISOR) ** 3) : (POWERLOSS_LINEAR_OFFSET + POWERLOSS_LINEAR_RATE * (power - POWERLOSS_LINEAR_THRESHOLD))
 		power_loss *= powerloss_inhibitor * (1 - (PSYCHOLOGIST_POWERLOSS_REDUCTION * psyCoeff))
 		power = max(power - power_loss, 0)
 	//After this point power is lowered


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Change the requirement for the linear powerloss to occur when the derivative of the cubic powerloss is equal to the rate of the linear powerloss. Offsets linear powerloss to make the transition between the two functions completely smooth. Adds defines for the powerloss magic numbers. Changes the powerloss inhibitor stuff to just reduce the powerloss instead of reducing the functions, meaning that reducing it by 90% would always reduce it by 90%.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is what powerloss currently looks like (black is power, red is powerloss): ![image](https://user-images.githubusercontent.com/58013024/171971909-8acd620e-33d8-4687-a1a5-5087f9475538.jpeg)

What it looks like with this PR's changes: ![image](https://user-images.githubusercontent.com/58013024/171971919-5c2dd28c-1275-4fac-b773-7392efba13b2.jpeg)

Now to show why I made this PR, this is what power after powerloss gets applied looks like (black is power, purple is power after powerloss gets applied): ![image](https://user-images.githubusercontent.com/58013024/171971970-7e009382-b90c-4afa-8141-3f1e86133f2d.jpeg)

What it looks like with the new changes in this PR: ![image](https://user-images.githubusercontent.com/58013024/171971986-f8f03a35-d415-4ee3-ad57-7c6546fe004e.jpeg)

Well, the consequence of powerloss being a cubic function means at one point the derivative of power minus powerloss will be negative, and at one insane point, this could make adding more emitters (or extremely high temperature) actually cause the SM to have lower power than if they didn't add emitters (or extremely high temperature), because linear powerloss doesn't occur in time.

This should make the powerloss function for high power supermatters to be more intuitive, where powerloss doesn't punish giving the supermatter high power to the point of being worse than giving it lower power. Changing powerloss inhibition related stuff will make it more intuitive for people to understand.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Changes supermatter powerloss function. It will transition to linear powerloss function at 5.88076GeV, and the linear powerloss function has been offset so that the transition between the two functions is completely smooth.
balance: Changes powerloss inhibition (both CO2 and psychologist effect) to change the rate of powerloss instead of changing the rate of both functions then comparing them to which one should be used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
