### PR TITLE
Gives the space ninja MODsuit a storage module

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -219,12 +219,13 @@
 	applied_cell = /obj/item/stock_parts/cell/ninja
 	initial_modules = list(
 		/obj/item/mod/module/noslip,
+		/obj/item/mod/module/status_readout,
+		/obj/item/mod/module/storage,
 		/obj/item/mod/module/stealth/ninja,
 		/obj/item/mod/module/dispenser/ninja,
 		/obj/item/mod/module/dna_lock/reinforced,
 		/obj/item/mod/module/emp_shield/pulse,
-		/obj/item/mod/module/status_readout,
-		/obj/item/mod/module/storage,
+
 	)
 
 /obj/item/mod/control/pre_equipped/prototype

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -218,14 +218,13 @@
 	theme = /datum/mod_theme/ninja
 	applied_cell = /obj/item/stock_parts/cell/ninja
 	initial_modules = list(
+		/obj/item/mod/module/storage,
 		/obj/item/mod/module/noslip,
 		/obj/item/mod/module/status_readout,
-		/obj/item/mod/module/storage,
 		/obj/item/mod/module/stealth/ninja,
 		/obj/item/mod/module/dispenser/ninja,
 		/obj/item/mod/module/dna_lock/reinforced,
 		/obj/item/mod/module/emp_shield/pulse,
-
 	)
 
 /obj/item/mod/control/pre_equipped/prototype

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -224,6 +224,7 @@
 		/obj/item/mod/module/dna_lock/reinforced,
 		/obj/item/mod/module/emp_shield/pulse,
 		/obj/item/mod/module/status_readout,
+		/obj/item/mod/module/storage,
 	)
 
 /obj/item/mod/control/pre_equipped/prototype


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What it says on the tin.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The space ninja currently can't use any form of storage if he wants to keep his MODsuit (and you know, all of his powers.) While the old ninja also didn't spawn with a backpack, it was relatively trivial to pop to dorms or kill some schmuck for their bag. Not having storage as a solo antag is pretty rough, so this should up the playability. And also cut down on the confused ahelps.
Closes https://github.com/tgstation/tgstation/issues/67658
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Space Ninja's MODsuit has a storage module now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
