### PR TITLE
Fixes supermatter cascade final objective rolling when the engine has already exploded

### DIFF
--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -20,6 +20,12 @@
 		return FALSE
 	if(SStraitor.get_taken_count(type) > 0) // Prevents multiple people from ever getting the same final objective.
 		return FALSE
+	var/valid_crystal = FALSE
+	for(var/obj/machinery/power/supermatter_crystal/engine/crystal in GLOB.machines)
+		if(is_station_level(crystal.z) || is_mining_level(crystal.z))
+			valid_crystal = TRUE
+	if(!valid_crystal)
+		return FALSE
 	return TRUE
 
 /datum/traitor_objective/final/on_objective_taken(mob/user)

--- a/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
@@ -9,11 +9,7 @@
 	var/sent_crystal = FALSE
 
 /datum/traitor_objective/final/supermatter_cascade/generate_objective(datum/mind/generating_for, list/possible_duplicates)
-	var/valid_crystal = FALSE
-	for(var/obj/machinery/power/supermatter_crystal/engine/crystal in GLOB.machines)
-		if(is_station_level(crystal.z) || is_mining_level(crystal.z))
-			valid_crystal = TRUE
-	if(!can_take_final_objective() || !valid_crystal)
+	if(!can_take_final_objective())
 		return
 	var/list/possible_areas = GLOB.the_station_areas.Copy()
 	for(var/area/possible_area as anything in possible_areas)

--- a/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
@@ -9,7 +9,11 @@
 	var/sent_crystal = FALSE
 
 /datum/traitor_objective/final/supermatter_cascade/generate_objective(datum/mind/generating_for, list/possible_duplicates)
-	if(!can_take_final_objective())
+	var/valid_crystal = FALSE
+	for(var/obj/machinery/power/supermatter_crystal/engine/crystal in GLOB.machines)
+		if(isturf(crystal.loc) || (is_station_level(crystal.z) || is_mining_level(crystal.z)))
+			valid_crystal = TRUE
+	if(!can_take_final_objective() || !valid_crystal)
 		return
 	var/list/possible_areas = GLOB.the_station_areas.Copy()
 	for(var/area/possible_area as anything in possible_areas)

--- a/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
@@ -11,7 +11,7 @@
 /datum/traitor_objective/final/supermatter_cascade/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	var/valid_crystal = FALSE
 	for(var/obj/machinery/power/supermatter_crystal/engine/crystal in GLOB.machines)
-		if(isturf(crystal.loc) || (is_station_level(crystal.z) || is_mining_level(crystal.z)))
+		if(is_station_level(crystal.z) || is_mining_level(crystal.z))
 			valid_crystal = TRUE
 	if(!can_take_final_objective() || !valid_crystal)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a check so that if there are no var/obj/machinery/power/supermatter_crystal/engine on the station. Testing was a bit hard because I didn't know how to test any of it with admin tools, so it involved a lot of running around doing objectives on local until I got a final objective. I'm _pretty sure_ this PR works correctly.

Also, regarding the idea to instead just make it work on shards instead of full crystals -- 

![image](https://user-images.githubusercontent.com/28870487/172961162-6af5436f-aa42-4156-b994-dc470669c7b8.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Closes #67598.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Supermatter cascade final objective no longer generates when the engine has exploded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
