### PR TITLE
Fixes slips being broken and adds a unit test to catch it happening again.

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -76,7 +76,7 @@
 	if(!isliving(arrived))
 		return
 	var/mob/living/victim = arrived
-	if(!(victim.movement_type & FLYING|FLOATING) && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
+	if(!(victim.movement_type & (FLYING | FLOATING)) && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
 		callback.Invoke(victim)
 
 /*

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -212,7 +212,7 @@
 	return TRUE
 
 /turf/open/handle_slip(mob/living/carbon/slipper, knockdown_amount, obj/O, lube, paralyze_amount, force_drop)
-	if(slipper.movement_type & FLYING|FLOATING)
+	if(slipper.movement_type & (FLYING | FLOATING))
 		return FALSE
 	if(has_gravity(src))
 		var/obj/buckled_obj

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube, paralyze, force_drop)
-	if(movement_type & FLYING|FLOATING)
+	if(movement_type & (FLYING | FLOATING))
 		return FALSE
 	if(!(lube&SLIDE_ICE))
 		log_combat(src, (O ? O : get_turf(src)), "slipped on the", null, ((lube & SLIDE) ? "(LUBE)" : null))

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -137,6 +137,7 @@
 #include "security_officer_distribution.dm"
 #include "serving_tray.dm"
 #include "siunit.dm"
+#include "slips.dm"
 #include "spawn_humans.dm"
 #include "spawn_mobs.dm"
 #include "species_config_sanity.dm"

--- a/code/modules/unit_tests/slips.dm
+++ b/code/modules/unit_tests/slips.dm
@@ -1,4 +1,7 @@
-/datum/unit_test/aaa/Run()
+/// Unit test that forces various slips on a mob and checks return values and mob state to see if the slip has likely been successful.
+/datum/unit_test/slips
+
+/datum/unit_test/slips/Run()
 	// Test just forced slipping, which calls turf slip code as well.
 	var/mob/living/carbon/human/mso = allocate(/mob/living/carbon/human)
 

--- a/code/modules/unit_tests/slips.dm
+++ b/code/modules/unit_tests/slips.dm
@@ -1,0 +1,13 @@
+/datum/unit_test/aaa/Run()
+	// Test just forced slipping, which calls turf slip code as well.
+	var/mob/living/carbon/human/mso = allocate(/mob/living/carbon/human)
+
+	TEST_ASSERT(mso.slip(100) == TRUE, "/mob/living/carbon/human/slip() returned FALSE when TRUE was expected")
+	TEST_ASSERT(!!(mso.IsKnockdown()), "/mob/living/carbon/human/slip() failed to knockdown target when knockdown was expected")
+
+	// Test the slipping component, which calls mob slip code. Just for good measure.
+	var/mob/living/carbon/human/msos_friend_mso = allocate(/mob/living/carbon/human, run_loc_floor_bottom_left)
+	var/obj/item/grown/bananapeel/specialpeel/mso_bane = allocate(/obj/item/grown/bananapeel/specialpeel, get_step(run_loc_floor_bottom_left, EAST))
+
+	msos_friend_mso.Move(get_turf(mso_bane), EAST)
+	TEST_ASSERT(!!(msos_friend_mso.IsKnockdown()), "Banana peel which should have slipping component failed to knockdown target when knockdown was expected")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#67694 fixed slipping floating things, but accidentally messed up the order of operations and was not fully tested to make sure the change didn't break things where slips were expected.

This logic in particular is the issue: `!(victim.movement_type & FLYING|FLOATING)`

![image](https://user-images.githubusercontent.com/24975989/173256044-b2918851-00bc-49ab-bab4-cf8a49e39f1e.png)

`victim.movement_type & FLYING|FLOATING` expands to `(victim.movement_type & FLYING) | FLOATING` as per Byond's order of ops.

As a result, this test was always truthy because (`any` bitwise OR `any truthy` == `truthy`)

This wraps the bitfield values in parenthesis to fix the issue.

It also adds a unit test to slips to prevent regressions. This test failed on local with the original code in place
![image](https://user-images.githubusercontent.com/24975989/173256273-6632a419-53ef-455b-beb9-3bf7a4a339d7.png)

It should not fail on CI. Hopefully.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex slip, prevent regressions.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes slips being broken again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
