### PR TITLE
Don't assume computers and applications still exist when broadcasting

### DIFF
--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -180,9 +180,11 @@
 	if (!logged)  // Can only go through if a message server logs it
 		return
 	for (var/obj/item/modular_computer/comp in data["targets"])
-		var/obj/item/computer_hardware/hard_drive/drive = comp.all_components[MC_HDD]
-		for(var/datum/computer_file/program/messenger/app in drive.stored_files)
-			app.receive_message(src)
+		if(!QDELETED(comp))
+			var/obj/item/computer_hardware/hard_drive/drive = comp.all_components[MC_HDD]
+			for(var/datum/computer_file/program/messenger/app in drive.stored_files)
+				if(!QDELETED(app))
+					app.receive_message(src)
 
 // Request Console signal datum
 /datum/signal/subspace/messaging/rc/broadcast()


### PR DESCRIPTION
subspace messages
```
[22:32:46] Runtime in ntmessenger.dm,359: Cannot execute null.ring().
  proc name: receive message (/datum/computer_file/program/messenger/proc/receive_message)
  usr: Shadowflame909/(Owen Kimple)
  usr.loc: (Central Primary Hallway (101,114,2))
  src: /datum/computer_file/program/m... (/datum/computer_file/program/messenger)
  call stack:
  /datum/computer_file/program/m... (/datum/computer_file/program/messenger): receive message(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg))
  /datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg): broadcast()
  the subspace broadcaster (/obj/machinery/telecomms/broadcaster/preset_left): receive information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), the telecommunication hub (/obj/machinery/telecomms/hub/preset))
  the telecommunication hub (/obj/machinery/telecomms/hub/preset): relay information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), /obj/machinery/telecomms/broad... (/obj/machinery/telecomms/broadcaster), null, 20)
  the telecommunication hub (/obj/machinery/telecomms/hub/preset): receive information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), Messaging Server (/obj/machinery/telecomms/message_server/preset))
  Messaging Server (/obj/machinery/telecomms/message_server/preset): relay information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), /obj/machinery/telecomms/hub (/obj/machinery/telecomms/hub), null, 20)
  Messaging Server (/obj/machinery/telecomms/message_server/preset): receive information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), the bus mainframe (/obj/machinery/telecomms/bus/preset_four))
  the bus mainframe (/obj/machinery/telecomms/bus/preset_four): relay information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), /obj/machinery/telecomms/messa... (/obj/machinery/telecomms/message_server), null, 20)
  the bus mainframe (/obj/machinery/telecomms/bus/preset_four): receive information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), the processor unit (/obj/machinery/telecomms/processor/preset_four))
  the processor unit (/obj/machinery/telecomms/processor/preset_four): relay direct information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), the bus mainframe (/obj/machinery/telecomms/bus/preset_four))
  ...
  the telecommunication hub (/obj/machinery/telecomms/hub/preset): relay information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), /obj/machinery/telecomms/bus (/obj/machinery/telecomms/bus), 1, 20)
  the telecommunication hub (/obj/machinery/telecomms/hub/preset): receive information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), the subspace receiver (/obj/machinery/telecomms/receiver/preset_right))
  the subspace receiver (/obj/machinery/telecomms/receiver/preset_right): relay information(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg), /obj/machinery/telecomms/hub (/obj/machinery/telecomms/hub), null, 20)
  the subspace receiver (/obj/machinery/telecomms/receiver/preset_right): receive signal(/datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg))
  /datum/signal/subspace/messagi... (/datum/signal/subspace/messaging/tablet_msg): send to receivers()
  /datum/computer_file/program/m... (/datum/computer_file/program/messenger): send message(Owen Kimple (/mob/living/carbon/human), /list (/list), 0, 0, null, null)
  /datum/computer_file/program/m... (/datum/computer_file/program/messenger): ui act("PDA_sendMessage", /list (/list), /datum/tgui (/datum/tgui), /datum/ui_state/default (/datum/ui_state/default))
  /datum/tgui_window (/datum/tgui_window): on message("act/PDA_sendMessage", /list (/list), /list (/list))
  Shadowflame909 (/client): Topic("type=act%2FPDA_sendMessage&pay...", /list (/list), null)
  ```