### PR TITLE
Fixes donksoft toy vendors

### DIFF
--- a/code/modules/vending/toys.dm
+++ b/code/modules/vending/toys.dm
@@ -17,7 +17,7 @@
 		/obj/item/toy/foamblade = 10,
 		/obj/item/toy/balloon/syndicate = 10,
 		/obj/item/clothing/suit/syndicatefake = 5,
-		/obj/item/clothing/head/syndicatefake = 5,,
+		/obj/item/clothing/head/syndicatefake = 5,
 	)
 	contraband = list(
 		/obj/item/gun/ballistic/shotgun/toy/crossbow = 10,


### PR DESCRIPTION
## About The Pull Request

Removes a duplicate comma from the end of the donksoft toy vendor list.

## Why It's Good For The Game

fixes https://github.com/tgstation/tgstation/issues/67333

## Changelog
:cl:
fix: Donksoft toy vendors no longer bluescreen.
/:cl: