### PR TITLE
The battlecruiser final objective no longer requires 8 active ghosts for it to spawn

### DIFF
--- a/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
@@ -1,5 +1,5 @@
 /// The minimum number of ghosts and observers needed before handing out battlecruiser objectives.
-#define MIN_GHOSTS_FOR_BATTLECRUISER 1
+#define MIN_GHOSTS_FOR_BATTLECRUISER 4
 
 /datum/traitor_objective/final/battlecruiser
 	name = "Reveal Station Coordinates to nearby Syndicate Battlecruiser"

--- a/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
@@ -1,5 +1,5 @@
 /// The minimum number of ghosts and observers needed before handing out battlecruiser objectives.
-#define MIN_GHOSTS_FOR_BATTLECRUISER 8
+#define MIN_GHOSTS_FOR_BATTLECRUISER 1
 
 /datum/traitor_objective/final/battlecruiser
 	name = "Reveal Station Coordinates to nearby Syndicate Battlecruiser"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This Pr changes the amount of ghosts needed for the battlecruiser to spawn from 8 to 4
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because this restriction has existed for a long time and nobody has seen the battlecruiser. and i think its unfair that there is a restriction like this, as its 100% possible for the battlecruiser to be a dangerous event with just 1-2 battlecruiser crew members (thats basically a lone op) - i have changed the amount of ghosts needed to 4
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

balance: The battlecruiser ghost restriction has been reduced from 8 to 4

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
