### PR TITLE
Limits pill names to 42 characters

### DIFF
--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -140,8 +140,9 @@
 		if("change_product_name")
 			var/formatted_name = html_encode(params["name"])
 			if (length(formatted_name) > MAX_PILL_NAME_LENGTH)
-				return
-			product_name = formatted_name
+				product_name = copytext(formatted_name, End = MAX_PILL_NAME_LENGTH+1)
+			else
+				product_name = formatted_name
 		if("change_product")
 			product = params["product"]
 			if (product == "pill")

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -140,7 +140,7 @@
 		if("change_product_name")
 			var/formatted_name = html_encode(params["name"])
 			if (length(formatted_name) > MAX_PILL_NAME_LENGTH)
-				product_name = copytext(formatted_name, End = MAX_PILL_NAME_LENGTH+1)
+				product_name = copytext(formatted_name, 1, MAX_PILL_NAME_LENGTH+1)
 			else
 				product_name = formatted_name
 		if("change_product")

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -1,5 +1,3 @@
-#define MAX_PILL_NAME_LENGTH 30
-
 ///We take a constant input of reagents, and produce a pill once a set volume is reached
 /obj/machinery/plumbing/pill_press
 	name = "chemical press"
@@ -139,8 +137,8 @@
 			current_volume = clamp(text2num(params["volume"]), min_volume, max_volume)
 		if("change_product_name")
 			var/formatted_name = html_encode(params["name"])
-			if (length(formatted_name) > MAX_PILL_NAME_LENGTH)
-				product_name = copytext(formatted_name, 1, MAX_PILL_NAME_LENGTH+1)
+			if (length(formatted_name) > MAX_NAME_LEN)
+				product_name = copytext(formatted_name, 1, MAX_NAME_LEN+1)
 			else
 				product_name = formatted_name
 		if("change_product")
@@ -154,5 +152,3 @@
 			current_volume = clamp(current_volume, min_volume, max_volume)
 		if("change_patch_style")
 			patch_style = params["patch_style"]
-
-#undef MAX_PILL_NAME_LENGTH

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -1,3 +1,5 @@
+#define MAX_PILL_NAME_LENGTH 30
+
 ///We take a constant input of reagents, and produce a pill once a set volume is reached
 /obj/machinery/plumbing/pill_press
 	name = "chemical press"
@@ -136,7 +138,10 @@
 		if("change_current_volume")
 			current_volume = clamp(text2num(params["volume"]), min_volume, max_volume)
 		if("change_product_name")
-			product_name = html_encode(params["name"])
+			var/formatted_name = html_encode(params["name"])
+			if (length(formatted_name) > MAX_PILL_NAME_LENGTH)
+				return
+			product_name = formatted_name
 		if("change_product")
 			product = params["product"]
 			if (product == "pill")
@@ -148,3 +153,5 @@
 			current_volume = clamp(current_volume, min_volume, max_volume)
 		if("change_patch_style")
 			patch_style = params["patch_style"]
+
+#undef MAX_PILL_NAME_LENGTH


### PR DESCRIPTION
Limits pill names to be no more than 42 characters. Currently there is no limit and it can be used to flood chat with extremely lengthy names.

Fixes https://github.com/tgstation/tgstation/issues/67738

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog

:cl:
fix: Pill names now have a cap at 42 characters to prevent chat spam.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
