### PR TITLE
Fixes (1) and future-proofs circuitboard's name

### DIFF
--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -5,6 +5,8 @@
 
 /obj/item/circuitboard
 	name = "circuit board"
+	/// extension that is applied after the initial name AKA (Computer/Machine Board)
+	var/name_extension = null
 	icon = 'icons/obj/module.dmi'
 	icon_state = "circuit_map"
 	inhand_icon_state = "electronic"
@@ -19,6 +21,8 @@
 	var/onstation = TRUE
 
 /obj/item/circuitboard/Initialize(mapload)
+	if(name_extension)
+		name = "[initial(name)] [name_extension]"
 	set_greyscale(new_config = /datum/greyscale_config/circuit)
 	return ..()
 
@@ -62,6 +66,7 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 */
 
 /obj/item/circuitboard/machine
+	name_extension = "(Machine Board)"
 	var/needs_anchored = TRUE // Whether this machine must be anchored to be constructed.
 	var/list/req_components // Components required by the machine.
 							// Example: list(/obj/item/stock_parts/matter_bin = 5)

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -1,297 +1,301 @@
+/obj/item/circuitboard/computer
+	name = "Generic"
+	name_extension = "(Computer Board)"
+
 //Command
 
 /obj/item/circuitboard/computer/aiupload
-	name = "AI Upload (Computer Board)"
+	name = "AI Upload"
 	greyscale_colors = CIRCUIT_COLOR_COMMAND
 	build_path = /obj/machinery/computer/upload/ai
 
 /obj/item/circuitboard/computer/borgupload
-	name = "Cyborg Upload (Computer Board)"
+	name = "Cyborg Upload"
 	greyscale_colors = CIRCUIT_COLOR_COMMAND
 	build_path = /obj/machinery/computer/upload/borg
 
 /obj/item/circuitboard/computer/bsa_control
-	name = "Bluespace Artillery Controls (Computer Board)"
+	name = "Bluespace Artillery Controls"
 	build_path = /obj/machinery/computer/bsa_control
 
 /obj/item/circuitboard/computer/accounting
-	name = "Account Lookup Console (Computer Board)"
+	name = "Account Lookup Console"
 	greyscale_colors = CIRCUIT_COLOR_COMMAND
 	build_path = /obj/machinery/computer/accounting
 
 //Engineering
 
 /obj/item/circuitboard/computer/apc_control
-	name = "\improper Power Flow Control Console (Computer Board)"
+	name = "\improper Power Flow Control Console"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/apc_control
 
 /obj/item/circuitboard/computer/atmos_alert
-	name = "Atmospheric Alert (Computer Board)"
+	name = "Atmospheric Alert"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/atmos_alert
 
 /obj/item/circuitboard/computer/atmos_control
-	name = "Atmospheric Control (Computer Board)"
+	name = "Atmospheric Control"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/atmos_control
 
 /obj/item/circuitboard/computer/atmos_control/nocontrol
-	name = "Atmospheric Monitor (Computer Board)"
+	name = "Atmospheric Monitor"
 	build_path = /obj/machinery/computer/atmos_control/nocontrol
 
 /obj/item/circuitboard/computer/atmos_control/noreconnect
-	name = "Atmospheric Control (Computer Board)"
+	name = "Atmospheric Control"
 	build_path = /obj/machinery/computer/atmos_control/noreconnect
 
 /obj/item/circuitboard/computer/atmos_control/fixed
-	name = "Atmospheric Monitor (Computer Board)"
+	name = "Atmospheric Monitor"
 	build_path = /obj/machinery/computer/atmos_control/fixed
 
 /obj/item/circuitboard/computer/atmos_control/nocontrol/master
-	name = "Station Atmospheric Monitor (Computer Board)"
+	name = "Station Atmospheric Monitor"
 	build_path = /obj/machinery/computer/atmos_control/nocontrol/master
 
 /obj/item/circuitboard/computer/atmos_control/nocontrol/incinerator
-	name = "Incinerator Chamber Monitor (Computer Board)"
+	name = "Incinerator Chamber Monitor"
 	build_path = /obj/machinery/computer/atmos_control/nocontrol/incinerator
 
 /obj/item/circuitboard/computer/atmos_control/ordnancemix
-	name = "Ordnance Chamber Control (Computer Board)"
+	name = "Ordnance Chamber Control"
 	build_path = /obj/machinery/computer/atmos_control/ordnancemix
 
 /obj/item/circuitboard/computer/atmos_control/oxygen_tank
-	name = "Oxygen Supply Control (Computer Board)"
+	name = "Oxygen Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/oxygen_tank
 
 /obj/item/circuitboard/computer/atmos_control/plasma_tank
-	name = "Plasma Supply Control (Computer Board)"
+	name = "Plasma Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/plasma_tank
 
 /obj/item/circuitboard/computer/atmos_control/air_tank
-	name = "Mixed Air Supply Control (Computer Board)"
+	name = "Mixed Air Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/air_tank
 
 /obj/item/circuitboard/computer/atmos_control/mix_tank
-	name = "Gas Mix Supply Control (Computer Board)"
+	name = "Gas Mix Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/mix_tank
 
 /obj/item/circuitboard/computer/atmos_control/nitrous_tank
-	name = "Nitrous Oxide Supply Control (Computer Board)"
+	name = "Nitrous Oxide Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/nitrous_tank
 
 /obj/item/circuitboard/computer/atmos_control/nitrogen_tank
-	name = "Nitrogen Supply Control (Computer Board)"
+	name = "Nitrogen Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/nitrogen_tank
 
 /obj/item/circuitboard/computer/atmos_control/carbon_tank
-	name = "Carbon Dioxide Supply Control (Computer Board)"
+	name = "Carbon Dioxide Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/carbon_tank
 
 /obj/item/circuitboard/computer/atmos_control/bz_tank
-	name = "BZ Supply Control (Computer Board)"
+	name = "BZ Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/bz_tank
 
 /obj/item/circuitboard/computer/atmos_control/freon_tank
-	name = "Freon Supply Control (Computer Board)"
+	name = "Freon Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/freon_tank
 
 /obj/item/circuitboard/computer/atmos_control/halon_tank
-	name = "Halon Supply Control (Computer Board)"
+	name = "Halon Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/halon_tank
 
 /obj/item/circuitboard/computer/atmos_control/healium_tank
-	name = "Healium Supply Control (Computer Board)"
+	name = "Healium Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/healium_tank
 
 /obj/item/circuitboard/computer/atmos_control/hydrogen_tank
-	name = "Hydrogen Supply Control (Computer Board)"
+	name = "Hydrogen Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/hydrogen_tank
 
 /obj/item/circuitboard/computer/atmos_control/hypernoblium_tank
-	name = "Hypernoblium Supply Control (Computer Board)"
+	name = "Hypernoblium Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/hypernoblium_tank
 
 /obj/item/circuitboard/computer/atmos_control/miasma_tank
-	name = "Miasma Supply Control (Computer Board)"
+	name = "Miasma Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/miasma_tank
 
 /obj/item/circuitboard/computer/atmos_control/nitrium_tank
-	name = "Nitrium Supply Control (Computer Board)"
+	name = "Nitrium Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/nitrium_tank
 
 /obj/item/circuitboard/computer/atmos_control/pluoxium_tank
-	name = "Pluoxium Supply Control (Computer Board)"
+	name = "Pluoxium Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/pluoxium_tank
 
 /obj/item/circuitboard/computer/atmos_control/proto_nitrate_tank
-	name = "Proto-Nitrate Supply Control (Computer Board)"
+	name = "Proto-Nitrate Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/proto_nitrate_tank
 
 /obj/item/circuitboard/computer/atmos_control/tritium_tank
-	name = "Tritium Supply Control (Computer Board)"
+	name = "Tritium Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/tritium_tank
 
 /obj/item/circuitboard/computer/atmos_control/water_vapor
-	name = "Water Vapor Supply Control (Computer Board)"
+	name = "Water Vapor Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/water_vapor
 
 /obj/item/circuitboard/computer/atmos_control/zauker_tank
-	name = "Zauker Supply Control (Computer Board)"
+	name = "Zauker Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/zauker_tank
 
 /obj/item/circuitboard/computer/atmos_control/helium_tank
-	name = "Helium Supply Control (Computer Board)"
+	name = "Helium Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/helium_tank
 
 /obj/item/circuitboard/computer/atmos_control/antinoblium_tank
-	name = "Antinoblium Supply Control (Computer Board)"
+	name = "Antinoblium Supply Control"
 	build_path = /obj/machinery/computer/atmos_control/antinoblium_tank
 
 /obj/item/circuitboard/computer/auxiliary_base
-	name = "Auxiliary Base Management Console (Computer Board)"
+	name = "Auxiliary Base Management Console"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/auxiliary_base
 
 /obj/item/circuitboard/computer/base_construction
-	name = "Generic Base Construction Console (Computer Board)"
+	name = "Generic Base Construction Console"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/camera_advanced/base_construction
 
 /obj/item/circuitboard/computer/base_construction/aux
-	name = "Aux Mining Base Construction Console (Computer Board)"
+	name = "Aux Mining Base Construction Console"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/camera_advanced/base_construction/aux
 
 /obj/item/circuitboard/computer/base_construction/centcom
-	name = "Centcom Base Construction Console (Computer Board)"
+	name = "Centcom Base Construction Console"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/camera_advanced/base_construction/centcom
 
 /obj/item/circuitboard/computer/comm_monitor
-	name = "Telecommunications Monitor (Computer Board)"
+	name = "Telecommunications Monitor"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/telecomms/monitor
 
 /obj/item/circuitboard/computer/comm_server
-	name = "Telecommunications Server Monitor (Computer Board)"
+	name = "Telecommunications Server Monitor"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/telecomms/server
 
 /obj/item/circuitboard/computer/communications
-	name = "Communications (Computer Board)"
+	name = "Communications"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/communications
 
 /obj/item/circuitboard/computer/communications/syndicate
-	name = "Syndicate Communications (Computer Board)"
+	name = "Syndicate Communications"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/communications/syndicate
 
 
 /obj/item/circuitboard/computer/message_monitor
-	name = "Message Monitor (Computer Board)"
+	name = "Message Monitor"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/message_monitor
 
 /obj/item/circuitboard/computer/powermonitor
-	name = "Power Monitor (Computer Board)"  //name fixed 250810
+	name = "Power Monitor"  //name fixed 250810
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/monitor
 
 /obj/item/circuitboard/computer/powermonitor/secret
-	name = "Outdated Power Monitor (Computer Board)" //Variant used on ruins to prevent them from showing up on PDA's.
+	name = "Outdated Power Monitor" //Variant used on ruins to prevent them from showing up on PDA's.
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/monitor/secret
 
 /obj/item/circuitboard/computer/sat_control
-	name = "Satellite Network Control (Computer Board)"
+	name = "Satellite Network Control"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/sat_control
 
 /obj/item/circuitboard/computer/solar_control
-	name = "Solar Control (Computer Board)"  //name fixed 250810
+	name = "Solar Control"  //name fixed 250810
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/solar_control
 
 /obj/item/circuitboard/computer/stationalert
-	name = "Station Alerts (Computer Board)"
+	name = "Station Alerts"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/station_alert
 
 /obj/item/circuitboard/computer/turbine_computer
-	name = "Turbine Computer (Computer Board)"
+	name = "Turbine Computer"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/turbine_computer
 
 //Generic
 
 /obj/item/circuitboard/computer/arcade/amputation
-	name = "Mediborg's Amputation Adventure (Computer Board)"
+	name = "Mediborg's Amputation Adventure"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/arcade/amputation
 
 /obj/item/circuitboard/computer/arcade/battle
-	name = "Arcade Battle (Computer Board)"
+	name = "Arcade Battle"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/arcade/battle
 
 /obj/item/circuitboard/computer/arcade/orion_trail
-	name = "Orion Trail (Computer Board)"
+	name = "Orion Trail"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/arcade/orion_trail
 
 /obj/item/circuitboard/computer/holodeck// Not going to let people get this, but it's just here for future
-	name = "Holodeck Control (Computer Board)"
+	name = "Holodeck Control"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/holodeck
 
 /obj/item/circuitboard/computer/libraryconsole
-	name = "Library Visitor Console (Computer Board)"
+	name = "Library Visitor Console"
 	build_path = /obj/machinery/computer/libraryconsole
 
 /obj/item/circuitboard/computer/libraryconsole/bookconsole
-	name =  "Book Inventory Management Console (Machine Board)"
+	name =  "Book Inventory Management Console"
 	build_path = /obj/machinery/computer/libraryconsole/bookmanagement
 
 /obj/item/circuitboard/computer/libraryconsole/screwdriver_act(mob/living/user, obj/item/tool)
 	if(build_path == /obj/machinery/computer/libraryconsole/bookmanagement)
-		name = "Library Visitor Console (Computer Board)"
+		name = "Library Visitor Console"
 		build_path = /obj/machinery/computer/libraryconsole
 		to_chat(user, span_notice("Defaulting access protocols."))
 	else
-		name = "Book Inventory Management Console (Computer Board)"
+		name = "Book Inventory Management Console"
 		build_path = /obj/machinery/computer/libraryconsole/bookmanagement
 		to_chat(user, span_notice("Access protocols successfully updated."))
 	return TRUE
 
 /obj/item/circuitboard/computer/monastery_shuttle
-	name = "Monastery Shuttle (Computer Board)"
+	name = "Monastery Shuttle"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/shuttle/monastery_shuttle
 
 /obj/item/circuitboard/computer/olddoor
-	name = "DoorMex (Computer Board)"
+	name = "DoorMex"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/pod/old
 
 /obj/item/circuitboard/computer/pod
-	name = "Massdriver control (Computer Board)"
+	name = "Massdriver control"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/pod
 
 /obj/item/circuitboard/computer/slot_machine
-	name = "Slot Machine (Computer Board)"
+	name = "Slot Machine"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/slot_machine
 
 /obj/item/circuitboard/computer/swfdoor
-	name = "Magix (Computer Board)"
+	name = "Magix"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/pod/old/swf
 
 /obj/item/circuitboard/computer/syndicate_shuttle
-	name = "Syndicate Shuttle (Computer Board)"
+	name = "Syndicate Shuttle"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/shuttle/syndicate
 	var/challenge = FALSE
@@ -306,177 +310,177 @@
 	return ..()
 
 /obj/item/circuitboard/computer/syndicatedoor
-	name = "ProComp Executive (Computer Board)"
+	name = "ProComp Executive"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/pod/old/syndicate
 
 /obj/item/circuitboard/computer/white_ship
-	name = "White Ship (Computer Board)"
+	name = "White Ship"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/shuttle/white_ship
 
 /obj/item/circuitboard/computer/white_ship/bridge
-	name = "White Ship Bridge (Computer Board)"
+	name = "White Ship Bridge"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/shuttle/white_ship/bridge
 
 /obj/item/circuitboard/computer/white_ship/pod
-	name = "Salvage Pod (Computer Board)"
+	name = "Salvage Pod"
 	build_path = /obj/machinery/computer/shuttle/white_ship/pod
 
 /obj/item/circuitboard/computer/white_ship/pod/recall
-	name = "Salvage Pod Recall (Computer Board)"
+	name = "Salvage Pod Recall"
 	build_path = /obj/machinery/computer/shuttle/white_ship/pod/recall
 
 /obj/item/circuitboard/computer/bountypad
-	name = "Bounty Pad (Computer Board)"
+	name = "Bounty Pad"
 	build_path = /obj/machinery/computer/piratepad_control/civilian
 
 /obj/item/circuitboard/computer/tram_controls
-	name = "Tram Controls (Computer Board)"
+	name = "Tram Controls"
 	build_path = /obj/machinery/computer/tram_controls
 
 /obj/item/circuitboard/computer/terminal
-	name = "Terminal (Computer Board)"
+	name = "Terminal"
 	build_path = /obj/machinery/computer/terminal
 
 //Medical
 
 /obj/item/circuitboard/computer/crew
-	name = "Crew Monitoring Console (Computer Board)"
+	name = "Crew Monitoring Console"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/computer/crew
 
 /obj/item/circuitboard/computer/med_data
-	name = "Medical Records Console (Computer Board)"
+	name = "Medical Records Console"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/computer/med_data
 
 /obj/item/circuitboard/computer/operating
-	name = "Operating Computer (Computer Board)"
+	name = "Operating Computer"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/computer/operating
 
 /obj/item/circuitboard/computer/pandemic
-	name = "PanD.E.M.I.C. 2200 (Computer Board)"
+	name = "PanD.E.M.I.C. 2200"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/computer/pandemic
 
 //Science
 
 /obj/item/circuitboard/computer/aifixer
-	name = "AI Integrity Restorer (Computer Board)"
+	name = "AI Integrity Restorer"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/aifixer
 
 /obj/item/circuitboard/computer/launchpad_console
-	name = "Launchpad Control Console (Computer Board)"
+	name = "Launchpad Control Console"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/launchpad
 
 /obj/item/circuitboard/computer/mech_bay_power_console
-	name = "Mech Bay Power Control Console (Computer Board)"
+	name = "Mech Bay Power Control Console"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/mech_bay_power_console
 
 /obj/item/circuitboard/computer/mecha_control
-	name = "Exosuit Control Console (Computer Board)"
+	name = "Exosuit Control Console"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/mecha
 
 /obj/item/circuitboard/computer/rdconsole
-	name = "R&D Console (Computer Board)"
+	name = "R&D Console"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/rdconsole
 
 /obj/item/circuitboard/computer/rdservercontrol
-	name = "R&D Server Control (Computer Board)"
+	name = "R&D Server Control"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/rdservercontrol
 
 /obj/item/circuitboard/computer/research
-	name = "Research Monitor (Computer Board)"
+	name = "Research Monitor"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/security/research
 
 /obj/item/circuitboard/computer/robotics
-	name = "Robotics Control (Computer Board)"
+	name = "Robotics Control"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/robotics
 
 /obj/item/circuitboard/computer/teleporter
-	name = "Teleporter (Computer Board)"
+	name = "Teleporter"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/teleporter
 
 /obj/item/circuitboard/computer/xenobiology
-	name = "Xenobiology Console (Computer Board)"
+	name = "Xenobiology Console"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/camera_advanced/xenobio
 
 /obj/item/circuitboard/computer/scan_consolenew
-	name = "DNA Console (Computer Board)"
+	name = "DNA Console"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/scan_consolenew
 
 /obj/item/circuitboard/computer/mechpad
-	name = "Mecha Orbital Pad Console (Computer Board)"
+	name = "Mecha Orbital Pad Console"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/mechpad
 
 //Security
 
 /obj/item/circuitboard/computer/labor_shuttle
-	name = "Labor Shuttle (Computer Board)"
+	name = "Labor Shuttle"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/computer/shuttle/labor
 
 /obj/item/circuitboard/computer/labor_shuttle/one_way
-	name = "Prisoner Shuttle Console (Computer Board)"
+	name = "Prisoner Shuttle Console"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/computer/shuttle/labor/one_way
 
 /obj/item/circuitboard/computer/gulag_teleporter_console
-	name = "Labor Camp teleporter console (Computer Board)"
+	name = "Labor Camp teleporter console"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/computer/prisoner/gulag_teleporter_computer
 
 /obj/item/circuitboard/computer/prisoner
-	name = "Prisoner Management Console (Computer Board)"
+	name = "Prisoner Management Console"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/computer/prisoner/management
 
 /obj/item/circuitboard/computer/secure_data
-	name = "Security Records Console (Computer Board)"
+	name = "Security Records Console"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/computer/secure_data
 
 /obj/item/circuitboard/computer/warrant
-	name = "Security Warrant Viewer (Computer Board)"
+	name = "Security Warrant Viewer"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/computer/warrant
 
 /obj/item/circuitboard/computer/security
-	name = "Security Cameras (Computer Board)"
+	name = "Security Cameras"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/computer/security
 
 /obj/item/circuitboard/computer/advanced_camera
-	name = "Advanced Camera Console (Computer Board)"
+	name = "Advanced Camera Console"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/computer/camera_advanced/syndie
 
 //Service
 
 /obj/item/circuitboard/computer/chef_order
-	name = "Produce Orders Console (Computer Board)"
+	name = "Produce Orders Console"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/chef_order
 
 //Supply
 
 /obj/item/circuitboard/computer/cargo
-	name = "Supply Console (Computer Board)"
+	name = "Supply Console"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/cargo
 	var/contraband = FALSE
@@ -506,7 +510,7 @@
 		machine.obj_flags &= ~EMAGGED
 
 /obj/item/circuitboard/computer/cargo/express
-	name = "Express Supply Console (Computer Board)"
+	name = "Express Supply Console"
 	build_path = /obj/machinery/computer/cargo/express
 
 /obj/item/circuitboard/computer/cargo/express/emag_act(mob/living/user)
@@ -525,62 +529,62 @@
 		obj_flags &= ~EMAGGED
 
 /obj/item/circuitboard/computer/cargo/request
-	name = "Supply Request Console (Computer Board)"
+	name = "Supply Request Console"
 	build_path = /obj/machinery/computer/cargo/request
 
 /obj/item/circuitboard/computer/ferry
-	name = "Transport Ferry (Computer Board)"
+	name = "Transport Ferry"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/shuttle/ferry
 
 /obj/item/circuitboard/computer/ferry/request
-	name = "Transport Ferry Console (Computer Board)"
+	name = "Transport Ferry Console"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/shuttle/ferry/request
 
 /obj/item/circuitboard/computer/mining
-	name = "Outpost Status Display (Computer Board)"
+	name = "Outpost Status Display"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/security/mining
 
 /obj/item/circuitboard/computer/mining_shuttle
-	name = "Mining Shuttle (Computer Board)"
+	name = "Mining Shuttle"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/shuttle/mining
 
 /obj/item/circuitboard/computer/mining_shuttle/common
-	name = "Lavaland Shuttle (Computer Board)"
+	name = "Lavaland Shuttle"
 	build_path = /obj/machinery/computer/shuttle/mining/common
 
 /obj/item/circuitboard/computer/exoscanner_console
-	name = "Scanner Array Control Console (Computer Board)"
+	name = "Scanner Array Control Console"
 	build_path = /obj/machinery/computer/exoscanner_control
 
 /obj/item/circuitboard/computer/exodrone_console
-	name = "Exploration Drone Control Console (Computer Board)"
+	name = "Exploration Drone Control Console"
 	build_path = /obj/machinery/computer/exodrone_control_console
 
 /obj/item/circuitboard/computer/service_orders
-	name = "Service Order (Computer Board)"
+	name = "Service Order"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/department_orders/service
 
 /obj/item/circuitboard/computer/engineering_orders
-	name = "Engineering Order (Computer Board)"
+	name = "Engineering Order"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/department_orders/engineering
 
 /obj/item/circuitboard/computer/science_orders
-	name = "Science Order (Computer Board)"
+	name = "Science Order"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/department_orders/science
 
 /obj/item/circuitboard/computer/security_orders
-	name = "Security Order (Computer Board)"
+	name = "Security Order"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/department_orders/security
 
 /obj/item/circuitboard/computer/medical_orders
-	name = "Medical Order (Computer Board)"
+	name = "Medical Order"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/department_orders/medical

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1,7 +1,7 @@
 //Command
 
 /obj/item/circuitboard/machine/bsa/back
-	name = "Bluespace Artillery Generator (Machine Board)"
+	name = "Bluespace Artillery Generator"
 	greyscale_colors = CIRCUIT_COLOR_COMMAND
 	build_path = /obj/machinery/bsa/back //No freebies!
 	req_components = list(
@@ -9,7 +9,7 @@
 		/obj/item/stack/cable_coil = 2)
 
 /obj/item/circuitboard/machine/bsa/front
-	name = "Bluespace Artillery Bore (Machine Board)"
+	name = "Bluespace Artillery Bore"
 	greyscale_colors = CIRCUIT_COLOR_COMMAND
 	build_path = /obj/machinery/bsa/front
 	req_components = list(
@@ -17,7 +17,7 @@
 		/obj/item/stack/cable_coil = 2)
 
 /obj/item/circuitboard/machine/bsa/middle
-	name = "Bluespace Artillery Fusor (Machine Board)"
+	name = "Bluespace Artillery Fusor"
 	greyscale_colors = CIRCUIT_COLOR_COMMAND
 	build_path = /obj/machinery/bsa/middle
 	req_components = list(
@@ -25,7 +25,7 @@
 		/obj/item/stack/cable_coil = 2)
 
 /obj/item/circuitboard/machine/dna_vault
-	name = "DNA Vault (Machine Board)"
+	name = "DNA Vault"
 	greyscale_colors = CIRCUIT_COLOR_COMMAND
 	build_path = /obj/machinery/dna_vault //No freebies!
 	req_components = list(
@@ -36,7 +36,7 @@
 //Engineering
 
 /obj/item/circuitboard/machine/announcement_system
-	name = "Announcement System (Machine Board)"
+	name = "Announcement System"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/announcement_system
 	req_components = list(
@@ -44,7 +44,7 @@
 		/obj/item/stack/sheet/glass = 1)
 
 /obj/item/circuitboard/machine/autolathe
-	name = "Autolathe (Machine Board)"
+	name = "Autolathe"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/autolathe
 	req_components = list(
@@ -53,7 +53,7 @@
 		/obj/item/stack/sheet/glass = 1)
 
 /obj/item/circuitboard/machine/grounding_rod
-	name = "Grounding Rod (Machine Board)"
+	name = "Grounding Rod"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/energy_accumulator/grounding_rod
 	req_components = list(/obj/item/stock_parts/capacitor = 1)
@@ -61,7 +61,7 @@
 
 
 /obj/item/circuitboard/machine/telecomms/broadcaster
-	name = "Subspace Broadcaster (Machine Board)"
+	name = "Subspace Broadcaster"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/telecomms/broadcaster
 	req_components = list(
@@ -72,7 +72,7 @@
 		/obj/item/stock_parts/micro_laser = 2)
 
 /obj/item/circuitboard/machine/telecomms/bus
-	name = "Bus Mainframe (Machine Board)"
+	name = "Bus Mainframe"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/telecomms/bus
 	req_components = list(
@@ -81,7 +81,7 @@
 		/obj/item/stock_parts/subspace/filter = 1)
 
 /obj/item/circuitboard/machine/telecomms/hub
-	name = "Hub Mainframe (Machine Board)"
+	name = "Hub Mainframe"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/telecomms/hub
 	req_components = list(
@@ -90,7 +90,7 @@
 		/obj/item/stock_parts/subspace/filter = 2)
 
 /obj/item/circuitboard/machine/telecomms/message_server
-	name = "Messaging Server (Machine Board)"
+	name = "Messaging Server"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/telecomms/message_server
 	req_components = list(
@@ -99,7 +99,7 @@
 		/obj/item/stock_parts/subspace/filter = 3)
 
 /obj/item/circuitboard/machine/telecomms/processor
-	name = "Processor Unit (Machine Board)"
+	name = "Processor Unit"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/telecomms/processor
 	req_components = list(
@@ -111,7 +111,7 @@
 		/obj/item/stock_parts/subspace/amplifier = 1)
 
 /obj/item/circuitboard/machine/telecomms/receiver
-	name = "Subspace Receiver (Machine Board)"
+	name = "Subspace Receiver"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/telecomms/receiver
 	req_components = list(
@@ -121,7 +121,7 @@
 		/obj/item/stock_parts/micro_laser = 1)
 
 /obj/item/circuitboard/machine/telecomms/relay
-	name = "Relay Mainframe (Machine Board)"
+	name = "Relay Mainframe"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/telecomms/relay
 	req_components = list(
@@ -130,7 +130,7 @@
 		/obj/item/stock_parts/subspace/filter = 2)
 
 /obj/item/circuitboard/machine/telecomms/server
-	name = "Telecommunication Server (Machine Board)"
+	name = "Telecommunication Server"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/telecomms/server
 	req_components = list(
@@ -139,7 +139,7 @@
 		/obj/item/stock_parts/subspace/filter = 1)
 
 /obj/item/circuitboard/machine/tesla_coil
-	name = "Tesla Controller (Machine Board)"
+	name = "Tesla Controller"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	desc = "Does not let you shoot lightning from your hands."
 	build_path = /obj/machinery/power/energy_accumulator/tesla_coil
@@ -147,20 +147,20 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/cell_charger
-	name = "Cell Charger (Machine Board)"
+	name = "Cell Charger"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/cell_charger
 	req_components = list(/obj/item/stock_parts/capacitor = 1)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/circulator
-	name = "Circulator/Heat Exchanger (Machine Board)"
+	name = "Circulator/Heat Exchanger"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/atmospherics/components/binary/circulator
 	req_components = list()
 
 /obj/item/circuitboard/machine/emitter
-	name = "Emitter (Machine Board)"
+	name = "Emitter"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/emitter
 	req_components = list(
@@ -169,13 +169,13 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/generator
-	name = "Thermo-Electric Generator (Machine Board)"
+	name = "Thermo-Electric Generator"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/generator
 	req_components = list()
 
 /obj/item/circuitboard/machine/ntnet_relay
-	name = "NTNet Relay (Machine Board)"
+	name = "NTNet Relay"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/ntnet_relay
 	req_components = list(
@@ -183,7 +183,7 @@
 		/obj/item/stock_parts/subspace/filter = 1)
 
 /obj/item/circuitboard/machine/pacman
-	name = "PACMAN-type Generator (Machine Board)"
+	name = "PACMAN-type Generator"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/port_gen/pacman
 	req_components = list(
@@ -205,7 +205,7 @@
 	to_chat(user, span_notice("You set the board for [message]"))
 
 /obj/item/circuitboard/machine/turbine_compressor
-	name = "Turbine - Inlet Compressor (Machine Board)"
+	name = "Turbine - Inlet Compressor"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/turbine/inlet_compressor/constructed
 	req_components = list(
@@ -213,7 +213,7 @@
 		/obj/item/stack/sheet/iron = 5)
 
 /obj/item/circuitboard/machine/turbine_rotor
-	name = "Turbine - Core Rotor (Machine Board)"
+	name = "Turbine - Core Rotor"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/turbine/core_rotor/constructed
 	req_components = list(
@@ -221,7 +221,7 @@
 		/obj/item/stack/sheet/iron = 5)
 
 /obj/item/circuitboard/machine/turbine_stator
-	name = "Turbine - Turbine Outlet (Machine Board)"
+	name = "Turbine - Turbine Outlet"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/turbine/turbine_outlet/constructed
 	req_components = list(
@@ -229,7 +229,7 @@
 		/obj/item/stack/sheet/iron = 5)
 
 /obj/item/circuitboard/machine/protolathe/department/engineering
-	name = "Departmental Protolathe - Engineering (Machine Board)"
+	name = "Departmental Protolathe - Engineering"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/rnd/production/protolathe/department/engineering
 
@@ -237,7 +237,7 @@
 	build_path = /obj/machinery/rnd/production/protolathe/department/engineering/no_tax
 
 /obj/item/circuitboard/machine/rtg
-	name = "RTG (Machine Board)"
+	name = "RTG"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/rtg
 	req_components = list(
@@ -246,7 +246,7 @@
 		/obj/item/stack/sheet/mineral/uranium = 10) // We have no Pu-238, and this is the closest thing to it.
 
 /obj/item/circuitboard/machine/rtg/advanced
-	name = "Advanced RTG (Machine Board)"
+	name = "Advanced RTG"
 	build_path = /obj/machinery/power/rtg/advanced
 	req_components = list(
 		/obj/item/stack/cable_coil = 5,
@@ -256,14 +256,14 @@
 		/obj/item/stack/sheet/mineral/plasma = 5)
 
 /obj/item/circuitboard/machine/scanner_gate
-	name = "Scanner Gate (Machine Board)"
+	name = "Scanner Gate"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/scanner_gate
 	req_components = list(
 		/obj/item/stock_parts/scanning_module = 3)
 
 /obj/item/circuitboard/machine/smes
-	name = "SMES (Machine Board)"
+	name = "SMES"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/smes
 	req_components = list(
@@ -273,12 +273,12 @@
 	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high/empty)
 
 /obj/item/circuitboard/machine/techfab/department/engineering
-	name = "\improper Departmental Techfab - Engineering (Machine Board)"
+	name = "\improper Departmental Techfab - Engineering"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/rnd/production/techfab/department/engineering
 
 /obj/item/circuitboard/machine/thermomachine
-	name = "Thermomachine (Machine Board)"
+	name = "Thermomachine"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/atmospherics/components/unary/thermomachine/freezer
 	var/pipe_layer = PIPING_LAYER_DEFAULT
@@ -298,28 +298,28 @@
 	. += span_notice("It is set to layer [pipe_layer].")
 
 /obj/item/circuitboard/machine/HFR_fuel_input
-	name = "HFR Fuel Input (Machine Board)"
+	name = "HFR Fuel Input"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/atmospherics/components/unary/hypertorus/fuel_input
 	req_components = list(
 		/obj/item/stack/sheet/plasteel = 5)
 
 /obj/item/circuitboard/machine/HFR_waste_output
-	name = "HFR Waste Output (Machine Board)"
+	name = "HFR Waste Output"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/atmospherics/components/unary/hypertorus/waste_output
 	req_components = list(
 		/obj/item/stack/sheet/plasteel = 5)
 
 /obj/item/circuitboard/machine/HFR_moderator_input
-	name = "HFR Moderator Input (Machine Board)"
+	name = "HFR Moderator Input"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/atmospherics/components/unary/hypertorus/moderator_input
 	req_components = list(
 		/obj/item/stack/sheet/plasteel = 5)
 
 /obj/item/circuitboard/machine/HFR_core
-	name = "HFR core (Machine Board)"
+	name = "HFR core"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/atmospherics/components/unary/hypertorus/core
 	req_components = list(
@@ -328,14 +328,14 @@
 		/obj/item/stack/sheet/plasteel = 10)
 
 /obj/item/circuitboard/machine/HFR_corner
-	name = "HFR Corner (Machine Board)"
+	name = "HFR Corner"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/hypertorus/corner
 	req_components = list(
 		/obj/item/stack/sheet/plasteel = 5)
 
 /obj/item/circuitboard/machine/HFR_interface
-	name = "HFR Interface (Machine Board)"
+	name = "HFR Interface"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/hypertorus/interface
 	req_components = list(
@@ -344,7 +344,7 @@
 		/obj/item/stack/sheet/plasteel = 5)
 
 /obj/item/circuitboard/machine/crystallizer
-	name = "Crystallizer (Machine Board)"
+	name = "Crystallizer"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/atmospherics/components/binary/crystallizer
 	req_components = list(
@@ -353,7 +353,7 @@
 		/obj/item/stack/sheet/plasteel = 5)
 
 /obj/item/circuitboard/machine/bluespace_sender
-	name = "Bluespace Sender (Machine Board)"
+	name = "Bluespace Sender"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/atmospherics/components/unary/bluespace_sender
 	req_components = list(
@@ -364,7 +364,7 @@
 //Generic
 
 /obj/item/circuitboard/machine/circuit_imprinter
-	name = "Circuit Imprinter (Machine Board)"
+	name = "Circuit Imprinter"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/rnd/production/circuit_imprinter
 	req_components = list(
@@ -373,16 +373,16 @@
 		/obj/item/reagent_containers/glass/beaker = 2)
 
 /obj/item/circuitboard/machine/circuit_imprinter/offstation
-	name = "Ancient Circuit Imprinter (Machine Board)"
+	name = "Ancient Circuit Imprinter"
 	build_path = /obj/machinery/rnd/production/circuit_imprinter/offstation
 
 /obj/item/circuitboard/machine/circuit_imprinter/department
-	name = "Departmental Circuit Imprinter (Machine Board)"
+	name = "Departmental Circuit Imprinter"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/rnd/production/circuit_imprinter/department
 
 /obj/item/circuitboard/machine/holopad
-	name = "AI Holopad (Machine Board)"
+	name = "AI Holopad"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/holopad
 	req_components = list(/obj/item/stock_parts/capacitor = 1)
@@ -406,7 +406,7 @@
 		. += "There is a red light flashing next to the word \"secure\""
 
 /obj/item/circuitboard/machine/launchpad
-	name = "Bluespace Launchpad (Machine Board)"
+	name = "Bluespace Launchpad"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/launchpad
 	req_components = list(
@@ -415,7 +415,7 @@
 	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
 
 /obj/item/circuitboard/machine/protolathe
-	name = "Protolathe (Machine Board)"
+	name = "Protolathe"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/rnd/production/protolathe
 	req_components = list(
@@ -424,16 +424,16 @@
 		/obj/item/reagent_containers/glass/beaker = 2)
 
 /obj/item/circuitboard/machine/protolathe/offstation
-	name = "Ancient Protolathe (Machine Board)"
+	name = "Ancient Protolathe"
 	build_path = /obj/machinery/rnd/production/protolathe/offstation
 
 /obj/item/circuitboard/machine/protolathe/department
-	name = "Departmental Protolathe (Machine Board)"
+	name = "Departmental Protolathe"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/rnd/production/protolathe/department
 
 /obj/item/circuitboard/machine/reagentgrinder
-	name = "All-In-One Grinder (Machine Board)"
+	name = "All-In-One Grinder"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/reagentgrinder/constructed
 	req_components = list(
@@ -441,7 +441,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/smartfridge
-	name = "Smartfridge (Machine Board)"
+	name = "Smartfridge"
 	build_path = /obj/machinery/smartfridge
 	req_components = list(/obj/item/stock_parts/matter_bin = 1)
 	var/static/list/fridges_name_paths = list(/obj/machinery/smartfridge = "plant produce",
@@ -458,7 +458,7 @@
 /obj/item/circuitboard/machine/smartfridge/apply_default_parts(obj/machinery/smartfridge/smartfridge)
 	build_path = smartfridge.base_build_path
 	if(!fridges_name_paths.Find(build_path, fridges_name_paths))
-		name = "[initial(smartfridge.name)] (Machine Board)" //if it's a unique type, give it a unique name.
+		name = "[initial(smartfridge.name)]" //if it's a unique type, give it a unique name.
 		is_special_type = TRUE
 	return ..()
 
@@ -479,7 +479,7 @@
 
 
 /obj/item/circuitboard/machine/space_heater
-	name = "Space Heater (Machine Board)"
+	name = "Space Heater"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/space_heater/constructed
 	req_components = list(
@@ -489,7 +489,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/electrolyzer
-	name = "Electrolyzer (Machine Board)"
+	name = "Electrolyzer"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/electrolyzer
 	req_components = list(
@@ -502,7 +502,7 @@
 
 
 /obj/item/circuitboard/machine/techfab
-	name = "\improper Techfab (Machine Board)"
+	name = "\improper Techfab"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/rnd/production/techfab
 	req_components = list(
@@ -511,11 +511,11 @@
 		/obj/item/reagent_containers/glass/beaker = 2)
 
 /obj/item/circuitboard/machine/techfab/department
-	name = "\improper Departmental Techfab (Machine Board)"
+	name = "\improper Departmental Techfab"
 	build_path = /obj/machinery/rnd/production/techfab/department
 
 /obj/item/circuitboard/machine/vendor
-	name = "Custom Vendor (Machine Board)"
+	name = "Custom Vendor"
 	desc = "You can turn the \"brand selection\" dial using a screwdriver."
 	custom_premium_price = PAYCHECK_CREW * 1.5
 	build_path = /obj/machinery/vending/custom
@@ -582,7 +582,7 @@
 
 /obj/item/circuitboard/machine/vendor/proc/set_type(obj/machinery/vending/typepath)
 	build_path = typepath
-	name = "[vending_names_paths[build_path]] Vendor (Machine Board)"
+	name = "[vending_names_paths[build_path]] Vendor"
 	req_components = list(initial(typepath.refill_canister) = 1)
 
 /obj/item/circuitboard/machine/vendor/apply_default_parts(obj/machinery/machine)
@@ -593,21 +593,21 @@
 	return ..()
 
 /obj/item/circuitboard/machine/vending/donksofttoyvendor
-	name = "Donksoft Toy Vendor (Machine Board)"
+	name = "Donksoft Toy Vendor"
 	build_path = /obj/machinery/vending/donksofttoyvendor
 	req_components = list(
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/vending_refill/donksoft = 1)
 
 /obj/item/circuitboard/machine/vending/syndicatedonksofttoyvendor
-	name = "Syndicate Donksoft Toy Vendor (Machine Board)"
+	name = "Syndicate Donksoft Toy Vendor"
 	build_path = /obj/machinery/vending/toyliberationstation
 	req_components = list(
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/vending_refill/donksoft = 1)
 
 /obj/item/circuitboard/machine/bountypad
-	name = "Civilian Bounty Pad (Machine Board)"
+	name = "Civilian Bounty Pad"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/piratepad/civilian
 	req_components = list(
@@ -619,7 +619,7 @@
 //Medical
 
 /obj/item/circuitboard/machine/chem_dispenser
-	name = "Chem Dispenser (Machine Board)"
+	name = "Chem Dispenser"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/chem_dispenser
 	req_components = list(
@@ -652,7 +652,8 @@
 	)
 
 /obj/item/circuitboard/machine/chem_dispenser/abductor
-	name = "Reagent Synthesizer (Abductor Machine Board)"
+	name = "Reagent Synthesizer"
+	name_extension = "(Abductor Machine Board)"
 	icon_state = "abductor_mod"
 	build_path = /obj/machinery/chem_dispenser/abductor
 	req_components = list(
@@ -665,7 +666,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/chem_heater
-	name = "Chemical Heater (Machine Board)"
+	name = "Chemical Heater"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/chem_heater
 	req_components = list(
@@ -673,7 +674,7 @@
 		/obj/item/stack/sheet/glass = 1)
 
 /obj/item/circuitboard/machine/chem_mass_spec
-	name = "High-Performance Liquid Chromatography (Machine Board)"
+	name = "High-Performance Liquid Chromatography"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/chem_mass_spec
 	req_components = list(
@@ -681,7 +682,7 @@
 	/obj/item/stack/cable_coil = 5)
 
 /obj/item/circuitboard/machine/chem_master
-	name = "ChemMaster 3000 (Machine Board)"
+	name = "ChemMaster 3000"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/chem_master
 	desc = "You can turn the \"mode selection\" dial using a screwdriver."
@@ -700,12 +701,12 @@
 		new_path = /obj/machinery/chem_master/condimaster
 
 	build_path = new_path
-	name = "[new_name] 3000 (Machine Board)"
+	name = "[new_name] 3000"
 	to_chat(user, span_notice("You change the circuit board setting to \"[new_name]\"."))
 	return TRUE
 
 /obj/item/circuitboard/machine/cryo_tube
-	name = "Cryotube (Machine Board)"
+	name = "Cryotube"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/atmospherics/components/unary/cryo_cell
 	req_components = list(
@@ -714,20 +715,20 @@
 		/obj/item/stack/sheet/glass = 4)
 
 /obj/item/circuitboard/machine/fat_sucker
-	name = "Lipid Extractor (Machine Board)"
+	name = "Lipid Extractor"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/fat_sucker
 	req_components = list(/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/kitchen/fork = 1)
 
 /obj/item/circuitboard/machine/harvester
-	name = "Harvester (Machine Board)"
+	name = "Harvester"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/harvester
 	req_components = list(/obj/item/stock_parts/micro_laser = 4)
 
 /obj/item/circuitboard/machine/medical_kiosk
-	name = "Medical Kiosk (Machine Board)"
+	name = "Medical Kiosk"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/medical_kiosk
 	var/custom_cost = 10
@@ -751,7 +752,7 @@
 	. += "The cost to use this kiosk is set to [custom_cost]."
 
 /obj/item/circuitboard/machine/limbgrower
-	name = "Limb Grower (Machine Board)"
+	name = "Limb Grower"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/limbgrower
 	req_components = list(
@@ -760,7 +761,7 @@
 		/obj/item/stack/sheet/glass = 1)
 
 /obj/item/circuitboard/machine/limbgrower/fullupgrade
-	name = "Limb Grower (Machine Board)"
+	name = "Limb Grower"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/limbgrower
 	req_components = list(
@@ -769,12 +770,12 @@
 		/obj/item/stack/sheet/glass = 1)
 
 /obj/item/circuitboard/machine/protolathe/department/medical
-	name = "Departmental Protolathe - Medical (Machine Board)"
+	name = "Departmental Protolathe - Medical"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/rnd/production/protolathe/department/medical
 
 /obj/item/circuitboard/machine/sleeper
-	name = "Sleeper (Machine Board)"
+	name = "Sleeper"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/sleeper
 	req_components = list(
@@ -784,7 +785,7 @@
 		/obj/item/stack/sheet/glass = 2)
 
 /obj/item/circuitboard/machine/sleeper/fullupgrade
-	name = "Sleeper (Machine Board)"
+	name = "Sleeper"
 	icon_state = "medical"
 	build_path = /obj/machinery/sleeper/syndie/fullupgrade
 	req_components = list(
@@ -794,11 +795,11 @@
 		/obj/item/stack/sheet/glass = 2)
 
 /obj/item/circuitboard/machine/sleeper/party
-	name = "Party Pod (Machine Board)"
+	name = "Party Pod"
 	build_path = /obj/machinery/sleeper/party
 
 /obj/item/circuitboard/machine/smoke_machine
-	name = "Smoke Machine (Machine Board)"
+	name = "Smoke Machine"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/smoke_machine
 	req_components = list(
@@ -810,7 +811,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/stasis
-	name = "\improper Lifeform Stasis Unit (Machine Board)"
+	name = "\improper Lifeform Stasis Unit"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/stasis
 	req_components = list(
@@ -819,26 +820,26 @@
 		/obj/item/stock_parts/capacitor = 1)
 
 /obj/item/circuitboard/machine/medipen_refiller
-	name = "Medipen Refiller (Machine Board)"
+	name = "Medipen Refiller"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/medipen_refiller
 	req_components = list(
 		/obj/item/stock_parts/matter_bin = 1)
 
 /obj/item/circuitboard/machine/techfab/department/medical
-	name = "\improper Departmental Techfab - Medical (Machine Board)"
+	name = "\improper Departmental Techfab - Medical"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/rnd/production/techfab/department/medical
 
 //Science
 
 /obj/item/circuitboard/machine/circuit_imprinter/department/science
-	name = "Departmental Circuit Imprinter - Science (Machine Board)"
+	name = "Departmental Circuit Imprinter - Science"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rnd/production/circuit_imprinter/department/science
 
 /obj/item/circuitboard/machine/cyborgrecharger
-	name = "Cyborg Recharger (Machine Board)"
+	name = "Cyborg Recharger"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/recharge_station
 	req_components = list(
@@ -848,7 +849,7 @@
 	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
 
 /obj/item/circuitboard/machine/destructive_analyzer
-	name = "Destructive Analyzer (Machine Board)"
+	name = "Destructive Analyzer"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rnd/destructive_analyzer
 	req_components = list(
@@ -857,7 +858,7 @@
 		/obj/item/stock_parts/micro_laser = 1)
 
 /obj/item/circuitboard/machine/experimentor
-	name = "E.X.P.E.R.I-MENTOR (Machine Board)"
+	name = "E.X.P.E.R.I-MENTOR"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rnd/experimentor
 	req_components = list(
@@ -866,7 +867,7 @@
 		/obj/item/stock_parts/micro_laser = 2)
 
 /obj/item/circuitboard/machine/mech_recharger
-	name = "Mechbay Recharger (Machine Board)"
+	name = "Mechbay Recharger"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/mech_bay_recharge_port
 	req_components = list(
@@ -874,7 +875,7 @@
 		/obj/item/stock_parts/capacitor = 5)
 
 /obj/item/circuitboard/machine/mechfab
-	name = "Exosuit Fabricator (Machine Board)"
+	name = "Exosuit Fabricator"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/mecha_part_fabricator
 	req_components = list(
@@ -884,7 +885,7 @@
 		/obj/item/stack/sheet/glass = 1)
 
 /obj/item/circuitboard/machine/monkey_recycler
-	name = "Monkey Recycler (Machine Board)"
+	name = "Monkey Recycler"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/monkey_recycler
 	req_components = list(
@@ -893,17 +894,17 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/processor/slime
-	name = "Slime Processor (Machine Board)"
+	name = "Slime Processor"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/processor/slime
 
 /obj/item/circuitboard/machine/protolathe/department/science
-	name = "Departmental Protolathe - Science (Machine Board)"
+	name = "Departmental Protolathe - Science"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rnd/production/protolathe/department/science
 
 /obj/item/circuitboard/machine/quantumpad
-	name = "Quantum Pad (Machine Board)"
+	name = "Quantum Pad"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/quantumpad
 	req_components = list(
@@ -914,7 +915,7 @@
 	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
 
 /obj/item/circuitboard/machine/rdserver
-	name = "R&D Server (Machine Board)"
+	name = "R&D Server"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rnd/server
 	req_components = list(
@@ -922,12 +923,12 @@
 		/obj/item/stock_parts/scanning_module = 1)
 
 /obj/item/circuitboard/machine/techfab/department/science
-	name = "\improper Departmental Techfab - Science (Machine Board)"
+	name = "\improper Departmental Techfab - Science"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rnd/production/techfab/department/science
 
 /obj/item/circuitboard/machine/teleporter_hub
-	name = "Teleporter Hub (Machine Board)"
+	name = "Teleporter Hub"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/teleport/hub
 	req_components = list(
@@ -936,7 +937,7 @@
 	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
 
 /obj/item/circuitboard/machine/teleporter_station
-	name = "Teleporter Station (Machine Board)"
+	name = "Teleporter Station"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/teleport/station
 	req_components = list(
@@ -946,7 +947,7 @@
 	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
 
 /obj/item/circuitboard/machine/dnascanner
-	name = "DNA Scanner (Machine Board)"
+	name = "DNA Scanner"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/dna_scannernew
 	req_components = list(
@@ -957,7 +958,7 @@
 		/obj/item/stack/cable_coil = 2)
 
 /obj/item/circuitboard/machine/mechpad
-	name = "Mecha Orbital Pad (Machine Board)"
+	name = "Mecha Orbital Pad"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/mechpad
 	req_components = list()
@@ -965,26 +966,26 @@
 //Security
 
 /obj/item/circuitboard/machine/protolathe/department/security
-	name = "Departmental Protolathe - Security (Machine Board)"
+	name = "Departmental Protolathe - Security"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/rnd/production/protolathe/department/security
 
 /obj/item/circuitboard/machine/recharger
-	name = "Weapon Recharger (Machine Board)"
+	name = "Weapon Recharger"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/recharger
 	req_components = list(/obj/item/stock_parts/capacitor = 1)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/techfab/department/security
-	name = "\improper Departmental Techfab - Security (Machine Board)"
+	name = "\improper Departmental Techfab - Security"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/rnd/production/techfab/department/security
 
 //Service
 
 /obj/item/circuitboard/machine/biogenerator
-	name = "Biogenerator (Machine Board)"
+	name = "Biogenerator"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/biogenerator
 	req_components = list(
@@ -994,7 +995,7 @@
 		/obj/item/stack/sheet/glass = 1)
 
 /obj/item/circuitboard/machine/chem_dispenser/drinks
-	name = "Soda Dispenser (Machine Board)"
+	name = "Soda Dispenser"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/chem_dispenser/drinks
 
@@ -1009,7 +1010,7 @@
 	)
 
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer
-	name = "Booze Dispenser (Machine Board)"
+	name = "Booze Dispenser"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/chem_dispenser/drinks/beer
 
@@ -1024,33 +1025,33 @@
 	)
 
 /obj/item/circuitboard/machine/chem_master/condi
-	name = "CondiMaster 3000 (Machine Board)"
+	name = "CondiMaster 3000"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/chem_master/condimaster
 
 /obj/item/circuitboard/machine/deep_fryer
-	name = "Deep Fryer (Machine Board)"
+	name = "Deep Fryer"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/deepfryer
 	req_components = list(/obj/item/stock_parts/micro_laser = 1)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/griddle
-	name = "Griddle (Machine Board)"
+	name = "Griddle"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/griddle
 	req_components = list(/obj/item/stock_parts/micro_laser = 1)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/oven
-	name = "Oven (Machine Board)"
+	name = "Oven"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/oven
 	req_components = list(/obj/item/stock_parts/micro_laser = 1)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/dish_drive
-	name = "Dish Drive (Machine Board)"
+	name = "Dish Drive"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/dish_drive
 	req_components = list(
@@ -1077,7 +1078,7 @@
 	to_chat(user, span_notice("You [transmit ? "enable" : "disable"] the board's automatic disposal transmission."))
 
 /obj/item/circuitboard/machine/gibber
-	name = "Gibber (Machine Board)"
+	name = "Gibber"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/gibber
 	req_components = list(
@@ -1086,7 +1087,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/hydroponics
-	name = "Hydroponics Tray (Machine Board)"
+	name = "Hydroponics Tray"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/hydroponics/constructable
 	req_components = list(
@@ -1096,7 +1097,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/microwave
-	name = "Microwave (Machine Board)"
+	name = "Microwave"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/microwave
 	req_components = list(
@@ -1107,7 +1108,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/processor
-	name = "Food Processor (Machine Board)"
+	name = "Food Processor"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/processor
 	req_components = list(
@@ -1117,22 +1118,22 @@
 
 /obj/item/circuitboard/machine/processor/screwdriver_act(mob/living/user, obj/item/tool)
 	if(build_path == /obj/machinery/processor)
-		name = "Slime Processor (Machine Board)"
+		name = "Slime Processor"
 		build_path = /obj/machinery/processor/slime
 		to_chat(user, span_notice("Name protocols successfully updated."))
 	else
-		name = "Food Processor (Machine Board)"
+		name = "Food Processor"
 		build_path = /obj/machinery/processor
 		to_chat(user, span_notice("Defaulting name protocols."))
 	return TRUE
 
 /obj/item/circuitboard/machine/protolathe/department/service
-	name = "Departmental Protolathe - Service (Machine Board)"
+	name = "Departmental Protolathe - Service"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/rnd/production/protolathe/department/service
 
 /obj/item/circuitboard/machine/recycler
-	name = "Recycler (Machine Board)"
+	name = "Recycler"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/recycler
 	req_components = list(
@@ -1141,7 +1142,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/seed_extractor
-	name = "Seed Extractor (Machine Board)"
+	name = "Seed Extractor"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/seed_extractor
 	req_components = list(
@@ -1150,12 +1151,12 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/techfab/department/service
-	name = "\improper Departmental Techfab - Service (Machine Board)"
+	name = "\improper Departmental Techfab - Service"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/rnd/production/techfab/department/service
 
 /obj/item/circuitboard/machine/vendatray
-	name = "Vend-A-Tray (Machine Board)"
+	name = "Vend-A-Tray"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/structure/displaycase/forsale
 	req_components = list(
@@ -1164,7 +1165,7 @@
 //Supply
 
 /obj/item/circuitboard/machine/mining_equipment_vendor
-	name = "Mining Equipment Vendor (Machine Board)"
+	name = "Mining Equipment Vendor"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/mineral/equipment_vendor
 	req_components = list(
@@ -1172,11 +1173,11 @@
 		/obj/item/stock_parts/matter_bin = 3)
 
 /obj/item/circuitboard/machine/mining_equipment_vendor/golem
-	name = "Golem Ship Equipment Vendor (Machine Board)"
+	name = "Golem Ship Equipment Vendor"
 	build_path = /obj/machinery/mineral/equipment_vendor/golem
 
 /obj/item/circuitboard/machine/ore_redemption
-	name = "Ore Redemption (Machine Board)"
+	name = "Ore Redemption"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/mineral/ore_redemption
 	req_components = list(
@@ -1188,18 +1189,18 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/ore_silo
-	name = "Ore Silo (Machine Board)"
+	name = "Ore Silo"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/ore_silo
 	req_components = list()
 
 /obj/item/circuitboard/machine/protolathe/department/cargo
-	name = "Departmental Protolathe - Cargo (Machine Board)"
+	name = "Departmental Protolathe - Cargo"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/rnd/production/protolathe/department/cargo
 
 /obj/item/circuitboard/machine/stacking_machine
-	name = "Stacking Machine (Machine Board)"
+	name = "Stacking Machine"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/mineral/stacking_machine
 	req_components = list(
@@ -1207,7 +1208,7 @@
 		/obj/item/stock_parts/matter_bin = 2)
 
 /obj/item/circuitboard/machine/stacking_unit_console
-	name = "Stacking Machine Console (Machine Board)"
+	name = "Stacking Machine Console"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/mineral/stacking_unit_console
 	req_components = list(
@@ -1215,12 +1216,12 @@
 		/obj/item/stack/cable_coil = 5)
 
 /obj/item/circuitboard/machine/techfab/department/cargo
-	name = "\improper Departmental Techfab - Cargo (Machine Board)"
+	name = "\improper Departmental Techfab - Cargo"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/rnd/production/techfab/department/cargo
 
 /obj/item/circuitboard/machine/bepis
-	name = "BEPIS Chamber (Machine Board)"
+	name = "BEPIS Chamber"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/rnd/bepis
 	req_components = list(
@@ -1232,7 +1233,7 @@
 
 //Misc
 /obj/item/circuitboard/machine/sheetifier
-	name = "Sheet-meister 2000 (Machine Board)"
+	name = "Sheet-meister 2000"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/sheetifier
 	req_components = list(
@@ -1251,7 +1252,8 @@
 	icon_state = "abductor_mod"
 
 /obj/item/circuitboard/machine/abductor/core
-	name = "alien board (Void Core)"
+	name = "alien board"
+	name_extension = "(Void Core)"
 	build_path = /obj/machinery/power/rtg/abductor
 	req_components = list(
 		/obj/item/stock_parts/capacitor = 1,
@@ -1262,7 +1264,7 @@
 		/obj/item/stock_parts/micro_laser = /obj/item/stock_parts/micro_laser/quadultra)
 
 /obj/item/circuitboard/machine/hypnochair
-	name = "Enhanced Interrogation Chamber (Machine Board)"
+	name = "Enhanced Interrogation Chamber"
 	greyscale_colors = CIRCUIT_COLOR_SECURITY
 	build_path = /obj/machinery/hypnochair
 	req_components = list(
@@ -1271,7 +1273,7 @@
 	)
 
 /obj/item/circuitboard/machine/plumbing_receiver
-	name = "Chemical Recipient (Machine Board)"
+	name = "Chemical Recipient"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/plumbing/receiver
 	req_components = list(
@@ -1282,7 +1284,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/skill_station
-	name = "Skill Station (Machine Board)"
+	name = "Skill Station"
 	build_path = /obj/machinery/skill_station
 	req_components = list(
 		/obj/item/stock_parts/matter_bin = 2,
@@ -1291,7 +1293,7 @@
 	)
 
 /obj/item/circuitboard/machine/destructive_scanner
-	name = "Experimental Destructive Scanner (Machine Board)"
+	name = "Experimental Destructive Scanner"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/destructive_scanner
 	req_components = list(
@@ -1300,7 +1302,7 @@
 		/obj/item/stock_parts/manipulator = 2)
 
 /obj/item/circuitboard/machine/doppler_array
-	name = "Tachyon-Doppler Research Array (Machine Board)"
+	name = "Tachyon-Doppler Research Array"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/doppler_array
 	req_components = list(
@@ -1308,7 +1310,7 @@
 		/obj/item/stock_parts/scanning_module = 4)
 
 /obj/item/circuitboard/machine/exoscanner
-	name = "Exoscanner (Machine Board)"
+	name = "Exoscanner"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/exoscanner
 	req_components = list(
@@ -1316,7 +1318,7 @@
 		/obj/item/stock_parts/scanning_module = 4)
 
 /obj/item/circuitboard/machine/exodrone_launcher
-	name = "Exploration Drone Launcher (Machine Board)"
+	name = "Exploration Drone Launcher"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/exodrone_launcher
 	req_components = list(
@@ -1324,14 +1326,14 @@
 		/obj/item/stock_parts/scanning_module = 4)
 
 /obj/item/circuitboard/machine/ecto_sniffer
-	name = "Ectoscopic Sniffer (Machine Board)"
+	name = "Ectoscopic Sniffer"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/ecto_sniffer
 	req_components = list(
 		/obj/item/stock_parts/scanning_module = 1)
 
 /obj/item/circuitboard/machine/anomaly_refinery
-	name = "Anomaly Refinery (Machine Board)"
+	name = "Anomaly Refinery"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/research/anomaly_refinery
 	req_components = list(
@@ -1341,7 +1343,7 @@
 		)
 
 /obj/item/circuitboard/machine/tank_compressor
-	name = "Tank Compressor (Machine Board)"
+	name = "Tank Compressor"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/atmospherics/components/binary/tank_compressor
 	req_components = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

```
/obj/item/circuitboard/computer/libraryconsole/bookconsole
	name =  "Book Inventory Management Console (Machine Board)"
```

See there, it's named machine board but it is actually built on a computer frame.
We just had a PR that fixed other mistakes like this so I went and did a tiny refactor to how these circuitboards are named so the second part is automatic.

Added a new var called `name_extension` that applies an extension to the base `name`
`/obj/item/circuitboard/computer` have `(Computer Board)` as their extension.
`/obj/item/circuitboard/machine` have `(Machine Board)`

And you can overwrite this `name_extension` on the board itself like:

```
/obj/item/circuitboard/machine/chem_dispenser/abductor
	name = "Reagent Synthesizer"
	name_extension = "(Abductor Machine Board)"
```
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less issues in the future with new players confused on why the machine board doesn't work on the machine frame.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
fix:  The circuit board of the Book Inventory Management Console now use the correct name extension (Computer Board) instead of (Machine Board)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
