### PR TITLE
Fixes mothic garlic pizza not producing the correct slice on slicing

### DIFF
--- a/code/game/objects/items/food/moth.dm
+++ b/code/game/objects/items/food/moth.dm
@@ -676,7 +676,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 25, /datum/reagent/consumable/nutriment/protein = 8, /datum/reagent/consumable/tomatojuice = 6, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("crust" = 1, "garlic" = 1, "butter" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY | NUTS
-	slice_type = /obj/item/food/pizzaslice/mothic_pesto
+	slice_type = /obj/item/food/pizzaslice/mothic_garlic
 	boxtag = "Garlic Bread alla Moffuchi"
 
 /obj/item/food/pizzaslice/mothic_garlic


### PR DESCRIPTION

## About The Pull Request

Mothic garlic pizza used to produce mothic pesto pizza slices instead of mothic garlic pizza slices. This Sucks so I fixed it to produce the correct garlic pizza slices.

## Why It's Good For The Game

Imagine cutting into a chocolate cake to reveal that its actually a strawberry cake, that's fucked up man srsly

## Changelog
:cl:
fix: Fixes mothic garlic pizza not producing the correct slice on slicing

/:cl:

