### PR TITLE
Fixes some cases which references are used in trait sources, potentially causing hard deletes

### DIFF
--- a/code/controllers/subsystem/eigenstate.dm
+++ b/code/controllers/subsystem/eigenstate.dm
@@ -41,7 +41,7 @@ SUBSYSTEM_DEF(eigenstates)
 		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/remove_eigen_entry)
 		RegisterSignal(target, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), .proc/tool_interact)
 		target.RegisterSignal(target, COMSIG_EIGENSTATE_ACTIVATE, /obj/structure/closet/proc/bust_open)
-		ADD_TRAIT(target, TRAIT_BANNED_FROM_CARGO_SHUTTLE, src)
+		ADD_TRAIT(target, TRAIT_BANNED_FROM_CARGO_SHUTTLE, REF(src))
 		var/obj/item = target
 		if(item)
 			item.color = COLOR_PERIWINKLEE //Tint the locker slightly.
@@ -75,7 +75,7 @@ SUBSYSTEM_DEF(eigenstates)
 		COMSIG_CLOSET_INSERT,
 		COMSIG_ATOM_TOOL_ACT(TOOL_WELDER),
 	))
-	REMOVE_TRAIT(entry, TRAIT_BANNED_FROM_CARGO_SHUTTLE, src)
+	REMOVE_TRAIT(entry, TRAIT_BANNED_FROM_CARGO_SHUTTLE, REF(src))
 	entry.UnregisterSignal(entry, COMSIG_EIGENSTATE_ACTIVATE) //This is a signal on the object itself so we have to call it from that
 	///Remove the current entry if we're empty
 	for(var/targets in eigen_targets)

--- a/code/datums/actions/mobs/lava_swoop.dm
+++ b/code/datums/actions/mobs/lava_swoop.dm
@@ -14,13 +14,13 @@
 
 /datum/action/cooldown/mob_cooldown/lava_swoop/Grant(mob/M)
 	. = ..()
-	ADD_TRAIT(M, TRAIT_LAVA_IMMUNE, src)
-	ADD_TRAIT(M, TRAIT_NOFIRE, src)
+	ADD_TRAIT(M, TRAIT_LAVA_IMMUNE, REF(src))
+	ADD_TRAIT(M, TRAIT_NOFIRE, REF(src))
 
 /datum/action/cooldown/mob_cooldown/lava_swoop/Remove(mob/M)
 	. = ..()
-	REMOVE_TRAIT(M, TRAIT_LAVA_IMMUNE, src)
-	REMOVE_TRAIT(M, TRAIT_NOFIRE, src)
+	REMOVE_TRAIT(M, TRAIT_LAVA_IMMUNE, REF(src))
+	REMOVE_TRAIT(M, TRAIT_NOFIRE, REF(src))
 
 /datum/action/cooldown/mob_cooldown/lava_swoop/Activate(atom/target_atom)
 	StartCooldown(30 SECONDS)

--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -77,7 +77,7 @@
 	else
 		InitializeOther()
 
-	ADD_TRAIT(parent, TRAIT_FISH_CASE_COMPATIBILE, src)
+	ADD_TRAIT(parent, TRAIT_FISH_CASE_COMPATIBILE, REF(src))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/enter_aquarium)
 
 	//If component is added to something already in aquarium at the time initialize it properly.
@@ -134,7 +134,7 @@
 
 /datum/component/aquarium_content/PreTransfer()
 	. = ..()
-	REMOVE_TRAIT(parent, TRAIT_FISH_CASE_COMPATIBILE, src)
+	REMOVE_TRAIT(parent, TRAIT_FISH_CASE_COMPATIBILE, REF(src))
 
 /datum/component/aquarium_content/Destroy(force, silent)
 	if(current_aquarium)
@@ -301,4 +301,3 @@
 	UnregisterSignal(current_aquarium, list(COMSIG_AQUARIUM_SURFACE_CHANGED, COMSIG_AQUARIUM_FLUID_CHANGED, COMSIG_PARENT_ATTACKBY, COMSIG_ATOM_EXITED))
 	remove_visual_from_aquarium()
 	current_aquarium = null
-

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -59,7 +59,7 @@
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/customizable_attack)
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
 	RegisterSignal(parent, COMSIG_ATOM_PROCESSED, .proc/on_processed)
-	ADD_TRAIT(parent, TRAIT_CUSTOMIZABLE_REAGENT_HOLDER, src)
+	ADD_TRAIT(parent, TRAIT_CUSTOMIZABLE_REAGENT_HOLDER, REF(src))
 
 
 /datum/component/customizable_reagent_holder/UnregisterFromParent()
@@ -69,7 +69,7 @@
 		COMSIG_PARENT_EXAMINE,
 		COMSIG_ATOM_PROCESSED,
 	))
-	REMOVE_TRAIT(parent, TRAIT_CUSTOMIZABLE_REAGENT_HOLDER, src)
+	REMOVE_TRAIT(parent, TRAIT_CUSTOMIZABLE_REAGENT_HOLDER, REF(src))
 
 /datum/component/customizable_reagent_holder/PostTransfer()
 	if(!isatom(parent))

--- a/code/datums/elements/deliver_first.dm
+++ b/code/datums/elements/deliver_first.dm
@@ -28,13 +28,13 @@
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/on_moved)
 	RegisterSignal(target, COMSIG_ATOM_EMAG_ACT, .proc/on_emag)
 	RegisterSignal(target, COMSIG_CLOSET_POST_OPEN, .proc/on_post_open)
-	ADD_TRAIT(target, TRAIT_BANNED_FROM_CARGO_SHUTTLE, src)
+	ADD_TRAIT(target, TRAIT_BANNED_FROM_CARGO_SHUTTLE, REF(src))
 	//registers pre_open when appropriate
 	area_check(target)
 
 /datum/element/deliver_first/Detach(datum/target)
 	. = ..()
-	REMOVE_TRAIT(target, TRAIT_BANNED_FROM_CARGO_SHUTTLE, src)
+	REMOVE_TRAIT(target, TRAIT_BANNED_FROM_CARGO_SHUTTLE, REF(src))
 	UnregisterSignal(target, list(
 		COMSIG_PARENT_EXAMINE,
 		COMSIG_MOVABLE_MOVED,

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -232,12 +232,12 @@
 	RegisterSignal(new_value, COMSIG_PARENT_QDELETING, .proc/source_died)
 	if(. && disabling)
 		var/obj/item/bodypart/old_limb = .
-		REMOVE_TRAIT(old_limb, TRAIT_PARALYSIS, src)
-		REMOVE_TRAIT(old_limb, TRAIT_DISABLED_BY_WOUND, src)
+		REMOVE_TRAIT(old_limb, TRAIT_PARALYSIS, REF(src))
+		REMOVE_TRAIT(old_limb, TRAIT_DISABLED_BY_WOUND, REF(src))
 	if(limb)
 		if(disabling)
-			ADD_TRAIT(limb, TRAIT_PARALYSIS, src)
-			ADD_TRAIT(limb, TRAIT_DISABLED_BY_WOUND, src)
+			ADD_TRAIT(limb, TRAIT_PARALYSIS, REF(src))
+			ADD_TRAIT(limb, TRAIT_DISABLED_BY_WOUND, REF(src))
 
 
 /// Proc called to change the variable `disabling` and react to the event.
@@ -248,11 +248,11 @@
 	disabling = new_value
 	if(disabling)
 		if(!. && limb) //Gained disabling.
-			ADD_TRAIT(limb, TRAIT_PARALYSIS, src)
-			ADD_TRAIT(limb, TRAIT_DISABLED_BY_WOUND, src)
+			ADD_TRAIT(limb, TRAIT_PARALYSIS, REF(src))
+			ADD_TRAIT(limb, TRAIT_DISABLED_BY_WOUND, REF(src))
 	else if(. && limb) //Lost disabling.
-		REMOVE_TRAIT(limb, TRAIT_PARALYSIS, src)
-		REMOVE_TRAIT(limb, TRAIT_DISABLED_BY_WOUND, src)
+		REMOVE_TRAIT(limb, TRAIT_PARALYSIS, REF(src))
+		REMOVE_TRAIT(limb, TRAIT_DISABLED_BY_WOUND, REF(src))
 	if(limb?.can_be_disabled)
 		limb.update_disabled()
 

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -67,7 +67,7 @@
 			return
 
 	if(immobilize)
-		ADD_TRAIT(AM, TRAIT_IMMOBILIZED, src)
+		ADD_TRAIT(AM, TRAIT_IMMOBILIZED, REF(src))
 
 	affecting[AM] = AM.dir
 	var/datum/move_loop/loop = SSmove_manager.move(AM, direction, speed, tiles ? tiles * speed : INFINITY)
@@ -103,7 +103,7 @@
 	SIGNAL_HANDLER
 	var/atom/movable/being_moved = source.moving
 	affecting -= being_moved
-	REMOVE_TRAIT(being_moved, TRAIT_IMMOBILIZED, src)
+	REMOVE_TRAIT(being_moved, TRAIT_IMMOBILIZED, REF(src))
 
 
 /* Stops things thrown by a thrower, doesn't do anything */

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -218,7 +218,7 @@
 	if(plasma_parts.len)
 		var/obj/item/bodypart/burn_limb = pick(plasma_parts) //using the above-mentioned list to get a choice of limbs
 		burn_human.emote("scream")
-		ADD_TRAIT(burn_limb, TRAIT_PLASMABURNT, src)
+		ADD_TRAIT(burn_limb, TRAIT_PLASMABURNT, REF(src))
 		burn_human.update_body_parts()
 		burn_human.emote("scream")
 		burn_human.visible_message(span_warning("[burn_human]'s [burn_limb.name] melts down to the bone!"), \

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -218,7 +218,7 @@
 	if(plasma_parts.len)
 		var/obj/item/bodypart/burn_limb = pick(plasma_parts) //using the above-mentioned list to get a choice of limbs
 		burn_human.emote("scream")
-		ADD_TRAIT(burn_limb, TRAIT_PLASMABURNT, REF(src))
+		ADD_TRAIT(burn_limb, TRAIT_PLASMABURNT, name)
 		burn_human.update_body_parts()
 		burn_human.emote("scream")
 		burn_human.visible_message(span_warning("[burn_human]'s [burn_limb.name] melts down to the bone!"), \

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -224,7 +224,7 @@
 			t_prod = new t_prod(output_loc, mutated_seed)
 			t_prod.transform = initial(t_prod.transform)
 			t_prod.transform *= TRANSFORM_USING_VARIABLE(t_prod.seed.potency, 100) + 0.5
-			ADD_TRAIT(t_prod, TRAIT_PLANT_WILDMUTATE, user)
+			ADD_TRAIT(t_prod, TRAIT_PLANT_WILDMUTATE, INNATE_TRAIT)
 			t_amount++
 			if(t_prod.seed)
 				t_prod.seed.set_instability(round(instability * 0.5))

--- a/code/modules/mining/equipment/kheiral_cuffs.dm
+++ b/code/modules/mining/equipment/kheiral_cuffs.dm
@@ -64,7 +64,7 @@
 		gps_name = id_card.registered_name
 	AddComponent(/datum/component/gps, "*[gps_name]'s Kheiral Link")
 	balloon_alert(user, "GPS activated")
-	ADD_TRAIT(user, TRAIT_MULTIZ_SUIT_SENSORS, src)
+	ADD_TRAIT(user, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
 	gps_enabled = TRUE
 
 /// Disables the GPS and removes the multiz trait
@@ -75,7 +75,7 @@
 		return
 	balloon_alert(user, "GPS de-activated")
 	qdel(GetComponent(/datum/component/gps))
-	REMOVE_TRAIT(user, TRAIT_MULTIZ_SUIT_SENSORS, src)
+	REMOVE_TRAIT(user, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
 	gps_enabled = FALSE
 
 /// If we're off the Z-level, set far_from_home = TRUE. If being worn, trigger kheiral_network proc

--- a/code/modules/surgery/organs/external/wings.dm
+++ b/code/modules/surgery/organs/external/wings.dm
@@ -191,7 +191,7 @@
 	. = ..()
 
 	UnregisterSignal(organ_owner, list(COMSIG_HUMAN_BURNING, COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_MOVABLE_PRE_MOVE))
-	REMOVE_TRAIT(organ_owner, TRAIT_FREE_FLOAT_MOVEMENT, src)
+	REMOVE_TRAIT(organ_owner, TRAIT_FREE_FLOAT_MOVEMENT, REF(src))
 
 /obj/item/organ/external/wings/moth/can_soften_fall()
 	return !burnt
@@ -203,10 +203,10 @@
 	if(!isspaceturf(owner.loc) && !burnt)
 		var/datum/gas_mixture/current = owner.loc.return_air()
 		if(current && (current.return_pressure() >= ONE_ATMOSPHERE*0.85)) //as long as there's reasonable pressure and no gravity, flight is possible
-			ADD_TRAIT(owner, TRAIT_FREE_FLOAT_MOVEMENT, src)
+			ADD_TRAIT(owner, TRAIT_FREE_FLOAT_MOVEMENT, REF(src))
 			return
 
-	REMOVE_TRAIT(owner, TRAIT_FREE_FLOAT_MOVEMENT, src)
+	REMOVE_TRAIT(owner, TRAIT_FREE_FLOAT_MOVEMENT, REF(src))
 
 ///check if our wings can burn off ;_;
 /obj/item/organ/external/wings/moth/proc/try_burn_wings(mob/living/carbon/human/human)

--- a/code/modules/surgery/organs/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/stomach/stomach_ethereal.dm
@@ -16,12 +16,12 @@
 	. = ..()
 	RegisterSignal(owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, .proc/charge)
 	RegisterSignal(owner, COMSIG_LIVING_ELECTROCUTE_ACT, .proc/on_electrocute)
-	ADD_TRAIT(owner, TRAIT_NOHUNGER, src)
+	ADD_TRAIT(owner, TRAIT_NOHUNGER, REF(src))
 
 /obj/item/organ/internal/stomach/ethereal/Remove(mob/living/carbon/carbon, special = 0)
 	UnregisterSignal(owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT)
 	UnregisterSignal(owner, COMSIG_LIVING_ELECTROCUTE_ACT)
-	REMOVE_TRAIT(owner, TRAIT_NOHUNGER, src)
+	REMOVE_TRAIT(owner, TRAIT_NOHUNGER, REF(src))
 
 	SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "charge")
 	carbon.clear_alert(ALERT_ETHEREAL_CHARGE)

--- a/code/modules/wiremod/components/action/mmi.dm
+++ b/code/modules/wiremod/components/action/mmi.dm
@@ -164,9 +164,9 @@
 	. = ..()
 	if(HAS_TRAIT(add_to, TRAIT_COMPONENT_MMI))
 		return FALSE
-	ADD_TRAIT(add_to, TRAIT_COMPONENT_MMI, src)
+	ADD_TRAIT(add_to, TRAIT_COMPONENT_MMI, REF(src))
 
 /obj/item/circuit_component/mmi/removed_from(obj/item/integrated_circuit/removed_from)
-	REMOVE_TRAIT(removed_from, TRAIT_COMPONENT_MMI, src)
+	REMOVE_TRAIT(removed_from, TRAIT_COMPONENT_MMI, REF(src))
 	remove_current_brain()
 	return ..()

--- a/code/modules/wiremod/components/action/printer.dm
+++ b/code/modules/wiremod/components/action/printer.dm
@@ -55,10 +55,10 @@
 	. = ..()
 	if(HAS_TRAIT(add_to, TRAIT_COMPONENT_PRINTER))
 		return FALSE
-	ADD_TRAIT(add_to, TRAIT_COMPONENT_PRINTER, src)
+	ADD_TRAIT(add_to, TRAIT_COMPONENT_PRINTER, REF(src))
 
 /obj/item/circuit_component/printer/removed_from(obj/item/integrated_circuit/removed_from)
-	REMOVE_TRAIT(removed_from, TRAIT_COMPONENT_PRINTER, src)
+	REMOVE_TRAIT(removed_from, TRAIT_COMPONENT_PRINTER, REF(src))
 	return ..()
 
 /obj/item/circuit_component/printer/register_shell(atom/movable/shell)

--- a/code/modules/wiremod/core/component.dm
+++ b/code/modules/wiremod/core/component.dm
@@ -303,12 +303,12 @@
 /// Called when this component is about to be added to an integrated_circuit.
 /obj/item/circuit_component/proc/add_to(obj/item/integrated_circuit/added_to)
 	if(circuit_flags & CIRCUIT_FLAG_ADMIN)
-		ADD_TRAIT(added_to, TRAIT_CIRCUIT_UNDUPABLE, src)
+		ADD_TRAIT(added_to, TRAIT_CIRCUIT_UNDUPABLE, REF(src))
 	return TRUE
 
 /// Called when this component is removed from an integrated_circuit.
 /obj/item/circuit_component/proc/removed_from(obj/item/integrated_circuit/removed_from)
-	REMOVE_TRAIT(removed_from, TRAIT_CIRCUIT_UNDUPABLE, src)
+	REMOVE_TRAIT(removed_from, TRAIT_CIRCUIT_UNDUPABLE, REF(src))
 	return
 
 /**


### PR DESCRIPTION
## About The Pull Request

Fixes some cases in which actual references were used in trait sources instead of keys (or `ref()` keys). 

This can cause some rare and difficult to find hard deletes. 

Trait sources should be a string key relating to the source of it, not an actual reference to what added it. References within trait sources are never handled in `Destroy()`, because it's not expected behavior, meaning it can cause hanging references. 

So, I went through with a regex to find some cases and replaced them. 
I used the following and just picked through the few by hand to find erroneous ones. 
`ADD_TRAIT\(.+, .+, [a-z]+\)`
`REMOVE_TRAIT_TRAIT\(.+, .+, [a-z]+\)`

## Why It's Good For The Game

Less hard deletes, probably. 

## Changelog

:cl: Melbert
code: Some traits which mistakenly were sourced from a hard reference are no longer. 
/:cl:

