### PR TITLE
Dynamic 2022 part 1 tweaks

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -100,7 +100,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// Basically, if this is set to 5, then for every 5 threat, one midround roll will be added.
 	/// The equation this is used in rounds up, meaning that if this is set to 5, and you have 6
 	/// threat, then you will get 2 midround rolls.
-	var/threat_per_midround_roll = 6.5
+	var/threat_per_midround_roll = 7
 
 	/// A number between -5 and +5.
 	/// A negative value will give a more peaceful round and
@@ -157,10 +157,10 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// The maximum threat that can roll with *zero* players.
 	/// As the number of players approaches `low_pop_player_threshold`, the maximum
 	/// threat level will increase.
-	/// For example, if `low_pop_minimum_threat` is 50, `low_pop_player_threshold` is 20,
+	/// For example, if `low_pop_maximum_threat` is 50, `low_pop_player_threshold` is 20,
 	/// and the number of readied players is 10, then the highest threat that can roll is
 	/// lerp(50, 100, 10 / 20), AKA 75.
-	var/low_pop_minimum_threat = 50
+	var/low_pop_maximum_threat = 40
 
 	/// The chance for latejoins to roll when ready
 	var/latejoin_roll_chance = 50
@@ -367,7 +367,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	threat_level = clamp(round(lorentz_to_amount(relative_threat), 0.1), 0, max_threat_level)
 
 	if (SSticker.totalPlayersReady < low_pop_player_threshold)
-		threat_level = min(threat_level, LERP(low_pop_minimum_threat, max_threat_level, SSticker.totalPlayersReady / low_pop_player_threshold))
+		threat_level = min(threat_level, LERP(low_pop_maximum_threat, max_threat_level, SSticker.totalPlayersReady / low_pop_player_threshold))
 
 	peaceful_percentage = round(LORENTZ_CUMULATIVE_DISTRIBUTION(relative_threat, threat_curve_centre, threat_curve_width), 0.01)*100
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -27,7 +27,7 @@
 	cost = 8 // Avoid raising traitor threat above this, as it is the default low cost ruleset.
 	scaling_cost = 9
 	requirements = list(8,8,8,8,8,8,8,8,8,8)
-	antag_cap = list("denominator" = 24)
+	antag_cap = list("denominator" = 38)
 	var/autotraitor_cooldown = (15 MINUTES)
 
 /datum/dynamic_ruleset/roundstart/traitor/pre_execute(population)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. Renames `low_pop_minimum_threat` to `low_pop_maximum_threat`. Untested but it'll fail CI if it doesn't work
2. Increases `threat_per_midround_roll` from 6.5 to 7, to slightly shift number of midrounds.
3. Lowered the number of roundstart traitors. I intend to do more in the larger part 2 PR, but the crux of it is that Dynamic 2022 part 1 creates a lot of midround traitors, which is great, but now that means we can lower the amount of total roundstart traitors. This changes it from 1 traitor every 24 people to 38. Eventually I want to make traitor not scale so hard, but it'll be tough to do that *and* make sure it doesn't just roll extremely chaotic rulesets in its place.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The amount of midround threat required for a midround roll has increased slightly from 6.5 to 7.
balance: Lowered the maximum threat level on sub-20 pop.
balance: Lowered the number of roundstart traitors.
server: Fixed "low_pop_minimum_threat" being incorrectly named. It has been changed to "low_pop_maximum_threat".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
