### PR TITLE
Fixes the white cane sounds, and blind mob's examine.

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -41,8 +41,6 @@
 #define IGNORE_DIGITIGRADE (1<<18)
 /// Has contextual screentips when HOVERING OVER OTHER objects
 #define ITEM_HAS_CONTEXTUAL_SCREENTIPS (1 << 19)
-/// Item still allows you to examine items while blind and actively held.
-#define BLIND_TOOL (1 << 20)
 
 // Flags for the clothing_flags var on /obj/item/clothing
 

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -413,6 +413,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Whether or not orbiting is blocked or not
 #define TRAIT_ORBITING_FORBIDDEN "orbiting_forbidden"
 
+/// Item still allows you to examine items while blind and actively held.
+#define TRAIT_BLIND_TOOL "blind_tool"
+
 // METABOLISMS
 // Various jobs on the station have historically had better reactions
 // to various drinks and foodstuffs. Security liking donuts is a classic
@@ -810,6 +813,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define ORBITING_TRAIT "orbiting"
 /// From the item_scaling element
 #define ITEM_SCALING_TRAIT "item_scaling"
+/// Trait given by Objects that provide blindsight
+#define ITEM_BLIND_TRAIT "blind_item_trait"
 
 /**
 * Trait granted by [/mob/living/carbon/Initialize] and

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -462,6 +462,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	AddComponent(/datum/component/transforming, \
 		force_on = 7, \
+		hitsound_on = hitsound, \
 		w_class_on = WEIGHT_CLASS_BULKY, \
 		clumsy_check = FALSE, \
 		attack_verb_continuous_on = list("smacks", "strikes", "cracks", "beats"), \

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -455,7 +455,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	force = 1
 	w_class = WEIGHT_CLASS_SMALL
-	item_flags = BLIND_TOOL
 	custom_materials = list(/datum/material/iron = 600)
 
 /obj/item/cane/white/Initialize(mapload)
@@ -468,6 +467,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		attack_verb_continuous_on = list("smacks", "strikes", "cracks", "beats"), \
 		attack_verb_simple_on = list("smack", "strike", "crack", "beat"))
 	RegisterSignal(src, COMSIG_TRANSFORMING_ON_TRANSFORM, .proc/on_transform)
+	ADD_TRAIT(src, TRAIT_BLIND_TOOL, ITEM_BLIND_TRAIT)
 
 /*
  * Signal proc for [COMSIG_TRANSFORMING_ON_TRANSFORM].

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -551,11 +551,12 @@
 	/// the item in our active hand
 	var/obj/item/active_item = get_active_held_item()
 	var/boosted = FALSE
-	if(active_item?.item_flags & BLIND_TOOL)
-		boosted = TRUE
-	if(active_item && (active_item != examined_thing && !(active_item?.item_flags & BLIND_TOOL)))
-		to_chat(src, span_warning("Your hands are too full to examine this!"))
-		return FALSE
+	if(active_item)
+		if(HAS_TRAIT(active_item, TRAIT_BLIND_TOOL))
+			boosted = TRUE
+		else if(active_item != examined_thing)
+			to_chat(src, span_warning("Your hands are too full to examine this!"))
+			return FALSE
 
 	//you can only initiate exaimines if you have a hand, it's not disabled, and only as many examines as you have hands
 	/// our active hand, to check if it's disabled/detatched

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -553,7 +553,7 @@
 	var/boosted = FALSE
 	if(active_item?.item_flags & BLIND_TOOL)
 		boosted = TRUE
-	if((active_item && active_item != examined_thing) && (active_item && !(active_item?.item_flags & BLIND_TOOL)))
+	if(active_item && (active_item != examined_thing && !(active_item?.item_flags & BLIND_TOOL)))
 		to_chat(src, span_warning("Your hands are too full to examine this!"))
 		return FALSE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -551,9 +551,9 @@
 	/// the item in our active hand
 	var/obj/item/active_item = get_active_held_item()
 	var/boosted = FALSE
-	if(active_item.item_flags & BLIND_TOOL)
+	if(active_item?.item_flags & BLIND_TOOL)
 		boosted = TRUE
-	if(active_item && active_item != examined_thing && !(active_item.item_flags & BLIND_TOOL))
+	if((active_item && active_item != examined_thing) && (active_item && !(active_item?.item_flags & BLIND_TOOL)))
 		to_chat(src, span_warning("Your hands are too full to examine this!"))
 		return FALSE
 


### PR DESCRIPTION

## About The Pull Request

Fixes #67914. 
The `blind_obj` flag was implemented slightly incorrectly, and as a result examining things while blind made it so that unintentionally. 
This fixes the logic on the mob check for blind tools, as well as makes the white cane not use the default attack sound when transformed, using the standard melee sounds..

## Why It's Good For The Game

Fixes a mistake made in the blind examine code.

## Changelog
:cl:
fix: White canes now examine objects properly and sound correct when hitting things.
/:cl:
