### PR TITLE
Fixes issues where players can enter the game without accepted interviews.

### DIFF
--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -46,6 +46,12 @@
 	if(owner != REF(usr))
 		return
 
+	if(!usr.client || usr.client.interviewee)
+		return
+
+	if(usr.client.interviewee)
+		return
+
 	. = ..()
 
 	if(!enabled)
@@ -58,12 +64,18 @@
 	if(owner != REF(usr))
 		return
 
+	if(!usr.client || usr.client.interviewee)
+		return
+
 	. = ..()
 	highlighted = TRUE
 	update_appearance(UPDATE_ICON)
 
 /atom/movable/screen/lobby/button/MouseExited()
 	if(owner != REF(usr))
+		return
+
+	if(!usr.client || usr.client.interviewee)
 		return
 
 	. = ..()

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -49,9 +49,6 @@
 	if(!usr.client || usr.client.interviewee)
 		return
 
-	if(usr.client.interviewee)
-		return
-
 	. = ..()
 
 	if(!enabled)

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -2,8 +2,13 @@
 
 /datum/hud/new_player/New(mob/owner)
 	..()
-	if (owner?.client?.interviewee)
+
+	if(!owner || !owner.client)
 		return
+
+	if (owner.client.interviewee)
+		return
+
 	var/list/buttons = subtypesof(/atom/movable/screen/lobby)
 	for(var/button_type in buttons)
 		var/atom/movable/screen/lobby/lobbyscreen = new button_type()

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -11,7 +11,7 @@
 		mind.set_current(src)
 
 	// Check if user should be added to interview queue
-	if (CONFIG_GET(flag/panic_bunker) && CONFIG_GET(flag/panic_bunker_interview) && !(client.ckey in GLOB.interviews.approved_ckeys))
+	if (!client.holder && CONFIG_GET(flag/panic_bunker) && CONFIG_GET(flag/panic_bunker_interview) && !(client.ckey in GLOB.interviews.approved_ckeys))
 		var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
 		var/living_minutes = client.get_exp_living(TRUE)
 		if (required_living_minutes >= living_minutes)

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -10,6 +10,13 @@
 		mind.active = TRUE
 		mind.set_current(src)
 
+	// Check if user should be added to interview queue
+	if (CONFIG_GET(flag/panic_bunker) && CONFIG_GET(flag/panic_bunker_interview) && !(client.ckey in GLOB.interviews.approved_ckeys))
+		var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
+		var/living_minutes = client.get_exp_living(TRUE)
+		if (required_living_minutes >= living_minutes)
+			client.interviewee = TRUE
+
 	. = ..()
 	if(!. || !client)
 		return FALSE
@@ -32,15 +39,15 @@
 	var/datum/asset/asset_datum = get_asset_datum(/datum/asset/simple/lobby)
 	asset_datum.send(client)
 
-	// Check if user should be added to interview queue
-	if (!client.holder && CONFIG_GET(flag/panic_bunker) && CONFIG_GET(flag/panic_bunker_interview) && !(client.ckey in GLOB.interviews.approved_ckeys))
-		var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
-		var/living_minutes = client.get_exp_living(TRUE)
-		if (required_living_minutes >= living_minutes)
-			client.interviewee = TRUE
-			register_for_interview()
-			return
+	// The parent call for Login() may do a bunch of stuff, like add verbs.
+	// Delaying the register_for_interview until the very end makes sure it can clean everything up
+	// and set the player's client up for interview.
+	if(client.interviewee)
+		register_for_interview()
+		return
 
 	if(SSticker.current_state < GAME_STATE_SETTING_UP)
 		var/tl = SSticker.GetTimeLeft()
 		to_chat(src, "Please set up your character and select \"Ready\". The game will start [tl > 0 ? "in about [DisplayTimeText(tl)]" : "soon"].")
+
+

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -439,5 +439,6 @@
 	if (I)
 		I.ui_interact(src)
 
-	// Add verb for re-opening the interview panel, and re-init the verbs for the stat panel
+	// Add verb for re-opening the interview panel, fixing chat and re-init the verbs for the stat panel
 	add_verb(src, /mob/dead/new_player/proc/open_interview)
+	add_verb(client, /client/verb/fix_tgui_panel)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #63595

Order of operations error:
`/mob/dead/new_player/Login()` calls parent before setting client interviewee status.
`/mob/Login()` parent calls sets up the hud, calling:
`/datum/hud/new_player/New(mob/owner)`  which goes "oh, they're not an interviewee" and sets up the complete HUD including `/atom/movable/screen/lobby/button` lobby buttons.
Lobby buttons don't care if they're an interviewee or not and register clicks and allow the user to enter the game without even completing an interview.

I moved the logic setting interviewee = TRUE higher up in the chain, and leave the `register_for_interview()` call later on.

I added some guards to the lobby buttons as a last-ditch failsafe.

As a final hail mary I noticed `if (owner?.client?.interviewee)` in `/datum/hud/new_player/New(mob/owner)` would not early return if there was no client because it's checking truthiness against potentially falsey owner? and client? vars. I don't know if it's even possible this will ever cause any issues. But it does create a possible code path that can fall through, especially if this code gets tweaked in the future somehow. It's now explicit.

Finally, removing all the verbs also killed the fix chat verb. This is tgui we're talking about here. So I re-added the fix chat verb so people can fix their chat too.

Debugged and tested on local with local database setup and appears to work.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes issue where lobby buttons were still visable and usable under panic bunker x interview system and also allows use of fix chat verb for interviewees.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
