### PR TITLE
Lets people light cigarettes in lava.

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -127,13 +127,13 @@
 		if(ciggie.lit)
 			to_chat(user, span_warning("The [ciggie.name] is already lit!"))
 			return
-		if(prob(75))
-			ciggie.light(span_rose("[user] expertly dips \the [ciggie.name] into [src], lighting it with the scorching heat of the planet. Witnessing such a feat is almost enough to make you cry."))
-		else
+		if(prob(25) || (HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50)))
 			ciggie.light(span_warning("[user] expertly dips \the [ciggie.name] into [src], along with the rest of [user.p_their()] arm. What a dumbass."))
 			var/mob/living/carbon/human/blunderer = user
 			var/obj/item/bodypart/affecting = blunderer.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
 			affecting?.receive_damage(burn = 90)
+		else
+			ciggie.light(span_rose("[user] expertly dips \the [ciggie.name] into [src], lighting it with the scorching heat of the planet. Witnessing such a feat is almost enough to make you cry."))
 		return
 
 /turf/open/lava/proc/is_safe()

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -118,6 +118,23 @@
 		else
 			to_chat(user, span_warning("You need one rod to build a heatproof lattice."))
 		return
+	// Light a cigarette in the lava
+	if(istype(C, /obj/item/clothing/mask/cigarette))
+		var/obj/item/clothing/mask/cigarette/ciggie = C
+		if(!ciggie)
+			..()
+			return
+		if(ciggie.lit)
+			to_chat(user, span_warning("The [ciggie.name] is already lit!"))
+			return
+		if(prob(75))
+			ciggie.light(span_rose("[user] expertly dips \the [ciggie.name] into [src], lighting it with the scorching heat of the planet. Witnessing such a feat is almost enough to make you cry."))
+		else
+			ciggie.light(span_warning("[user] expertly dips \the [ciggie.name] into [src], along with the rest of [user.p_their()] arm. What a dumbass."))
+			var/mob/living/carbon/human/blunderer = user
+			var/obj/item/bodypart/affecting = blunderer.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
+			affecting?.receive_damage(burn = 90)
+		return
 
 /turf/open/lava/proc/is_safe()
 	//if anything matching this typecache is found in the lava, we don't burn things

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -121,20 +121,17 @@
 	// Light a cigarette in the lava
 	if(istype(C, /obj/item/clothing/mask/cigarette))
 		var/obj/item/clothing/mask/cigarette/ciggie = C
-		if(!ciggie)
-			..()
-			return
 		if(ciggie.lit)
 			to_chat(user, span_warning("The [ciggie.name] is already lit!"))
-			return
-		if(prob(25) || (HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50)))
+			return TRUE
+		var/clumsy_modifier = HAS_TRAIT(user, TRAIT_CLUMSY) ? 2 : 1
+		if(prob(25 * clumsy_modifier ))
 			ciggie.light(span_warning("[user] expertly dips \the [ciggie.name] into [src], along with the rest of [user.p_their()] arm. What a dumbass."))
-			var/mob/living/carbon/human/blunderer = user
-			var/obj/item/bodypart/affecting = blunderer.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
+			var/obj/item/bodypart/affecting = user.get_active_hand()
 			affecting?.receive_damage(burn = 90)
 		else
 			ciggie.light(span_rose("[user] expertly dips \the [ciggie.name] into [src], lighting it with the scorching heat of the planet. Witnessing such a feat is almost enough to make you cry."))
-		return
+		return TRUE
 
 /turf/open/lava/proc/is_safe()
 	//if anything matching this typecache is found in the lava, we don't burn things


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lets people light cigarettes in lava. There's only a _small_ chance of burning your entire arm off, so it's fine!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I was surprised when I attempted to light a cigarette in lava and nothing happened. Even the plasmacutter has an interaction with cigs, but not lava. This fixes that.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Wallem
add: For the brave smokers out there, legends tell of a new lighting technique involving molten stone from the planet's core. Only the brave are advised to attempt this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
