### PR TITLE
Fixed synthetic limbs to display the proper skin color.

### DIFF
--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -216,7 +216,7 @@
 	limb = new buildpath(loc)
 	limb.name = "\improper synthetic [selected_category] [limb.plaintext_zone]"
 	limb.limb_id = selected_category
-	limb.mutation_color = "#62A262"
+	limb.species_color = "#62A262"
 	limb.update_icon_dropped()
 
 ///Returns a valid limb typepath based on the selected option


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes a bug with the Limb Grower where synthetic limbs permanently revert to the default coloration when attached to a body. As it is now, the green coloration of synthetic limbs is stored in the mutation_color variable, which is nullified when attached. This makes all limbs draw with the default coloration - "albino" for humans and a neutral grey for other species. This PR updates the limb grower to use the species_color variable instead, which is maintained when attached/detached.

**Before:**
![01](https://user-images.githubusercontent.com/105025397/176561927-5f113044-0e82-4044-b1b5-30faac2fa654.PNG)
_Limb is green when printed._
![02](https://user-images.githubusercontent.com/105025397/176561941-35baa0cb-804e-44ed-a81c-1336adb8d6e4.PNG)
_Limb loses coloration when attached, defaulting to "albino" skin tone._
![03](https://user-images.githubusercontent.com/105025397/176561944-dcf874d2-97db-42e4-bda4-4acdc76e9c76.PNG)
_Limb retains lack of coloration when detached again._

**After:**
![04](https://user-images.githubusercontent.com/105025397/176562046-424cbc39-d021-4646-a220-e0c89129f808.PNG)
_Limb is green when printed._
![05](https://user-images.githubusercontent.com/105025397/176562060-f8477e3d-1d46-4592-900c-bf524dbd340c.PNG)
_Limb remains green when attached._
![06](https://user-images.githubusercontent.com/105025397/176562104-2a046e06-881b-452e-8e0e-286c21c8d44c.PNG)
_Limb is still green when detached again._

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

This is a simple bug, possibly introduced with changes to the mutation_color variable. Changing to use species_color retains the Frankenstein green coloration synthetic limbs are (I assume) meant to have. As a side effect, this also removes the unfortunate implications of synthetic human limbs only having white skin. Furthermore, this could possibly be extended in the future to allow printing synthetic limbs in custom colors.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Limb growing code now uses species_color instead of mutant_color for synthetic limb coloration
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
