### PR TITLE
Fixes an ert bounty hunter's outfit, and the bounty hunter ID in general

### DIFF
--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -216,7 +216,7 @@
 
 /datum/antagonist/ert/bounty_hook
 	role = "Hookgun Bounty Hunter"
-	outfit = /datum/outfit/bountyarmor/ert
+	outfit = /datum/outfit/bountyhook/ert
 
 /datum/antagonist/ert/bounty_synth
 	role = "Synthetic Bounty Hunter"

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -230,7 +230,7 @@
 
 /obj/item/card/id/advanced/bountyhunter
 	assignment = "Bounty Hunter"
-	icon_state = "card_flames" //oh SHIT
+	icon_state = "card_flame" //oh SHIT
 	trim = /datum/id_trim/bounty_hunter
 
 /datum/outfit/bountyarmor/ert


### PR DESCRIPTION

## About The Pull Request

The ert version of the harpoon gun bounty hunter's outfit was the same as the pyromaniac's. This restores them to be unique once again.
The bounty hunter ID's were invisible, they are now visible again.

## Why It's Good For The Game

The bounty hunters (ert version) are once again three different people, and the bounty hunter IDs are properly on fire.

## Changelog

:cl:
fix: the hookshot bounty hunter, when summoned as an ert team member, is no longer identical to the armoured bounty hunter.
fix: bounty hunter IDs are no longer invisible save for the trim
/:cl:
