### PR TITLE
Cursed Dufflebag is now less picky + no longer permanently applies you with pacifism even after being removed + causes less wounding

### DIFF
--- a/code/datums/components/curse_of_hunger.dm
+++ b/code/datums/components/curse_of_hunger.dm
@@ -124,8 +124,9 @@
 	var/mob/living/carbon/cursed = cursed_item.loc
 	///check hp
 	if(current_health <= 0)
-		the_curse_ends(dropper)
+		the_curse_ends(cursed)
 		return
+
 	hunger += delta_time
 	if((hunger <= HUNGER_THRESHOLD_TRY_EATING) || prob(80))
 		return

--- a/code/datums/components/curse_of_hunger.dm
+++ b/code/datums/components/curse_of_hunger.dm
@@ -1,5 +1,3 @@
-///inital food tolerances, two dishes
-#define FULL_HEALTH 2
 ///the point where you can notice the item is hungry on examine.
 #define HUNGER_THRESHOLD_WARNING 25
 ///the point where the item has a chance to eat something on every tick. possibly you!
@@ -17,14 +15,18 @@
 	var/awakened = FALSE
 	///counts time passed since it ate food
 	var/hunger = 0
-	///how many times it needs to be fed poisoned food for it to drop off of you
-	var/poison_food_tolerance = FULL_HEALTH
+	///The bag's max "health". IE, how many times you need to poison it.
+	var/max_health = 2
+	///The bag's current "health". IE, how many more times you need to poison it to stop it.
+	var/current_health = 2
 
-/datum/component/curse_of_hunger/Initialize(add_dropdel = FALSE)
+/datum/component/curse_of_hunger/Initialize(add_dropdel = FALSE, max_health = 2)
 	. = ..()
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 	src.add_dropdel = add_dropdel
+	src.max_health = max_health
+	src.current_health = max_health
 
 /datum/component/curse_of_hunger/RegisterWithParent()
 	. = ..()
@@ -46,7 +48,7 @@
 	SIGNAL_HANDLER
 	if(!awakened)
 		return //we should not reveal we are cursed until equipped
-	if(poison_food_tolerance != FULL_HEALTH)
+	if(current_health < max_health)
 		examine_list += span_notice("[parent] looks sick from something it ate.")
 	if(hunger > HUNGER_THRESHOLD_WARNING)
 		examine_list += span_danger("[parent] hungers for something to eat...")
@@ -102,7 +104,8 @@
 	playsound(vomit_turf, 'sound/effects/splat.ogg', 50, TRUE)
 	new /obj/effect/decal/cleanable/vomit(vomit_turf)
 
-	if(!add_dropdel) //gives a head start for the person to get away from the cursed item before it begins hunting again!
+	uncursed.dropItemToGround(at_least_item, force = TRUE)
+	if(!QDELETED(at_least_item)) //gives a head start for the person to get away from the cursed item before it begins hunting again!
 		addtimer(CALLBACK(src, .proc/seek_new_target), 10 SECONDS)
 
 ///proc called after a timer to awaken the AI in the cursed item if it doesn't have a target already.
@@ -120,39 +123,45 @@
 	var/obj/item/cursed_item = parent
 	var/mob/living/carbon/cursed = cursed_item.loc
 	///check hp
-	if(!poison_food_tolerance)
-		cursed.dropItemToGround(cursed_item, TRUE)
+	if(current_health <= 0)
+		the_curse_ends(dropper)
 		return
 	hunger += delta_time
 	if((hunger <= HUNGER_THRESHOLD_TRY_EATING) || prob(80))
 		return
 
-	var/list/locations_to_check = (cursed.contents + cursed_item.contents)
+	playsound(cursed_item, 'sound/items/eatfood.ogg', 20, TRUE)
+	hunger = 0
+
 	//check hungry enough to eat something!
-	for(var/obj/item/food in locations_to_check)
+	for(var/obj/item/food in cursed_item.contents + cursed.contents)
 		if(!IS_EDIBLE(food))
 			continue
 		food.forceMove(cursed.loc)
-		playsound(cursed_item, 'sound/items/eatfood.ogg', 20, TRUE)
 		///poisoned food damages it
-		if(istype(food, /obj/item/food/badrecipe))
-			to_chat(cursed, span_warning("[cursed_item] eats your [food] to sate [cursed_item.p_their()] hunger, and looks [pick("queasy", "sick", "iffy", "unwell")] afterwards!"))
-			poison_food_tolerance--
+		if(locate(/datum/reagent/toxin) in food.reagents.reagent_list)
+			var/sick_word = pick("queasy", "sick", "iffy", "unwell")
+			cursed.visible_message(
+				span_notice("[cursed_item] eats something from [cursed], and looks [sick_word] afterwards!"),
+				span_notice("[cursed_item] eats your [food.name] to sate [cursed_item.p_their()] hunger, and looks [sick_word] afterwards!"),
+			)
+			current_health--
 		else
-			to_chat(cursed, span_notice("[cursed_item] eats your [food] to sate [cursed_item.p_their()] hunger."))
+			cursed.visible_message(
+				span_warning("[cursed_item] eats something from [cursed] to sate [cursed_item.p_their()] hunger."),
+				span_warning("[cursed_item] eats your [food.name] to sate [cursed_item.p_their()] hunger."),
+			)
 		cursed.temporarilyRemoveItemFromInventory(food, force = TRUE)
 		qdel(food)
-		hunger = 0
 		return
-	///no food found: it bites you and regains some poison food tolerance
-	playsound(cursed_item, 'sound/items/eatfood.ogg', 20, TRUE)
-	to_chat(cursed, span_userdanger("[cursed_item] bites you to sate [cursed_item.p_their()] hunger!"))
-	var/affecting = cursed.get_bodypart(BODY_ZONE_CHEST)
-	cursed.apply_damage(60, BRUTE, affecting)
-	hunger = 0
-	poison_food_tolerance = min(poison_food_tolerance + 1, FULL_HEALTH)
 
-/datum/component/curse_of_hunger/proc/test()
-	var/obj/item/cursed_item = parent
-	var/mob/living/carbon/cursed = cursed_item.loc
-	cursed.dropItemToGround(cursed_item, TRUE)
+	///no food found, but you're dead: it bites you slightly, and doesn't regain health.
+	if(cursed.stat == DEAD)
+		cursed.visible_message(span_danger("[cursed_item] nibbles on [cursed]."), span_userdanger("[cursed_item] nibbles on you!"))
+		cursed.apply_damage(10, BRUTE, BODY_ZONE_CHEST)
+		return
+
+	///no food found: it bites you and regains some health.
+	cursed.visible_message(span_danger("[cursed_item] bites [cursed]!"), span_userdanger("[cursed_item] bites you to sate [cursed_item.p_their()] hunger!"))
+	cursed.apply_damage(60, BRUTE, BODY_ZONE_CHEST, wound_bonus = -20, bare_wound_bonus = 20)
+	current_health = min(current_health + 1, max_health)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -358,13 +358,10 @@
 	slowdown = 2
 	item_flags = DROPDEL
 	max_integrity = 100
-	///counts time passed since it ate food
-	var/hunger = 0
 
 /obj/item/storage/backpack/duffelbag/cursed/Initialize(mapload)
 	. = ..()
-	var/add_dropdel = TRUE //clarified boolean
-	AddComponent(/datum/component/curse_of_hunger, add_dropdel)
+	AddComponent(/datum/component/curse_of_hunger, add_dropdel = TRUE)
 
 /obj/item/storage/backpack/duffelbag/captain
 	name = "captain's duffel bag"
@@ -680,4 +677,3 @@
 	name = "police bag"
 	desc = "A large duffel bag for holding extra police gear."
 	slowdown = 0
-

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -352,7 +352,9 @@
 
 /obj/item/storage/backpack/duffelbag/cursed
 	name = "living duffel bag"
-	desc = "A cursed clown duffel bag that hungers for food of any kind.\n A warning label suggests that it eats food inside. If that food happens to be a horribly ruined, burned mess the chef scrapped out of the microwave, then it might have negative effects on the bag..."
+	desc = "A cursed clown duffel bag that hungers for food of any kind. A warning label suggests that it eats food inside. \
+		If that food happens to be a horribly ruined mess or the chef scrapped out of the microwave, or poisoned in some way, \
+		then it might have negative effects on the bag..."
 	icon_state = "duffel-curse"
 	inhand_icon_state = "duffel-curse"
 	slowdown = 2


### PR DESCRIPTION
## About The Pull Request

- Cursed Duffelbag is less picky, now. Instead of snowflaking for only burnt food, it will take any item with `/toxin` reagents within it.
   - `/badfood` (in burnt recipes) are considered toxins, so it still works.
- The damage from the duffelbag now has a wounding penalty.
   - A negative penalty to wounding, but no penalty to bare wounding. 
- If the attached mob is dead, it now deals significantly less damage, and doesn't heal the dufflebag. 
- The dufflebag now uses visible messages to convey it's eating to people nearby, instead of just to_chats. 
- Fixes the cursed duffelbag cursing the mob to gain pacifism and clumsiness permanently. 
  - dropdel causes items to be qdeleted before the drop signal is sent so it never uncursed the mob. 

## Why It's Good For The Game

> Cursed Duffelbag is less picky now.

Burnt food is surprisingly a little less common now-a-days, due to food changes / decomposition / etc. 
This led to it being much easier to literally acid the dufflebag off instead of engage with it's mechanic, which is pretty lame.

By allowing any toxin type to be used, it greatly opens up more options to get it removed. 

> The damage from the duffelbag now has a wounding penalty.

Dufflebag's damage had no wounding modifier, meaning it was surefire guaranteed to break your ribs, which was incredibly debilitating. 

Now, it can still break your ribs if you have very little chest protection, but it's much much less likely if you're wearing equipment. 

> If the attached mob is dead, it now deals significantly less damage.

Makes it a bit easier to treat people who are afflicted with a dufflebag. Reviving people with a cursed dufflebag would constantly result in them being damaged greatly beyond the defib threshold. Just annoying. 

> The dufflebag now uses visible messages to convey it's eating to people nearby, instead of just to_chats. 

Mostly QoL. Some people would be confused why someone's being damaged from seemingly nowhere. 

> Fixes the cursed duffelbag cursing the mob to gain pacifism and clumsiness permanently. 

Bugfeex. Sue me. 

## Changelog

:cl: Melbert
qol: The Cursed Dufflebag now tells nearby people when it takes a bite out of someone.
balance: The Cursed Dufflebag takes any food poisoned by any means, instead of just burnt messes.
balance: The Cursed Dufflebag deals out slightly less wounds now to people wearing armor and protection. 
balance: The Cursed Dufflebag deals less damage if the mob it's attached to is dead, and doesn't heal if so. 
fix: The Cursed Dufflebag no longer permanently makes you a pacifist and clumsy.
/:cl:
