### PR TITLE
Make scientist outfit in antag icons consistent

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -49,7 +49,7 @@
 	brother1_icon.Blend(icon('icons/effects/blood.dmi', "maskblood"), ICON_OVERLAY)
 	brother1_icon.Shift(WEST, 8)
 
-	var/icon/brother2_icon = render_preview_outfit(/datum/outfit/job/scientist, brother2)
+	var/icon/brother2_icon = render_preview_outfit(/datum/outfit/job/scientist/consistent, brother2)
 	brother2_icon.Blend(icon('icons/effects/blood.dmi', "uniformblood"), ICON_OVERLAY)
 	brother2_icon.Shift(EAST, 8)
 

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -53,9 +53,19 @@
 
 /datum/outfit/job/scientist/pre_equip(mob/living/carbon/human/H)
 	..()
-	if(prob(0.4))
+	try_giving_horrible_tie()
+
+/datum/outfit/job/scientist/proc/try_giving_horrible_tie()
+	if (prob(0.4))
 		neck = /obj/item/clothing/neck/tie/horrible
 
 /datum/outfit/job/scientist/get_types_to_preload()
 	. = ..()
 	. += /obj/item/clothing/neck/tie/horrible
+
+/// A version of the scientist outfit that is guaranteed to be the same every time
+/datum/outfit/job/scientist/consistent
+	name = "Scientist - Consistent"
+
+/datum/outfit/job/scientist/consistent/try_giving_horrible_tie()
+	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an inconsistency where the antag icon would sometimes generate differently.

![image](https://user-images.githubusercontent.com/35135081/173259514-3b864d56-ef2b-4500-9f0c-b76c728f6751.png)
