### PR TITLE
Updates how holopads look like in map editors

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -39,7 +39,8 @@ Possible to do for anyone motivated enough:
 	icon_state = "holopad0"
 	base_icon_state = "holopad"
 	layer = LOW_OBJ_LAYER
-	plane = FLOOR_PLANE
+	/// The plane is set such that it shows up without being covered by pipes/wires in a map editor, we change this on initialize.
+	plane = GAME_PLANE
 	req_access = list(ACCESS_KEYCARD_AUTH) //Used to allow for forced connecting to other (not secure) holopads. Anyone can make a call, though.
 	max_integrity = 300
 	armor = list(MELEE = 50, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 0, BIO = 0, FIRE = 50, ACID = 0)
@@ -85,6 +86,12 @@ Possible to do for anyone motivated enough:
 	var/calling = FALSE
 	///bitfield. used to turn on and off hearing sensitivity depending on if we can act on Hear() at all - meant for lowering the number of unessesary hearable atoms
 	var/can_hear_flags = NONE
+
+/obj/machinery/holopad/Initialize(mapload)
+	. = ..()
+	/// We set the plane on mapload such that we can see the holopad render over atmospherics pipe and cabling in a map editor (without initialization), but so it gets that "inset" look in the floor in-game.
+	plane = FLOOR_PLANE
+	update_overlays()
 
 /obj/machinery/holopad/secure
 	name = "secure holopad"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

There was this really picky thing with Holopads being in `FLOOR_PLANE`, so you would get stuff like this since wires+pipes are in the `GAME_PLANE`:

![image](https://user-images.githubusercontent.com/34697715/175764630-f66188ca-5d62-4b53-8eba-b05bb28d2aa2.png)

Looks ugly, right? So, let's set the holopad to `GAME_PLANE` for mapping purposes (since it'll help you visualize what you're looking at in game), and have it set to `FLOOR_PLANE` on Initialize. If we didn't set it on mapload, you'd get this really jarring shadow effect that doesn't really feel "in-place".

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/175764635-56046c76-a5fa-463b-82f2-e12505cb3c24.png)

![image](https://user-images.githubusercontent.com/34697715/175764640-cfa62583-c59b-4d04-b2fe-59e4bd08fdfd.png)

You truly get the best of both worlds this way.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing particularly player-facing.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
