### PR TITLE
Changed a "lil pump" to a normal pump.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -75332,6 +75332,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
+"xCc" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/office)
 "xCh" = (
 /obj/machinery/button/door/directional/west{
 	id = "xenobio5";
@@ -257985,7 +257989,7 @@ kgo
 sCx
 gWr
 iHc
-gXv
+xCc
 gXv
 vaa
 xLq


### PR DESCRIPTION
## About The Pull Request

Changes one of the portable air pumps in the ordinance lab on icebox from "lil pump" to a normal portable air pump to match the standard of every other map.

I hate fun. And give my life to San.

## Why It's Good For The Game

Fixes #68148 

## Changelog

:cl:
fix: icebox pumps now match the standard of every other map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
