### PR TITLE
Fix for randomized recipes not working (metalgen and secret sauce)

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -407,14 +407,7 @@ SUBSYSTEM_DEF(persistence)
 	for(var/randomized_type in subtypesof(/datum/chemical_reaction/randomized))
 		var/datum/chemical_reaction/randomized/R = get_chemical_reaction(randomized_type) //ew, would be nice to add some simple tracking
 		if(R?.persistent)
-			var/recipe_data = list()
-			recipe_data["timestamp"] = R.created
-			recipe_data["required_reagents"] = R.required_reagents
-			recipe_data["required_catalysts"] = R.required_catalysts
-			recipe_data["required_temp"] = R.required_temp
-			recipe_data["is_cold_recipe"] = R.is_cold_recipe
-			recipe_data["results"] = R.results
-			recipe_data["required_container"] = "[R.required_container]"
+			var/list/recipe_data = R.SaveOldRecipe()
 			file_data["[R.type]"] = recipe_data
 
 	fdel(json_file)

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -190,6 +190,31 @@ GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 			return null
 		.[pathR] = textreagents[R]
 
+/datum/chemical_reaction/randomized/proc/SaveOldRecipe()
+	var/recipe_data = list()
+
+	recipe_data["timestamp"] = created
+	recipe_data["required_reagents"] = required_reagents
+	recipe_data["required_catalysts"] = required_catalysts
+
+	recipe_data["is_cold_recipe"] = is_cold_recipe
+	recipe_data["required_temp"] = required_temp
+	recipe_data["optimal_temp"] = optimal_temp
+	recipe_data["overheat_temp"] = overheat_temp
+	recipe_data["thermic_constant"] = thermic_constant
+
+	recipe_data["optimal_ph_min"] = optimal_ph_min
+	recipe_data["optimal_ph_max"] = optimal_ph_max
+	recipe_data["determin_ph_range"] = determin_ph_range
+	recipe_data["H_ion_release"] = H_ion_release
+
+	recipe_data["purity_min"] = purity_min
+
+	recipe_data["results"] = results
+	recipe_data["required_container"] = required_container
+
+	return recipe_data
+
 /datum/chemical_reaction/randomized/proc/LoadOldRecipe(recipe_data)
 	created = text2num(recipe_data["timestamp"])
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes saving/loading randomized recipes. 
Code that is saving those recipes was never ported to fermichem and when trying to load things like `optimal_ph_min` it was getting nulls and reaction could never succeed because of those nulls.
Fixed code for saving recipes to contain everything that is loaded after.
Moved code for saving recipe data into its own proc SaveOldRecipe similar to LoadOldRecipe.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Randomized recipes (metalgen and secret sauce) are working again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
