### PR TITLE
Readds netherworld statues to the NO_SPAWN list for gold slime reactions.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -10,6 +10,7 @@
 	gender = NEUTER
 	combat_mode = TRUE
 	mob_biotypes = MOB_HUMANOID
+	gold_core_spawnable = NO_SPAWN
 
 	response_help_continuous = "touches"
 	response_help_simple = "touch"


### PR DESCRIPTION

## About The Pull Request

Some changes to the super statues in #67105 caused them to appear in the hostile gold slime pool, and this PR amends that.

## Why It's Good For The Game

Bro, they have 50,000 and can teleport. Xenobio has enough toys as is.

## Changelog

:cl:
fix: Eldritch nightmares were incorrectly added to the gold slime pool
/:cl:
