### PR TITLE
Fix unfavorable situations yielding, causing revs to fire them every process

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -3,6 +3,11 @@
 /// It tries to spawn a heavy midround if possible, otherwise it will trigger a "bad" random event after a short period.
 /// Calling this function will not use up any threat.
 /datum/game_mode/dynamic/proc/unfavorable_situation()
+	SHOULD_NOT_SLEEP(TRUE)
+
+	INVOKE_ASYNC(src, .proc/_unfavorable_situation)
+
+/datum/game_mode/dynamic/proc/_unfavorable_situation()
 	var/static/list/unfavorable_random_events = list(
 		/datum/round_event_control/immovable_rod,
 		/datum/round_event_control/meteor_wave,


### PR DESCRIPTION
## About The Pull Request
Fixes #67879.

Not tested but there are no runtimes so I don't know what else this can be, so I'm gonna fling this off to some server and see what happens

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed revolutions blaring alerts for a few seconds after winning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
