### PR TITLE
New Event: Gravity Generator Blackout

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -186,7 +186,8 @@
 
 /obj/effect/anomaly/grav/high/detonate()
 	for(var/obj/machinery/gravity_generator/main/the_generator in GLOB.machines)
-		the_generator.blackout()
+		if(is_station_level(the_generator.z))
+			the_generator.blackout()
 
 /obj/effect/anomaly/grav/high/Destroy()
 	QDEL_NULL(grav_field)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -184,6 +184,10 @@
 /obj/effect/anomaly/grav/high/proc/setup_grav_field()
 	grav_field = new(src, 7, TRUE, rand(0, 3))
 
+/obj/effect/anomaly/grav/high/detonate()
+	for(var/obj/machinery/gravity_generator/main/the_generator in GLOB.machines)
+		the_generator.blackout()
+
 /obj/effect/anomaly/grav/high/Destroy()
 	QDEL_NULL(grav_field)
 	. = ..()

--- a/code/modules/events/anomaly_grav.dm
+++ b/code/modules/events/anomaly_grav.dm
@@ -23,4 +23,4 @@
 	anomaly_path = /obj/effect/anomaly/grav/high
 
 /datum/round_event/anomaly/anomaly_grav/announce(fake)
-	priority_announce("Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
+	priority_announce("Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert" , ANNOUNCER_GRANOMALIES)

--- a/code/modules/events/gravity_generator_blackout.dm
+++ b/code/modules/events/gravity_generator_blackout.dm
@@ -9,7 +9,7 @@
 	announceChance = 33
 
 /datum/round_event/gravity_generator_blackout/announce(fake)
-	priority_announce("Gravnospheric anomalies detected near [station_name()]. Manual reset of generators is required.")
+	priority_announce("Gravnospheric anomalies detected near [station_name()]. Manual reset of generators is required.", "Anomaly Alert" , ANNOUNCER_GRANOMALIES)
 
 /datum/round_event/gravity_generator_blackout/start()
 	for(var/obj/machinery/gravity_generator/main/the_generator in GLOB.machines)

--- a/code/modules/events/gravity_generator_blackout.dm
+++ b/code/modules/events/gravity_generator_blackout.dm
@@ -1,0 +1,18 @@
+/datum/round_event_control/gravity_generator_blackout
+	name = "Gravity Generator Blackout"
+	typepath = /datum/round_event/gravity_generator_blackout
+	weight = 30
+
+/datum/round_event/gravity_generator_blackout
+	announceWhen = 1
+
+/datum/round_event/gravity_generator_blackout/announce(fake)
+	var/alert = pick( "Gravnospheric anomalies detected. Temporary gravity field failure imminent.")
+
+	if(prob(30) || fake) //most of the time, we don't want an announcement, allows quiet sabotage.
+		priority_announce(alert)
+
+
+/datum/round_event/gravity_generator_blackout/start()
+	for(var/obj/machinery/gravity_generator/main/the_generator in GLOB.gravity_generators)
+		the_generator.blackout

--- a/code/modules/events/gravity_generator_blackout.dm
+++ b/code/modules/events/gravity_generator_blackout.dm
@@ -5,14 +5,12 @@
 
 /datum/round_event/gravity_generator_blackout
 	announceWhen = 1
+	startWhen = 1
+	announceChance = 33
 
 /datum/round_event/gravity_generator_blackout/announce(fake)
-	var/alert = pick( "Gravnospheric anomalies detected. Temporary gravity field failure imminent.")
-
-	if(prob(30) || fake) //most of the time, we don't want an announcement, allows quiet sabotage.
-		priority_announce(alert)
-
+	priority_announce("Gravnospheric anomalies detected near [station_name()]. Manual reset of generators is required.")
 
 /datum/round_event/gravity_generator_blackout/start()
-	for(var/obj/machinery/gravity_generator/main/the_generator in GLOB.gravity_generators)
-		the_generator.blackout
+	for(var/obj/machinery/gravity_generator/main/the_generator in GLOB.machines)
+		the_generator.blackout()

--- a/code/modules/events/gravity_generator_blackout.dm
+++ b/code/modules/events/gravity_generator_blackout.dm
@@ -3,14 +3,22 @@
 	typepath = /datum/round_event/gravity_generator_blackout
 	weight = 30
 
+/datum/round_event_control/gravity_generator_blackout/canSpawnEvent()
+	for(var/obj/machinery/gravity_generator/main/the_generator in GLOB.machines)
+		if(!the_generator)
+			return FALSE
+
+	return ..()
+
 /datum/round_event/gravity_generator_blackout
 	announceWhen = 1
 	startWhen = 1
 	announceChance = 33
 
 /datum/round_event/gravity_generator_blackout/announce(fake)
-	priority_announce("Gravnospheric anomalies detected near [station_name()]. Manual reset of generators is required.", "Anomaly Alert" , ANNOUNCER_GRANOMALIES)
+	priority_announce("Gravnospheric anomalies detected near [station_name()]. Manual reset of generators is required.", "Anomaly Alert", ANNOUNCER_GRANOMALIES)
 
 /datum/round_event/gravity_generator_blackout/start()
 	for(var/obj/machinery/gravity_generator/main/the_generator in GLOB.machines)
-		the_generator.blackout()
+		if(is_station_level(the_generator.z))
+			the_generator.blackout()

--- a/code/modules/events/gravity_generator_blackout.dm
+++ b/code/modules/events/gravity_generator_blackout.dm
@@ -4,11 +4,13 @@
 	weight = 30
 
 /datum/round_event_control/gravity_generator_blackout/canSpawnEvent()
+	var/station_generator_exists = FALSE
 	for(var/obj/machinery/gravity_generator/main/the_generator in GLOB.machines)
-		if(!the_generator)
-			return FALSE
+		if(is_station_level(the_generator.z))
+			station_generator_exists = TRUE
 
-	return ..()
+	if(!station_generator_exists)
+		return FALSE
 
 /datum/round_event/gravity_generator_blackout
 	announceWhen = 1

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -441,13 +441,11 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 		shake_everyone()
 
 /obj/machinery/gravity_generator/main/proc/blackout()
-	charging_state = POWER_IDLE
-	on = FALSE
 	charge_count = 0
 	breaker = FALSE
 	set_power()
 	disable()
-	investigate_log("has turned down by blackout event.", INVESTIGATE_GRAVITY)
+	investigate_log("was turned off by blackout event or a gravity anomaly detonation.", INVESTIGATE_GRAVITY)
 
 // Misc
 

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -441,6 +441,8 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 		shake_everyone()
 
 /obj/machinery/gravity_generator/main/proc/blackout()
+	charging_state = POWER_IDLE
+	on = FALSE
 	charge_count = 0
 	breaker = FALSE
 	set_power()

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -440,6 +440,13 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 		setting = value
 		shake_everyone()
 
+/obj/machinery/gravity_generator/main/proc/blackout()
+	charge_count = 0
+	breaker = FALSE
+	set_power()
+	disable()
+	investigate_log("has turned down by blackout event.", INVESTIGATE_GRAVITY)
+
 // Misc
 
 /obj/item/paper/guides/jobs/engi/gravity_gen

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2775,6 +2775,7 @@
 #include "code\modules\events\false_alarm.dm"
 #include "code\modules\events\fugitive_spawning.dm"
 #include "code\modules\events\ghost_role.dm"
+#include "code\modules\events\gravity_generator_blackout.dm"
 #include "code\modules\events\grid_check.dm"
 #include "code\modules\events\heart_attack.dm"
 #include "code\modules\events\immovable_rod.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new event which turns off the gravity generators and set their charge to zero, demanding a manual (or silicon) reset and then waiting for the generator's short charging period to reenable gravity for the station.

As a bonus, high intensity gravitational anomalies will trigger this blackout if they are not disarmed before their timer runs out.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The lack of gravity is an interesting change on the station that it is quite rare, most of the times the gravity stop working it is because of the grid check event and no one resetting it's APC.
These 2 events should make the lack of gravity something more common but in a easy way for the crew to fix it.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
add: Gravity generator blackout is a new random event to spice the rounds.
balance: High intensity gravitational anomalies that don't get neutralized in time will trigger a gravity generator blackout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
