### PR TITLE
Removes the 10 second hardstun from Xeno Queen neurotoxin because it's not 2012 anymore and we don't do ranged one hit instant hard stuns anymore.

### DIFF
--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -4,7 +4,6 @@
 	damage = 5
 	damage_type = TOX
 	nodamage = FALSE
-	paralyze = 100
 	armor_flag = BIO
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/neurotoxin
 
@@ -12,4 +11,6 @@
 	if(isalien(target))
 		paralyze = 0
 		nodamage = TRUE
+	else
+		target.acid_act(200, 1000)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Removes the 10 second hardstun from Xeno Queen neurotoxin because it's not 2012 anymore and we don't do one hit instant hard stuns anymore. 
Neurotoxin spit is no longer a 10 second hardstun.
Neurotoxin spit is now a ranged acid application method.

## Why It's Good For The Game

Fuck one hit ranged hardstuns. It's not 2012 anymore. Xeno queens should not be able to solo the crew in one on one combat and you're supposed to operate with backup from your hive.

## Changelog
:cl:
qol: Neurotoxin spit is no longer a 10 second hardstun.
balance: Neurotoxin spit is now a ranged acid application method.
/:cl: