### PR TITLE
Fixes all access fan requiring more IDs that possibly available 

### DIFF
--- a/code/modules/antagonists/thief/thief_objectives.dm
+++ b/code/modules/antagonists/thief/thief_objectives.dm
@@ -120,7 +120,7 @@ GLOBAL_LIST_INIT(hoarder_targets, list(
 
 /datum/objective/all_access/find_target(dupe_search_range, blacklist)
 	var/list/possible_targets = list()
-	for(var/datum/mind/possible_target in get_crewmember_minds())
+	for(var/datum/mind/possible_target as anything in get_crewmember_minds())
 		var/target_area = get_area(possible_target.current)
 		if(possible_target == owner)
 			continue

--- a/code/modules/antagonists/thief/thief_objectives.dm
+++ b/code/modules/antagonists/thief/thief_objectives.dm
@@ -122,7 +122,7 @@ GLOBAL_LIST_INIT(hoarder_targets, list(
 	var/list/possible_targets = list()
 	for(var/datum/mind/possible_target in get_crewmember_minds())
 		var/target_area = get_area(possible_target.current)
-		if(possible_target in owners)
+		if(possible_target == owner)
 			continue
 		if(!ishuman(possible_target.current))
 			continue

--- a/code/modules/antagonists/thief/thief_objectives.dm
+++ b/code/modules/antagonists/thief/thief_objectives.dm
@@ -119,7 +119,26 @@ GLOBAL_LIST_INIT(hoarder_targets, list(
 	var/amount = 8
 
 /datum/objective/all_access/find_target(dupe_search_range, blacklist)
-	amount = rand(amount - 2, amount + 2)
+	var/list/possible_targets = list()
+	for(var/datum/mind/possible_target in get_crewmember_minds())
+		var/target_area = get_area(possible_target.current)
+		if(possible_target in owners)
+			continue
+		if(!ishuman(possible_target.current))
+			continue
+		if(possible_target.current.stat == DEAD)
+			continue
+		if(!is_unique_objective(possible_target,dupe_search_range))
+			continue
+		if(!HAS_TRAIT(SSstation, STATION_TRAIT_LATE_ARRIVALS) && istype(target_area, /area/shuttle/arrival))
+			continue
+		if(possible_target in blacklist)
+			continue
+		possible_targets += possible_target
+	if(length(possible_targets) >= amount + 2)
+		amount = rand(amount - 2, amount + 2)
+	else
+		amount = length(possible_targets)
 
 /datum/objective/all_access/check_completion()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes #67524

## Why It's Good For The Game

Fixes #67524

## Changelog
:cl:
fix: You can no longer roll more IDs to steal than there are crewmembers for All Access Fan.
/:cl: