### PR TITLE
Fix some dashes breaking permanently (heirophant staff and ninja sword)

### DIFF
--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -51,7 +51,7 @@
 
 	// Note: It's possible do_teleport, for whatever reason,
 	// caused our owner to be unassigned by this point.
-	/// (Such as dropping our item after landing).
+	// (Such as dropping our item after landing.)
 
 	var/obj/spot_one = new phaseout(current_turf, user.dir)
 	var/obj/spot_two = new phasein(target_turf, user.dir)

--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -1,32 +1,30 @@
+/// Actions that you can use to dash (teleport) to places in view.
 /datum/action/innate/dash
 	name = "Dash"
 	desc = "Teleport to the targeted location."
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "jetboot"
+	/// How many dash charges do we have?
 	var/current_charges = 1
+	/// How many dash charges can we hold?
 	var/max_charges = 1
-	var/charge_rate = 250
-	var/obj/item/dashing_item
+	/// How long does it take to get a dash charge back?
+	var/charge_rate = 25 SECONDS
+	/// What sound do we play on dash?
 	var/dash_sound = 'sound/magic/blink.ogg'
+	/// What sound do we play on recharge?
 	var/recharge_sound = 'sound/magic/charge.ogg'
+	/// What effect does our beam use?
 	var/beam_effect = "blur"
+	/// How long does our beam last?
 	var/beam_length = 2 SECONDS
+	/// What effect should we play when we phase in (at the teleport target turf)
 	var/phasein = /obj/effect/temp_visual/dir_setting/ninja/phase
+	/// What effect should we play when we phase out (at the source turf)
 	var/phaseout = /obj/effect/temp_visual/dir_setting/ninja/phase/out
 
-/datum/action/innate/dash/Grant(mob/user, obj/dasher)
-	. = ..()
-	dashing_item = dasher
-
-/datum/action/innate/dash/Destroy()
-	dashing_item = null
-	return ..()
-
 /datum/action/innate/dash/IsAvailable()
-	if(current_charges > 0)
-		return TRUE
-	else
-		return FALSE
+	return ..() && (current_charges > 0)
 
 /datum/action/innate/dash/Activate()
 	dashing_item.attack_self(owner) //Used to toggle dash behavior in the dashing item
@@ -39,21 +37,24 @@
 
 	var/turf/current_turf = get_turf(user)
 	var/turf/target_turf = get_turf(target)
-	if(target in view(user.client.view, user))
-		if(!do_teleport(user, target_turf, no_effects = TRUE))
-			user.balloon_alert(user, "dash blocked by location!")
-			return FALSE
-		var/obj/spot1 = new phaseout(current_turf, user.dir)
-		var/obj/spot2 = new phasein(target_turf, user.dir)
-		spot1.Beam(spot2,beam_effect, time = beam_length)
-		playsound(target_turf, dash_sound, 25, TRUE)
-		current_charges--
-		owner.update_action_buttons_icon()
-		addtimer(CALLBACK(src, .proc/charge), charge_rate)
-		return TRUE
+	if(!(target in view(user.client.view, user)))
+		user.balloon_alert(user, "out of view!")
+		return FALSE
 
-	return FALSE
+	if(!do_teleport(user, target_turf, no_effects = TRUE))
+		user.balloon_alert(user, "dash blocked!")
+		return FALSE
 
+	var/obj/spot_one = new phaseout(current_turf, user.dir)
+	var/obj/spot_two = new phasein(target_turf, user.dir)
+	spot_one.Beam(spot_two, beam_effect, time = beam_length)
+	playsound(target_turf, dash_sound, 25, TRUE)
+	current_charges--
+	addtimer(CALLBACK(src, .proc/charge), charge_rate)
+	owner?.update_action_buttons_icon()
+	return TRUE
+
+/// Callback for [/proc/teleport] to increment our charges back up.
 /datum/action/innate/dash/proc/charge()
 	current_charges = clamp(current_charges + 1, 0, max_charges)
 	if(recharge_sound)

--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -27,6 +27,10 @@
 	return ..() && (current_charges > 0)
 
 /datum/action/innate/dash/Activate()
+	var/obj/item/dashing_item = target
+	if(!istype(dashing_item))
+		return
+
 	dashing_item.attack_self(owner) //Used to toggle dash behavior in the dashing item
 
 /// Teleports user to target using do_teleport. Returns TRUE if teleport successful, FALSE otherwise.
@@ -45,6 +49,10 @@
 		user.balloon_alert(user, "dash blocked!")
 		return FALSE
 
+	// Note: It's possible do_teleport, for whatever reason,
+	// caused our owner to be unassigned by this point.
+	/// (Such as dropping our item after landing).
+
 	var/obj/spot_one = new phaseout(current_turf, user.dir)
 	var/obj/spot_two = new phasein(target_turf, user.dir)
 	spot_one.Beam(spot_two, beam_effect, time = beam_length)
@@ -52,11 +60,17 @@
 	current_charges--
 	addtimer(CALLBACK(src, .proc/charge), charge_rate)
 	owner?.update_action_buttons_icon()
+
 	return TRUE
 
-/// Callback for [/proc/teleport] to increment our charges back up.
+/// Callback for [/proc/teleport] to increment our charges after  use.
 /datum/action/innate/dash/proc/charge()
 	current_charges = clamp(current_charges + 1, 0, max_charges)
+
+	var/obj/item/dashing_item = target
+	if(!istype(dashing_item))
+		return
+
 	if(recharge_sound)
 		playsound(dashing_item, recharge_sound, 50, TRUE)
 

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -20,11 +20,11 @@
 	var/dist = get_dist(user, target)
 	if(dist > HIEROPHANT_BLINK_RANGE)
 		user.balloon_alert(user, "destination out of range!")
-		return
+		return FALSE
 	var/turf/target_turf = get_turf(target)
 	if(target_turf.is_blocked_turf_ignore_climbable())
 		user.balloon_alert(user, "destination blocked!")
-		return
+		return FALSE
 
 	. = ..()
 	var/obj/item/hierophant_club/club = target

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -25,28 +25,21 @@
 	if(target_turf.is_blocked_turf_ignore_climbable())
 		user.balloon_alert(user, "destination blocked!")
 		return
+
 	. = ..()
-	if(!current_charges)
-		var/obj/item/hierophant_club/club = src.target
-		if(istype(club))
-			club.blink_charged = FALSE
-			club.update_appearance()
+	var/obj/item/hierophant_club/club = target
+	if(!istype(club))
+		return
+
+	club.update_appearance(UPDATE_ICON_STATE)
 
 /datum/action/innate/dash/hierophant/charge()
+	. = ..()
 	var/obj/item/hierophant_club/club = target
-	if(istype(club))
-		club.blink_charged = TRUE
-		club.update_appearance()
-
-	current_charges = clamp(current_charges + 1, 0, max_charges)
-
-	if(recharge_sound)
-		playsound(dashing_item, recharge_sound, 50, TRUE)
-
-	if(!owner)
+	if(!istype(club))
 		return
-	owner.update_action_buttons_icon()
-	to_chat(owner, span_notice("[src] now has [current_charges]/[max_charges] charges."))
+
+	club.update_appearance(UPDATE_ICON_STATE)
 
 /obj/item/hierophant_club
 	name = "hierophant club"
@@ -74,16 +67,14 @@
 	var/datum/action/innate/dash/hierophant/blink
 	/// Whether the blink ability is activated. IF TRUE, left clicking a location will blink to it. If FALSE, this is disabled.
 	var/blink_activated = TRUE
-	/// Whether the blink is charged. Set and unset by the blink action. Used as part of setting the appropriate icon states.
-	var/blink_charged = TRUE
 
 /obj/item/hierophant_club/Initialize(mapload)
 	. = ..()
 	blink = new(src)
 
 /obj/item/hierophant_club/Destroy()
-	. = ..()
 	QDEL_NULL(blink)
+	return ..()
 
 /obj/item/hierophant_club/ComponentInitialize()
 	. = ..()
@@ -120,7 +111,7 @@
 		blink.teleport(user, target)
 
 /obj/item/hierophant_club/update_icon_state()
-	icon_state = inhand_icon_state = "hierophant_club[blink_charged ? "_ready":""][(!QDELETED(beacon)) ? "":"_beacon"]"
+	icon_state = inhand_icon_state = "hierophant_club[blink?.current_charges > 0 ? "_ready":""][(!QDELETED(beacon)) ? "":"_beacon"]"
 	return ..()
 
 /obj/item/hierophant_club/ui_action_click(mob/user, action)


### PR DESCRIPTION
## About The Pull Request

Fixes #62283

On some occasions, a dashing action could be removed from the owner before the recharge began.
This would cause a runtime error and permanently brick the dash. 

This fixes it by `null` checking for `owner` after the teleport is successful. 

Also cleans up the dash action a bit - improves code, doc, etc. 

## Why It's Good For The Game

Stops dashes from breaking. 

## Changelog

:cl: Melbert
fix: Dashes such as the Heirophant staff and Ninja sword should no longer permanently break on rare occasions.
/:cl:
