### PR TITLE
Removes Breathing Internals From Emoji Mask

### DIFF
--- a/code/modules/clothing/masks/costume.dm
+++ b/code/modules/clothing/masks/costume.dm
@@ -2,7 +2,6 @@
 	name = "emotion mask"
 	desc = "Express your happiness or hide your sorrows with this cultured cutout."
 	icon_state = "joy"
-	clothing_flags = MASKINTERNALS
 	flags_inv = HIDESNOUT
 	unique_reskin = list(
 			"Joy" = "joy",


### PR DESCRIPTION
Been thinking about this, I added this in the emoji mask update but shouldn't have, makes no sense for you to be able to breathe internals through it it's literally a cardboard cutout. If you want to breathe internals you should have to ditch the emoji mask for a breathe/gas mask

:cl:
del: Can no longer breathe internals through the emotion mask
/:cl: