### PR TITLE
Add monitor decryption key to Listening post

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -363,6 +363,7 @@
 /obj/machinery/computer/message_monitor{
 	dir = 8
 	},
+/obj/item/paper/monitorkey,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "uI" = (


### PR DESCRIPTION
## About The Pull Request

Fixes #68001

The new Syndicate Listening Post comes with a server message monitor but not the decryption key (unlike every* iteration of the Syndie lava base), this is both confusing and frustrating (especially when both comms roles are available and you picked the broken one).

\* every iteration with a server message monitor, we don't talk about `commswilding_3.dmm`

## Why It's Good For The Game

Syndie comms agent should be able to use the tools at their disposal.

## Changelog

:cl:
fix: The decryption key to the Nanotrasen message network has been delivered to the Syndicate Listening Post
/:cl:
