### PR TITLE
Adds Material tab for the autolathe to dispense the desired mats one put in and fixes a condition

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -33,6 +33,7 @@
 							"Tools",
 							"Electronics",
 							"Construction",
+							"Material",
 							"T-Comm",
 							"Security",
 							"Machinery",

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -112,9 +112,9 @@
 				var/datum/component/material_container/mats = GetComponent(/datum/component/material_container)
 				for(var/datum/material/mat in D.materials)
 					max_multiplier = min(D.maxstack, round(mats.get_material_amount(mat)/D.materials[mat]))
-				if (max_multiplier>10 && !disabled)
+				if (max_multiplier >= 10 && !disabled)
 					m10 = TRUE
-				if (max_multiplier>25 && !disabled)
+				if (max_multiplier >= 25 && !disabled)
 					m25 = TRUE
 		else
 			if(!unbuildable)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -315,25 +315,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT)
 	build_path = /obj/item/stack/sheet/iron
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/glass
-	name = "Glass"
-	id = "glass"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/glass = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/glass
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/rglass
-	name = "Reinforced Glass"
-	id = "rglass"
-	build_type = AUTOLATHE | SMELTER | PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/iron = 1000, /datum/material/glass = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/rglass
-	category = list("initial","Construction","Stock Parts")
+	category = list("initial","Material")
 	maxstack = 50
 
 /datum/design/rods
@@ -342,7 +324,97 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/stack/rods
-	category = list("initial","Construction")
+	category = list("initial","Material")
+	maxstack = 50
+
+/datum/design/glass
+	name = "Glass"
+	id = "glass"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/glass = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/glass
+	category = list("initial","Material")
+	maxstack = 50
+
+/datum/design/rglass
+	name = "Reinforced Glass"
+	id = "rglass"
+	build_type = AUTOLATHE | SMELTER | PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/rglass
+	category = list("initial","Material","Stock Parts")
+	maxstack = 50
+
+/datum/design/silver
+	name = "Silver"
+	id = "silver"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/silver = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/mineral/silver
+	category = list("initial","Material")
+	maxstack = 50
+
+/datum/design/gold
+	name = "Gold"
+	id = "gold"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/gold = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/mineral/gold
+	category = list("initial","Material")
+	maxstack = 50
+
+/datum/design/diamond
+	name = "Diamond"
+	id = "diamond"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/diamond = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/mineral/diamond
+	category = list("initial","Material")
+	maxstack = 50
+
+/datum/design/plasma
+	name = "Plasma"
+	id = "plasma"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/plasma = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/mineral/plasma
+	category = list("initial","Material")
+	maxstack = 50
+
+/datum/design/uranium
+	name = "Uranium"
+	id = "uranium"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/uranium = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/mineral/uranium
+	category = list("initial","Material")
+	maxstack = 50
+
+/datum/design/bananium
+	name = "Bananium"
+	id = "bananium"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/bananium = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/mineral/bananium
+	category = list("initial","Material")
+	maxstack = 50
+
+/datum/design/titanium
+	name = "Titanium"
+	id = "titanium"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/titanium = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/mineral/titanium
+	category = list("initial","Material")
+	maxstack = 50
+
+/datum/design/plastic
+	name = "Plastic"
+	id = "plastic"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/plastic= MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/plastic
+	category = list("initial","Material")
 	maxstack = 50
 
 /datum/design/rcd_ammo


### PR DESCRIPTION
## About The Pull Request
closes:https://github.com/tgstation/tgstation/issues/67847

In the Autolathe, moves all the matts from construction to the new tab Material which allows you to dispense all the mats you put in
Also fixes missing "=" operator which wouldnt let you print 10 or 25 stack immiadetly once you reached it
![grafik](https://user-images.githubusercontent.com/33989683/174433604-da8b5d3e-e74b-4a13-871e-52d429437cf9.png)

## Why It's Good For The Game

You dont have to deconstruct the autolathe anymore to get your desired material
## Changelog

:cl:@Salex08
qol: Added a new tab for the autolathe which allows you to dispense not only iron or glass but all the mats you put in
fix: Fixes missing "=" operator in autolathe
/:cl:
