### PR TITLE
Fixes jitteriness stacking up to insane amounts while dead

### DIFF
--- a/code/datums/status_effects/debuffs/jitteriness.dm
+++ b/code/datums/status_effects/debuffs/jitteriness.dm
@@ -4,15 +4,14 @@
 	alert_type = null
 
 /datum/status_effect/jitter/on_creation(mob/living/new_owner, duration = 10 SECONDS)
-	if(new_owner.stat == DEAD)
-		new_owner.do_jitter_animation(duration / 10)
-		return FALSE
-
 	src.duration = duration
 	return ..()
 
 /datum/status_effect/jitter/on_apply()
+	// If we're being applied to a dead person, don't make the status effect.
+	// Just do a bit of jitter animation and be done.
 	if(owner.stat == DEAD)
+		owner.do_jitter_animation(duration / 10)
 		return FALSE
 
 	RegisterSignal(owner, list(COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_LIVING_DEATH), .proc/remove_jitter)

--- a/code/datums/status_effects/debuffs/jitteriness.dm
+++ b/code/datums/status_effects/debuffs/jitteriness.dm
@@ -4,10 +4,17 @@
 	alert_type = null
 
 /datum/status_effect/jitter/on_creation(mob/living/new_owner, duration = 10 SECONDS)
+	if(new_owner.stat == DEAD)
+		new_owner.do_jitter_animation(duration / 10)
+		return FALSE
+
 	src.duration = duration
 	return ..()
 
 /datum/status_effect/jitter/on_apply()
+	if(owner.stat == DEAD)
+		return FALSE
+
 	RegisterSignal(owner, list(COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_LIVING_DEATH), .proc/remove_jitter)
 	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, id, /datum/mood_event/jittery)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Jitteriness status effect is intended to clear on death - dead people shouldn't be jittering and shaking around in most circumstances.

However, there are certain events that will add a lot of jitteriness to people _even if they're already dead_, which is fine. 
Some things should cause dead bodies to jitter, like electric shocks, but they should not KEEP jittering (even though it's very funny).

The example that revealed this to me: Being space-winded into a grille added such insane amounts of jitter that they'd be jittering for like 15 minutes, _even while dead_.

So, instead of applying the jittery status effect to dead mobs, it instead just plays the jitter animation once and stops. 

## Why It's Good For The Game

Dead bodies shouldn't jitter for multiple minutes after death, but they also shouldn't be completely lifeless if they're told to jitter. 
This should be a happy medium (?).

## Changelog

:cl: Melbert
fix: Dead bodies shouldn't keep jittering for ages. 
/:cl: