### PR TITLE
Fixes igniters, stunprods and teleprods not working properly

### DIFF
--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -36,7 +36,8 @@
 	var/turf/location = get_turf(loc)
 	if(location)
 		location.hotspot_expose(heat, EXPOSED_VOLUME)
-	SEND_SIGNAL(holder.loc, COMSIG_IGNITER_ACTIVATE)
+	if(holder)
+		SEND_SIGNAL(holder.loc, COMSIG_IGNITER_ACTIVATE)
 	if(QDELETED(src))
 		return TRUE
 	sparks.start()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #67616. Activating igniters ouside assembly holders was runtiming due to a change from #67160, which made stundprods and teleprods neither stun nor consume cell charge.
![Video evidence of this bug](https://user-images.githubusercontent.com/102324362/173083482-afcf948d-8281-402e-9159-8ac0dc084878.mp4)
Edit: Also fixes #67697.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: stundprods and teleprods now stun again
fix: igniters now work again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
