### PR TITLE
Fixes a runtime when inflicting a blunt wound on an armless human

### DIFF
--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -142,9 +142,9 @@
 	alert_type = NONE
 
 /datum/status_effect/wound/on_creation(mob/living/new_owner, incoming_wound)
-	. = ..()
 	linked_wound = incoming_wound
 	linked_limb = linked_wound.limb
+	return ..()
 
 /datum/status_effect/wound/on_remove()
 	linked_wound = null


### PR DESCRIPTION
## About The Pull Request

I discovered this runtime while doing some admin lua scripting testing, despite it having nothing to do with such. When you inflict a blunt wound on someone without arms, `on_swap_hands` gets called before `linked_limb` or `linked_wound` can be set. Thus, when testing to see if `get_active_hand()` equals `linked_limb` on an armless human, the check returns true, and tries to reference a null `linked_wound` to get its actionspeed penalty. This is where the runtime comes from. To avoid this, and other wound-related runtimes in the future, I made `/datum/status_effect/wound/on_creation` call `..()` *after* setting `linked_limb` and `linked_wound`.

## Why It's Good For The Game

Runtimes bad.

## Changelog

:cl:
fix: Fixed a runtime that occurs when inflicting a blunt wound on an armless human.
/:cl:
