### PR TITLE
Fixes spontaneous test failure that made nuclear disks not teleport correctly in Multi-Z debug by adding the blobstart that it should have anyway

### DIFF
--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -1360,6 +1360,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
+"DN" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "DU" = (
 /obj/structure/table,
 /obj/item/flashlight{
@@ -3009,7 +3013,7 @@ eb
 eb
 bu
 cD
-bE
+DN
 bE
 Rl
 Ra


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #67789

This was spontaneous because stationloving uses `find_safe_turf`, which has an iteration limit of 1,000.

