### PR TITLE
Fixes the Lavaland Mafia map's floor

### DIFF
--- a/_maps/map_files/Mafia/mafia_lavaland.dmm
+++ b/_maps/map_files/Mafia/mafia_lavaland.dmm
@@ -44,11 +44,11 @@
 	name = "miner equipment locker"
 	},
 /obj/item/clothing/under/rank/cargo/miner/lavaland,
-/turf/open/floor/grass/fakebasalt,
+/turf/open/floor/fakebasalt,
 /area/centcom/mafia)
 "m" = (
 /obj/effect/landmark/mafia,
-/turf/open/floor/grass/fakebasalt,
+/turf/open/floor/fakebasalt,
 /area/centcom/mafia)
 "n" = (
 /obj/effect/landmark/mafia,
@@ -80,7 +80,7 @@
 /turf/closed/indestructible/fakeglass,
 /area/centcom/mafia)
 "q" = (
-/turf/open/floor/grass/fakebasalt,
+/turf/open/floor/fakebasalt,
 /area/centcom/mafia)
 "r" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/25415050/174500283-1662b5e0-6c67-4030-9907-86bd9ed566bc.png)

## Why It's Good For The Game

The map was mostly just space tiles as its floor's paths were never updated, this fixes that.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Lavaland Mafia map now displays safer flooring over empty space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
