### PR TITLE
Significant rework to hydrogen/tritium combustion.

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -59,34 +59,26 @@
 // - Hydrogen:
 /// The minimum temperature hydrogen combusts at.
 #define HYDROGEN_MINIMUM_BURN_TEMPERATURE FIRE_MINIMUM_TEMPERATURE_TO_EXIST
-/// The minimum thermal energy necessary for hydrogen fires to use the [HYDROGEN_OXYBURN_MULTIPLIER]. Used to prevent overpowered hydrogen/oxygen singletank bombs to moderate success.
-#define MINIMUM_HYDROGEN_OXYBURN_ENERGY 2e6
-/// A multiplier to released hydrogen fire energy when in an oxygen-rich mix.
-#define HYDROGEN_OXYBURN_MULTIPLIER 10
-/// What fraction of the oxygen content of the mix is used for the burn rate in an oxygen-poor mix.
-#define HYDROGEN_BURN_OXY_FACTOR 100
-/// What fraction of the hydrogen content of the mix is used for the burn rate in an oxygen-rich mix.
-#define HYDROGEN_BURN_H2_FACTOR 10
-/// The amount of energy released by burning one mole of hydrogen. (Before [HYDROGEN_OXYBURN_MULTIPLIER] is applied if applicable.)
-#define FIRE_HYDROGEN_ENERGY_RELEASED 2.8e5
+/// The amount of energy released by burning one mole of hydrogen.
+#define FIRE_HYDROGEN_ENERGY_RELEASED 2.8e6
+/// Multiplier for hydrogen fire with O2 moles * HYDROGEN_OXYGEN_FULLBURN for the maximum fuel consumption
+#define HYDROGEN_OXYGEN_FULLBURN 10
+/// The divisor for the maximum hydrogen burn rate. (1/2 of the hydrogen can burn in one reaction tick.)
+#define FIRE_HYDROGEN_BURN_RATE_DELTA 2
 
 // - Tritium:
 /// The minimum temperature tritium combusts at.
 #define TRITIUM_MINIMUM_BURN_TEMPERATURE FIRE_MINIMUM_TEMPERATURE_TO_EXIST
-/// The minimum thermal energy necessary for tritium fires to use the [TRITIUM_OXYBURN_MULTIPLIER]. Used to prevent overpowered tritium/oxygen singletank bombs to moderate success.
-#define MINIMUM_TRITIUM_OXYBURN_ENERGY 2e6
-/// A multiplier to all secondary tritium fire effects when in an oxygen-rich mix.
-#define TRITIUM_OXYBURN_MULTIPLIER 10
-/// What fraction of the oxygen content of the mix is used for the burn rate in an oxygen-poor mix.
-#define TRITIUM_BURN_OXY_FACTOR 100
-/// What fraction of the tritium content of the mix is used for the burn rate in an oxygen-rich mix.
-#define TRITIUM_BURN_TRIT_FACTOR 10
-/// The amount of energy released by burning one mole of tritium. (Before [TRITIUM_OXYBURN_MULTIPLIER] is applied if applicable.)
-#define FIRE_TRITIUM_ENERGY_RELEASED 2.8e5
+/// The amount of energy released by burning one mole of tritium.
+#define FIRE_TRITIUM_ENERGY_RELEASED FIRE_HYDROGEN_ENERGY_RELEASED
+/// Multiplier for TRITIUM fire with O2 moles * TRITIUM_OXYGEN_FULLBURN for the maximum fuel consumption
+#define TRITIUM_OXYGEN_FULLBURN HYDROGEN_OXYGEN_FULLBURN
+/// The divisor for the maximum tritium burn rate. (1/2 of the tritium can burn in one reaction tick.)
+#define FIRE_TRITIUM_BURN_RATE_DELTA FIRE_HYDROGEN_BURN_RATE_DELTA
 /// The minimum number of moles of trit that must be burnt for a tritium fire reaction to produce a radiation pulse. (0.01 moles trit or 10 moles oxygen to start producing rads.)
 #define TRITIUM_RADIATION_MINIMUM_MOLES 0.1
 /// The minimum released energy necessary for tritium to release radiation during combustion. (at a mix volume of [CELL_VOLUME]).
-#define TRITIUM_RADIATION_RELEASE_THRESHOLD (FIRE_TRITIUM_ENERGY_RELEASED * TRITIUM_OXYBURN_MULTIPLIER)
+#define TRITIUM_RADIATION_RELEASE_THRESHOLD (FIRE_TRITIUM_ENERGY_RELEASED)
 /// A scaling factor for the range of radiation pulses produced by tritium fires.
 #define TRITIUM_RADIATION_RANGE_DIVISOR 1.5
 /// A scaling factor for the irradiation threshold of radiation pulses produced by tritium fires.

--- a/code/modules/atmospherics/gasmixtures/reaction_factors.dm
+++ b/code/modules/atmospherics/gasmixtures/reaction_factors.dm
@@ -26,20 +26,20 @@
 
 /datum/gas_reaction/h2fire/init_factors()
 	factor = list(
-		/datum/gas/oxygen = "Oxygen is consumed equal to the amount of hydrogen available on the fast burn. Not consumed on the slow burn. Needs to be more than the hydrogen amount to trigger fast burn. Acts as the reaction rate on slow burn.",
-		/datum/gas/hydrogen = "[(1/HYDROGEN_BURN_H2_FACTOR)*100]% of the hydrogen is always consumed on the fast burn. [(1/HYDROGEN_BURN_OXY_FACTOR)*100]% of the oxygen amount is consumed on the slow burn. Need to be less than the oxygen amount to trigger fast burn. Acts as the reaction rate on fast burn.",
-		/datum/gas/water_vapor = "Water vapor is formed at [1/HYDROGEN_BURN_H2_FACTOR] reaction rate for the fast burn, [1/HYDROGEN_BURN_OXY_FACTOR]% reaction rate for the slow burn.",
+		/datum/gas/oxygen = "Oxygen is consumed at 0.5 reaction rate. Higher oxygen concentration up to [HYDROGEN_OXYGEN_FULLBURN] times the hydrogen increases the reaction rate.",
+		/datum/gas/hydrogen = "Hydrogen is consumed at 1 reaction rate. Its relationship with oxygen also determines the reaction speed.",
+		/datum/gas/water_vapor = "Water vapor is formed at 1 reaction rate.",
 		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST] kelvin to occur",
-		"Energy" = "[FIRE_HYDROGEN_ENERGY_RELEASED*HYDROGEN_OXYBURN_MULTIPLIER] joules of energy is released per rate for the fast burn, [FIRE_HYDROGEN_ENERGY_RELEASED] joules for the slow burn. Needs [MINIMUM_TRITIUM_OXYBURN_ENERGY] joules to start the fast burn.",
+		"Energy" = "[FIRE_HYDROGEN_ENERGY_RELEASED] joules of energy is released per mol of hydrogen consumed.",
 	)
 
 /datum/gas_reaction/tritfire/init_factors()
 	factor = list(
-		/datum/gas/oxygen = "Oxygen is consumed equal to the amount of tritium available on the fast burn. Not consumed on the slow burn. Need to be more than the tritium amount to trigger fast burn. Acts as the reaction rate on slow burn.",
-		/datum/gas/tritium = "[(1/TRITIUM_BURN_TRIT_FACTOR)*100]% of the tritium is always consumed on the fast burn. [(1/TRITIUM_BURN_OXY_FACTOR)*100]% of the oxygen amount is consumed on the slow burn. Need to be less than the oxygen amount to trigger fast burn. Acts as the reaction rate on fast burn.",
-		/datum/gas/water_vapor = "Water vapor is formed at [1/TRITIUM_BURN_TRIT_FACTOR]% reaction rate for the fast burn, [1/TRITIUM_BURN_OXY_FACTOR]% reaction rate for the slow burn.",
+		/datum/gas/oxygen = "Oxygen is consumed at 0.5 reaction rate. Higher oxygen concentration up to [TRITIUM_OXYGEN_FULLBURN] times the tritium increases the reaction rate.",
+		/datum/gas/tritium = "Tritium is consumed at 1 reaction rate. Its relationship with oxygen also determines the reaction speed.",
+		/datum/gas/water_vapor = "Water vapor is formed at 1 reaction rate.",
 		"Temperature" = "Minimum temperature of [FIRE_MINIMUM_TEMPERATURE_TO_EXIST] kelvin to occur",
-		"Energy" = "[FIRE_TRITIUM_ENERGY_RELEASED*TRITIUM_OXYBURN_MULTIPLIER] joules of energy is released per rate for the fast burn, [FIRE_TRITIUM_ENERGY_RELEASED] joules for the slow burn. Needs [MINIMUM_TRITIUM_OXYBURN_ENERGY] joules to start the fast burn.",
+		"Energy" = "[FIRE_TRITIUM_ENERGY_RELEASED] joules of energy is released per mol of tritium consumed.",
 		"Radiation" = "This reaction emits radiation proportional to the amount of energy released.",
 	)
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -260,7 +260,7 @@
 	var/temperature = air.temperature
 
 	var/burned_fuel = min(cached_gases[/datum/gas/hydrogen][MOLES] / FIRE_HYDROGEN_BURN_RATE_DELTA, cached_gases[/datum/gas/oxygen][MOLES] / (FIRE_HYDROGEN_BURN_RATE_DELTA * HYDROGEN_OXYGEN_FULLBURN), cached_gases[/datum/gas/hydrogen][MOLES], cached_gases[/datum/gas/oxygen][MOLES] * INVERSE(0.5))
-	if(burned_fuel <= 0 || (cached_gases[/datum/gas/hydrogen][MOLES] - burned_fuel < 0) || (cached_gases[/datum/gas/oxygen][MOLES] - burned_fuel * 0.5 < 0)) //Shouldn't produce gas from nothing.
+	if(burned_fuel <= 0 || cached_gases[/datum/gas/hydrogen][MOLES] - burned_fuel < 0 || cached_gases[/datum/gas/oxygen][MOLES] - burned_fuel * 0.5 < 0) //Shouldn't produce gas from nothing.
 		return NO_REACTION
 
 	cached_gases[/datum/gas/hydrogen][MOLES] -= burned_fuel
@@ -314,7 +314,7 @@
 	var/temperature = air.temperature
 
 	var/burned_fuel = min(cached_gases[/datum/gas/tritium][MOLES] / FIRE_TRITIUM_BURN_RATE_DELTA, cached_gases[/datum/gas/oxygen][MOLES] / (FIRE_TRITIUM_BURN_RATE_DELTA * TRITIUM_OXYGEN_FULLBURN), cached_gases[/datum/gas/tritium][MOLES], cached_gases[/datum/gas/oxygen][MOLES] * INVERSE(0.5))
-	if(burned_fuel <= 0 || (cached_gases[/datum/gas/tritium][MOLES] - burned_fuel < 0) || (cached_gases[/datum/gas/oxygen][MOLES] - burned_fuel * 0.5 < 0)) //Shouldn't produce gas from nothing.
+	if(burned_fuel <= 0 || cached_gases[/datum/gas/tritium][MOLES] - burned_fuel < 0 || cached_gases[/datum/gas/oxygen][MOLES] - burned_fuel * 0.5 < 0) //Shouldn't produce gas from nothing.
 		return NO_REACTION
 
 	cached_gases[/datum/gas/tritium][MOLES] -= burned_fuel

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -259,27 +259,18 @@
 	var/old_heat_capacity = air.heat_capacity()
 	var/temperature = air.temperature
 
-	var/burned_fuel
-	var/fire_scale
-	if(cached_gases[/datum/gas/oxygen][MOLES] < cached_gases[/datum/gas/hydrogen][MOLES] || MINIMUM_HYDROGEN_OXYBURN_ENERGY > (temperature * old_heat_capacity))
-		burned_fuel = cached_gases[/datum/gas/oxygen][MOLES] / HYDROGEN_BURN_OXY_FACTOR // const must be at least one
-		fire_scale = 1
+	var/burned_fuel = min(cached_gases[/datum/gas/hydrogen][MOLES] / FIRE_HYDROGEN_BURN_RATE_DELTA, cached_gases[/datum/gas/oxygen][MOLES] / (FIRE_HYDROGEN_BURN_RATE_DELTA * HYDROGEN_OXYGEN_FULLBURN), cached_gases[/datum/gas/hydrogen][MOLES], cached_gases[/datum/gas/oxygen][MOLES] * INVERSE(0.5))
+	if(burned_fuel <= 0 || (cached_gases[/datum/gas/hydrogen][MOLES] - burned_fuel < 0) || (cached_gases[/datum/gas/oxygen][MOLES] - burned_fuel * 0.5 < 0)) //Shouldn't produce gas from nothing.
+		return NO_REACTION
 
-		cached_gases[/datum/gas/hydrogen][MOLES] -= burned_fuel
-		ASSERT_GAS(/datum/gas/water_vapor, air)
-		cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel / HYDROGEN_BURN_OXY_FACTOR
-	else
-		burned_fuel = cached_gases[/datum/gas/hydrogen][MOLES]
-		fire_scale = HYDROGEN_OXYBURN_MULTIPLIER
+	cached_gases[/datum/gas/hydrogen][MOLES] -= burned_fuel
+	cached_gases[/datum/gas/oxygen][MOLES] -= burned_fuel * 0.5
+	ASSERT_GAS(/datum/gas/water_vapor, air)
+	cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel
 
-		cached_gases[/datum/gas/hydrogen][MOLES] -= burned_fuel / HYDROGEN_BURN_H2_FACTOR
-		cached_gases[/datum/gas/oxygen][MOLES] -= burned_fuel
-		ASSERT_GAS(/datum/gas/water_vapor, air)
-		cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel / HYDROGEN_BURN_H2_FACTOR
+	SET_REACTION_RESULTS(burned_fuel)
 
-	SET_REACTION_RESULTS(burned_fuel * fire_scale) // This is actually a lie. We use 10x less moles here but make 10x more energy.
-
-	var/energy_released = FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel * fire_scale
+	var/energy_released = FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
@@ -322,26 +313,16 @@
 	var/old_heat_capacity = air.heat_capacity()
 	var/temperature = air.temperature
 
-	var/burned_fuel
-	var/effect_scale
-	if(cached_gases[/datum/gas/oxygen][MOLES] < cached_gases[/datum/gas/tritium][MOLES] || MINIMUM_TRITIUM_OXYBURN_ENERGY > (temperature * old_heat_capacity))
-		burned_fuel = cached_gases[/datum/gas/oxygen][MOLES] / TRITIUM_BURN_OXY_FACTOR // const must be at least one
-		effect_scale = 1
+	var/burned_fuel = min(cached_gases[/datum/gas/tritium][MOLES] / FIRE_TRITIUM_BURN_RATE_DELTA, cached_gases[/datum/gas/oxygen][MOLES] / (FIRE_TRITIUM_BURN_RATE_DELTA * TRITIUM_OXYGEN_FULLBURN), cached_gases[/datum/gas/tritium][MOLES], cached_gases[/datum/gas/oxygen][MOLES] * INVERSE(0.5))
+	if(burned_fuel <= 0 || (cached_gases[/datum/gas/tritium][MOLES] - burned_fuel < 0) || (cached_gases[/datum/gas/oxygen][MOLES] - burned_fuel * 0.5 < 0)) //Shouldn't produce gas from nothing.
+		return NO_REACTION
 
-		cached_gases[/datum/gas/tritium][MOLES] -= burned_fuel
-		ASSERT_GAS(/datum/gas/water_vapor, air)
-		cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel / TRITIUM_BURN_OXY_FACTOR
-	else
-		burned_fuel = cached_gases[/datum/gas/tritium][MOLES]
-		effect_scale = TRITIUM_OXYBURN_MULTIPLIER
+	cached_gases[/datum/gas/tritium][MOLES] -= burned_fuel
+	cached_gases[/datum/gas/oxygen][MOLES] -= burned_fuel * 0.5
+	ASSERT_GAS(/datum/gas/water_vapor, air)
+	cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel
 
-		cached_gases[/datum/gas/tritium][MOLES] -= burned_fuel / TRITIUM_BURN_TRIT_FACTOR
-		cached_gases[/datum/gas/oxygen][MOLES] -= burned_fuel
-		ASSERT_GAS(/datum/gas/water_vapor, air)
-		cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel / TRITIUM_BURN_TRIT_FACTOR
-
-
-	SET_REACTION_RESULTS(burned_fuel * effect_scale)
+	SET_REACTION_RESULTS(burned_fuel)
 
 	var/turf/open/location
 	if(istype(holder, /datum/pipeline)) //Find the tile the reaction is occuring on, or a random part of the network if it's a pipenet.
@@ -350,9 +331,9 @@
 	else if(isatom(holder))
 		location = holder
 
-	var/energy_released = FIRE_TRITIUM_ENERGY_RELEASED * burned_fuel * effect_scale
+	var/energy_released = FIRE_TRITIUM_ENERGY_RELEASED * burned_fuel
 	if(location && burned_fuel > TRITIUM_RADIATION_MINIMUM_MOLES && energy_released > TRITIUM_RADIATION_RELEASE_THRESHOLD * (air.volume / CELL_VOLUME) ** ATMOS_RADIATION_VOLUME_EXP && prob(10))
-		radiation_pulse(location, max_range = min(sqrt(burned_fuel * effect_scale / TRITIUM_OXYBURN_MULTIPLIER) / TRITIUM_RADIATION_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = TRITIUM_RADIATION_THRESHOLD_BASE * INVERSE(TRITIUM_RADIATION_THRESHOLD_BASE + (burned_fuel * effect_scale / TRITIUM_OXYBURN_MULTIPLIER)))
+		radiation_pulse(location, max_range = min(sqrt(burned_fuel) / TRITIUM_RADIATION_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = TRITIUM_RADIATION_THRESHOLD_BASE * INVERSE(TRITIUM_RADIATION_THRESHOLD_BASE + burned_fuel))
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes hydrogen and tritium combustion gas reactions. Hydrogen/tritium will get consumed at 1 times the burn rate, while oxygen gets consumed at 0.5 times the burn rate, to produce 1 mol of water vapour per burn rate. Significantly changes how the reaction efficiency works. Instead of being an if check on whether there is more oxygen than hydrogen/tritium, then switching between high energy or low energy burn modes, the burn efficiency will instead just be the minimum of half the hydrogen/tritium and 1/20th of the oxygen. The reaction will burn incredibly fast and can end quickly if there is enough oxygen. The energy release of the reactions have been reduced by 90%, which makes them slightly less effective than plasma in total energy gain, but due to their reaction speed, can still be more dangerous and effective for bombs.

As a consequence for the reaction speed, you will collect less tritium when making it as more of the tritium gets consumed before getting scrubbed. The optimal bomb mix has also been changed due to the reaction changes. Generally around 12.85% tritium/hydrogen in a tritium/hydrogen + oxygen mix will give you the best results, filling the tritium or hydrogen to 325.5kPa and oxygen max pressure with portable pump. This does not account of the hot plasma you put in which might change it slightly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixing the stoichiometry of hydrogen and tritium combustion means there won't be weird gas duplication and deletion when you combust then electrolyse them, and will make power balance easier. The weird binary high energy low energy burn modes are a relic of the ancient past, are confusing to understand and is just generally overcomplicated, and doesn't even achieve its job of preventing singlecaps (it actually allows classic singlecaps to be timed). The new combustion formula is much more intuitive to understand, and combined with the lower energy release, changes its purpose in combustion to be a fast reaction that releases energy quickly, rather than just being a better plasma with a weird if check.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Changes hydrogen and tritium gas reaction stoichiometry. 1 mol of hydrogen/tritium and 0.5 mols of oxygen getting consumed will produce 1 mol of water vapour.
balance: Hydrogen and tritium burn rate has been changed to be the minimum of half the hydrogen/tritium, or 1/20th of the oxygen, rather than a binary if check on whether there is more oxygen or not.
balance: Hydrogen and tritium energy release has been reduced by 90%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
