### PR TITLE
Adds a delay to check if a wall is false/opening it

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -96,6 +96,9 @@
 	if(!density)
 		to_chat(user, span_warning("You can't reach, close it first!"))
 		return
+	balloon_alert(user, "tighting bolts...")
+	if(!do_after(user, 2 SECONDS, target = src))
+		return
 	var/turf/loc_turf = get_turf(src)
 	if(loc_turf.density)
 		to_chat(user, span_warning("[src] is blocked!"))
@@ -103,15 +106,14 @@
 	if(!isfloorturf(loc_turf))
 		to_chat(user, span_warning("[src] bolts must be tightened on the floor!"))
 		return TOOL_ACT_TOOLTYPE_SUCCESS
-	if(!do_after(user, 2 SECONDS, target = src))
-		return
 	user.visible_message(span_notice("[user] tightens some bolts on the wall."), span_notice("You tighten the bolts on the wall."))
 	ChangeToWall()
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 
 /obj/structure/falsewall/welder_act(mob/living/user, obj/item/tool)
-	if(tool.use_tool(src, user, 0 SECONDS, volume=50))
+	balloon_alert(user, "slicing down...")
+	if(tool.use_tool(src, user, 5 SECONDS, volume=50))
 		dismantle(user, TRUE)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 	return

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -34,6 +34,9 @@
 	air_update_turf(TRUE, TRUE)
 
 /obj/structure/falsewall/attack_hand(mob/user, list/modifiers)
+	balloon_alert(user, "[src.density ? "searching..." : "closing..."]")
+	if(!do_after(user, 2 SECONDS, target = src))
+		return
 	if(opening)
 		return
 	. = ..()
@@ -100,6 +103,8 @@
 	if(!isfloorturf(loc_turf))
 		to_chat(user, span_warning("[src] bolts must be tightened on the floor!"))
 		return TOOL_ACT_TOOLTYPE_SUCCESS
+	if(!do_after(user, 2 SECONDS, target = src))
+		return
 	user.visible_message(span_notice("[user] tightens some bolts on the wall."), span_notice("You tighten the bolts on the wall."))
 	ChangeToWall()
 	return TOOL_ACT_TOOLTYPE_SUCCESS

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -179,6 +179,9 @@
 	smasher.break_an_arm(arm)
 
 /turf/closed/wall/attack_hand(mob/user, list/modifiers)
+	balloon_alert(user, "searching...")
+	if(!do_after(user, 2 SECONDS, target = src))
+		return
 	. = ..()
 	if(.)
 		return

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -247,7 +247,7 @@
 		if(!I.tool_start_check(user, amount=0))
 			return FALSE
 
-		to_chat(user, span_notice("You begin slicing through the outer plating..."))
+		balloon_alert(user, "slicing down...")
 		if(I.use_tool(src, user, slicing_duration, volume=100))
 			if(iswallturf(src))
 				to_chat(user, span_notice("You remove the outer plating."))
@@ -255,6 +255,13 @@
 			return TRUE
 
 	return FALSE
+
+//Exists to prevent spam clicking on walls with a screwdriver to find false walls
+/turf/closed/wall/screwdriver_act(mob/living/user, obj/item/tool)
+	balloon_alert(user, "tighting bolts...")
+	if(!do_after(user, 2 SECONDS, target = src))
+		return
+	balloon_alert(user, "already tightened!")
 
 /turf/closed/wall/singularity_pull(S, current_size)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Add a small delay for:
Checking if a wall is a false one/opening false walls.
Screwdriving false walls into real ones, and if you try to use a screwdriver on a normal wall.
Welding down false walls.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We often have a paramedic/greytider/security officer running down on maint and clicking on every wall looking for a hidden valid base.

The 2 seconds to search a wall/open a false wall by hand makes spam searching at random be a chore.
The screwdriver change needs to exist so people can't go using a screwdriver on walls until they see a text saying they turned a false wall into a real one.
Welding tool is for the same reason.

With these changes it is not viable to go randomly looking for bases in maint, but it doesn't get much in the way if you have a good reason to search an area for false walls.
It will also make hidden walls/bases a lot safer for the user unless someone catches you getting out of one while losing it's mid combat potential of spawning a wall between you and someone trying to catch you in a split second.
I'm sure that "spawning" a wall to hide behind when chased isn't what people expect from false walls.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
balance: It takes 2 seconds to check if a wall is false, this should cut on people spam clicking every wall in maintenance looking for valids.
balance: Screwdriving and welding down false and real walls also have a delay as they could work as easy false wall checking otherwise.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
