### PR TITLE
[Ice Box] Minor arrivals/departures qol aesthetics, also adds vents to the arrivals hall

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -63,6 +63,13 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"abu" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "abB" = (
 /obj/item/clothing/head/helmet/skull,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -1680,6 +1687,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "aEA" = (
@@ -5073,6 +5081,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"bFs" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bFL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5086,6 +5100,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "bFU" = (
@@ -19063,6 +19078,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "gdC" = (
@@ -27514,6 +27530,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "iQt" = (
@@ -34496,6 +34513,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"kYQ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/entry)
 "kZa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35511,6 +35537,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"loW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "lpv" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -38167,6 +38199,14 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"mmo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "mmA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -40309,6 +40349,15 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"mXm" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "mXn" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -43440,6 +43489,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"nSX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "nTf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/secure_closet/personal{
@@ -55525,6 +55581,16 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"rOj" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "rOA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -61596,6 +61662,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"tJa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "tJe" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced,
@@ -63798,6 +63874,13 @@
 "uvt" = (
 /turf/closed/wall,
 /area/station/science/robotics/mechbay)
+"uvv" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "uvM" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
@@ -65258,6 +65341,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"uVf" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "uVg" = (
 /obj/structure/sign/warning/electric_shock{
 	pixel_y = -32
@@ -216505,7 +216595,7 @@ qNk
 qNk
 hsI
 qjj
-fsv
+abu
 dDp
 cJt
 jMw
@@ -216519,7 +216609,7 @@ sEB
 skc
 cJt
 qYz
-fsv
+mXm
 wOy
 uhx
 bln
@@ -216529,7 +216619,7 @@ bln
 bln
 ydI
 aST
-fsv
+uVf
 uQS
 cJt
 dBj
@@ -217290,7 +217380,7 @@ bln
 uhx
 joB
 fsv
-fsv
+loW
 wOy
 uhx
 bln
@@ -217547,7 +217637,7 @@ bln
 uhx
 eVn
 fsv
-fsv
+wfs
 wOy
 uhx
 bln
@@ -218061,7 +218151,7 @@ sEB
 uhx
 uhx
 fHb
-fdO
+nSX
 wOy
 uhx
 bln
@@ -218304,7 +218394,7 @@ vLl
 vLl
 hsI
 wAU
-wfs
+mmo
 dDp
 cJt
 jMw
@@ -218318,8 +218408,8 @@ sEB
 lAC
 cJt
 sde
-fsv
-wOy
+rOj
+kYQ
 uhx
 bln
 sEB
@@ -218328,7 +218418,7 @@ sEB
 bln
 uhx
 qjj
-fsv
+uVf
 jcw
 cJt
 sQm
@@ -218575,7 +218665,7 @@ sEB
 uhx
 uhx
 rwW
-fdO
+nSX
 gdx
 ydI
 bln
@@ -218832,7 +218922,7 @@ bln
 bln
 uhx
 jJa
-nXR
+wda
 bFP
 ydI
 uhx
@@ -219089,7 +219179,7 @@ ydI
 ydI
 ydI
 std
-fsv
+wfs
 aDN
 fUR
 cSb
@@ -219351,7 +219441,7 @@ iwJ
 nIf
 bxy
 jlf
-iwJ
+tJa
 rDR
 wda
 wfs
@@ -257638,17 +257728,17 @@ sEB
 tpd
 hOt
 ejn
-vXy
+bFs
 tpd
-vXy
+uvv
 ejn
 ejn
 jOD
 tGx
 ejn
-vXy
+uvv
 ejn
-vXy
+uvv
 ejn
 udw
 jZM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
QoL aesthetics for trim, also adds atmos to the tiny slither of hall, whereas before there were no vents or scrubbers prior.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Atmos fix for an area without any vents, and aesthetics look nicer.
For ref, if the primary arrivals portion got spaced to the wastes, there are no vents currently to rectify any issues. It'll just create a negative feedback loop of the area being an eternal hell to fix.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
qol: On Icebox, some of the warning tapes have been properly rounded off with corners.
fix: On Icebox, a vent and scrubber has been added to the primary hall the arrival shuttle drops crew members off at. This should also stop this portion of the hall from having atmos specific issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
