### PR TITLE
Maids in the Mirror take no damage from ghosts examining them

### DIFF
--- a/code/modules/antagonists/heretic/mobs/maid_in_mirror.dm
+++ b/code/modules/antagonists/heretic/mobs/maid_in_mirror.dm
@@ -42,6 +42,9 @@
 	if(!weak_on_examine)
 		return
 
+	if(!isliving(user))
+		return
+
 	if(IS_HERETIC_OR_MONSTER(user) || user == src)
 		return
 

--- a/code/modules/antagonists/heretic/mobs/maid_in_mirror.dm
+++ b/code/modules/antagonists/heretic/mobs/maid_in_mirror.dm
@@ -42,7 +42,7 @@
 	if(!weak_on_examine)
 		return
 
-	if(!isliving(user))
+	if(!isliving(user) || user.stat == DEAD)
 		return
 
 	if(IS_HERETIC_OR_MONSTER(user) || user == src)


### PR DESCRIPTION
## About The Pull Request

Adds an `isliving` check to the maid in the mirror's examine proc

## Why It's Good For The Game

Fixes #68090 

## Changelog

:cl:
fix: Maids in the Mirror are unaffected by the gaze of ghosts
/:cl:
