### PR TITLE
DISABLE_NON_OBSJOBS now only toggled if nuke actually blows up the station

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -527,8 +527,6 @@ GLOBAL_VAR(station_nuke_source)
 		SSticker.roundend_check_paused = FALSE
 		return
 
-	SSlag_switch.set_measure(DISABLE_NON_OBSJOBS, TRUE)
-
 	var/detonation_status
 	var/turf/bomb_location = get_turf(src)
 	var/area/nuke_area = get_area(bomb_location)
@@ -549,6 +547,7 @@ GLOBAL_VAR(station_nuke_source)
 
 		// Confirming good hits, the nuke hit the station
 		else
+			SSlag_switch.set_measure(DISABLE_NON_OBSJOBS, TRUE)
 			detonation_status = DETONATION_HIT_STATION
 			GLOB.station_was_nuked = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

An ancient relic from our pre-dynamic days. Back when the idea of a round continuing past a nuke detonation was unthinkable. Now, jobs will only be closed if the station is hit by the nuclear blast. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Closes #67554

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Jobs are no longer closed when the nuke detonates off-station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
