### PR TITLE
removes a tile of metastation xenobiology poking into space

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1736,10 +1736,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
-"aGr" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/station/science/xenobiology)
 "aGD" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/left/directional/east{
@@ -118999,7 +118995,7 @@ jlU
 jlU
 jlU
 jlU
-aGr
+lMJ
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -119505,9 +119505,9 @@ lKu
 aaa
 aaa
 lMJ
-lAu
+aaa
 lMJ
-lAu
+aaa
 lMJ
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
before:
![image](https://user-images.githubusercontent.com/54422837/172085423-2c3f2112-e7a8-40fd-bdf6-4d246888f59e.png)
after:
![image](https://user-images.githubusercontent.com/54422837/172085449-43527061-d871-44ff-ad8b-07bb9245cde3.png)

## Why It's Good For The Game

areas actually being areas... good?

## Changelog


:cl:
fix: metastation xenobiology area no longer extends 1 tile into space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
