### PR TITLE
Custom reagent holders no longer blow through the overlay cap

### DIFF
--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -28,7 +28,7 @@
 		atom/replacement,
 		fill_type,
 		ingredient_type = CUSTOM_INGREDIENT_TYPE_EDIBLE,
-		max_ingredients = MAX_ATOM_OVERLAYS - 2,
+		max_ingredients = MAX_ATOM_OVERLAYS - 3, // The cap is >= MAX_ATOM_OVERLAYS so we reserve 2 for top /bottom of item + 1 to stay under cap
 		list/obj/item/initial_ingredients = null)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE


### PR DESCRIPTION
```
[22:29:25] Runtime in stack_trace.dm,3: Too many overlays on /obj/item/food/burger/empty - 100, refusing to update and cutting.
 What follows is a printout of all existing overlays at the time of the overflow 
(icons/obj/food/burgerbread.dmi-custburg-0) = 1
(icons/obj/food/burgerbread.dmi-custburg_filling-0) = 98
(icons/obj/food/burgerbread.dmi-custburg_top-0) = 1
  proc name: stack trace (/proc/stack_trace)
  ```
Fixes #68203 by changing the logic of how max recipe items are calculated