### PR TITLE
Balloonify welders and extinguishers (and more later)

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -56,10 +56,10 @@
 //because you're expecting user input.
 /obj/item/airlock_painter/proc/can_use(mob/user)
 	if(!ink)
-		to_chat(user, span_warning("There is no toner cartridge installed in [src]!"))
+		balloon_alert(user, "no cartridge!")
 		return FALSE
 	else if(ink.charges < 1)
-		to_chat(user, span_warning("[src] is out of ink!"))
+		balloon_alert(user, "out of ink!")
 		return FALSE
 	else
 		return TRUE
@@ -211,7 +211,7 @@
 /obj/item/airlock_painter/decal/afterattack(atom/target, mob/user, proximity)
 	. = ..()
 	if(!proximity)
-		to_chat(user, span_notice("You need to get closer!"))
+		balloon_alert(user, "get closer!")
 		return
 
 	if(isfloorturf(target) && use_paint(user))

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -65,7 +65,7 @@
 		qdel(GetComponent(/datum/component/geiger_sound))
 
 	update_appearance(UPDATE_ICON)
-	to_chat(user, span_notice("[icon2html(src, user)] You switch [scanning ? "on" : "off"] [src]."))
+	balloon_alert(user, "switch [scanning ? "on" : "off"]")
 
 /obj/item/geiger_counter/afterattack(atom/target, mob/living/user, params)
 	. = ..()

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -70,8 +70,8 @@
 		to_chat(user, "<span class='info'>[M]'s biological structure is too complex for the health analyzer.")
 		return
 
-	user.visible_message(span_notice("[user] analyzes [M]'s vitals."), \
-						span_notice("You analyze [M]'s vitals."))
+	user.visible_message(span_notice("[user] analyzes [M]'s vitals."))
+	balloon_alert(user, "analyzing vitals")
 
 	switch (scanmode)
 		if (SCANMODE_HEALTH)

--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -25,10 +25,8 @@
 	add_fingerprint(user)
 	//no scanning if its a husk or DNA-less Species
 	if (!HAS_TRAIT(target, TRAIT_GENELESS) && !HAS_TRAIT(target, TRAIT_BADDNA))
-		user.visible_message(
-			span_notice("[user] analyzes [target]'s genetic sequence."),
-			span_notice("You analyze [target]'s genetic sequence.")
-			)
+		user.visible_message(span_notice("[user] analyzes [target]'s genetic sequence."))
+		balloon_alert(user, "sequence analyzed")
 		gene_scan(target, user)
 	else
 		user.visible_message(span_notice("[user] fails to analyze [target]'s genetic sequence."), span_warning("[target] has no readable genetic sequence!"))

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -113,7 +113,7 @@
 /obj/item/extinguisher/attack_self(mob/user)
 	safety = !safety
 	src.icon_state = "[sprite_name][!safety]"
-	to_chat(user, "<span class='infoplain'>The safety is [safety ? "on" : "off"].</span>")
+	balloon_alert(user, "safety is [safety ? "on" : "off"]")
 	return
 
 /obj/item/extinguisher/attack(mob/M, mob/living/user)

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -113,7 +113,7 @@
 /obj/item/extinguisher/attack_self(mob/user)
 	safety = !safety
 	src.icon_state = "[sprite_name][!safety]"
-	balloon_alert(user, "safety is [safety ? "on" : "off"]")
+	balloon_alert(user, "safety [safety ? "on" : "off"]")
 	return
 
 /obj/item/extinguisher/attack(mob/M, mob/living/user)
@@ -139,7 +139,7 @@
 /obj/item/extinguisher/proc/AttemptRefill(atom/target, mob/user)
 	if(istype(target, tanktype) && target.Adjacent(user))
 		if(reagents.total_volume == reagents.maximum_volume)
-			to_chat(user, span_warning("\The [src] is already full!"))
+			balloon_alert(user, "already full!")
 			return TRUE
 		var/obj/structure/reagent_dispensers/W = target //will it work?
 		var/transferred = W.reagents.trans_to(src, max_water, transfered_by = user)
@@ -169,7 +169,7 @@
 
 
 		if (src.reagents.total_volume < 1)
-			to_chat(usr, span_warning("\The [src] is empty!"))
+			balloon_alert(user, "it's empty!")
 			return
 
 		if (world.time < src.last_use + 12)

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -41,7 +41,6 @@
 	var/turf/target_turf = get_turf(target)
 	var/obj/structure/holosign/target_holosign = locate(holosign_type) in target_turf
 	if(target_holosign)
-		to_chat(user, span_notice("You use [src] to deactivate [target_holosign]."))
 		qdel(target_holosign)
 		return
 	if(target_turf.is_blocked_turf(TRUE)) //can't put holograms on a tile that has dense stuff
@@ -50,7 +49,7 @@
 		to_chat(user, span_notice("[src] is busy creating a hologram."))
 		return
 	if(LAZYLEN(signs) >= max_signs)
-		to_chat(user, span_notice("[src] is projecting at max capacity!"))
+		balloon_alert(user, "max capacity!")
 		return
 	playsound(loc, 'sound/machines/click.ogg', 20, TRUE)
 	if(creation_time)
@@ -64,7 +63,6 @@
 		if(target_turf.is_blocked_turf(TRUE)) //don't try to sneak dense stuff on our tile during the wait.
 			return
 	target_holosign = new holosign_type(get_turf(target), src)
-	to_chat(user, span_notice("You create \a [target_holosign] with [src]."))
 
 /obj/item/holosign_creator/attack(mob/living/carbon/human/M, mob/user)
 	return
@@ -73,7 +71,7 @@
 	if(LAZYLEN(signs))
 		for(var/H in signs)
 			qdel(H)
-		to_chat(user, span_notice("You clear all active holograms."))
+		balloon_alert(user, "holograms cleared")
 
 /obj/item/holosign_creator/Destroy()
 	. = ..()
@@ -151,4 +149,4 @@
 			return
 	for(var/sign in signs)
 		qdel(sign)
-	to_chat(user, span_notice("You clear all active holograms."))
+	balloon_alert(user, "holograms cleared")

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -51,11 +51,11 @@
 		return TRUE
 
 	if(!cell)
-		to_chat(user, span_warning("[src] doesn't have a power cell installed!"))
+		balloon_alert(user, "no cell installed!")
 		return TRUE
 
 	if(!cell.charge)
-		to_chat(user, span_warning("[src]'s battery is dead!"))
+		balloon_alert(user, "no charge!")
 		return TRUE
 	return FALSE
 
@@ -116,7 +116,7 @@
 	if(C)
 		var/done_any = FALSE
 		if(C.charge >= C.maxcharge)
-			to_chat(user, span_notice("[A] is fully charged!"))
+			balloon_alert(user, "it's fully charged!")
 			recharging = FALSE
 			return TRUE
 		user.visible_message(span_notice("[user] starts recharging [A] with [src]."), span_notice("You start recharging [A] with [src]."))

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -234,7 +234,6 @@
 	set_welding(!welding)
 	if(welding)
 		if(get_fuel() >= 1)
-			balloon_alert(user, "welder is lit")
 			playsound(loc, activation_sound, 50, TRUE)
 			force = 15
 			damtype = BURN
@@ -242,10 +241,9 @@
 			update_appearance()
 			START_PROCESSING(SSobj, src)
 		else
-			balloon_alert(user, "need more fuel!")
+			balloon_alert(user, "no fuel!")
 			switched_off(user)
 	else
-		balloon_alert(user, "welder is off")
 		playsound(loc, deactivation_sound, 50, TRUE)
 		switched_off(user)
 

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -234,7 +234,7 @@
 	set_welding(!welding)
 	if(welding)
 		if(get_fuel() >= 1)
-			to_chat(user, span_notice("You switch [src] on."))
+			balloon_alert(user, "welder is lit")
 			playsound(loc, activation_sound, 50, TRUE)
 			force = 15
 			damtype = BURN
@@ -242,10 +242,10 @@
 			update_appearance()
 			START_PROCESSING(SSobj, src)
 		else
-			to_chat(user, span_warning("You need more fuel!"))
+			balloon_alert(user, "need more fuel!")
 			switched_off(user)
 	else
-		to_chat(user, span_notice("You switch [src] off."))
+		balloon_alert(user, "welder is off")
 		playsound(loc, deactivation_sound, 50, TRUE)
 		switched_off(user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
List of things I changed:
1 - Airlock painter error messages (out of ink!) give you a balloon alert so it is easier to see why it failed.
2 - Balloon alert instead of chat message for the Geiger counter. Might be unnecessary because of the noise, I assume it is something small but that might be helpful for new players.
3 - Health/Gene Analyzers send a balloon alert on a successful scan instead of a `to_chat`.
Some instant feedback that the scan was successful is nice, even more for the gene analyzer when you're driving by scanning everyone you see.
4 - Error messages for extinguishers (it's empty!) are balloon alerts.
5 - Error messages for the holosign projectors (max capacity!") are balloon alerts and I removed the `to_chat` about creating and deleting barriers as it is something quite visible in the world.
6 - Error messages for the inducers ("no charge!") are balloon alerts.
7 - Error messages for the welding tools ("no fuel!") are balloon alerts and I removed the unnecessary `to_chat` about being turned on/off as it has a distinct sound effect and icon change.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less spam on the chat tab gives room for radio chatter which is good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
qol: Airlock painter, extinguishers, geiger counter, holosign projectors, inducers and welding tools use balloon alerts on some of their more spammy/error actions and have some useless `to_chat` messages removed.
qol: Health and Gene analyzers give a balloon alert on a successful scan.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
