### PR TITLE
Fixes Reagent Dispensers Not Removing Reagents

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -82,6 +82,7 @@
 		reagents.expose(get_turf(src), TOUCH, amount_to_leak / max(amount_to_leak, reagents.total_volume))
 		reagents.remove_reagent(reagent_id, amount_to_leak)
 		return TRUE
+	return FALSE
 
 /obj/structure/reagent_dispensers/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
@@ -96,6 +97,7 @@
 /obj/structure/reagent_dispensers/Moved(atom/OldLoc, Dir)
 	. = ..()
 	tank_leak()
+
 /obj/structure/reagent_dispensers/watertank
 	name = "water tank"
 	desc = "A water tank."

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -19,6 +19,8 @@
 	var/openable = FALSE
 	///Is this dispenser slowly leaking its reagent?
 	var/leaking = FALSE
+	///How much reagent to leak
+	var/amount_to_leak = 10
 
 /obj/structure/reagent_dispensers/Initialize(mapload)
 	. = ..()
@@ -75,6 +77,12 @@
 	else
 		qdel(src)
 
+/obj/structure/reagent_dispensers/proc/tank_leak()
+	if(leaking && reagents && reagents.total_volume >= amount_to_leak)
+		reagents.expose(get_turf(src), TOUCH, amount_to_leak / max(amount_to_leak, reagents.total_volume))
+		reagents.remove_reagent(reagent_id, amount_to_leak)
+		return TRUE
+
 /obj/structure/reagent_dispensers/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
 	if(!openable)
@@ -82,15 +90,12 @@
 	leaking = !leaking
 	balloon_alert(user, "[leaking ? "opened" : "closed"] [src]'s tap")
 	log_game("[key_name(user)] [leaking ? "opened" : "closed"] [src]")
-	if(leaking && reagents)
-		reagents.expose(get_turf(src), TOUCH, 10 / max(10, reagents.total_volume))
+	tank_leak()
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/structure/reagent_dispensers/Moved(atom/OldLoc, Dir)
 	. = ..()
-	if(leaking && reagents)
-		reagents.expose(get_turf(src), TOUCH, 10 / max(10, reagents.total_volume))
-
+	tank_leak()
 /obj/structure/reagent_dispensers/watertank
 	name = "water tank"
 	desc = "A water tank."


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/67329
tested and works with fuel, large fuel, foam, water, large water, etc.
stops leaking reagents at  <amount_to_leak

:cl:
fix: Reagent dispensers will actually remove reagents upon leaking
/:cl: