### PR TITLE
Gives gorillas monkey faction, gives the cargorilla neutral faction

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -32,7 +32,7 @@
 	attack_sound = 'sound/weapons/punch1.ogg'
 	dextrous = TRUE
 	held_items = list(null, null)
-	faction = list("jungle")
+	faction = list("monkey", "jungle")
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
 	minbodytemp = 270
@@ -121,7 +121,7 @@
 	desc = "Cargo's pet gorilla."
 	maxHealth = 200
 	health = 200
-	faction = list(FACTION_STATION, "neutral", "monkey", "jungle")
+	faction = list("neutral", "monkey", "jungle")
 	gold_core_spawnable = NO_SPAWN
 	unique_name = FALSE
 	/// Whether we're currently being polled over

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -121,7 +121,7 @@
 	desc = "Cargo's pet gorilla."
 	maxHealth = 200
 	health = 200
-	faction = list(FACTION_STATION)
+	faction = list(FACTION_STATION, "neutral", "monkey", "jungle")
 	gold_core_spawnable = NO_SPAWN
 	unique_name = FALSE
 	/// Whether we're currently being polled over


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/51863163/173730028-dd4eda5e-d1f4-402f-8d6d-434ccc9675a3.png)

he was confidently wrong and was not called out on it.

Gives gorillas the "monkey" faction. I just thought this would be funny. This puts them in a faction with (most) monkeys. (Specifically, `/mob/living/carbon/human/species/monkey`s, because they don't gain the faction on species change, only on mapspawn. Which is funny I guess)

Gives the cargorilla neutral faction instead of station faction. I misread some job code, fulp willard saw it, and didn't counter my claim. They won't constantly try to punch cargo techs now. 

## Why It's Good For The Game

Gorillas are friends to monkeys. Cargorillas are neutral creatures of peace. 

## Changelog

:cl: Melbert
balance: AI Gorillas are now allied to AI monkeys, and AI Cargorillas won't try (and fail) to wail on crewmembers.
/:cl:
