### PR TITLE
Moves the FUCKING LIGHT FIXTURES on tiles with surgery beds

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -14903,6 +14903,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "eMr" = (
@@ -17147,6 +17148,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "fxe" = (
@@ -21894,9 +21896,9 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "gZb" = (
-/mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "gZl" = (
@@ -35263,10 +35265,10 @@
 /turf/open/floor/grass,
 /area/station/maintenance/starboard/aft)
 "lkP" = (
+/obj/structure/flora/grass/green/style_random,
 /mob/living/simple_animal/pet/penguin/emperor{
 	name = "Club"
 	},
-/obj/structure/flora/grass/green/style_random,
 /turf/open/misc/asteroid/snow/standard_air,
 /area/station/science/research)
 "lkS" = (
@@ -40336,8 +40338,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/structure/cable/layer3,
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "mXl" = (
@@ -54788,11 +54790,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /mob/living/simple_animal/bot/secbot/beepsky{
 	desc = "Powered by the tears and sweat of laborers.";
 	name = "Prison Ofitser"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "rAC" = (
@@ -59168,7 +59170,6 @@
 /area/station/hallway/secondary/service)
 "sUR" = (
 /obj/structure/table/optable,
-/obj/machinery/light/directional/east,
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -66127,7 +66128,6 @@
 /area/mine/eva)
 "vgP" = (
 /obj/structure/table/optable,
-/obj/machinery/light/directional/east,
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -73439,10 +73439,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "xuQ" = (
-/mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "xuR" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1732,8 +1732,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "aGD" = (
@@ -12413,8 +12413,8 @@
 /area/station/command/teleporter)
 "eyl" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "eyz" = (
@@ -18286,8 +18286,8 @@
 /area/station/science/explab)
 "gND" = (
 /obj/machinery/iv_drip,
-/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "gNF" = (
@@ -25578,8 +25578,8 @@
 	dir = 4
 	},
 /obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/item/toy/cattoy,
+/mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "jgt" = (
@@ -28091,6 +28091,7 @@
 "jXQ" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "jXU" = (
@@ -38202,9 +38203,8 @@
 /area/station/cargo/drone_bay)
 "nzh" = (
 /obj/structure/table/optable,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "nzo" = (
@@ -50464,10 +50464,10 @@
 	dir = 9
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/mob/living/simple_animal/pet/dog/pug/mcgriff,
 /obj/machinery/firealarm/directional/west{
 	pixel_y = 26
 	},
+/mob/living/simple_animal/pet/dog/pug/mcgriff,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "rOF" = (


### PR DESCRIPTION
## About The Pull Request

Moves around some wall objects in surgery rooms on both Meta and Box, primarily so that there aren't light fixtures on the same tiles as surgery beds. I moved a few unrelated things for QOL.
![image](https://user-images.githubusercontent.com/10399117/172758337-63104b86-7f89-4c0c-b71c-0ebd73394c20.png)
IceBox surgery. Moved the lights down a tile to be next to the lockers.

![image](https://user-images.githubusercontent.com/10399117/172758400-dd9dfb77-1064-419f-91d9-9dfbb41f8962.png)
Meta Aux surgery. Switched the positions of the radio and the light tube. Moved the air alarm to the right (it shared a tile with the light fixture for some reason)

![image](https://user-images.githubusercontent.com/10399117/172758528-fe947fb7-8c45-4c43-ac18-b00b50e8a929.png)
Meta surgery. I switched the fire alarm with the intercom because I liked the idea of the radio being there more. Unrelated to the lights thing but minor QOL.

## Why It's Good For The Game

EVERY MOTHER FUCKING TIME I DO SURGERY I ALWAYS SMASH THE FUCKING LIGHT TUBE BY ACCIDENT AND IT PISSES ME THE FUCK OFF. WHY WOULD YOU PUT A THING THERE THAT JUTS OUT OVER THE FUCKING BED AND GETS IN THE WAY OF CLICKING ON THE SPACEMAN SPRITE FUCK GOD DAMN IT.

## Changelog

:cl:
qol: Changed the position of light tubes in certain surgery rooms to not be directly over a surgery bed. No more smashing lights with your saw by accident!
qol: Aspiring AIs can now listen in on patient talk in Meta's primary surgery room. Or you could listen to the soothing sounds of the the crew dying from the comfort of a surgery bed when comms are down too, I guess.
/:cl:
