### PR TITLE
Gorillas Move Slightly Faster When Not Holding Anything

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -21,7 +21,7 @@
 	response_disarm_simple = "challenge"
 	response_harm_continuous = "thumps"
 	response_harm_simple = "thump"
-	speed = 1
+	speed = 0.5
 	melee_damage_lower = 15
 	melee_damage_upper = 18
 	damage_coeff = list(BRUTE = 1, BURN = 1.5, TOX = 1.5, CLONE = 0, STAMINA = 0, OXY = 1.5)

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/visuals_icons.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/visuals_icons.dm
@@ -21,11 +21,11 @@
 	if(!standing)
 		if(stat != DEAD)
 			icon_state = "crawling"
-			speed = 1
+			set_varspeed(0.5)
 		return ..()
 	if(stat != DEAD)
 		icon_state = "standing"
-		speed = 3 // Gorillas are slow when standing up.
+		set_varspeed(1) // Gorillas are slow when standing up.
 
 	var/list/hands_overlays = list()
 


### PR DESCRIPTION
## About The Pull Request

So, if you look at gorilla code, you'll see in the code that handles displaying their held items that gorillas are supposed to significantly slow down when holding an item.  However, setting the speed var of a simplemob outside of its initialization doesn't work, so I made it use the proper set_varspeed() method instead.  Now, speed = 3 sucks a lot, so we're not going to do that because I think that's too slow.  Instead, this PR takes that broken intended mechanic and instead just makes gorillas slightly faster than they are now when they aren't holding anything.

## Why It's Good For The Game

Gorillas aren't too common anymore and I remember seeing this code a while back when I was making a mob that could also hold items as a prototype to a new midround antagonist.  I'd figure this change would be a nice little fix to implement the mechanic the original creator initially intended for gorillas, while not making them play like complete ass.

## Changelog

:cl:
fix: Gorillas now change speed when holding something vs. not holding something, as was always intended
balance: Made gorillas use their old speed value when they're holding something, and made them slightly faster when they're not holding something
/:cl: