### PR TITLE
Fixes firelocks checking the atmospheric contents of solid walls.

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -215,6 +215,8 @@
 			var/turf/checked_turf = get_step(get_turf(firelock), dir)
 			if(!checked_turf)
 				continue
+			if(isclosedturf(checked_turf))
+				continue
 			process_results(checked_turf)
 
 /obj/machinery/door/firedoor/proc/register_adjacent_turfs(atom/loc)
@@ -226,6 +228,8 @@
 		var/turf/checked_turf = get_step(get_turf(loc), dir)
 
 		if(!checked_turf)
+			continue
+		if(isclosedturf(checked_turf))
 			continue
 		process_results(checked_turf)
 		RegisterSignal(checked_turf, COMSIG_TURF_EXPOSE, .proc/process_results)


### PR DESCRIPTION
## About The Pull Request

Fixes #67491

## Why It's Good For The Game

Fixes #67491

## Changelog
:cl:
fix: Firelocks no longer check the atmospheric contents of solid walls.
/:cl: