### PR TITLE
Fixes wizard's spellbook becoming inaccessible

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -686,9 +686,9 @@
 /obj/item/spellbook/attack_self(mob/user)
 	if(!owner)
 		to_chat(user, span_notice("You bind the spellbook to yourself."))
-		owner = user
+		owner = user.mind
 		return
-	if(user != owner)
+	if(user.mind != owner)
 		if(user.mind.special_role == ROLE_WIZARD_APPRENTICE)
 			to_chat(user, "If you got caught sneaking a peek from your teacher's spellbook, you'd likely be expelled from the Wizard Academy. Better not.")
 		else

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -698,7 +698,7 @@
 		else
 			to_chat(user, span_warning("The [name] does not recognize you as its owner and refuses to open!"))
 		return
-	. = ..()
+	return ..()
 
 /obj/item/spellbook/attackby(obj/item/O, mob/user, params)
 	if(!can_refund)

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -687,6 +687,8 @@
 
 /obj/item/spellbook/attack_self(mob/user)
 	if(!owner)
+		if(!user.mind)
+			return
 		to_chat(user, span_notice("You bind the spellbook to yourself."))
 		owner = user.mind
 		return

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -647,7 +647,9 @@
 	/// Determines if this spellbook can refund anything.
 	var/can_refund = TRUE
 
-	var/mob/living/carbon/human/owner
+	/// The mind that first used the book. Automatically assigned when a wizard spawns.
+	var/datum/mind/owner
+
 	var/list/entries = list()
 
 /obj/item/spellbook/examine(mob/user)

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -329,13 +329,13 @@
 	r_pocket = /obj/item/teleportation_scroll
 	l_hand = /obj/item/staff
 
-/datum/outfit/wizard/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/wizard/post_equip(mob/living/carbon/human/wizard, visualsOnly = FALSE)
 	if(visualsOnly)
 		return
 
-	var/obj/item/spellbook/S = locate() in H.back
-	if(S)
-		S.owner = H
+	var/obj/item/spellbook/spellbook = locate() in wizard.back
+	if(spellbook)
+		spellbook.owner = wizard.mind
 
 /datum/outfit/wizard/apprentice
 	name = "Wizard Apprentice"

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -333,9 +333,9 @@
 	if(visualsOnly)
 		return
 
-	var/obj/item/spellbook/spellbook = locate() in wizard.back
-	if(spellbook)
-		spellbook.owner = wizard.mind
+	var/obj/item/spellbook/new_spellbook = locate() in wizard.back
+	if(new_spellbook)
+		new_spellbook.owner = wizard.mind
 
 /datum/outfit/wizard/apprentice
 	name = "Wizard Apprentice"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Wizard spellbooks have a mechanic that binds the book to their first user, so other people can't use it. However, it binds the spellbook to the wizard's body, not their mind. This makes it so the spellbook is inaccessible to the wizard after becoming a lich or mindswapping, which doesn't seem to be intended. The PR just makes the spellbook check for the mind, not the body, to fix this. Fixes #64927 and #56216

## Why It's Good For The Game

Wizards shouldn't be punished for using their own tools, nor does it seem to be said anywhere that mindswaps and lichdom make your spellbook inaccessible. Fixes the bug.

## Changelog

:cl:
fix: switching bodies, such as becoming a lich or mindswapping will no longer revoke a wizard's access to their spell book
/:cl: