### PR TITLE
Fix reinforcement nukeops not getting their HUDs

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -145,6 +145,10 @@
 	C.prefs.safe_transfer_prefs_to(nukie, is_antag = TRUE)
 	nukie.ckey = C.key
 	var/datum/mind/op_mind = nukie.mind
+	if(length(GLOB.newplayer_start)) // needed as hud code doesn't render huds if the atom (in this case the nukie) is in nullspace, so just move the nukie somewhere safe
+		nukie.forceMove(pick(GLOB.newplayer_start))
+	else
+		nukie.forceMove(locate(1,1,1))
 
 	antag_datum = new()
 	antag_datum.send_to_spawnpoint = FALSE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -572,7 +572,7 @@
 		if(!isnull(E.lighting_alpha))
 			lighting_alpha = E.lighting_alpha
 
-	if(client.eye != src)
+	if(client.eye && client.eye != src)
 		var/atom/A = client.eye
 		if(A.update_remote_sight(src)) //returns 1 if we override all other sight updates.
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title, also fixes a red herring [runtime](https://scrubby.melonmesa.com/round/185450/runtimes) I found when trying to debug this issue with `update_sight` trying to call `null.update_remote_sight`

So what caused this: 
#65189, out of all the other changes it made, added a slight check to not render / do anything if a HUD was added to, or was shown to, an atom in nullspace, because that makes sense, why would you be rendering a HUD in nullspace
Well turns out nuke op reinforcement code did that, since it spawns them in a pod, it didn't set the mob's loc before adding the antag datum, which after a bunch of nested proc calls tries to add the HUD to the nukie mob, but then doesn't do anything because it's in nullspace.

This fixes it by moving the nukie character to newplayer_start or (1,1,1) if that's not found (ie. the newplayer start box) for a split second so the HUD initialises properly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes are good, and so are less runtimes
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes nuke op reinforcements having no HUD icon when seen by other nukeops, nor being able to see the HUD icons of other nuke ops
code: Fixed a runtime if update_sight is called on a mob whose client has no eye
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
