### PR TITLE
Replaces the tram generic construction console with an aux construction console

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2077,10 +2077,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen/diner)
 "aUt" = (
-/obj/machinery/computer/camera_advanced/base_construction,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
+/obj/machinery/computer/camera_advanced/base_construction/aux,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "aUA" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2078,6 +2078,9 @@
 /area/station/service/kitchen/diner)
 "aUt" = (
 /obj/machinery/computer/camera_advanced/base_construction/aux,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "aUA" = (


### PR DESCRIPTION

## About The Pull Request

This has been fixed in #64702, but the map has regressed.

## Why It's Good For The Game

Aux mining base can once again be built at speed, and the camera is confined to the aux base itself.

## Changelog

:cl:
fix: Tramstation aux construction console works again as intended.
/:cl:
