### PR TITLE
Gives tacticool turtlenecks and skirtlenecks suit sensors

### DIFF
--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -42,6 +42,7 @@
 	desc = "Just looking at it makes you want to buy an SKS, go into the woods, and -operate-."
 	icon_state = "tactifool"
 	inhand_icon_state = "bl_suit"
+	has_sensor = HAS_SENSORS
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 50, ACID = 40)
 
 /obj/item/clothing/under/syndicate/tacticool/skirt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All this PR does is allow tacticool turtlenecks and skirtlenecks to use suit sensors. That's it. It doesn't touch any other syndicate clothing. Not even the pajamas, since I think it's a fair argument that nukies who purchase those in the uplink might forget and lose because of it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The tacticool turtleneck and skirtleneck are station-based clothing. They aren't armored, they come from a plain old hacked ClothesMate, and they look great (thanks spriters!). People, myself included, love wearing them. Medical players, myself included, don't enjoy forcing people to choose between style or being found when they die in maintenance. This is just a little QOL for the players.... myself included. Antagonists don't have any special means of obtaining these pieces, and if you CHOOSE to wear it, you can make sure your sensors are disabled if it matters that much to you. I won't hear any """lore""" arguments about the Syndicate not knowing how to make NT sensors or the replica not using sensors to stay true to Syndicate guidelines because the chameleon jumpsuit HAS sensors already.

Although it is a very small change, I DID test it to make sure only the intended jumpsuits were affected.
![image](https://user-images.githubusercontent.com/44104681/177680547-1c87622e-04de-44fe-8011-803e84a3784b.png)
![image](https://user-images.githubusercontent.com/44104681/177680588-931f3624-6397-42e6-be22-f203ea01750f.png)
![image](https://user-images.githubusercontent.com/44104681/177680651-9582ed17-8a33-4d09-94dd-713775c278a0.png)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Vladoricious
qol: Tacticool turtlenecks and skirtlenecks now have suit sensors installed! No more excuses. Turn em up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
