### PR TITLE
Minor edits to Clown Biodome ruin (moves a chasm tile)

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -704,6 +704,7 @@
 /area/ruin/powered/clownplanet)
 "Or" = (
 /obj/machinery/light/directional/east,
+/obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/powered/clownplanet)
 "QT" = (
@@ -1779,7 +1780,7 @@ cc
 cc
 Zg
 QT
-QT
+gX
 QT
 QT
 gX
@@ -1813,7 +1814,7 @@ aa
 aa
 aa
 QT
-gX
+QT
 QT
 QT
 QT


### PR DESCRIPTION

## About The Pull Request

![image](https://user-images.githubusercontent.com/10399117/173023805-4099977b-6db3-49cd-9ce1-ff69900671ef.png)
Moves a chasm turf (the top and rightmost one) one tile left to connect with the other ones

![image](https://user-images.githubusercontent.com/10399117/173023967-87076b58-b855-4c9d-a5f0-02d92b5347df.png)
Added No Lava helpers to the turfs with lights, which were missing them for whatever reason.

## Why It's Good For The Game

Makes the outside parts symmetrical because that seemed to be the intent of them.
The single lone chasm tile is hard to see and kind of lame to fall into, even for chasm tiles in general.

## Changelog

:cl:
fix: Fixed a symmetry issue with the lava clown puzzle where a lone chasm tile wasn't connected with its fellow chasms.
/:cl: