### PR TITLE
APC balloon alerts

### DIFF
--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -24,16 +24,16 @@
 
 	if(istype(attacking_object, /obj/item/stock_parts/cell) && opened)
 		if(cell)
-			to_chat(user, span_warning("There is a power cell already installed!"))
+			balloon_alert(user, "cell already installed!")
 			return
 		if(machine_stat & MAINT)
-			to_chat(user, span_warning("There is no connector for your power cell!"))
+			balloon_alert(user, "no connector for a cell!")
 			return
 		if(!user.transferItemToLoc(attacking_object, src))
 			return
 		cell = attacking_object
-		user.visible_message(span_notice("[user.name] inserts the power cell to [src.name]!"),\
-			span_notice("You insert the power cell."))
+		user.visible_message(span_notice("[user.name] inserts the power cell to [src.name]!"))
+		balloon_alert(user, "cell inserted")
 		chargecount = 0
 		update_appearance()
 		return
@@ -47,22 +47,22 @@
 		if(!host_turf)
 			CRASH("attackby on APC when it's not on a turf")
 		if(host_turf.underfloor_accessibility < UNDERFLOOR_INTERACTABLE)
-			to_chat(user, span_warning("You must remove the floor plating in front of the APC first!"))
+			balloon_alert(user, "remove the floor plating!")
 			return
 		if(terminal)
-			to_chat(user, span_warning("This APC is already wired!"))
+			balloon_alert(user, "APC is already wired!")
 			return
 		if(!has_electronics)
-			to_chat(user, span_warning("There is nothing to wire!"))
+			balloon_alert(user, "no board to wire!")
 			return
 
 		var/obj/item/stack/cable_coil/installing_cable = attacking_object
 		if(installing_cable.get_amount() < 10)
-			to_chat(user, span_warning("You need ten lengths of cable for APC!"))
+			balloon_alert(user, "need ten lengths of cable!")
 			return
 
-		user.visible_message(span_notice("[user.name] adds cables to the APC frame."), \
-							span_notice("You start adding cables to the APC frame..."))
+		user.visible_message(span_notice("[user.name] adds cables to the APC frame."))
+		balloon_alert(user, "adding cables to the frame...")
 		playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 		if(!do_after(user, 20, target = src))
 			return
@@ -76,22 +76,22 @@
 			do_sparks(5, TRUE, src)
 			return
 		installing_cable.use(10)
-		to_chat(user, span_notice("You add cables to the APC frame."))
+		balloon_alert(user, "cables added to the frame")
 		make_terminal()
 		terminal.connect_to_network()
 		return
 
 	if(istype(attacking_object, /obj/item/electronics/apc) && opened)
 		if(has_electronics)
-			to_chat(user, span_warning("There is already a board inside the [src]!"))
+			balloon_alert(user, "there is already a board!")
 			return
 
 		if(machine_stat & BROKEN)
-			to_chat(user, span_warning("You cannot put the board inside, the frame is damaged!"))
+			balloon_alert(user, "the frame is damaged!")
 			return
 
-		user.visible_message(span_notice("[user.name] inserts the power control board into [src]."), \
-							span_notice("You start to insert the power control board into the frame..."))
+		user.visible_message(span_notice("[user.name] inserts the power control board into [src]."))
+		balloon_alert(user, "you start to insert the board...")
 		playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 
 		if(!do_after(user, 10, target = src) || has_electronics)
@@ -99,7 +99,7 @@
 
 		has_electronics = APC_ELECTRONICS_INSTALLED
 		locked = FALSE
-		to_chat(user, span_notice("You place the power control board inside the frame."))
+		balloon_alert(user, "board installed")
 		qdel(attacking_object)
 		return
 
@@ -107,7 +107,7 @@
 		var/obj/item/electroadaptive_pseudocircuit/pseudocircuit = attacking_object
 		if(!has_electronics)
 			if(machine_stat & BROKEN)
-				to_chat(user, span_warning("[src]'s frame is too damaged to support a circuit."))
+				balloon_alert(user, "frame is too damaged!")
 				return
 			if(!pseudocircuit.adapt_circuit(user, 50))
 				return
@@ -119,7 +119,7 @@
 
 		if(!cell)
 			if(machine_stat & MAINT)
-				to_chat(user, span_warning("There's no connector for a power cell."))
+				balloon_alert(user, "no board for a cell!")
 				return
 			if(!pseudocircuit.adapt_circuit(user, 500))
 				return
@@ -132,29 +132,29 @@
 			update_appearance()
 			return
 
-		to_chat(user, span_warning("[src] has both electronics and a cell."))
+		balloon_alert(user, "has both board and cell!")
 		return
 
 	if(istype(attacking_object, /obj/item/wallframe/apc) && opened)
 		if(!(machine_stat & BROKEN || opened==APC_COVER_REMOVED || atom_integrity < max_integrity)) // There is nothing to repair
-			to_chat(user, span_warning("You found no reason for repairing this APC!"))
+			balloon_alert(user, "no reason for repairs!")
 			return
 		if(!(machine_stat & BROKEN) && opened==APC_COVER_REMOVED) // Cover is the only thing broken, we do not need to remove elctronicks to replace cover
-			user.visible_message(span_notice("[user.name] replaces missing APC's cover."), \
-							span_notice("You begin to replace APC's cover..."))
+			user.visible_message(span_notice("[user.name] replaces missing APC's cover."))
+			balloon_alert(user, "replacing APC's cover...")
 			if(do_after(user, 20, target = src)) // replacing cover is quicker than replacing whole frame
-				to_chat(user, span_notice("You replace missing APC's cover."))
+				balloon_alert(user, "cover replaced")
 				qdel(attacking_object)
 				opened = APC_COVER_OPENED
 				update_appearance()
 			return
 		if(has_electronics)
-			to_chat(user, span_warning("You cannot repair this APC until you remove the electronics still inside!"))
+			balloon_alert(user, "remove the board inside!")
 			return
-		user.visible_message(span_notice("[user.name] replaces the damaged APC frame with a new one."), \
-							span_notice("You begin to replace the damaged APC frame..."))
+		user.visible_message(span_notice("[user.name] replaces the damaged APC frame with a new one."))
+		balloon_alert(user, "replacing damaged frame...")
 		if(do_after(user, 50, target = src))
-			to_chat(user, span_notice("You replace the damaged APC frame with a new one."))
+			balloon_alert(user, "APC frame replaced")
 			qdel(attacking_object)
 			set_machine_stat(machine_stat & ~BROKEN)
 			atom_integrity = max_integrity
@@ -201,40 +201,40 @@
 		return
 	if(ethereal.combat_mode)
 		if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
-			to_chat(ethereal, span_warning("The APC's syphon safeties prevent you from draining power!"))
+			balloon_alert(ethereal, "safeties prevent draining!")
 			return
 		if(stomach.crystal_charge > charge_limit)
-			to_chat(ethereal, span_warning("Your charge is full!"))
+			balloon_alert(ethereal, "charge is full!")
 			return
 		stomach.drain_time = world.time + APC_DRAIN_TIME
-		to_chat(ethereal, span_notice("You start channeling some power through the APC into your body."))
+		balloon_alert(ethereal, "draining power")
 		if(do_after(user, APC_DRAIN_TIME, target = src))
 			if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
 				return
-			to_chat(ethereal, span_notice("You receive some charge from the APC."))
+			balloon_alert(ethereal, "received charge")
 			stomach.adjust_charge(APC_POWER_GAIN)
 			cell.use(APC_POWER_GAIN)
 		return
 
 	if(cell.charge >= cell.maxcharge - APC_POWER_GAIN)
-		to_chat(ethereal, span_warning("The APC can't receive anymore power!"))
+		balloon_alert(ethereal, "APC can't receive more power!")
 		return
 	if(stomach.crystal_charge < APC_POWER_GAIN)
-		to_chat(ethereal, span_warning("Your charge is too low!"))
+		balloon_alert(ethereal, "charge is too low!")
 		return
 	stomach.drain_time = world.time + APC_DRAIN_TIME
-	to_chat(ethereal, span_notice("You start channeling power through your body into the APC."))
+	balloon_alert(ethereal, "transfering power")
 	if(!do_after(user, APC_DRAIN_TIME, target = src))
 		return
 	if((cell.charge >= (cell.maxcharge - APC_POWER_GAIN)) || (stomach.crystal_charge < APC_POWER_GAIN))
-		to_chat(ethereal, span_warning("You can't transfer power to the APC!"))
+		balloon_alert(ethereal, "can't transfer power!")
 		return
 	if(istype(stomach))
-		to_chat(ethereal, span_notice("You transfer some power to the APC."))
+		balloon_alert(ethereal, "transfered power")
 		stomach.adjust_charge(-APC_POWER_GAIN)
 		cell.give(APC_POWER_GAIN)
 	else
-		to_chat(ethereal, span_warning("You can't transfer power to the APC!"))
+		balloon_alert(ethereal, "can't transfer power!")
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 /obj/machinery/power/apc/attack_hand(mob/user, list/modifiers)
@@ -244,7 +244,8 @@
 
 	if(opened && (!issilicon(user)))
 		if(cell)
-			user.visible_message(span_notice("[user] removes \the [cell] from [src]!"), span_notice("You remove \the [cell]."))
+			user.visible_message(span_notice("[user] removes \the [cell] from [src]!"))
+			balloon_alert(user, "cell removed")
 			user.put_in_hands(cell)
 			cell.update_appearance()
 			cell = null
@@ -284,7 +285,7 @@
 	var/mob/living/silicon/robot/robot = user
 	if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai!=AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots))))
 		if(!loud)
-			to_chat(user, span_danger("\The [src] has been disabled!"))
+			balloon_alert(user, "APC has been disabled!")
 		return FALSE
 	return TRUE
 

--- a/code/modules/power/apc/apc_power_proc.dm
+++ b/code/modules/power/apc/apc_power_proc.dm
@@ -16,7 +16,7 @@
 
 /obj/machinery/power/apc/proc/toggle_nightshift_lights(mob/living/user)
 	if(last_nightshift_switch > world.time - 100) //~10 seconds between each toggle to prevent spamming
-		to_chat(usr, span_warning("[src]'s night lighting circuit breaker is still cycling!"))
+		balloon_alert(user, "night breaker is cycling!")
 		return
 	last_nightshift_switch = world.time
 	set_nightshift(!nightshift_lights)

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -3,10 +3,10 @@
 	. = TRUE
 	if((!opened && opened != APC_COVER_REMOVED) && !(machine_stat & BROKEN))
 		if(coverlocked && !(machine_stat & MAINT)) // locked...
-			to_chat(user, span_warning("The cover is locked and cannot be opened!"))
+			balloon_alert(user, "cover is locked!")
 			return
 		else if(panel_open)
-			to_chat(user, span_warning("Exposed wires prevents you from opening it!"))
+			balloon_alert(user, "wires prevents opening it!")
 			return
 		else
 			opened = APC_COVER_OPENED
@@ -16,39 +16,40 @@
 	if((opened && has_electronics == APC_ELECTRONICS_SECURED) && !(machine_stat & BROKEN))
 		opened = APC_COVER_CLOSED
 		coverlocked = TRUE //closing cover relocks it
+		balloon_alert(user, "locking the cover")
 		update_appearance()
 		return
 
 	if(!opened || has_electronics != APC_ELECTRONICS_INSTALLED)
 		return
 	if(terminal)
-		to_chat(user, span_warning("Disconnect the wires first!"))
+		balloon_alert(user, "disconnect the wires first!")
 		return
 	crowbar.play_tool_sound(src)
-	to_chat(user, span_notice("You attempt to remove the power control board...") )
+	balloon_alert(user, "removing the board")
 	if(!crowbar.use_tool(src, user, 50))
 		return
 	if(has_electronics != APC_ELECTRONICS_INSTALLED)
 		return
 	has_electronics = APC_ELECTRONICS_MISSING
 	if(machine_stat & BROKEN)
-		user.visible_message(span_notice("[user.name] breaks the power control board inside [name]!"),\
-			span_notice("You break the charred power control board and remove the remains."),
+		user.visible_message(span_notice("[user.name] breaks the power control board inside [name]!")
 			span_hear("You hear a crack."))
+		balloon_alert(user, "charred board breaks")
 		return
 	else if(obj_flags & EMAGGED)
 		obj_flags &= ~EMAGGED
-		user.visible_message(span_notice("[user.name] discards an emagged power control board from [name]!"),\
-			span_notice("You discard the emagged power control board."))
+		user.visible_message(span_notice("[user.name] discards an emagged power control board from [name]!"))
+		balloon_alert(user, "emagged board discarted")
 		return
 	else if(malfhack)
-		user.visible_message(span_notice("[user.name] discards a strangely programmed power control board from [name]!"),\
-			span_notice("You discard the strangely programmed board."))
+		user.visible_message(span_notice("[user.name] discards a strangely programmed power control board from [name]!"))
+		balloon_alert(user, "hacked board discarted")
 		malfai = null
 		malfhack = 0
 		return
-	user.visible_message(span_notice("[user.name] removes the power control board from [name]!"),\
-		span_notice("You remove the power control board."))
+	user.visible_message(span_notice("[user.name] removes the power control board from [name]!"))
+	balloon_alert(user, "removed the board")
 	new /obj/item/electronics/apc(loc)
 	return
 
@@ -59,15 +60,16 @@
 
 	if(!opened)
 		if(obj_flags & EMAGGED)
-			to_chat(user, span_warning("The interface is broken!"))
+			balloon_alert(user, "the interface is broken!")
 			return
 		panel_open = !panel_open
-		to_chat(user, span_notice("The wires have been [panel_open ? "exposed" : "unexposed"]."))
+		balloon_alert(user, "wires are [panel_open ? "exposed" : "unexposed"]")
 		update_appearance()
 		return
 
 	if(cell)
-		user.visible_message(span_notice("[user] removes \the [cell] from [src]!"), span_notice("You remove \the [cell]."))
+		user.visible_message(span_notice("[user] removes \the [cell] from [src]!"))
+		balloon_alert(user, "cell removed")
 		var/turf/user_turf = get_turf(user)
 		cell.forceMove(user_turf)
 		cell.update_appearance()
@@ -81,14 +83,14 @@
 			has_electronics = APC_ELECTRONICS_SECURED
 			set_machine_stat(machine_stat & ~MAINT)
 			W.play_tool_sound(src)
-			to_chat(user, span_notice("You screw the circuit electronics into place."))
+			balloon_alert(user, "board fastened")
 		if(APC_ELECTRONICS_SECURED)
 			has_electronics = APC_ELECTRONICS_INSTALLED
 			set_machine_stat(machine_stat | MAINT)
 			W.play_tool_sound(src)
-			to_chat(user, span_notice("You unfasten the electronics."))
+			balloon_alert(user, "board unfastened")
 		else
-			to_chat(user, span_warning("There is nothing to secure!"))
+			balloon_alert(user, "no board to faster!")
 			return
 	update_appearance()
 
@@ -105,18 +107,18 @@
 	if(!welder.tool_start_check(user, amount=3))
 		return
 	user.visible_message(span_notice("[user.name] welds [src]."), \
-						span_notice("You start welding the APC frame..."), \
 						span_hear("You hear welding."))
+	balloon_alert(user, "welding the APC frame")
 	if(!welder.use_tool(src, user, 50, volume=50, amount=3))
 		return
 	if((machine_stat & BROKEN) || opened==APC_COVER_REMOVED)
 		new /obj/item/stack/sheet/iron(loc)
-		user.visible_message(span_notice("[user.name] cuts [src] apart with [welder]."),\
-			span_notice("You disassembled the broken APC frame."))
+		user.visible_message(span_notice("[user.name] cuts [src] apart with [welder]."))
+		balloon_alert(user, "disassembled the broken frame")
 	else
 		new /obj/item/wallframe/apc(loc)
-		user.visible_message(span_notice("[user.name] cuts [src] from the wall with [welder]."),\
-			span_notice("You cut the APC frame from the wall."))
+		user.visible_message(span_notice("[user.name] cuts [src] from the wall with [welder]."))
+		balloon_alert(user, "cut the frame from the wall")
 	qdel(src)
 	return TRUE
 
@@ -126,17 +128,17 @@
 
 	if(!has_electronics)
 		if(machine_stat & BROKEN)
-			to_chat(user, span_warning("[src]'s frame is too damaged to support a circuit."))
+			balloon_alert(user, "frame is too damaged!")
 			return FALSE
 		return list("mode" = RCD_UPGRADE_SIMPLE_CIRCUITS, "delay" = 20, "cost" = 1)
 
 	if(!cell)
 		if(machine_stat & MAINT)
-			to_chat(user, span_warning("There's no connector for a power cell."))
+			balloon_alert(user, "no board for a cell!")
 			return FALSE
 		return list("mode" = RCD_UPGRADE_SIMPLE_CIRCUITS, "delay" = 50, "cost" = 10) //16 for a wall
 
-	to_chat(user, span_warning("[src] has both electronics and a cell."))
+	balloon_alert(user, "has both board and cell!")
 	return FALSE
 
 /obj/machinery/power/apc/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
@@ -144,17 +146,17 @@
 		return FALSE
 	if(!has_electronics)
 		if(machine_stat & BROKEN)
-			to_chat(user, span_warning("[src]'s frame is too damaged to support a circuit."))
+			balloon_alert(user, "frame is too damaged!")
 			return
-		user.visible_message(span_notice("[user] fabricates a circuit and places it into [src]."), \
-		span_notice("You adapt a power control board and click it into place in [src]'s guts."))
+		user.visible_message(span_notice("[user] fabricates a circuit and places it into [src]."))
+		balloon_alert(user, "control board placed")
 		has_electronics = TRUE
 		locked = TRUE
 		return TRUE
 
 	if(!cell)
 		if(machine_stat & MAINT)
-			to_chat(user, span_warning("There's no connector for a power cell."))
+			balloon_alert(user, "no board for a cell!")
 			return FALSE
 		var/obj/item/stock_parts/cell/crap/empty/C = new(src)
 		C.forceMove(src)
@@ -165,7 +167,7 @@
 		update_appearance()
 		return TRUE
 
-	to_chat(user, span_warning("[src] has both electronics and a cell."))
+	balloon_alert(user, "has both board and cell!")
 	return FALSE
 
 /obj/machinery/power/apc/emag_act(mob/user)
@@ -173,17 +175,17 @@
 		return
 
 	if(opened)
-		to_chat(user, span_warning("You must close the cover to swipe an ID card!"))
+		balloon_alert(user, "must close the cover to swipe!")
 	else if(panel_open)
-		to_chat(user, span_warning("You must close the panel first!"))
+		balloon_alert(user, "must close the panel first!")
 	else if(machine_stat & (BROKEN|MAINT))
-		to_chat(user, span_warning("Nothing happens!"))
+		balloon_alert(user, "nothing happens!")
 	else
 		flick("apc-spark", src)
 		playsound(src, SFX_SPARKS, 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 		obj_flags |= EMAGGED
 		locked = FALSE
-		to_chat(user, span_notice("You emag the APC interface."))
+		balloon_alert(user, "you emag the APC")
 		update_appearance()
 
 // damage and destruction acts
@@ -205,19 +207,19 @@
 
 /obj/machinery/power/apc/proc/togglelock(mob/living/user)
 	if(obj_flags & EMAGGED)
-		to_chat(user, span_warning("The interface is broken!"))
+		balloon_alert(user, "interface is broken!")
 	else if(opened)
-		to_chat(user, span_warning("You must close the cover to swipe an ID card!"))
+		balloon_alert(user, "must close the cover to swipe!")
 	else if(panel_open)
-		to_chat(user, span_warning("You must close the panel!"))
+		balloon_alert(user, "must close the panel!")
 	else if(machine_stat & (BROKEN|MAINT))
-		to_chat(user, span_warning("Nothing happens!"))
+		balloon_alert(user, "nothing happens!")
 	else
 		if(allowed(usr) && !wires.is_cut(WIRE_IDSCAN) && !malfhack)
 			locked = !locked
-			to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the APC interface."))
+			balloon_alert(user, "APC [ locked ? "locked" : "unlocked"]")
 			update_appearance()
 			if(!locked)
 				ui_interact(user)
 		else
-			to_chat(user, span_warning("Access denied."))
+			balloon_alert(user, "access denied!")

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -33,18 +33,18 @@
 		return
 	has_electronics = APC_ELECTRONICS_MISSING
 	if(machine_stat & BROKEN)
-		user.visible_message(span_notice("[user.name] breaks the power control board inside [name]!")
+		user.visible_message(span_notice("[user.name] breaks the power control board inside [name]!"), \
 			span_hear("You hear a crack."))
 		balloon_alert(user, "charred board breaks")
 		return
 	else if(obj_flags & EMAGGED)
 		obj_flags &= ~EMAGGED
 		user.visible_message(span_notice("[user.name] discards an emagged power control board from [name]!"))
-		balloon_alert(user, "emagged board discarted")
+		balloon_alert(user, "emagged board discarded")
 		return
 	else if(malfhack)
 		user.visible_message(span_notice("[user.name] discards a strangely programmed power control board from [name]!"))
-		balloon_alert(user, "hacked board discarted")
+		balloon_alert(user, "reprogrammed board discarded")
 		malfai = null
 		malfhack = 0
 		return

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -43,14 +43,14 @@
 	if(isturf(loc))
 		var/turf/T = loc
 		if(T.underfloor_accessibility < UNDERFLOOR_INTERACTABLE)
-			to_chat(user, span_warning("You must first expose the power terminal!"))
+			balloon_alert(user, "must expose the cable terminal!")
 			return
 
 	if(master && !master.can_terminal_dismantle())
 		return
 
-	user.visible_message(span_notice("[user.name] dismantles the power terminal from [master]."),
-		span_notice("You begin to cut the cables..."))
+	user.visible_message(span_notice("[user.name] dismantles the cable terminal from [master]."))
+	balloon_alert(user, "cutting the cables...")
 
 	playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 	if(I.use_tool(src, user, 50))
@@ -62,7 +62,7 @@
 			return
 
 		new /obj/item/stack/cable_coil(drop_location(), 10)
-		to_chat(user, span_notice("You cut the cables and dismantle the power terminal."))
+		balloon_alert(user, "cable terminal dismantled")
 		qdel(src)
 
 /obj/machinery/power/terminal/wirecutter_act(mob/living/user, obj/item/I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the `to_chat` messages from building/repairing/deconstruction/etherealing APCs to balloon alerts.

I tried to standardize the multiple names that some items get into one, example: control board or electronics into just board.
Renamed other things just to be cleaner on what tools to use, example: power terminal was change to cable terminal.
And added ! at the end of all error messages so it is easier to know that your attempt failed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dealing with APCs is a pain, hopefully this makes things less of a pain as you don't need to: 
1 - look down right on chat tab
2 - figure out what happened in the middle of the clown screaming on the radio/people are coughing nearby
3 - then to your inventory to juggle the multiple items needed for construction/repair
4 - then to the APC
5 - now repeat it 7 or so times

This should make things easier.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
qol: APC construction/repairs/deconstruction uses balloon alerts now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
