### PR TITLE
Allows the mass downloading of server logs

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -19,6 +19,7 @@ GLOBAL_VAR_INIT(fileaccess_timer, 0)
 		var/list/choices = flist(path)
 		if(path != root)
 			choices.Insert(1,"/")
+			choices.Insert(length(choices) + 1, "_Download Folder")
 
 		var/choice = input(src,"Choose a file to access:","Download",null) as null|anything in sort_list(choices)
 		switch(choice)
@@ -27,6 +28,14 @@ GLOBAL_VAR_INIT(fileaccess_timer, 0)
 			if("/")
 				path = root
 				continue
+			if("_Download Folder") //Underscore is intended so it always appears at the bottom
+				var/list/comp_flist = flist(path)
+				var/confirmation = input(src, "Are you SURE you want to download all the files in this folder? (This will open [length(comp_flist)] prompt[length(comp_flist) == 1 ? "" : "s"])", "Confirmation") in list("Yes", "No")
+				if(confirmation != "Yes")
+					continue
+				for(var/file in comp_flist)
+					src << ftp(path + file)
+				return
 		path += choice
 
 		if(copytext_char(path, -1) != "/") //didn't choose a directory, no need to iterate again

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -19,16 +19,17 @@ GLOBAL_VAR_INIT(fileaccess_timer, 0)
 		var/list/choices = flist(path)
 		if(path != root)
 			choices.Insert(1,"/")
-		choices.Insert(length(choices) + 1, "_Download Folder")
+		var/list/sorted_choices = sort_list(choices)
+		choices.Insert(length(choices) + 1, "Download Folder")
 
-		var/choice = input(src,"Choose a file to access:","Download",null) as null|anything in sort_list(choices)
+		var/choice = input(src,"Choose a file to access:","Download",null) as null|anything in sorted_choices
 		switch(choice)
 			if(null)
 				return
 			if("/")
 				path = root
 				continue
-			if("_Download Folder") //Underscore is intended so it always appears at the bottom
+			if("Download Folder")
 				var/list/comp_flist = flist(path)
 				var/confirmation = input(src, "Are you SURE you want to download all the files in this folder? (This will open [length(comp_flist)] prompt[length(comp_flist) == 1 ? "" : "s"])", "Confirmation") in list("Yes", "No")
 				if(confirmation != "Yes")

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -19,7 +19,7 @@ GLOBAL_VAR_INIT(fileaccess_timer, 0)
 		var/list/choices = flist(path)
 		if(path != root)
 			choices.Insert(1,"/")
-			choices.Insert(length(choices) + 1, "_Download Folder")
+		choices.Insert(length(choices) + 1, "_Download Folder")
 
 		var/choice = input(src,"Choose a file to access:","Download",null) as null|anything in sort_list(choices)
 		switch(choice)

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -19,10 +19,9 @@ GLOBAL_VAR_INIT(fileaccess_timer, 0)
 		var/list/choices = flist(path)
 		if(path != root)
 			choices.Insert(1,"/")
-		var/list/sorted_choices = sort_list(choices)
-		choices.Insert(length(choices) + 1, "Download Folder")
+		choices = sort_list(choices) + "Download Folder"
 
-		var/choice = input(src,"Choose a file to access:","Download",null) as null|anything in sorted_choices
+		var/choice = input(src,"Choose a file to access:","Download",null) as null|anything in choices
 		switch(choice)
 			if(null)
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Using the get-current-logs and get-server-logs verbs, you can now download the entire current directory you're in.

## Why It's Good For The Game
Good for saving time so you don't have to click through a dozen+ files to download them all, or bug someone with box access to do it for you

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Get-Current-Logs and Get-Server-Logs now let you download entire folders at once
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
