### PR TITLE
[NO GBP]You no longer need to change 2 other defines based on math in order to change one of the powerloss defines.

### DIFF
--- a/code/__DEFINES/supermatter.dm
+++ b/code/__DEFINES/supermatter.dm
@@ -124,10 +124,6 @@
 
 /// The divisor scaling value for cubic power loss.
 #define POWERLOSS_CUBIC_DIVISOR 500
-/// The power threshold required to transform power loss into a linear function. It is the power needed for the derivative of the cubic power loss to be equal to POWERLOSS_LINEAR_RATE.
-#define POWERLOSS_LINEAR_THRESHOLD 5880.76
-/// The offset for the linear power loss function. It is the power loss when power is at POWERLOSS_LINEAR_THRESHOLD.
-#define POWERLOSS_LINEAR_OFFSET 1627.01
 /// The rate at which the linear power loss function scales with power.
 #define POWERLOSS_LINEAR_RATE 0.83
 /// How much a psychologist can reduce power loss.

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -278,6 +278,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/atom/movable/supermatter_warp_effect/warp
 	///The power threshold required to transform the powerloss function into a linear function from a cubic function.
 	var/powerloss_linear_threshold = 0
+	///The offset of the linear powerloss function set so the transition is differentiable.
+	var/powerloss_linear_offset = 0
 
 /obj/machinery/power/supermatter_crystal/Initialize(mapload)
 	. = ..()
@@ -335,6 +337,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	pressure_bonus_derived_steepness = (1 - 1 / pressure_bonus_max_multiplier) / (pressure_bonus_max_pressure ** pressure_bonus_curve_angle)
 	pressure_bonus_derived_constant = 1 / pressure_bonus_max_multiplier - pressure_bonus_derived_steepness
 	powerloss_linear_threshold = sqrt(POWERLOSS_LINEAR_RATE / 3 * POWERLOSS_CUBIC_DIVISOR ** 3)
+	powerloss_linear_offset = -1 * powerloss_linear_threshold * POWERLOSS_LINEAR_RATE + (powerloss_linear_threshold / POWERLOSS_CUBIC_DIVISOR) ** 3
 
 /obj/machinery/power/supermatter_crystal/examine(mob/user)
 	. = ..()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -276,6 +276,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/cascade_initiated = FALSE
 	///Reference to the warp effect
 	var/atom/movable/supermatter_warp_effect/warp
+	///The power threshold required to transform the powerloss function into a linear function from a cubic function.
+	var/powerloss_linear_threshold = 0
 
 /obj/machinery/power/supermatter_crystal/Initialize(mapload)
 	. = ..()
@@ -332,6 +334,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 /obj/machinery/power/supermatter_crystal/proc/update_constants()
 	pressure_bonus_derived_steepness = (1 - 1 / pressure_bonus_max_multiplier) / (pressure_bonus_max_pressure ** pressure_bonus_curve_angle)
 	pressure_bonus_derived_constant = 1 / pressure_bonus_max_multiplier - pressure_bonus_derived_steepness
+	powerloss_linear_threshold = sqrt(POWERLOSS_LINEAR_RATE / 3 * POWERLOSS_CUBIC_DIVISOR ** 3)
 
 /obj/machinery/power/supermatter_crystal/examine(mob/user)
 	. = ..()

--- a/code/modules/power/supermatter/supermatter_process.dm
+++ b/code/modules/power/supermatter/supermatter_process.dm
@@ -99,7 +99,7 @@
 	//Use of the second function improves the power gain imparted by using co2
 	if(power_changes)
 		///The power that is getting lost this tick.
-		var/power_loss = power < POWERLOSS_LINEAR_THRESHOLD ? ((power / POWERLOSS_CUBIC_DIVISOR) ** 3) : (POWERLOSS_LINEAR_OFFSET + POWERLOSS_LINEAR_RATE * (power - POWERLOSS_LINEAR_THRESHOLD))
+		var/power_loss = max(POWERLOSS_LINEAR_RATE * (power - powerloss_linear_threshold), 0) + min((power / POWERLOSS_CUBIC_DIVISOR) ** 3, (powerloss_linear_threshold / POWERLOSS_CUBIC_DIVISOR) ** 3)
 		power_loss *= powerloss_inhibitor * (1 - (PSYCHOLOGIST_POWERLOSS_REDUCTION * psyCoeff))
 		power = max(power - power_loss, 0)
 	//After this point power is lowered

--- a/code/modules/power/supermatter/supermatter_process.dm
+++ b/code/modules/power/supermatter/supermatter_process.dm
@@ -99,7 +99,7 @@
 	//Use of the second function improves the power gain imparted by using co2
 	if(power_changes)
 		///The power that is getting lost this tick.
-		var/power_loss = max(POWERLOSS_LINEAR_RATE * (power - powerloss_linear_threshold), 0) + min((power / POWERLOSS_CUBIC_DIVISOR) ** 3, (powerloss_linear_threshold / POWERLOSS_CUBIC_DIVISOR) ** 3)
+		var/power_loss = power < powerloss_linear_threshold ? ((power / POWERLOSS_CUBIC_DIVISOR) ** 3) : (power * POWERLOSS_LINEAR_RATE + powerloss_linear_offset)
 		power_loss *= powerloss_inhibitor * (1 - (PSYCHOLOGIST_POWERLOSS_REDUCTION * psyCoeff))
 		power = max(power - power_loss, 0)
 	//After this point power is lowered


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the POWERLOSS_LINEAR_THRESHOLD and POWERLOSS_LINEAR_OFFSET defines, and instead add a constant for the supermatter that adjusts itself based on POWERLOSS_LINEAR_RATE and POWERLOSS_CUBIC_DIVISOR. Changes powerloss math to negate the need for a linear offset constant, should give the same results. Not player facing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is better this way.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->