### PR TITLE
Re-add Send Admin Message functionality

### DIFF
--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -33,6 +33,13 @@
 	var/message = "<span class='notice'>System bootup complete. Please select an option.</span>" // The message that shows on the main menu.
 	var/auth = FALSE // Are they authenticated?
 	var/optioncount = 7
+	// Custom Message Properties
+	var/customsender = "System Administrator"
+	var/customrecepient = null
+	var/customjob = "Admin"
+	var/custommessage = "This is a test, please ignore."
+
+
 
 /obj/machinery/computer/message_monitor/screwdriver_act(mob/living/user, obj/item/I)
 	if(obj_flags & EMAGGED)
@@ -183,6 +190,24 @@
 				10010000001110100011010000110000101110100001000000111010<br>
 				001101001011011010110010100101110"}
 
+		//Fake messages
+		if(MSG_MON_SCREEN_CUSTOM_MSG)
+			dat += "<center><A href='?src=[REF(src)];back=1'>Back</a> - <A href='?src=[REF(src)];Reset=1'>Reset</a></center><hr>"
+
+			dat += {"<table border='1' width='100%'>
+					<tr><td width='20%'><A href='?src=[REF(src)];select=Sender'>Sender</a></td>
+					<td width='20%'><A href='?src=[REF(src)];select=RecJob'>Sender's Job</a></td>
+					<td width='20%'><A href='?src=[REF(src)];select=Recepient'>Recipient</a></td>
+					<td width='300px' word-wrap: break-word><A href='?src=[REF(src)];select=Message'>Message</a></td></tr>"}
+				//Sender  - Sender's Job  - Recepient - Message
+				//Al Green- Your Dad   - Your Mom  - WHAT UP!?
+
+			dat += {"<tr><td width='20%'>[customsender]</td>
+			<td width='20%'>[customjob]</td>
+			<td width='20%'>[customrecepient ? customrecepient : "NONE"]</td>
+			<td width='300px'>[custommessage]</td></tr>"}
+			dat += "</table><br><center><A href='?src=[REF(src)];select=Send'>Send</a>"
+
 		//Request Console Logs
 		if(MSG_MON_SCREEN_REQUEST_LOGS)
 
@@ -225,6 +250,12 @@
 
 /obj/machinery/computer/message_monitor/proc/UnmagConsole()
 	obj_flags &= ~EMAGGED
+
+/obj/machinery/computer/message_monitor/proc/ResetMessage()
+	customsender = "System Administrator"
+	customrecepient = null
+	custommessage = "This is a test, please ignore."
+	customjob = "Admin"
 
 /obj/machinery/computer/message_monitor/Topic(href, href_list)
 	if(..())
@@ -333,6 +364,77 @@
 				else if(istype(href_list["delete_logs"], /datum/data_tablet_msg))
 					linkedServer.rc_msgs -= locate(href_list["delete_requests"]) in linkedServer.rc_msgs
 					message = span_notice("NOTICE: Log Deleted!")
+
+		//Create a custom message
+		if (href_list["msg"])
+			if(LINKED_SERVER_NONRESPONSIVE)
+				message = noserver
+			else if(auth)
+				screen = MSG_MON_SCREEN_CUSTOM_MSG
+
+		//Fake messaging selection - KEY REQUIRED
+		if (href_list["select"])
+			if(LINKED_SERVER_NONRESPONSIVE)
+				message = noserver
+				screen = MSG_MON_SCREEN_MAIN
+			else
+				switch(href_list["select"])
+
+					//Reset
+					if("Reset")
+						ResetMessage()
+
+					//Select Your Name
+					if("Sender")
+						customsender = tgui_input_text(usr, "Please enter the sender's name.", "Sender") || customsender
+
+					//Select Receiver
+					if("Recepient")
+						// Get out list of viable tablets
+						var/list/viewable_tablets = list()
+						for (var/obj/item/modular_computer/tablet in GLOB.TabletMessengers)
+							if(!tablet.saved_identification || tablet.invisible)
+								continue
+							viewable_tablets += tablet
+						if(length(viewable_tablets) > 0)
+							customrecepient = tgui_input_list(usr, "Select a tablet from the list", "Tablet Selection", viewable_tablets)
+						else
+							customrecepient = null
+
+					//Enter custom job
+					if("RecJob")
+						customjob = tgui_input_text(usr, "Please enter the sender's job.", "Job") || customjob
+
+					//Enter message
+					if("Message")
+						custommessage = tgui_input_text(usr, "Please enter your message.", "Message") || custommessage
+
+					//Send message
+					if("Send")
+						if(isnull(customsender) || customsender == "")
+							customsender = "UNKNOWN"
+
+						if(isnull(customrecepient))
+							message = span_notice("NOTICE: No recepient selected!")
+							return attack_hand(usr)
+
+						if(isnull(custommessage) || custommessage == "")
+							message = span_notice("NOTICE: No message entered!")
+							return attack_hand(usr)
+
+						var/datum/signal/subspace/messaging/tablet_msg/signal = new(src, list(
+							"name" = "[customsender]",
+							"job" = "[customjob]",
+							"message" = html_decode(custommessage),
+							"ref" = REF(src),
+							"targets" = list(customrecepient),
+							"emojis" = FALSE,
+							"rigged" = FALSE,
+							"automated" = FALSE,
+						))
+						// this will log the signal and transmit it to the target
+						linkedServer.receive_information(signal, null)
+						usr.log_message("(Tablet: [name] | [usr.real_name]) sent \"[custommessage]\" to [signal.format_target()]", LOG_PDA)
 
 		//Request Console Logs - KEY REQUIRED
 		if(href_list["view_requests"])


### PR DESCRIPTION
## About The Pull Request


Re-adds the code that went missing when #65755 was merged.
Closes #66777
There is also a PR (#66786) that tried to kill this functionality altogether, but was closed because the feature is considered valuable.


I admit the code doesn't look great (I tried to keep it as it was as much as possible) and it should be TGUI going forward, but this has been broken for a while now and it's incredibly confusing to have a button that doesn't work while no one seems interested in fixing it properly.

## Why It's Good For The Game

Sending fake messages is a nice tool for traitors or just pranks. Syndie Comms Agent has a message console next to it, and not being able to send fake messages has been a big downgrade to how it can interact with the station (you can do radio but you get found out pretty easily).

## Changelog

:cl:
fix: the message monitor console can now send admin messages again
/:cl:
