### PR TITLE
Fixes some heretic focus funk

### DIFF
--- a/code/modules/antagonists/heretic/heretic_focus.dm
+++ b/code/modules/antagonists/heretic/heretic_focus.dm
@@ -11,6 +11,14 @@
 	RegisterSignal(target, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 	RegisterSignal(target, COMSIG_ITEM_DROPPED, .proc/on_drop)
 
+	var/obj/item/item_target = target
+	// If our loc is a living mob, it's possible we already have it equippied
+	if(isliving(item_target.loc))
+		var/mob/living/wearer = item_target.loc
+		// We're not being held, that means we're PROBABLY equipped. Give the trait out.
+		if(!(target in wearer.held_items))
+			ADD_TRAIT(item_target.loc, TRAIT_ALLOW_HERETIC_CASTING, ELEMENT_TRAIT(target))
+
 /datum/element/heretic_focus/Detach(obj/item/source)
 	. = ..()
 	UnregisterSignal(source, list(COMSIG_PARENT_EXAMINE, COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))

--- a/code/modules/antagonists/heretic/heretic_focus.dm
+++ b/code/modules/antagonists/heretic/heretic_focus.dm
@@ -12,12 +12,11 @@
 	RegisterSignal(target, COMSIG_ITEM_DROPPED, .proc/on_drop)
 
 	var/obj/item/item_target = target
-	// If our loc is a living mob, it's possible we already have it equippied
-	if(isliving(item_target.loc))
-		var/mob/living/wearer = item_target.loc
-		// We're not being held, that means we're PROBABLY equipped. Give the trait out.
-		if(!(target in wearer.held_items))
-			ADD_TRAIT(item_target.loc, TRAIT_ALLOW_HERETIC_CASTING, ELEMENT_TRAIT(target))
+	// If our loc is a mob, it's possible we already have it equippied
+	if(ismob(item_target.loc))
+		var/mob/wearer = item_target.loc
+		if(!item_target.slot_flags || wearer.get_item_by_slot(item_target.slot_flags) == item_target)
+			ADD_TRAIT(wearer, TRAIT_ALLOW_HERETIC_CASTING, ELEMENT_TRAIT(target))
 
 /datum/element/heretic_focus/Detach(obj/item/source)
 	. = ..()

--- a/code/modules/antagonists/heretic/magic/furious_steel.dm
+++ b/code/modules/antagonists/heretic/magic/furious_steel.dm
@@ -35,6 +35,9 @@
 	if(our_heretic && !our_heretic.ascended && !HAS_TRAIT(living_user, TRAIT_ALLOW_HERETIC_CASTING))
 		user.balloon_alert(living_user, "you need a focus!")
 		return
+	// Delete existing
+	if(blade_effect)
+		QDEL_NULL(blade_effect)
 
 	. = ..()
 	blade_effect = living_user.apply_status_effect(/datum/status_effect/protective_blades, null, 3, 25, 0.66 SECONDS)

--- a/code/modules/antagonists/heretic/magic/furious_steel.dm
+++ b/code/modules/antagonists/heretic/magic/furious_steel.dm
@@ -40,6 +40,12 @@
 	blade_effect = living_user.apply_status_effect(/datum/status_effect/protective_blades, null, 3, 25, 0.66 SECONDS)
 	RegisterSignal(blade_effect, COMSIG_PARENT_QDELETING, .proc/on_status_effect_deleted)
 
+/obj/effect/proc_holder/spell/aimed/furious_steel/cast_check(skipcharge = 0,mob/user = usr)
+	. = ..()
+	if(!.)
+		// We shouldn't cast for some reason, likely due to losing our focus - delete the blades
+		QDEL_NULL(blade_effect)
+
 /obj/effect/proc_holder/spell/aimed/furious_steel/on_deactivation(mob/user)
 	. = ..()
 	QDEL_NULL(blade_effect)


### PR DESCRIPTION
## About The Pull Request

I fixed this before the last PR was merged, but completely forgot to push the changes. oops
Heretic focus element adds the focus trait on attach if it's equipped on a mob. 

Also, I forgot about furious steel when it came to focuses being removed. 
Furious Steel now deletes the blades if you try to activate it or shoot it out after removing your focus, instead of keeping them around forever.

(In the future furious steel should listen for the trait being added or removed. I'll do it after the proc holder pr)

## Why It's Good For The Game

Heretic focuses should probably always apply when they should.
Furious steel shouldn't stick around when it shouldn't.

## Changelog

:cl: Melbert
fix: Some heretic focuses apply more consistently now. 
fix: Furious Steel should go away more often than not now. 
/:cl: