### PR TITLE
Makes gas filters smaller

### DIFF
--- a/code/modules/clothing/masks/gas_filter.dm
+++ b/code/modules/clothing/masks/gas_filter.dm
@@ -16,6 +16,7 @@
 	desc = "A piece of filtering cloth to be used with atmospheric gas masks and emergency gas masks."
 	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = "gas_atmos_filter"
+	w_class = WEIGHT_CLASS_TINY
 	///Amount of filtering points available
 	var/filter_status = 100
 	///strength of the filter against high filtering gases


### PR DESCRIPTION
They're presently at the default of WEIGHT_CLASS_NORMAL, which is the same size as fire extinguishers, batons, guns, ect. They're tiny little cloth filter inserts for masks, and should be able to fit in boxes tbh.

:cl: ShizCalev
qol: Gas filtering cloth are now smaller and can fit inside boxes! 
/:cl:
