### PR TITLE
Adds Round Time and Alert Level to Hub entry

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -340,6 +340,9 @@ GLOBAL_VAR(restart_counter)
 	if (features)
 		s += ": [jointext(features, ", ")]"
 
+	s += "<br>Round time: <b>[gameTimestamp("hh:mm")]</b>"
+	s += "<br>Alert level: <b>[capitalize(get_security_level())]</b>"
+
 	status = s
 
 /world/proc/update_hub_visibility(new_visibility)


### PR DESCRIPTION
You can already see the round time on the TG website and on TGMC
I added the alert level too

## Why?

It's useful being able to see the round time and alert level, it helps players make informed decisions when joining the server

Another thing is that these are dynamic elements of the hub entry, they'll never always be the same
in tandem with the round time the alert level also makes people intrigued like "round time 0:20 and red alert? shit must be going down" or "round time 2:00 and green alert? they probably have all the cool endgame stuff lets check it out"

I know TG might not be on the hub but when it is, it's useful to have these
![tghub](https://user-images.githubusercontent.com/46101244/172483164-e2bd3f46-445f-485d-a307-68a0bef074a6.png)

