### PR TITLE
Adjusts Layering of Broken/Burnt Floor Helpers

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -706,6 +706,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	icon = 'icons/turf/damaged.dmi'
 	icon_state = "damaged1"
 	late = TRUE
+	layer = ABOVE_NORMAL_TURF_LAYER
 
 /obj/effect/mapping_helpers/broken_floor/Initialize(mapload)
 	.=..()
@@ -721,6 +722,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	icon = 'icons/turf/damaged.dmi'
 	icon_state = "floorscorched1"
 	late = TRUE
+	layer = ABOVE_NORMAL_TURF_LAYER
 
 /obj/effect/mapping_helpers/burnt_floor/Initialize(mapload)
 	.=..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Small QoL thing for mappers. Mapping Helpers automatically go on the highest plane possible, `POINT_LAYER`. This would result in broken/burnt flooring having the following appearance in map editors:

![image](https://user-images.githubusercontent.com/34697715/175399884-28233e47-acbf-4a8e-b791-e1d738109035.png)

This is just weird clutter that doesn't particularly look good- and it's a lot harder to visualize what these broken/burnt floors will look like in-game when it just renders over every single thing possible. So, I just switched both of those subtypes to the same layer that we use for cleanable decal effects `ABOVE_NORMAL_TURF_LAYER`, just for nice visual clarify. Here's what that looks like:

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/175399746-aba92e67-332c-4e85-9ad0-7dcf3f197ef5.png)

Muuuuch better.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing player facing.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
