### PR TITLE
Nerfs pre-loaded pacman plasma sheets

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -278,4 +278,4 @@
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
 
 /obj/machinery/power/port_gen/pacman/pre_loaded
-	sheets = 50
+	sheets = 15


### PR DESCRIPTION
## About The Pull Request

Lowers the number of plasma sheets in pre-loaded PACMAN generators from 50 to 15.

## Why It's Good For The Game

Being able to run around looting the generators and selling it to make like 10k round-start is not so bueno.

## Changelog
:cl:
balance: Pre-loaded PACMAN generators now have 15 plasma sheets, instead of 50.
/:cl: