### PR TITLE
Fixes for language headset keys.

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -384,9 +384,11 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	// learned from our installed key chips are all still accurate
 	var/mob/mob_loc = loc
 	if(istype(mob_loc) && mob_loc.get_item_by_slot(slot_flags) == src)
+		// Remove all the languages we may not be able to know anymore
 		for(var/language in old_language_list)
 			mob_loc.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
 
+		// And grant all the languages we definitely should know now
 		grant_headset_langauges(mob_loc)
 
 /obj/item/radio/headset/AltClick(mob/living/user)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -100,7 +100,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 /obj/item/radio/headset/dropped(mob/user, silent)
 	. = ..()
 	for(var/language in language_list)
-		remove_from.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
+		user.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
 
 /obj/item/radio/headset/syndicate //disguised to look like a normal headset for stealth ops
 
@@ -385,7 +385,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	var/mob/mob_loc = loc
 	if(istype(mob_loc) && mob_loc.get_item_by_slot(slot_flags) == src)
 		for(var/language in old_language_list)
-			remove_from.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
+			mob_loc.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
 
 		grant_headset_langauges(mob_loc)
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -27,6 +27,8 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	slot_flags = ITEM_SLOT_EARS
 	dog_fashion = null
 	var/obj/item/encryptionkey/keyslot2 = null
+	/// A list of all languages that this headset allows the user to understand. Populated by language encryption keys.
+	var/list/language_list
 
 /obj/item/radio/headset/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins putting \the [src]'s antenna up [user.p_their()] nose! It looks like [user.p_theyre()] trying to give [user.p_them()]self cancer!"))
@@ -58,8 +60,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	set_listening(TRUE)
 	recalculateChannels()
 	possibly_deactivate_in_loc()
-	RegisterSignal(src, COMSIG_ITEM_EQUIPPED, .proc/learn_language)
-	RegisterSignal(src, COMSIG_ITEM_POST_UNEQUIP, .proc/unlearn_language)
 
 /obj/item/radio/headset/proc/possibly_deactivate_in_loc()
 	if(ismob(loc))
@@ -85,33 +85,26 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 		return attack_self(headset_user)
 	return ..()
 
-/obj/item/radio/headset/proc/learn_language()
-	SIGNAL_HANDLER
-	if(!istype(loc, /mob/living/carbon))
-		return
-	var/list/language_list = list()
-	if(keyslot?.translated_language)
-		language_list += keyslot.translated_language
-	if(keyslot2?.translated_language)
-		language_list += keyslot2.translated_language
-
-	var/mob/living/carbon/person = loc
+/// Grants all the languages this headset allows the mob to understand via installed chips.
+/obj/item/radio/headset/proc/grant_headset_langauges(mob/grant_to)
 	for(var/language in language_list)
-		person.grant_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
+		grant_to.grant_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
 
-/obj/item/radio/headset/proc/unlearn_language()
-	SIGNAL_HANDLER
-	if(!istype(loc, /mob/living/carbon))
-		return
-	var/list/language_list = list()
-	if(keyslot?.translated_language)
-		language_list += keyslot.translated_language
-	if(keyslot2?.translated_language)
-		language_list += keyslot2.translated_language
-
-	var/mob/living/carbon/person = loc
+/// Removes all the languages this headset allowed the mob to understand via installed chips.
+/obj/item/radio/headset/proc/remove_headset_langauges(mob/remove_from)
 	for(var/language in language_list)
-		person.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
+		remove_from.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
+
+/obj/item/radio/headset/equipped(mob/user, slot, initial)
+	. = ..()
+	if(!(slot_flags & slot))
+		return
+
+	grant_headset_langauges(user)
+
+/obj/item/radio/headset/dropped(mob/user, silent)
+	. = ..()
+	remove_headset_langauges(user)
 
 /obj/item/radio/headset/syndicate //disguised to look like a normal headset for stealth ops
 
@@ -367,7 +360,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	else
 		return ..()
 
-
 /obj/item/radio/headset/recalculateChannels()
 	. = ..()
 	if(keyslot2)
@@ -379,11 +371,25 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 			translate_binary = TRUE
 		if(keyslot2.syndie)
 			syndie = TRUE
-		if (keyslot2.independent)
+		if(keyslot2.independent)
 			independent = TRUE
 
 		for(var/ch_name in channels)
 			secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])
+
+	// If we're equipped on a mob, we should make sure all the languages
+	// learned from our installed key chips are all still accurate
+	var/mob/mob_loc = loc
+	if(istype(mob_loc) && mob_loc.get_item_by_slot(slot_flags) == src)
+		remove_headset_langauges(mob_loc)
+
+		language_list = list()
+		if(keyslot?.translated_language)
+			language_list += keyslot.translated_language
+		if(keyslot2?.translated_language)
+			language_list += keyslot2.translated_language
+
+		grant_headset_langauges(mob_loc)
 
 /obj/item/radio/headset/AltClick(mob/living/user)
 	if(!istype(user) || !Adjacent(user) || user.incapacitated())

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -90,11 +90,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	for(var/language in language_list)
 		grant_to.grant_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
 
-/// Removes all the languages this headset allowed the mob to understand via installed chips.
-/obj/item/radio/headset/proc/remove_headset_langauges(mob/remove_from)
-	for(var/language in language_list)
-		remove_from.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
-
 /obj/item/radio/headset/equipped(mob/user, slot, initial)
 	. = ..()
 	if(!(slot_flags & slot))
@@ -104,7 +99,8 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/dropped(mob/user, silent)
 	. = ..()
-	remove_headset_langauges(user)
+	for(var/language in language_list)
+		remove_from.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
 
 /obj/item/radio/headset/syndicate //disguised to look like a normal headset for stealth ops
 
@@ -377,17 +373,19 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 		for(var/ch_name in channels)
 			secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])
 
+	var/list/old_language_list = language_list?.Copy()
+	language_list = list()
+	if(keyslot?.translated_language)
+		language_list += keyslot.translated_language
+	if(keyslot2?.translated_language)
+		language_list += keyslot2.translated_language
+
 	// If we're equipped on a mob, we should make sure all the languages
 	// learned from our installed key chips are all still accurate
 	var/mob/mob_loc = loc
 	if(istype(mob_loc) && mob_loc.get_item_by_slot(slot_flags) == src)
-		remove_headset_langauges(mob_loc)
-
-		language_list = list()
-		if(keyslot?.translated_language)
-			language_list += keyslot.translated_language
-		if(keyslot2?.translated_language)
-			language_list += keyslot2.translated_language
+		for(var/language in old_language_list)
+			remove_from.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
 
 		grant_headset_langauges(mob_loc)
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	return ..()
 
 /// Grants all the languages this headset allows the mob to understand via installed chips.
-/obj/item/radio/headset/proc/grant_headset_langauges(mob/grant_to)
+/obj/item/radio/headset/proc/grant_headset_languages(mob/grant_to)
 	for(var/language in language_list)
 		grant_to.grant_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
 
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	if(!(slot_flags & slot))
 		return
 
-	grant_headset_langauges(user)
+	grant_headset_languages(user)
 
 /obj/item/radio/headset/dropped(mob/user, silent)
 	. = ..()
@@ -389,7 +389,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 			mob_loc.remove_language(language, understood = TRUE, spoken = FALSE, source = LANGUAGE_RADIOKEY)
 
 		// And grant all the languages we definitely should know now
-		grant_headset_langauges(mob_loc)
+		grant_headset_languages(mob_loc)
 
 /obj/item/radio/headset/AltClick(mob/living/user)
 	if(!istype(user) || !Adjacent(user) || user.incapacitated())


### PR DESCRIPTION
## About The Pull Request

- `Equipped` is called whenever it's equipped to ANY slot, not just the correct slot. This means that languages were granted even if it was just in hand, or in pocket. 
   - Moved it from signal to proc, and checked slot flags prior to granting languages. 
- `doUnEquip` can be called when the item is no longer in the mob's loc, meaning it was possible to keep the languages forever.
   - Moved it to `dropped` instead, which is more typical of items. 
- Languages never updated when they were installed or removed, only on equip or drop.
   - Tracks languages in a list outside of equip and drop, so that they are and removed or added when keys are removed or added, instead of only in equip or drop. 

## Why It's Good For The Game

More consistent behavior.

## Changelog

:cl: Melbert
fix: Language encryption keys now only work when you've equipped the headset
fix: Language encryption keys no longer forever-grant you the language in some circumstances
fix: Language encryption keys now update when they're installed if you're currently wearing the headset
/:cl:
