### PR TITLE
Buffs heat, pressure limit of pumps and scrubbers. Buffs can release pressure.

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	///Player controlled var that set the release pressure of the canister
 	var/release_pressure = ONE_ATMOSPHERE
 	///Maximum pressure allowed for release_pressure var
-	var/can_max_release_pressure = (ONE_ATMOSPHERE * 10)
+	var/can_max_release_pressure = (ONE_ATMOSPHERE * 25)
 	///Minimum pressure allower for release_pressure var
 	var/can_min_release_pressure = (ONE_ATMOSPHERE * 0.1)
 	///Maximum amount of external heat that the canister can handle before taking damage

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -43,8 +43,6 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 	integrity_failure = 0.4
 	pressure_resistance = 7 * ONE_ATMOSPHERE
 	req_access = list()
-	temp_limit = 10000
-	pressure_limit = 500000
 
 	var/icon/canister_overlay_file = 'icons/obj/atmospherics/canisters.dmi'
 

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -20,9 +20,9 @@
 	var/excited = TRUE
 
 	/// Max amount of heat allowed inside the machine before it starts to melt. [PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT] is special value meaning we are immune.
-	var/temp_limit = 5000
+	var/temp_limit = 10000
 	/// Max amount of pressure allowed inside of the canister before it starts to break. [PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT] is special value meaning we are immune.
-	var/pressure_limit = 50000
+	var/pressure_limit = 500000
 
 /obj/machinery/portable_atmospherics/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Title
Balance portion of #66460. With a few changes.

## Why It's Good For The Game
First part is consistency. I hope it justifies itself.

Second part is for gameplay. We need hot plasma for bombs, and currently only 1013kpa is attainable, through canisters. Using pumps (2533kpa) will melt it. The 10k buff after this pr is not enough to contain it, just there for consistency.

The 1033 itself is usable for bombs but does not leave a lot of wiggle room, making dud bombs more frequent than what I'd like. 
Random ran the numbers on the pr linked above so check those out. Basically they require specialized temps and an even more cookbook like recipe than what we currently have, which is already cookbook-y enough.

I can think of three options that doesn't require snowflaked objects here:
1. Buff the heat limit and pressure limit of pumps even more to allow for hot burn, this would effectively be a nearly complete roll back to before #50542, same pressure and everything, discounting very very high temps of course. Honestly I kinda like this.
2. Increase the release pressure of the canisters, keep the pumps in place.
3. Increase the release pressure of both cans and pumps.

Currently going with number 2 since I feel like it has the most minimal effect on things, but honestly not really heavy on any of those. What I don't want is for the current state of affairs to remain. If you have thoughts drop them.

## Changelog
:cl:
balance: pumps and scrubbers have their heat and pressure limit buffed to be the same as unshielded cans.
balance: cans have their release pressure buffed to 2533kpa.
/:cl: