### PR TITLE
Makes ore silo connecting work on multi-z

### DIFF
--- a/code/__HELPERS/levels.dm
+++ b/code/__HELPERS/levels.dm
@@ -1,0 +1,19 @@
+/**
+ * - is_valid_z_level
+ *
+ * Checks if source_loc and checking_loc is both on the station, or on the same z level.
+ * This is because the station's several levels aren't considered the same z, so multi-z stations need this special case.
+ *
+ * Args:
+ * source_loc - turf of the source we're comparing.
+ * checking_loc - turf we are comparing to source_loc.
+ *
+ * returns TRUE if connection is valid, FALSE otherwise.
+ */
+/proc/is_valid_z_level(turf/source_loc, turf/checking_loc)
+	// if we're both on "station", regardless of multi-z, we'll pass by.
+	if(is_station_level(source_loc.z) && is_station_level(checking_loc.z))
+		return TRUE
+	if(source_loc.z == checking_loc.z)
+		return TRUE
+	return FALSE

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -106,8 +106,9 @@ handles linking back and forth.
 		if (silo == M.buffer)
 			to_chat(user, span_warning("[parent] is already connected to [silo]!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
+		var/turf/silo_turf = get_turf(M.buffer)
 		var/turf/user_loc = get_turf(user)
-		if(!is_valid_z_level(user_loc, M.buffer))
+		if(!is_valid_z_level(silo_turf, user_loc))
 			to_chat(user, span_warning("[parent] is too far away to get a connection signal!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
 		if (silo)
@@ -128,30 +129,9 @@ handles linking back and forth.
 	if(!silo)
 		return
 
-	if(!is_valid_z_level(new_turf))
+	var/turf/silo_turf = get_turf(silo)
+	if(!is_valid_z_level(silo_turf, new_turf))
 		disconnect_from(silo)
-
-/**
- * - is_valid_z_level
- *
- * Checks if sync_location and the ore silo (or silo_override, for connecting new silos) is both on the station, or on the same z level.
- * This is because the station's several levels aren't considered the same z, so multi-z stations need this special case.
- *
- * Args:
- * sync_location - current turf where parent (or user making the connection) is.
- * silo_override - if we lack an ore silo, this is the silo we are trying to connect to.
- *
- * returns TRUE if connection is valid
- * returns FALSE if not.
- */
-/datum/component/remote_materials/proc/is_valid_z_level(turf/sync_location, obj/silo_override)
-	var/turf/silo_turf = get_turf(silo || silo_override)
-	// if we're both on "station", regardless of multi-z, we'll pass by.
-	if(is_station_level(silo_turf.z) && is_station_level(sync_location.z))
-		return TRUE
-	if(silo_turf.z == sync_location.z)
-		return TRUE
-	return FALSE
 
 /datum/component/remote_materials/proc/on_hold()
 	return silo?.holds["[get_area(parent)]/[category]"]

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -106,9 +106,8 @@ handles linking back and forth.
 		if (silo == M.buffer)
 			to_chat(user, span_warning("[parent] is already connected to [silo]!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
-		var/turf/silo_turf = get_turf(M.buffer)
 		var/turf/user_loc = get_turf(user)
-		if(user_loc.z != silo_turf.z)
+		if(!is_valid_z_level(user_loc, M.buffer))
 			to_chat(user, span_warning("[parent] is too far away to get a connection signal!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
 		if (silo)
@@ -129,12 +128,30 @@ handles linking back and forth.
 	if(!silo)
 		return
 
-	var/turf/silo_turf = get_turf(silo)
-	if(is_station_level(silo_turf.z) && is_station_level(new_turf.z)) // if we're both on "station", regardless of multi-z, we'll pass by.
-		return
-	if(silo_turf.z == new_turf.z)
-		return
-	disconnect_from(silo)
+	if(!is_valid_z_level(new_turf))
+		disconnect_from(silo)
+
+/**
+ * - is_valid_z_level
+ *
+ * Checks if sync_location and the ore silo (or silo_override, for connecting new silos) is both on the station, or on the same z level.
+ * This is because the station's several levels aren't considered the same z, so multi-z stations need this special case.
+ *
+ * Args:
+ * sync_location - current turf where parent (or user making the connection) is.
+ * silo_override - if we lack an ore silo, this is the silo we are trying to connect to.
+ *
+ * returns TRUE if connection is valid
+ * returns FALSE if not.
+ */
+/datum/component/remote_materials/proc/is_valid_z_level(turf/sync_location, obj/silo_override)
+	var/turf/silo_turf = get_turf(silo || silo_override)
+	// if we're both on "station", regardless of multi-z, we'll pass by.
+	if(is_station_level(silo_turf.z) && is_station_level(sync_location.z))
+		return TRUE
+	if(silo_turf.z == sync_location.z)
+		return TRUE
+	return FALSE
 
 /datum/component/remote_materials/proc/on_hold()
 	return silo?.holds["[get_area(parent)]/[category]"]

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -305,6 +305,7 @@
 #include "code\__HELPERS\icons.dm"
 #include "code\__HELPERS\jatum.dm"
 #include "code\__HELPERS\level_traits.dm"
+#include "code\__HELPERS\levels.dm"
 #include "code\__HELPERS\lighting.dm"
 #include "code\__HELPERS\maths.dm"
 #include "code\__HELPERS\matrices.dm"


### PR DESCRIPTION
## About The Pull Request

Lets players connect ore silos through multi-z maps by making both connecting and disconnecting share a common proc.

## Why It's Good For The Game

It's inconsistent to have it be this way, which I'm not really a fan of.
Closes https://github.com/tgstation/tgstation/issues/67638

## Changelog

:cl:
fix: Ore silos can once again be synced to machines on the station on other z levels, for multi-z maps.
/:cl:
