### PR TITLE
Fixed DeltaStation mining firelock placement

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -12495,7 +12495,6 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},


### PR DESCRIPTION
## About The Pull Request
DeltaStation has a firelock placed adjacent to it's mining shuttle, meaning that once the shuttle departs it instantly triggers the firelock. This PR removes that firelock

## Why It's Good For The Game
Roundstart fire alarms bad.

## Changelog
:cl:
del: Delta-pattern station quartermasters no longer have to listen to the sound of a fire alarm every time their miners use the mining shuttle.
/:cl: