### PR TITLE
Fixes kilo xenobio and medical sec post

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -21307,6 +21307,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/landmark/start/depsec/medical,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "fZk" = (
@@ -40819,6 +40822,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "lAA" = (
@@ -44689,9 +44693,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "mHm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/landmark/start/depsec/medical,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -44703,6 +44704,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/checkpoint/medical)
 "mHq" = (
@@ -49491,7 +49493,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "odd" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/machinery/door/airlock/research{
 	glass = 1;
@@ -50899,6 +50900,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/checkpoint/medical)


### PR DESCRIPTION
## About The Pull Request

Removes a firelock from the Kilostation's Xenobiology kill room (so now it no longer has constant firelocks roundstart), and adds a scrubber to the Medical security post, since it only had a vent.

## Why It's Good For The Game

this map sucks where's pubbystation
Fixes the station a little bit.

## Changelog

:cl:
fix: Kilostation's Xenobiology is no longer roundstart on firelocks, and the security medical post now has a scrubber.
/:cl: