### PR TITLE
Adds cancel event option for midround random events

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -39,6 +39,10 @@
 #define COMSIG_GLOB_PRE_RANDOM_EVENT "!pre_random_event"
 	/// Do not allow this random event to continue.
 	#define CANCEL_PRE_RANDOM_EVENT (1<<0)
+/// Called by (/datum/round_event_control/RunEvent).
+#define COMSIG_GLOB_RANDOM_EVENT "!random_event"
+	/// Do not allow this random event to continue.
+	#define CANCEL_RANDOM_EVENT (1<<0)
 /// a person somewhere has thrown something : (mob/living/carbon/carbon_thrower, target)
 #define COMSIG_GLOB_CARBON_THROW_THING	"!throw_thing"
 /// a trapdoor remote has sent out a signal to link with a trapdoor

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -54,6 +54,8 @@
 		if(E)
 			E.admin_setup(usr)
 			var/datum/round_event/event = E.runEvent()
+			if(SEND_GLOBAL_SIGNAL(COMSIG_GLOB_RANDOM_EVENT, src) & CANCEL_RANDOM_EVENT)
+				return
 			if(event.announceWhen>0)
 				event.processing = FALSE
 				var/prompt = tgui_alert(usr, "Would you like to alert the crew?", "Alert", list("Yes", "No", "Cancel"))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -54,7 +54,7 @@
 		if(E)
 			E.admin_setup(usr)
 			var/datum/round_event/event = E.runEvent()
-			if(SEND_GLOBAL_SIGNAL(COMSIG_GLOB_RANDOM_EVENT, src) & CANCEL_RANDOM_EVENT)
+			if(event.cancel_event)
 				return
 			if(event.announceWhen>0)
 				event.processing = FALSE

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -93,7 +93,12 @@
 		SSblackbox.record_feedback("tally", "event_admin_cancelled", 1, typepath)
 
 /datum/round_event_control/proc/runEvent(random = FALSE)
-	//We clear our signals first
+/*
+* We clear our signals first so we dont cancel a wanted event by accident,
+* the majority of time the admin will probably want to cancel a single midround spawned random events
+* and not multiple events called by others admins
+* * In the worst case scenario we can still recall a event which we cancelled by accident, which is much better then to have a unwanted event
+*/
 	UnregisterSignal(SSdcs, COMSIG_GLOB_RANDOM_EVENT)
 	var/datum/round_event/E = new typepath()
 	E.current_players = get_active_player_count(alive_check = 1, afk_check = 1, human_check = 1)
@@ -104,8 +109,8 @@
 	triggering = TRUE
 
 	if (alert_observers)
-		message_admins("Random Event triggering in [RANDOM_EVENT_ADMIN_INTERVENTION_TIME] seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
-		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME SECONDS)
+		message_admins("Random Event triggering in 10 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
+		sleep(100)
 
 	if(!triggering)
 		RegisterSignal(SSdcs, COMSIG_GLOB_RANDOM_EVENT, .proc/stop_random_event)
@@ -141,6 +146,7 @@
 	var/activeFor = 0 //How long the event has existed. You don't need to change this.
 	var/current_players = 0 //Amount of of alive, non-AFK human players on server at the time of event start
 	var/fakeable = TRUE //Can be faked by fake news event.
+	var/cancel_event = FALSE //Wheter a admin wants this event to be cancelled
 
 //Called first before processing.
 //Allows you to setup your event, such as randomly
@@ -200,8 +206,10 @@
 
 	if(SEND_GLOBAL_SIGNAL(COMSIG_GLOB_RANDOM_EVENT, src) & CANCEL_RANDOM_EVENT)
 		processing = FALSE
+		cancel_event = TRUE
 		kill()
-		
+		return
+
 	if(activeFor == startWhen)
 		processing = FALSE
 		start()

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -1,4 +1,4 @@
-#define RANDOM_EVENT_ADMIN_INTERVENTION_TIME 10
+#define RANDOM_EVENT_ADMIN_INTERVENTION_TIME (10 SECONDS)
 
 //this singleton datum is used by the events controller to dictate how it selects events
 /datum/round_event_control
@@ -69,8 +69,8 @@
 
 	triggering = TRUE
 	if (alert_observers)
-		message_admins("Random Event triggering in [RANDOM_EVENT_ADMIN_INTERVENTION_TIME] seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
-		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME SECONDS)
+		message_admins("Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
+		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)
 		var/players_amt = get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE)
 		if(!canSpawnEvent(players_amt))
 			message_admins("Second pre-condition check for [name] failed, skipping...")
@@ -93,12 +93,12 @@
 		SSblackbox.record_feedback("tally", "event_admin_cancelled", 1, typepath)
 
 /datum/round_event_control/proc/runEvent(random = FALSE)
-/*
-* We clear our signals first so we dont cancel a wanted event by accident,
-* the majority of time the admin will probably want to cancel a single midround spawned random events
-* and not multiple events called by others admins
-* * In the worst case scenario we can still recall a event which we cancelled by accident, which is much better then to have a unwanted event
-*/
+	/*
+	* We clear our signals first so we dont cancel a wanted event by accident,
+	* the majority of time the admin will probably want to cancel a single midround spawned random events
+	* and not multiple events called by others admins
+	* * In the worst case scenario we can still recall a event which we cancelled by accident, which is much better then to have a unwanted event
+	*/
 	UnregisterSignal(SSdcs, COMSIG_GLOB_RANDOM_EVENT)
 	var/datum/round_event/E = new typepath()
 	E.current_players = get_active_player_count(alive_check = 1, afk_check = 1, human_check = 1)
@@ -109,11 +109,12 @@
 	triggering = TRUE
 
 	if (alert_observers)
-		message_admins("Random Event triggering in 10 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
-		sleep(100)
+		message_admins("Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
+		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)
 
 	if(!triggering)
 		RegisterSignal(SSdcs, COMSIG_GLOB_RANDOM_EVENT, .proc/stop_random_event)
+		E.cancel_event = TRUE
 		return E
 
 	triggering = FALSE
@@ -206,7 +207,6 @@
 
 	if(SEND_GLOBAL_SIGNAL(COMSIG_GLOB_RANDOM_EVENT, src) & CANCEL_RANDOM_EVENT)
 		processing = FALSE
-		cancel_event = TRUE
 		kill()
 		return
 

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -129,6 +129,7 @@
 
 //Returns the component for the listener
 /datum/round_event_control/proc/stop_random_event()
+	SIGNAL_HANDLER
 	return CANCEL_RANDOM_EVENT
 
 //Special admins setup
@@ -147,7 +148,8 @@
 	var/activeFor = 0 //How long the event has existed. You don't need to change this.
 	var/current_players = 0 //Amount of of alive, non-AFK human players on server at the time of event start
 	var/fakeable = TRUE //Can be faked by fake news event.
-	var/cancel_event = FALSE //Wheter a admin wants this event to be cancelled
+	/// Whether a admin wants this event to be cancelled
+	var/cancel_event = FALSE
 
 //Called first before processing.
 //Allows you to setup your event, such as randomly


### PR DESCRIPTION
## About The Pull Request

closes: https://github.com/tgstation/tgstation/issues/67962
Adds a Cancel button to stop midround random events

## Why It's Good For The Game
Admins can stop unwanted midround random events

## Changelog

:cl:@Salex08
admin: Admins can now cancel midround random events
/:cl:
