### PR TITLE
Set crossOrigin to anonymous when doing Byond.loadJs()

### DIFF
--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -304,6 +304,7 @@
     if (type === 'js') {
       var node = document.createElement('script');
       node.type = 'text/javascript';
+      node.crossOrigin = 'anonymous';
       // IE8: Prefer non-https protocols
       node.src = Byond.IS_LTE_IE9
         ? url.replace('https://', 'http://')


### PR DESCRIPTION
## About The Pull Request

Attempts to fix the "Script Error" by adding a `crossOrigin` attribute to the injected script node.

## Changelog

:cl:
fix: Fixed "Script Error" in tgui and tgchat (hopefully).
/:cl:
