### PR TITLE
Refactors Knock to use Connect Loc

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -337,6 +337,9 @@
 	/// Returns if the item had a negative side effect occur while recharging
 	#define COMPONENT_ITEM_BURNT_OUT (1 << 1)
 
+/// Sent from /obj/effect/proc_holder/spell/aoe_turf/knock/cast(), to every nearby turf: (obj/effect/proc_holder/spell/targeted/charge/spell, mob/living/caster)
+#define COMSIG_ATOM_MAGICALLY_UNLOCKED "atom_magic_unlock"
+
 // /obj/item/camera signals
 
 ///from /obj/item/camera/captureimage(): (atom/target, mob/user)

--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -76,6 +76,7 @@
 		radio_connection = SSradio.add_object(src, frequency, RADIO_AIRLOCK)
 
 /obj/machinery/door/airlock/on_magic_unlock(datum/source, obj/effect/proc_holder/spell/aoe_turf/knock/spell, mob/living/caster)
+	// Airlocks should unlock themselves when knock is casted, THEN open up.
 	locked = FALSE
 	return ..()
 

--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -7,7 +7,6 @@
 	var/frequency
 	var/datum/radio_frequency/radio_connection
 
-
 /obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 	if(!signal)
 		return
@@ -50,7 +49,6 @@
 
 	send_status()
 
-
 /obj/machinery/door/airlock/proc/send_status()
 	if(radio_connection)
 		var/datum/signal/signal = new(list(
@@ -61,24 +59,25 @@
 		))
 		radio_connection.post_signal(src, signal, range = AIRLOCK_CONTROL_RANGE, filter = RADIO_AIRLOCK)
 
-
 /obj/machinery/door/airlock/open(surpress_send)
 	. = ..()
 	if(!surpress_send)
 		send_status()
-
 
 /obj/machinery/door/airlock/close(surpress_send)
 	. = ..()
 	if(!surpress_send)
 		send_status()
 
-
 /obj/machinery/door/airlock/proc/set_frequency(new_frequency)
 	SSradio.remove_object(src, frequency)
 	if(new_frequency)
 		frequency = new_frequency
 		radio_connection = SSradio.add_object(src, frequency, RADIO_AIRLOCK)
+
+/obj/machinery/door/airlock/on_magic_unlock(datum/source, obj/effect/proc_holder/spell/aoe_turf/knock/spell, mob/living/caster)
+	locked = FALSE
+	return ..()
 
 /obj/machinery/door/airlock/Destroy()
 	if(frequency)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -488,6 +488,7 @@
 	zap_flags &= ~ZAP_OBJ_DAMAGE
 	. = ..()
 
+/// Signal proc for [COMSIG_ATOM_MAGICALLY_UNLOCKED]. Open up when someone casts knock.
 /obj/machinery/door/proc/on_magic_unlock(datum/source, obj/effect/proc_holder/spell/aoe_turf/knock/spell, mob/living/caster)
 	SIGNAL_HANDLER
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -65,6 +65,11 @@
 	explosion_block = EXPLOSION_BLOCK_PROC
 	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, .proc/check_security_level)
 
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_MAGICALLY_UNLOCKED = .proc/on_magic_unlock,
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+
 /obj/machinery/door/examine(mob/user)
 	. = ..()
 	if(red_alert_access)
@@ -483,5 +488,9 @@
 	zap_flags &= ~ZAP_OBJ_DAMAGE
 	. = ..()
 
+/obj/machinery/door/proc/on_magic_unlock(datum/source, obj/effect/proc_holder/spell/aoe_turf/knock/spell, mob/living/caster)
+	SIGNAL_HANDLER
+
+	INVOKE_ASYNC(src, .proc/open)
 
 #undef DOOR_CLOSE_WAIT

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -721,6 +721,7 @@
 	log_combat(src, target, "shoved", "into [src] (locker/crate)")
 	return COMSIG_CARBON_SHOVE_HANDLED
 
+/// Signal proc for [COMSIG_ATOM_MAGICALLY_UNLOCKED]. Unlock and open up when we get knock casted.
 /obj/structure/closet/proc/on_magic_unlock(datum/source, obj/effect/proc_holder/spell/aoe_turf/knock/spell, mob/living/caster)
 	SIGNAL_HANDLER
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -78,6 +78,7 @@
 		return //Why
 	var/static/list/loc_connections = list(
 		COMSIG_CARBON_DISARM_COLLIDE = .proc/locker_carbon,
+		COMSIG_ATOM_MAGICALLY_UNLOCKED = .proc/on_magic_unlock,
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
@@ -719,5 +720,11 @@
 	to_chat(src, span_danger("You shove [target.name] into \the [src]!"))
 	log_combat(src, target, "shoved", "into [src] (locker/crate)")
 	return COMSIG_CARBON_SHOVE_HANDLED
+
+/obj/structure/closet/proc/on_magic_unlock(datum/source, obj/effect/proc_holder/spell/aoe_turf/knock/spell, mob/living/caster)
+	SIGNAL_HANDLER
+
+	locked = FALSE
+	INVOKE_ASYNC(src, .proc/open)
 
 #undef LOCKER_FULL

--- a/code/modules/spells/spell_types/knock.dm
+++ b/code/modules/spells/spell_types/knock.dm
@@ -14,18 +14,5 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/knock/cast(list/targets,mob/user = usr)
 	SEND_SOUND(user, sound('sound/magic/knock.ogg'))
-	for(var/turf/T in targets)
-		for(var/obj/machinery/door/door in T.contents)
-			INVOKE_ASYNC(src, .proc/open_door, door)
-		for(var/obj/structure/closet/C in T.contents)
-			INVOKE_ASYNC(src, .proc/open_closet, C)
-
-/obj/effect/proc_holder/spell/aoe_turf/knock/proc/open_door(obj/machinery/door/door)
-	if(istype(door, /obj/machinery/door/airlock))
-		var/obj/machinery/door/airlock/A = door
-		A.locked = FALSE
-	door.open()
-
-/obj/effect/proc_holder/spell/aoe_turf/knock/proc/open_closet(obj/structure/closet/C)
-	C.locked = FALSE
-	C.open()
+	for(var/turf/nearby_turf in targets)
+		SEND_SIGNAL(nearby_turf, COMSIG_ATOM_MAGICALLY_UNLOCKED, src, user)


### PR DESCRIPTION
## About The Pull Request

More atomization from #67083 

Changes Knock to use connect loc instead of hard-coding interactions in the spell itself. 

Because this is ugly. 

![image](https://user-images.githubusercontent.com/51863163/174520959-7d34fe41-de19-4bd6-a798-e3c4a2d6e0c4.png)

## Why It's Good For The Game

Cleaner code, easier to add interactions, more optimized maybe?

## Changelog

:cl: Melbert
refactor: Refactored how Knock (spell) tells stuff to open up, makes it easier to add more knockable things. 
/:cl:

