### PR TITLE
Examine Blocks

### DIFF
--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -34,3 +34,5 @@
 	text = "DEBUG: [msg]")
 /// Used for debug messages to the server
 #define debug_world_log(msg) if (GLOB.Debug2) log_world("DEBUG: [msg]")
+/// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
+#define examine_block(str) ("<div class='examine_block'>" + str + "</div>")

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -407,4 +407,4 @@
 		message = html_encode(message)
 	else
 		message = copytext(message, 2)
-	to_chat(target, span_purple("<span class='oocplain'><b>Tip of the round: </b>[message]</span>"))
+	to_chat(target, span_purple(examine_block("<span class='oocplain'><b>Tip of the round: </b>[message]</span>")))

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -102,7 +102,7 @@
 					msg += span_boldnicegreen(event.description + "\n")
 	else
 		msg += "[span_grey("I don't have much of a reaction to anything right now.")]\n"
-	to_chat(user, msg)
+	to_chat(user, examine_block(msg))
 
 ///Called after moodevent/s have been added/removed.
 /datum/component/mood/proc/update_mood()

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -48,7 +48,7 @@
 		RegisterSignal(parent, COMSIG_ADD_MOOD_EVENT_RND, .proc/add_event) //Mood events that are only for RnD members
 
 /datum/component/mood/proc/print_mood(mob/user)
-	var/msg = "[span_info("*---------*\n<EM>My current mental status:</EM>")]\n"
+	var/msg = "[span_info("<EM>My current mental status:</EM>")]\n"
 	msg += span_notice("My current sanity: ") //Long term
 	switch(sanity)
 		if(SANITY_GREAT to INFINITY)

--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -62,7 +62,7 @@
 	SIGNAL_HANDLER
 
 	if(href_list["examine"])
-		to_chat(user, span_notice("[build_label_text(source)]"))
+		to_chat(user, span_notice(examine_block("[build_label_text(source)]")))
 
 /**
  *

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -263,12 +263,12 @@
 	if(!length(shown_skills))
 		to_chat(user, span_notice("You don't seem to have any particularly outstanding skills."))
 		return
-	var/msg = "[span_info("*---------*\n<EM>Your skills</EM>")]\n<span class='notice'>"
+	var/msg = "[span_info("<EM>Your skills</EM>")]\n<span class='notice'>"
 	for(var/i in shown_skills)
 		var/datum/skill/the_skill = i
 		msg += "[initial(the_skill.name)] - [get_skill_level_name(the_skill)]\n"
 	msg += "</span>"
-	to_chat(user, msg)
+	to_chat(user, examine_block(msg))
 
 /datum/mind/proc/set_death_time()
 	SIGNAL_HANDLER

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -637,7 +637,11 @@
  * Produces a signal [COMSIG_PARENT_EXAMINE]
  */
 /atom/proc/examine(mob/user)
-	. = list("[get_examine_string(user, TRUE)][!get_examine_string() ? null : "."]")
+	var/examine_string = get_examine_string(user, thats = TRUE)
+	if(examine_string)
+		. = list("[examine_string].")
+	else
+		. = list()
 
 	. += get_name_chaser(user)
 	if(desc)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -637,18 +637,20 @@
  * Produces a signal [COMSIG_PARENT_EXAMINE]
  */
 /atom/proc/examine(mob/user)
-	. = list("[get_examine_string(user, TRUE)].")
+	. = list("[get_examine_string(user, TRUE)].<hr>")
 
 	. += get_name_chaser(user)
 	if(desc)
 		. += desc
 
 	if(custom_materials)
+		. += "<hr>"
 		var/list/materials_list = list()
 		for(var/datum/material/current_material as anything in custom_materials)
 			materials_list += "[current_material.name]"
 		. += "<u>It is made out of [english_list(materials_list)]</u>."
 	if(reagents)
+		. += "<hr>"
 		if(reagents.flags & TRANSPARENT)
 			. += "It contains:"
 			if(length(reagents.reagent_list))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -637,7 +637,7 @@
  * Produces a signal [COMSIG_PARENT_EXAMINE]
  */
 /atom/proc/examine(mob/user)
-	. = list("[get_examine_string(user, TRUE)].<hr>")
+	. = list("[get_examine_string(user, TRUE)][!get_examine_string() ? null : ".<hr>"]")
 
 	. += get_name_chaser(user)
 	if(desc)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -656,7 +656,7 @@
 			if(length(reagents.reagent_list))
 				if(user.can_see_reagents()) //Show each individual reagent
 					for(var/datum/reagent/current_reagent as anything in reagents.reagent_list)
-						. += "[round(current_reagent.volume, 0.01)] units of [current_reagent.name]"
+						. += "&bull; [round(current_reagent.volume, 0.01)] units of [current_reagent.name]"
 					if(reagents.is_reacting)
 						. += span_warning("It is currently reacting!")
 					. += span_notice("The solution's pH is [round(reagents.ph, 0.01)] and has a temperature of [reagents.chem_temp]K.")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -602,10 +602,10 @@
  * [COMSIG_ATOM_GET_EXAMINE_NAME] signal
  */
 /atom/proc/get_examine_name(mob/user)
-	. = "\a [src]"
+	. = "\a <b>[src]</b>"
 	var/list/override = list(gender == PLURAL ? "some" : "a", " ", "[name]")
 	if(article)
-		. = "[article] [src]"
+		. = "[article] <b>[src]</b>"
 		override[EXAMINE_POSITION_ARTICLE] = article
 	if(SEND_SIGNAL(src, COMSIG_ATOM_GET_EXAMINE_NAME, user, override) & COMPONENT_EXNAME_CHANGED)
 		. = override.Join("")
@@ -637,20 +637,18 @@
  * Produces a signal [COMSIG_PARENT_EXAMINE]
  */
 /atom/proc/examine(mob/user)
-	. = list("[get_examine_string(user, TRUE)][!get_examine_string() ? null : ".<hr>"]")
+	. = list("[get_examine_string(user, TRUE)][!get_examine_string() ? null : "."]")
 
 	. += get_name_chaser(user)
 	if(desc)
 		. += desc
 
 	if(custom_materials)
-		. += "<hr>"
 		var/list/materials_list = list()
 		for(var/datum/material/current_material as anything in custom_materials)
 			materials_list += "[current_material.name]"
 		. += "<u>It is made out of [english_list(materials_list)]</u>."
 	if(reagents)
-		. += "<hr>"
 		if(reagents.flags & TRANSPARENT)
 			. += "It contains:"
 			if(length(reagents.reagent_list))

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -189,5 +189,5 @@
 			message += span_notice("Volume: [volume] L") // don't want to change the order volume appears in, suck it
 
 	// we let the join apply newlines so we do need handholding
-	to_chat(user, jointext(message, "\n"), type = MESSAGE_TYPE_INFO)
+	to_chat(user, examine_block(jointext(message, "\n")), type = MESSAGE_TYPE_INFO)
 	return TRUE

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -377,7 +377,7 @@
 	// we handled the last <br> so we don't need handholding
 
 	if(tochat)
-		to_chat(user, jointext(render_list, ""), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
+		to_chat(user, examine_block(jointext(render_list, "")), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 	else
 		return(jointext(render_list, ""))
 
@@ -436,7 +436,7 @@
 				render_list += "<span class='alert ml-2'>[allergies]</span>\n"
 
 		// we handled the last <br> so we don't need handholding
-		to_chat(user, jointext(render_list, ""), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
+		to_chat(user, examine_block(jointext(render_list, "")), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 
 /obj/item/healthanalyzer/AltClick(mob/user)
 	..()
@@ -475,7 +475,7 @@
 		else
 			to_chat(user, "<span class='notice ml-1'>No wounds detected in subject.</span>")
 	else
-		to_chat(user, jointext(render_list, ""), type = MESSAGE_TYPE_INFO)
+		to_chat(user, examine_block(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
 
 /obj/item/healthanalyzer/wound
 	name = "first aid analyzer"

--- a/code/game/objects/items/devices/scanners/slime_scanner.dm
+++ b/code/game/objects/items/devices/scanners/slime_scanner.dm
@@ -51,4 +51,4 @@
 	if(T.effectmod)
 		to_render += "\n[span_notice("Core mutation in progress: [T.effectmod]")]\
 					  \n[span_notice("Progress in core mutation: [T.applied] / [SLIME_EXTRACT_CROSSING_REQUIRED]")]"
-	to_chat(user, to_render + "\n========================")
+	to_chat(user, examine_block(to_render + "\n========================"))

--- a/code/game/objects/items/devices/scanners/slime_scanner.dm
+++ b/code/game/objects/items/devices/scanners/slime_scanner.dm
@@ -23,8 +23,7 @@
 	slime_scan(T, user)
 
 /proc/slime_scan(mob/living/simple_animal/slime/T, mob/living/user)
-	var/to_render = "========================\
-					\n<b>Slime scan results:</b>\
+	var/to_render = "<b>Slime scan results:</b>\
 					\n[span_notice("[T.colour] [T.is_adult ? "adult" : "baby"] slime")]\
 					\nNutrition: [T.nutrition]/[T.get_max_nutrition()]"
 	if (T.nutrition < T.get_starve_nutrition())
@@ -51,4 +50,4 @@
 	if(T.effectmod)
 		to_render += "\n[span_notice("Core mutation in progress: [T.effectmod]")]\
 					  \n[span_notice("Progress in core mutation: [T.applied] / [SLIME_EXTRACT_CROSSING_REQUIRED]")]"
-	to_chat(user, examine_block(to_render + "\n========================"))
+	to_chat(user, examine_block(to_render))

--- a/code/modules/hydroponics/grown/weeds/kudzu.dm
+++ b/code/modules/hydroponics/grown/weeds/kudzu.dm
@@ -54,7 +54,7 @@
 	var/output_message = ""
 	for(var/datum/spacevine_mutation/SM in mutations)
 		kudzu_mutations += "[(kudzu_mutations == "") ? "" : ", "][SM.name]"
-	output_message += "- Plant Mutations: [(kudzu_mutations == "") ? "None." : "[kudzu_mutations]."]"
+	output_message += "Plant Mutations: [(kudzu_mutations == "") ? "None." : "[kudzu_mutations]."]"
 	return output_message
 
 /obj/item/seeds/kudzu/on_chem_reaction(datum/reagents/reagents)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -213,7 +213,7 @@
 		for(var/datum/reagent/reagent_id in scanned_tray.reagents.reagent_list)
 			if(newline)
 				returned_message += "\n"
-			returned_message += "[span_notice("[reagent_id.volume] / [scanned_tray.maxnutri] units of [reagent_id]")]"
+			returned_message += "[span_notice("&bull; [reagent_id.volume] / [scanned_tray.maxnutri] units of [reagent_id]")]"
 			newline = TRUE
 	else
 		returned_message += "[span_notice("No reagents found.")]"
@@ -356,7 +356,7 @@
 		chem_cap += reagent.volume
 		if(newline)
 			reagents_text += "\n"
-		reagents_text += "[reagent.name]: [amount]"
+		reagents_text += "&bull; [reagent.name]: [amount]"
 		newline = TRUE
 	if(chem_cap > 100)
 		text += "\n[span_danger("Reagent Traits Over 100% Production")]"

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -74,19 +74,19 @@
  */
 /obj/item/plant_analyzer/proc/do_plant_stats_scan(atom/scan_target, mob/user)
 	if(istype(scan_target, /obj/machinery/hydroponics))
-		to_chat(user, scan_tray_stats(scan_target))
+		to_chat(user, examine_block(scan_tray_stats(scan_target)))
 		return TRUE
 	if(istype(scan_target, /obj/structure/glowshroom))
 		var/obj/structure/glowshroom/shroom_plant = scan_target
-		to_chat(user, scan_plant_stats(shroom_plant.myseed))
+		to_chat(user, examine_block(scan_plant_stats(shroom_plant.myseed)))
 		return TRUE
 	if(istype(scan_target, /obj/item/graft))
-		to_chat(user, get_graft_text(scan_target))
+		to_chat(user, examine_block(get_graft_text(scan_target)))
 		return TRUE
 	if(isitem(scan_target))
 		var/obj/item/scanned_object = scan_target
 		if(scanned_object.get_plant_seed() || istype(scanned_object, /obj/item/seeds))
-			to_chat(user, scan_plant_stats(scanned_object))
+			to_chat(user, examine_block(scan_plant_stats(scanned_object)))
 			return TRUE
 	if(isliving(scan_target))
 		var/mob/living/L = scan_target
@@ -107,19 +107,19 @@
  */
 /obj/item/plant_analyzer/proc/do_plant_chem_scan(atom/scan_target, mob/user)
 	if(istype(scan_target, /obj/machinery/hydroponics))
-		to_chat(user, scan_tray_chems(scan_target))
+		to_chat(user, examine_block(scan_tray_chems(scan_target)))
 		return TRUE
 	if(istype(scan_target, /obj/structure/glowshroom))
 		var/obj/structure/glowshroom/shroom_plant = scan_target
-		to_chat(user, scan_plant_chems(shroom_plant.myseed))
+		to_chat(user, examine_block(scan_plant_chems(shroom_plant.myseed)))
 		return TRUE
 	if(istype(scan_target, /obj/item/graft))
-		to_chat(user, get_graft_text(scan_target))
+		to_chat(user, examine_block(get_graft_text(scan_target)))
 		return TRUE
 	if(isitem(scan_target))
 		var/obj/item/scanned_object = scan_target
 		if(scanned_object.get_plant_seed() || istype(scanned_object, /obj/item/seeds))
-			to_chat(user, scan_plant_chems(scanned_object))
+			to_chat(user, examine_block(scan_plant_chems(scanned_object)))
 			return TRUE
 	if(isliving(scan_target))
 		var/mob/living/L = scan_target
@@ -223,7 +223,7 @@
  * Returns the formatted output as text.
  */
 /obj/item/plant_analyzer/proc/scan_plant_stats(obj/item/scanned_object)
-	var/returned_message = "*---------*\nThis is [span_name("\a [scanned_object]")].\n"
+	var/returned_message = "This is [span_name("\a [scanned_object]")].\n"
 	var/obj/item/seeds/our_seed = scanned_object
 	if(!istype(our_seed)) //if we weren't passed a seed, we were passed a plant with a seed
 		our_seed = scanned_object.get_plant_seed()

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -172,13 +172,12 @@
 		returned_message += "[span_bold("[scanned_tray.myseed.plantname]")]"
 		returned_message += "\nPlant Age: [span_notice("[scanned_tray.age]")]"
 		returned_message += "\nPlant Health: [span_notice("[scanned_tray.plant_health]")]"
-		returned_message += "<hr>"
-		returned_message += scan_plant_stats(scanned_tray.myseed)
-		returned_message += "<hr>"
+		returned_message += scan_plant_stats(scanned_tray.myseed, TRUE)
+		returned_message += "\n<b>Growth medium</b>"
 	else
-		returned_message += span_bold("No plant found.\n")
+		returned_message += span_bold("No plant found.")
 
-	returned_message += "Weed level: [span_notice("[scanned_tray.weedlevel] / [MAX_TRAY_WEEDS]")]"
+	returned_message += "\nWeed level: [span_notice("[scanned_tray.weedlevel] / [MAX_TRAY_WEEDS]")]"
 	returned_message += "\nPest level: [span_notice("[scanned_tray.pestlevel] / [MAX_TRAY_PESTS]")]"
 	returned_message += "\nToxicity level: [span_notice("[scanned_tray.toxic] / [MAX_TRAY_TOXINS]")]"
 	returned_message += "\nWater level: [span_notice("[scanned_tray.waterlevel] / [scanned_tray.maxwater]")]"
@@ -201,22 +200,16 @@
 	if(scanned_tray.myseed)
 		returned_message += "[span_bold("[scanned_tray.myseed.plantname]")]"
 		returned_message += "\nPlant Age: [span_notice("[scanned_tray.age]")]"
-		returned_message += "<hr>"
-		returned_message += scan_plant_chems(scanned_tray.myseed)
-		returned_message += "<hr>"
+		returned_message += scan_plant_chems(scanned_tray.myseed, TRUE)
 	else
-		returned_message += span_bold("No plant found.\n")
+		returned_message += span_bold("No plant found.")
 
-	returned_message += "Tray contains:\n"
+	returned_message += "\nGrowth medium contains:"
 	if(scanned_tray.reagents.reagent_list.len)
-		var/newline = FALSE
 		for(var/datum/reagent/reagent_id in scanned_tray.reagents.reagent_list)
-			if(newline)
-				returned_message += "\n"
-			returned_message += "[span_notice("&bull; [reagent_id.volume] / [scanned_tray.maxnutri] units of [reagent_id]")]"
-			newline = TRUE
+			returned_message += "\n[span_notice("&bull; [reagent_id.volume] / [scanned_tray.maxnutri] units of [reagent_id]")]"
 	else
-		returned_message += "[span_notice("No reagents found.")]"
+		returned_message += "\n[span_notice("No reagents found.")]"
 
 	return span_info(returned_message)
 
@@ -228,8 +221,12 @@
  *
  * Returns the formatted output as text.
  */
-/obj/item/plant_analyzer/proc/scan_plant_stats(obj/item/scanned_object)
-	var/returned_message = "This is [span_name("\a [scanned_object]")]."
+/obj/item/plant_analyzer/proc/scan_plant_stats(obj/item/scanned_object, in_tray = FALSE)
+	var/returned_message = ""
+	if(!in_tray)
+		returned_message += "This is [span_name("\a [scanned_object]")]."
+	else
+		returned_message += "\n<b>Seed Stats</b>"
 	var/obj/item/seeds/our_seed = scanned_object
 	if(!istype(our_seed)) //if we weren't passed a seed, we were passed a plant with a seed
 		our_seed = scanned_object.get_plant_seed()
@@ -237,7 +234,7 @@
 	if(our_seed && istype(our_seed))
 		returned_message += get_analyzer_text_traits(our_seed)
 	else
-		returned_message += "<hr>No genes found."
+		returned_message += "\nNo genes found."
 
 	return span_info(returned_message)
 
@@ -249,8 +246,12 @@
  *
  * Returns the formatted output as text.
  */
-/obj/item/plant_analyzer/proc/scan_plant_chems(obj/item/scanned_object)
-	var/returned_message = "This is [span_name("\a [scanned_object]")]."
+/obj/item/plant_analyzer/proc/scan_plant_chems(obj/item/scanned_object, in_tray = FALSE)
+	var/returned_message = ""
+	if(!in_tray)
+		returned_message += "This is [span_name("\a [scanned_object]")]."
+	else
+		returned_message += "\n<b>Seed Stats</b>"
 	var/obj/item/seeds/our_seed = scanned_object
 	if(!istype(our_seed)) //if we weren't passed a seed, we were passed a plant with a seed
 		our_seed = scanned_object.get_plant_seed()
@@ -260,7 +261,7 @@
 	else if (our_seed.reagents_add?.len) //we have a seed with reagent genes
 		returned_message += get_analyzer_text_chem_genes(our_seed)
 	else
-		returned_message += "<hr>No reagents found."
+		returned_message += "\nNo reagents found."
 
 	return span_info(returned_message)
 
@@ -313,8 +314,7 @@
 	QDEL_NULL(scanned_graft_result) //graft genes are stored as typepaths so if we want to get their formatted name we need a datum ref - musn't forget to clean up afterwards
 	var/unique_text = scanned.get_unique_analyzer_text()
 	if(unique_text)
-		text += "<hr>"
-		text += unique_text
+		text += "\n[unique_text]"
 	return text
 
 /**
@@ -325,15 +325,9 @@
  * Returns the formatted output as text.
  */
 /obj/item/plant_analyzer/proc/get_analyzer_text_chem_genes(obj/item/seeds/scanned)
-	var/text = ""
-	text += "\nPlant Reagent Genes"
-	text += "<hr>"
-	var/newline = FALSE
+	var/text = "\nPlant Reagent Genes:"
 	for(var/datum/plant_gene/reagent/gene in scanned.genes)
-		if(newline)
-			text += "\n"
-		text += "[gene.get_name()]"
-		newline = TRUE
+		text += "\n&bull; [gene.get_name()]"
 	return text
 
 /**
@@ -346,24 +340,19 @@
 /obj/item/plant_analyzer/proc/get_analyzer_text_chem_contents(obj/item/scanned_plant)
 	var/text = ""
 	var/reagents_text = ""
-	text += "\nPlant Reagents"
-	text += "\nMaximum reagent capacity: [scanned_plant.reagents.maximum_volume]"
+	text += "\nPlant Reagents:"
 	var/chem_cap = 0
-	var/newline = FALSE
 	for(var/_reagent in scanned_plant.reagents.reagent_list)
 		var/datum/reagent/reagent = _reagent
 		var/amount = reagent.volume
 		chem_cap += reagent.volume
-		if(newline)
-			reagents_text += "\n"
-		reagents_text += "&bull; [reagent.name]: [amount]"
-		newline = TRUE
+		reagents_text += "\n&bull; [reagent.name]: [amount]"
+	if(reagents_text)
+		text += reagents_text
+	text += "\nMaximum reagent capacity: [scanned_plant.reagents.maximum_volume]"
 	if(chem_cap > 100)
 		text += "\n[span_danger("Reagent Traits Over 100% Production")]"
 
-	if(reagents_text)
-		text += "<hr>"
-		text += reagents_text
 	return text
 
 /**
@@ -379,8 +368,7 @@
 		text += "\nParent Plant: [span_notice("[scanned_graft.parent_name]")]"
 	if(scanned_graft.stored_trait)
 		text += "\nGraftable Traits: [span_notice("[scanned_graft.stored_trait.get_name()]")]"
-	text += "<hr>"
-	text += "Yield: [span_notice("[scanned_graft.yield]")]"
+	text += "\nYield: [span_notice("[scanned_graft.yield]")]"
 	text += "\nProduction speed: [span_notice("[scanned_graft.production]")]"
 	text += "\nEndurance: [span_notice("[scanned_graft.endurance]")]"
 	text += "\nLifespan: [span_notice("[scanned_graft.lifespan]")]"

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -167,24 +167,25 @@
  * Returns the formatted message as text.
  */
 /obj/item/plant_analyzer/proc/scan_tray_stats(obj/machinery/hydroponics/scanned_tray)
-	var/returned_message = "*---------*\n"
+	var/returned_message = ""
 	if(scanned_tray.myseed)
-		returned_message += "*** [span_bold("[scanned_tray.myseed.plantname]")] ***\n"
-		returned_message += "- Plant Age: [span_notice("[scanned_tray.age]")]\n"
-		returned_message += "- Plant Health: [span_notice("[scanned_tray.plant_health]")]\n"
+		returned_message += "[span_bold("[scanned_tray.myseed.plantname]")]"
+		returned_message += "\nPlant Age: [span_notice("[scanned_tray.age]")]"
+		returned_message += "\nPlant Health: [span_notice("[scanned_tray.plant_health]")]"
+		returned_message += "<hr>"
 		returned_message += scan_plant_stats(scanned_tray.myseed)
+		returned_message += "<hr>"
 	else
 		returned_message += span_bold("No plant found.\n")
 
-	returned_message += "- Weed level: [span_notice("[scanned_tray.weedlevel] / [MAX_TRAY_WEEDS]")]\n"
-	returned_message += "- Pest level: [span_notice("[scanned_tray.pestlevel] / [MAX_TRAY_PESTS]")]\n"
-	returned_message += "- Toxicity level: [span_notice("[scanned_tray.toxic] / [MAX_TRAY_TOXINS]")]\n"
-	returned_message += "- Water level: [span_notice("[scanned_tray.waterlevel] / [scanned_tray.maxwater]")]\n"
-	returned_message += "- Nutrition level: [span_notice("[scanned_tray.reagents.total_volume] / [scanned_tray.maxnutri]")]\n"
+	returned_message += "Weed level: [span_notice("[scanned_tray.weedlevel] / [MAX_TRAY_WEEDS]")]"
+	returned_message += "\nPest level: [span_notice("[scanned_tray.pestlevel] / [MAX_TRAY_PESTS]")]"
+	returned_message += "\nToxicity level: [span_notice("[scanned_tray.toxic] / [MAX_TRAY_TOXINS]")]"
+	returned_message += "\nWater level: [span_notice("[scanned_tray.waterlevel] / [scanned_tray.maxwater]")]"
+	returned_message += "\nNutrition level: [span_notice("[scanned_tray.reagents.total_volume] / [scanned_tray.maxnutri]")]"
 	if(scanned_tray.yieldmod != 1)
-		returned_message += "- Yield modifier on harvest: [span_notice("[scanned_tray.yieldmod]x")]\n"
+		returned_message += "\nYield modifier on harvest: [span_notice("[scanned_tray.yieldmod]x")]"
 
-	returned_message += "*---------*"
 	return span_info(returned_message)
 
 /**
@@ -196,22 +197,27 @@
  * Returns the formatted message as text.
  */
 /obj/item/plant_analyzer/proc/scan_tray_chems(obj/machinery/hydroponics/scanned_tray)
-	var/returned_message = "*---------*\n"
+	var/returned_message = ""
 	if(scanned_tray.myseed)
-		returned_message += "*** [span_bold("[scanned_tray.myseed.plantname]")] ***\n"
-		returned_message += "- Plant Age: [span_notice("[scanned_tray.age]")]\n"
+		returned_message += "[span_bold("[scanned_tray.myseed.plantname]")]"
+		returned_message += "\nPlant Age: [span_notice("[scanned_tray.age]")]"
+		returned_message += "<hr>"
 		returned_message += scan_plant_chems(scanned_tray.myseed)
+		returned_message += "<hr>"
 	else
 		returned_message += span_bold("No plant found.\n")
 
-	returned_message += "- Tray contains:\n"
+	returned_message += "Tray contains:\n"
 	if(scanned_tray.reagents.reagent_list.len)
+		var/newline = FALSE
 		for(var/datum/reagent/reagent_id in scanned_tray.reagents.reagent_list)
-			returned_message += "- [span_notice("[reagent_id.volume] / [scanned_tray.maxnutri] units of [reagent_id]")]\n"
+			if(newline)
+				returned_message += "\n"
+			returned_message += "[span_notice("[reagent_id.volume] / [scanned_tray.maxnutri] units of [reagent_id]")]"
+			newline = TRUE
 	else
-		returned_message += "[span_notice("No reagents found.")]\n"
+		returned_message += "[span_notice("No reagents found.")]"
 
-	returned_message += "*---------*"
 	return span_info(returned_message)
 
 /**
@@ -223,7 +229,7 @@
  * Returns the formatted output as text.
  */
 /obj/item/plant_analyzer/proc/scan_plant_stats(obj/item/scanned_object)
-	var/returned_message = "This is [span_name("\a [scanned_object]")].\n"
+	var/returned_message = "This is [span_name("\a [scanned_object]")]."
 	var/obj/item/seeds/our_seed = scanned_object
 	if(!istype(our_seed)) //if we weren't passed a seed, we were passed a plant with a seed
 		our_seed = scanned_object.get_plant_seed()
@@ -231,9 +237,8 @@
 	if(our_seed && istype(our_seed))
 		returned_message += get_analyzer_text_traits(our_seed)
 	else
-		returned_message += "*---------*\nNo genes found.\n*---------*"
+		returned_message += "<hr>No genes found."
 
-	returned_message += "\n"
 	return span_info(returned_message)
 
 /**
@@ -245,7 +250,7 @@
  * Returns the formatted output as text.
  */
 /obj/item/plant_analyzer/proc/scan_plant_chems(obj/item/scanned_object)
-	var/returned_message = "*---------*\nThis is [span_name("\a [scanned_object]")].\n"
+	var/returned_message = "This is [span_name("\a [scanned_object]")]."
 	var/obj/item/seeds/our_seed = scanned_object
 	if(!istype(our_seed)) //if we weren't passed a seed, we were passed a plant with a seed
 		our_seed = scanned_object.get_plant_seed()
@@ -255,9 +260,8 @@
 	else if (our_seed.reagents_add?.len) //we have a seed with reagent genes
 		returned_message += get_analyzer_text_chem_genes(our_seed)
 	else
-		returned_message += "*---------*\nNo reagents found.\n*---------*"
+		returned_message += "<hr>No reagents found."
 
-	returned_message += "\n"
 	return span_info(returned_message)
 
 /**
@@ -270,28 +274,28 @@
 /obj/item/plant_analyzer/proc/get_analyzer_text_traits(obj/item/seeds/scanned)
 	var/text = ""
 	if(scanned.get_gene(/datum/plant_gene/trait/plant_type/weed_hardy))
-		text += "- Plant type: [span_notice("Weed. Can grow in nutrient-poor soil.")]\n"
+		text += "\nPlant type: [span_notice("Weed. Can grow in nutrient-poor soil.")]"
 	else if(scanned.get_gene(/datum/plant_gene/trait/plant_type/fungal_metabolism))
-		text += "- Plant type: [span_notice("Mushroom. Can grow in dry soil.")]\n"
+		text += "\nPlant type: [span_notice("Mushroom. Can grow in dry soil.")]"
 	else if(scanned.get_gene(/datum/plant_gene/trait/plant_type/alien_properties))
-		text += "- Plant type: [span_warning("UNKNOWN")] \n"
+		text += "\nPlant type: [span_warning("UNKNOWN")]"
 	else
-		text += "- Plant type: [span_notice("Normal plant")]\n"
+		text += "\nPlant type: [span_notice("Normal plant")]"
 
 	if(scanned.potency != -1)
-		text += "- Potency: [span_notice("[scanned.potency]")]\n"
+		text += "\nPotency: [span_notice("[scanned.potency]")]"
 	if(scanned.yield != -1)
-		text += "- Yield: [span_notice("[scanned.yield]")]\n"
-	text += "- Maturation speed: [span_notice("[scanned.maturation]")]\n"
+		text += "\nYield: [span_notice("[scanned.yield]")]"
+	text += "\nMaturation speed: [span_notice("[scanned.maturation]")]"
 	if(scanned.yield != -1)
-		text += "- Production speed: [span_notice("[scanned.production]")]\n"
-	text += "- Endurance: [span_notice("[scanned.endurance]")]\n"
-	text += "- Lifespan: [span_notice("[scanned.lifespan]")]\n"
-	text += "- Instability: [span_notice("[scanned.instability]")]\n"
-	text += "- Weed Growth Rate: [span_notice("[scanned.weed_rate]")]\n"
-	text += "- Weed Vulnerability: [span_notice("[scanned.weed_chance]")]\n"
+		text += "\nProduction speed: [span_notice("[scanned.production]")]"
+	text += "\nEndurance: [span_notice("[scanned.endurance]")]"
+	text += "\nLifespan: [span_notice("[scanned.lifespan]")]"
+	text += "\nInstability: [span_notice("[scanned.instability]")]"
+	text += "\nWeed Growth Rate: [span_notice("[scanned.weed_rate]")]"
+	text += "\nWeed Vulnerability: [span_notice("[scanned.weed_chance]")]"
 	if(scanned.rarity)
-		text += "- Species Discovery Value: [span_notice("[scanned.rarity]")]\n"
+		text += "\nSpecies Discovery Value: [span_notice("[scanned.rarity]")]"
 	var/all_removable_traits = ""
 	var/all_immutable_traits = ""
 	for(var/datum/plant_gene/trait/traits in scanned.genes)
@@ -302,17 +306,15 @@
 		else
 			all_immutable_traits += "[(all_immutable_traits == "") ? "" : ", "][traits.get_name()]"
 
-	text += "- Plant Traits: [span_notice("[all_removable_traits? all_removable_traits : "None."]")]\n"
-	text += "- Core Plant Traits: [span_notice("[all_immutable_traits? all_immutable_traits : "None."]")]\n"
+	text += "\nPlant Traits: [span_notice("[all_removable_traits? all_removable_traits : "None."]")]"
+	text += "\nCore Plant Traits: [span_notice("[all_immutable_traits? all_immutable_traits : "None."]")]"
 	var/datum/plant_gene/scanned_graft_result = scanned.graft_gene? new scanned.graft_gene : new /datum/plant_gene/trait/repeated_harvest
-	text += "- Grafting this plant would give: [span_notice("[scanned_graft_result.get_name()]")]\n"
+	text += "\nGrafting this plant would give: [span_notice("[scanned_graft_result.get_name()]")]"
 	QDEL_NULL(scanned_graft_result) //graft genes are stored as typepaths so if we want to get their formatted name we need a datum ref - musn't forget to clean up afterwards
-	text += "*---------*"
 	var/unique_text = scanned.get_unique_analyzer_text()
 	if(unique_text)
-		text += "\n"
+		text += "<hr>"
 		text += unique_text
-		text += "\n*---------*"
 	return text
 
 /**
@@ -324,11 +326,14 @@
  */
 /obj/item/plant_analyzer/proc/get_analyzer_text_chem_genes(obj/item/seeds/scanned)
 	var/text = ""
-	text += "- Plant Reagent Genes -\n"
-	text += "*---------*\n"
+	text += "\nPlant Reagent Genes"
+	text += "<hr>"
+	var/newline = FALSE
 	for(var/datum/plant_gene/reagent/gene in scanned.genes)
-		text += "- [gene.get_name()] -\n"
-	text += "*---------*"
+		if(newline)
+			text += "\n"
+		text += "[gene.get_name()]"
+		newline = TRUE
 	return text
 
 /**
@@ -341,21 +346,24 @@
 /obj/item/plant_analyzer/proc/get_analyzer_text_chem_contents(obj/item/scanned_plant)
 	var/text = ""
 	var/reagents_text = ""
-	text += "- Plant Reagents -\n"
-	text += "Maximum reagent capacity: [scanned_plant.reagents.maximum_volume]\n"
+	text += "\nPlant Reagents"
+	text += "\nMaximum reagent capacity: [scanned_plant.reagents.maximum_volume]"
 	var/chem_cap = 0
+	var/newline = FALSE
 	for(var/_reagent in scanned_plant.reagents.reagent_list)
 		var/datum/reagent/reagent = _reagent
 		var/amount = reagent.volume
 		chem_cap += reagent.volume
-		reagents_text += "\n- [reagent.name]: [amount]"
+		if(newline)
+			reagents_text += "\n"
+		reagents_text += "[reagent.name]: [amount]"
+		newline = TRUE
 	if(chem_cap > 100)
-		text += "- [span_danger("Reagent Traits Over 100% Production")]\n"
+		text += "\n[span_danger("Reagent Traits Over 100% Production")]"
 
 	if(reagents_text)
-		text += "*---------*"
+		text += "<hr>"
 		text += reagents_text
-	text += "\n*---------*"
 	return text
 
 /**
@@ -366,19 +374,18 @@
  * Returns the formatted output as text.
  */
 /obj/item/plant_analyzer/proc/get_graft_text(obj/item/graft/scanned_graft)
-	var/text = "*---------*\n- Plant Graft -\n"
+	var/text = "Plant Graft"
 	if(scanned_graft.parent_name)
-		text += "- Parent Plant: [span_notice("[scanned_graft.parent_name]")] -\n"
+		text += "\nParent Plant: [span_notice("[scanned_graft.parent_name]")]"
 	if(scanned_graft.stored_trait)
-		text += "- Graftable Traits: [span_notice("[scanned_graft.stored_trait.get_name()]")] -\n"
-	text += "*---------*\n"
-	text += "- Yield: [span_notice("[scanned_graft.yield]")]\n"
-	text += "- Production speed: [span_notice("[scanned_graft.production]")]\n"
-	text += "- Endurance: [span_notice("[scanned_graft.endurance]")]\n"
-	text += "- Lifespan: [span_notice("[scanned_graft.lifespan]")]\n"
-	text += "- Weed Growth Rate: [span_notice("[scanned_graft.weed_rate]")]\n"
-	text += "- Weed Vulnerability: [span_notice("[scanned_graft.weed_chance]")]\n"
-	text += "*---------*"
+		text += "\nGraftable Traits: [span_notice("[scanned_graft.stored_trait.get_name()]")]"
+	text += "<hr>"
+	text += "Yield: [span_notice("[scanned_graft.yield]")]"
+	text += "\nProduction speed: [span_notice("[scanned_graft.production]")]"
+	text += "\nEndurance: [span_notice("[scanned_graft.endurance]")]"
+	text += "\nLifespan: [span_notice("[scanned_graft.lifespan]")]"
+	text += "\nWeed Growth Rate: [span_notice("[scanned_graft.weed_rate]")]"
+	text += "\nWeed Vulnerability: [span_notice("[scanned_graft.weed_chance]")]"
 	return span_info(text)
 
 

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -6,7 +6,7 @@
 	var/t_has = p_have()
 	var/t_is = p_are()
 
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!<hr>")
 	var/obscured = check_obscured_slots()
 
 	if (handcuffed)
@@ -150,7 +150,7 @@
 				. += "[t_He] look[p_s()] very happy."
 			if(MOOD_LEVEL_HAPPY4 to INFINITY)
 				. += "[t_He] look[p_s()] ecstatic."
-	. += "*---------*</span>"
+	. += "</span>"
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
 

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -6,7 +6,7 @@
 	var/t_has = p_have()
 	var/t_is = p_are()
 
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!<hr>")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!>")
 	var/obscured = check_obscured_slots()
 
 	if (handcuffed)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -14,7 +14,7 @@
 		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA) || HAS_TRAIT(L, TRAIT_INVISIBLE_MAN))
 			obscure_name = TRUE
 
-	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>!<hr>")
+	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
 
 	var/obscured = check_obscured_slots()
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -14,7 +14,7 @@
 		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA) || HAS_TRAIT(L, TRAIT_INVISIBLE_MAN))
 			obscure_name = TRUE
 
-	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
+	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>!<hr>")
 
 	var/obscured = check_obscured_slots()
 
@@ -399,7 +399,7 @@
 					"<a href='?src=[REF(src)];hud=s;add_comment=1;examine_time=[world.time]'>\[Add comment\]</a>"), "")
 	else if(isobserver(user))
 		. += span_info("<b>Traits:</b> [get_quirk_string(FALSE, CAT_QUIRK_ALL)]")
-	. += "*---------*</span>"
+	. += "</span>"
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -711,7 +711,7 @@
 
 	visible_message(span_notice("[src] examines [p_them()]self."))
 
-	combined_msg += span_notice("You check yourself for injuries.")
+	combined_msg += span_notice("<b>You check yourself for injuries.</b>")
 
 	var/list/missing = list(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -707,10 +707,11 @@
 /mob/living/carbon/human/check_self_for_injuries()
 	if(stat >= UNCONSCIOUS)
 		return
-	var/list/combined_msg = list()
+	var/list/combined_msg = list("<div class='examine_block'>")
 
-	visible_message(span_notice("[src] examines [p_them()]self."), \
-		span_notice("You check yourself for injuries."))
+	visible_message(span_notice("[src] examines [p_them()]self."))
+
+	combined_msg += span_boldnotice("You check yourself for injuries.<hr>")
 
 	var/list/missing = list(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -707,11 +707,11 @@
 /mob/living/carbon/human/check_self_for_injuries()
 	if(stat >= UNCONSCIOUS)
 		return
-	var/list/combined_msg = list("<div class='examine_block'>")
+	var/list/combined_msg = list()
 
 	visible_message(span_notice("[src] examines [p_them()]self."))
 
-	combined_msg += span_boldnotice("You check yourself for injuries.<hr>")
+	combined_msg += span_notice("You check yourself for injuries.")
 
 	var/list/missing = list(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 
@@ -895,7 +895,7 @@
 	if(quirks.len)
 		combined_msg += span_notice("You have these quirks: [get_quirk_string(FALSE, CAT_QUIRK_ALL)].")
 
-	to_chat(src, combined_msg.Join("\n"))
+	to_chat(src, examine_block(combined_msg.Join("\n")))
 
 /mob/living/carbon/human/damage_clothes(damage_amount, damage_type = BRUTE, damage_flag = 0, def_zone)
 	if(damage_type != BRUTE && damage_type != BURN)

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -7,7 +7,6 @@
 		return
 
 	var/list/print_msg = list()
-	print_msg += span_info("*---------*")
 	print_msg += span_userdanger("As you snap back to consciousness, you recall people messing with your stuff...")
 
 	afk_thefts = reverse_range(afk_thefts)
@@ -28,7 +27,6 @@
 
 	if(LAZYLEN(afk_thefts) >= AFK_THEFT_MAX_MESSAGES)
 		print_msg += span_warning("There may have been more, but that's all you can remember...")
-	print_msg += span_info("*---------*")
 
-	to_chat(src, print_msg.Join("\n"))
+	to_chat(src, examine_block(print_msg.Join("\n")))
 	LAZYNULL(afk_thefts)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -233,6 +233,9 @@
 		ai_voicechanger = null
 	return ..()
 
+/mob/living/silicon/ai/get_examine_string()
+	return null
+
 /// Removes all malfunction-related abilities from the AI
 /mob/living/silicon/ai/proc/remove_malf_abilities()
 	QDEL_NULL(modules_action)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -233,9 +233,6 @@
 		ai_voicechanger = null
 	return ..()
 
-/mob/living/silicon/ai/get_examine_string()
-	return null
-
 /// Removes all malfunction-related abilities from the AI
 /mob/living/silicon/ai/proc/remove_malf_abilities()
 	QDEL_NULL(modules_action)

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -20,3 +20,6 @@
 	. += "</span>"
 
 	. += ..()
+
+/mob/living/silicon/ai/get_examine_string(mob/user, thats = FALSE)
+	return null

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/ai/examine(mob/user)
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] <EM>[src]</EM>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] <EM>[src]</EM>!<hr>")
 	if (stat == DEAD)
 		. += span_deadsay("It appears to be powered-down.")
 	else
@@ -17,6 +17,6 @@
 			. += "The wireless networking light is blinking.\n"
 		else if (!shunted && !client)
 			. += "[src]Core.exe has stopped responding! NTOS is searching for a solution to the problem...\n"
-	. += "*---------*</span>"
+	. += "</span>"
 
 	. += ..()

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/ai/examine(mob/user)
-	. = list("<span class='info'>This is [icon2html(src, user)] <EM>[src]</EM>!<hr>")
+	. = list("<span class='info'>This is [icon2html(src, user)] <EM>[src]</EM>!")
 	if (stat == DEAD)
 		. += span_deadsay("It appears to be powered-down.")
 	else
@@ -14,9 +14,9 @@
 			else
 				. += span_warning("<B>Its casing is melted and heat-warped!</B>")
 		if(deployed_shell)
-			. += "The wireless networking light is blinking.\n"
+			. += "The wireless networking light is blinking."
 		else if (!shunted && !client)
-			. += "[src]Core.exe has stopped responding! NTOS is searching for a solution to the problem...\n"
+			. += "[src]Core.exe has stopped responding! NTOS is searching for a solution to the problem..."
 	. += "</span>"
 
 	. += ..()

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -46,3 +46,6 @@
 	. += "</span>"
 
 	. += ..()
+
+/mob/living/silicon/robot/get_examine_string(mob/user, thats = FALSE)
+	return null

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/examine(mob/user)
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] <EM>[src]</EM>!")
 	if(desc)
 		. += "[desc]"
 

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/examine(mob/user)
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!<hr>")
 	if(desc)
 		. += "[desc]"
 
@@ -43,6 +43,6 @@
 			. += span_warning("It doesn't seem to be responding.")
 		if(DEAD)
 			. += span_deadsay("It looks like its system is corrupted and requires a reset.")
-	. += "*---------*</span>"
+	. += "</span>"
 
 	. += ..()

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/examine(mob/user)
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!<hr>")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!")
 	if(desc)
 		. += "[desc]"
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -202,6 +202,8 @@
 
 	model.transform_to(model_list[input_model])
 
+/mob/living/silicon/robot/get_examine_string()
+	return null
 
 /// Used to setup the a basic and (somewhat) unique name for the robot.
 /mob/living/silicon/robot/proc/setup_default_name()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -202,8 +202,6 @@
 
 	model.transform_to(model_list[input_model])
 
-/mob/living/silicon/robot/get_examine_string()
-	return null
 
 /// Used to setup the a basic and (somewhat) unique name for the robot.
 /mob/living/silicon/robot/proc/setup_default_name()

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -92,7 +92,7 @@
 			text_span = "purple"
 		if(THEME_HOLY)
 			text_span = "blue"
-	. = list("<span class='[text_span]'>This is [icon2html(src, user)] \a <b>[src]</b>!\n[desc]<hr>")
+	. = list("<span class='[text_span]'>This is [icon2html(src, user)] \a <b>[src]</b>!\n[desc]")
 	if(health < maxHealth)
 		if(health >= maxHealth/2)
 			. += span_warning("[t_He] look[t_s] slightly dented.")

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -92,13 +92,13 @@
 			text_span = "purple"
 		if(THEME_HOLY)
 			text_span = "blue"
-	. = list("<span class='[text_span]'>*---------*\nThis is [icon2html(src, user)] \a <b>[src]</b>!\n[desc]")
+	. = list("<span class='[text_span]'>This is [icon2html(src, user)] \a <b>[src]</b>!\n[desc]<hr>")
 	if(health < maxHealth)
 		if(health >= maxHealth/2)
 			. += span_warning("[t_He] look[t_s] slightly dented.")
 		else
 			. += span_warning("<b>[t_He] look[t_s] severely dented!</b>")
-	. += "*---------*</span>"
+	. += "</span>"
 
 /mob/living/simple_animal/hostile/construct/attack_animal(mob/living/simple_animal/user, list/modifiers)
 	if(isconstruct(user)) //is it a construct?

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -250,7 +250,7 @@
 	dust()
 
 /mob/living/simple_animal/drone/examine(mob/user)
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <b>[src]</b>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <b>[src]</b>!<hr>")
 
 	//Hands
 	for(var/obj/item/I in held_items)
@@ -286,7 +286,7 @@
 			. += span_deadsay("A message repeatedly flashes on its display: \"REBOOT -- REQUIRED\".")
 		else
 			. += span_deadsay("A message repeatedly flashes on its display: \"ERROR -- OFFLINE\".")
-	. += "*---------*</span>"
+	. += "</span>"
 
 
 /mob/living/simple_animal/drone/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) //Secbots won't hunt maintenance drones.

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -250,7 +250,7 @@
 	dust()
 
 /mob/living/simple_animal/drone/examine(mob/user)
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <b>[src]</b>!<hr>")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <b>[src]</b>!")
 
 	//Hands
 	for(var/obj/item/I in held_items)

--- a/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
@@ -19,13 +19,13 @@
 
 /mob/living/simple_animal/hostile/guardian/dextrous/examine(mob/user)
 	if(dextrous)
-		. = list("<span class='info'>*---------*\nThis is [icon2html(src)] \a <b>[src]</b>!\n[desc]")
+		. = list("<span class='info'>This is [icon2html(src)] \a <b>[src]</b>!\n[desc]<hr>")
 		for(var/obj/item/I in held_items)
 			if(!(I.item_flags & ABSTRACT))
 				. += "It has [I.get_examine_string(user)] in its [get_held_index_name(get_held_index_of_item(I))]."
 		if(internal_storage && !(internal_storage.item_flags & ABSTRACT))
 			. += "It is holding [internal_storage.get_examine_string(user)] in its internal storage."
-		. += "*---------*</span>"
+		. += "</span>"
 	else
 		return ..()
 

--- a/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
@@ -19,7 +19,7 @@
 
 /mob/living/simple_animal/hostile/guardian/dextrous/examine(mob/user)
 	if(dextrous)
-		. = list("<span class='info'>This is [icon2html(src)] \a <b>[src]</b>!\n[desc]<hr>")
+		. = list("<span class='info'>This is [icon2html(src)] \a <b>[src]</b>!\n[desc]")
 		for(var/obj/item/I in held_items)
 			if(!(I.item_flags & ABSTRACT))
 				. += "It has [I.get_examine_string(user)] in its [get_held_index_name(get_held_index_of_item(I))]."

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -438,7 +438,7 @@
 	return
 
 /mob/living/simple_animal/slime/examine(mob/user)
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!<hr>")
 	if (stat == DEAD)
 		. += span_deadsay("It is limp and unresponsive.")
 	else
@@ -465,7 +465,7 @@
 			if(10)
 				. += span_warning("<B>It is radiating with massive levels of electrical activity!</B>")
 
-	. += "*---------*</span>"
+	. += "</span>"
 
 /mob/living/simple_animal/slime/proc/discipline_slime(mob/user)
 	if(stat)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -438,7 +438,7 @@
 	return
 
 /mob/living/simple_animal/slime/examine(mob/user)
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!<hr>")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!")
 	if (stat == DEAD)
 		. += span_deadsay("It is limp and unresponsive.")
 	else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -534,11 +534,11 @@
 		result = examinify.examine(src) // if a tree is examined but no client is there to see it, did the tree ever really exist?
 
 	if(result.len)
-		for(var/i = 1, i <= result.len, i++)
+		for(var/i in 1 to (length(result) - 1))
 			if(!findtext(result[i], "<hr>"))
 				result[i] += "\n"
 
-	to_chat(src, "<div class='examine_block'><span class='infoplain'>[result.Join()]</span></div>")
+	to_chat(src, examine_block("<span class='infoplain'>[result.Join()]</span>"))
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, examinify)
 
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -535,8 +535,7 @@
 
 	if(result.len)
 		for(var/i in 1 to (length(result) - 1))
-			if(!findtext(result[i], "<hr>"))
-				result[i] += "\n"
+			result[i] += "\n"
 
 	to_chat(src, examine_block("<span class='infoplain'>[result.Join()]</span>"))
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, examinify)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -533,7 +533,12 @@
 	else
 		result = examinify.examine(src) // if a tree is examined but no client is there to see it, did the tree ever really exist?
 
-	to_chat(src, "<span class='infoplain'>[result.Join("\n")]</span>")
+	if(result.len)
+		for(var/i = 1, i <= result.len, i++)
+			if(!findtext(result[i], "<hr>"))
+				result[i] += "\n"
+
+	to_chat(src, "<div class='examine_block'><span class='infoplain'>[result.Join()]</span></div>")
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, examinify)
 
 

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -901,18 +901,11 @@ em {
 }
 
 .examine_block {
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px solid rgba(55, 55, 55, 0.33);
-  margin: 7px 4px;
+  background: #1b1c1e;
+  border: 1px solid #a4bad6;
+  margin: 7px;
   padding: 8px 12px;
   max-width: 550px;
-}
-
-.examine_block hr {
-  border: none;
-  background: #222;
-  height: 1px;
-  margin: 8px 16px 8px 16px;
 }
 
 .tooltip {

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -905,7 +905,6 @@ em {
   border: 1px solid #a4bad6;
   margin: 7px;
   padding: 8px 12px;
-  max-width: 550px;
 }
 
 .tooltip {

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -903,8 +903,8 @@ em {
 .examine_block {
   background: #1b1c1e;
   border: 1px solid #a4bad6;
-  margin: 7px;
-  padding: 8px 12px;
+  margin: 0.5em;
+  padding: 0.5em 0.75em;
 }
 
 .tooltip {

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -900,6 +900,21 @@ em {
   margin-left: 3em;
 }
 
+.examine_block {
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(55, 55, 55, 0.33);
+  margin: 7px 4px;
+  padding: 8px 12px;
+  max-width: 550px;
+}
+
+.examine_block hr {
+  border: none;
+  background: #222;
+  height: 1px;
+  margin: 8px 16px 8px 16px;
+}
+
 .tooltip {
   font-style: italic;
   border-bottom: 1px dashed #fff;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -936,8 +936,8 @@ h1.alert, h2.alert {
 .examine_block {
   background: #f2f7fa;
   border: 1px solid #111a27;
-  margin: 7px;
-  padding: 8px 12px;
+  margin: 0.5em;
+  padding: 0.5em 0.75em;
 }
 
 .tooltip {

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -934,18 +934,11 @@ h1.alert, h2.alert {
 }
 
 .examine_block {
-  background: rgba(0, 0, 0, 0.1);
+  background: #f2f7fa;
   border: 1px solid #111a27;
-  margin: 2px 8px;
+  margin: 7px;
   padding: 8px 12px;
   max-width: 550px;
-}
-
-.examine_block hr {
-  border: none;
-  background: #333;
-  height: 1px;
-  margin: 8px 16px 8px 16px;
 }
 
 .tooltip {

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -933,6 +933,21 @@ h1.alert, h2.alert {
   margin-left: 3em;
 }
 
+.examine_block {
+  background: rgba(0, 0, 0, 0.1);
+  border: 1px solid #111a27;
+  margin: 2px 8px;
+  padding: 8px 12px;
+  max-width: 550px;
+}
+
+.examine_block hr {
+  border: none;
+  background: #333;
+  height: 1px;
+  margin: 8px 16px 8px 16px;
+}
+
 .tooltip {
   font-style: italic;
   border-bottom: 1px dashed #000;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -938,7 +938,6 @@ h1.alert, h2.alert {
   border: 1px solid #111a27;
   margin: 7px;
   padding: 8px 12px;
-  max-width: 550px;
 }
 
 .tooltip {


### PR DESCRIPTION
Adds Examine Blocks as seen on Skyrat and other servers, but tweaked a bit to look better

LIGHT MODE:
![13pxlight](https://user-images.githubusercontent.com/46101244/175790441-0d540b6a-71c2-4bab-9b74-01ff03cc4f4a.png)


DARK MODE:
![13pxdark](https://user-images.githubusercontent.com/46101244/175790450-d2ab8d4f-97ec-4f3a-aa59-b82a9a920207.png)




- [x] Add examine blocks to more places
- [x] Remove initial and final `*---------*` since that was a separator but is no longer needed
- [x] Tweak the colors a bit
- [x] Fix any bugs

Fixes https://github.com/tgstation/tgstation/issues/67983

## Why?
Helps multi-text outputs stand out from the rest of the chat, makes it way more readable when you use the various analyzers or examine someone or something

:cl: 13spacemen, Gandalf2k15
add: Examining and other chat outputs now display in blocks to make them easier to see
fix: AI and borgs no longer have their name show twice upon being examined
/:cl: