### PR TITLE
Mild plane tweaks, thermomachine dropshadow

### DIFF
--- a/code/_onclick/hud/rendering/plane_master_controller.dm
+++ b/code/_onclick/hud/rendering/plane_master_controller.dm
@@ -94,6 +94,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 		GHOST_PLANE,
 		POINT_PLANE,
 		LIGHTING_PLANE,
+		AREA_PLANE,
 	)
 
 /// Controller of all planes we're ok with changing with colorblind logic
@@ -121,5 +122,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 		RUNECHAT_PLANE,
 		HUD_PLANE,
 		ABOVE_HUD_PLANE,
+		AREA_PLANE,
 	)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -3,6 +3,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine
 	icon = 'icons/obj/atmospherics/components/thermomachine.dmi'
 	icon_state = "thermo_base"
+	plane = GAME_PLANE
 
 	name = "Temperature control unit"
 	desc = "Heats or cools gas in connected pipes."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the area plane to the game and colorblind plane master controllers
Mostly because it's actually used now, for weather, and should be
blurred/recolored

Sets the thermomachine on the game plane
I want it to have a dropshadow, and right now it's on the floor plane,
just from atmospherics, which I think is stupid

## Logchain

:cl:
fix: Thermomachines will properly have a dropshadow
fix: Weather will be blurred as expected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
