### PR TITLE
Gas canisters and other portable atmospheric machinery can now be packaged with packaging paper.

### DIFF
--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -78,14 +78,14 @@
 /obj/item/stack/package_wrap/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins wrapping [user.p_them()]self in \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	if(use(3))
-		var/obj/item/delivery/big/P = new(get_turf(user.loc))
-		P.base_icon_state = "deliverypackage5"
-		P.update_icon()
-		user.forceMove(P)
-		P.add_fingerprint(user)
+		var/obj/item/delivery/big/parcel = new(get_turf(user.loc))
+		parcel.base_icon_state = "deliverypackage5"
+		parcel.update_icon()
+		user.forceMove(parcel)
+		parcel.add_fingerprint(user)
 		return OXYLOSS
 	else
-		to_chat(user, span_warning("You need more paper!"))
+		balloon_alert(user, span_warning("You need more paper!"))
 		return SHAME
 
 /obj/item/proc/can_be_package_wrapped() //can the item be wrapped with package wrapper into a delivery package
@@ -110,48 +110,68 @@
 		return
 
 	if(isitem(target))
-		var/obj/item/I = target
-		if(!I.can_be_package_wrapped())
+		var/obj/item/item = target
+		if(!item.can_be_package_wrapped())
+			balloon_alert(user, "The [target] can not be wrapped!")
 			return
-		if(user.is_holding(I))
-			if(!user.dropItemToGround(I))
+		if(user.is_holding(item))
+			if(!user.dropItemToGround(item))
 				return
-		else if(!isturf(I.loc))
+		else if(!isturf(item.loc))
 			return
 		if(use(1))
-			var/obj/item/delivery/small/P = new(get_turf(I.loc))
-			if(user.Adjacent(I))
-				P.add_fingerprint(user)
-				I.add_fingerprint(user)
-				user.put_in_hands(P)
-			I.forceMove(P)
-			var/size = round(I.w_class)
-			P.name = "[weight_class_to_text(size)] parcel"
-			P.w_class = size
+			var/obj/item/delivery/small/parcel = new(get_turf(item.loc))
+			if(user.Adjacent(item))
+				parcel.add_fingerprint(user)
+				item.add_fingerprint(user)
+				user.put_in_hands(parcel)
+			item.forceMove(parcel)
+			var/size = round(item.w_class)
+			parcel.name = "[weight_class_to_text(size)] parcel"
+			parcel.w_class = size
 			size = min(size, 5)
-			P.base_icon_state = "deliverypackage[size]"
-			P.update_icon()
+			parcel.base_icon_state = "deliverypackage[size]"
+			parcel.update_icon()
 
-	else if(istype (target, /obj/structure/closet))
-		var/obj/structure/closet/O = target
-		if(O.opened)
+	else if(istype(target, /obj/structure/closet))
+		var/obj/structure/closet/closet = target
+		if(closet.opened)
+			balloon_alert(user, span_warning("You can not wrap the [target] while it is opened!"))
 			return
-		if(!O.delivery_icon) //no delivery icon means unwrappable closet (e.g. body bags)
-			to_chat(user, span_warning("You can't wrap this!"))
+		if(!closet.delivery_icon) //no delivery icon means unwrappable closet (e.g. body bags)
+			balloon_alert(user, span_warning("You can't wrap this!"))
 			return
 		if(use(3))
-			var/obj/item/delivery/big/P = new(get_turf(O.loc))
-			P.base_icon_state = O.delivery_icon
-			P.update_icon()
-			P.drag_slowdown = O.drag_slowdown
-			O.forceMove(P)
-			P.add_fingerprint(user)
-			O.add_fingerprint(user)
+			var/obj/item/delivery/big/parcel = new(get_turf(closet.loc))
+			parcel.base_icon_state = closet.delivery_icon
+			parcel.update_icon()
+			parcel.drag_slowdown = closet.drag_slowdown
+			closet.forceMove(parcel)
+			parcel.add_fingerprint(user)
+			closet.add_fingerprint(user)
 		else
-			to_chat(user, span_warning("You need more paper!"))
+			balloon_alert(user, span_warning("You need more paper!"))
 			return
+
+	else if(istype(target,  /obj/machinery/portable_atmospherics))
+		var/obj/machinery/portable_atmospherics/portable_atmospherics = target
+		if(portable_atmospherics.anchored)
+			balloon_alert(user, span_warning("You can not wrap the [target] while it is anchored!"))
+			return
+		if(use(3))
+			var/obj/item/delivery/big/parcel = new(get_turf(portable_atmospherics.loc))
+			parcel.base_icon_state = "deliverybox"
+			parcel.update_icon()
+			parcel.drag_slowdown = portable_atmospherics.drag_slowdown
+			portable_atmospherics.forceMove(parcel)
+			parcel.add_fingerprint(user)
+			portable_atmospherics.add_fingerprint(user)
+		else
+			balloon_alert(user, span_warning("You need more paper!"))
+			return
+
 	else
-		to_chat(user, span_warning("The object you are trying to wrap is unsuitable for the sorting machinery!"))
+		balloon_alert(user, span_warning("The object you are trying to wrap is unsuitable for the sorting machinery!"))
 		return
 
 	user.visible_message(span_notice("[user] wraps [target]."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows gas canisters and other portable atmospheric machinery to be wrapped with packaging paper. Replaces chat warnings with balloon alerts for packaging related failures.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the process for gas delivery to a department much faster and quicker. This should allow atmospheric technicians to deliver gases to ordnance for their experiments or any other department if they wish to, without the hassle of dragging a canister through the hallways in front of every clown.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Gas canisters and other portable atmospheric machinery can now be packaged with wrapping paper.
add: Replaces chat messages with balloon alerts for package wrapping related failures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
