### PR TITLE
CRINGE Cheshify BREAKS PRIDE MIRROR (Unforgivable)

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -6,7 +6,7 @@
 	},
 /obj/structure/stone_tile/surrounding/cracked,
 /obj/effect/mob_spawn/corpse/human/skeleton,
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/indestructible/necropolis,
 /area/lavaland/surface/outdoors)
 "aO" = (
 /obj/structure/stone_tile/surrounding_tile/burnt{
@@ -95,7 +95,7 @@
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 8
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/indestructible/necropolis,
 /area/lavaland/surface/outdoors)
 "hV" = (
 /obj/structure/stone_tile/center/burnt,
@@ -108,7 +108,7 @@
 /obj/structure/stone_tile/surrounding_tile/burnt{
 	dir = 8
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ie" = (
 /obj/item/veilrender/vealrender,
@@ -130,7 +130,7 @@
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 1
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "jM" = (
 /turf/closed/indestructible/necropolis,
@@ -182,7 +182,7 @@
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 1
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "nT" = (
 /turf/closed/indestructible/riveted/boss,
@@ -268,7 +268,7 @@
 /obj/structure/stone_tile/block/burnt{
 	dir = 4
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/indestructible/necropolis,
 /area/lavaland/surface/outdoors)
 "zr" = (
 /obj/structure/stone_tile/block/burnt{
@@ -311,7 +311,7 @@
 /area/ruin/powered/gluttony)
 "DB" = (
 /obj/structure/stone_tile/slab/burnt,
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/indestructible/necropolis,
 /area/lavaland/surface/outdoors)
 "DH" = (
 /obj/structure/headpike/bone,
@@ -322,7 +322,7 @@
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 6
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/indestructible/necropolis,
 /area/lavaland/surface/outdoors)
 "Eq" = (
 /obj/structure/stone_tile/surrounding_tile/burnt,
@@ -341,7 +341,7 @@
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 1
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/indestructible/necropolis,
 /area/lavaland/surface/outdoors)
 "Fi" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
@@ -387,6 +387,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
+"Ma" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "MH" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -394,7 +400,7 @@
 /obj/structure/stone_tile/block/burnt{
 	dir = 8
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Ol" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -444,6 +450,9 @@
 /obj/effect/gluttony,
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
+"Rz" = (
+/turf/open/indestructible/necropolis,
+/area/lavaland/surface/outdoors)
 "Sr" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 1
@@ -676,7 +685,7 @@ ls
 ls
 eN
 vU
-MH
+Rz
 MH
 MH
 DH
@@ -726,7 +735,7 @@ Eq
 Sr
 fY
 zd
-zd
+Ma
 nM
 Zu
 "}

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -9,13 +9,16 @@
 /obj/structure/stone_tile/block/burnt{
 	dir = 8
 	},
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "i" = (
 /obj/structure/mirror/directional/east,
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "j" = (
+/obj/structure/mirror/magic/pride{
+	pixel_y = -6
+	},
 /turf/closed/wall/mineral/silver,
 /area/ruin/powered/pride)
 "k" = (
@@ -34,7 +37,7 @@
 "q" = (
 /obj/structure/mirror/directional/east,
 /obj/structure/stone_tile/surrounding_tile,
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "r" = (
 /turf/open/floor/mineral/silver,
@@ -48,32 +51,23 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "u" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 4
 	},
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
-"x" = (
-/obj/structure/stone_tile/burnt{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "y" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding,
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "z" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding/burnt,
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "B" = (
 /obj/structure/stone_tile/center,
@@ -84,24 +78,11 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "G" = (
 /turf/closed/wall/mineral/cult,
 /area/ruin/powered/pride)
-"H" = (
-/obj/structure/mirror/magic/pride{
-	pixel_y = 26
-	},
-/turf/open/floor/mineral/silver,
-/area/ruin/powered/pride)
-"J" = (
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/turf/open/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "K" = (
 /obj/structure/mirror/directional/east,
 /obj/structure/stone_tile/center,
@@ -112,20 +93,20 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "N" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding/burnt,
 /obj/machinery/door/airlock/cult/unruned/friendly,
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "O" = (
 /obj/structure/mirror/directional/west,
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "R" = (
 /obj/structure/mirror/directional/west,
@@ -137,7 +118,7 @@
 	dir = 8
 	},
 /obj/structure/stone_tile/surrounding_tile,
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "S" = (
 /obj/structure/stone_tile/block,
@@ -147,17 +128,17 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
 	},
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "U" = (
 /obj/structure/stone_tile/block{
 	dir = 8
 	},
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "X" = (
 /obj/structure/mirror/directional/west,
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "Y" = (
 /turf/closed/indestructible/riveted/boss,
@@ -166,7 +147,7 @@
 /obj/structure/stone_tile/block{
 	dir = 4
 	},
-/turf/open/lava/smooth,
+/turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 
 (1,1,1) = {"
@@ -208,7 +189,7 @@ X
 X
 X
 G
-x
+c
 a
 "}
 (4,1,1) = {"
@@ -230,7 +211,7 @@ c
 c
 G
 j
-H
+r
 S
 y
 z
@@ -264,7 +245,7 @@ i
 i
 i
 Y
-J
+c
 a
 "}
 (8,1,1) = {"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Yeah so the mirror doesn't also go with you to the station anymore
I also replaced some lava tiles with basalt or weak lava tiles
No GPB please
it also removes a pesky active turf
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I make an error and I gotta fix it, should result in less jank and a better experience with the ruins.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The pride and gluttony ruins have had some minor fixes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
