### PR TITLE
removes kilo solars having catwalk and plating on same tile

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -9289,9 +9289,9 @@
 	},
 /area/station/maintenance/port/greater)
 "cLo" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/station/solars/port/aft)
 "cLq" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -14732,9 +14732,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "eoD" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/station/solars/starboard/aft)
 "eoM" = (
 /obj/machinery/door/poddoor/preopen{
@@ -26938,9 +26938,9 @@
 	},
 /area/station/maintenance/disposal)
 "hyB" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/station/solars/starboard/fore)
 "hyJ" = (
 /obj/effect/turf_decal/bot,
@@ -28467,10 +28467,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "hTs" = (
-/obj/structure/lattice/catwalk,
 /obj/effect/landmark/carpspawn,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/station/solars/starboard/fore)
 "hTz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -32353,6 +32353,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"iTC" = (
+/obj/structure/cable,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/station/solars/port/fore)
 "iTL" = (
 /obj/structure/chair{
 	dir = 4
@@ -36398,10 +36403,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"kfp" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/station/solars/starboard/aft)
 "kgc" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37943,10 +37944,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "kFo" = (
-/obj/structure/lattice/catwalk,
 /obj/effect/landmark/carpspawn,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/station/solars/starboard/aft)
 "kFx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -42480,6 +42481,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/fore)
+"lTD" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/station/solars/starboard/fore)
 "lTM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -63834,10 +63840,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
-"rZl" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/station/solars/starboard/fore)
 "rZE" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -78822,10 +78824,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/bridge)
-"whD" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/station/solars/port/aft)
 "whP" = (
 /obj/machinery/vending/engivend,
 /obj/effect/turf_decal/tile/neutral{
@@ -86113,10 +86111,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
-"yeb" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/station/solars/port/fore)
 "yef" = (
 /obj/item/target/clown,
 /obj/effect/turf_decal/stripes/line{
@@ -97675,7 +97669,7 @@ acm
 aaa
 acm
 aaa
-mMv
+iTC
 cmU
 cmU
 cmU
@@ -97932,7 +97926,7 @@ hpG
 hpG
 ala
 hpG
-mMv
+iTC
 hpG
 hpG
 hpG
@@ -98189,7 +98183,7 @@ mMv
 mMv
 mMv
 mMv
-yeb
+tpp
 mMv
 mMv
 mMv
@@ -98446,7 +98440,7 @@ hpG
 hpG
 hpG
 hpG
-yeb
+tpp
 hpG
 hpG
 hpG
@@ -98698,17 +98692,17 @@ aaQ
 acm
 acm
 aaa
-yeb
+tpp
 ckk
 aaa
 aaa
 ckk
-yeb
+tpp
 ckk
 aaa
 aaa
 ckk
-yeb
+tpp
 cmU
 cmU
 aeU
@@ -98960,7 +98954,7 @@ hpG
 hpG
 hpG
 lDc
-yeb
+tpp
 tpp
 hpG
 hpG
@@ -99211,19 +99205,19 @@ aaa
 aeo
 aaa
 cmU
-mMv
-mMv
-mMv
-mMv
-mMv
-yeb
-yeb
-yeb
-mMv
-mMv
-mMv
-mMv
-mMv
+iTC
+iTC
+iTC
+iTC
+iTC
+tpp
+tpp
+tpp
+iTC
+iTC
+iTC
+iTC
+iTC
 cmU
 aeU
 aeU
@@ -99474,7 +99468,7 @@ hpG
 hpG
 hpG
 tpp
-yeb
+tpp
 tpp
 hpG
 hpG
@@ -99726,17 +99720,17 @@ vku
 aeU
 cmU
 cmU
-yeb
+tpp
 ckk
 aaa
 aaa
 ckk
-yeb
+tpp
 ckk
 aaa
 aaa
 ckk
-yeb
+tpp
 cmU
 cmU
 aUz
@@ -99800,7 +99794,7 @@ cmU
 cmU
 cmU
 cmU
-whD
+awn
 cmU
 cmU
 cmU
@@ -99988,7 +99982,7 @@ hpG
 hpG
 hpG
 hpG
-yeb
+tpp
 hpG
 hpG
 hpG
@@ -100057,7 +100051,7 @@ aeU
 aeU
 aeU
 cmU
-whD
+awn
 cmU
 aeU
 aeU
@@ -100240,17 +100234,17 @@ aeu
 aof
 aUz
 cmU
-mMv
-mMv
-mMv
-mMv
-mMv
-yeb
-mMv
-mMv
-mMv
-mMv
-mMv
+iTC
+iTC
+iTC
+iTC
+iTC
+tpp
+iTC
+iTC
+iTC
+iTC
+iTC
 cmU
 aeU
 rYc
@@ -100314,7 +100308,7 @@ aeu
 aeU
 aeU
 cmU
-whD
+awn
 cmU
 aeU
 aeU
@@ -100502,7 +100496,7 @@ hpG
 hpG
 hpG
 hpG
-yeb
+tpp
 hpG
 hpG
 hpG
@@ -100571,7 +100565,7 @@ aeu
 aeu
 rkn
 aDS
-whD
+awn
 bFI
 aeU
 coy
@@ -100759,7 +100753,7 @@ cmU
 cmU
 cmU
 aDS
-yeb
+tpp
 bFI
 cmU
 cmU
@@ -101016,7 +101010,7 @@ aeU
 coy
 woH
 aDS
-yeb
+tpp
 bFI
 rkn
 aeU
@@ -101273,7 +101267,7 @@ aeU
 aeU
 coy
 aDS
-mMv
+iTC
 bFI
 aeU
 aeu
@@ -101530,7 +101524,7 @@ aeU
 aeU
 aeU
 aDS
-mMv
+iTC
 bFI
 aeu
 aeu
@@ -127830,7 +127824,7 @@ aeu
 aeu
 aeU
 aDS
-kfp
+nNb
 bFI
 rkn
 coy
@@ -128087,7 +128081,7 @@ aeU
 aeU
 aUz
 aDS
-kfp
+nNb
 bFI
 aeU
 aeU
@@ -128344,7 +128338,7 @@ cmU
 cmU
 cmU
 aDS
-kfp
+nNb
 bFI
 cmU
 cmU
@@ -128601,7 +128595,7 @@ gix
 gix
 gix
 gix
-kfp
+nNb
 kgD
 kgD
 kgD
@@ -128858,7 +128852,7 @@ eoD
 eoD
 eoD
 eoD
-kfp
+nNb
 eoD
 eoD
 eoD
@@ -129115,7 +129109,7 @@ kgD
 gix
 gix
 gix
-kfp
+nNb
 kgD
 kgD
 kgD
@@ -129367,17 +129361,17 @@ pcC
 aeU
 cmU
 cmU
-kfp
+nNb
 ckk
 aaa
 aaa
 ckk
-kfp
+nNb
 ckk
 aaa
 aaa
 ckk
-kfp
+nNb
 aaa
 aaa
 aaQ
@@ -129629,7 +129623,7 @@ gix
 kgD
 kgD
 nNb
-kfp
+nNb
 nNb
 kgD
 kgD
@@ -129885,9 +129879,9 @@ eoD
 eoD
 eoD
 eoD
-kfp
-kfp
-kfp
+nNb
+nNb
+nNb
 eoD
 eoD
 eoD
@@ -130143,7 +130137,7 @@ kgD
 kgD
 gix
 nNb
-kfp
+nNb
 nNb
 gix
 gix
@@ -130395,17 +130389,17 @@ acm
 aaa
 acm
 aaa
-kfp
+nNb
 ckk
 aaa
 aaa
 ckk
-kfp
+nNb
 ckk
 aaa
 aaa
 ckk
-kfp
+nNb
 aaa
 aaa
 aeo
@@ -130657,7 +130651,7 @@ kgD
 kgD
 kgD
 kgD
-kfp
+nNb
 gix
 gix
 gix
@@ -130914,7 +130908,7 @@ eoD
 kFo
 eoD
 eoD
-kfp
+nNb
 eoD
 eoD
 eoD
@@ -131601,7 +131595,7 @@ cmU
 cmU
 cmU
 aDS
-rZl
+qzg
 bFI
 cmU
 cmU
@@ -131858,7 +131852,7 @@ pyg
 pyg
 pyg
 pyg
-rZl
+qzg
 pyg
 pyg
 pyg
@@ -132115,7 +132109,7 @@ hTs
 hyB
 hyB
 hyB
-rZl
+qzg
 hyB
 hyB
 hyB
@@ -132372,7 +132366,7 @@ pyg
 pyg
 pyg
 pyg
-rZl
+qzg
 pyg
 pyg
 pyg
@@ -132624,17 +132618,17 @@ aaa
 aeo
 aaa
 aaa
-rZl
+qzg
 ckk
 aaa
 aaa
 ckk
-rZl
+qzg
 ckk
 aaa
 aaa
 ckk
-rZl
+qzg
 cmU
 cmU
 aUz
@@ -132886,7 +132880,7 @@ pyg
 pyg
 pyg
 qzg
-rZl
+qzg
 qzg
 pyg
 pyg
@@ -133142,9 +133136,9 @@ hyB
 hyB
 hyB
 hyB
-rZl
-rZl
-rZl
+qzg
+lTD
+qzg
 hyB
 hyB
 hyB
@@ -133400,8 +133394,8 @@ pyg
 pyg
 pyg
 qzg
-rZl
 qzg
+lTD
 pyg
 pyg
 pyg
@@ -133652,17 +133646,17 @@ aaa
 aaQ
 aaa
 aaa
-rZl
+qzg
 ckk
 aaa
 aaa
 ckk
-rZl
+qzg
 ckk
 aaa
 aaa
 ckk
-rZl
+qzg
 cmU
 cmU
 aeU
@@ -133914,7 +133908,7 @@ pyg
 pyg
 pyg
 pyg
-rZl
+qzg
 pyg
 pyg
 pyg
@@ -134171,7 +134165,7 @@ hyB
 hyB
 hyB
 hyB
-rZl
+qzg
 hyB
 hyB
 hyB

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -42481,11 +42481,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/fore)
-"lTD" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/station/solars/starboard/fore)
 "lTM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -133137,7 +133132,7 @@ hyB
 hyB
 hyB
 qzg
-lTD
+qzg
 qzg
 hyB
 hyB
@@ -133395,7 +133390,7 @@ pyg
 pyg
 qzg
 qzg
-lTD
+qzg
 pyg
 pyg
 pyg


### PR DESCRIPTION


## About The Pull Request
![image](https://user-images.githubusercontent.com/54422837/173263532-25842a0c-306a-40e2-ba4d-b6ccab2bea7c.png)


3 out of the 4 solars on kilo had both plating and catwalks on the same tile, now they only have catwalks, as all other stations (and the 4th solar area on kilo) do
## Why It's Good For The Game
~~fixes kilo and makes it a good map without a doubt~~
last time I checked you can't have a catwalk and plating on the same tile.
## Changelog

:cl:
fix: kilostation solars no longer have plating and catwalks on the same tile
/:cl:


