### PR TITLE
Shortens Hub Entry Descriptors

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -316,23 +316,7 @@ GLOBAL_VAR(restart_counter)
 	if (CONFIG_GET(flag/station_name_in_hub_entry))
 		s += " &#8212; <b>[station_name()]</b>"
 
-	s += " ("
-	s += "<a href=\"http://\">" //Change this to wherever you want the hub to link to.
-	s += "Default"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
-	s += "</a>"
-	s += ")"
-
 	var/players = GLOB.clients.len
-
-	var/popcaptext = ""
-	var/popcap = max(CONFIG_GET(number/extreme_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/soft_popcap))
-	if (popcap)
-		popcaptext = "/[popcap]"
-
-	if (players > 1)
-		features += "[players][popcaptext] players"
-	else if (players > 0)
-		features += "[players][popcaptext] player"
 
 	game_state = (CONFIG_GET(number/extreme_popcap) && players >= CONFIG_GET(number/extreme_popcap)) //tells the hub if we are full
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -341,10 +341,10 @@ GLOBAL_VAR(restart_counter)
 	if (features)
 		s += ": [jointext(features, ", ")]"
 
-	s += "<br>Round time: <b>[gameTimestamp("hh:mm")]</b>"
+	s += "<br>Time: <b>[gameTimestamp("hh:mm")]</b>"
 	if(SSmapping.config)
 		s += "<br>Map: <b>[SSmapping.config.map_path == CUSTOM_MAP_PATH ? "Uncharted Territory" : SSmapping.config.map_name]</b>"
-	s += "<br>Alert level: <b>[capitalize(SSsecurity_level.get_current_level_as_text())]</b>"
+	s += "<br>Alert: <b>[capitalize(SSsecurity_level.get_current_level_as_text())]</b>"
 
 	status = s
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -307,9 +307,10 @@ GLOBAL_VAR(restart_counter)
 		var/server_name = CONFIG_GET(string/servername)
 		if (server_name)
 			s += "<b>[server_name]</b> "
-		features += "[CONFIG_GET(flag/norespawn) ? "no " : ""]respawn"
-		if(CONFIG_GET(flag/allow_ai))
-			features += "AI allowed"
+		if(!CONFIG_GET(flag/norespawn))
+			features += "respawn"
+		if(!CONFIG_GET(flag/allow_ai))
+			features += "AI disabled"
 		hostedby = CONFIG_GET(string/hostedby)
 
 	if (CONFIG_GET(flag/station_name_in_hub_entry))


### PR DESCRIPTION
Short and sweet, the removed words are obvious and unnecessary

no changelog because it's just a very minor edit