### PR TITLE
meteor with engines strapped to it rocks now have air 

### DIFF
--- a/_maps/shuttles/emergency_meteor.dmm
+++ b/_maps/shuttles/emergency_meteor.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/turf/closed/mineral,
+/turf/closed/mineral/asteroid/porous,
 /area/shuttle/escape/meteor)
 "c" = (
 /obj/structure/window/reinforced{
@@ -67,7 +67,7 @@
 /obj/docking_port/mobile/emergency{
 	dwidth = 20;
 	height = 40;
-	movement_force = list("KNOCKDOWN" = 3, "THROW" = 6);
+	movement_force = list("KNOCKDOWN"=3,"THROW"=6);
 	name = "\proper a meteor with engines strapped to it";
 	width = 40
 	},


### PR DESCRIPTION

## About The Pull Request


![image](https://user-images.githubusercontent.com/54422837/175758989-e4f0b02b-58db-45a4-84e4-560dc26100f6.png)

## Why It's Good For The Game

attempting to mine the rocks will no longer result in you dying because they had 0 atmos in them (despite the open turf of the shuttle having air)


## Changelog

:cl:
balance: the meteor with engines strapped to it now has air in its rocks 
/:cl:


