### PR TITLE
Adds unit tests for bar sign datums

### DIFF
--- a/code/game/objects/structures/barsigns.dm
+++ b/code/game/objects/structures/barsigns.dm
@@ -22,7 +22,7 @@
 
 	icon_state = sign.icon
 
-	if(sign.name)
+	if(sign.rename_area)
 		name = "[initial(name)] ([sign.name])"
 	else
 		name = "[initial(name)]"
@@ -30,7 +30,7 @@
 	if(sign.desc)
 		desc = sign.desc
 
-	if(sign.rename_area && sign.name)
+	if(sign.rename_area)
 		rename_area(src, sign.name)
 
 	return sign
@@ -138,15 +138,20 @@
 	var/list/names = list()
 	for(var/d in subtypesof(/datum/barsign))
 		var/datum/barsign/D = d
-		if(initial(D.name) && !initial(D.hidden))
+		if(!initial(D.hidden))
 			names += initial(D.name)
 	. = names
 
 /datum/barsign
-	var/name = "Name"
-	var/icon = "Icon"
-	var/desc = "desc"
+	/// User-visible name of the sign.
+	var/name
+	/// Icon state associated with this sign
+	var/icon
+	/// Description shown in the sign's examine text.
+	var/desc
+	/// Hidden from list of selectable options.
 	var/hidden = FALSE
+	/// Rename the area when this sign is selected.
 	var/rename_area = TRUE
 
 /datum/barsign/New()
@@ -304,7 +309,7 @@
 
 
 /datum/barsign/hiddensigns/empbarsign
-	name = null
+	name = "EMP'd"
 	icon = "empbarsign"
 	desc = "Something has gone very wrong."
 	rename_area = FALSE
@@ -315,7 +320,7 @@
 	desc = "Syndicate or die."
 
 /datum/barsign/hiddensigns/signoff
-	name = null
+	name = "Off"
 	icon = "empty"
 	desc = "This sign doesn't seem to be on."
 	rename_area = FALSE

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -70,6 +70,7 @@
 #include "anchored_mobs.dm"
 #include "anonymous_themes.dm"
 #include "autowiki.dm"
+#include "barsigns.dm"
 #include "bespoke_id.dm"
 #include "binary_insert.dm"
 #include "bloody_footprints.dm"

--- a/code/modules/unit_tests/barsigns.dm
+++ b/code/modules/unit_tests/barsigns.dm
@@ -1,17 +1,15 @@
 /**
  * Test if icon states for each datum actually exist in the DMI.
  */
+/datum/unit_test/barsigns_icon
+
 /datum/unit_test/barsigns_icon/Run()
 	var/obj/structure/sign/barsign_type = /obj/structure/sign/barsign
 	var/icon/barsign_icon = initial(barsign_type.icon)
 	var/list/barsign_icon_states = icon_states(barsign_icon)
 
-	// Check every datum
-	for(var/sign_type in subtypesof(/datum/barsign))
-		// Special supertype
-		if(sign_type == /datum/barsign/hiddensigns)
-			continue
-
+	// Check every datum real bar sign
+	for(var/sign_type in (subtypesof(/datum/barsign) - /datum/barsign/hiddensigns))
 		var/datum/barsign/sign = new sign_type()
 
 		if(!(sign.icon in barsign_icon_states))
@@ -20,6 +18,8 @@
 /**
  * Check that bar signs have a name and desc, and that the name is unique.
  */
+/datum/unit_test/barsigns_name
+
 /datum/unit_test/barsigns_name/Run()
 	var/list/existing_names = list()
 

--- a/code/modules/unit_tests/barsigns.dm
+++ b/code/modules/unit_tests/barsigns.dm
@@ -23,12 +23,8 @@
 /datum/unit_test/barsigns_name/Run()
 	var/list/existing_names = list()
 
-	for(var/sign_type in subtypesof(/datum/barsign))
+	for(var/sign_type in subtypesof(/datum/barsign) - /datum/barsign/hiddensigns)
 		var/datum/barsign/sign = new sign_type()
-
-		// Hidden bar signs aren't expected to have a name.
-		if(sign.hidden)
-			continue
 
 		if(!sign.name)
 			TEST_FAIL("[sign_type] does not have a name.")

--- a/code/modules/unit_tests/barsigns.dm
+++ b/code/modules/unit_tests/barsigns.dm
@@ -1,0 +1,41 @@
+/**
+ * Test if icon states for each datum actually exist in the DMI.
+ */
+/datum/unit_test/barsigns_icon/Run()
+	var/obj/structure/sign/barsign_type = /obj/structure/sign/barsign
+	var/icon/barsign_icon = initial(barsign_type.icon)
+	var/list/barsign_icon_states = icon_states(barsign_icon)
+
+	// Check every datum
+	for(var/sign_type in subtypesof(/datum/barsign))
+		// Special supertype
+		if(sign_type == /datum/barsign/hiddensigns)
+			continue
+
+		var/datum/barsign/sign = new sign_type()
+
+		if(!(sign.icon in barsign_icon_states))
+			TEST_FAIL("Icon state for [sign_type] does not exist in [barsign_icon].")
+
+/**
+ * Check that bar signs have a name and desc, and that the name is unique.
+ */
+/datum/unit_test/barsigns_name/Run()
+	var/list/existing_names = list()
+
+	for(var/sign_type in subtypesof(/datum/barsign))
+		var/datum/barsign/sign = new sign_type()
+
+		// Hidden bar signs aren't expected to have a name.
+		if(sign.hidden)
+			continue
+
+		if(!sign.name)
+			TEST_FAIL("[sign_type] does not have a name.")
+		if(!sign.desc)
+			TEST_FAIL("[sign_type] does not have a desc.")
+
+		if(sign.name in existing_names)
+			TEST_FAIL("[sign_type] does not have a unique name.")
+
+		existing_names += sign.name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds unit tests for the `/datum/barsign`s, testing that:
- The icon states the bar sign choices use actually exist in the barsigns.dmi
- The `name`s and `desc`s are set for the visible bar sign choices.
- The names are unique.

These tests were created due to a desync in a downstream fork, but can't hurt up here.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Testing data validity.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

No user or admin visible changes.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
