### PR TITLE
Allow Agent cards to use numbers in their names

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1483,7 +1483,7 @@
 		if(popup_input == "Forge/Reset")
 			if(!forged)
 				var/input_name = tgui_input_text(user, "What name would you like to put on this card? Leave blank to randomise.", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name), MAX_NAME_LEN)
-				input_name = sanitize_name(input_name)
+				input_name = sanitize_name(input_name, allow_numbers = TRUE)
 				if(!input_name)
 					// Invalid/blank names give a randomly generated one.
 					if(user.gender == MALE)


### PR DESCRIPTION
## About The Pull Request

Agend cards allow you to forge a fake identity but currently don't allow numbers. This hinders the ability of Syndies (in particular comms agent) to mess with people over radio.

I initially thought this was by design, however as the new listening post comes with the possibility of sounding like a robot (thanks to autosurgeon + robotic tongue) it feels like an oversight that you can only impersonate borgs without numbers in their name.

Not sure if this is a fix/qol/change/add, so please correct the CL if it looks wrong!

<sub>Also yes this is like my third PR this month fixing syndie comms agent things. I really like the role ok?</sub>

## Why It's Good For The Game

Lets agent cards be forged for anyone on the station, carbon or silicon alike, for better comms shenanigans. Stops some names from being "just better" than others.

## Changelog

:cl:
fix: The agent card now correctly allows you to take anyone's identity, even if their name contains numbers
/:cl: