### PR TITLE
Fixes trapdoor runtime when they're destroyed when not linked to a remote

### DIFF
--- a/code/datums/components/trapdoor.dm
+++ b/code/datums/components/trapdoor.dm
@@ -50,7 +50,8 @@
 /datum/component/trapdoor/UnregisterFromParent()
 	. = ..()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_TRAPDOOR_LINK)
-	UnregisterSignal(assembly, COMSIG_ASSEMBLY_PULSED)
+	if(assembly)
+		UnregisterSignal(assembly, COMSIG_ASSEMBLY_PULSED)
 	UnregisterSignal(parent, COMSIG_TURF_CHANGE)
 
 /datum/component/trapdoor/proc/decal_detached(datum/source, description, cleanable, directional, pic)


### PR DESCRIPTION
## About The Pull Request
Basically, you can run in a situation where there's no remote linked to the trapdoor, and if it gets destroyed, it runtimes.

## Why It's Good For The Game
Runtime bad, no runtime = good.

## Changelog

:cl: GoldenAlpharex
fix: Fixed trapdoors freaking out when you destroy their floor tile without having a remote attached to said trapdoor.
/:cl: