### PR TITLE
Fixes Invisible Equipment on Monkified Monkeys

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -27,6 +27,7 @@
 	set_species(/datum/species/monkey)
 	SEND_SIGNAL(src, COMSIG_HUMAN_MONKEYIZE)
 	uncuff()
+	regenerate_icons()
 	return src
 
 //////////////////////////           Humanize               //////////////////////////////
@@ -57,6 +58,7 @@
 	invisibility = 0
 	set_species(species)
 	SEND_SIGNAL(src, COMSIG_MONKEY_HUMANIZE)
+	regenerate_icons()
 	return src
 
 /mob/proc/AIize(client/preference_source, move = TRUE)


### PR DESCRIPTION
## About The Pull Request

So as it is on live right now, transforming into a monkey using a monkifier injector will unequip items you can no longer wear and keep the ones you can wear on.  This, however, makes the items you keep on invisible, which obviously isn't intended.  This also happens for monkeys when they become a human as well.  This PR simply fixes this issue.

## Why It's Good For The Game

We probably shouldn't have monkified people walking around with invisible backpacks and whatnot.

## Changelog

:cl:
fix: People who gain or lose the monkified mutation no longer have invisible equipped items.
/:cl:
