### PR TITLE
Crew starts with the right amount of breathing mask again

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -120,7 +120,6 @@
 		new mask_type(src)
 
 	if(!isplasmaman(loc))
-		new mask_type(src)
 		new internal_type(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)


### PR DESCRIPTION
## About The Pull Request
closes:https://github.com/tgstation/tgstation/issues/68145
https://github.com/tgstation/tgstation/pull/61603 works again

## Why It's Good For The Game

Crew starts with the right amount of breathing mask again

## Changelog

:cl:@Salex08
fix: you start with the right amount of breathing mask again
/:cl:
