### PR TITLE
Makes GPS units autolathe banned

### DIFF
--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -43,6 +43,7 @@
 	build_path = /obj/item/gps
 	category = list("Bluespace Designs")
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
+	autolathe_exportable = FALSE
 
 /datum/design/desynchronizer
 	name = "Desynchronizer"


### PR DESCRIPTION
## About The Pull Request
Prevents exports of GPS units to autolathes

#57367 reasoned that ghost roles should not get GPS units by default, they should have to put some minor amount of effort into getting one. For some, this means finding a nearby space ruin with a GPS. For lavaland roles this means doing some mining and buying an item from the mining vendor that gets one (such as the modsuit).
This increases the amount of risk/effort needed to get a GPS for these roles from "none" to "some", at the very minimum.

## Why It's Good For The Game
It forces ghost roles with access to ancient lathes to take at least some risk in order to acquire a GPS, meaning they will have to take some amount of risk in order to do things such as finding the station, or more reliably finding other ruins or ghost roles.

The intention for ghost roles is to take risks to get a GPS, this fixes that behavior by removing an easy, risk free way to get one.

## Changelog

:cl:
balance: GPS designs can no longer be exported to autolathes.
/:cl: