### PR TITLE
Rapid Lighting Device fits on a toolbelt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -52,6 +52,7 @@
 		/obj/item/assembly/signaler,
 		/obj/item/clothing/gloves,
 		/obj/item/construction/rcd,
+		/obj/item/construction/rld,
 		/obj/item/crowbar,
 		/obj/item/extinguisher/mini,
 		/obj/item/flashlight,


### PR DESCRIPTION
## About The Pull Request
![dreamseeker_0Xornj5hyj](https://user-images.githubusercontent.com/77534246/174611766-d3420069-64a7-44a4-8e88-2f345aed84bf.png)

## Why It's Good For The Game
Probably an oversight.

## Changelog

:cl:
qol: Rapid Lighting Device now fits in the utility toolbelt
/:cl: