### PR TITLE
Fixes the science speedsuits not being correctly named.

### DIFF
--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -63,13 +63,13 @@
 
 /obj/item/clothing/under/rank/rnd/scientist
 	desc = "It's made of a special fiber that provides minor protection against explosives. It has markings that denote the wearer as a scientist."
-	name = "scientist's jumpsuit"
+	name = "scientist's speedsuit"
 	icon_state = "science"
 	inhand_icon_state = "w_suit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 0, ACID = 0)
 
 /obj/item/clothing/under/rank/rnd/scientist/skirt
-	name = "scientist's jumpskirt"
+	name = "scientist's speedskirt"
 	desc = "It's made of a special fiber that provides minor protection against explosives. It has markings that denote the wearer as a scientist."
 	icon_state = "sciwhite_skirt"
 	inhand_icon_state = "w_suit"
@@ -80,13 +80,13 @@
 
 /obj/item/clothing/under/rank/rnd/roboticist
 	desc = "It's a slimming black with reinforced seams; great for industrial work."
-	name = "roboticist's jumpsuit"
+	name = "roboticist's speedsuit"
 	icon_state = "robotics"
 	inhand_icon_state = "robotics"
 	resistance_flags = NONE
 
 /obj/item/clothing/under/rank/rnd/roboticist/skirt
-	name = "roboticist's jumpskirt"
+	name = "roboticist's speedskirt"
 	desc = "It's a slimming black with reinforced seams; great for industrial work."
 	icon_state = "robotics_skirt"
 	inhand_icon_state = "robotics"
@@ -97,13 +97,13 @@
 
 /obj/item/clothing/under/rank/rnd/geneticist
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a genetics rank stripe on it."
-	name = "geneticist's jumpsuit"
+	name = "geneticist's speedsuit"
 	icon_state = "genetics"
 	inhand_icon_state = "w_suit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 0, ACID = 0)
 
 /obj/item/clothing/under/rank/rnd/geneticist/skirt
-	name = "geneticist's jumpskirt"
+	name = "geneticist's speedskirt"
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a genetics rank stripe on it."
 	icon_state = "geneticswhite_skirt"
 	inhand_icon_state = "w_suit"


### PR DESCRIPTION
## About The Pull Request

Fixes the science speedsuits not being correctly named.

## Why It's Good For The Game
Every self respecting super-scientist wears a speed suit. 

![chrome_FpalaJAWRu](https://user-images.githubusercontent.com/4081722/174475584-d2ed5809-3b9a-4a3a-8447-0da8a464f102.png)

I mean, just look at this bespoke speedsuit. Finest of it's class. It's an insult to call it a mere jumpsuit. No man or woman of science would be caught dead in a mere jumpsuit.

## Changelog
:cl:
spellcheck: Fixes the science speedsuits not being correctly named.
/:cl: