### PR TITLE
TGUI Say no longer deletes your currently typed message on history

### DIFF
--- a/code/modules/tgui_input/say_modal/speech.dm
+++ b/code/modules/tgui_input/say_modal/speech.dm
@@ -31,18 +31,18 @@
  *  boolean - on success or failure
  */
 /datum/tgui_say/proc/delegate_speech(entry, channel)
-	if(channel == OOC_CHANNEL)
-		client.ooc(entry)
-		return TRUE
 	switch(channel)
+		if(SAY_CHANNEL)
+			client.mob.say_verb(entry)
+			return TRUE
 		if(RADIO_CHANNEL)
 			client.mob.say_verb(";" + entry)
 			return TRUE
 		if(ME_CHANNEL)
 			client.mob.me_verb(entry)
 			return TRUE
-		if(SAY_CHANNEL)
-			client.mob.say_verb(entry)
+		if(OOC_CHANNEL)
+			client.ooc(entry)
 			return TRUE
 	return FALSE
 

--- a/tgui/packages/tgui-say/constants/index.tsx
+++ b/tgui/packages/tgui-say/constants/index.tsx
@@ -2,18 +2,18 @@
 export const CHANNELS = ['Say', 'Radio', 'Me', 'OOC'] as const;
 
 /** Window sizes in pixels */
-export const WINDOW_SIZES = {
-  small: 30,
-  medium: 50,
-  large: 70,
-  width: 231,
-} as const;
+export enum WINDOW_SIZES {
+  small = 30,
+  medium = 50,
+  large = 70,
+  width = 231,
+}
 
 /** Line lengths for autoexpand */
-export const LINE_LENGTHS = {
-  small: 20,
-  medium: 35,
-} as const;
+export enum LINE_LENGTHS {
+  small = 20,
+  medium = 35,
+}
 
 /**
  * Radio prefixes.

--- a/tgui/packages/tgui-say/handlers/arrowKeys.tsx
+++ b/tgui/packages/tgui-say/handlers/arrowKeys.tsx
@@ -3,9 +3,16 @@ import { getHistoryLength } from '../helpers';
 import { Modal } from '../types';
 
 /** Increments the chat history counter, looping through entries */
-export const handleArrowKeys = function (this: Modal, direction: number) {
+export const handleArrowKeys = function (
+  this: Modal,
+  direction: number,
+  value: string
+) {
   const { historyCounter } = this.fields;
   if (direction === KEY_UP && historyCounter < getHistoryLength()) {
+    if (!historyCounter) {
+      this.fields.tempHistory = value;
+    }
     this.fields.historyCounter++;
     this.events.onViewHistory();
   } else if (direction === KEY_DOWN && historyCounter > 0) {

--- a/tgui/packages/tgui-say/handlers/backspaceDelete.tsx
+++ b/tgui/packages/tgui-say/handlers/backspaceDelete.tsx
@@ -14,9 +14,9 @@ export const handleBackspaceDelete = function (this: Modal) {
     this.fields.historyCounter = 0;
     this.setState({ buttonContent: CHANNELS[channel] });
   }
-  if (!value.length && radioPrefix) {
+  if (!value?.length && radioPrefix) {
     this.fields.radioPrefix = '';
     this.setState({ buttonContent: CHANNELS[channel] });
   }
-  this.events.onSetSize(value.length);
+  this.events.onSetSize(value?.length);
 };

--- a/tgui/packages/tgui-say/handlers/keyDown.tsx
+++ b/tgui/packages/tgui-say/handlers/keyDown.tsx
@@ -9,27 +9,35 @@ import { Modal } from '../types';
  * BKSP/DEL - Resets history counter and checks window size.
  * TYPING - When users key, it tells byond that it's typing.
  */
-export const handleKeyDown = function (this: Modal, event: KeyboardEvent) {
+export const handleKeyDown = function (
+  this: Modal,
+  event: KeyboardEvent,
+  value: string
+) {
   const { channel } = this.state;
   const { radioPrefix } = this.fields;
   if (!event.keyCode) {
     return; // Really doubt it, but...
   }
+  if (event.keyCode === KEY_UP || event.keyCode === KEY_DOWN) {
+    event.preventDefault();
+    if (getHistoryLength()) {
+      this.events.onArrowKeys(event.keyCode, value);
+    }
+    return;
+  }
+  if (event.keyCode === KEY_TAB) {
+    event.preventDefault();
+    this.events.onIncrementChannel();
+    return;
+  }
+  if (event.keyCode === KEY_DELETE || event.keyCode === KEY_BACKSPACE) {
+    this.events.onBackspaceDelete();
+    return;
+  }
   if (isAlphanumeric(event.keyCode)) {
     if (channel !== 3 && radioPrefix !== ':b ') {
       this.timers.typingThrottle();
     }
-  }
-  if (event.keyCode === KEY_UP || event.keyCode === KEY_DOWN) {
-    if (getHistoryLength()) {
-      this.events.onArrowKeys(event.keyCode);
-    }
-  }
-  if (event.keyCode === KEY_DELETE || event.keyCode === KEY_BACKSPACE) {
-    this.events.onBackspaceDelete();
-  }
-  if (event.keyCode === KEY_TAB) {
-    this.events.onIncrementChannel();
-    event.preventDefault();
   }
 };

--- a/tgui/packages/tgui-say/handlers/radioPrefix.tsx
+++ b/tgui/packages/tgui-say/handlers/radioPrefix.tsx
@@ -11,14 +11,14 @@ import { Modal } from '../types';
 export const handleRadioPrefix = function (this: Modal) {
   const { channel } = this.state;
   const { radioPrefix, value } = this.fields;
-  if (channel > 1 || value.length < 3) {
+  if (channel > 1 || !value || value.length < 3) {
     return;
   }
-  const nextPrefix = value.slice(0, 3)?.toLowerCase();
+  const nextPrefix = value?.slice(0, 3)?.toLowerCase();
   if (!RADIO_PREFIXES[nextPrefix] || radioPrefix === nextPrefix) {
     return;
   }
-  this.fields.value = value.slice(3);
+  this.fields.value = value?.slice(3);
   // Binary is a "secret" channel
   if (nextPrefix === ':b ') {
     Byond.sendMessage('thinking', { mode: false });

--- a/tgui/packages/tgui-say/handlers/reset.tsx
+++ b/tgui/packages/tgui-say/handlers/reset.tsx
@@ -11,6 +11,7 @@ import { Modal } from '../types';
 export const handleReset = function (this: Modal, channel?: number) {
   this.fields.historyCounter = 0;
   this.fields.radioPrefix = '';
+  this.fields.tempHistory = '';
   this.fields.value = '';
   this.setState({
     buttonContent: valueExists(channel) ? CHANNELS[channel!] : '',

--- a/tgui/packages/tgui-say/handlers/viewHistory.tsx
+++ b/tgui/packages/tgui-say/handlers/viewHistory.tsx
@@ -14,11 +14,13 @@ export const handleViewHistory = function (this: Modal) {
     this.setState({ buttonContent: historyCounter, edited: true });
     this.events.onSetSize(0);
   } else {
-    this.fields.value = '';
+    /** Restores any saved history */
+    this.fields.value = this.fields.tempHistory;
+    this.fields.tempHistory = '';
     this.setState({
       buttonContent: CHANNELS[channel],
       edited: true,
     });
-    this.events.onSetSize(0);
   }
+  this.events.onSetSize(this.fields.value?.length);
 };

--- a/tgui/packages/tgui-say/interfaces/TguiSay.tsx
+++ b/tgui/packages/tgui-say/interfaces/TguiSay.tsx
@@ -15,6 +15,7 @@ export class TguiSay extends Component<{}, State> {
     lightMode: false,
     maxLength: 1024,
     radioPrefix: '',
+    tempHistory: '',
     value: '',
   };
   state: Modal['state'] = {
@@ -62,7 +63,7 @@ export class TguiSay extends Component<{}, State> {
             onEnter={onEnter}
             onEscape={onEscape}
             onInput={onInput}
-            onKeyDown={onKeyDown}
+            onKey={onKeyDown}
             selfClear
             value={edited && value}
           />

--- a/tgui/packages/tgui-say/types/index.tsx
+++ b/tgui/packages/tgui-say/types/index.tsx
@@ -9,7 +9,7 @@ export type Modal = {
 };
 
 type Events = {
-  onArrowKeys: (direction: number) => void;
+  onArrowKeys: (direction: number, value: string) => void;
   onBackspaceDelete: () => void;
   onClick: () => void;
   onEscape: () => void;
@@ -32,6 +32,7 @@ type Fields = {
   lightMode: boolean;
   maxLength: number;
   radioPrefix: string;
+  tempHistory: string;
   value: string;
 };
 

--- a/tgui/packages/tgui/components/TextArea.js
+++ b/tgui/packages/tgui/components/TextArea.js
@@ -52,7 +52,7 @@ export class TextArea extends Component {
     };
     this.handleKeyDown = (e) => {
       const { editing } = this.state;
-      const { onChange, onInput, onEnter, onKeyDown } = this.props;
+      const { onChange, onInput, onEnter, onKey } = this.props;
       if (e.keyCode === KEY_ENTER) {
         this.setEditing(false);
         if (onChange) {
@@ -86,8 +86,9 @@ export class TextArea extends Component {
       if (!editing) {
         this.setEditing(true);
       }
-      if (onKeyDown) {
-        onKeyDown(e, e.target.value);
+      // Custom key handler
+      if (onKey) {
+        onKey(e, e.target.value);
       }
       if (!dontUseTabForIndent) {
         const keyCode = e.keyCode || e.which;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Another atomization of #67809 (this is like the third one, it was really wild)
Fixes #67851

I added draft functionality to TGUI Say and fixed a weird double key event bug
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Players can now check their chat history mid-sentence and won't lose their place

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: TGUI Say now retains current messages / keying through history doesn't erase your current message.
fix: TextArea keydown prop has been renamed so as to not trigger double keydown events.
fix: TGUI say now properly expands when viewing recent messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
