### PR TITLE
Fixes centcom announcements referring to icebox as a station in orbit

### DIFF
--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -42,6 +42,7 @@
 			"No Parallax": true
 		}
 	],
+	"orbit_shift_replacement": "Attention crew, it appears that someone on your outpost has shifted your planet into more dangerous territory.",
 	"minetype": "none",
 	"job_changes": {
 		"Cook": {

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -35,6 +35,8 @@
 	var/job_changes = list()
 	/// List of additional areas that count as a part of the library
 	var/library_areas = list()
+	/// What message shows up when the orbit is shifted.
+	var/orbit_shift_replacement = "Attention crew, it appears that someone on your station has shifted your orbit into more dangerous territory."
 
 /**
  * Proc that simply loads the default map config, which should always be functional.
@@ -165,6 +167,9 @@
 	else if (!isnull(temp))
 		log_world("map_config space_empty_levels is not a number!")
 		return
+
+	if("orbit_shift_replacement" in json)
+		orbit_shift_replacement = json["orbit_shift_replacement"]
 
 	if ("minetype" in json)
 		minetype = json["minetype"]

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -821,7 +821,7 @@
 
 		if(HACK_FUGITIVES) // Triggers fugitives, which can cause confusion / chaos as the crew decides which side help
 			priority_announce(
-				"Attention crew, it appears that someone on your station has established an unexpected orbit with an unmarked ship in nearby space.",
+				"Attention crew, it appears that someone on your station has made unexpected communication with an unmarked ship in nearby space.",
 				"[command_name()] High-Priority Update"
 				)
 
@@ -832,7 +832,7 @@
 
 		if(HACK_THREAT) // Adds a flat amount of threat to buy a (probably) more dangerous antag later
 			priority_announce(
-				"Attention crew, it appears that someone on your station has shifted your orbit into more dangerous territory.",
+				SSmapping.config.orbit_shift_replacement,
 				"[command_name()] High-Priority Update"
 				)
 


### PR DESCRIPTION
## About The Pull Request

Fixes #67467

## Why It's Good For The Game

Fixes #67467

## Changelog
:cl:
fix: Central Command no longer erroneously refers to the Ice Box planet as a station in orbit.
/:cl:
