### PR TITLE
Fix: #67960 Mech tgui does not let you drop some crates from cargo compartment

### DIFF
--- a/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
@@ -6,7 +6,7 @@ export const UtilityModulesPane = (props, context) => {
   const { act, data } = useBackend<OperatorData>(context);
   const { mech_equipment } = data;
   return (
-    <Box style={{ 'overflow-x': 'auto' }}>
+    <Box style={{ 'overflow': 'auto', 'max-height': '16rem' }}>
       <LabeledList>
         {mech_equipment['utility'].map((module, i) => (
           <LabeledList.Item key={i} label={module.name} verticalAlign="middle">

--- a/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
@@ -13,7 +13,11 @@ export const UtilityModulesPane = (props, context) => {
             {module.snowflake.snowflake_id ? (
               <Snowflake module={module} />
             ) : (
-              <Box width="100%" display="flex" flexDirection="row" alignItems="center">
+              <Box
+                width="100%"
+                display="flex"
+                flexDirection="row"
+                alignItems="center">
                 <Button
                   verticalAlignContent="middle"
                   content={(module.activated ? 'En' : 'Dis') + 'abled'}

--- a/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
@@ -1,49 +1,66 @@
 import { useBackend } from '../../backend';
-import { Box, Button, LabeledList, ProgressBar, Tooltip } from '../../components';
+import { Box, Button, ProgressBar, Tooltip } from '../../components';
 import { OperatorData, MechaUtility } from './data';
 
+const UtilityName = (props: { name: string }) => {
+  const { name } = props;
+  return (
+    <Tooltip content={name} position="top">
+      <span className="UtilityModulePane__UtilityName">{`${name}:`}</span>
+    </Tooltip>
+  );
+};
+
+type EquipmentProps = {
+  module: MechaUtility;
+};
+
+const Equipment = (props: EquipmentProps, context) => {
+  const { module } = props;
+  const { act } = useBackend<OperatorData>(context);
+
+  return (
+    <div className="UtilityModulePane__Equipment">
+      <UtilityName name={module.name} />
+      <Button
+        className="UtilityModulePane__Equipment__button"
+        content={(module.activated ? 'En' : 'Dis') + 'abled'}
+        onClick={() =>
+          act('equip_act', {
+            ref: module.ref,
+            gear_action: 'toggle',
+          })
+        }
+        selected={module.activated}
+      />
+      <Button
+        className="UtilityModulePane__Equipment__button"
+        content={'Detach'}
+        onClick={() =>
+          act('equip_act', {
+            ref: module.ref,
+            gear_action: 'detach',
+          })
+        }
+      />
+    </div>
+  );
+};
+
 export const UtilityModulesPane = (props, context) => {
-  const { act, data } = useBackend<OperatorData>(context);
+  const { data } = useBackend<OperatorData>(context);
   const { mech_equipment } = data;
   return (
     <Box style={{ 'overflow': 'auto', 'max-height': '16rem' }}>
-      <LabeledList>
-        {mech_equipment['utility'].map((module, i) => (
-          <LabeledList.Item key={i} label={module.name} verticalAlign="middle">
-            {module.snowflake.snowflake_id ? (
-              <Snowflake module={module} />
-            ) : (
-              <Box
-                width="100%"
-                display="flex"
-                flexDirection="row"
-                alignItems="center">
-                <Button
-                  verticalAlignContent="middle"
-                  content={(module.activated ? 'En' : 'Dis') + 'abled'}
-                  onClick={() =>
-                    act('equip_act', {
-                      ref: module.ref,
-                      gear_action: 'toggle',
-                    })
-                  }
-                  selected={module.activated}
-                />
-                <Button
-                  verticalAlignContent="middle"
-                  content={'Detach'}
-                  onClick={() =>
-                    act('equip_act', {
-                      ref: module.ref,
-                      gear_action: 'detach',
-                    })
-                  }
-                />
-              </Box>
-            )}
-          </LabeledList.Item>
-        ))}
-      </LabeledList>
+      <div>
+        {mech_equipment['utility'].map((module, i) => {
+          return module.snowflake.snowflake_id ? (
+            <Snowflake module={module} />
+          ) : (
+            <Equipment module={module} />
+          );
+        })}
+      </div>
     </Box>
   );
 };
@@ -64,44 +81,32 @@ const Snowflake = (props: { module: MechaUtility }, context) => {
   }
 };
 
-const EjectorLabel = (props: { name: string }) => {
-  const { name } = props;
-  return (
-    <Tooltip content={name} position="top">
-      <Box
-        style={{
-          'display': 'inline-block',
-          'vertical-align': 'middle',
-          'max-width': '6rem',
-          'overflow-x': 'hidden',
-          'text-overflow': 'ellipsis',
-        }}>
-        {`${name}:`}
-      </Box>
-    </Tooltip>
-  );
-};
-
 const SnowflakeEjector = (props: { module: MechaUtility }, context) => {
   const { act, data } = useBackend<OperatorData>(context);
   const { cargo } = props.module.snowflake;
   return (
-    <LabeledList>
-      {cargo.map((item, i) => (
-        <LabeledList.Item key={i} label={<EjectorLabel name={item.name} />}>
-          <Button
-            onClick={() =>
-              act('equip_act', {
-                ref: props.module.ref,
-                cargoref: item.ref,
-                gear_action: 'eject',
-              })
-            }>
-            {'Eject'}
-          </Button>
-        </LabeledList.Item>
-      ))}
-    </LabeledList>
+    <>
+      {cargo && cargo.length > 0 && <Box>Cargo</Box>}
+      <Box style={{ 'margin-left': '1rem' }}>
+        {cargo.map((item) => (
+          <div
+            key={props.module.ref}
+            className="UtilityModulePane__SnowflakeEjector__entry">
+            <UtilityName name={item.name} />
+            <Button
+              onClick={() =>
+                act('equip_act', {
+                  ref: props.module.ref,
+                  cargoref: item.ref,
+                  gear_action: 'eject',
+                })
+              }>
+              {'Eject'}
+            </Button>
+          </div>
+        ))}
+      </Box>
+    </>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
@@ -13,30 +13,28 @@ export const UtilityModulesPane = (props, context) => {
             {module.snowflake.snowflake_id ? (
               <Snowflake module={module} />
             ) : (
-              <Box display="flex" flexDirection="row" alignItems="center">
-                <Box>
-                  <Button
-                    verticalAlignContent="middle"
-                    content={(module.activated ? 'En' : 'Dis') + 'abled'}
-                    onClick={() =>
-                      act('equip_act', {
-                        ref: module.ref,
-                        gear_action: 'toggle',
-                      })
-                    }
-                    selected={module.activated}
-                  />
-                  <Button
-                    verticalAlignContent="middle"
-                    content={'Detach'}
-                    onClick={() =>
-                      act('equip_act', {
-                        ref: module.ref,
-                        gear_action: 'detach',
-                      })
-                    }
-                  />
-                </Box>
+              <Box width="100%" display="flex" flexDirection="row" alignItems="center">
+                <Button
+                  verticalAlignContent="middle"
+                  content={(module.activated ? 'En' : 'Dis') + 'abled'}
+                  onClick={() =>
+                    act('equip_act', {
+                      ref: module.ref,
+                      gear_action: 'toggle',
+                    })
+                  }
+                  selected={module.activated}
+                />
+                <Button
+                  verticalAlignContent="middle"
+                  content={'Detach'}
+                  onClick={() =>
+                    act('equip_act', {
+                      ref: module.ref,
+                      gear_action: 'detach',
+                    })
+                  }
+                />
               </Box>
             )}
           </LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
@@ -1,5 +1,5 @@
 import { useBackend } from '../../backend';
-import { Button, LabeledList, ProgressBar } from '../../components';
+import { Box, Button, LabeledList, ProgressBar, Tooltip } from '../../components';
 import { OperatorData, MechaUtility } from './data';
 
 export const UtilityModulesPane = (props, context) => {
@@ -62,13 +62,31 @@ const Snowflake = (props: { module: MechaUtility }, context) => {
   }
 };
 
+const EjectorLabel = (props: { name: string }) => {
+  const { name } = props;
+  return (
+    <Tooltip content={name} position="top">
+      <Box
+        style={{
+          'display': 'inline-block',
+          'vertical-align': 'middle',
+          'max-width': '6rem',
+          'overflow-x': 'hidden',
+          'text-overflow': 'ellipsis',
+        }}>
+        {`${name}:`}
+      </Box>
+    </Tooltip>
+  );
+};
+
 const SnowflakeEjector = (props: { module: MechaUtility }, context) => {
   const { act, data } = useBackend<OperatorData>(context);
   const { cargo } = props.module.snowflake;
   return (
     <LabeledList>
       {cargo.map((item, i) => (
-        <LabeledList.Item key={i} label={item.name}>
+        <LabeledList.Item key={i} label={<EjectorLabel name={item.name} />}>
           <Button
             onClick={() =>
               act('equip_act', {

--- a/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
@@ -6,37 +6,43 @@ export const UtilityModulesPane = (props, context) => {
   const { act, data } = useBackend<OperatorData>(context);
   const { mech_equipment } = data;
   return (
-    <LabeledList>
-      {mech_equipment['utility'].map((module, i) => (
-        <LabeledList.Item key={i} label={module.name}>
-          {module.snowflake.snowflake_id ? (
-            <Snowflake module={module} />
-          ) : (
-            <>
-              <Button
-                content={(module.activated ? 'En' : 'Dis') + 'abled'}
-                onClick={() =>
-                  act('equip_act', {
-                    ref: module.ref,
-                    gear_action: 'toggle',
-                  })
-                }
-                selected={module.activated}
-              />
-              <Button
-                content={'Detach'}
-                onClick={() =>
-                  act('equip_act', {
-                    ref: module.ref,
-                    gear_action: 'detach',
-                  })
-                }
-              />
-            </>
-          )}
-        </LabeledList.Item>
-      ))}
-    </LabeledList>
+    <Box style={{ 'overflow-x': 'auto' }}>
+      <LabeledList>
+        {mech_equipment['utility'].map((module, i) => (
+          <LabeledList.Item key={i} label={module.name} verticalAlign="middle">
+            {module.snowflake.snowflake_id ? (
+              <Snowflake module={module} />
+            ) : (
+              <Box display="flex" flexDirection="row" alignItems="center">
+                <Box>
+                  <Button
+                    verticalAlignContent="middle"
+                    content={(module.activated ? 'En' : 'Dis') + 'abled'}
+                    onClick={() =>
+                      act('equip_act', {
+                        ref: module.ref,
+                        gear_action: 'toggle',
+                      })
+                    }
+                    selected={module.activated}
+                  />
+                  <Button
+                    verticalAlignContent="middle"
+                    content={'Detach'}
+                    onClick={() =>
+                      act('equip_act', {
+                        ref: module.ref,
+                        gear_action: 'detach',
+                      })
+                    }
+                  />
+                </Box>
+              </Box>
+            )}
+          </LabeledList.Item>
+        ))}
+      </LabeledList>
+    </Box>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/UtilityModulesPane.tsx
@@ -1,5 +1,5 @@
 import { useBackend } from '../../backend';
-import { Box, Button, ProgressBar, Tooltip } from '../../components';
+import { Box, Button, ProgressBar, Section, Tooltip } from '../../components';
 import { OperatorData, MechaUtility } from './data';
 
 const UtilityName = (props: { name: string }) => {
@@ -51,16 +51,18 @@ export const UtilityModulesPane = (props, context) => {
   const { data } = useBackend<OperatorData>(context);
   const { mech_equipment } = data;
   return (
-    <Box style={{ 'overflow': 'auto', 'max-height': '16rem' }}>
-      <div>
-        {mech_equipment['utility'].map((module, i) => {
-          return module.snowflake.snowflake_id ? (
-            <Snowflake module={module} />
-          ) : (
-            <Equipment module={module} />
-          );
-        })}
-      </div>
+    <Box style={{ 'height': '16rem' }}>
+      <Section scrollable fill>
+        <div>
+          {mech_equipment['utility'].map((module, i) => {
+            return module.snowflake.snowflake_id ? (
+              <Snowflake module={module} />
+            ) : (
+              <Equipment module={module} />
+            );
+          })}
+        </div>
+      </Section>
     </Box>
   );
 };

--- a/tgui/packages/tgui/interfaces/Mecha/data.ts
+++ b/tgui/packages/tgui/interfaces/Mecha/data.ts
@@ -91,6 +91,7 @@ export type OperatorData = {
 };
 
 export type MechaUtility = {
+  activated: boolean;
   name: string;
   ref: string;
   snowflake: any;

--- a/tgui/packages/tgui/styles/interfaces/UtilityModulesPane.scss
+++ b/tgui/packages/tgui/styles/interfaces/UtilityModulesPane.scss
@@ -1,0 +1,30 @@
+.UtilityModulePane__Equipment {
+  display: flex;
+  vertical-align: middle;
+  align-items: center;
+  flex-direction: row;
+  align-content: center;
+  margin: 0.5rem 0.5rem 0.5rem 0;
+}
+
+.UtilityModulePane__Equipment__button {
+  margin: 0 0 0 0.5rem !important;
+  height: 100%;
+}
+
+.UtilityModulePane__SnowflakeEjector__entry {
+  display: flex;
+  vertical-align: middle;
+  align-items: center;
+  flex-direction: row;
+  margin: 0.5rem;
+}
+
+.UtilityModulePane__UtilityName {
+  vertical-align: middle;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-right: 1rem;
+  flex-grow: 1;
+}

--- a/tgui/packages/tgui/styles/main.scss
+++ b/tgui/packages/tgui/styles/main.scss
@@ -68,6 +68,7 @@
 @include meta.load-css('./interfaces/TachyonArray.scss');
 @include meta.load-css('./interfaces/Techweb.scss');
 @include meta.load-css('./interfaces/RequestManager.scss');
+@include meta.load-css('./interfaces/UtilityModulesPane.scss');
 
 // Layouts
 @include meta.load-css('./layouts/Layout.scss');


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

An attempt at fixing #67960.
This prevents the `UtilityModulesPane` from overflowing. The `LabeledList` uses table for layout which is not ideal so it may be worth looking into changing  `LabeledList`.

## Why It's Good For The Game

Before:
![image](https://user-images.githubusercontent.com/32263167/177052872-e7c65951-5861-4efa-b99e-67c394518f82.png)
![image](https://user-images.githubusercontent.com/32263167/177053386-9ea3de8d-788f-4de6-a7ee-b9e7918da7fe.png)

Now:
![image](https://user-images.githubusercontent.com/32263167/177053230-4ff6b215-6f37-421d-9079-62e1ec4027e3.png)
![image](https://user-images.githubusercontent.com/32263167/177053244-4ac130cc-bb79-4ee4-82fa-f8a302db994d.png)


The buttons are now usable again.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed mecha cargo names breaking the utility module interface
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
