### PR TITLE
Fixes airlock shock indicators not being removed when the airlock is unshocked

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -129,9 +129,8 @@
 	if(!istext(hud_category))
 		return FALSE
 
-	LAZYREMOVE(active_hud_list, hud_category)
-
 	if(!update_huds)
+		LAZYREMOVE(active_hud_list, hud_category)
 		return TRUE
 
 	if(exclusive_hud)
@@ -139,6 +138,8 @@
 	else
 		for(var/datum/atom_hud/hud_to_update as anything in GLOB.huds_by_category[hud_category])
 			hud_to_update.remove_single_hud_category_on_atom(src, hud_category)
+
+	LAZYREMOVE(active_hud_list, hud_category)
 
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Long story short, the HUD datum proc[^1] responsible for removing HUD images checks if the atom owning the HUD element has anything in its `active_hud_list` list. If not, it runs some other (seemingly basic housekeeping) code and returns.

Meanwhile, the atom-level proc[^2] for setting HUD images to inactive clears the `active_hud_list` *before* calling the above proc. This meant that the image was never actually removed from HUD viewers, and was stuck forever (unless the client reconnects). For AIs at least, even disabling sensors (Diag/Med/Sec combo) didn't get rid of the shock indicator.

[^1]: https://github.com/tgstation/tgstation/blob/24326bc649544c0bfbec3de0730ace33107a97cf/code/datums/hud.dm#L256
[^2]: https://github.com/tgstation/tgstation/blob/53f19b85b36455b9bb904902333ecf4b32e2a73a/code/modules/mob/mob.dm#L128

This PR moves the line to clear `active_hud_list` to the end of the proc, which allows the code on the HUD datum to correctly remove the image.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Airlock shock indicators on diagnostics HUDs will now correctly be removed when the door is unshocked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
