### PR TITLE
trailer modification and safe qdel

### DIFF
--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -159,8 +159,21 @@
 			remove_controller_actions_by_flag(controller, i)
 	return TRUE
 
+/// To add a trailer to the vehicle in a manner that allows safe qdels
+/obj/vehicle/proc/add_trailer(obj/vehicle/added_vehicle)
+	trailer = added_vehicle
+	RegisterSignal(trailer, COMSIG_PARENT_QDELETING, .proc/remove_trailer)
+
+/// To remove a trailer from the vehicle in a manner that allows safe qdels
+/obj/vehicle/proc/remove_trailer()
+	UnregisterSignal(trailer, COMSIG_PARENT_QDELETING)
+	trailer = null
+
 /obj/vehicle/Move(newloc, dir)
+	// It is unfortunate, but this is the way to make it not mess up
+	var/atom/old_loc = loc
+	// When we do this, it will set the loc to the new loc
 	. = ..()
 	if(trailer && .)
-		var/dir_to_move = get_dir(trailer.loc, newloc)
+		var/dir_to_move = get_dir(trailer.loc, old_loc)
 		step(trailer, dir_to_move)

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -166,6 +166,7 @@
 
 /// To remove a trailer from the vehicle in a manner that allows safe qdels
 /obj/vehicle/proc/remove_trailer()
+	SIGNAL_HANDLER
 	UnregisterSignal(trailer, COMSIG_PARENT_QDELETING)
 	trailer = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So when I was doing stuff on a downstream, I noticed that trailers were functioning oddly-- they wouldn't attempt to go to the previous loc at times and would just downright go the direction I was going. This PR fixes that weird interaction as well as adds a thing for removing a ref for trailers that are added through a proc.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Making trailers actually trail behind is good...
![image](https://user-images.githubusercontent.com/55967837/176566636-3d30039c-1091-47ca-b358-404ff92074fe.png)
![image](https://user-images.githubusercontent.com/55967837/176566645-449781a4-1b08-4d7b-a752-2f8a0b7e8b0a.png)

Hard dels are bad.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: trailers will actually trail their attached vehicles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
