### PR TITLE
Fixes some incorrect/missing nearstation areas around Kilo's ordnance launch site

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -489,9 +489,9 @@
 "aeH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "chemistry_shutters";
-	name = "Chemistry Lobby Shutters";
-	dir = 1
+	name = "Chemistry Lobby Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
@@ -624,9 +624,9 @@
 "agy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
+	dir = 1;
 	id = "visitation";
-	name = "Visitation Shutters";
-	dir = 1
+	name = "Visitation Shutters"
 	},
 /obj/machinery/flasher/directional/east{
 	id = "visitorflash"
@@ -1364,9 +1364,9 @@
 "apL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "justiceshutter";
-	name = "Justice Shutter";
-	dir = 4
+	name = "Justice Shutter"
 	},
 /turf/open/floor/plating,
 /area/station/security/execution/education)
@@ -2109,9 +2109,9 @@
 "aDL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "chemistry_shutters";
-	name = "Chemistry Lobby Shutters";
-	dir = 4
+	name = "Chemistry Lobby Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
@@ -2964,9 +2964,9 @@
 /obj/structure/flora/bush/ferny/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "emmd";
-	name = "Emergency Medical Lockdown Shutters";
-	dir = 4
+	name = "Emergency Medical Lockdown Shutters"
 	},
 /turf/open/floor/grass,
 /area/station/medical/paramedic)
@@ -4082,9 +4082,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "kitchenshutters";
-	name = "Kitchen Shutters";
-	dir = 8
+	name = "Kitchen Shutters"
 	},
 /obj/item/paper_bin{
 	pixel_x = -4;
@@ -4540,9 +4540,9 @@
 /area/station/tcommsat/computer)
 "bso" = (
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "ordnancestorage";
-	name = "Ordnance Storage Shutters";
-	dir = 1
+	name = "Ordnance Storage Shutters"
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -9426,9 +9426,9 @@
 "cRW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "chemistry_shutters_2";
-	name = "Chemistry Hall Shutters";
-	dir = 4
+	name = "Chemistry Hall Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
@@ -11918,9 +11918,9 @@
 /area/station/security/prison)
 "dAz" = (
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "emmd";
-	name = "Emergency Medical Lockdown Shutters";
-	dir = 4
+	name = "Emergency Medical Lockdown Shutters"
 	},
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/firedoor,
@@ -16337,9 +16337,9 @@
 "eQg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
+	dir = 8;
 	id = "virologysurgery";
-	name = "Virology Privacy Shutters";
-	dir = 8
+	name = "Virology Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/medical/virology)
@@ -23286,9 +23286,9 @@
 "gHC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "cmoprivacy";
-	name = "Office Privacy Shutters";
-	dir = 1
+	name = "Office Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/cmo)
@@ -24494,9 +24494,9 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "ordnancestorage";
-	name = "Ordnance Storage Shutters";
-	dir = 1
+	name = "Ordnance Storage Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable,
@@ -24674,9 +24674,9 @@
 	pixel_x = 4
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "research_shutters";
-	name = "Research Privacy Shutter";
-	dir = 8
+	name = "Research Privacy Shutter"
 	},
 /obj/machinery/door/window/right/directional/east{
 	name = "Research Lab Desk";
@@ -25380,9 +25380,9 @@
 	req_access = list("ai_upload")
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "AI Core shutters";
-	name = "AI Core Shutter";
-	dir = 8
+	name = "AI Core Shutter"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
@@ -27251,9 +27251,9 @@
 /obj/item/storage/bag/tray,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "kitchenshutters";
-	name = "Kitchen Shutters";
-	dir = 8
+	name = "Kitchen Shutters"
 	},
 /turf/open/floor/iron,
 /area/station/service/kitchen)
@@ -29890,9 +29890,9 @@
 "ivh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "cmoprivacy";
-	name = "Office Privacy Shutters";
-	dir = 4
+	name = "Office Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/cmo)
@@ -31621,9 +31621,9 @@
 "iTj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
+	dir = 8;
 	id = "sparemech";
-	name = "Abandoned Mech Bay";
-	dir = 8
+	name = "Abandoned Mech Bay"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -32429,9 +32429,9 @@
 "jdR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
+	dir = 1;
 	id = "virologysurgery";
-	name = "Virology Privacy Shutters";
-	dir = 1
+	name = "Virology Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/medical/virology)
@@ -32439,9 +32439,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
+	dir = 4;
 	id = "bankshutter";
-	name = "Bank Shutter";
-	dir = 4
+	name = "Bank Shutter"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/blood/old,
@@ -33384,9 +33384,9 @@
 "jsV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
+	dir = 1;
 	id = "visitation";
-	name = "Visitation Shutters";
-	dir = 1
+	name = "Visitation Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
@@ -36231,9 +36231,9 @@
 /area/station/command/bridge)
 "kqn" = (
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "emmd";
-	name = "Emergency Medical Lockdown Shutters";
-	dir = 4
+	name = "Emergency Medical Lockdown Shutters"
 	},
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/firedoor,
@@ -38929,9 +38929,9 @@
 	req_access = list("ai_upload")
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "AI Core shutters";
-	name = "AI Core Shutter";
-	dir = 4
+	name = "AI Core Shutter"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light_switch/directional/north{
@@ -41062,9 +41062,9 @@
 /area/station/security/execution/education)
 "lIR" = (
 /obj/machinery/door/poddoor/shutters{
+	dir = 1;
 	id = "custodialwagon";
-	name = "Custodial Bay";
-	dir = 1
+	name = "Custodial Bay"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
@@ -41094,9 +41094,9 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "lJw" = (
 /obj/machinery/door/poddoor/shutters{
+	dir = 8;
 	id = "ordnancemix";
-	name = "Ordnance Lab Shutters";
-	dir = 8
+	name = "Ordnance Lab Shutters"
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
@@ -42957,9 +42957,9 @@
 /area/station/security/warden)
 "mlm" = (
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "chem_lockdown";
-	name = "Chemistry Shutters";
-	dir = 8
+	name = "Chemistry Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -44522,9 +44522,9 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "mJk" = (
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "chemistry_shutters";
-	name = "Chemistry Lobby Shutters";
-	dir = 1
+	name = "Chemistry Lobby Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/medical/glass{
@@ -44993,9 +44993,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
+	dir = 1;
 	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter";
-	dir = 1
+	name = "Vacant Commissary Shutter"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/noticeboard/directional/east,
@@ -45237,9 +45237,9 @@
 	req_access = list("armory")
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "justiceshutter";
-	name = "Justice Shutter";
-	dir = 4
+	name = "Justice Shutter"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -46899,9 +46899,9 @@
 "nsA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "Shower_1Privacy";
-	name = "Shower 1 Privacy Shutter";
-	dir = 1
+	name = "Shower 1 Privacy Shutter"
 	},
 /turf/open/floor/plating,
 /area/station/commons/toilet/restrooms)
@@ -47307,9 +47307,9 @@
 /area/station/maintenance/starboard)
 "nxc" = (
 /obj/machinery/door/poddoor/shutters{
+	dir = 1;
 	id = "custodialwagon";
-	name = "Custodial Bay";
-	dir = 1
+	name = "Custodial Bay"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
@@ -47455,9 +47455,9 @@
 "nBc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "detective_shutters";
-	name = "Detective's Office Shutter";
-	dir = 8
+	name = "Detective's Office Shutter"
 	},
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
@@ -47697,9 +47697,9 @@
 "nEk" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/machinery/door/poddoor/shutters{
+	dir = 8;
 	id = "ordnancemix";
-	name = "Ordnance Lab Shutters";
-	dir = 8
+	name = "Ordnance Lab Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/disposalpipe/segment{
@@ -52966,9 +52966,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "ceprivate";
-	name = "Chief Engineer's Privacy Shutters";
-	dir = 8
+	name = "Chief Engineer's Privacy Shutters"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53882,9 +53882,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "kitchenshutters";
-	name = "Kitchen Shutters";
-	dir = 8
+	name = "Kitchen Shutters"
 	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
@@ -56244,9 +56244,9 @@
 "qdk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "robotics_shutters";
-	name = "Robotics Privacy Shutters";
-	dir = 8
+	name = "Robotics Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
@@ -57975,9 +57975,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
+	dir = 4;
 	id = "bankshutter";
-	name = "Bank Shutter";
-	dir = 4
+	name = "Bank Shutter"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/blood/old,
@@ -58178,9 +58178,9 @@
 /area/station/service/chapel)
 "qFw" = (
 /obj/machinery/door/poddoor/shutters{
+	dir = 4;
 	id = "aux_base_shutters";
-	name = "Auxillary Base Shutters";
-	dir = 4
+	name = "Auxillary Base Shutters"
 	},
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
@@ -60160,9 +60160,9 @@
 "rkU" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
+	dir = 4;
 	id = "sidearmory";
-	name = "Side Armoury Shutter";
-	dir = 4
+	name = "Side Armoury Shutter"
 	},
 /obj/machinery/button/door/directional/south{
 	id = "sidearmory";
@@ -60223,9 +60223,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
+	dir = 1;
 	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter";
-	dir = 1
+	name = "Vacant Commissary Shutter"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/blood/old,
@@ -60827,9 +60827,9 @@
 /area/station/medical/pharmacy)
 "rtw" = (
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "ordnancestorage";
-	name = "Ordnance Storage Shutters";
-	dir = 1
+	name = "Ordnance Storage Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/showroomfloor,
@@ -61254,9 +61254,9 @@
 "rxD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "chem_lockdown";
-	name = "Chemistry Shutters";
-	dir = 4
+	name = "Chemistry Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -61899,9 +61899,9 @@
 /area/station/hallway/primary/central)
 "rHX" = (
 /obj/machinery/door/poddoor/shutters{
+	dir = 1;
 	id = "evashutter";
-	name = "E.V.A. Storage Shutter";
-	dir = 1
+	name = "E.V.A. Storage Shutter"
 	},
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
@@ -62105,9 +62105,9 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "emmd";
-	name = "Emergency Medical Lockdown Shutters";
-	dir = 4
+	name = "Emergency Medical Lockdown Shutters"
 	},
 /turf/open/floor/grass,
 /area/station/medical/paramedic)
@@ -63405,9 +63405,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "kitchenshutters";
-	name = "Kitchen Shutters";
-	dir = 8
+	name = "Kitchen Shutters"
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/bot,
@@ -68597,9 +68597,9 @@
 /area/station/engineering/supermatter/room)
 "tzg" = (
 /obj/machinery/door/poddoor/shutters{
+	dir = 4;
 	id = "aux_base_shutters";
-	name = "Auxillary Base Shutters";
-	dir = 4
+	name = "Auxillary Base Shutters"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -68986,9 +68986,9 @@
 /area/station/cargo/drone_bay)
 "tDJ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "engineaccess";
-	name = "Engine Access Shutters";
-	dir = 4
+	name = "Engine Access Shutters"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -71044,9 +71044,9 @@
 /obj/item/folder/white,
 /obj/item/pen,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "chemistry_shutters";
-	name = "Chemistry Lobby Shutters";
-	dir = 1
+	name = "Chemistry Lobby Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/left/directional/north{
@@ -73367,9 +73367,9 @@
 "uTa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "research_shutters";
-	name = "Research Privacy Shutter";
-	dir = 8
+	name = "Research Privacy Shutter"
 	},
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Lab"
@@ -73503,9 +73503,9 @@
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/reed/style_random,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "emmd";
-	name = "Emergency Medical Lockdown Shutters";
-	dir = 4
+	name = "Emergency Medical Lockdown Shutters"
 	},
 /turf/open/floor/grass,
 /area/station/medical/paramedic)
@@ -75772,9 +75772,9 @@
 	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters{
+	dir = 1;
 	id = "visitation";
-	name = "Visitation Shutters";
-	dir = 1
+	name = "Visitation Shutters"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
@@ -76986,9 +76986,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "justiceshutter";
-	name = "Justice Shutter";
-	dir = 4
+	name = "Justice Shutter"
 	},
 /turf/open/floor/plating,
 /area/station/security/execution/education)
@@ -82744,9 +82744,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/hos,
 /obj/machinery/door/poddoor/shutters{
+	dir = 8;
 	id = "frontarmory";
-	name = "Front Armoury Shutter";
-	dir = 8
+	name = "Front Armoury Shutter"
 	},
 /obj/machinery/button/door/directional/north{
 	id = "frontarmory";
@@ -83349,9 +83349,9 @@
 /area/station/commons/fitness/recreation)
 "xDj" = (
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "ceprivate";
-	name = "Chief Engineer's Privacy Shutters";
-	dir = 8
+	name = "Chief Engineer's Privacy Shutters"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -83389,9 +83389,9 @@
 "xDM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "research_shutters";
-	name = "Research Privacy Shutter";
-	dir = 8
+	name = "Research Privacy Shutter"
 	},
 /turf/open/floor/plating,
 /area/station/science/lab)
@@ -84918,9 +84918,9 @@
 	pixel_x = -4
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
 	id = "chemistry_shutters_2";
-	name = "Chemistry Hall Shutters";
-	dir = 4
+	name = "Chemistry Hall Shutters"
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/left/directional/north{
@@ -85045,9 +85045,9 @@
 "ybO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "Shower_2Privacy";
-	name = "Shower 2 Privacy Shutter";
-	dir = 1
+	name = "Shower 2 Privacy Shutter"
 	},
 /turf/open/floor/plating,
 /area/station/commons/toilet/restrooms)
@@ -102417,7 +102417,7 @@ ecY
 pxe
 beK
 sRm
-acy
+qJs
 aaa
 aaa
 aaa
@@ -102674,7 +102674,7 @@ aaa
 aaa
 cry
 aoe
-afI
+acK
 aaa
 aaa
 aaa
@@ -102931,7 +102931,7 @@ aaa
 aaa
 cry
 cCX
-cmJ
+acm
 aaa
 aaa
 aaa
@@ -103188,7 +103188,7 @@ aaa
 aaa
 cry
 aoe
-afI
+acK
 aaa
 aaa
 aaa
@@ -103445,7 +103445,7 @@ ecY
 pxe
 aeZ
 pmM
-acy
+qJs
 aaa
 aaa
 aaa
@@ -131919,7 +131919,7 @@ acm
 aaa
 acm
 eiW
-cry
+aaa
 aaa
 acm
 aaa
@@ -132433,7 +132433,7 @@ acm
 aaa
 acm
 viq
-cry
+aaa
 acm
 aaa
 aaa
@@ -132944,7 +132944,7 @@ aeu
 vku
 acm
 acm
-cry
+aaa
 acm
 acK
 acm
@@ -133201,7 +133201,7 @@ aeU
 aUz
 aaa
 aeo
-cmJ
+acm
 acm
 acK
 aeo
@@ -133461,7 +133461,7 @@ aeo
 aaa
 acm
 qDp
-cry
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/25415050/177387162-616c3e7c-72a0-4dad-b452-0ab2548c0dbc.png)

I assume this happened when ordnance got its cold chamber for BZ production and the entire launch site had to be moved right to compensate.

## Why It's Good For The Game

Looks and feels better.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Kilostation had a few areas in space around the ordnance test site fixed up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
