### PR TITLE
Fixes gunshot sound runtime

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -37,7 +37,7 @@
 /obj/item/gun/energy/fire_sounds()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	var/batt_percent = FLOOR(clamp(cell.charge / cell.maxcharge, 0, 1) * 100, 1)
-	// What percent of the full battery a shot will expend
+	// What percentage of the full battery a shot will expend
 	var/shot_cost_percent = 0
 	// The total amount of shots the fully charged energy gun can fire before running out
 	var/max_shots = 0

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -36,11 +36,22 @@
 
 /obj/item/gun/energy/fire_sounds()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-	var/shot_cost_percent = FLOOR(clamp(shot.e_cost / cell.maxcharge, 0, 1) * 100, 1)
 	var/batt_percent = FLOOR(clamp(cell.charge / cell.maxcharge, 0, 1) * 100, 1)
-	var/max_shots = round(100/shot_cost_percent)
-	var/shots_left = round(batt_percent/shot_cost_percent)
-	var/frequency_to_use = sin((90/max_shots) * shots_left)
+	// What percent of the full battery a shot will expend
+	var/shot_cost_percent = 0
+	// The total amount of shots the fully charged energy gun can fire before running out
+	var/max_shots = 0
+	// How many shots left before the energy gun's current battery runs out of energy
+	var/shots_left = 0
+	// What frequency the energy gun's sound will make
+	var/frequency_to_use = 0
+
+	if(shot.e_cost > 0)
+		shot_cost_percent = FLOOR(clamp(shot.e_cost / cell.maxcharge, 0, 1) * 100, 1)
+		max_shots = round(100/shot_cost_percent)
+		shots_left = round(batt_percent/shot_cost_percent)
+		frequency_to_use = sin((90/max_shots) * shots_left)
+
 	if(suppressed)
 		playsound(src, suppressed_sound, suppressed_volume, vary_fire_sound, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0, frequency = frequency_to_use)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #67930. Goof's recent gunshot sound PR calculates the frequency of the gunshot using the energy cost of the projectile. However, when a gun with no energy cost fires, such as a chameleon gun or a CTF gun, `energy/fire_sounds()` attempts to divide by 0, causing a runtime. This PR fixes it by having the frequency only be modified if the projectile has an energy cost in the first place.

## Why It's Good For The Game

Runtimes are bad, this preserves existing behavior.


<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
