### PR TITLE
Fixes regenerative core implants not functioning

### DIFF
--- a/code/game/objects/effects/spawners/random/medical.dm
+++ b/code/game/objects/effects/spawners/random/medical.dm
@@ -34,7 +34,7 @@
 		/obj/item/organ/internal/heart/gland/slime = 4,
 		/obj/item/organ/internal/heart/gland/trauma = 4,
 		/obj/item/organ/internal/heart/gland/electric = 3,
-		/obj/item/organ/regenerative_core = 2,
+		/obj/item/organ/internal/regenerative_core = 2,
 		/obj/item/organ/internal/heart/gland/ventcrawling = 1,
 		/obj/item/organ/internal/body_egg/alien_embryo = 1,
 	)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -366,7 +366,7 @@
 		/obj/item/lighter,
 		/obj/item/mining_scanner,
 		/obj/item/multitool,
-		/obj/item/organ/regenerative_core,
+		/obj/item/organ/internal/regenerative_core,
 		/obj/item/pickaxe,
 		/obj/item/radio,
 		/obj/item/reagent_containers/food/drinks,

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_mexican.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_mexican.dm
@@ -107,7 +107,7 @@
 	time = 40
 	reqs = list(
 		/obj/item/food/meat/steak/goliath = 1,
-		/obj/item/organ/regenerative_core/legion = 1,
+		/obj/item/organ/internal/regenerative_core/legion = 1,
 		/datum/reagent/consumable/ketchup = 2,
 		/datum/reagent/consumable/capsaicin = 2
 	)

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -76,7 +76,7 @@
 		/obj/item/flashlight,
 		/obj/item/knife/combat/bone,
 		/obj/item/knife/combat/survival,
-		/obj/item/organ/regenerative_core/legion,
+		/obj/item/organ/internal/regenerative_core/legion,
 		/obj/item/pickaxe,
 		/obj/item/spear,
 		/obj/item/tank/internals,

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -82,7 +82,7 @@
 				to_chat(user, span_notice("[src] is useless on the dead."))
 				return
 			if(target_human != user)
-				target_human.visible_message(span_notice("[user] forces [target_human] to apply [src]... Black tendrils entangle and reinforce [H.p_them()]!"))
+				target_human.visible_message(span_notice("[user] forces [target_human] to apply [src]... Black tendrils entangle and reinforce [target_human.p_them()]!"))
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "other"))
 			else
 				to_chat(user, span_notice("You start to smear [src] on yourself. Disgusting tendrils hold you together and allow you to keep moving, but for how long?"))

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -10,8 +10,8 @@
 	. = ..()
 	if(!proximity)
 		return
-	var/obj/item/organ/regenerative_core/C = M
-	if(!istype(C, /obj/item/organ/regenerative_core))
+	var/obj/item/organ/internal/regenerative_core/C = M
+	if(!istype(C, /obj/item/organ/internal/regenerative_core))
 		to_chat(user, span_warning("The stabilizer only works on certain types of monster organs, generally regenerative in nature."))
 		return
 
@@ -20,7 +20,7 @@
 	qdel(src)
 
 /************************Hivelord core*******************/
-/obj/item/organ/regenerative_core
+/obj/item/organ/internal/regenerative_core
 	name = "regenerative core"
 	desc = "All that remains of a hivelord. It can be used to help keep your body going, but it will rapidly decay into uselessness."
 	icon_state = "roro core 2"
@@ -33,15 +33,15 @@
 	var/inert = 0
 	var/preserved = 0
 
-/obj/item/organ/regenerative_core/Initialize(mapload)
+/obj/item/organ/internal/regenerative_core/Initialize(mapload)
 	. = ..()
 	addtimer(CALLBACK(src, .proc/inert_check), 2400)
 
-/obj/item/organ/regenerative_core/proc/inert_check()
+/obj/item/organ/internal/regenerative_core/proc/inert_check()
 	if(!preserved)
 		go_inert()
 
-/obj/item/organ/regenerative_core/proc/preserved(implanted = 0)
+/obj/item/organ/internal/regenerative_core/proc/preserved(implanted = 0)
 	inert = FALSE
 	preserved = TRUE
 	update_appearance()
@@ -51,27 +51,27 @@
 	else
 		SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "stabilizer"))
 
-/obj/item/organ/regenerative_core/proc/go_inert()
+/obj/item/organ/internal/regenerative_core/proc/go_inert()
 	inert = TRUE
 	name = "decayed regenerative core"
 	desc = "All that remains of a hivelord. It has decayed, and is completely useless."
 	SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "inert"))
 	update_appearance()
 
-/obj/item/organ/regenerative_core/ui_action_click()
+/obj/item/organ/internal/regenerative_core/ui_action_click()
 	if(inert)
 		to_chat(owner, span_notice("[src] breaks down as it tries to activate."))
 	else
 		owner.revive(full_heal = TRUE, admin_revive = FALSE)
 	qdel(src)
 
-/obj/item/organ/regenerative_core/on_life(delta_time, times_fired)
+/obj/item/organ/internal/regenerative_core/on_life(delta_time, times_fired)
 	..()
 	if(owner.health <= owner.crit_threshold)
 		ui_action_click()
 
 ///Handles applying the core, logging and status/mood events.
-/obj/item/organ/regenerative_core/proc/applyto(atom/target, mob/user)
+/obj/item/organ/internal/regenerative_core/proc/applyto(atom/target, mob/user)
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(inert)
@@ -91,37 +91,37 @@
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "core", /datum/mood_event/healsbadman) //Now THIS is a miner buff (fixed - nerf)
 			qdel(src)
 
-/obj/item/organ/regenerative_core/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/organ/internal/regenerative_core/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
 	if(proximity_flag)
 		applyto(target, user)
 
-/obj/item/organ/regenerative_core/attack_self(mob/user)
+/obj/item/organ/internal/regenerative_core/attack_self(mob/user)
 	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		applyto(user, user)
 
-/obj/item/organ/regenerative_core/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
+/obj/item/organ/internal/regenerative_core/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
 	. = ..()
 	if(!preserved && !inert)
 		preserved(TRUE)
 		owner.visible_message(span_notice("[src] stabilizes as it's inserted."))
 
-/obj/item/organ/regenerative_core/Remove(mob/living/carbon/M, special = 0)
+/obj/item/organ/internal/regenerative_core/Remove(mob/living/carbon/M, special = 0)
 	if(!inert && !special)
 		owner.visible_message(span_notice("[src] rapidly decays as it's removed."))
 		go_inert()
 	return ..()
 
 /*************************Legion core********************/
-/obj/item/organ/regenerative_core/legion
+/obj/item/organ/internal/regenerative_core/legion
 	desc = "A strange rock that crackles with power. It can be used to heal completely, but it will rapidly decay into uselessness."
 	icon_state = "legion_soul"
 
-/obj/item/organ/regenerative_core/legion/Initialize(mapload)
+/obj/item/organ/internal/regenerative_core/legion/Initialize(mapload)
 	. = ..()
 	update_appearance()
 
-/obj/item/organ/regenerative_core/update_icon_state()
+/obj/item/organ/internal/regenerative_core/update_icon_state()
 	if (inert)
 		icon_state = "legion_soul_inert"
 	if (preserved)
@@ -130,10 +130,10 @@
 		icon_state = "legion_soul_unstable"
 	return ..()
 
-/obj/item/organ/regenerative_core/legion/go_inert()
+/obj/item/organ/internal/regenerative_core/legion/go_inert()
 	..()
 	desc = "[src] has become inert. It has decayed, and is completely useless."
 
-/obj/item/organ/regenerative_core/legion/preserved(implanted = 0)
+/obj/item/organ/internal/regenerative_core/legion/preserved(implanted = 0)
 	..()
 	desc = "[src] has been stabilized. It is preserved, allowing you to use it to heal completely without danger of decay."

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -6,17 +6,17 @@
 	desc = "Inject certain types of monster organs with this stabilizer to preserve their healing powers indefinitely."
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/hivelordstabilizer/afterattack(obj/item/organ/M, mob/user, proximity)
+/obj/item/hivelordstabilizer/afterattack(obj/item/organ/target_organ, mob/user, proximity)
 	. = ..()
 	if(!proximity)
 		return
-	var/obj/item/organ/internal/regenerative_core/C = M
-	if(!istype(C, /obj/item/organ/internal/regenerative_core))
+	var/obj/item/organ/internal/regenerative_core/target_core = target_organ
+	if(!istype(target_core, /obj/item/organ/internal/regenerative_core))
 		to_chat(user, span_warning("The stabilizer only works on certain types of monster organs, generally regenerative in nature."))
 		return
 
-	C.preserved()
-	to_chat(user, span_notice("You inject the [M] with the stabilizer. It will no longer go inert."))
+	target_core.preserved()
+	to_chat(user, span_notice("You inject the [target_organ] with the stabilizer. It will no longer go inert."))
 	qdel(src)
 
 /************************Hivelord core*******************/
@@ -73,22 +73,22 @@
 ///Handles applying the core, logging and status/mood events.
 /obj/item/organ/internal/regenerative_core/proc/applyto(atom/target, mob/user)
 	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
+		var/mob/living/carbon/human/target_human = target
 		if(inert)
 			to_chat(user, span_notice("[src] has decayed and can no longer be used to heal."))
 			return
 		else
-			if(H.stat == DEAD)
+			if(target_human.stat == DEAD)
 				to_chat(user, span_notice("[src] is useless on the dead."))
 				return
-			if(H != user)
-				H.visible_message(span_notice("[user] forces [H] to apply [src]... Black tendrils entangle and reinforce [H.p_them()]!"))
+			if(target_human != user)
+				target_human.visible_message(span_notice("[user] forces [target_human] to apply [src]... Black tendrils entangle and reinforce [H.p_them()]!"))
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "other"))
 			else
 				to_chat(user, span_notice("You start to smear [src] on yourself. Disgusting tendrils hold you together and allow you to keep moving, but for how long?"))
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
-			H.apply_status_effect(/datum/status_effect/regenerative_core)
-			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "core", /datum/mood_event/healsbadman) //Now THIS is a miner buff (fixed - nerf)
+			target_human.apply_status_effect(/datum/status_effect/regenerative_core)
+			SEND_SIGNAL(target_human, COMSIG_ADD_MOOD_EVENT, "core", /datum/mood_event/healsbadman) //Now THIS is a miner buff (fixed - nerf)
 			qdel(src)
 
 /obj/item/organ/internal/regenerative_core/afterattack(atom/target, mob/user, proximity_flag)
@@ -100,13 +100,13 @@
 	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		applyto(user, user)
 
-/obj/item/organ/internal/regenerative_core/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
+/obj/item/organ/internal/regenerative_core/Insert(mob/living/carbon/target_carbon, special = 0, drop_if_replaced = TRUE)
 	. = ..()
 	if(!preserved && !inert)
 		preserved(TRUE)
 		owner.visible_message(span_notice("[src] stabilizes as it's inserted."))
 
-/obj/item/organ/internal/regenerative_core/Remove(mob/living/carbon/M, special = 0)
+/obj/item/organ/internal/regenerative_core/Remove(mob/living/carbon/target_carbon, special = 0)
 	if(!inert && !special)
 		owner.visible_message(span_notice("[src] rapidly decays as it's removed."))
 		go_inert()

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -605,7 +605,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	resistance_flags = FIRE_PROOF
 	clothing_flags = THICKMATERIAL
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/pickaxe, /obj/item/spear, /obj/item/organ/regenerative_core/legion, /obj/item/knife, /obj/item/kinetic_crusher, /obj/item/resonator, /obj/item/melee/cleaving_saw)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/pickaxe, /obj/item/spear, /obj/item/organ/internal/regenerative_core/legion, /obj/item/knife, /obj/item/kinetic_crusher, /obj/item/resonator, /obj/item/melee/cleaving_saw)
 
 /obj/item/clothing/suit/hooded/berserker/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -255,8 +255,8 @@ While using this makes the system rely on OnFire, it still gives options for tim
 
 /obj/structure/elite_tumor/attackby(obj/item/attacking_item, mob/user, params)
 	. = ..()
-	if(istype(attacking_item, /obj/item/organ/regenerative_core) && activity == TUMOR_INACTIVE && !boosted)
-		var/obj/item/organ/regenerative_core/core = attacking_item
+	if(istype(attacking_item, /obj/item/organ/internal/regenerative_core) && activity == TUMOR_INACTIVE && !boosted)
+		var/obj/item/organ/internal/regenerative_core/core = attacking_item
 		visible_message(span_boldwarning("As [user] drops the core into [src], [src] appears to swell."))
 		icon_state = "advanced_tumor"
 		boosted = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -30,7 +30,7 @@
 	retreat_distance = 3
 	minimum_distance = 3
 	pass_flags = PASSTABLE
-	loot = list(/obj/item/organ/regenerative_core)
+	loot = list(/obj/item/organ/internal/regenerative_core)
 	var/brood_type = /mob/living/simple_animal/hostile/asteroid/hivelordbrood
 	var/has_clickbox = TRUE
 
@@ -122,7 +122,7 @@
 	attack_sound = 'sound/weapons/pierce.ogg'
 	throw_message = "bounces harmlessly off of"
 	crusher_loot = /obj/item/crusher_trophy/legion_skull
-	loot = list(/obj/item/organ/regenerative_core/legion)
+	loot = list(/obj/item/organ/internal/regenerative_core/legion)
 	brood_type = /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion
 	del_on_death = 1
 	stat_attack = HARD_CRIT
@@ -267,7 +267,7 @@
 	layer = MOB_LAYER
 	del_on_death = TRUE
 	sentience_type = SENTIENCE_BOSS
-	loot = list(/obj/item/organ/regenerative_core/legion = 3, /obj/effect/mob_spawn/corpse/human/legioninfested = 5)
+	loot = list(/obj/item/organ/internal/regenerative_core/legion = 3, /obj/effect/mob_spawn/corpse/human/legioninfested = 5)
 	move_to_delay = 14
 	vision_range = 5
 	aggro_vision_range = 9
@@ -294,7 +294,7 @@
 	icon_aggro = "snowlegion_alive"
 	icon_dead = "snowlegion"
 	crusher_loot = /obj/item/crusher_trophy/legion_skull
-	loot = list(/obj/item/organ/regenerative_core/legion)
+	loot = list(/obj/item/organ/internal/regenerative_core/legion)
 	brood_type = /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/snow
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/snow/make_legion(mob/living/carbon/human/H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #67950. Kapu forgot to repath the regenerative core to `organ/internal` in #67017. `organ/on_life` doesn't have any behavior, as that got moved to `organ/internal/on_life`. This PR just repaths the regenerative core to `organ/internal` so its auto-revive function works again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes bug, bugs bad.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: regenerative core implants will automatically revive you again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
