### PR TITLE
Fixes a rogue parent area on a tile in TramStation Maint

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -39234,9 +39234,6 @@
 /obj/machinery/power/apc/sm_apc/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"ndi" = (
-/turf/closed/wall,
-/area/station/maintenance/central)
 "ndn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -101323,7 +101320,7 @@ hFr
 hFr
 hFr
 hFr
-ndi
+hFr
 lko
 oUL
 hov


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin. Just paints over that one tile with the proper area.

## Why It's Good For The Game

Fixes #67544 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can no longer get objectives on a random tile in maintenance on TramStation, along with any other area/based assignments.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
