### PR TITLE
Brand of Dance spell fix

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -96,7 +96,7 @@
 
 /datum/heretic_knowledge/blade_dance
 	name = "Dance of the Brand"
-	desc = "Being attacked while wielding a Darkened Blade in either hand will deliver a riposte \
+	desc = "Being attacked while wielding a Heretic Blade in either hand will deliver a riposte \
 		towards your attacker. This effect can only trigger once every 20 seconds."
 	gain_text = "Having the prowess to wield such a thing requires great dedication and terror."
 	next_knowledge = list(


### PR DESCRIPTION
## About The Pull Request

Changes the Brand of Dance description correctly, the fact that any heretic blade would work for it to activate

## Why It's Good For The Game

The Brand of Dance description is not wrong anymore, clears up misunderstanding

## Changelog

:cl:@Salex08
spellcheck: The Brand of Dance description is correct now
/:cl: