### PR TITLE
Replace a statbrowser verb call with send message

### DIFF
--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -6,11 +6,11 @@ if (!Array.prototype.includes) {
 			if (this[i] == thing) return true;
 		}
 		return false;
-	}
+	};
 }
 if (!String.prototype.trim) {
 	String.prototype.trim = function () {
-		return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+		return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "");
 	};
 }
 
@@ -31,9 +31,9 @@ var turfcontents = [];
 var turfname = "";
 var imageRetryDelay = 500;
 var imageRetryLimit = 50;
-var menu = document.getElementById('menu');
-var under_menu = document.getElementById('under_menu');
-var statcontentdiv = document.getElementById('statcontent');
+var menu = document.getElementById("menu");
+var under_menu = document.getElementById("under_menu");
+var statcontentdiv = document.getElementById("statcontent");
 var storedimages = [];
 var split_admin_tabs = false;
 
@@ -47,10 +47,8 @@ function run_after_focus(callback) {
 function createStatusTab(name) {
 	if (name.indexOf(".") != -1) {
 		var splitName = name.split(".");
-		if (split_admin_tabs && splitName[0] === "Admin")
-			name = splitName[1];
-		else
-			name = splitName[0];
+		if (split_admin_tabs && splitName[0] === "Admin") name = splitName[1];
+		else name = splitName[0];
 	}
 	if (document.getElementById(name) || name.trim() == "") {
 		return;
@@ -74,7 +72,7 @@ function createStatusTab(name) {
 	//END ORDERING
 	menu.appendChild(B);
 	SendTabToByond(name);
-	under_menu.style.height = menu.clientHeight + 'px';
+	under_menu.style.height = menu.clientHeight + "px";
 }
 
 function removeStatusTab(name) {
@@ -88,7 +86,7 @@ function removeStatusTab(name) {
 	}
 	menu.removeChild(document.getElementById(name));
 	TakeTabFromByond(name);
-	under_menu.style.height = menu.clientHeight + 'px';
+	under_menu.style.height = menu.clientHeight + "px";
 }
 
 function sortVerbs() {
@@ -96,17 +94,16 @@ function sortVerbs() {
 		var selector = a[0] == b[0] ? 1 : 0;
 		if (a[selector].toUpperCase() < b[selector].toUpperCase()) {
 			return 1;
-		}
-		else if (a[selector].toUpperCase() > b[selector].toUpperCase()) {
+		} else if (a[selector].toUpperCase() > b[selector].toUpperCase()) {
 			return -1;
 		}
 		return 0;
-	})
+	});
 }
 
 window.onresize = function () {
-	under_menu.style.height = menu.clientHeight + 'px';
-}
+	under_menu.style.height = menu.clientHeight + "px";
+};
 
 function addPermanentTab(name) {
 	if (!permanent_tabs.includes(name)) {
@@ -126,7 +123,10 @@ function removePermanentTab(name) {
 
 function checkStatusTab() {
 	for (var i = 0; i < menu.children.length; i++) {
-		if (!verb_tabs.includes(menu.children[i].id) && !permanent_tabs.includes(menu.children[i].id)) {
+		if (
+			!verb_tabs.includes(menu.children[i].id) &&
+			!permanent_tabs.includes(menu.children[i].id)
+		) {
 			menu.removeChild(menu.children[i]);
 		}
 	}
@@ -137,7 +137,7 @@ function remove_verb(v) {
 	for (var i = verbs.length - 1; i >= 0; i--) {
 		var part_to_remove = verbs[i];
 		if (part_to_remove[1] == verb_to_remove[1]) {
-			verbs.splice(i, 1)
+			verbs.splice(i, 1);
 		}
 	}
 }
@@ -152,10 +152,8 @@ function verbs_cat_check(cat) {
 	var tabCat = cat;
 	if (cat.indexOf(".") != -1) {
 		var splitName = cat.split(".");
-		if (split_admin_tabs && splitName[0] === "Admin")
-			tabCat = splitName[1];
-		else
-			tabCat = splitName[0];
+		if (split_admin_tabs && splitName[0] === "Admin") tabCat = splitName[1];
+		else tabCat = splitName[0];
 	}
 	var verbs_in_cat = 0;
 	var verbcat = "";
@@ -170,29 +168,25 @@ function verbs_cat_check(cat) {
 			var splitName = verbcat.split(".");
 			if (split_admin_tabs && splitName[0] === "Admin")
 				verbcat = splitName[1];
-			else
-				verbcat = splitName[0];
+			else verbcat = splitName[0];
 		}
 		if (verbcat != tabCat || verbcat.trim() == "") {
 			continue;
-		}
-		else {
+		} else {
 			verbs_in_cat = 1;
 			break; // we only need one
 		}
 	}
 	if (verbs_in_cat != 1) {
 		removeStatusTab(tabCat);
-		if (current_tab == tabCat)
-			tab_change("Status");
+		if (current_tab == tabCat) tab_change("Status");
 	}
 }
 
 function findVerbindex(name, verblist) {
 	for (var i = 0; i < verblist.length; i++) {
 		var part = verblist[i];
-		if (part[1] == name)
-			return i;
+		if (part[1] == name) return i;
 	}
 }
 function wipe_verbs() {
@@ -215,12 +209,12 @@ function SendTabsToByond() {
 }
 
 function SendTabToByond(tab) {
-	Byond.sendMessage("Send-Tabs", {tab: tab});
+	Byond.sendMessage("Send-Tabs", { tab: tab });
 }
 
 //Byond can't have this tab anymore since we're removing it
 function TakeTabFromByond(tab) {
-	Byond.sendMessage("Remove-Tabs", {tab: tab});
+	Byond.sendMessage("Remove-Tabs", { tab: tab });
 }
 
 function spell_cat_check(cat) {
@@ -246,8 +240,8 @@ function tab_change(tab) {
 	set_byond_tab(tab);
 	if (document.getElementById(tab))
 		document.getElementById(tab).className = "button active"; // make current button active
-	var spell_tabs_thingy = (spell_tabs.includes(tab));
-	var verb_tabs_thingy = (verb_tabs.includes(tab));
+	var spell_tabs_thingy = spell_tabs.includes(tab);
+	var verb_tabs_thingy = verb_tabs.includes(tab);
 	if (tab == "Status") {
 		draw_status();
 	} else if (tab == "MC") {
@@ -269,25 +263,29 @@ function tab_change(tab) {
 		statcontentdiv.textContext = "Loading...";
 	}
 	Byond.winset(Byond.windowId, {
-		'is-visible': true,
+		"is-visible": true,
 	});
 }
 
 function set_byond_tab(tab) {
-	Byond.sendMessage("Set-Tab", {tab: tab});
+	Byond.sendMessage("Set-Tab", { tab: tab });
 }
 
 function draw_debug() {
 	statcontentdiv.textContent = "";
 	var wipeverbstabs = document.createElement("div");
 	var link = document.createElement("a");
-	link.onclick = function () { wipe_verbs() };
+	link.onclick = function () {
+		wipe_verbs();
+	};
 	link.textContent = "Wipe All Verbs";
 	wipeverbstabs.appendChild(link);
 	document.getElementById("statcontent").appendChild(wipeverbstabs);
 	var wipeUpdateVerbsTabs = document.createElement("div");
 	var updateLink = document.createElement("a");
-	updateLink.onclick = function () { update_verbs() };
+	updateLink.onclick = function () {
+		update_verbs();
+	};
 	updateLink.textContent = "Wipe and Update All Verbs";
 	wipeUpdateVerbsTabs.appendChild(updateLink);
 	document.getElementById("statcontent").appendChild(wipeUpdateVerbsTabs);
@@ -302,16 +300,17 @@ function draw_debug() {
 			var splitName = verb_tabs[i].split(".");
 			if (split_admin_tabs && splitName[0] === "Admin")
 				part = splitName[1];
-			else
-				continue;
+			else continue;
 		}
 		var tr = document.createElement("tr");
 		var td1 = document.createElement("td");
 		td1.textContent = part;
 		var a = document.createElement("a");
-		a.onclick = function (part) {
-			return function () { removeStatusTab(part) };
-		}(part);
+		a.onclick = (function (part) {
+			return function () {
+				removeStatusTab(part);
+			};
+		})(part);
 		a.textContent = " Delete Tab " + part;
 		td1.appendChild(a);
 		tr.appendChild(td1);
@@ -347,17 +346,18 @@ function draw_debug() {
 		table3.appendChild(trrr);
 	}
 	document.getElementById("statcontent").appendChild(table3);
-
 }
 function draw_status() {
 	if (!document.getElementById("Status")) {
 		createStatusTab("Status");
 		current_tab = "Status";
 	}
-	statcontentdiv.textContent = '';
+	statcontentdiv.textContent = "";
 	for (var i = 0; i < status_tab_parts.length; i++) {
 		if (status_tab_parts[i].trim() == "") {
-			document.getElementById("statcontent").appendChild(document.createElement("br"));
+			document
+				.getElementById("statcontent")
+				.appendChild(document.createElement("br"));
 		} else {
 			var div = document.createElement("div");
 			div.textContent = status_tab_parts[i];
@@ -380,7 +380,8 @@ function draw_mc() {
 		var td2 = document.createElement("td");
 		if (part[2]) {
 			var a = document.createElement("a");
-			a.href = "?_src_=vars;admin_token=" + href_token + ";Vars=" + part[2];
+			a.href =
+				"?_src_=vars;admin_token=" + href_token + ";Vars=" + part[2];
 			a.textContent = part[1];
 			td2.appendChild(a);
 		} else {
@@ -397,8 +398,7 @@ function remove_tickets() {
 	if (tickets) {
 		tickets = [];
 		removePermanentTab("Tickets");
-		if (current_tab == "Tickets")
-			tab_change("Status");
+		if (current_tab == "Tickets") tab_change("Status");
 	}
 	checkStatusTab();
 }
@@ -407,8 +407,7 @@ function remove_sdql2() {
 	if (sdql2) {
 		sdql2 = [];
 		removePermanentTab("SDQL2");
-		if (current_tab == "SDQL2")
-			tab_change("Status");
+		if (current_tab == "SDQL2") tab_change("Status");
 	}
 	checkStatusTab();
 }
@@ -421,19 +420,19 @@ function remove_interviews() {
 }
 
 function iconError(e) {
-	if(current_tab != turfname) {
+	if (current_tab != turfname) {
 		return;
 	}
 	setTimeout(function () {
 		var node = e.target;
-		var current_attempts = Number(node.getAttribute("data-attempts")) || 0
+		var current_attempts = Number(node.getAttribute("data-attempts")) || 0;
 		if (current_attempts > imageRetryLimit) {
 			return;
 		}
 		var src = node.src;
 		node.src = null;
-		node.src = src + '#' + current_attempts;
-		node.setAttribute("data-attempts", current_attempts + 1)
+		node.src = src + "#" + current_attempts;
+		node.setAttribute("data-attempts", current_attempts + 1);
 		draw_listedturf();
 	}, imageRetryDelay);
 }
@@ -460,7 +459,7 @@ function draw_listedturf() {
 		var b = document.createElement("div");
 		var clickcatcher = "";
 		b.className = "link";
-		b.onmousedown = function (part) {
+		b.onmousedown = (function (part) {
 			// The outer function is used to close over a fresh "part" variable,
 			// rather than every onmousedown getting the "part" of the last entry.
 			return function (e) {
@@ -468,13 +467,13 @@ function draw_listedturf() {
 				clickcatcher = "?src=" + part[1];
 				switch (e.button) {
 					case 1:
-						clickcatcher += ";statpanel_item_click=middle"
+						clickcatcher += ";statpanel_item_click=middle";
 						break;
 					case 2:
-						clickcatcher += ";statpanel_item_click=right"
+						clickcatcher += ";statpanel_item_click=right";
 						break;
 					default:
-						clickcatcher += ";statpanel_item_click=left"
+						clickcatcher += ";statpanel_item_click=left";
 				}
 				if (e.shiftKey) {
 					clickcatcher += ";statpanel_item_shiftclick=1";
@@ -486,8 +485,8 @@ function draw_listedturf() {
 					clickcatcher += ";statpanel_item_altclick=1";
 				}
 				window.location.href = clickcatcher;
-			}
-		}(part);
+			};
+		})(part);
 		b.textContent = part[0];
 		table.appendChild(b);
 		table.appendChild(document.createElement("br"));
@@ -508,7 +507,7 @@ function remove_mc() {
 	if (current_tab == "MC") {
 		tab_change("Status");
 	}
-};
+}
 
 function draw_sdql2() {
 	statcontentdiv.textContent = "";
@@ -548,7 +547,12 @@ function draw_tickets() {
 		var td2 = document.createElement("td");
 		if (part[2]) {
 			var a = document.createElement("a");
-			a.href = "?_src_=holder;admin_token=" + href_token + ";ahelp=" + part[2] + ";ahelp_action=ticket;statpanel_item_click=left;action=ticket";
+			a.href =
+				"?_src_=holder;admin_token=" +
+				href_token +
+				";ahelp=" +
+				part[2] +
+				";ahelp_action=ticket;statpanel_item_click=left;action=ticket";
 			a.textContent = part[1];
 			td2.appendChild(a);
 		} else if (part[3]) {
@@ -572,10 +576,13 @@ function draw_interviews() {
 	header.textContent = "Interviews";
 	body.appendChild(header);
 	var manDiv = document.createElement("div");
-	manDiv.className = "interview_panel_controls"
+	manDiv.className = "interview_panel_controls";
 	var manLink = document.createElement("a");
 	manLink.textContent = "Open Interview Manager Panel";
-	manLink.href = "?_src_=holder;admin_token=" + href_token + ";interview_man=1;statpanel_item_click=left";
+	manLink.href =
+		"?_src_=holder;admin_token=" +
+		href_token +
+		";interview_man=1;statpanel_item_click=left";
 	manDiv.appendChild(manLink);
 	body.appendChild(manDiv);
 
@@ -608,7 +615,12 @@ function draw_interviews() {
 		var td = document.createElement("td");
 		var a = document.createElement("a");
 		a.textContent = part["status"];
-		a.href = "?_src_=holder;admin_token=" + href_token + ";interview=" + part["ref"] + ";statpanel_item_click=left";
+		a.href =
+			"?_src_=holder;admin_token=" +
+			href_token +
+			";interview=" +
+			part["ref"] +
+			";statpanel_item_click=left";
 		td.appendChild(a);
 		tr.appendChild(td);
 		table.appendChild(tr);
@@ -657,8 +669,7 @@ function draw_verbs(cat) {
 	sortVerbs();
 	if (split_admin_tabs && cat.lastIndexOf(".") != -1) {
 		var splitName = cat.split(".");
-		if (splitName[0] === "Admin")
-			cat = splitName[1];
+		if (splitName[0] === "Admin") cat = splitName[1];
 	}
 	verbs.reverse(); // sort verbs backwards before we draw
 	for (var i = 0; i < verbs.length; ++i) {
@@ -666,13 +677,17 @@ function draw_verbs(cat) {
 		var name = part[0];
 		if (split_admin_tabs && name.lastIndexOf(".") != -1) {
 			var splitName = name.split(".");
-			if (splitName[0] === "Admin")
-				name = splitName[1];
+			if (splitName[0] === "Admin") name = splitName[1];
 		}
 		var command = part[1];
 
-		if (command && name.lastIndexOf(cat, 0) != -1 && (name.length == cat.length || name.charAt(cat.length) == ".")) {
-			var subCat = name.lastIndexOf(".") != -1 ? name.split(".")[1] : null;
+		if (
+			command &&
+			name.lastIndexOf(cat, 0) != -1 &&
+			(name.length == cat.length || name.charAt(cat.length) == ".")
+		) {
+			var subCat =
+				name.lastIndexOf(".") != -1 ? name.split(".")[1] : null;
 			if (subCat && !additions[subCat]) {
 				var newTable = document.createElement("div");
 				newTable.className = "grid-container";
@@ -722,35 +737,35 @@ function set_style_sheet(sheet) {
 		var currentSheet = document.getElementById("goonStyle");
 		currentSheet.parentElement.removeChild(currentSheet);
 	}
-	var head = document.getElementsByTagName('head')[0];
+	var head = document.getElementsByTagName("head")[0];
 	var sheetElement = document.createElement("link");
 	sheetElement.id = "goonStyle";
 	sheetElement.rel = "stylesheet";
 	sheetElement.type = "text/css";
 	sheetElement.href = sheet + ".css";
-	sheetElement.media = 'all';
+	sheetElement.media = "all";
 	head.appendChild(sheetElement);
 }
 
 function restoreFocus() {
 	run_after_focus(function () {
-		Byond.winset('map', {
+		Byond.winset("map", {
 			focus: true,
 		});
 	});
 }
 
 function getCookie(cname) {
-	var name = cname + '=';
-	var ca = document.cookie.split(';');
+	var name = cname + "=";
+	var ca = document.cookie.split(";");
 	for (var i = 0; i < ca.length; i++) {
 		var c = ca[i];
-		while (c.charAt(0) == ' ') c = c.substring(1);
+		while (c.charAt(0) == " ") c = c.substring(1);
 		if (c.indexOf(name) === 0) {
 			return decoder(c.substring(name.length, c.length));
 		}
 	}
-	return '';
+	return "";
 }
 
 function add_verb_list(payload) {
@@ -758,18 +773,15 @@ function add_verb_list(payload) {
 	to_add.sort(); // sort what we're adding
 	for (var i = 0; i < to_add.length; i++) {
 		var part = to_add[i];
-		if (!part[0])
-			continue;
+		if (!part[0]) continue;
 		var category = part[0];
 		if (category.indexOf(".") != -1) {
 			var splitName = category.split(".");
 			if (split_admin_tabs && splitName[0] === "Admin")
 				category = splitName[1];
-			else
-				category = splitName[0];
+			else category = splitName[0];
 		}
-		if (findVerbindex(part[1], verbs))
-			continue;
+		if (findVerbindex(part[1], verbs)) continue;
 		if (verb_tabs.includes(category)) {
 			verbs.push(part);
 			if (current_tab == category) {
@@ -781,7 +793,7 @@ function add_verb_list(payload) {
 			createStatusTab(category);
 		}
 	}
-};
+}
 
 function init_spells() {
 	var cat = "";
@@ -803,10 +815,10 @@ if (!current_tab) {
 }
 
 window.onload = function () {
-	Byond.command("Update-Verbs");
+	Byond.sendMessage("Update-Verbs");
 };
 
-Byond.subscribeTo('update_spells', function (payload) {
+Byond.subscribeTo("update_spells", function (payload) {
 	spell_tabs = payload.spell_tabs;
 	var do_update = false;
 	if (spell_tabs.includes(current_tab)) {
@@ -823,20 +835,19 @@ Byond.subscribeTo('update_spells', function (payload) {
 	}
 });
 
-Byond.subscribeTo('remove_verb_list', function (v) {
+Byond.subscribeTo("remove_verb_list", function (v) {
 	var to_remove = v;
 	for (var i = 0; i < to_remove.length; i++) {
 		remove_verb(to_remove[i]);
 	}
 	check_verbs();
 	sortVerbs();
-	if (verb_tabs.includes(current_tab))
-		draw_verbs(current_tab);
+	if (verb_tabs.includes(current_tab)) draw_verbs(current_tab);
 });
 
 // passes a 2D list of (verbcategory, verbname) creates tabs and adds verbs to respective list
 // example (IC, Say)
-Byond.subscribeTo('init_verbs', function (payload) {
+Byond.subscribeTo("init_verbs", function (payload) {
 	wipe_verbs(); // remove all verb categories so we can replace them
 	checkStatusTab(); // remove all status tabs
 	verb_tabs = payload.panel_tabs;
@@ -860,15 +871,17 @@ Byond.subscribeTo('init_verbs', function (payload) {
 	SendTabsToByond();
 });
 
-Byond.subscribeTo('update_stat', function (payload) {
+Byond.subscribeTo("update_stat", function (payload) {
 	status_tab_parts = [payload.ping_str];
 	var parsed = payload.global_data;
 
-	for (var i = 0; i < parsed.length; i++) if (parsed[i] != null) status_tab_parts.push(parsed[i]);
+	for (var i = 0; i < parsed.length; i++)
+		if (parsed[i] != null) status_tab_parts.push(parsed[i]);
 
 	parsed = payload.other_str;
 
-	for (var i = 0; i < parsed.length; i++) if (parsed[i] != null) status_tab_parts.push(parsed[i]);
+	for (var i = 0; i < parsed.length; i++)
+		if (parsed[i] != null) status_tab_parts.push(parsed[i]);
 
 	if (current_tab == "Status") {
 		draw_status();
@@ -877,7 +890,7 @@ Byond.subscribeTo('update_stat', function (payload) {
 	}
 });
 
-Byond.subscribeTo('update_mc', function (payload) {
+Byond.subscribeTo("update_mc", function (payload) {
 	mc_tab_parts = payload.mc_data;
 	mc_tab_parts.splice(0, 0, ["Location:", payload.coord_entry]);
 
@@ -892,13 +905,13 @@ Byond.subscribeTo('update_mc', function (payload) {
 	}
 });
 
-Byond.subscribeTo('remove_spells', function () {
+Byond.subscribeTo("remove_spells", function () {
 	for (var s = 0; s < spell_tabs.length; s++) {
 		removeStatusTab(spell_tabs[s]);
 	}
 });
 
-Byond.subscribeTo('init_spells', function () {
+Byond.subscribeTo("init_spells", function () {
 	var cat = "";
 	for (var i = 0; i < spell_tabs.length; i++) {
 		cat = spell_tabs[i];
@@ -909,13 +922,13 @@ Byond.subscribeTo('init_spells', function () {
 	}
 });
 
-Byond.subscribeTo('check_spells', function () {
+Byond.subscribeTo("check_spells", function () {
 	for (var v = 0; v < spell_tabs.length; v++) {
 		spell_cat_check(spell_tabs[v]);
 	}
 });
 
-Byond.subscribeTo('create_debug', function () {
+Byond.subscribeTo("create_debug", function () {
 	if (!document.getElementById("Debug Stat Panel")) {
 		addPermanentTab("Debug Stat Panel");
 	} else {
@@ -923,14 +936,14 @@ Byond.subscribeTo('create_debug', function () {
 	}
 });
 
-Byond.subscribeTo('create_listedturf', function (TN) {
+Byond.subscribeTo("create_listedturf", function (TN) {
 	remove_listedturf(); // remove the last one if we had one
 	turfname = TN;
 	addPermanentTab(turfname);
 	tab_change(turfname);
 });
 
-Byond.subscribeTo('remove_admin_tabs', function () {
+Byond.subscribeTo("remove_admin_tabs", function () {
 	href_token = null;
 	remove_mc();
 	remove_tickets();
@@ -938,22 +951,22 @@ Byond.subscribeTo('remove_admin_tabs', function () {
 	remove_interviews();
 });
 
-Byond.subscribeTo('update_listedturf', function (TC) {
+Byond.subscribeTo("update_listedturf", function (TC) {
 	turfcontents = TC;
 	if (current_tab == turfname) {
 		draw_listedturf();
 	}
 });
 
-Byond.subscribeTo('update_interviews', function (I) {
+Byond.subscribeTo("update_interviews", function (I) {
 	interviewManager = I;
 	if (current_tab == "Tickets") {
 		draw_interviews();
 	}
 });
 
-Byond.subscribeTo('update_split_admin_tabs', function (status) {
-	status = (status == true);
+Byond.subscribeTo("update_split_admin_tabs", function (status) {
+	status = status == true;
 
 	if (split_admin_tabs !== status) {
 		if (split_admin_tabs === true) {
@@ -966,13 +979,13 @@ Byond.subscribeTo('update_split_admin_tabs', function (status) {
 	split_admin_tabs = status;
 });
 
-Byond.subscribeTo('add_admin_tabs', function (ht) {
+Byond.subscribeTo("add_admin_tabs", function (ht) {
 	href_token = ht;
 	addPermanentTab("MC");
 	addPermanentTab("Tickets");
 });
 
-Byond.subscribeTo('update_sdql2', function (S) {
+Byond.subscribeTo("update_sdql2", function (S) {
 	sdql2 = S;
 	if (sdql2.length > 0 && !verb_tabs.includes("SDQL2")) {
 		verb_tabs.push("SDQL2");
@@ -983,7 +996,7 @@ Byond.subscribeTo('update_sdql2', function (S) {
 	}
 });
 
-Byond.subscribeTo('update_tickets', function (T) {
+Byond.subscribeTo("update_tickets", function (T) {
 	tickets = T;
 	if (!verb_tabs.includes("Tickets")) {
 		verb_tabs.push("Tickets");
@@ -994,10 +1007,10 @@ Byond.subscribeTo('update_tickets', function (T) {
 	}
 });
 
-Byond.subscribeTo('remove_listedturf', remove_listedturf);
+Byond.subscribeTo("remove_listedturf", remove_listedturf);
 
-Byond.subscribeTo('remove_sdql2', remove_sdql2);
+Byond.subscribeTo("remove_sdql2", remove_sdql2);
 
-Byond.subscribeTo('remove_mc', remove_mc);
+Byond.subscribeTo("remove_mc", remove_mc);
 
-Byond.subscribeTo('add_verb_list', add_verb_list);
+Byond.subscribeTo("add_verb_list", add_verb_list);

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -6,11 +6,11 @@ if (!Array.prototype.includes) {
 			if (this[i] == thing) return true;
 		}
 		return false;
-	};
+	}
 }
 if (!String.prototype.trim) {
 	String.prototype.trim = function () {
-		return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "");
+		return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
 	};
 }
 
@@ -31,9 +31,9 @@ var turfcontents = [];
 var turfname = "";
 var imageRetryDelay = 500;
 var imageRetryLimit = 50;
-var menu = document.getElementById("menu");
-var under_menu = document.getElementById("under_menu");
-var statcontentdiv = document.getElementById("statcontent");
+var menu = document.getElementById('menu');
+var under_menu = document.getElementById('under_menu');
+var statcontentdiv = document.getElementById('statcontent');
 var storedimages = [];
 var split_admin_tabs = false;
 
@@ -47,8 +47,10 @@ function run_after_focus(callback) {
 function createStatusTab(name) {
 	if (name.indexOf(".") != -1) {
 		var splitName = name.split(".");
-		if (split_admin_tabs && splitName[0] === "Admin") name = splitName[1];
-		else name = splitName[0];
+		if (split_admin_tabs && splitName[0] === "Admin")
+			name = splitName[1];
+		else
+			name = splitName[0];
 	}
 	if (document.getElementById(name) || name.trim() == "") {
 		return;
@@ -72,7 +74,7 @@ function createStatusTab(name) {
 	//END ORDERING
 	menu.appendChild(B);
 	SendTabToByond(name);
-	under_menu.style.height = menu.clientHeight + "px";
+	under_menu.style.height = menu.clientHeight + 'px';
 }
 
 function removeStatusTab(name) {
@@ -86,7 +88,7 @@ function removeStatusTab(name) {
 	}
 	menu.removeChild(document.getElementById(name));
 	TakeTabFromByond(name);
-	under_menu.style.height = menu.clientHeight + "px";
+	under_menu.style.height = menu.clientHeight + 'px';
 }
 
 function sortVerbs() {
@@ -94,16 +96,17 @@ function sortVerbs() {
 		var selector = a[0] == b[0] ? 1 : 0;
 		if (a[selector].toUpperCase() < b[selector].toUpperCase()) {
 			return 1;
-		} else if (a[selector].toUpperCase() > b[selector].toUpperCase()) {
+		}
+		else if (a[selector].toUpperCase() > b[selector].toUpperCase()) {
 			return -1;
 		}
 		return 0;
-	});
+	})
 }
 
 window.onresize = function () {
-	under_menu.style.height = menu.clientHeight + "px";
-};
+	under_menu.style.height = menu.clientHeight + 'px';
+}
 
 function addPermanentTab(name) {
 	if (!permanent_tabs.includes(name)) {
@@ -123,10 +126,7 @@ function removePermanentTab(name) {
 
 function checkStatusTab() {
 	for (var i = 0; i < menu.children.length; i++) {
-		if (
-			!verb_tabs.includes(menu.children[i].id) &&
-			!permanent_tabs.includes(menu.children[i].id)
-		) {
+		if (!verb_tabs.includes(menu.children[i].id) && !permanent_tabs.includes(menu.children[i].id)) {
 			menu.removeChild(menu.children[i]);
 		}
 	}
@@ -137,7 +137,7 @@ function remove_verb(v) {
 	for (var i = verbs.length - 1; i >= 0; i--) {
 		var part_to_remove = verbs[i];
 		if (part_to_remove[1] == verb_to_remove[1]) {
-			verbs.splice(i, 1);
+			verbs.splice(i, 1)
 		}
 	}
 }
@@ -152,8 +152,10 @@ function verbs_cat_check(cat) {
 	var tabCat = cat;
 	if (cat.indexOf(".") != -1) {
 		var splitName = cat.split(".");
-		if (split_admin_tabs && splitName[0] === "Admin") tabCat = splitName[1];
-		else tabCat = splitName[0];
+		if (split_admin_tabs && splitName[0] === "Admin")
+			tabCat = splitName[1];
+		else
+			tabCat = splitName[0];
 	}
 	var verbs_in_cat = 0;
 	var verbcat = "";
@@ -168,25 +170,29 @@ function verbs_cat_check(cat) {
 			var splitName = verbcat.split(".");
 			if (split_admin_tabs && splitName[0] === "Admin")
 				verbcat = splitName[1];
-			else verbcat = splitName[0];
+			else
+				verbcat = splitName[0];
 		}
 		if (verbcat != tabCat || verbcat.trim() == "") {
 			continue;
-		} else {
+		}
+		else {
 			verbs_in_cat = 1;
 			break; // we only need one
 		}
 	}
 	if (verbs_in_cat != 1) {
 		removeStatusTab(tabCat);
-		if (current_tab == tabCat) tab_change("Status");
+		if (current_tab == tabCat)
+			tab_change("Status");
 	}
 }
 
 function findVerbindex(name, verblist) {
 	for (var i = 0; i < verblist.length; i++) {
 		var part = verblist[i];
-		if (part[1] == name) return i;
+		if (part[1] == name)
+			return i;
 	}
 }
 function wipe_verbs() {
@@ -209,12 +215,12 @@ function SendTabsToByond() {
 }
 
 function SendTabToByond(tab) {
-	Byond.sendMessage("Send-Tabs", { tab: tab });
+	Byond.sendMessage("Send-Tabs", {tab: tab});
 }
 
 //Byond can't have this tab anymore since we're removing it
 function TakeTabFromByond(tab) {
-	Byond.sendMessage("Remove-Tabs", { tab: tab });
+	Byond.sendMessage("Remove-Tabs", {tab: tab});
 }
 
 function spell_cat_check(cat) {
@@ -240,8 +246,8 @@ function tab_change(tab) {
 	set_byond_tab(tab);
 	if (document.getElementById(tab))
 		document.getElementById(tab).className = "button active"; // make current button active
-	var spell_tabs_thingy = spell_tabs.includes(tab);
-	var verb_tabs_thingy = verb_tabs.includes(tab);
+	var spell_tabs_thingy = (spell_tabs.includes(tab));
+	var verb_tabs_thingy = (verb_tabs.includes(tab));
 	if (tab == "Status") {
 		draw_status();
 	} else if (tab == "MC") {
@@ -263,29 +269,25 @@ function tab_change(tab) {
 		statcontentdiv.textContext = "Loading...";
 	}
 	Byond.winset(Byond.windowId, {
-		"is-visible": true,
+		'is-visible': true,
 	});
 }
 
 function set_byond_tab(tab) {
-	Byond.sendMessage("Set-Tab", { tab: tab });
+	Byond.sendMessage("Set-Tab", {tab: tab});
 }
 
 function draw_debug() {
 	statcontentdiv.textContent = "";
 	var wipeverbstabs = document.createElement("div");
 	var link = document.createElement("a");
-	link.onclick = function () {
-		wipe_verbs();
-	};
+	link.onclick = function () { wipe_verbs() };
 	link.textContent = "Wipe All Verbs";
 	wipeverbstabs.appendChild(link);
 	document.getElementById("statcontent").appendChild(wipeverbstabs);
 	var wipeUpdateVerbsTabs = document.createElement("div");
 	var updateLink = document.createElement("a");
-	updateLink.onclick = function () {
-		update_verbs();
-	};
+	updateLink.onclick = function () { update_verbs() };
 	updateLink.textContent = "Wipe and Update All Verbs";
 	wipeUpdateVerbsTabs.appendChild(updateLink);
 	document.getElementById("statcontent").appendChild(wipeUpdateVerbsTabs);
@@ -300,17 +302,16 @@ function draw_debug() {
 			var splitName = verb_tabs[i].split(".");
 			if (split_admin_tabs && splitName[0] === "Admin")
 				part = splitName[1];
-			else continue;
+			else
+				continue;
 		}
 		var tr = document.createElement("tr");
 		var td1 = document.createElement("td");
 		td1.textContent = part;
 		var a = document.createElement("a");
-		a.onclick = (function (part) {
-			return function () {
-				removeStatusTab(part);
-			};
-		})(part);
+		a.onclick = function (part) {
+			return function () { removeStatusTab(part) };
+		}(part);
 		a.textContent = " Delete Tab " + part;
 		td1.appendChild(a);
 		tr.appendChild(td1);
@@ -346,18 +347,17 @@ function draw_debug() {
 		table3.appendChild(trrr);
 	}
 	document.getElementById("statcontent").appendChild(table3);
+
 }
 function draw_status() {
 	if (!document.getElementById("Status")) {
 		createStatusTab("Status");
 		current_tab = "Status";
 	}
-	statcontentdiv.textContent = "";
+	statcontentdiv.textContent = '';
 	for (var i = 0; i < status_tab_parts.length; i++) {
 		if (status_tab_parts[i].trim() == "") {
-			document
-				.getElementById("statcontent")
-				.appendChild(document.createElement("br"));
+			document.getElementById("statcontent").appendChild(document.createElement("br"));
 		} else {
 			var div = document.createElement("div");
 			div.textContent = status_tab_parts[i];
@@ -380,8 +380,7 @@ function draw_mc() {
 		var td2 = document.createElement("td");
 		if (part[2]) {
 			var a = document.createElement("a");
-			a.href =
-				"?_src_=vars;admin_token=" + href_token + ";Vars=" + part[2];
+			a.href = "?_src_=vars;admin_token=" + href_token + ";Vars=" + part[2];
 			a.textContent = part[1];
 			td2.appendChild(a);
 		} else {
@@ -398,7 +397,8 @@ function remove_tickets() {
 	if (tickets) {
 		tickets = [];
 		removePermanentTab("Tickets");
-		if (current_tab == "Tickets") tab_change("Status");
+		if (current_tab == "Tickets")
+			tab_change("Status");
 	}
 	checkStatusTab();
 }
@@ -407,7 +407,8 @@ function remove_sdql2() {
 	if (sdql2) {
 		sdql2 = [];
 		removePermanentTab("SDQL2");
-		if (current_tab == "SDQL2") tab_change("Status");
+		if (current_tab == "SDQL2")
+			tab_change("Status");
 	}
 	checkStatusTab();
 }
@@ -420,19 +421,19 @@ function remove_interviews() {
 }
 
 function iconError(e) {
-	if (current_tab != turfname) {
+	if(current_tab != turfname) {
 		return;
 	}
 	setTimeout(function () {
 		var node = e.target;
-		var current_attempts = Number(node.getAttribute("data-attempts")) || 0;
+		var current_attempts = Number(node.getAttribute("data-attempts")) || 0
 		if (current_attempts > imageRetryLimit) {
 			return;
 		}
 		var src = node.src;
 		node.src = null;
-		node.src = src + "#" + current_attempts;
-		node.setAttribute("data-attempts", current_attempts + 1);
+		node.src = src + '#' + current_attempts;
+		node.setAttribute("data-attempts", current_attempts + 1)
 		draw_listedturf();
 	}, imageRetryDelay);
 }
@@ -459,7 +460,7 @@ function draw_listedturf() {
 		var b = document.createElement("div");
 		var clickcatcher = "";
 		b.className = "link";
-		b.onmousedown = (function (part) {
+		b.onmousedown = function (part) {
 			// The outer function is used to close over a fresh "part" variable,
 			// rather than every onmousedown getting the "part" of the last entry.
 			return function (e) {
@@ -467,13 +468,13 @@ function draw_listedturf() {
 				clickcatcher = "?src=" + part[1];
 				switch (e.button) {
 					case 1:
-						clickcatcher += ";statpanel_item_click=middle";
+						clickcatcher += ";statpanel_item_click=middle"
 						break;
 					case 2:
-						clickcatcher += ";statpanel_item_click=right";
+						clickcatcher += ";statpanel_item_click=right"
 						break;
 					default:
-						clickcatcher += ";statpanel_item_click=left";
+						clickcatcher += ";statpanel_item_click=left"
 				}
 				if (e.shiftKey) {
 					clickcatcher += ";statpanel_item_shiftclick=1";
@@ -485,8 +486,8 @@ function draw_listedturf() {
 					clickcatcher += ";statpanel_item_altclick=1";
 				}
 				window.location.href = clickcatcher;
-			};
-		})(part);
+			}
+		}(part);
 		b.textContent = part[0];
 		table.appendChild(b);
 		table.appendChild(document.createElement("br"));
@@ -507,7 +508,7 @@ function remove_mc() {
 	if (current_tab == "MC") {
 		tab_change("Status");
 	}
-}
+};
 
 function draw_sdql2() {
 	statcontentdiv.textContent = "";
@@ -547,12 +548,7 @@ function draw_tickets() {
 		var td2 = document.createElement("td");
 		if (part[2]) {
 			var a = document.createElement("a");
-			a.href =
-				"?_src_=holder;admin_token=" +
-				href_token +
-				";ahelp=" +
-				part[2] +
-				";ahelp_action=ticket;statpanel_item_click=left;action=ticket";
+			a.href = "?_src_=holder;admin_token=" + href_token + ";ahelp=" + part[2] + ";ahelp_action=ticket;statpanel_item_click=left;action=ticket";
 			a.textContent = part[1];
 			td2.appendChild(a);
 		} else if (part[3]) {
@@ -576,13 +572,10 @@ function draw_interviews() {
 	header.textContent = "Interviews";
 	body.appendChild(header);
 	var manDiv = document.createElement("div");
-	manDiv.className = "interview_panel_controls";
+	manDiv.className = "interview_panel_controls"
 	var manLink = document.createElement("a");
 	manLink.textContent = "Open Interview Manager Panel";
-	manLink.href =
-		"?_src_=holder;admin_token=" +
-		href_token +
-		";interview_man=1;statpanel_item_click=left";
+	manLink.href = "?_src_=holder;admin_token=" + href_token + ";interview_man=1;statpanel_item_click=left";
 	manDiv.appendChild(manLink);
 	body.appendChild(manDiv);
 
@@ -615,12 +608,7 @@ function draw_interviews() {
 		var td = document.createElement("td");
 		var a = document.createElement("a");
 		a.textContent = part["status"];
-		a.href =
-			"?_src_=holder;admin_token=" +
-			href_token +
-			";interview=" +
-			part["ref"] +
-			";statpanel_item_click=left";
+		a.href = "?_src_=holder;admin_token=" + href_token + ";interview=" + part["ref"] + ";statpanel_item_click=left";
 		td.appendChild(a);
 		tr.appendChild(td);
 		table.appendChild(tr);
@@ -669,7 +657,8 @@ function draw_verbs(cat) {
 	sortVerbs();
 	if (split_admin_tabs && cat.lastIndexOf(".") != -1) {
 		var splitName = cat.split(".");
-		if (splitName[0] === "Admin") cat = splitName[1];
+		if (splitName[0] === "Admin")
+			cat = splitName[1];
 	}
 	verbs.reverse(); // sort verbs backwards before we draw
 	for (var i = 0; i < verbs.length; ++i) {
@@ -677,17 +666,13 @@ function draw_verbs(cat) {
 		var name = part[0];
 		if (split_admin_tabs && name.lastIndexOf(".") != -1) {
 			var splitName = name.split(".");
-			if (splitName[0] === "Admin") name = splitName[1];
+			if (splitName[0] === "Admin")
+				name = splitName[1];
 		}
 		var command = part[1];
 
-		if (
-			command &&
-			name.lastIndexOf(cat, 0) != -1 &&
-			(name.length == cat.length || name.charAt(cat.length) == ".")
-		) {
-			var subCat =
-				name.lastIndexOf(".") != -1 ? name.split(".")[1] : null;
+		if (command && name.lastIndexOf(cat, 0) != -1 && (name.length == cat.length || name.charAt(cat.length) == ".")) {
+			var subCat = name.lastIndexOf(".") != -1 ? name.split(".")[1] : null;
 			if (subCat && !additions[subCat]) {
 				var newTable = document.createElement("div");
 				newTable.className = "grid-container";
@@ -737,35 +722,35 @@ function set_style_sheet(sheet) {
 		var currentSheet = document.getElementById("goonStyle");
 		currentSheet.parentElement.removeChild(currentSheet);
 	}
-	var head = document.getElementsByTagName("head")[0];
+	var head = document.getElementsByTagName('head')[0];
 	var sheetElement = document.createElement("link");
 	sheetElement.id = "goonStyle";
 	sheetElement.rel = "stylesheet";
 	sheetElement.type = "text/css";
 	sheetElement.href = sheet + ".css";
-	sheetElement.media = "all";
+	sheetElement.media = 'all';
 	head.appendChild(sheetElement);
 }
 
 function restoreFocus() {
 	run_after_focus(function () {
-		Byond.winset("map", {
+		Byond.winset('map', {
 			focus: true,
 		});
 	});
 }
 
 function getCookie(cname) {
-	var name = cname + "=";
-	var ca = document.cookie.split(";");
+	var name = cname + '=';
+	var ca = document.cookie.split(';');
 	for (var i = 0; i < ca.length; i++) {
 		var c = ca[i];
-		while (c.charAt(0) == " ") c = c.substring(1);
+		while (c.charAt(0) == ' ') c = c.substring(1);
 		if (c.indexOf(name) === 0) {
 			return decoder(c.substring(name.length, c.length));
 		}
 	}
-	return "";
+	return '';
 }
 
 function add_verb_list(payload) {
@@ -773,15 +758,18 @@ function add_verb_list(payload) {
 	to_add.sort(); // sort what we're adding
 	for (var i = 0; i < to_add.length; i++) {
 		var part = to_add[i];
-		if (!part[0]) continue;
+		if (!part[0])
+			continue;
 		var category = part[0];
 		if (category.indexOf(".") != -1) {
 			var splitName = category.split(".");
 			if (split_admin_tabs && splitName[0] === "Admin")
 				category = splitName[1];
-			else category = splitName[0];
+			else
+				category = splitName[0];
 		}
-		if (findVerbindex(part[1], verbs)) continue;
+		if (findVerbindex(part[1], verbs))
+			continue;
 		if (verb_tabs.includes(category)) {
 			verbs.push(part);
 			if (current_tab == category) {
@@ -793,7 +781,7 @@ function add_verb_list(payload) {
 			createStatusTab(category);
 		}
 	}
-}
+};
 
 function init_spells() {
 	var cat = "";
@@ -818,7 +806,7 @@ window.onload = function () {
 	Byond.sendMessage("Update-Verbs");
 };
 
-Byond.subscribeTo("update_spells", function (payload) {
+Byond.subscribeTo('update_spells', function (payload) {
 	spell_tabs = payload.spell_tabs;
 	var do_update = false;
 	if (spell_tabs.includes(current_tab)) {
@@ -835,19 +823,20 @@ Byond.subscribeTo("update_spells", function (payload) {
 	}
 });
 
-Byond.subscribeTo("remove_verb_list", function (v) {
+Byond.subscribeTo('remove_verb_list', function (v) {
 	var to_remove = v;
 	for (var i = 0; i < to_remove.length; i++) {
 		remove_verb(to_remove[i]);
 	}
 	check_verbs();
 	sortVerbs();
-	if (verb_tabs.includes(current_tab)) draw_verbs(current_tab);
+	if (verb_tabs.includes(current_tab))
+		draw_verbs(current_tab);
 });
 
 // passes a 2D list of (verbcategory, verbname) creates tabs and adds verbs to respective list
 // example (IC, Say)
-Byond.subscribeTo("init_verbs", function (payload) {
+Byond.subscribeTo('init_verbs', function (payload) {
 	wipe_verbs(); // remove all verb categories so we can replace them
 	checkStatusTab(); // remove all status tabs
 	verb_tabs = payload.panel_tabs;
@@ -871,17 +860,15 @@ Byond.subscribeTo("init_verbs", function (payload) {
 	SendTabsToByond();
 });
 
-Byond.subscribeTo("update_stat", function (payload) {
+Byond.subscribeTo('update_stat', function (payload) {
 	status_tab_parts = [payload.ping_str];
 	var parsed = payload.global_data;
 
-	for (var i = 0; i < parsed.length; i++)
-		if (parsed[i] != null) status_tab_parts.push(parsed[i]);
+	for (var i = 0; i < parsed.length; i++) if (parsed[i] != null) status_tab_parts.push(parsed[i]);
 
 	parsed = payload.other_str;
 
-	for (var i = 0; i < parsed.length; i++)
-		if (parsed[i] != null) status_tab_parts.push(parsed[i]);
+	for (var i = 0; i < parsed.length; i++) if (parsed[i] != null) status_tab_parts.push(parsed[i]);
 
 	if (current_tab == "Status") {
 		draw_status();
@@ -890,7 +877,7 @@ Byond.subscribeTo("update_stat", function (payload) {
 	}
 });
 
-Byond.subscribeTo("update_mc", function (payload) {
+Byond.subscribeTo('update_mc', function (payload) {
 	mc_tab_parts = payload.mc_data;
 	mc_tab_parts.splice(0, 0, ["Location:", payload.coord_entry]);
 
@@ -905,13 +892,13 @@ Byond.subscribeTo("update_mc", function (payload) {
 	}
 });
 
-Byond.subscribeTo("remove_spells", function () {
+Byond.subscribeTo('remove_spells', function () {
 	for (var s = 0; s < spell_tabs.length; s++) {
 		removeStatusTab(spell_tabs[s]);
 	}
 });
 
-Byond.subscribeTo("init_spells", function () {
+Byond.subscribeTo('init_spells', function () {
 	var cat = "";
 	for (var i = 0; i < spell_tabs.length; i++) {
 		cat = spell_tabs[i];
@@ -922,13 +909,13 @@ Byond.subscribeTo("init_spells", function () {
 	}
 });
 
-Byond.subscribeTo("check_spells", function () {
+Byond.subscribeTo('check_spells', function () {
 	for (var v = 0; v < spell_tabs.length; v++) {
 		spell_cat_check(spell_tabs[v]);
 	}
 });
 
-Byond.subscribeTo("create_debug", function () {
+Byond.subscribeTo('create_debug', function () {
 	if (!document.getElementById("Debug Stat Panel")) {
 		addPermanentTab("Debug Stat Panel");
 	} else {
@@ -936,14 +923,14 @@ Byond.subscribeTo("create_debug", function () {
 	}
 });
 
-Byond.subscribeTo("create_listedturf", function (TN) {
+Byond.subscribeTo('create_listedturf', function (TN) {
 	remove_listedturf(); // remove the last one if we had one
 	turfname = TN;
 	addPermanentTab(turfname);
 	tab_change(turfname);
 });
 
-Byond.subscribeTo("remove_admin_tabs", function () {
+Byond.subscribeTo('remove_admin_tabs', function () {
 	href_token = null;
 	remove_mc();
 	remove_tickets();
@@ -951,22 +938,22 @@ Byond.subscribeTo("remove_admin_tabs", function () {
 	remove_interviews();
 });
 
-Byond.subscribeTo("update_listedturf", function (TC) {
+Byond.subscribeTo('update_listedturf', function (TC) {
 	turfcontents = TC;
 	if (current_tab == turfname) {
 		draw_listedturf();
 	}
 });
 
-Byond.subscribeTo("update_interviews", function (I) {
+Byond.subscribeTo('update_interviews', function (I) {
 	interviewManager = I;
 	if (current_tab == "Tickets") {
 		draw_interviews();
 	}
 });
 
-Byond.subscribeTo("update_split_admin_tabs", function (status) {
-	status = status == true;
+Byond.subscribeTo('update_split_admin_tabs', function (status) {
+	status = (status == true);
 
 	if (split_admin_tabs !== status) {
 		if (split_admin_tabs === true) {
@@ -979,13 +966,13 @@ Byond.subscribeTo("update_split_admin_tabs", function (status) {
 	split_admin_tabs = status;
 });
 
-Byond.subscribeTo("add_admin_tabs", function (ht) {
+Byond.subscribeTo('add_admin_tabs', function (ht) {
 	href_token = ht;
 	addPermanentTab("MC");
 	addPermanentTab("Tickets");
 });
 
-Byond.subscribeTo("update_sdql2", function (S) {
+Byond.subscribeTo('update_sdql2', function (S) {
 	sdql2 = S;
 	if (sdql2.length > 0 && !verb_tabs.includes("SDQL2")) {
 		verb_tabs.push("SDQL2");
@@ -996,7 +983,7 @@ Byond.subscribeTo("update_sdql2", function (S) {
 	}
 });
 
-Byond.subscribeTo("update_tickets", function (T) {
+Byond.subscribeTo('update_tickets', function (T) {
 	tickets = T;
 	if (!verb_tabs.includes("Tickets")) {
 		verb_tabs.push("Tickets");
@@ -1007,10 +994,10 @@ Byond.subscribeTo("update_tickets", function (T) {
 	}
 });
 
-Byond.subscribeTo("remove_listedturf", remove_listedturf);
+Byond.subscribeTo('remove_listedturf', remove_listedturf);
 
-Byond.subscribeTo("remove_sdql2", remove_sdql2);
+Byond.subscribeTo('remove_sdql2', remove_sdql2);
 
-Byond.subscribeTo("remove_mc", remove_mc);
+Byond.subscribeTo('remove_mc', remove_mc);
 
-Byond.subscribeTo("add_verb_list", add_verb_list);
+Byond.subscribeTo('add_verb_list', add_verb_list);


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

replaces `Byond.command("Update-Verbs")` with `Byond.sendMessage("Update-Verbs")`, which was an oversight after we removed the Update Verbs verb and replaced it with a message. woops!

## Why It's Good For The Game

it stops a bunch of errors because the verb no longer exists

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: removes a stray verb call from the status tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
