### PR TITLE
Balloonify and removes some `to_chat` spam for miners

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -80,7 +80,7 @@
 
 		TIMER_COOLDOWN_START(src, REF(user), tool_mine_speed)
 
-		balloon_alert(user, "start picking...")
+		balloon_alert(user, "picking...")
 
 		if(!I.use_tool(src, user, tool_mine_speed, volume=50))
 			TIMER_COOLDOWN_END(src, REF(user)) //if we fail we can start again immediately
@@ -100,7 +100,7 @@
 	TIMER_COOLDOWN_START(src, REF(user), hand_mine_speed)
 	var/skill_modifier = 1
 	skill_modifier = user?.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
-	balloon_alert(user, "start pulling out pieces...")
+	balloon_alert(user, "pulling out pieces...")
 	if(!do_after(user, hand_mine_speed * skill_modifier, target = src))
 		TIMER_COOLDOWN_END(src, REF(user)) //if we fail we can start again immediately
 		return
@@ -140,10 +140,9 @@
 	..()
 
 /turf/closed/mineral/attack_alien(mob/living/carbon/alien/user, list/modifiers)
-	balloon_alert(user, "digging into the rock...")
+	balloon_alert(user, "digging...")
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE)
 	if(do_after(user, 4 SECONDS, target = src))
-		balloon_alert(user, "finish digging")
 		gets_drilled(user)
 
 /turf/closed/mineral/attack_hulk(mob/living/carbon/human/H)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -80,13 +80,12 @@
 
 		TIMER_COOLDOWN_START(src, REF(user), tool_mine_speed)
 
-		to_chat(user, span_notice("You start picking..."))
+		balloon_alert(user, "start picking...")
 
 		if(!I.use_tool(src, user, tool_mine_speed, volume=50))
 			TIMER_COOLDOWN_END(src, REF(user)) //if we fail we can start again immediately
 			return
 		if(ismineralturf(src))
-			to_chat(user, span_notice("You finish cutting into the rock."))
 			gets_drilled(user, TRUE)
 			SSblackbox.record_feedback("tally", "pick_used_mining", 1, I.type)
 
@@ -101,12 +100,11 @@
 	TIMER_COOLDOWN_START(src, REF(user), hand_mine_speed)
 	var/skill_modifier = 1
 	skill_modifier = user?.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
-	to_chat(user, span_notice("You start pulling out pieces of [src]..."))
+	balloon_alert(user, "start pulling out pieces...")
 	if(!do_after(user, hand_mine_speed * skill_modifier, target = src))
 		TIMER_COOLDOWN_END(src, REF(user)) //if we fail we can start again immediately
 		return
 	if(ismineralturf(src))
-		to_chat(user, span_notice("You finish pulling apart [src]."))
 		gets_drilled(user)
 
 /turf/closed/mineral/attack_robot(mob/living/silicon/robot/user)
@@ -142,10 +140,10 @@
 	..()
 
 /turf/closed/mineral/attack_alien(mob/living/carbon/alien/user, list/modifiers)
-	to_chat(user, span_notice("You start digging into the rock..."))
+	balloon_alert(user, "digging into the rock...")
 	playsound(src, 'sound/effects/break_stone.ogg', 50, TRUE)
 	if(do_after(user, 4 SECONDS, target = src))
-		to_chat(user, span_notice("You tunnel into the rock."))
+		balloon_alert(user, "finish digging")
 		gets_drilled(user)
 
 /turf/closed/mineral/attack_hulk(mob/living/carbon/human/H)

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -71,12 +71,11 @@
 		if(!isturf(user.loc))
 			return
 
-		to_chat(user, span_notice("You start digging..."))
+		balloon_alert(user, "start digging...")
 
 		if(W.use_tool(src, user, 40, volume=50))
 			if(!can_dig(user))
 				return TRUE
-			to_chat(user, span_notice("You dig a hole."))
 			getDug()
 			SSblackbox.record_feedback("tally", "pick_used_mining", 1, W.type)
 			return TRUE

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -71,7 +71,7 @@
 		if(!isturf(user.loc))
 			return
 
-		balloon_alert(user, "start digging...")
+		balloon_alert(user, "digging...")
 
 		if(W.use_tool(src, user, 40, volume=50))
 			if(!can_dig(user))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -160,15 +160,15 @@
 		if(message)
 			if(tk_firing(user))
 				visible_message(
-								span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"),
-								blind_message = span_hear("You hear a gunshot!"),
-								vision_distance = COMBAT_MESSAGE_RANGE
+						span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"),
+						blind_message = span_hear("You hear a gunshot!"),
+						vision_distance = COMBAT_MESSAGE_RANGE
 				)
 			else if(pointblank)
 				user.visible_message(
-									span_danger("[user] fires [src] point blank at [pbtarget]!"),
-									span_danger("You fire [src] point blank at [pbtarget]!"),
-									span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget
+						span_danger("[user] fires [src] point blank at [pbtarget]!"),
+						span_danger("You fire [src] point blank at [pbtarget]!"),
+						span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget
 				)
 				to_chat(pbtarget, span_userdanger("[user] fires [src] point blank at you!"))
 				if(pb_knockback > 0 && ismob(pbtarget))
@@ -177,10 +177,10 @@
 					PBT.throw_at(throw_target, pb_knockback, 2)
 			else if(!tk_firing(user))
 				user.visible_message(
-									span_danger("[user] fires [src]!"),
-									blind_message = span_hear("You hear a gunshot!"),
-									vision_distance = COMBAT_MESSAGE_RANGE,
-									ignored_mobs = user
+						span_danger("[user] fires [src]!"),
+						blind_message = span_hear("You hear a gunshot!"),
+						vision_distance = COMBAT_MESSAGE_RANGE,
+						ignored_mobs = user
 				)
 
 /obj/item/gun/emp_act(severity)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -173,7 +173,6 @@
 					PBT.throw_at(throw_target, pb_knockback, 2)
 			else if(!tk_firing(user))
 				user.visible_message(span_danger("[user] fires [src]!"), \
-								span_danger("You fire [src]!"), \
 								span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE)
 
 /obj/item/gun/emp_act(severity)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -160,15 +160,15 @@
 		if(message)
 			if(tk_firing(user))
 				visible_message(
-				span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"),
-				blind_message = span_hear("You hear a gunshot!"),
-				vision_distance = COMBAT_MESSAGE_RANGE
+								span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"),
+								blind_message = span_hear("You hear a gunshot!"),
+								vision_distance = COMBAT_MESSAGE_RANGE
 				)
 			else if(pointblank)
 				user.visible_message(
-				span_danger("[user] fires [src] point blank at [pbtarget]!"),
-				span_danger("You fire [src] point blank at [pbtarget]!"),
-				span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget
+									span_danger("[user] fires [src] point blank at [pbtarget]!"),
+									span_danger("You fire [src] point blank at [pbtarget]!"),
+									span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget
 				)
 				to_chat(pbtarget, span_userdanger("[user] fires [src] point blank at you!"))
 				if(pb_knockback > 0 && ismob(pbtarget))
@@ -177,10 +177,10 @@
 					PBT.throw_at(throw_target, pb_knockback, 2)
 			else if(!tk_firing(user))
 				user.visible_message(
-				span_danger("[user] fires [src]!"),
-				blind_message = span_hear("You hear a gunshot!"),
-				vision_distance = COMBAT_MESSAGE_RANGE,
-				ignored_mobs = user
+									span_danger("[user] fires [src]!"),
+									blind_message = span_hear("You hear a gunshot!"),
+									vision_distance = COMBAT_MESSAGE_RANGE,
+									ignored_mobs = user
 				)
 
 /obj/item/gun/emp_act(severity)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -160,16 +160,16 @@
 		if(message)
 			if(tk_firing(user))
 				visible_message(
-					span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"),
-					blind_message = span_hear("You hear a gunshot!"),
-					vision_distance = COMBAT_MESSAGE_RANGE
-					)
+				span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"),
+				blind_message = span_hear("You hear a gunshot!"),
+				vision_distance = COMBAT_MESSAGE_RANGE
+				)
 			else if(pointblank)
 				user.visible_message(
-					span_danger("[user] fires [src] point blank at [pbtarget]!"),
-					span_danger("You fire [src] point blank at [pbtarget]!"),
-					span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget
-					)
+				span_danger("[user] fires [src] point blank at [pbtarget]!"),
+				span_danger("You fire [src] point blank at [pbtarget]!"),
+				span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget
+				)
 				to_chat(pbtarget, span_userdanger("[user] fires [src] point blank at you!"))
 				if(pb_knockback > 0 && ismob(pbtarget))
 					var/mob/PBT = pbtarget
@@ -177,11 +177,11 @@
 					PBT.throw_at(throw_target, pb_knockback, 2)
 			else if(!tk_firing(user))
 				user.visible_message(
-					span_danger("[user] fires [src]!"),
-					blind_message = span_hear("You hear a gunshot!"),
-					vision_distance = COMBAT_MESSAGE_RANGE,
-					ignored_mobs = user
-					)
+				span_danger("[user] fires [src]!"),
+				blind_message = span_hear("You hear a gunshot!"),
+				vision_distance = COMBAT_MESSAGE_RANGE,
+				ignored_mobs = user
+				)
 
 /obj/item/gun/emp_act(severity)
 	. = ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -159,21 +159,29 @@
 	if(!suppressed)
 		if(message)
 			if(tk_firing(user))
-				visible_message(span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"), \
-								blind_message = span_hear("You hear a gunshot!"), \
-								vision_distance = COMBAT_MESSAGE_RANGE)
+				visible_message(
+					span_danger("[src] fires itself[pointblank ? " point blank at [pbtarget]!" : "!"]"),
+					blind_message = span_hear("You hear a gunshot!"),
+					vision_distance = COMBAT_MESSAGE_RANGE
+					)
 			else if(pointblank)
-				user.visible_message(span_danger("[user] fires [src] point blank at [pbtarget]!"), \
-								span_danger("You fire [src] point blank at [pbtarget]!"), \
-								span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget)
+				user.visible_message(
+					span_danger("[user] fires [src] point blank at [pbtarget]!"),
+					span_danger("You fire [src] point blank at [pbtarget]!"),
+					span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE, pbtarget
+					)
 				to_chat(pbtarget, span_userdanger("[user] fires [src] point blank at you!"))
 				if(pb_knockback > 0 && ismob(pbtarget))
 					var/mob/PBT = pbtarget
 					var/atom/throw_target = get_edge_target_turf(PBT, user.dir)
 					PBT.throw_at(throw_target, pb_knockback, 2)
 			else if(!tk_firing(user))
-				user.visible_message(span_danger("[user] fires [src]!"), \
-								span_hear("You hear a gunshot!"), COMBAT_MESSAGE_RANGE)
+				user.visible_message(
+					span_danger("[user] fires [src]!"),
+					blind_message = span_hear("You hear a gunshot!"),
+					vision_distance = COMBAT_MESSAGE_RANGE,
+					ignored_mobs = user
+					)
 
 /obj/item/gun/emp_act(severity)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -15,6 +15,10 @@
 	var/max_mod_capacity = 100
 	var/list/modkits = list()
 
+/obj/item/gun/energy/recharge/kinetic_accelerator/shoot_with_empty_chamber(mob/living/user)
+	playsound(src, dry_fire_sound, 30, TRUE) //click sound but no to_chat message to cut on spam
+	return
+
 /obj/item/gun/energy/recharge/kinetic_accelerator/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
 		light_overlay_icon = 'icons/obj/guns/flashlights.dmi', \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Playing as miner and paying attention to the radio is pure pain, so many of your job related actions create useless spam messages inside your chat/radio tab (unless you split them, which creates other issues) so this PR changes a few of them:

1 - PKAs won't send a useless * click *  message to your chat window when it's not ready to fire. It already has a different and clear sound that does it's job.
2 - Guns won't send a message to your chat with "you shoot the gun". You clicked your mouse, you hear the sound, you see the projectile leave and you already get a message logged there with what you hit.
3 - Digging with a pickaxe/shovel/hand is a balloon alert and the message for when you finish digging a wall is removed as you just seen the wall of basalt disappear so you know what happened...
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As a miner most of your interaction with the station is over the radio, less useless spam on the chat tab will hopefully help make mining feel less like a single player game.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
qol: Miners rejoice! A few of the mostly useless and spammy messages that get send to your chat were changed to balloon alerts or straight up removed. Hopefully, you will have an easier time listening to the radio chatter now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
