### PR TITLE
Fixes some soulstone issues, overall makes soulstone behavior more consistent

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -342,13 +342,11 @@ structure_check() searches for nearby cultist structures required for the invoca
 		return TRUE
 	var/obj/item/soulstone/stone = new /obj/item/soulstone(get_turf(src))
 	if(sacrificial.mind && !sacrificial.suiciding)
-		stone.invisibility = INVISIBILITY_MAXIMUM //so it's not picked up during transfer_soul()
 		stone.capture_soul(sacrificial, first_invoker, TRUE)
-		stone.invisibility = 0
 
 	if(sacrificial)
 		playsound(sacrificial, 'sound/magic/disintegrate.ogg', 100, TRUE)
-		sacrificial.gib(TRUE)
+		sacrificial.gib()
 	return TRUE
 
 /obj/effect/rune/empower

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -125,9 +125,11 @@
 	RegisterSignal(src, COMSIG_BIBLE_SMACKED)
 	return TRUE
 
+/// Checks if the passed mob has the required antag datum set on the soulstone.
 /obj/item/soulstone/proc/role_check(mob/who)
 	return required_role ? (who.mind && who.mind.has_antag_datum(required_role, TRUE)) : TRUE
 
+/// Called whenever the soulstone releases a shade from it.
 /obj/item/soulstone/proc/on_release_spirits()
 	if(!one_use)
 		return
@@ -360,6 +362,14 @@
 		return FALSE
 	return TRUE
 
+/**
+ * Creates a new shade mob to inhabit the stone.
+ *
+ * victim - the body that's being shaded
+ * user - the person doing the shading. Optional.
+ * message_user - if TRUE, we send the user (if present) a message that a shade has been created / captured.
+ * shade_controller - the mob (usually, a ghost) that will take over control of the victim / new shade. Optional, if not passed the victim itself will take control.
+ */
 /obj/item/soulstone/proc/init_shade(mob/living/carbon/human/victim, mob/user, message_user = FALSE, mob/shade_controller)
 	if(!shade_controller)
 		shade_controller = victim
@@ -394,6 +404,17 @@
 
 	victim.dust(drop_items = TRUE)
 
+/**
+ * Gets a ghost from dead chat to replace a missing player when a shade is created.
+ *
+ * Gets ran if a soulstone is used on a body that has no client to take over the shade.
+ *
+ * victim - the body that's being shaded
+ * user - the mob shading the body
+ *
+ * Returns FALSE if no ghosts are available or the replacement fails.
+ * Returns TRUE otherwise.
+ */
 /obj/item/soulstone/proc/get_ghost_to_replace_shade(mob/living/carbon/victim, mob/user)
 	var/mob/dead/observer/chosen_ghost
 	var/list/consenting_candidates = poll_ghost_candidates("Would you like to play as a Shade?", "Cultist", ROLE_CULTIST, 5 SECONDS, POLL_IGNORE_SHADE)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -315,8 +315,8 @@
 	return TRUE //it'll probably get someone ;)
 
 ///captures a shade that was previously released from a soulstone.
-/obj/item/soulstone/proc/capture_shade(mob/living/simple_animal/shade/shade, mob/user)
-	if(user && !role_check(user))
+/obj/item/soulstone/proc/capture_shade(mob/living/simple_animal/shade/shade, mob/living/user)
+	if(isliving(user) && !role_check(user))
 		user.Unconscious(10 SECONDS)
 		to_chat(user, span_userdanger("Your body is wracked with debilitating pain!"))
 		return

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -168,7 +168,7 @@
 
 /obj/item/soulstone/attack(mob/living/carbon/human/M, mob/living/user)
 	if(!role_check(user))
-		user.Unconscious(100)
+		user.Unconscious(10 SECONDS)
 		to_chat(user, span_userdanger("Your body is wracked with debilitating pain!"))
 		return
 	if(spent)
@@ -176,6 +176,8 @@
 		return
 	if(!ishuman(M))//If target is not a human.
 		return ..()
+	if(M == user)
+		return
 	if(IS_CULTIST(M) && IS_CULTIST(user))
 		to_chat(user, span_cultlarge("\"Come now, do not capture your bretheren's soul.\""))
 		return
@@ -314,6 +316,10 @@
 
 ///captures a shade that was previously released from a soulstone.
 /obj/item/soulstone/proc/capture_shade(mob/living/simple_animal/shade/shade, mob/user)
+	if(user && !role_check(user))
+		user.Unconscious(10 SECONDS)
+		to_chat(user, span_userdanger("Your body is wracked with debilitating pain!"))
+		return
 	if(contents.len)
 		to_chat(user, "[span_userdanger("Capture failed!")]: [src] is full! Free an existing soul to make room.")
 		return FALSE

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -9,10 +9,16 @@
 	desc = "A fragment of the legendary treasure known simply as the 'Soul Stone'. The shard still flickers with a fraction of the full artefact's power."
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = ITEM_SLOT_BELT
+	/// if TRUE, we can only be used once.
 	var/one_use = FALSE
-	var/grab_sleeping = TRUE
+	/// Only used if one_use is TRUE. Whether it's used.
 	var/spent = FALSE
-	/// This controls the color of the soulstone as well as restrictions for who can use it. THEME_CULT is red and is the default of cultist THEME_WIZARD is purple and is the default of wizard and THEME_HOLY is for purified soul stone
+	/// if TRUE, our soulstone will work on mobs which are in crit. if FALSE, the mob must be dead.
+	var/grab_sleeping = TRUE
+	/// This controls the color of the soulstone as well as restrictions for who can use it.
+	/// THEME_CULT is red and is the default of cultist
+	/// THEME_WIZARD is purple and is the default of wizard
+	/// THEME_HOLY is for purified soul stone
 	var/theme = THEME_CULT
 	/// Role check, if any needed
 	var/required_role = /datum/antagonist/cult
@@ -21,6 +27,55 @@
 	. = ..()
 	if(theme != THEME_HOLY)
 		RegisterSignal(src, COMSIG_BIBLE_SMACKED, .proc/on_bible_smacked)
+
+/obj/item/soulstone/update_appearance(updates)
+	. = ..()
+	for(var/mob/living/simple_animal/shade/sharded_shade in src)
+		switch(theme)
+			if(THEME_HOLY)
+				sharded_shade.name = "Purified [sharded_shade.real_name]"
+				sharded_shade.icon_state = "shade_holy"
+				sharded_shade.loot = list(/obj/item/ectoplasm/angelic)
+			if(THEME_CULT)
+				sharded_shade.name = sharded_shade.real_name
+				sharded_shade.icon_state = "shade_cult"
+				sharded_shade.loot = list(/obj/item/ectoplasm)
+			if(THEME_WIZARD)
+				sharded_shade.name = sharded_shade.real_name
+				sharded_shade.icon_state = "shade_wizard"
+				sharded_shade.loot = list(/obj/item/ectoplasm/mystic)
+
+/obj/item/soulstone/update_icon_state()
+	. = ..()
+	switch(theme)
+		if(THEME_HOLY)
+			icon_state = "purified_soulstone"
+		if(THEME_CULT)
+			icon_state = "soulstone"
+		if(THEME_WIZARD)
+			icon_state = "mystic_soulstone"
+
+	if(contents.len)
+		icon_state = "[icon_state]2"
+
+/obj/item/soulstone/update_name(updates)
+	. = ..()
+	if(spent)
+		name = "dull [name]"
+		return
+
+	var/mob/living/simple_animal/shade/shade = locate() in src
+	if(shade)
+		name = "[name]: [shade.real_name]"
+	else
+		name = initial(name)
+
+/obj/item/soulstone/update_desc(updates)
+	. = ..()
+	if(spent)
+		desc = "A fragment of the legendary treasure known simply as \
+			the 'Soul Stone'. The shard lies still, dull and lifeless; \
+			whatever spark it once held long extinguished."
 
 ///signal called whenever a soulstone is smacked by a bible
 /obj/item/soulstone/proc/on_bible_smacked(datum/source, mob/living/user, direction)
@@ -38,21 +93,17 @@
 	if(IS_CULTIST(exorcist) || theme == THEME_HOLY)
 		return
 	balloon_alert(exorcist, span_notice("exorcising [src]..."))
-	playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,TRUE)
+	playsound(src, 'sound/hallucinations/veryfar_noise.ogg', 40, TRUE)
 	if(!do_after(exorcist, 4 SECONDS, target = src))
 		return
-	playsound(src,'sound/effects/pray_chaplain.ogg',60,TRUE)
+	playsound(src, 'sound/effects/pray_chaplain.ogg', 60, TRUE)
 	required_role = null
 	theme = THEME_HOLY
-	icon_state = "purified_soulstone"
-	for(var/mob/mob_cultist in contents)
-		if(!mob_cultist.mind)
-			continue
-		icon_state = "purified_soulstone2"
-		mob_cultist.mind.remove_antag_datum(/datum/antagonist/cult)
-	for(var/mob/living/simple_animal/shade/sharded_shade in src)
-		sharded_shade.icon_state = "ghost1"
-		sharded_shade.name = "Purified [sharded_shade.real_name]"
+
+	update_appearance()
+	for(var/mob/shade_to_deconvert in contents)
+		shade_to_deconvert.mind?.remove_antag_datum(/datum/antagonist/cult)
+
 	exorcist.visible_message(span_notice("[exorcist] purifies [src]!"))
 	UnregisterSignal(src, COMSIG_BIBLE_SMACKED)
 
@@ -62,65 +113,27 @@
 /obj/item/soulstone/proc/corrupt()
 	if(theme == THEME_CULT)
 		return FALSE
-	required_role = null
+
+	required_role = /datum/antagonist/cult
 	theme = THEME_CULT
-	icon_state = "soulstone"
+	update_appearance()
 	for(var/mob/shade_to_convert in contents)
-		if(!shade_to_convert.mind)
-			continue
-		icon_state = "soulstone2"
 		if(IS_CULTIST(shade_to_convert))
 			continue
-		shade_to_convert.mind.add_antag_datum(/datum/antagonist/cult)
-	for(var/mob/living/simple_animal/shade/sharded_shade in src)
-		sharded_shade.icon_state = "shade_cult"
-		sharded_shade.name = sharded_shade.real_name
+		shade_to_convert.mind?.add_antag_datum(/datum/antagonist/cult)
+
 	RegisterSignal(src, COMSIG_BIBLE_SMACKED)
 	return TRUE
 
 /obj/item/soulstone/proc/role_check(mob/who)
 	return required_role ? (who.mind && who.mind.has_antag_datum(required_role, TRUE)) : TRUE
 
-/obj/item/soulstone/proc/was_used()
-	if(one_use)
-		spent = TRUE
-		name = "dull [name]"
-		desc = "A fragment of the legendary treasure known simply as \
-			the 'Soul Stone'. The shard lies still, dull and lifeless; \
-			whatever spark it once held long extinguished."
+/obj/item/soulstone/proc/on_release_spirits()
+	if(!one_use)
+		return
 
-/obj/item/soulstone/anybody
-	required_role = null
-
-/obj/item/soulstone/mystic
-	icon_state = "mystic_soulstone"
-	theme = THEME_WIZARD
-	required_role = /datum/antagonist/wizard
-
-/obj/item/soulstone/anybody/revolver
-	one_use = TRUE
-	grab_sleeping = FALSE
-
-/obj/item/soulstone/anybody/purified
-	icon_state = "purified_soulstone"
-	theme = THEME_HOLY
-
-/obj/item/soulstone/anybody/chaplain
-	name = "mysterious old shard"
-	one_use = TRUE
-	grab_sleeping = FALSE
-
-/obj/item/soulstone/anybody/chaplain/sparring
-	icon_state = "purified_soulstone"
-	theme = THEME_HOLY
-
-/obj/item/soulstone/anybody/chaplain/sparring/Initialize(mapload)
-	. = ..()
-	name = "[GLOB.deity]'s punishment"
-	desc = "A prison for those who lost [GLOB.deity]'s game."
-
-/obj/item/soulstone/anybody/mining
-	grab_sleeping = FALSE
+	spent = TRUE
+	update_appearance()
 
 /obj/item/soulstone/pickup(mob/living/user)
 	..()
@@ -190,28 +203,21 @@
 	release_shades(user)
 
 /obj/item/soulstone/proc/release_shades(mob/user, silent = FALSE)
-	for(var/mob/living/simple_animal/shade/A in src)
-		A.forceMove(get_turf(user))
-		A.cancel_camera()
-		switch(theme)
-			if(THEME_HOLY)
-				icon_state = "purified_soulstone"
-				A.icon_state = "shade_holy"
-				A.name = "Purified [A.real_name]"
-				A.loot = list(/obj/item/ectoplasm/angelic)
-			if(THEME_WIZARD)
-				icon_state = "mystic_soulstone"
-				A.icon_state = "shade_wizard"
-				A.loot = list(/obj/item/ectoplasm/mystic)
-			if(THEME_CULT)
-				icon_state = "soulstone"
-		name = initial(name)
+	for(var/mob/living/simple_animal/shade/captured_shade in src)
+		captured_shade.forceMove(get_turf(user))
+		captured_shade.cancel_camera()
+		update_appearance()
 		if(!silent)
 			if(IS_CULTIST(user))
-				to_chat(A, "<b>You have been released from your prison, but you are still bound to the cult's will. Help them succeed in their goals at all costs.</b>")
+				to_chat(captured_shade, span_bold("You have been released from your prison, \
+					but you are still bound to the cult's will. Help them succeed in their goals at all costs."))
+
 			else if(role_check(user))
-				to_chat(A, "<b>You have been released from your prison, but you are still bound to [user.real_name]'s will. Help [user.p_them()] succeed in [user.p_their()] goals at all costs.</b>")
-		was_used()
+				to_chat(captured_shade, span_bold("You have been released from your prison, \
+					but you are still bound to [user.real_name]'s will. Help [user.p_them()] succeed in \
+					[user.p_their()] goals at all costs."))
+
+		on_release_spirits()
 
 /obj/item/soulstone/pre_attack(atom/A, mob/living/user, params)
 	var/mob/living/simple_animal/shade/occupant = (locate() in src)
@@ -277,28 +283,34 @@
 
 /// Procs for moving soul in and out off stone
 
-/// transfer the mind of a carbon mob (which is then dusted) into a shade mob inside src. If forced, sacrifical and stat checks are skipped.
+/// Transfer the mind of a carbon mob (which is then dusted) into a shade mob inside src.
+/// If forced, sacrifical and stat checks are skipped.
 /obj/item/soulstone/proc/capture_soul(mob/living/carbon/victim, mob/user, forced = FALSE)
 	if(!iscarbon(victim)) //TODO: Add sacrifice stoning for non-organics, just because you have no body doesnt mean you dont have a soul
 		return FALSE
-	if(!forced)
-		var/datum/antagonist/cult/C = user?.mind?.has_antag_datum(/datum/antagonist/cult,TRUE)
-		if(C?.cult_team.is_sacrifice_target(victim.mind))
-			to_chat(user, span_cult("<b>\"This soul is mine.</b></span> <span class='cultlarge'>SACRIFICE THEM!\""))
-			return FALSE
 	if(contents.len)
 		return FALSE
-	if(!forced && (grab_sleeping ? victim.stat == CONSCIOUS : victim.stat != DEAD))
-		to_chat(user, "[span_userdanger("Capture failed!")]: Kill or maim the victim first!")
-		return FALSE
+
+	if(!forced)
+		var/datum/antagonist/cult/cultist = IS_CULTIST(user)
+		if(cultist)
+			var/datum/team/cult/cult_team = cultist.get_team()
+			if(cult_team.is_sacrifice_target(victim.mind))
+				to_chat(user, span_cult("<b>\"This soul is mine.</b></span> <span class='cultlarge'>SACRIFICE THEM!\""))
+				return FALSE
+
+		if(grab_sleeping ? victim.stat == CONSCIOUS : victim.stat != DEAD)
+			to_chat(user, "[span_userdanger("Capture failed!")]: Kill or maim the victim first!")
+			return FALSE
+
+	victim.grab_ghost()
 	if(victim.client)
-		victim.unequip_everything()
 		init_shade(victim, user)
 		return TRUE
-	else
-		to_chat(user, "[span_userdanger("Capture failed!")]: The soul has already fled its mortal frame. You attempt to bring it back...")
-		INVOKE_ASYNC(src, .proc/getCultGhost, victim, user)
-		return TRUE //it'll probably get someone ;)
+
+	to_chat(user, "[span_userdanger("Capture failed!")]: The soul has already fled its mortal frame. You attempt to bring it back...")
+	INVOKE_ASYNC(src, .proc/get_ghost_to_replace_shade, victim, user)
+	return TRUE //it'll probably get someone ;)
 
 ///captures a shade that was previously released from a soulstone.
 /obj/item/soulstone/proc/capture_shade(mob/living/simple_animal/shade/shade, mob/user)
@@ -306,17 +318,18 @@
 		to_chat(user, "[span_userdanger("Capture failed!")]: [src] is full! Free an existing soul to make room.")
 		return FALSE
 	shade.AddComponent(/datum/component/soulstoned, src)
+	update_appearance()
 	if(theme == THEME_HOLY)
-		icon_state = "purified_soulstone2"
-		shade.mind?.remove_antag_datum(/datum/antagonist/cult)
-	if(theme == THEME_WIZARD)
-		icon_state = "mystic_soulstone2"
-	if(theme == THEME_CULT)
-		icon_state = "soulstone2"
-	name = "soulstone: [shade.real_name]"
-	to_chat(shade, span_notice("Your soul has been captured by [src]. Its arcane energies are reknitting your ethereal form."))
+		for(var/mob/shade_to_deconvert in contents)
+			shade_to_deconvert.mind?.remove_antag_datum(/datum/antagonist/cult)
+
+	to_chat(shade, span_notice("Your soul has been captured by [src]. \
+		Its arcane energies are reknitting your ethereal form."))
+
 	if(user != shade)
-		to_chat(user, "[span_info("<b>Capture successful!</b>:")] [shade.real_name]'s soul has been captured and stored within [src].")
+		to_chat(user, "[span_info("<b>Capture successful!</b>:")] [shade.real_name]'s soul \
+			has been captured and stored within [src].")
+
 	return TRUE
 
 ///transfer the mind of the shade to a construct mob selected by the user, then deletes both the shade and src.
@@ -326,7 +339,7 @@
 		to_chat(user, "[span_userdanger("Creation failed!")]: [src] is empty! Go kill someone!")
 		return FALSE
 	var/construct_class = show_radial_menu(user, src, GLOB.construct_radial_images, custom_check = CALLBACK(src, .proc/check_menu, user, shell), require_near = TRUE, tooltips = TRUE)
-	if(!shell || !construct_class)
+	if(QDELETED(shell) || !construct_class)
 		return FALSE
 	make_new_construct_from_class(construct_class, theme, shade, user, FALSE, shell.loc)
 	shade.mind?.remove_antag_datum(/datum/antagonist/cult)
@@ -339,6 +352,58 @@
 		return FALSE
 	if(user.incapacitated() || !user.is_holding(src) || !user.CanReach(shell, src))
 		return FALSE
+	return TRUE
+
+/obj/item/soulstone/proc/init_shade(mob/living/carbon/human/victim, mob/user, message_user = FALSE, mob/shade_controller)
+	if(!shade_controller)
+		shade_controller = victim
+	victim.stop_sound_channel(CHANNEL_HEARTBEAT)
+	var/mob/living/simple_animal/shade/soulstone_spirit = new /mob/living/simple_animal/shade(src)
+	soulstone_spirit.AddComponent(/datum/component/soulstoned, src)
+	soulstone_spirit.name = "Shade of [victim.real_name]"
+	soulstone_spirit.real_name = "Shade of [victim.real_name]"
+	soulstone_spirit.key = shade_controller.key
+	soulstone_spirit.copy_languages(victim, LANGUAGE_MIND)//Copies the old mobs languages into the new mob holder.
+	if(user)
+		soulstone_spirit.copy_languages(user, LANGUAGE_MASTER)
+	soulstone_spirit.update_atom_languages()
+	soulstone_spirit.grant_all_languages(FALSE, FALSE, TRUE) //Grants omnitongue
+	if(user)
+		soulstone_spirit.faction |= "[REF(user)]" //Add the master as a faction, allowing inter-mob cooperation
+		if(IS_CULTIST(user))
+			soulstone_spirit.mind.add_antag_datum(/datum/antagonist/cult)
+
+	soulstone_spirit.cancel_camera()
+	update_appearance()
+	if(user)
+		if(IS_CULTIST(user))
+			to_chat(soulstone_spirit, span_bold("Your soul has been captured! \
+				You are now bound to the cult's will. Help them succeed in their goals at all costs."))
+		else if(role_check(user))
+			to_chat(soulstone_spirit, span_bold("Your soul has been captured! You are now bound to [user.real_name]'s will. \
+				Help [user.p_them()] succeed in [user.p_their()] goals at all costs."))
+		if(message_user)
+			to_chat(user, "[span_info("<b>Capture successful!</b>:")] [victim.real_name]'s soul has been ripped \
+				from [victim.p_their()] body and stored within [src].")
+
+	victim.dust(drop_items = TRUE)
+
+/obj/item/soulstone/proc/get_ghost_to_replace_shade(mob/living/carbon/victim, mob/user)
+	var/mob/dead/observer/chosen_ghost
+	var/list/consenting_candidates = poll_ghost_candidates("Would you like to play as a Shade?", "Cultist", ROLE_CULTIST, 5 SECONDS, POLL_IGNORE_SHADE)
+	if(length(consenting_candidates))
+		chosen_ghost = pick(consenting_candidates)
+
+	if(!victim || user.incapacitated() || !user.is_holding(src) || !user.CanReach(victim, src))
+		return FALSE
+	if(!chosen_ghost || !chosen_ghost.client)
+		to_chat(user, span_danger("There were no spirits willing to become a shade."))
+		return FALSE
+	if(contents.len) //If they used the soulstone on someone else in the meantime
+		return FALSE
+	to_chat(user, "[span_info("<b>Capture successful!</b>:")] A spirit has entered [src], \
+		taking upon the identity of [victim].")
+	init_shade(victim, user, shade_controller = chosen_ghost)
 	return TRUE
 
 /proc/make_new_construct_from_class(construct_class, theme, mob/target, mob/creator, cultoverride, loc_override)
@@ -404,60 +469,37 @@
 		BS.Cviewer = newstruct
 	newstruct.cancel_camera()
 
+/obj/item/soulstone/anybody
+	required_role = null
 
-/obj/item/soulstone/proc/init_shade(mob/living/carbon/human/victim, mob/user, message_user = FALSE, mob/shade_controller)
-	if(!shade_controller)
-		shade_controller = victim
-	victim.stop_sound_channel(CHANNEL_HEARTBEAT)
-	var/mob/living/simple_animal/shade/soulstone_spirit = new /mob/living/simple_animal/shade(src)
-	soulstone_spirit.AddComponent(/datum/component/soulstoned, src)
-	soulstone_spirit.name = "Shade of [victim.real_name]"
-	soulstone_spirit.real_name = "Shade of [victim.real_name]"
-	soulstone_spirit.key = shade_controller.key
-	soulstone_spirit.copy_languages(victim, LANGUAGE_MIND)//Copies the old mobs languages into the new mob holder.
-	if(user)
-		soulstone_spirit.copy_languages(user, LANGUAGE_MASTER)
-	soulstone_spirit.update_atom_languages()
-	soulstone_spirit.grant_all_languages(FALSE, FALSE, TRUE) //Grants omnitongue
-	if(user)
-		soulstone_spirit.faction |= "[REF(user)]" //Add the master as a faction, allowing inter-mob cooperation
-	if(user && IS_CULTIST(user))
-		soulstone_spirit.mind.add_antag_datum(/datum/antagonist/cult)
-	soulstone_spirit.cancel_camera()
-	name = "soulstone: Shade of [victim.real_name]"
-	switch(theme)
-		if(THEME_HOLY)
-			icon_state = "purified_soulstone2"
-		if(THEME_WIZARD)
-			icon_state = "mystic_soulstone2"
-		if(THEME_CULT)
-			icon_state = "soulstone2"
-	if(user)
-		if(IS_CULTIST(user))
-			to_chat(soulstone_spirit, "Your soul has been captured! You are now bound to the cult's will. Help them succeed in their goals at all costs.")
-		else if(role_check(user))
-			to_chat(soulstone_spirit, "Your soul has been captured! You are now bound to [user.real_name]'s will. Help [user.p_them()] succeed in [user.p_their()] goals at all costs.")
-		if(message_user)
-			to_chat(user, "[span_info("<b>Capture successful!</b>:")] [victim.real_name]'s soul has been ripped from [victim.p_their()] body and stored within [src].")
-	victim.dust()
+/obj/item/soulstone/mystic
+	icon_state = "mystic_soulstone"
+	theme = THEME_WIZARD
+	required_role = /datum/antagonist/wizard
 
+/obj/item/soulstone/anybody/revolver
+	one_use = TRUE
+	grab_sleeping = FALSE
 
-/obj/item/soulstone/proc/getCultGhost(mob/living/carbon/victim, mob/user)
-	var/mob/dead/observer/chosen_ghost
+/obj/item/soulstone/anybody/purified
+	icon_state = "purified_soulstone"
+	theme = THEME_HOLY
 
-	chosen_ghost = victim.get_ghost(TRUE,TRUE) //Try to grab original owner's ghost first
+/obj/item/soulstone/anybody/chaplain
+	name = "mysterious old shard"
+	one_use = TRUE
+	grab_sleeping = FALSE
 
-	if(!chosen_ghost || !chosen_ghost.client) //Failing that, we grab a ghosts
-		var/list/consenting_candidates = poll_ghost_candidates("Would you like to play as a Shade?", "Cultist", ROLE_CULTIST, 50, POLL_IGNORE_SHADE)
-		if(consenting_candidates.len)
-			chosen_ghost = pick(consenting_candidates)
-	if(!victim || user.incapacitated() || !user.is_holding(src) || !user.CanReach(victim, src))
-		return FALSE
-	if(!chosen_ghost || !chosen_ghost.client)
-		to_chat(user, span_danger("There were no spirits willing to become a shade."))
-		return FALSE
-	if(contents.len) //If they used the soulstone on someone else in the meantime
-		return FALSE
-	victim.unequip_everything()
-	init_shade(victim, user, shade_controller = chosen_ghost)
-	return TRUE
+/obj/item/soulstone/anybody/chaplain/sparring
+	name = "divine punishment"
+	desc = "A prison for those who lost a divine game."
+	icon_state = "purified_soulstone"
+	theme = THEME_HOLY
+
+/obj/item/soulstone/anybody/chaplain/sparring/Initialize(mapload)
+	. = ..()
+	name = "[GLOB.deity]'s punishment"
+	desc = "A prison for those who lost [GLOB.deity]'s game."
+
+/obj/item/soulstone/anybody/mining
+	grab_sleeping = FALSE

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -295,7 +295,7 @@
 		var/datum/antagonist/cult/cultist = IS_CULTIST(user)
 		if(cultist)
 			var/datum/team/cult/cult_team = cultist.get_team()
-			if(cult_team.is_sacrifice_target(victim.mind))
+			if(victim.mind && cult_team.is_sacrifice_target(victim.mind))
 				to_chat(user, span_cult("<b>\"This soul is mine.</b></span> <span class='cultlarge'>SACRIFICE THEM!\""))
 				return FALSE
 


### PR DESCRIPTION
## About The Pull Request

- Fixes #67014

Soulstones had a `if(client)` check prior to making a shade, which failed if the mob wasn't in their body.
So, we just grab the ghost before making a shade on capture.

This also allowed for the weird hack from #63707 to become unnecessary, so I reverted it.

- Fixes #66629

If you used a soulstone on a mindless mob, it would pass in `is_sacrifice_target(null)`, which would always succeed if the cult team had an objective without a target. Which cults do have. 

- Overall increases readability and reduces copypaste of soulstone code, making it a tad more consistent. 

Moved a lot of copy+pasted "theme" code to the appropriate `update_x` procs. Cleaned up code in general, as is tradition with cult code. 

## Why It's Good For The Game

Soulstones should work, and ghosts should not disappear. 

## Changelog

:cl: Melbert
fix: Cult sacrificing someone with a soul will no longer give you an empty soulstone when it should give you a filled one.
fix: Using a soulstone on a soulless corpse will now properly poll ghosts and allow a new shade.
fix: You can no longer capture spirits with soulstones you can't even release spirits from
fix: You can no longer hypothetically capture yourself with a soulstone
code: Some cleanup on aisle soulstone. 
/:cl:
