### PR TITLE
Changes How Gatfruit Is Obtained (To Be From Ruins To Traitors)

### DIFF
--- a/code/__HELPERS/randoms.dm
+++ b/code/__HELPERS/randoms.dm
@@ -23,7 +23,8 @@
 		/obj/item/food/meat/slab/human/mutant,
 		/obj/item/food/grown/ash_flora,
 		/obj/item/food/grown/nettle,
-		/obj/item/food/grown/shell
+		/obj/item/food/grown/shell,
+		/obj/item/food/grown/shell/gatfruit
 		)
 
 	return pick(subtypesof(/obj/item/food) - blocked)

--- a/code/game/objects/effects/spawners/random/food_or_drink.dm
+++ b/code/game/objects/effects/spawners/random/food_or_drink.dm
@@ -171,7 +171,7 @@
 	name = "seed vault seeds"
 	icon_state = "seed"
 	loot = list(
-		/obj/item/seeds/gatfruit = 10,
+		/obj/item/seeds/random = 10,
 		/obj/item/seeds/cherry/bomb = 10,
 		/obj/item/seeds/berry/glow = 10,
 		/obj/item/seeds/sunflower/moonflower = 8,

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -169,7 +169,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 			new /obj/item/ship_in_a_bottle(loc)
 			new /obj/item/oar(loc)
 		if(16)
-			new /obj/item/seeds/gatfruit(loc)
+			new /obj/item/seeds/nettle/death(loc)
 		if(17)
 			new /obj/item/reagent_containers/food/drinks/drinkingglass/filled/nuka_cola(loc)
 		if(18)

--- a/code/modules/explorer_drone/exploration_events/trader.dm
+++ b/code/modules/explorer_drone/exploration_events/trader.dm
@@ -71,7 +71,7 @@
 	required_site_traits = list(EXPLORATION_SITE_HABITABLE,EXPLORATION_SITE_SURFACE)
 	band_values = list(EXOSCANNER_BAND_LIFE=2)
 	required_path = /obj/item/stock_parts/manipulator/nano
-	traded_path = list(/obj/item/seeds/tomato/killer,/obj/item/seeds/orange_3d,/obj/item/seeds/firelemon,/obj/item/seeds/gatfruit)
+	traded_path = list(/obj/item/seeds/tomato/killer,/obj/item/seeds/orange_3d,/obj/item/seeds/firelemon,/obj/item/seeds/random)
 	amount = 1
 
 /datum/exploration_event/simple/trader/fish

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -90,6 +90,17 @@
 	surplus = 0
 	restricted_roles = list(JOB_COOK, JOB_BOTANIST, JOB_CLOWN, JOB_MIME)
 
+/datum/uplink_item/role_restricted/gatfruit_seeds
+	name = "Pack Of Gatfruit Seeds"
+	desc = "A pack of Pyrus Gatt'Gat seeds, geneticially engineered to grow into Syndicate Revolvers upon maturity. \
+			Outer shell must be injested before use. Caution should be used while growing these, as a savvy \
+			co-worker may turn the tables and use them for their own purposes."
+	progression_minimum = 50 MINUTES
+	item = /obj/item/seeds/gatfruit
+	cost = 30 // You have to either ration your telecrystals to reach this by 50 minutes, or do objectives the hard way without any items until then.
+	surplus = 1
+	restricted_roles = list(JOB_COOK, JOB_BOTANIST)
+
 /datum/uplink_item/role_restricted/ez_clean_bundle
 	name = "EZ Clean Grenade Bundle"
 	desc = "A box with three cleaner grenades using the trademark Waffle Co. formula. Serves as a cleaner and causes acid damage to anyone standing nearby. \

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -95,9 +95,9 @@
 	desc = "A pack of Pyrus Gatt'Gat seeds, geneticially engineered to grow into Syndicate Revolvers upon maturity. \
 			Outer shell must be injested before use. Caution should be used while growing these, as a savvy \
 			co-worker may turn the tables and use them for their own purposes."
-	progression_minimum = 50 MINUTES
+	progression_minimum = 30 MINUTES
 	item = /obj/item/seeds/gatfruit
-	cost = 30 // You have to either ration your telecrystals to reach this by 50 minutes, or do objectives the hard way without any items until then.
+	cost = 30 // You have to either ration your telecrystals to reach this by 30 minutes, or do objectives the hard way without any items until then.
 	surplus = 1
 	restricted_roles = list(JOB_COOK, JOB_BOTANIST)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I'm not going to beat around the bush, I audibly groan every time I see botany mass produce free .357s for everyone. Nothing quite ruins the "Everyone has a job to do" magic like everyone suddenly having the same two-shot crit funny revolver. It *shouldn't* be something normal crew should be able to do.

So.. I changed it.
Gatfruit is no longer obtainable in the seed vault, from icemoon monster spawners, or from exodrones. All instances therein have been replaced with strange seeds or death nettles.

However.
Rather than remove gatfruit outright, I've given the power to botanist/chef traitors. 30 minutes into the round, and for 30 TC. You WILL have to do objectives for this, and either ration your starting TC or go without any gear until you can buy this, and that's by design - although it does make it the single most expensive bit of traitor kit.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
.357s are one of the most broken pieces of kit in the game. They can 3 shot near anything, from players, to machines, all the way to dragon rifts. Them being mass produced by normal crewmembers was, quite frankly, fucking absurd. They're traitor gear, first and foremost - and while this won't *stop* normal crew from growing them should a traitor get owned with them, it at least places the ball for them existing in antagonists' court.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Traitor Botanists (And chefs) are now the sole source of gatfruit. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
