### PR TITLE
Adds windup autofire functionality. The future is now. (Later)

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -22,6 +22,7 @@
 	var/windup_autofire_cap = 0.3
 	///How long it takes for weapons that have spooled-up to reset back to the original firing speed
 	var/windup_spindown = 3 SECONDS
+	///Timer for tracking the spindown reset timings
 	var/timerid
 	COOLDOWN_DECLARE(next_shot_cd)
 

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -13,7 +13,7 @@
 
 	///windup autofire vars
 	///Whether the delay between shots increases over time, simulating a spooling weapon
-	var/windup_autofire = FALSE //
+	var/windup_autofire = FALSE
 	///the reduction to shot delay for windup
 	var/current_windup_reduction = 0
 	///the percentage of autfire_shot_delay that is added to current_windup_reduction

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -262,7 +262,7 @@
 	stop_autofiring()
 	return FALSE
 
-// Reset for our windup, resetting everything back to initial values after a variable set amount of time (determined by var/windup_spindown).
+/// Reset for our windup, resetting everything back to initial values after a variable set amount of time (determined by var/windup_spindown).
 /datum/component/automatic_fire/proc/windup_reset(deltimer)
 	current_windup_reduction = initial(current_windup_reduction)
 	if(deltimer && timerid)

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -11,9 +11,16 @@
 	var/autofire_shot_delay = 0.3 SECONDS //Time between individual shots.
 	var/mouse_status = AUTOFIRE_MOUSEUP //This seems hacky but there can be two MouseDown() without a MouseUp() in between if the user holds click and uses alt+tab, printscreen or similar.
 
+	//windup autofire vars
+	var/windup_autofire = FALSE //Whether the delay between shots increases over time, simulating a spooling weapon. Resets when you stop firing.
+	var/current_windup_reduction = 0 //the reduction to shot delay for windup. Resets when you stop firing to 0.
+	var/windup_autofire_reduction_multiplier = 0.3 //the percentage of autfire_shot_delay that is added to current_windup_reduction. In the default example, every shot reduces the shot delay by 30%.
+	var/windup_autofire_cap = 0.3 //How high of a reduction that current_windup_reduction can reach. In the default example, the delay between shots would be 30% of the original fire delay.
+	var/windup_spindown = 3 SECONDS //How long it takes for weapons that have spooled-up to reset back to the original firing speed
+	var/timerid
 	COOLDOWN_DECLARE(next_shot_cd)
 
-/datum/component/automatic_fire/Initialize(_autofire_shot_delay)
+/datum/component/automatic_fire/Initialize(_autofire_shot_delay, _windup_autofire, _windup_autofire_reduction_multiplier, _windup_autofire_cap, _windup_spindown)
 	. = ..()
 	if(!isgun(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -21,6 +28,11 @@
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/wake_up)
 	if(_autofire_shot_delay)
 		autofire_shot_delay = _autofire_shot_delay
+	if(_windup_autofire)
+		src.windup_autofire = _windup_autofire
+		src.windup_autofire_reduction_multiplier = _windup_autofire_reduction_multiplier
+		src.windup_autofire_cap = _windup_autofire_cap
+		src.windup_spindown = _windup_spindown
 	if(autofire_stat == AUTOFIRE_STAT_IDLE && ismob(gun.loc))
 		var/mob/user = gun.loc
 		wake_up(src, user)
@@ -233,6 +245,10 @@
 		return FALSE
 	shooter.face_atom(target)
 	var/next_delay = autofire_shot_delay
+	if(windup_autofire)
+		next_delay = clamp(next_delay - current_windup_reduction, round(autofire_shot_delay * windup_autofire_cap), autofire_shot_delay)
+		current_windup_reduction = (current_windup_reduction + round(autofire_shot_delay * windup_autofire_reduction_multiplier))
+		timerid = addtimer(CALLBACK(src, .proc/windup_reset, FALSE), windup_spindown, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_STOPPABLE)
 	if(HAS_TRAIT(shooter, TRAIT_DOUBLE_TAP))
 		next_delay = round(next_delay * 0.5)
 	COOLDOWN_START(src, next_shot_cd, next_delay)
@@ -240,6 +256,11 @@
 		return TRUE
 	stop_autofiring()
 	return FALSE
+
+/datum/component/automatic_fire/proc/windup_reset(deltimer)
+	current_windup_reduction = initial(current_windup_reduction)
+	if(deltimer && timerid)
+		deltimer(timerid)
 
 // Gun procs.
 

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -11,28 +11,33 @@
 	var/autofire_shot_delay = 0.3 SECONDS //Time between individual shots.
 	var/mouse_status = AUTOFIRE_MOUSEUP //This seems hacky but there can be two MouseDown() without a MouseUp() in between if the user holds click and uses alt+tab, printscreen or similar.
 
-	//windup autofire vars
-	var/windup_autofire = FALSE //Whether the delay between shots increases over time, simulating a spooling weapon. Resets when you stop firing.
-	var/current_windup_reduction = 0 //the reduction to shot delay for windup. Resets when you stop firing to 0.
-	var/windup_autofire_reduction_multiplier = 0.3 //the percentage of autfire_shot_delay that is added to current_windup_reduction. In the default example, every shot reduces the shot delay by 30%.
-	var/windup_autofire_cap = 0.3 //How high of a reduction that current_windup_reduction can reach. In the default example, the delay between shots would be 30% of the original fire delay.
-	var/windup_spindown = 3 SECONDS //How long it takes for weapons that have spooled-up to reset back to the original firing speed
+	///windup autofire vars
+	///Whether the delay between shots increases over time, simulating a spooling weapon
+	var/windup_autofire = FALSE //
+	///the reduction to shot delay for windup
+	var/current_windup_reduction = 0
+	///the percentage of autfire_shot_delay that is added to current_windup_reduction
+	var/windup_autofire_reduction_multiplier = 0.3
+	///How high of a reduction that current_windup_reduction can reach
+	var/windup_autofire_cap = 0.3
+	///How long it takes for weapons that have spooled-up to reset back to the original firing speed
+	var/windup_spindown = 3 SECONDS
 	var/timerid
 	COOLDOWN_DECLARE(next_shot_cd)
 
-/datum/component/automatic_fire/Initialize(_autofire_shot_delay, _windup_autofire, _windup_autofire_reduction_multiplier, _windup_autofire_cap, _windup_spindown)
+/datum/component/automatic_fire/Initialize(autofire_shot_delay, windup_autofire, windup_autofire_reduction_multiplier, windup_autofire_cap, windup_spindown)
 	. = ..()
 	if(!isgun(parent))
 		return COMPONENT_INCOMPATIBLE
 	var/obj/item/gun = parent
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/wake_up)
-	if(_autofire_shot_delay)
-		autofire_shot_delay = _autofire_shot_delay
-	if(_windup_autofire)
-		src.windup_autofire = _windup_autofire
-		src.windup_autofire_reduction_multiplier = _windup_autofire_reduction_multiplier
-		src.windup_autofire_cap = _windup_autofire_cap
-		src.windup_spindown = _windup_spindown
+	if(autofire_shot_delay)
+		src.autofire_shot_delay = autofire_shot_delay
+	if(windup_autofire)
+		src.windup_autofire = windup_autofire
+		src.windup_autofire_reduction_multiplier = windup_autofire_reduction_multiplier
+		src.windup_autofire_cap = windup_autofire_cap
+		src.windup_spindown = windup_spindown
 	if(autofire_stat == AUTOFIRE_STAT_IDLE && ismob(gun.loc))
 		var/mob/user = gun.loc
 		wake_up(src, user)
@@ -257,6 +262,7 @@
 	stop_autofiring()
 	return FALSE
 
+// Reset for our windup, resetting everything back to initial values after a variable set amount of time (determined by var/windup_spindown).
 /datum/component/automatic_fire/proc/windup_reset(deltimer)
 	current_windup_reduction = initial(current_windup_reduction)
 	if(deltimer && timerid)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pulls the wind up autofire functionality from my energy weapon pr as a standalone code improvement. The original use case for this was for the Deltra, which you can see [here](https://github.com/tgstation/tgstation/pull/67768). That's not in this PR, it's just a working example.

## Why It's Good For The Game

I think it'd be real cool to use this for something. That is to say, I know **I** want to use it for something, but why wait on me?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Added code functionality for autofire windup and resetting, both redefinable. Nothing uses this code just yet!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
