### PR TITLE
Landmark Opportunities - In them their OBJ_LAYER hills

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/effects/landmarks_static.dmi'
 	icon_state = "x2"
 	anchored = TRUE
-	layer = TURF_LAYER
+	layer = OBJ_LAYER
 	plane = GAME_PLANE
 	invisibility = INVISIBILITY_ABSTRACT
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
@@ -406,8 +406,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 /obj/effect/landmark/event_spawn
 	name = "generic event spawn"
 	icon_state = "generic_event"
-	layer = OBJ_LAYER
-
 
 /obj/effect/landmark/event_spawn/Initialize(mapload)
 	. = ..()
@@ -519,7 +517,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 /obj/effect/landmark/navigate_destination
 	name = "navigate verb destination"
 	icon_state = "navigate"
-	layer = OBJ_LAYER
 	var/location
 
 /obj/effect/landmark/navigate_destination/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Landmarks were in the `TURF_LAYER`... layer, so that means you would see bizarre stuff like this in mapping:

![image](https://user-images.githubusercontent.com/34697715/175763388-12631ce7-0214-4e6a-a5f9-27ed0e1acacd.png)

See how the turf_decals are overlaying the "locker"?

![image](https://user-images.githubusercontent.com/34697715/175763413-b66038e3-1287-4d81-a9e1-1c3106b803ac.png)

I doubt people really knew this landmark existed.

Really obtuse to have everything, and I do mean everything, just be on the same layer of the turf just due to how often stuff gets covered up and left behind. So, I decided to make every single landmark (except for the jobstart ones, which were already on `MOB_LAYER`) to the `OBJ_LAYER` layer. This looks a lot better to my eyes, and the results speak for themselves:

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/175763420-5ab02f94-c122-4857-9d5a-5ff95fecbc3d.png)

![image](https://user-images.githubusercontent.com/34697715/175763417-7487811a-09a4-4cf7-88a1-d8be3a6081a4.png)

Much, much better to my eyes. Some landmarks are deliberately made so you can visualize how they look in game, and it's just really silly that the floor will "over write" on the object-not-object. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing particularly player facing.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
