### PR TITLE
In preparation for fullscreen SS13, announcements are now displayed at the top of the screen as well as in the chat.

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -3,6 +3,8 @@
 		return
 
 	var/announcement
+	var/chosen_title
+	var/chosen_text
 	if(!sound)
 		sound = SSstation.announcer.get_rand_alert_sound()
 	else if(SSstation.announcer.event_sounds[sound])
@@ -10,21 +12,28 @@
 
 	if(type == "Priority")
 		announcement += "<h1 class='alert'>Priority Announcement</h1>"
+		chosen_title = "Priority Announcement"
 		if (title && length(title) > 0)
 			announcement += "<br><h2 class='alert'>[html_encode(title)]</h2>"
+			chosen_title = "[html_encode(title)]"
 	else if(type == "Captain")
 		announcement += "<h1 class='alert'>Captain Announces</h1>"
+		chosen_title = "Captain Announces"
 		GLOB.news_network.submit_article(html_encode(text), "Captain's Announcement", "Station Announcements", null)
 	else if(type == "Syndicate Captain")
 		announcement += "<h1 class='alert'>Syndicate Captain Announces</h1>"
+		chosen_title = "Syndicate Captain Announces"
 
 	else
 		if(!sender_override)
 			announcement += "<h1 class='alert'>[command_name()] Update</h1>"
+			chosen_title = "[command_name()] Update"
 		else
 			announcement += "<h1 class='alert'>[sender_override]</h1>"
+			chosen_title = "[sender_override]"
 		if (title && length(title) > 0)
 			announcement += "<br><h2 class='alert'>[html_encode(title)]</h2>"
+			chosen_title = "[html_encode(title)]"
 
 		if(!sender_override)
 			if(title == "")
@@ -35,10 +44,14 @@
 	///If the announcer overrides alert messages, use that message.
 	if(SSstation.announcer.custom_alert_message && !has_important_message)
 		announcement += SSstation.announcer.custom_alert_message
+		chosen_text = SSstation.announcer.custom_alert_message_raw
 	else
 		announcement += "<br>[span_alert("[html_encode(text)]")]<br>"
+		chosen_text = "[html_encode(text)]"
 	announcement += "<br>"
 
+	var/priority_announcement_screentip = "<span class='maptext' style='text-align: center; font-size: 32px; color: red;'>[chosen_title]</span><br/>\
+	<span class='maptext' style='text-align: center; font-size: 24px; color: white; background-color: rgba(0, 0, 0, 0.5); border-radius: 25px'>[chosen_text]</span>"
 	if(!players)
 		players = GLOB.player_list
 
@@ -48,6 +61,8 @@
 			to_chat(target, announcement)
 			if(target.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
 				SEND_SOUND(target, sound_to_play)
+	for(var/atom/movable/screen/screentip/announcements/announcement_text as anything in GLOB.announcements_huds)
+		announcement_text.set_text(priority_announcement_screentip)
 
 /**
  * Summon the crew for an emergency meeting

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -55,6 +55,9 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	///UI for screentips that appear when you mouse over things
 	var/atom/movable/screen/screentip/screentip_text
 
+	///UI for announcements
+	var/atom/movable/screen/screentip/announcements/announcements_text
+
 	/// Whether or not screentips are enabled.
 	/// This is updated by the preference for cheaper reads than would be
 	/// had with a proc call, especially on one of the hottest procs in the
@@ -110,6 +113,9 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	screentips_enabled = preferences?.read_preference(/datum/preference/choiced/enable_screentips)
 	screentip_text = new(null, src)
 	static_inventory += screentip_text
+
+	announcements_text = new(null, src)
+	static_inventory += announcements_text
 
 	for(var/mytype in subtypesof(/atom/movable/plane_master_controller))
 		var/atom/movable/plane_master_controller/controller_instance = new mytype(null,src)

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -1,3 +1,5 @@
+GLOBAL_LIST_EMPTY(announcements_huds)
+
 /atom/movable/screen/screentip
 	icon = null
 	icon_state = null
@@ -19,4 +21,25 @@
 		return
 	maptext_width = view_to_pixels(hud.mymob.client.view_size.getView())[1]
 
+/atom/movable/screen/screentip/announcements
+	screen_loc = "TOP,CENTER"
+	maptext_y = -30
+	maptext_x = -130
+	maptext_width = 300
+	maptext_height = 480
 
+/atom/movable/screen/screentip/announcements/Initialize(mapload, _hud)
+	. = ..()
+	GLOB.announcements_huds += src
+	maptext_width = 300
+
+/atom/movable/screen/screentip/announcements/Destroy()
+	GLOB.announcements_huds -= src
+	. = ..()
+
+/atom/movable/screen/screentip/announcements/proc/set_text(text, raw_msg)
+	maptext = text
+	addtimer(CALLBACK(src, .proc/clear_text), 10 SECONDS)
+
+/atom/movable/screen/screentip/announcements/proc/clear_text()
+	maptext = ""

--- a/code/datums/announcers/_announcer.dm
+++ b/code/datums/announcers/_announcer.dm
@@ -10,6 +10,8 @@
 	var/event_sounds = list()
 	///Override this to have a custom message to show instead of the normal priority announcement
 	var/custom_alert_message
+	///The raw text of the above message, without html tags.
+	var/custom_alert_message_raw
 
 
 /datum/centcom_announcer/proc/get_rand_welcome_sound()

--- a/code/datums/announcers/intern_announcer.dm
+++ b/code/datums/announcers/intern_announcer.dm
@@ -44,3 +44,4 @@
 		ANNOUNCER_SPANOMALIES = 'sound/ai/intern/spanomalies.ogg')
 
 	custom_alert_message = "<br><span class='alert'>Please stand by for an important message from our new intern.</span><br>"
+	custom_alert_message_raw = "Please stand by for an important message from our new intern."


### PR DESCRIPTION
## About The Pull Request
![dreamseeker_IcPKrGtdNW](https://user-images.githubusercontent.com/4081722/172085069-c69eb705-0284-4dd4-a8ac-6cbff922e682.png)

## Why It's Good For The Game

Since we're aiming for fullscreen SS13, a big problem is the chatbox. Minimizing usage of the chatbox is a long term goal for the project, so adding this allows us to take one more thing out of the chatbox. I haven't removed it from the chat yet, but in the future we can do so using this.

## Changelog

:cl:
code: In preparation for fullscreen SS13, announcements are now displayed at the top of the screen as well as in the chat.
/:cl: