### PR TITLE
Fixes space tackling + mothcurity buff

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -80,6 +80,15 @@
 	if(!A || !(isturf(A) || isturf(A.loc)))
 		return
 
+	if(!HAS_TRAIT(user, TRAIT_FREE_FLOAT_MOVEMENT) ||  !HAS_TRAIT(user, TRAIT_MOVE_FLYING))
+		if(HAS_TRAIT(user, TRAIT_MOVE_FLOATING))
+			to_chat(user, span_warning("You can't tackle while floating!"))
+			return
+
+	if(HAS_TRAIT(user, TRAIT_NEGATES_GRAVITY))
+		to_chat(user, span_warning("You're magnetically attached to the floor and cannot tackle!"))
+		return
+
 	if(HAS_TRAIT(user, TRAIT_HULK))
 		to_chat(user, span_warning("You're too angry to remember how to tackle!"))
 		return
@@ -317,6 +326,13 @@
 			attack_mod += 2
 			sacker.adjustStaminaLoss(20)
 
+	if(ismoth(sacker))
+		var/obj/item/organ/external/wings/moth/sacker_wing = sacker.getorganslot(ORGAN_SLOT_EXTERNAL_WINGS)
+		if(!sacker_wing || sacker_wing.burnt) // moths without wing/burnt ones can't tackle properly
+			attack_mod -= 2
+		else
+			attack_mod += 2 // healty wings are used as extra propulsion
+
 	var/r = rand(-3, 3) - defense_mod + attack_mod + skill_mod
 	return r
 
@@ -372,6 +388,9 @@
 
 	if(HAS_TRAIT(user, TRAIT_CLUMSY))
 		oopsie_mod += 6 //honk!
+
+	if(isflyperson(user))
+		oopsie_mod += 6 //flies don't take smacking into a window/wall easily
 
 	var/oopsie = rand(danger_zone, 100)
 	if(oopsie >= 94 && oopsie_mod < 0) // good job avoiding getting paralyzed! gold star!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Space tackling was a silly but quite efficient means of space travel that is fixed here.
I tried to add a check so people can still tackle in no gravity if they can push an object like a wall or locker (the standard no gravity movement behavior) but after 2 hours of trying it I just got tired, another day perhaps...

To not just completely remove tackling inside the station when the gravity falls, you can still tackle if you have wings and atmosphere to use as propulsion.

Just remember that since tackling distances are extended in no gravity... don't miss your target if you like your spine...

And since I was here buffing mothcurity indirectly, I though it would be a nice time to push tackling to interact with a few more variables so:
1 - Moths with wings will have a better tackle (+2, same as riot armor or gigantism mutation)
2 - Moths without or burnt wings will have a worse tackle (-2, same as dwarfism or clumsy)
3 - Fly people have a higher chance of breaking their spine after splatting themselves into a window/wall (+6 same as clumsy)

Lastly, if you are glued to the floor with Magboots you can't tackle either, it just makes sense.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The bug fix part is well... a bug fix...

As I said, completely disabling tackling if the gravity falls would make an already niche and dangerous, but extremely funny, tool that security has even worse.
Mothcurity is probably the worst species to play as security by hurting the most important side of the department, cooperation as your fellow officer's flashbangs ruin your day or they just avoid using it near you in the first place.
With this change they have a small niche above other officers, just like how plasmamen is an interesting species to play as security with their unique pros and cons. (horrible at direct confrontation against antags/resilient against environmental antags).

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
fix: You can no longer tackle in deep space or if you are not affected by gravity unless you have wings and enough atmosphere, same values that allow flight.
balance: Moths get modifiers to their tackling values if they have/don't have wings.
balance: Fly people don't take splatting themselves on windows/walls easily and have a higher chance to get a bad result from that.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
