### PR TITLE
Change tape recorders to use languages for messages.

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -95,7 +95,6 @@
 		playsound(src, 'sound/items/taperecorder/taperecorder_close.ogg', 50, FALSE)
 		update_appearance()
 
-
 /obj/item/taperecorder/proc/eject(mob/user)
 	if(mytape)
 		playsound(src, 'sound/items/taperecorder/taperecorder_open.ogg', 50, FALSE)
@@ -121,7 +120,6 @@
 			return TRUE
 	return FALSE
 
-
 /obj/item/taperecorder/verb/ejectverb()
 	set name = "Eject Tape"
 	set category = "Object"
@@ -132,7 +130,6 @@
 		return
 
 	eject(usr)
-
 
 /obj/item/taperecorder/update_icon_state()
 	if(!mytape)
@@ -152,6 +149,7 @@
 	. = ..()
 	if(mytape && recording)
 		mytape.timestamp += mytape.used_capacity
+		mytape.stored_languages += message_langs
 		mytape.storedinfo += "\[[time2text(mytape.used_capacity,"mm:ss")]\] [message]"
 
 
@@ -239,7 +237,7 @@
 		if(mytape.storedinfo.len < i)
 			say("End of recording.")
 			break
-		say("[mytape.storedinfo[i]]", sanitize=FALSE)//We want to display this properly, don't double encode
+		say("[mytape.storedinfo[i]]", sanitize=FALSE, language=mytape.stored_languages[i]) //We want to display this properly, don't double encode
 		if(mytape.storedinfo.len < i + 1)
 			playsleepseconds = 1
 			sleep(1 SECONDS)
@@ -310,11 +308,9 @@
 	canprint = FALSE
 	addtimer(VARSET_CALLBACK(src, canprint, TRUE), 30 SECONDS)
 
-
 //empty tape recorders
 /obj/item/taperecorder/empty
 	starting_tape_type = null
-
 
 /obj/item/tape
 	name = "tape"
@@ -337,10 +333,13 @@
 	var/used_capacity = 0 SECONDS
 	///Numbered list of chat messages the recorder has heard with spans and prepended timestamps. Used for playback and transcription.
 	var/list/storedinfo = list()
+	///Numbered list of chat languages the recorder has heard via storedinfo. Used for playback and transcription.
+	var/list/stored_languages = list()
 	///Numbered list of seconds the messages in the previous list appear at on the tape. Used by playback to get the timing right.
 	var/list/timestamp = list()
 	var/used_capacity_otherside = 0 SECONDS //Separate my side
 	var/list/storedinfo_otherside = list()
+	var/list/stored_languages_otherside = list()
 	var/list/timestamp_otherside = list()
 	var/unspooled = FALSE
 	var/list/icons_available = list()
@@ -406,14 +405,17 @@
 /obj/item/tape/proc/tapeflip()
 	//first we save a copy of our current side
 	var/list/storedinfo_currentside = storedinfo.Copy()
+	var/list/stored_languages_currentside = stored_languages.Copy()
 	var/list/timestamp_currentside = timestamp.Copy()
 	var/used_capacity_currentside = used_capacity
 	//then we overwite our current side with our other side
 	storedinfo = storedinfo_otherside.Copy()
+	stored_languages = stored_languages_otherside.Copy()
 	timestamp = timestamp_otherside.Copy()
 	used_capacity = used_capacity_otherside
 	//then we overwrite our other side with the saved side
 	storedinfo_otherside = storedinfo_currentside.Copy()
+	stored_languages_otherside = stored_languages_currentside.Copy()
 	timestamp_otherside = timestamp_currentside.Copy()
 	used_capacity_otherside = used_capacity_currentside
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -1,6 +1,6 @@
 /obj/item/taperecorder
 	name = "universal recorder"
-	desc = "A device that can record to cassette tapes, and play them. It automatically translates the content in playback."
+	desc = "A device that can record to cassette tapes, and play them. It automatically translates the content when a transcript is printed."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "taperecorder_empty"
 	inhand_icon_state = "analyzer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Tape recorders will now record whichever language was used to speak with and play it back.  This is an old bug (and exploit) that was never reported.  For years people were using this with xenos and monkeys to bypass talking to the crew.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Tape recorders should not function like the book of babel. (which is reserved lavaland loot)  My changes give language mechanics more depth in that it cannot be negated as easily.  People can still: 

- **Use another person as a translator** _(this is fine and great for roleplay)_
- **pAIs** _(this is also fine, see above)_
- **Circuits** _(I don't know how difficult this is or if there are restrictions but I don't think most of the crew has access to this?)_
- **Book of babel** _(reserved lavaland loot)_
- **Printing the transcript of the tape recorder** _(technically only works if the mob is literate, but languages don't apply to written form just yet so this may get changed later)_ 

But the goal should be that another player should have to translate or require special loot to be able decipher messages. A player can take a tape recorder and decipher binary or codespeak (3 Telecrystals) which is cheesy.  Players were also using tape recorders to communicate with xenos and monkeys and vice-versa.  

I think it's good for people to have options, but also there should be some _minimal effort_ required to obtain it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Change tape recorders to use languages for messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
