### PR TITLE
Removes upload boards from steal objectives.

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -34,34 +34,6 @@
 /datum/objective_item/steal/low_risk
 	objective_type = OBJECTIVE_ITEM_TYPE_TRAITOR
 
-/datum/objective_item/steal/low_risk/techboard
-	name = "the (TECH BOARD) circuitboard in secure tech storage"
-	var/circuitboard_name
-	excludefromjob = list(
-		JOB_CAPTAIN,
-		JOB_CHIEF_ENGINEER,
-		JOB_RESEARCH_DIRECTOR,
-	)
-	exists_on_map = TRUE
-
-/datum/objective_item/steal/low_risk/techboard/aiupload
-	targetitem = /obj/item/circuitboard/computer/aiupload
-	circuitboard_name = "ai upload"
-
-/obj/item/circuitboard/computer/aiupload/add_stealing_item_objective()
-	ADD_STEAL_ITEM(src, /obj/item/circuitboard/computer/aiupload)
-
-/datum/objective_item/steal/low_risk/techboard/borgupload
-	targetitem = /obj/item/circuitboard/computer/borgupload
-	circuitboard_name = "cyborg upload"
-
-/obj/item/circuitboard/computer/borgupload/add_stealing_item_objective()
-	ADD_STEAL_ITEM(src, /obj/item/circuitboard/computer/borgupload)
-
-/datum/objective_item/steal/low_risk/techboard/New()
-	. = ..()
-	name = replacetext(name, "(TECH BOARD)", circuitboard_name)
-
 /datum/objective_item/steal/low_risk/aicard
 	targetitem = /obj/item/aicard
 	name = "an intelliCard"

--- a/code/modules/antagonists/traitor/objectives/steal.dm
+++ b/code/modules/antagonists/traitor/objectives/steal.dm
@@ -85,8 +85,6 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	telecrystal_reward = 0
 	minutes_per_telecrystal = 6
 	possible_items = list(
-		/datum/objective_item/steal/low_risk/techboard/borgupload,
-		/datum/objective_item/steal/low_risk/techboard/aiupload,
 		/datum/objective_item/steal/low_risk/aicard,
 	)
 


### PR DESCRIPTION

## About The Pull Request

Removes both of the upload boards as potential traitor objectives.

## Why It's Good For The Game

The ease of obtaining upload boards led to constant early-round break-ins and hoarding when the boards became printable from science. Upload wars are incredibly unfun for the crew and for the silicons. The only person that benefits from them is the person doing the uploading from maintenance dens. 

## Changelog

:cl:
balance: Syndicate no longer wants easily printed upload boards.
/:cl: