### PR TITLE
Don't process topic calls when the ntmessenger program is qdeleted

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -360,7 +360,8 @@
 
 /datum/computer_file/program/messenger/Topic(href, href_list)
 	..()
-
+	if(QDELETED(src))
+		return
 	if(!href_list["close"] && usr.canUseTopic(computer, BE_CLOSE, FALSE, NO_TK))
 		switch(href_list["choice"])
 			if("Message")


### PR DESCRIPTION
but not yet fully reaped by the garbage collector
```
[22:35:55] Runtime in living.dm,1155: Cannot read null.loc
  proc name: canUseTopic (/mob/living/canUseTopic)
  usr: Grobnok/(Slippo Supreme)
  usr.loc: (Command Hallway (117,126,2))
  src: Unknown (/mob/living/carbon/human)
  src.loc: the floor (117,126,2) (/turf/open/floor/iron)
  call stack:
  Unknown (/mob/living/carbon/human): canUseTopic(null, 1, 0, 1, 0, 0)
  /datum/computer_file/program/m... (/datum/computer_file/program/messenger): Topic("src=\[0x210168b4];choice=Messa...", /list (/list))
  Grobnok (/client): Topic("src=\[0x210168b4];choice=Messa...", /list (/list), /datum/computer_file/program/m... (/datum/computer_file/program/messenger))
  Grobnok (/client): Topic("src=\[0x210168b4];choice=Messa...", /list (/list), /datum/computer_file/program/m... (/datum/computer_file/program/messenger))
  ```

also @magatsuchi what the hell are these topic overrides? this thing has a tgui, use it's ui act