### PR TITLE
Space dragon despawning empties their contents

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -141,6 +141,7 @@
 	if(riftTimer >= maxRiftTimer)
 		to_chat(src, span_boldwarning("You've failed to summon the rift in a timely manner! You're being pulled back from whence you came!"))
 		destroy_rifts()
+		empty_contents()
 		playsound(src, 'sound/magic/demon_dies.ogg', 100, TRUE)
 		QDEL_NULL(src)
 


### PR DESCRIPTION
## About The Pull Request

Not spawning your rift as a Space Dragon now causes you to spit everything out when you expire.

## Why It's Good For The Game

Round removing people with yourself over a bug is probably a bad idea.

## Changelog

:cl:
fix: Space Dragons' expiring no longer deletes the people they had already eaten.
/:cl: