### PR TITLE
Nerfs Nettle / Deathnettle size to Normal 

### DIFF
--- a/code/modules/hydroponics/grown/weeds/nettle.dm
+++ b/code/modules/hydroponics/grown/weeds/nettle.dm
@@ -44,7 +44,7 @@
 	force = 15
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	throwforce = 5
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 1
 	throw_range = 3
 	attack_verb_continuous = list("stings")


### PR DESCRIPTION
## About The Pull Request

Nettles and Deathnettles are normal sized, up from tiny. 

This reduces the number per plant bag from 100 to 33. 

## Why It's Good For The Game

Nettles really serve no purpose being tiny sized. 

Holding 100 45 force weapons is very absurd. 

Holding 33 is still a little absurd, but a much healthier amount - especially for the most common usecase of Deathnettles (slippery, prickly thrown weapons). 

## Changelog

:cl: Melbert
balance: Nettles and Deathnettles are now normal sized, up from tiny. (Number per plant bag has decreased from 100 to 33.)
/:cl:
