### PR TITLE
Replace red colored beacons on solars/catwalk areas outside Meta to be colored according to department 

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6158,6 +6158,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
+"cpH" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/yellow,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cpR" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -9392,6 +9397,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"dxK" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/purple,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dxO" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/camera/directional/east{
@@ -14714,10 +14724,10 @@
 /area/station/security/holding_cell)
 "fxr" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy,
 /obj/item/instrument/musicalmoth{
 	name = "Syl Labee"
 	},
+/obj/structure/marker_beacon/olive,
 /turf/open/space/basic,
 /area/space/nearstation)
 "fxI" = (
@@ -41780,6 +41790,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"oPS" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/olive,
+/turf/open/space/basic,
+/area/space/nearstation)
 "oPY" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -47488,6 +47503,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"qPs" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/indigo,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qPx" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -69036,11 +69056,11 @@
 /area/station/science/explab)
 "yib" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy,
 /obj/item/toy/plush/space_lizard_plushie{
 	desc = "He stared into the void and listened. He didn't expect an answer...";
 	name = "Void-Stares-Back"
 	},
+/obj/structure/marker_beacon/purple,
 /turf/open/space/basic,
 /area/space/nearstation)
 "yih" = (
@@ -77044,7 +77064,7 @@ aaa
 aaa
 aaa
 aaa
-quc
+oPS
 aaa
 aaa
 fxr
@@ -77059,19 +77079,19 @@ aaa
 aaa
 aaa
 aaa
-quc
+oPS
 aaa
 aaa
-quc
+oPS
 aaa
 aaa
 aaa
 aaa
 aaa
-quc
+oPS
 aaa
 aaa
-quc
+oPS
 aaa
 aaa
 aaa
@@ -78322,7 +78342,7 @@ aaa
 aaa
 aaa
 aaa
-quc
+oPS
 lMJ
 eeg
 wdr
@@ -78606,9 +78626,9 @@ ndI
 nDP
 qEt
 aox
-quc
+oPS
 aox
-quc
+oPS
 aox
 qEt
 jjS
@@ -79350,7 +79370,7 @@ aaa
 aaa
 aaa
 aaa
-quc
+oPS
 lMJ
 eeg
 wdr
@@ -80985,7 +81005,7 @@ rrt
 rrt
 rrt
 rrt
-quc
+qPs
 aaa
 aaa
 aaa
@@ -82530,7 +82550,7 @@ anS
 wDi
 anS
 lMJ
-quc
+qPs
 aaa
 aaa
 aaa
@@ -84072,7 +84092,7 @@ tPH
 tPH
 nRb
 lMJ
-quc
+qPs
 aaa
 aaa
 aaa
@@ -85614,7 +85634,7 @@ anS
 anS
 anS
 lMJ
-quc
+qPs
 aaa
 aaa
 aaa
@@ -87156,7 +87176,7 @@ nRb
 tPH
 anS
 lMJ
-quc
+qPs
 aaa
 aaa
 aaa
@@ -99231,7 +99251,7 @@ uGg
 dKC
 nRb
 lMJ
-quc
+oPS
 aaa
 aaa
 aaa
@@ -101544,7 +101564,7 @@ rQO
 dKC
 anS
 lMJ
-quc
+oPS
 aaa
 aaa
 aaa
@@ -103849,7 +103869,7 @@ kYD
 lMJ
 lMJ
 aaa
-quc
+dxK
 lMJ
 lMJ
 aaa
@@ -103857,7 +103877,7 @@ lMJ
 aaa
 lMJ
 lMJ
-quc
+dxK
 lMJ
 lMJ
 aaa
@@ -103865,7 +103885,7 @@ lMJ
 aaa
 lMJ
 lMJ
-quc
+dxK
 lMJ
 lMJ
 aaa
@@ -103873,7 +103893,7 @@ lMJ
 aaa
 lMJ
 lMJ
-quc
+dxK
 lMJ
 lMJ
 aaa
@@ -103881,14 +103901,14 @@ lMJ
 aaa
 lMJ
 lMJ
-quc
+dxK
 lMJ
 lMJ
 aaa
 lMJ
 aaa
 lMJ
-quc
+dxK
 aaf
 aaf
 weq
@@ -104877,7 +104897,7 @@ uZM
 kYD
 aaa
 aaa
-quc
+dxK
 lMJ
 lMJ
 aaa
@@ -104885,7 +104905,7 @@ lMJ
 aaa
 lMJ
 lMJ
-quc
+dxK
 lMJ
 lMJ
 aaa
@@ -104893,7 +104913,7 @@ lMJ
 aaa
 lMJ
 lMJ
-quc
+dxK
 lMJ
 lMJ
 aaa
@@ -104901,7 +104921,7 @@ lMJ
 aaa
 lMJ
 lMJ
-quc
+dxK
 lMJ
 lMJ
 aaa
@@ -104909,14 +104929,14 @@ lMJ
 aaa
 lMJ
 lMJ
-quc
+dxK
 lMJ
 lMJ
 aaa
 lMJ
 aaa
 lMJ
-quc
+dxK
 aaf
 aaf
 weq
@@ -107845,7 +107865,7 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 aaa
 aaa
 aaa
@@ -108873,7 +108893,7 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 aaa
 aaa
 aaa
@@ -109476,9 +109496,9 @@ pnH
 aaa
 aaa
 aaa
-quc
+dxK
 lMJ
-quc
+dxK
 lMJ
 tOg
 tOg
@@ -109901,7 +109921,7 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 aaa
 aaa
 blx
@@ -110929,7 +110949,7 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 aaa
 aaa
 ffP
@@ -111787,9 +111807,9 @@ eoU
 aaf
 aaa
 aaa
-quc
+dxK
 aaa
-quc
+dxK
 aaa
 aaa
 oMA
@@ -111957,7 +111977,7 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 aaa
 aaa
 aaa
@@ -112985,7 +113005,7 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 aaa
 aaa
 aaa
@@ -116077,13 +116097,13 @@ oIG
 oIG
 lMJ
 lMJ
-quc
+cpH
 aaa
 aaa
 aaa
 aaa
 aaa
-quc
+cpH
 lMJ
 lMJ
 tlE
@@ -116114,11 +116134,11 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 aaa
 gFa
 aaa
-quc
+cpH
 twf
 lMJ
 lMJ
@@ -117385,13 +117405,13 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 lMJ
 wDi
 ghL
 anS
 lMJ
-quc
+cpH
 lMJ
 lMJ
 lMJ
@@ -118445,7 +118465,7 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 lMJ
 jBX
 ghL
@@ -120022,11 +120042,11 @@ aaa
 aaa
 aaa
 aaa
-jLw
+dxK
 aaa
 lMJ
 aaa
-jLw
+dxK
 aaa
 aaa
 aaa
@@ -120469,13 +120489,13 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 lMJ
 jBX
 ghL
 anS
 lMJ
-quc
+cpH
 aaa
 aaa
 aaa
@@ -120501,13 +120521,13 @@ aaa
 aaa
 aaa
 aaa
-quc
+cpH
 lMJ
 nRb
 ghL
 wDi
 lMJ
-quc
+cpH
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This replaces all the red colored beacons to the solars/catwalks areas of Meta with the following:

- Medbay - Blue
- Security - Red
- Engineering - Yellow
- Research - Purple
- Arrivals/Departures - Green

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

<details>
<summary>Arrivals</summary>

![2022-06-05 20_48_03-tgstation dme  MetaStation dmm  - StrongDMM](https://user-images.githubusercontent.com/5195984/172081915-485419c0-e688-4552-add1-22b53863cafb.png)
</details>

<details>
<summary>Medical</summary>

![2022-06-05 20_48_38-tgstation dme  MetaStation dmm  - StrongDMM](https://user-images.githubusercontent.com/5195984/172081917-1f3e3549-21cb-4c39-ab19-77ceb66e008a.png)
</details>

<details>
<summary>Departure/Research</summary>

![2022-06-05 20_48_57-tgstation dme  MetaStation dmm  - StrongDMM](https://user-images.githubusercontent.com/5195984/172081919-0af363d9-ece3-4ec0-abc7-9babbf873703.png)
</details>

<details>
<summary>Research</summary>

![2022-06-05 20_49_18-tgstation dme  MetaStation dmm  - StrongDMM](https://user-images.githubusercontent.com/5195984/172081921-38a85308-d2b3-4c41-a931-f676b634c276.png)
</details>

<details>
<summary>Engineering 1</summary>

![2022-06-05 20_49_36-tgstation dme  MetaStation dmm  - StrongDMM](https://user-images.githubusercontent.com/5195984/172081924-0e92b44d-3d95-4d15-9357-b9b5976b34bd.png)
</details>

<details>
<summary>Engineering 2</summary>

![2022-06-05 20_49_58-tgstation dme  MetaStation dmm  - StrongDMM](https://user-images.githubusercontent.com/5195984/172081925-9b725fe3-cf60-4cd9-9351-428d798db75c.png)
</details>

<details>
<summary>Security</summary>

![2022-06-05 20_50_15-tgstation dme  MetaStation dmm  - StrongDMM](https://user-images.githubusercontent.com/5195984/172081927-2f8c3bb9-64a7-4032-a66c-a3db2cc5febe.png)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Replace red colored beacons on solars/catwalk areas outside Meta to be colored according to department (sec is red, medical is blue, etc.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
