### PR TITLE
Removes counter-intuitive var edits off Kilo's SM's pumps

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -45114,9 +45114,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	external_pressure_bound = 140;
-	pressure_checks = 0
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Before:
![image](https://user-images.githubusercontent.com/25415050/176911721-94f0ce9a-f95c-4faa-98cb-b8fa7d400ec9.png)

This isn't used on any other station, `pressure_checks = 0` means that both Internal and External pressure targets start Off for the vents as opposed to External being on like it normally is at roundstart. This can have pretty bad drawbacks if the air alarm is set last as often recommended on most guides.

Not even sure what the External target being set to 140 is about.

## Why It's Good For The Game

Kilo's SM is now consistent with other stations', its pumps external target will no longer start Off.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Kilostation's Supermatter was made more consistent, it will no longer start with its pumps lacking pressure target checking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
