### PR TITLE
Delta Sec pod airless plating

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -26628,11 +26628,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7";
-	luminosity = 2;
-	temperature = 2.7
-	},
+/turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "hmx" = (
 /obj/docking_port/stationary/random{
@@ -43033,11 +43029,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7";
-	luminosity = 2;
-	temperature = 2.7
-	},
+/turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "lIu" = (
 /obj/structure/table/reinforced,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
From this:
![StrongDMM-16 33 01 106](https://user-images.githubusercontent.com/85910816/172069812-59a03891-b050-426a-80bb-e5b34238ead2.png)
To this:
![StrongDMM-16 33 07 239](https://user-images.githubusercontent.com/85910816/172069813-0880954f-8af4-4c3e-b91f-e1c4a5f2785f.png)
Location:
![image](https://user-images.githubusercontent.com/85910816/172069839-34a2c461-338f-4492-bf0d-e38629e17c27.png)

## Why It's Good For The Game
Why was it airless when other pods aren't?

## Changelog

:cl:
fix: There is now air in the Deltastation security escape pod airlock.
/:cl:
