### PR TITLE
Fixes a big oversight with steal guns objective

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -87,7 +87,8 @@
 
 /// Flags for the gun_flags var for firearms
 #define TOY_FIREARM_OVERLAY (1<<0) // If update_overlay would add some indicator that the gun is a toy, like a plastic cap on a pistol
-#define NOT_A_REAL_GUN (1<<1) // Currently used to identify valid guns to steal
+/// Currently used to identify valid guns to steal
+#define NOT_A_REAL_GUN (1<<1)
 
 /// Flags for sharpness in obj/item
 #define SHARP_EDGED (1<<0)

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -87,6 +87,7 @@
 
 /// Flags for the gun_flags var for firearms
 #define TOY_FIREARM_OVERLAY (1<<0) // If update_overlay would add some indicator that the gun is a toy, like a plastic cap on a pistol
+#define NOT_A_REAL_GUN (1<<1) // Currently used to identify valid guns to steal
 
 /// Flags for sharpness in obj/item
 #define SHARP_EDGED (1<<0)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -845,14 +845,21 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		var/list/all_items = M.current.get_all_contents() //this should get things in cheesewheels, books, etc.
 		for(var/obj/I in all_items) //Check for wanted items
 			if(is_type_in_typecache(I, wanted_items))
-				stolen_count++
+				if(check_if_valid_item(I))
+					stolen_count++
 	return stolen_count >= amount
+
+/datum/objective/steal_n_of_type/proc/check_if_valid_item(obj/item/I)
+   return TRUE
 
 /datum/objective/steal_n_of_type/summon_guns
 	name = "steal guns"
 	explanation_text = "Steal at least five guns!"
 	wanted_items = list(/obj/item/gun)
 	amount = 5
+
+/datum/objective/steal_n_of_type/summon_guns/check_if_valid_item(obj/item/gun/G)
+   return !(G.gun_flags & NOT_A_REAL_GUN)
 
 /datum/objective/steal_n_of_type/summon_guns/thief
 	explanation_text = "Steal at least 3 guns!"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -843,13 +843,13 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		if(!isliving(M.current))
 			continue
 		var/list/all_items = M.current.get_all_contents() //this should get things in cheesewheels, books, etc.
-		for(var/obj/I in all_items) //Check for wanted items
-			if(is_type_in_typecache(I, wanted_items))
-				if(check_if_valid_item(I))
+		for(var/obj/current_item in all_items) //Check for wanted items
+			if(is_type_in_typecache(current_item, wanted_items))
+				if(check_if_valid_item(current_item))
 					stolen_count++
 	return stolen_count >= amount
 
-/datum/objective/steal_n_of_type/proc/check_if_valid_item(obj/item/I)
+/datum/objective/steal_n_of_type/proc/check_if_valid_item(obj/item/current_item)
 	return TRUE
 
 /datum/objective/steal_n_of_type/summon_guns
@@ -858,8 +858,9 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	wanted_items = list(/obj/item/gun)
 	amount = 5
 
-/datum/objective/steal_n_of_type/summon_guns/check_if_valid_item(obj/item/gun/G)
-	return !(G.gun_flags & NOT_A_REAL_GUN)
+/datum/objective/steal_n_of_type/summon_guns/check_if_valid_item(obj/item/current_item)
+	var/obj/item/gun/gun = current_item
+	return !(gun.gun_flags & NOT_A_REAL_GUN)
 
 /datum/objective/steal_n_of_type/summon_guns/thief
 	explanation_text = "Steal at least 3 guns!"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -850,7 +850,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	return stolen_count >= amount
 
 /datum/objective/steal_n_of_type/proc/check_if_valid_item(obj/item/I)
-   return TRUE
+	return TRUE
 
 /datum/objective/steal_n_of_type/summon_guns
 	name = "steal guns"
@@ -859,7 +859,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	amount = 5
 
 /datum/objective/steal_n_of_type/summon_guns/check_if_valid_item(obj/item/gun/G)
-   return !(G.gun_flags & NOT_A_REAL_GUN)
+	return !(G.gun_flags & NOT_A_REAL_GUN)
 
 /datum/objective/steal_n_of_type/summon_guns/thief
 	explanation_text = "Steal at least 3 guns!"

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -156,6 +156,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rus357
 	var/spun = FALSE
 	hidden_chambered = TRUE //Cheater.
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/ballistic/revolver/russian/do_spin()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -12,7 +12,7 @@
 	can_suppress = TRUE
 	clumsy_check = FALSE
 	item_flags = NONE
-	gun_flags = TOY_FIREARM_OVERLAY
+	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 	casing_ejector = FALSE
 
 /obj/item/gun/ballistic/automatic/toy/unrestricted
@@ -23,7 +23,7 @@
 	desc = "A small, easily concealable toy handgun. Ages 8 and up."
 	mag_type = /obj/item/ammo_box/magazine/toy/pistol
 	fire_sound = 'sound/items/syringeproj.ogg'
-	gun_flags = TOY_FIREARM_OVERLAY
+	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 
 /obj/item/gun/ballistic/automatic/pistol/toy/riot
 	mag_type = /obj/item/ammo_box/magazine/toy/pistol/riot
@@ -45,7 +45,7 @@
 	can_suppress = FALSE
 	weapon_weight = WEAPON_LIGHT
 	pb_knockback = 0
-	gun_flags = TOY_FIREARM_OVERLAY
+	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 
 /obj/item/gun/ballistic/shotgun/toy/handle_chamber()
 	. = ..()
@@ -77,7 +77,7 @@
 	mag_type = /obj/item/ammo_box/magazine/toy/smgm45/riot
 	casing_ejector = FALSE
 	clumsy_check = FALSE
-	gun_flags = TOY_FIREARM_OVERLAY
+	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted //Use this for actual toys
 	pin = /obj/item/firing_pin
@@ -95,7 +95,7 @@
 	mag_type = /obj/item/ammo_box/magazine/toy/m762/riot
 	casing_ejector = FALSE
 	clumsy_check = FALSE
-	gun_flags = TOY_FIREARM_OVERLAY
+	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 
 /obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted //Use this for actual toys
 	pin = /obj/item/firing_pin

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -58,6 +58,7 @@
 	icon_state = "decloner"
 	//You have no icons for energy types, you're a decloner
 	modifystate = FALSE
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/e_gun/hos
 	name = "\improper X-01 MultiPhase Energy Gun"

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -14,6 +14,7 @@
 	var/mob/holder
 	var/max_mod_capacity = 100
 	var/list/modkits = list()
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/recharge/kinetic_accelerator/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -15,6 +15,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/practice)
 	clumsy_check = FALSE
 	item_flags = NONE
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/laser/retro
 	name ="retro laser gun"
@@ -135,6 +136,7 @@
 	pin = /obj/item/firing_pin/tag/blue
 	ammo_x_offset = 2
 	selfcharge = TRUE
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/laser/bluetag/hitscan
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/bluetag/hitscan)
@@ -149,6 +151,7 @@
 	pin = /obj/item/firing_pin/tag/red
 	ammo_x_offset = 2
 	selfcharge = TRUE
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/laser/redtag/hitscan
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/redtag/hitscan)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -58,6 +58,7 @@
 	modifystate = 1
 	ammo_x_offset = 1
 	selfcharge = 1
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/meteorgun
 	name = "meteor gun"
@@ -104,6 +105,7 @@
 	force = 12
 	sharpness = SHARP_EDGED
 	can_charge = FALSE
+	gun_flags = NOT_A_REAL_GUN
 
 	heat = 3800
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
@@ -198,6 +200,7 @@
 	var/obj/effect/portal/p_blue
 	var/obj/effect/portal/p_orange
 	var/firing_core = FALSE
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/wormhole_projector/examine(mob/user)
 	. = ..()
@@ -336,6 +339,7 @@
 	automatic_charge_overlays = FALSE
 	var/power = 4
 	var/firing_core = FALSE
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/energy/gravity_gun/attackby(obj/item/C, mob/user)
 	if(istype(C, /obj/item/assembly/signaler/anomaly/grav))

--- a/code/modules/projectiles/guns/special/syringe_gun.dm
+++ b/code/modules/projectiles/guns/special/syringe_gun.dm
@@ -23,6 +23,7 @@
 	var/list/syringes = list()
 	var/max_syringes = 1 ///The number of syringes it can store.
 	var/has_syringe_overlay = TRUE ///If it has an overlay for inserted syringes. If true, the overlay is determined by the number of syringes inserted into it.
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/gun/syringe/Initialize(mapload)
 	. = ..()

--- a/code/modules/wiremod/shell/gun.dm
+++ b/code/modules/wiremod/shell/gun.dm
@@ -15,6 +15,7 @@
 	light_on = FALSE
 	automatic_charge_overlays = FALSE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
+	gun_flags = NOT_A_REAL_GUN
 
 /obj/item/ammo_casing/energy/wiremod_gun
 	projectile_type = /obj/projectile/energy/wiremod_gun


### PR DESCRIPTION
## About The Pull Request

People with steal gun objectives like survivalist or thiefs would be able to greentext with items like toy guns, mining items or any other item which has its type as obj/item/gun

## Why It's Good For The Game

This PR adds a flag for unwanted guns which were not intended to be included in the steal guns objective and filters them out in a proc

## Changelog

:cl:@Salex08
fix: fixes a major oversight with steal gun objectives
/:cl: