### PR TITLE
Fixed recycler stack deletion and removed matter bins for it

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -49,14 +49,8 @@
 /obj/machinery/recycler/RefreshParts()
 	. = ..()
 	var/amt_made = 0
-	var/mat_mod = 0
-	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
-		mat_mod = 2 * B.rating
-	mat_mod *= 50000
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		amt_made = 12.5 * M.rating //% of materials salvaged
-	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
-	materials.max_amount = mat_mod
 	amount_produced = min(50, amt_made) + 50
 	var/datum/component/butchering/butchering = GetComponent(/datum/component/butchering/recycler)
 	butchering.effectiveness = amount_produced
@@ -167,22 +161,21 @@
 			qdel(content)
 
 /obj/machinery/recycler/proc/recycle_item(obj/item/I)
-
 	var/obj/item/grown/log/L = I
 	if(istype(L))
 		var/seed_modifier = 0
 		if(L.seed)
 			seed_modifier = round(L.seed.potency / 25)
 		new L.plank_type(loc, 1 + seed_modifier)
+		qdel(I)
 	else
 		var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 		var/material_amount = materials.get_item_material_amount(I, BREAKDOWN_FLAGS_RECYCLER)
 		if(!material_amount)
 			return
 		materials.insert_item(I, material_amount, multiplier = (amount_produced / 100), breakdown_flags=BREAKDOWN_FLAGS_RECYCLER)
+		qdel(I)
 		materials.retrieve_all()
-	qdel(I)
-
 
 /obj/machinery/recycler/proc/emergency_stop()
 	playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1136,7 +1136,6 @@
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/recycler
 	req_components = list(
-		/obj/item/stock_parts/matter_bin = 1,
 		/obj/item/stock_parts/manipulator = 1)
 	needs_anchored = FALSE
 


### PR DESCRIPTION
## About The Pull Request

FIxing two issues with Recycler:

1. https://github.com/tgstation/tgstation/issues/67710 - The output item was merged with the original BEFORE the original was deleted, and that's why the output was lost.
2. Didn't find corresponding issue. The recycler has infinite internal storage upon init, but it resets it to 100000 on stock parts check. Because of this, when you throw a stack of 50 items and the recycler has less than 1 sheet of this item inside, it was saying that there is not enough space for 50 items, but deleted them anyway. Now recycler doesn't require matter bins, and the internal storage is infinity.

## Why It's Good For The Game

Bugs fixed are good.

## Changelog

:cl:
fix: Fixed recycler bug that deleted the output stack because it was merged with the input stack
fix: Fixed recycler bug where it deleted stacks of 50 because it didn't have enough space by removing recycle bins that reset its internal space from infinity to the level of matter bin part
/:cl:

