### PR TITLE
Gets rid of the Druggy var on `/living`, "fixes" Earthsblood

### DIFF
--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -153,7 +153,6 @@
 
 	///a list of all status effects the mob has
 	var/list/status_effects
-	var/druggy = 0
 
 	var/list/implants = null
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1154,7 +1154,7 @@
 		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2 * REM * delta_time, 150)
 		if(DT_PROB(5, delta_time))
 			M.say(pick("Yeah, well, you know, that's just, like, uh, your opinion, man.", "Am I glad he's frozen in there and that we're out here, and that he's the sheriff and that we're frozen out here, and that we're in there, and I just remembered, we're out here. What I wanna know is: Where's the caveman?", "It ain't me, it ain't me...", "Make love, not war!", "Stop, hey, what's that sound? Everybody look what's going down...", "Do you believe in magic in a young girl's heart?"), forced = /datum/reagent/medicine/earthsblood)
-	M.druggy = clamp(M.druggy + (10 * REM * delta_time), 0, 15 * REM * delta_time) //See above
+	M.adjust_timed_status_effect(20 SECONDS * REM * delta_time, /datum/status_effect/drugginess, max_duration = 30 SECONDS * REM * delta_time)
 	..()
 	. = TRUE
 


### PR DESCRIPTION
## About The Pull Request

This should have been deleted in #66331 . Missed it. Why? Because it didn't use the dang setter. 

## Why It's Good For The Game

Removes a unused var, fixes Earthsblood

## Changelog

:cl: Melbert
fix: Earthsblood makes you see colors again.
/:cl:
