### PR TITLE
[MDB Ignore] Makes mining and labor shuttle home docks their own type, rather than varedits

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4294,14 +4294,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bgU" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 5;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/delta;
-	width = 7
+/obj/docking_port/stationary/mining_home{
+	dir = 4
 	},
 /turf/open/space/basic,
 /area/space)
@@ -5802,14 +5796,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "bAc" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/delta;
-	width = 9
+/obj/docking_port/stationary/laborcamp_home{
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space)
@@ -61244,14 +61232,7 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "qzS" = (
-/obj/docking_port/stationary{
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
-	},
+/obj/docking_port/stationary/mining_home/common,
 /turf/open/space/basic,
 /area/space)
 "qzX" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -5788,14 +5788,8 @@
 /turf/open/misc/asteroid,
 /area/space/nearstation)
 "bKA" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 10;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/kilo;
-	width = 7
+/obj/docking_port/stationary/mining_home/kilo{
+	dir = 4
 	},
 /turf/open/space/basic,
 /area/space)
@@ -6402,14 +6396,8 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "bUU" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/kilo;
-	width = 9
+/obj/docking_port/stationary/laborcamp_home/kilo{
+	dir = 2
 	},
 /turf/open/space,
 /area/space)
@@ -80299,14 +80287,7 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "wHM" = (
-/obj/docking_port/stationary{
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/kilo;
-	width = 7
-	},
+/obj/docking_port/stationary/mining_home/common/kilo,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "wHQ" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1379,14 +1379,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "aAA" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/box;
-	width = 7
+/obj/docking_port/stationary/mining_home{
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space)
@@ -27540,14 +27534,8 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "jOb" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
+/obj/docking_port/stationary/mining_home/common{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/port)
@@ -67640,14 +67628,8 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "xOF" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/generic;
-	width = 9
+/obj/docking_port/stationary/laborcamp_home{
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space)

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1126,14 +1126,8 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "eb" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/generic;
-	width = 9
+/obj/docking_port/stationary/laborcamp_home{
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space)
@@ -2384,14 +2378,8 @@
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
 "Kd" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/box;
-	width = 7
+/obj/docking_port/stationary/mining_home{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/station/cargo/miningoffice)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -23192,14 +23192,8 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/tram/mid)
 "hWV" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 5;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/box;
-	width = 7
+/obj/docking_port/stationary/mining_home{
+	dir = 4
 	},
 /turf/open/misc/asteroid/airless,
 /area/mine/explored)
@@ -23936,14 +23930,7 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "iia" = (
-/obj/docking_port/stationary{
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/generic;
-	width = 9
-	},
+/obj/docking_port/stationary/laborcamp_home,
 /turf/open/misc/asteroid/airless,
 /area/mine/explored)
 "iib" = (
@@ -54794,14 +54781,8 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "suI" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
+/obj/docking_port/stationary/mining_home/common{
+	dir = 4
 	},
 /turf/open/misc/asteroid/airless,
 /area/mine/explored)

--- a/code/modules/mining/laborcamp/laborshuttle.dm
+++ b/code/modules/mining/laborcamp/laborshuttle.dm
@@ -26,3 +26,14 @@
 		to_chat(user, span_warning("Shuttle is already at the outpost!"))
 		return FALSE
 	return TRUE
+
+/obj/docking_port/stationary/laborcamp_home
+	name = "SS13: Labor Shuttle Dock"
+	id = "laborcamp_home"
+	roundstart_template = /datum/map_template/shuttle/labour/delta
+	width = 9
+	dwidth = 2
+	height = 5
+
+/obj/docking_port/stationary/laborcamp_home/kilo
+	roundstart_template = /datum/map_template/shuttle/labour/kilo

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -122,6 +122,26 @@
 	shuttleId = "mining_common"
 	possible_destinations = "commonmining_home;lavaland_common_away;landing_zone_dock;mining_public"
 
+/obj/docking_port/stationary/mining_home
+	name = "SS13: Mining Dock"
+	id = "mining_home"
+	roundstart_template = /datum/map_template/shuttle/mining/delta
+	width = 7
+	dwidth = 3
+	height = 5
+
+/obj/docking_port/stationary/mining_home/kilo
+	roundstart_template = /datum/map_template/shuttle/mining/kilo
+	height = 10
+
+/obj/docking_port/stationary/mining_home/common
+	name = "SS13: Common Mining Dock"
+	id = "commonmining_home"
+	roundstart_template = /datum/map_template/shuttle/mining_common/meta
+
+/obj/docking_port/stationary/mining_home/common/kilo
+	roundstart_template = /datum/map_template/shuttle/mining_common/kilo
+
 /**********************Mining car (Crate like thing, not the rail car)**************************/
 
 /obj/structure/closet/crate/miningcar


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Idk seems kinda bad that every shuttle dock ever on stations is just a varedited /stationary, rather than an easy to modify, set thing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
At least seven less varedits, allows easier changing to mining shuttle docks in the future should it be desired.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: mining and labor shuttle home docks are no longer varedits of /stationary, and are now their own subtype
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
