### PR TITLE
Fixes coffin's export values to what they actually should be

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -3,7 +3,12 @@
 	k_elasticity = 0
 	unit_name = "crate"
 	export_types = list(/obj/structure/closet/crate)
-	exclude_types = list(/obj/structure/closet/crate/large, /obj/structure/closet/crate/wooden, /obj/structure/closet/crate/mail)
+	exclude_types = list(
+		/obj/structure/closet/crate/coffin,
+		/obj/structure/closet/crate/large,
+		/obj/structure/closet/crate/mail,
+		/obj/structure/closet/crate/wooden,
+		)
 
 /datum/export/large/crate/total_printout(datum/export_report/ex, notes = TRUE) // That's why a goddamn metal crate costs that much.
 	. = ..()

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -32,7 +32,7 @@
 	exclude_types = list()
 
 /datum/export/large/crate/coffin
-	cost = CARGO_CRATE_VALUE/2 //50 wooden crates cost 2000 points, and you can make 10 coffins in seconds with those planks. Each coffin selling for 250 means you can make a net gain of 500 points for wasting your time making coffins.
+	cost = CARGO_CRATE_VALUE/2 //50 wooden crates cost 800 credits, and you can make 10 coffins in seconds with those planks. Each coffin selling for 100 means you can make a net gain of 200 credits for wasting your time making coffins.
 	unit_name = "coffin"
 	export_types = list(/obj/structure/closet/crate/coffin)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I've noticed a lot of players mass-producing coffins to sell for increased profits, getting profits from doing so has always been a thing as pointed out by this comment: 
https://github.com/tgstation/tgstation/blob/a7c9bebf96e517c142434f4142d6c8f11018623b/code/modules/cargo/exports/large_objects.dm#L29-L30

I noticed however the process had become even more popular following the last economy rework and since the comment hadn't been updated, I assumed it had become unintentionally even more profitable. When gathering the current numbers, I noticed this:

![image](https://user-images.githubusercontent.com/25415050/174974609-3a287fac-41f5-4172-bc95-4b1037c6ce98.png)

Which shouldn't be happening as CARGO_CRATE_VALUE/2 should return 100, half of what is displayed.
The source of the issue is that coffins weren't added to the crate export's exclude_list, making it sell as a regular crate with the actual cargo crate value as opposed to its own value which is half of it.

Buying a crate of 50 wood planks and selling all of them back as coffins will now only result in a 200 credits profit as opposed to the unintended 1200 credits profits.

## Why It's Good For The Game

Coffins selling for their intended coded-in value instead of inheriting its parent's value is the intended behaviour.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Coffins' base sell price adjusted back to 100 credits as previously intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
