### PR TITLE
Removes a misleading tip + unused defines related to the Ballmer peak

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -401,26 +401,6 @@
 		if(HM?.timeout)
 			dna.remove_mutation(HM.type)
 
-/*
-Alcohol Poisoning Chart
-Note that all higher effects of alcohol poisoning will inherit effects for smaller amounts (i.e. light poisoning inherts from slight poisoning)
-In addition, severe effects won't always trigger unless the drink is poisonously strong
-All effects don't start immediately, but rather get worse over time; the rate is affected by the imbiber's alcohol tolerance
-
-0: Non-alcoholic
-1-10: Barely classifiable as alcohol - occassional slurring
-11-20: Slight alcohol content - slurring
-21-30: Below average - imbiber begins to look slightly drunk
-31-40: Just below average - no unique effects
-41-50: Average - mild disorientation, imbiber begins to look drunk
-51-60: Just above average - disorientation, vomiting, imbiber begins to look heavily drunk
-61-70: Above average - small chance of blurry vision, imbiber begins to look smashed
-71-80: High alcohol content - blurry vision, imbiber completely shitfaced
-81-90: Extremely high alcohol content - light brain damage, passing out
-91-100: Dangerously toxic - swift death
-*/
-#define BALLMER_POINTS 5
-
 // This updates all special effects that really should be status effect datums: Druggy, Hallucinations, Drunkenness, Mute, etc..
 /mob/living/carbon/handle_status_effects(delta_time, times_fired)
 	..()

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -34,7 +34,6 @@ As a Scientist, you can maximize the number of uses you get out of a slime by fe
 As a Scientist, you can disable anomalies by scanning them with an analyzer, then send a signal on the frequency it gives you with a remote signaling device, or if researched, hit the anomaly an anomaly analyzer. This will leave behind an anomaly core, which can be used to construct a Phazon mech, reactive armors, or various unique and powerful weapons!
 As a Scientist, researchable stock parts can seriously improve the efficiency and speed of machines around the station. In some cases, it can even unlock new functions.
 As a Scientist, you can generate money for Science, and complete experiments by letting the tachyon-doppler array record increasingly large explosions.
-As a Scientist, getting drunk just enough will speed up research. Skol!
 As a Roboticist, keep an ear out for anomaly announcements. If you get your hands on a bluespace anomaly core, you can build a Phazon mech!
 As a Roboticist, you can repair your cyborgs with a welding tool. If they have taken burn damage, you can remove their battery, expose the wiring with a screwdriver and replace their wires with a cable coil.
 As a Roboticist, you can reset a cyborg's model by cutting and mending the reset wire with a wire cutter.


### PR DESCRIPTION
## About The Pull Request

- Removes a misleading tip about the ballmer peak giving additional science points. 
   - This was removed with science reworks and never cleaned up.

- Removes an unused define for bonus points for being in the ballmer peak. 
   - Again, removed with science reworks and never cleaned up. It was never even `undef`'d. Shame. 

- Removes a comment detailing what each level of drunkness does in `carbon/life.dm`
   - I moved the contents of this comment to the drunk status effect, and it no longer needs to be here. 

## Why It's Good For The Game

Less lying to people. 

## Changelog

:cl: Melbert
del: Removed a tip suggesting being a drunk scientists boosts research point gain. This was removed at some point, but the tip remained, despite being incorrect. 
/:cl:
