### PR TITLE
Replace varedited apc in Deepstorage ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2830,10 +2830,7 @@
 /area/ruin/space/has_grav/deepstorage/dorm)
 "Az" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/ten_k{
-	name = "Pharmacy APC";
-	pixel_x = 25
-	},
+/obj/machinery/power/apc/ten_k/directional/east,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "AI" = (


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

An APC yelled at me for being var-edited while I was reviewing something else and I wanted it to stop.

## Why It's Good For The Game

This throws an error during server startup and using directional helpers is good for consistency and maintability.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: A manually edited APC in the deepstorage ruin has been replaced with an APC of the appropriate type.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
