### PR TITLE
Fix Dynamic midrounds spawning heavies significantly earlier than they're supposed to

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -26,11 +26,12 @@
 	if (EMERGENCY_PAST_POINT_OF_NO_RETURN)
 		return
 
+	var/spawn_heavy = prob(get_heavy_midround_injection_chance())
+
 	last_midround_injection_attempt = world.time
 	next_midround_injection = null
 	forced_injection = FALSE
 
-	var/spawn_heavy = prob(get_heavy_midround_injection_chance())
 	dynamic_log("A midround ruleset is rolling, and will be [spawn_heavy ? "HEAVY" : "LIGHT"].")
 
 	random_event_hijacked = HIJACKED_NOTHING


### PR DESCRIPTION
## About The Pull Request

This is the code for determining whether a heavy should spawn.

![image](https://user-images.githubusercontent.com/35135081/172511275-4cbe8329-8953-4be3-9f63-41527cfbbdb8.png)

It works by making heavies more and more likely the longer the round goes on.

However, it is currently ran *after* the following code:

![image](https://user-images.githubusercontent.com/35135081/172511328-04f2f193-2d6b-4514-9b71-0e81abb1a06d.png)

...which means that it is actually judging based off the *next* roll, rather than the current one.

This fixes that. Untested, you know how it is with Dynamic.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed Dynamic midrounds spawning heavies significantly earlier than they're supposed to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
