### PR TITLE
Fix deafness virus symptom to be permanent if resistance threshold is met

### DIFF
--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -56,6 +56,7 @@
 					// Just absolutely murder me man
 					ears.applyOrganDamage(ears.maxHealth)
 					M.emote("scream")
+					ADD_TRAIT(M.affected_mob, TRAIT_DEAF, DISEASE_TRAIT)
 			else
 				to_chat(M, span_userdanger("Your ears pop and begin ringing loudly!"))
 				ears.deaf = min(20, ears.deaf + 15)

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -65,8 +65,6 @@
 	if(!.)
 		return FALSE
 	var/mob/living/carbon/infected_mob = advanced_disease.affected_mob
-	if(advanced_disease.stage >= 4 && causes_permanent_deafness)
-		ADD_TRAIT(infected_mob, TRAIT_DEAF, DISEASE_TRAIT)
-	else
+	if(advanced_disease.stage < 5 || !causes_permanent_deafness)
 		REMOVE_TRAIT(infected_mob, TRAIT_DEAF, DISEASE_TRAIT)
 	return TRUE

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -22,6 +22,7 @@
 		"Resistance 9" = "Causes permanent deafness, instead of intermittent.",
 		"Stealth 4" = "The symptom remains hidden until active.",
 	)
+	var/causes_permanent_deafness = FALSE
 
 /datum/symptom/deafness/Start(datum/disease/advance/A)
 	. = ..()
@@ -30,7 +31,11 @@
 	if(A.totalStealth() >= 4)
 		suppress_warning = TRUE
 	if(A.totalResistance() >= 9) //permanent deafness
-		power = 2
+		causes_permanent_deafness = TRUE
+
+/datum/symptom/deafness/End(datum/disease/advance/advanced_disease)
+	REMOVE_TRAIT(advanced_disease.affected_mob, TRAIT_DEAF, DISEASE_TRAIT)
+	return ..()
 
 /datum/symptom/deafness/Activate(datum/disease/advance/A)
 	. = ..()
@@ -45,7 +50,7 @@
 			if(prob(base_message_chance) && !suppress_warning)
 				to_chat(M, span_warning("[pick("You hear a ringing in your ear.", "Your ears pop.")]"))
 		if(5)
-			if(power >= 2)
+			if(causes_permanent_deafness)
 				if(ears.damage < ears.maxHealth)
 					to_chat(M, span_userdanger("Your ears pop painfully and start bleeding!"))
 					// Just absolutely murder me man
@@ -54,3 +59,14 @@
 			else
 				to_chat(M, span_userdanger("Your ears pop and begin ringing loudly!"))
 				ears.deaf = min(20, ears.deaf + 15)
+
+/datum/symptom/deafness/on_stage_change(datum/disease/advance/advanced_disease)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/infected_mob = advanced_disease.affected_mob
+	if(advanced_disease.stage >= 4 && causes_permanent_deafness)
+		ADD_TRAIT(infected_mob, TRAIT_DEAF, DISEASE_TRAIT)
+	else
+		REMOVE_TRAIT(infected_mob, TRAIT_DEAF, DISEASE_TRAIT)
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #60818

The Deafness virus symptom was not causing permanent deafness to mobs if the `Resistance >= 9` was obtained.  This is fixed now.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

The deafness virus symptom now behaves properly.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix deafness virus symptom to be permanent if resistance threshold is met.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
