### PR TITLE
Roller beds and bodybags are folded with right click now

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -62,7 +62,7 @@
 
 /obj/structure/bed/roller/examine(mob/user)
 	. = ..()
-	. += span_notice("You can fold it up by <b>dragging</b> it onto you.")
+	. += span_notice("You can fold it up with a Right-click.")
 
 /obj/structure/bed/roller/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/roller/robo))
@@ -85,17 +85,16 @@
 	else
 		return ..()
 
-/obj/structure/bed/roller/MouseDrop(over_object, src_location, over_location)
+/obj/structure/bed/roller/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
-	if(over_object == usr && Adjacent(usr))
-		if(!ishuman(usr) || !usr.canUseTopic(src, BE_CLOSE))
-			return FALSE
-		if(has_buckled_mobs())
-			return FALSE
-		usr.visible_message(span_notice("[usr] collapses \the [src.name]."), span_notice("You collapse \the [src.name]."))
-		var/obj/structure/bed/roller/B = new foldabletype(get_turf(src))
-		usr.put_in_hands(B)
-		qdel(src)
+	if(!ishuman(usr) || !usr.canUseTopic(src, BE_CLOSE))
+		return FALSE
+	if(has_buckled_mobs())
+		return FALSE
+	usr.visible_message(span_notice("[usr] collapses \the [src.name]."), span_notice("You collapse \the [src.name]."))
+	var/obj/structure/bed/roller/B = new foldabletype(get_turf(src))
+	usr.put_in_hands(B)
+	qdel(src)
 
 /obj/structure/bed/roller/post_buckle_mob(mob/living/M)
 	set_density(TRUE)

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -87,13 +87,15 @@
 
 /obj/structure/bed/roller/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
-	if(!ishuman(usr) || !usr.canUseTopic(src, BE_CLOSE))
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	if(!ishuman(user) || !user.canUseTopic(src, BE_CLOSE))
 		return FALSE
 	if(has_buckled_mobs())
 		return FALSE
-	usr.visible_message(span_notice("[usr] collapses \the [src.name]."), span_notice("You collapse \the [src.name]."))
-	var/obj/structure/bed/roller/B = new foldabletype(get_turf(src))
-	usr.put_in_hands(B)
+	user.visible_message(span_notice("[user] collapses [src.name]."), span_notice("You collapse [src.name]."))
+	var/obj/structure/bed/roller/folding_bed = new foldabletype(get_turf(src))
+	user.put_in_hands(folding_bed)
 	qdel(src)
 
 /obj/structure/bed/roller/post_buckle_mob(mob/living/M)

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -93,7 +93,7 @@
 		return FALSE
 	if(has_buckled_mobs())
 		return FALSE
-	user.visible_message(span_notice("[user] collapses [src.name]."), span_notice("You collapse [src.name]."))
+	user.visible_message(span_notice("[user] collapses [src]."), span_notice("You collapse [src]."))
 	var/obj/structure/bed/roller/folding_bed = new foldabletype(get_turf(src))
 	user.put_in_hands(folding_bed)
 	qdel(src)

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -64,16 +64,18 @@
 
 /obj/structure/closet/body_bag/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
-	if(!attempt_fold(usr))
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
-	perform_fold(usr)
+	if(!attempt_fold(user))
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
+	perform_fold(user)
 	qdel(src)
 
 		/**
 		  * Checks to see if we can fold. Return TRUE to actually perform the fold and delete.
 			*
 		  * Arguments:
-		  * * the_folder - over_object of MouseDrop aka usr
+		  * * the_folder - over_object of MouseDrop aka user
 		  */
 /obj/structure/closet/body_bag/proc/attempt_fold(mob/living/carbon/human/the_folder)
 	. = FALSE
@@ -93,12 +95,12 @@
 		* Performs the actual folding. Deleting is automatic, please do not include.
 		*
 		* Arguments:
-		* * the_folder - over_object of MouseDrop aka usr
+		* * the_folder - over_object of MouseDrop aka user
 		*/
 /obj/structure/closet/body_bag/proc/perform_fold(mob/living/carbon/human/the_folder)
-	visible_message(span_notice("[usr] folds up [src]."))
-	var/obj/item/bodybag/B = foldedbag_instance || new foldedbag_path
-	the_folder.put_in_hands(B)
+	visible_message(span_notice("[the_folder] folds up [src]."))
+	var/obj/item/bodybag/folding_bodybag = foldedbag_instance || new foldedbag_path
+	the_folder.put_in_hands(folding_bodybag)
 
 /obj/structure/closet/body_bag/bluespace
 	name = "bluespace body bag"
@@ -119,20 +121,20 @@
 		return
 	//end copypaste zone
 	if(contents.len >= mob_storage_capacity / 2)
-		to_chat(usr, span_warning("There are too many things inside of [src] to fold it up!"))
+		to_chat(the_folder, span_warning("There are too many things inside of [src] to fold it up!"))
 		return
 	for(var/obj/item/bodybag/bluespace/B in src)
-		to_chat(usr, span_warning("You can't recursively fold bluespace body bags!") )
+		to_chat(the_folder, span_warning("You can't recursively fold bluespace body bags!") )
 		return
 	return TRUE
 
 /obj/structure/closet/body_bag/bluespace/perform_fold(mob/living/carbon/human/the_folder)
-	visible_message(span_notice("[usr] folds up [src]."))
-	var/obj/item/bodybag/B = foldedbag_instance || new foldedbag_path
-	var/max_weight_of_contents = initial(B.w_class)
+	visible_message(span_notice("[the_folder] folds up [src]."))
+	var/obj/item/bodybag/folding_bodybag = foldedbag_instance || new foldedbag_path
+	var/max_weight_of_contents = initial(folding_bodybag.w_class)
 	for(var/am in contents)
 		var/atom/movable/content = am
-		content.forceMove(B)
+		content.forceMove(folding_bodybag)
 		if(isliving(content))
 			to_chat(content, span_userdanger("You're suddenly forced into a tiny, compressed space!"))
 		if(iscarbon(content))
@@ -147,8 +149,8 @@
 		if(A_is_item.w_class < max_weight_of_contents)
 			continue
 		max_weight_of_contents = A_is_item.w_class
-	B.w_class = max_weight_of_contents
-	usr.put_in_hands(B)
+	folding_bodybag.w_class = max_weight_of_contents
+	the_folder.put_in_hands(folding_bodybag)
 
 /// Environmental bags. They protect against bad weather.
 

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -75,7 +75,7 @@
 		  * Checks to see if we can fold. Return TRUE to actually perform the fold and delete.
 			*
 		  * Arguments:
-		  * * the_folder - over_object of MouseDrop aka user
+		  * * the_folder - aka user
 		  */
 /obj/structure/closet/body_bag/proc/attempt_fold(mob/living/carbon/human/the_folder)
 	. = FALSE
@@ -95,7 +95,7 @@
 		* Performs the actual folding. Deleting is automatic, please do not include.
 		*
 		* Arguments:
-		* * the_folder - over_object of MouseDrop aka user
+		* * the_folder - aka user
 		*/
 /obj/structure/closet/body_bag/proc/perform_fold(mob/living/carbon/human/the_folder)
 	visible_message(span_notice("[the_folder] folds up [src]."))

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -15,7 +15,6 @@
 	delivery_icon = null //unwrappable
 	anchorable = FALSE
 	cutting_tool = null // Bodybags are not deconstructed by cutting
-	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	drag_slowdown = 0
 	has_closed_overlay = FALSE
 	var/foldedbag_path = /obj/item/bodybag
@@ -45,7 +44,9 @@
 		else
 			name = initial(name)
 		return
-	else if((interact_tool.tool_behaviour == TOOL_WIRECUTTER) && tagged)
+	if(!tagged)
+		return
+	if(interact_tool.tool_behaviour == TOOL_WIRECUTTER || interact_tool.get_sharpness())
 		to_chat(user, span_notice("You cut the tag off [src]."))
 		name = "body bag"
 		tagged = FALSE
@@ -56,24 +57,17 @@
 	if(tagged)
 		. += "bodybag_label"
 
-/obj/structure/closet/body_bag/open(mob/living/user, force = FALSE)
-	. = ..()
-	if(.)
-		mouse_drag_pointer = MOUSE_INACTIVE_POINTER
-
 /obj/structure/closet/body_bag/close()
 	. = ..()
 	if(.)
 		set_density(FALSE)
-		mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
-/obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
+/obj/structure/closet/body_bag/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
-	if(over_object == usr && Adjacent(usr) && (in_range(src, usr) || usr.contents.Find(src)))
-		if(!attempt_fold(usr))
-			return
-		perform_fold(usr)
-		qdel(src)
+	if(!attempt_fold(usr))
+		return
+	perform_fold(usr)
+	qdel(src)
 
 		/**
 		  * Checks to see if we can fold. Return TRUE to actually perform the fold and delete.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This, and you can cut the bodybag tag with any sharp object too!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
MouseDrop is just pain and is probably one small annoyance that pushes people to not use roller beds and bodybags as much... well they use the bluespace one for murder but...

The only way to remove a tag from a bodybag was a wirecutter, this cuts down on doctors needing to loot tools for something minor and let them use their scalpel instead.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
qol: You fold roller beds and bodybags with a right click instead of click and dragging into you.
qol: You can use any sharp object to cut a bodybag's tag instead of being forced to use a wirecutter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
