### PR TITLE
Jungle salad fix

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_salad.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_salad.dm
@@ -77,10 +77,9 @@
 	name = "Jungle salad"
 	reqs = list(
 		/obj/item/reagent_containers/glass/bowl = 1,
-		/obj/item/food/grown/apple = 1,
-		/obj/item/food/grown/grapes = 1,
+		/obj/item/food/grown/apple = 2,
+		/obj/item/food/grown/grapes = 2,
 		/obj/item/food/grown/banana = 2,
-		/obj/item/food/watermelonslice = 2
 
 	)
 	result = /obj/item/food/salad/jungle


### PR DESCRIPTION

## About The Pull Request

So uhhhhh, jungle salad was made with watermelon + banana, and everyone knows what that means. This replaces the watermelon slices with other fruits in the recipe. There is a minor reaction that causes the recipe to produce laughter when eaten, but I thought that was pretty endearing so let's leave that in :) It makes me think of this stock image of a man laughing while eating salad.

![image](https://user-images.githubusercontent.com/16896032/174966851-b5c54a61-a5d3-4f34-8309-3e62cd3d5bf4.png)


## Why It's Good For The Game

Broken recipes that don't work are bad, so having things work as intended is good. 

## Changelog


:cl:
fix: Jungle salad can now be eaten again
/:cl:
