### PR TITLE
Fixes the "stuck in a vertical fireman carry" curse

### DIFF
--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -7,7 +7,7 @@
  * just having the variables, behavior, and procs be standardized is still a big improvement.
  */
 /datum/element/ridable
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
 	id_arg_index = 2
 
 	/// The specific riding component subtype we're loading our instructions from, don't leave this as default please!
@@ -24,6 +24,7 @@
 		stack_trace("Tried attaching a ridable element to [target] with basic/abstract /datum/component/riding component type. Please designate a specific riding component subtype when adding the ridable element.")
 		return COMPONENT_INCOMPATIBLE
 
+	target.can_buckle = TRUE
 	riding_component_type = component_type
 	potion_boosted = potion_boost
 
@@ -31,10 +32,11 @@
 	if(isvehicle(target))
 		RegisterSignal(target, COMSIG_SPEED_POTION_APPLIED, .proc/check_potion)
 	if(ismob(target))
-		RegisterSignal(target, COMSIG_LIVING_DEATH, .proc/handle_removal)
+		RegisterSignal(target, COMSIG_MOB_STATCHANGE, .proc/on_stat_change)
 
-/datum/element/ridable/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_MOVABLE_PREBUCKLE, COMSIG_SPEED_POTION_APPLIED, COMSIG_LIVING_DEATH))
+/datum/element/ridable/Detach(atom/movable/target)
+	target.can_buckle = initial(target.can_buckle)
+	UnregisterSignal(target, list(COMSIG_MOVABLE_PREBUCKLE, COMSIG_SPEED_POTION_APPLIED, COMSIG_MOB_STATCHANGE))
 	return ..()
 
 /// Someone is buckling to this movable, which is literally the only thing we care about (other than speed potions)
@@ -147,13 +149,17 @@
 			qdel(O)
 	return TRUE
 
-/datum/element/ridable/proc/handle_removal(datum/source)
+/datum/element/ridable/proc/on_stat_change(mob/source)
 	SIGNAL_HANDLER
 
-	var/atom/movable/ridden = source
-	ridden.unbuckle_all_mobs()
+	// If we're dead, don't let anyone buckle onto us
+	if(source.stat == DEAD)
+		source.can_buckle = FALSE
+		source.unbuckle_all_mobs()
 
-	Detach(source)
+	// If we're alive, back to being buckle-able
+	else
+		source.can_buckle = TRUE
 
 /obj/item/riding_offhand
 	name = "offhand"

--- a/code/modules/mob/living/basic/farm_animals/cows.dm
+++ b/code/modules/mob/living/basic/farm_animals/cows.dm
@@ -50,7 +50,6 @@
 	AddComponent(/datum/component/tameable, food_types = list(/obj/item/food/grown/wheat), tame_chance = 25, bonus_tame_chance = 15, after_tame = CALLBACK(src, .proc/tamed))
 
 /mob/living/basic/cow/proc/tamed(mob/living/tamer)
-	can_buckle = TRUE
 	buckle_lying = 0
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/cow)
 

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -103,7 +103,6 @@
 
 /mob/living/simple_animal/hostile/carp/proc/tamed(mob/living/tamer)
 	tamed = TRUE
-	can_buckle = TRUE
 	buckle_lying = 0
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/carp)
 	if(ai_controller)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -118,7 +118,6 @@
 		user.visible_message(span_notice("You manage to put [O] on [src], you can now ride [p_them()]."))
 		qdel(O)
 		saddled = TRUE
-		can_buckle = TRUE
 		buckle_lying = 0
 		add_overlay("goliath_saddled")
 		AddElement(/datum/element/ridable, /datum/component/riding/creature/goliath)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -457,7 +457,6 @@
 	flick("glutton_mouth", src)
 
 /mob/living/simple_animal/hostile/retaliate/clown/mutant/glutton/proc/tamed(mob/living/tamer)
-	can_buckle = TRUE
 	buckle_lying = 0
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/glutton)
 

--- a/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
@@ -37,7 +37,6 @@
 	QDEL_NULL(tentacle_slap)
 
 /mob/living/simple_animal/hostile/vatbeast/proc/tamed(mob/living/tamer)
-	can_buckle = TRUE
 	buckle_lying = 0
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/vatbeast)
 	faction = list("neutral")
@@ -115,4 +114,3 @@
 	our_action.StartCooldown()
 
 	return TRUE
-


### PR DESCRIPTION
## About The Pull Request

Fixes #67622

#66530 made it so anything with the ridable element lost the element whenever it died.
Unfortunately it added NO supplementary logic that re-adds the ridable element of that thing died. 

Guess what uses the ridable element? Humans, for fireman carrying and piggybacking

So, if you ever died, it'd permanently brick your ability to fireman carry. 

## Why It's Good For The Game

People can fireman carry people and not get stuck

## Changelog

:cl: Melbert
fix: Fixes the fireman carry "body stuck to you forever" curse
/:cl:

