### PR TITLE
Fixes donk pocket box description, big microwave in shambles.

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -451,7 +451,7 @@
 
 /obj/item/storage/box/donkpockets
 	name = "box of donk-pockets"
-	desc = "<B>Instructions:</B> <I>Heat in microwave. Product will cool if not eaten within seven minutes.</I>"
+	desc = "<B>Instructions:</B> <I>Heat in microwave. Product perpetually warmed with cutting edge Donk Co. technology.</I>"
 	icon_state = "donkpocketbox"
 	illustration=null
 	var/donktype = /obj/item/food/donkpocket

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -451,7 +451,7 @@
 
 /obj/item/storage/box/donkpockets
 	name = "box of donk-pockets"
-	desc = "<B>Instructions:</B> <I>Heat in microwave. Product perpetually warmed with cutting edge Donk Co. technology.</I>"
+	desc = "<B>Instructions:</B> <I>Heat in microwave. Product will stay perpetually warmed with cutting edge Donk Co. technology.</I>"
 	icon_state = "donkpocketbox"
 	illustration=null
 	var/donktype = /obj/item/food/donkpocket


### PR DESCRIPTION
Donk Co. has been forced to update their donk pocket packaging under threat of legal action. 

## About The Pull Request
Donk pocket boxes used to say "Product will cool if not eaten within seven minutes." This is a blatant lie and has been corrected.

Fixes #67751
## Why It's Good For The Game
Crew members can now enjoy their donk pockets at a leisurely pace 
## Changelog
:cl:
fix: updates donk pocket box examine text to be more accurate
/:cl: