### PR TITLE
Adds Preferences To Suppress Ghost Role Rolls

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -167,7 +167,7 @@
 		return
 
 	// Opt-out for admins whom are currently adminned.
-	if ((!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin)) && (!candidate_mob.client.holder))
+	if ((!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin)) && (candidate_mob.client.holder))
 		return
 
 	SEND_SOUND(candidate_mob, 'sound/misc/notice2.ogg') //Alerting them to their consideration

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -167,7 +167,7 @@
 		return
 
 	// Opt-out for admins whom are currently adminned.
-	if ((!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin)) && (candidate_mob.client.holder))
+	if ((!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin)) && candidate_mob.client.holder)
 		return
 
 	SEND_SOUND(candidate_mob, 'sound/misc/notice2.ogg') //Alerting them to their consideration

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -162,12 +162,12 @@
 /proc/show_candidate_poll_window(mob/candidate_mob, poll_time, question, list/candidates, ignore_category, time_passed, flashwindow = TRUE)
 	set waitfor = 0
 
-	/// Universal Opt-Out For All Players
-	if (candidate_mob.client.prefs.read_preference(/datum/preference/toggle/no_ghost_roles))
+	// Universal opt-out for all players.
+	if ((!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles)))
 		return
 
-	/// Opt-out for admins whom are currently adminned.
-	if (candidate_mob.client.prefs.read_preference(/datum/preference/toggle/no_ghost_roles_as_admin) && candidate_mob.client.holder)
+	// Opt-out for admins whom are currently adminned.
+	if ((!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin)) && (!candidate_mob.client.holder))
 		return
 
 	SEND_SOUND(candidate_mob, 'sound/misc/notice2.ogg') //Alerting them to their consideration

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -162,6 +162,14 @@
 /proc/show_candidate_poll_window(mob/candidate_mob, poll_time, question, list/candidates, ignore_category, time_passed, flashwindow = TRUE)
 	set waitfor = 0
 
+	/// Universal Opt-Out For All Players
+	if (candidate_mob.client.prefs.read_preference(/datum/preference/toggle/no_ghost_roles))
+		return
+
+	/// Opt-out for admins whom are currently adminned.
+	if (candidate_mob.client.prefs.read_preference(/datum/preference/toggle/no_ghost_roles_as_admin) && candidate_mob.client.holder)
+		return
+
 	SEND_SOUND(candidate_mob, 'sound/misc/notice2.ogg') //Alerting them to their consideration
 	if(flashwindow)
 		window_flash(candidate_mob.client)

--- a/code/modules/client/preferences/admin.dm
+++ b/code/modules/client/preferences/admin.dm
@@ -52,11 +52,10 @@
 	return is_admin(preferences.parent)
 
 /// When enabled, prevents any and all ghost role pop-ups WHILE ADMINNED.
-/datum/preference/toggle/no_ghost_roles_as_admin
+/datum/preference/toggle/ghost_roles_as_admin
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_key = "no_ghost_roles_as_admin"
+	savefile_key = "ghost_roles_as_admin"
 	savefile_identifier = PREFERENCE_PLAYER
-	default_value = FALSE
 
 /datum/preference/toggle/no_ghost_roles_as_admin/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))

--- a/code/modules/client/preferences/admin.dm
+++ b/code/modules/client/preferences/admin.dm
@@ -57,7 +57,7 @@
 	savefile_key = "ghost_roles_as_admin"
 	savefile_identifier = PREFERENCE_PLAYER
 
-/datum/preference/toggle/no_ghost_roles_as_admin/is_accessible(datum/preferences/preferences)
+/datum/preference/toggle/ghost_roles_as_admin/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE
 

--- a/code/modules/client/preferences/admin.dm
+++ b/code/modules/client/preferences/admin.dm
@@ -50,3 +50,16 @@
 		return FALSE
 
 	return is_admin(preferences.parent)
+
+/// When enabled, prevents any and all ghost role pop-ups WHILE ADMINNED.
+/datum/preference/toggle/no_ghost_roles_as_admin
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "no_ghost_roles_as_admin"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = FALSE
+
+/datum/preference/toggle/no_ghost_roles_as_admin/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return is_admin(preferences.parent)

--- a/code/modules/client/preferences/ghost.dm
+++ b/code/modules/client/preferences/ghost.dm
@@ -176,3 +176,10 @@
 	savefile_key = "inquisitive_ghost"
 	savefile_identifier = PREFERENCE_PLAYER
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+
+/// When enabled, prevents any and all ghost role pop-ups.
+/datum/preference/toggle/no_ghost_roles
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "no_ghost_roles"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = FALSE

--- a/code/modules/client/preferences/ghost.dm
+++ b/code/modules/client/preferences/ghost.dm
@@ -178,8 +178,7 @@
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 
 /// When enabled, prevents any and all ghost role pop-ups.
-/datum/preference/toggle/no_ghost_roles
+/datum/preference/toggle/ghost_roles
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_key = "no_ghost_roles"
+	savefile_key = "ghost_roles"
 	savefile_identifier = PREFERENCE_PLAYER
-	default_value = FALSE

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
@@ -31,13 +31,13 @@ export const fast_mc_refresh: FeatureToggle = {
   component: CheckboxInput,
 };
 
-export const no_ghost_roles_as_admin: FeatureToggle = {
-  name: 'Suppress all Ghost Rolls while Adminned',
+export const ghost_roles_as_admin: FeatureToggle = {
+  name: 'Get ghost roles while adminned',
   category: 'ADMIN',
   description: multiline`
-  WARNING: If you select this, you will not get any ghost rolls while adminned!
-  Every single pop-up WILL be muted for you while adminned. However, this
-  does not surpress notifications when you are a regular player.
+    WARNING: If you de-select this, you will not get any ghost roll pop-ups
+    while adminned! Every single pop-up WILL be muted for you while adminned.
+    However, this does not surpress notifications when you are a regular player.
 `,
   component: CheckboxInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
@@ -1,4 +1,5 @@
 import { CheckboxInput, FeatureColorInput, Feature, FeatureDropdownInput, FeatureToggle } from '../base';
+import { multiline } from 'common/string';
 
 export const asaycolor: Feature<string> = {
   name: 'Admin chat color',
@@ -27,5 +28,16 @@ export const fast_mc_refresh: FeatureToggle = {
   category: 'ADMIN',
   description:
     'Whether or not the MC tab of the Stat Panel refreshes fast. This is expensive so make sure you need it.',
+  component: CheckboxInput,
+};
+
+export const no_ghost_roles_as_admin: FeatureToggle = {
+  name: 'Suppress all Ghost Rolls while Adminned',
+  category: 'ADMIN',
+  description: multiline`
+  WARNING: If you select this, you will not get any ghost rolls while adminned!
+  Every single pop-up WILL be muted for you while adminned. However, this
+  does not surpress notifications when you are a regular player.
+`,
   component: CheckboxInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
@@ -35,9 +35,9 @@ export const ghost_roles_as_admin: FeatureToggle = {
   name: 'Get ghost roles while adminned',
   category: 'ADMIN',
   description: multiline`
-    WARNING: If you de-select this, you will not get any ghost roll pop-ups
+    WARNING: If you de-select this, you will not get any ghost role pop-ups
     while adminned! Every single pop-up WILL be muted for you while adminned.
-    However, this does not surpress notifications when you are a regular player.
+    However, this does not suppress notifications when you are a regular player.
 `,
   component: CheckboxInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
@@ -35,9 +35,10 @@ export const ghost_roles_as_admin: FeatureToggle = {
   name: 'Get ghost roles while adminned',
   category: 'ADMIN',
   description: multiline`
-    WARNING: If you de-select this, you will not get any ghost role pop-ups
-    while adminned! Every single pop-up WILL be muted for you while adminned.
-    However, this does not suppress notifications when you are a regular player.
+    If you de-select this, you will not get any ghost role pop-ups while
+    adminned! Every single pop-up WILL never show up for you in an adminned
+    state. However, this does not suppress notifications when you are
+    a regular player (deadminned).
 `,
   component: CheckboxInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost.tsx
@@ -135,9 +135,10 @@ export const ghost_roles: FeatureToggle = {
   name: 'Get ghost roles',
   category: 'GHOST',
   description: multiline`
-    WARNING: If you de-select this, you will not get any ghost role pop-ups
-    what-so-ever! Every single type of these pop-up WILL be muted for you.
-    Very useful for those who find ghost roles annoying, use at your own peril.
+    If you de-select this, you will not get any ghost role pop-ups what-so-ever!
+    Every single type of these pop-ups WILL be muted for you when you are
+    ghosted. Very useful for those who find ghost roles or the
+    pop-ups annoying, use at your own peril.
 `,
   component: CheckboxInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost.tsx
@@ -130,3 +130,14 @@ export const inquisitive_ghost: FeatureToggle = {
   description: 'Clicking on something as a ghost will examine it.',
   component: CheckboxInput,
 };
+
+export const no_ghost_roles: FeatureToggle = {
+  name: 'Suppress all Ghost Rolls',
+  category: 'GHOST',
+  description: multiline`
+  WARNING: If you select this, you will not get any ghost rolls what-so-ever!
+  Every single pop-up WILL be muted for you. This is only useful for those
+  who find ghost roles annoying, use at your own peril.
+`,
+  component: CheckboxInput,
+};

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost.tsx
@@ -135,9 +135,9 @@ export const ghost_roles: FeatureToggle = {
   name: 'Get ghost roles',
   category: 'GHOST',
   description: multiline`
-    WARNING: If you de-select this, you will not get any ghost rolls pop-ups
-    what-so-ever! Every single pop-up WILL be muted for you. This is only
-    useful for those who find ghost roles annoying, use at your own peril.
+    WARNING: If you de-select this, you will not get any ghost role pop-ups
+    what-so-ever! Every single type of these pop-up WILL be muted for you.
+    Very useful for those who find ghost roles annoying, use at your own peril.
 `,
   component: CheckboxInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost.tsx
@@ -131,13 +131,13 @@ export const inquisitive_ghost: FeatureToggle = {
   component: CheckboxInput,
 };
 
-export const no_ghost_roles: FeatureToggle = {
-  name: 'Suppress all Ghost Rolls',
+export const ghost_roles: FeatureToggle = {
+  name: 'Get ghost roles',
   category: 'GHOST',
   description: multiline`
-  WARNING: If you select this, you will not get any ghost rolls what-so-ever!
-  Every single pop-up WILL be muted for you. This is only useful for those
-  who find ghost roles annoying, use at your own peril.
+    WARNING: If you de-select this, you will not get any ghost rolls pop-ups
+    what-so-ever! Every single pop-up WILL be muted for you. This is only
+    useful for those who find ghost roles annoying, use at your own peril.
 `,
   component: CheckboxInput,
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Ever since November of 2021, I've wanted something where I could simply not get any ghost roles while adminned. Some people also do not want to get any ghost rolls whatsoever when they play, for it is their personal preference. This PR seeks to resolve both of these issues with two new preferences.

The first preference will show up to everyone, Suppress All Ghost Rolls. It will return on the main proc that pops up the window, does the sound, all that. You will not hear a peep of a word out of your game. This is dangerous if you like playing as ghost roles, but if you abhor the thought of it... it's just for you.

The second preference is for admins. You can selectively suppress ghost roles while adminned. This is useful because when you're running an event or doing stuff where you need to offer multiple ghost roles (or you need to focus on a ticket and someone is spamming Xenobiology mob spawns), this is absolutely perfect for suppressing. Same return as the player option, but it checks to see if you are currently adminned via the client.holder variable. This is just because some admins (i'm some admins) don't want to turn in on just in case they forget to turn it off down the line because they actually play the game (lying).

There's probably a much cleaner way to do this code-wise, but I couldn't figure it out. Any help is appreciated. I tested it extensively on my local (even using a guest account), and everything seems to work rather nicely after about an hour of trial-and-error.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Players who want to just alt-tab or maybe chill in deadchat (or have an extreme loathing of ghost roles) can just simply not get any of that. Admins who want to focus on tickets and not have windows pop up to interfere in good administrative work (and be the most annoying thing in the world) can also do that. Everyone is happy.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: There is now a new preference in Game Preferences, Suppress All Ghost Rolls. If you tick this preference, you will not get a singular window pop-up whenever a Ghost Role is available. Intended for the few who really do need it.
admin: Admins get another additional preference where Suppress All Ghost Roles only works while they are currently in an adminned state. They will still get ghost rolls normally when they are in a deadminned state.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
