### PR TITLE
Sets minimum player count for sentient disease

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -876,6 +876,7 @@
 	antag_datum = /datum/antagonist/disease
 	antag_flag = ROLE_SENTIENT_DISEASE
 	required_candidates = 1
+	minimum_players = 25
 	weight = 4
 	cost = 8
 	requirements = list(101,101,101,80,60,50,30,20,10,10)

--- a/code/modules/antagonists/disease/disease_event.dm
+++ b/code/modules/antagonists/disease/disease_event.dm
@@ -4,7 +4,7 @@
 	typepath = /datum/round_event/ghost_role/sentient_disease
 	weight = 7
 	max_occurrences = 1
-	min_players = 5
+	min_players = 25
 
 
 /datum/round_event/ghost_role/sentient_disease

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -2,7 +2,7 @@
 	name = "Disease Outbreak"
 	typepath = /datum/round_event/disease_outbreak
 	max_occurrences = 1
-	min_players = 25
+	min_players = 10
 	weight = 5
 
 /datum/round_event/disease_outbreak


### PR DESCRIPTION

## About The Pull Request
The PR #65619 tried to make the sentient disease rarer by altering the required player amount, but has by accident, altered the the regular disease spawning event instead. This PR fixes this.

## Why It's Good For The Game

Normal disease outbreak is once again allowed on low pop, and sentient disease is now actually gated to high pop.

## Changelog

:cl:
fix: corrected the minimum player count of a few disease events
/:cl:

