### PR TITLE
Blacklists placeholder food items in the random food generator

### DIFF
--- a/code/__HELPERS/randoms.dm
+++ b/code/__HELPERS/randoms.dm
@@ -1,6 +1,9 @@
 ///Get a random food item exluding the blocked ones
 /proc/get_random_food()
-	var/list/blocked = list(/obj/item/food/bread,
+	var/list/blocked = list(
+		/obj/item/food/drug,
+		/obj/item/food/spaghetti,
+		/obj/item/food/bread,
 		/obj/item/food/breadslice,
 		/obj/item/food/cake,
 		/obj/item/food/cakeslice,


### PR DESCRIPTION
## About The Pull Request
closes:https://github.com/tgstation/tgstation/issues/68060
Blacklists placeholder food items for the random food generator

## Why It's Good For The Game
Those items have no use and are placeholder

## Changelog

:cl:@Salex08
fix: blacklists placeholder food items in the random food generator which caused error sprites appearing
/:cl: