### PR TITLE
Fixes the frozen status trait never being applied

### DIFF
--- a/code/datums/elements/frozen.dm
+++ b/code/datums/elements/frozen.dm
@@ -11,6 +11,9 @@
 	if(target_obj.obj_flags & FREEZE_PROOF)
 		return ELEMENT_INCOMPATIBLE
 
+	if(HAS_TRAIT_FROM(target, TRAIT_FROZEN, ELEMENT_TRAIT(type)))
+		return ELEMENT_INCOMPATIBLE
+
 	ADD_TRAIT(target_obj, TRAIT_FROZEN, ELEMENT_TRAIT(type))
 	target_obj.name = "frozen [target_obj.name]"
 	target_obj.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)

--- a/code/datums/elements/frozen.dm
+++ b/code/datums/elements/frozen.dm
@@ -11,7 +11,7 @@
 	if(target_obj.obj_flags & FREEZE_PROOF)
 		return ELEMENT_INCOMPATIBLE
 
-	if(HAS_TRAIT_FROM(target, TRAIT_FROZEN, ELEMENT_TRAIT(type)))
+	if(HAS_TRAIT(target_obj, TRAIT_FROZEN))
 		return ELEMENT_INCOMPATIBLE
 
 	ADD_TRAIT(target_obj, TRAIT_FROZEN, ELEMENT_TRAIT(type))

--- a/code/datums/elements/frozen.dm
+++ b/code/datums/elements/frozen.dm
@@ -11,6 +11,7 @@
 	if(target_obj.obj_flags & FREEZE_PROOF)
 		return ELEMENT_INCOMPATIBLE
 
+	ADD_TRAIT(target_obj, TRAIT_FROZEN, ELEMENT_TRAIT(type))
 	target_obj.name = "frozen [target_obj.name]"
 	target_obj.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
 	target_obj.alpha -= 25
@@ -21,6 +22,7 @@
 
 /datum/element/frozen/Detach(datum/source, ...)
 	var/obj/obj_source = source
+	REMOVE_TRAIT(obj_source, TRAIT_FROZEN, ELEMENT_TRAIT(type))
 	obj_source.name = replacetext(obj_source.name, "frozen ", "")
 	obj_source.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, GLOB.freon_color_matrix)
 	obj_source.alpha += 25


### PR DESCRIPTION
## About The Pull Request

The frozen trait exists, and specifically exists to prevent stuff that is frozen from being re-frozen again...

But nothing ever applied it.

This makes the frozen element apply the frozen trait. 

## Why It's Good For The Game

No more frozen frozen goods.

## Changelog

:cl: Melbert
fix: Frozen stuff is now properly actually recognized as frozen and won't re-freeze. 
/:cl:
