### PR TITLE
Fixes an area issue in crashedship.dmm ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1176,9 +1176,6 @@
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/awaymission/bmpship/aft)
-"OF" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/template_noop)
 "OZ" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/mapping_helpers/broken_floor,
@@ -2251,9 +2248,9 @@ UA
 UA
 Yl
 di
-OF
-OF
-OF
+fp
+fp
+fp
 fp
 Gf
 yB


### PR DESCRIPTION
## About The Pull Request

There were some walls which were area/template_noop instead of the room's area, causing lighting issues
## Why It's Good For The Game

full-bright walls are bad for immersion 

## Changelog

:cl:
fix: some walls in the crashed ship ruin, they are no longer full-bright
/:cl:
