### PR TITLE
Clothing (as food for Moths) now only give temporary nourishment.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -410,7 +410,8 @@
 
 #define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
 #define ETHEREAL_CHARGE_FACTOR 0.8 //factor at which ethereal's charge decreases per second
-#define CLOTHING_NUTRITION_GAIN 15 //How much nutrition eating clothes as moth gives and drains
+/// How much nutrition eating clothes as moth gives and drains
+#define CLOTHING_NUTRITION_GAIN 15
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4) // By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -410,6 +410,7 @@
 
 #define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
 #define ETHEREAL_CHARGE_FACTOR 0.8 //factor at which ethereal's charge decreases per second
+#define CLOTHING_NUTRITION_GAIN 15 //How much nutrition eating clothes as moth gives and drains
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4) // By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -82,7 +82,8 @@
 	// sigh, ok, so it's not ACTUALLY infinite nutrition. this is so you can eat clothes more than...once.
 	// bite_consumption limits how much you actually get, and the take_damage in after eat makes sure you can't abuse this.
 	// ...maybe this was a mistake after all.
-	food_reagents = list(/datum/reagent/consumable/nutriment = INFINITY)
+	food_reagents = list(/datum/reagent/consumable/nutriment/clothiment = INFINITY)
+	junkiness = 15
 	tastes = list("dust" = 1, "lint" = 1)
 	foodtypes = CLOTH
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -82,7 +82,7 @@
 	// sigh, ok, so it's not ACTUALLY infinite nutrition. this is so you can eat clothes more than...once.
 	// bite_consumption limits how much you actually get, and the take_damage in after eat makes sure you can't abuse this.
 	// ...maybe this was a mistake after all.
-	food_reagents = list(/datum/reagent/consumable/nutriment/clothiment = INFINITY)
+	food_reagents = list(/datum/reagent/consumable/nutriment/cloth_fibers = INFINITY)
 	tastes = list("dust" = 1, "lint" = 1)
 	foodtypes = CLOTH
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -83,7 +83,6 @@
 	// bite_consumption limits how much you actually get, and the take_damage in after eat makes sure you can't abuse this.
 	// ...maybe this was a mistake after all.
 	food_reagents = list(/datum/reagent/consumable/nutriment/clothiment = INFINITY)
-	junkiness = 15
 	tastes = list("dust" = 1, "lint" = 1)
 	foodtypes = CLOTH
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -118,7 +118,7 @@
 	burn_heal = 1
 
 /datum/reagent/consumable/nutriment/vitamin/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(M.satiety < 600)
+	if(M.satiety < MAX_SATIETY)
 		M.satiety += 30 * REM * delta_time
 	. = ..()
 
@@ -136,26 +136,25 @@
 	taste_description = "rich earthy pungent"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/nutriment/clothiment
-	name = "Clothiment"
-	description = "It's not actually a form of nutriment but it does keep Moth people going for a short while..."
+/datum/reagent/consumable/nutriment/cloth_fibers
+	name = "Cloth Fibers"
+	description = "It's not actually a form of nutriment but it does keep Mothpeople going for a short while..."
 	nutriment_factor = 30 * REAGENTS_METABOLISM
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	brute_heal = 0
 	burn_heal = 0
-	///Amount of satiety that will be drained when the clothiment is fully metabolized
-	var/delayed_satiety_drain = 30
+	///Amount of satiety that will be drained when the cloth_fibers is fully metabolized
+	var/delayed_satiety_drain = 2 * CLOTHING_NUTRITION_GAIN
 
-/datum/reagent/consumable/nutriment/clothiment/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(M.satiety < 600)
-		M.adjust_nutrition(15)
-		delayed_satiety_drain += 15
-	. = ..()
+/datum/reagent/consumable/nutriment/cloth_fibers/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	if(M.satiety < MAX_SATIETY)
+		M.adjust_nutrition(CLOTHING_NUTRITION_GAIN)
+		delayed_satiety_drain += CLOTHING_NUTRITION_GAIN
+	return ..()
 
-/datum/reagent/consumable/nutriment/clothiment/on_mob_delete(mob/living/carbon/M)
+/datum/reagent/consumable/nutriment/cloth_fibers/on_mob_delete(mob/living/carbon/M)
 	M.adjust_nutrition(-delayed_satiety_drain)
-	to_chat(M, span_warning("Your stomach suddently feels empty!"))
-	. = ..()
+	return ..()
 
 /datum/reagent/consumable/cooking_oil
 	name = "Cooking Oil"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -136,6 +136,14 @@
 	taste_description = "rich earthy pungent"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
+/datum/reagent/consumable/nutriment/clothiment
+	name = "Clothiment"
+	description = "It's not actually a form of nutriment but it does keep Moth people going for a short while..."
+	nutriment_factor = 3 * REAGENTS_METABOLISM
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	brute_heal = 0
+	burn_heal = 0
+
 /datum/reagent/consumable/cooking_oil
 	name = "Cooking Oil"
 	description = "A variety of cooking oil derived from fat or plants. Used in food preparation and frying."

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -139,10 +139,23 @@
 /datum/reagent/consumable/nutriment/clothiment
 	name = "Clothiment"
 	description = "It's not actually a form of nutriment but it does keep Moth people going for a short while..."
-	nutriment_factor = 3 * REAGENTS_METABOLISM
+	nutriment_factor = 30 * REAGENTS_METABOLISM
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	brute_heal = 0
 	burn_heal = 0
+	///Amount of satiety that will be drained when the clothiment is fully metabolized
+	var/delayed_satiety_drain = 30
+
+/datum/reagent/consumable/nutriment/clothiment/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	if(M.satiety < 600)
+		M.adjust_nutrition(15)
+		delayed_satiety_drain += 15
+	. = ..()
+
+/datum/reagent/consumable/nutriment/clothiment/on_mob_delete(mob/living/carbon/M)
+	M.adjust_nutrition(-delayed_satiety_drain)
+	to_chat(M, span_warning("Your stomach suddently feels empty!"))
+	. = ..()
 
 /datum/reagent/consumable/cooking_oil
 	name = "Cooking Oil"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clothing as food now gives cloth fibers which is a weaker version of nutriment, it doesn't heal brute damage.
Cloth fibers gives a lot of nourishment but once it is finished metabolizing it takes that nourishment away with a small extra fee to avoid a micromanaging Moth to stay feeding on a stack of whatever creative clothing they can craft like gloves.
It also makes Moths fat fast (and the fatness goes away when it finishes metabolizing) to be a cap against Moths just going around devouring everything they can get their hands on.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Right now 3 out of our 6 species don't really care about food balance. (And I'm being generous by counting Felinids different than humans when they are basically just a better version diet wise...)
Plasmamen don't need to eat and it is fair since it would be a hard task with their sealed suits.
Ethereals do need electrical nourishment, but it is not food. Still we shouldn't change that as it is their unique thing.
Moths just... eat clothing in the corner, never worried about food supply while having their own unique cuisine...
 
Mothblocks said that their intent with the original PR that allowed Moths to eat clothes was to be something funny and not to work as their main source of nutrition, sadly the feature powercreeped over time so let's fix that.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
balance: Eating clothing as Mothpeople will give you cloth fibers instead of nutriment. Cloth fibers give temporary nourishment that gets removed when it finishes metabolizing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
