### PR TITLE
Fixes warp whistle's cooldown

### DIFF
--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -306,17 +306,12 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "whistle"
 
-	/// Cooldown between whistle uses.
-	COOLDOWN_DECLARE(whistle_cooldown)
 	/// Person using the warp whistle
 	var/mob/living/whistler
 
 /obj/item/warp_whistle/attack_self(mob/user)
-	if(!COOLDOWN_FINISHED(src, whistle_cooldown))
-		to_chat(user, span_warning("[src] is still on cooldown!"))
-		return
 	if(whistler)
-		to_chat(user, span_warning("[src] is already warping."))
+		to_chat(user, span_warning("[src] is on cooldown."))
 		return
 
 	whistler = user
@@ -324,7 +319,6 @@
 	var/turf/spawn_location = locate(user.x + pick(-7, 7), user.y, user.z)
 	playsound(current_turf,'sound/magic/warpwhistle.ogg', 200, TRUE)
 	new /obj/effect/temp_visual/teleporting_tornado(spawn_location, src)
-	COOLDOWN_START(src, whistle_cooldown, 4 SECONDS)
 
 ///Teleporting tornado, spawned by warp whistle, teleports the user if they manage to pick them up.
 /obj/effect/temp_visual/teleporting_tornado
@@ -335,7 +329,7 @@
 	layer = FLY_LAYER
 	plane = ABOVE_GAME_PLANE
 	randomdir = FALSE
-	duration = 10 SECONDS
+	duration = 8 SECONDS
 	movement_type = PHASING
 
 	/// Reference to the whistle
@@ -376,5 +370,6 @@
 /// Destroy the tornado and teleport everyone on it away.
 /obj/effect/temp_visual/teleporting_tornado/Destroy()
 	if(whistle)
+		whistle.whistler = null
 		whistle = null
 	return ..()


### PR DESCRIPTION
## About The Pull Request

When I refactored Warp whistle in https://github.com/tgstation/tgstation/pull/67064, I removed ``whistle.whistler = null`` in the tornado's Destroy in the very last commit https://github.com/tgstation/tgstation/pull/67064/commits/2648d851280c81395135c6ec0be98da60e376041, because I thought I had made the warp whistle itself deal with it instead, but I was entirely wrong. This reference to whistler remained, and made it impossible to re-use the whistle after the first time. 

Also in this PR, because the whistle can't be used while there was already a whistler, which is only cleared after the tornado is destroyed (which is 10 seconds, compared to warp whistle's 4 second cooldown), I removed the warp whistle cooldown entirely, only checking if the warp whistle no longer has a whistler- so the tornado is destroyed.

Because of this new cooldown timer, I brought down the duration of the tornado's existence (and therefore the cooldown) down to 8 seconds.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/67646
Makes warp whistle have more consistent feedback when wondering why it isn't working- Just the one cooldown every time.

## Changelog

:cl:
fix: The Warp whistle can be used more than once again.
/:cl: