### PR TITLE
cloaks can now initiate surgeries

### DIFF
--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -10,6 +10,10 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDESUITSTORAGE
 
+/obj/item/clothing/neck/cloak/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/surgery_initiator)
+
 /obj/item/clothing/neck/cloak/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is strangling [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return(OXYLOSS)


### PR DESCRIPTION
## About The Pull Request

Cloaks, like surgical drapes and bedsheets, can now initiate surgeries.

This change affects both head of staff cloaks and skill capes.

## Why It's Good For The Game

Cloaks are pretty close to bedsheets in shape/function, and bedsheets can initiate surgery. Widening the (ghetto) surgery-initiation funnel to include more than just surgical drapes and bedsheets is probably a good thing.

## Changelog

:cl: ATHATH
add: Cloaks, like surgical drapes and bedsheets, can now initiate surgeries. This change affects both head of staff cloaks and skill capes.
/:cl: