### PR TITLE
Adds player requirement for structural weakpoint traitor objective

### DIFF
--- a/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
+++ b/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
@@ -1,3 +1,6 @@
+/// The minimum number of ghosts and players needed before handing out objective.
+#define MIN_PLAYERS_FOR_OBJECTIVE 35
+
 /datum/traitor_objective_category/locate_weakpoint
 	name = "Locate And Destroy Weakpoint"
 	objectives = list(
@@ -8,7 +11,7 @@
 	name = "Triangulate station's structural weakpoint and detonate an explosive charge nearby."
 	description = "You will be given a handheld device that you'll need to use in %AREA1% and %AREA2% in order to triangulate the station's structural weakpoint and detonate an explosive charge there. Warning: Once you start scanning either one of the areas, station's AI will be alerted."
 
-	progression_minimum = 45 MINUTES
+	progression_minimum = 50 MINUTES
 	progression_reward = list(15 MINUTES, 20 MINUTES)
 	telecrystal_reward = list(3, 5)
 
@@ -26,6 +29,12 @@
 /datum/traitor_objective/locate_weakpoint/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	////if(handler.get_completion_progression(/datum/traitor_objective) < progression_objectives_minimum)
 	////	return FALSE
+
+	// Check how many alive players + dead players there are.
+	// If the 35+ requirement is not met objective wont pop up,
+	var/num_players = length(GLOB.alive_player_list) + length(GLOB.dead_player_list)
+	if(num_players < MIN_PLAYERS_FOR_OBJECTIVE)
+		return FALSE
 
 	if(!SStraitor.station_weakpoints || !LAZYLEN(SStraitor.station_weakpoints)) //This means that the weakpoint has already been hit
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://tgstation13.org/phpBB/viewtopic.php?f=10&t=31908&sid=9da8c418657700396f77418d106766af

Adds a 35+ player requirement to the objective and ups time from 45 to 50 min.
When construction is made less annoying it can be made more common but as is people seem to dislike it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Too much destruction on low pop shifts, makes it so it only pops when theres an adequate amount of players.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Added 35+ population requirement to locate weakpoint objective
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
