### PR TITLE
Adjusts Door Mapping Helper Layers

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -70,7 +70,8 @@
 #define BELOW_OPEN_DOOR_LAYER 2.6
 #define BLASTDOOR_LAYER 2.65
 #define OPEN_DOOR_LAYER 2.7
-#define DOOR_HELPER_LAYER 2.71 //keep this above OPEN_DOOR_LAYER
+#define DOOR_ACCESS_HELPER_LAYER 2.71 //keep this above OPEN_DOOR_LAYER, special layer used for /obj/effect/mapping_helpers/airlock/access
+#define DOOR_HELPER_LAYER 2.72 //keep this above DOOR_ACCESS_HELPER_LAYER and OPEN_DOOR_LAYER since the others tend to have tiny sprites that tend to be covered up.
 #define PROJECTILE_HIT_THRESHHOLD_LAYER 2.75 //projectiles won't hit objects at or below this layer if possible
 #define TABLE_LAYER 2.8
 #define GATEWAY_UNDERLAY_LAYER 2.85

--- a/code/modules/mapping/access_helpers.dm
+++ b/code/modules/mapping/access_helpers.dm
@@ -1,5 +1,5 @@
 /obj/effect/mapping_helpers/airlock/access
-	layer = DOOR_HELPER_LAYER
+	layer = DOOR_ACCESS_HELPER_LAYER
 	icon_state = "access_helper"
 
 // These are mutually exclusive; can't have req_any and req_all

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -189,7 +189,6 @@
 	else
 		airlock.locked = TRUE
 
-
 /obj/effect/mapping_helpers/airlock/unres
 	name = "airlock unrestricted side helper"
 	icon_state = "airlock_unres_helper"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Access helper layers are great and all, but they tended to have this sort of effect on maps where since they were on the same layer as all of the other mapping helpers for doors, they would just tend to cover up the smaller sprites the others used, like this:

![image](https://user-images.githubusercontent.com/34697715/175842093-c291fda4-8916-4e92-841d-7daa5bc48e15.png)

So, this just switches up the layers a bit by having a new layer called `DOOR_ACCESS_HELPER_LAYER` (that is still above `OPEN_DOOR_LAYER`) just for Access Helpers, while every other airlock helper takes the `DOOR_HELPER_LAYER` (like before), which has been increased by 0.01 more funny number.

Ok?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/175842047-75cb2e4f-fd5c-430f-b9c4-4ee855f378fb.png)

I like this a lot more.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing particularly player facing.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
