### PR TITLE
Fixes xenomorph corrosive acid being able to be used on mobs

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -82,7 +82,7 @@
 ///The limb is snouted
 #define BODYTYPE_SNOUTED (1<<5)
 
-//Defines for Species IDs
+// Defines for Species IDs. Used to refer to the name of a species, for things like bodypart names or species preferences.
 #define SPECIES_ABDUCTOR "abductor"
 #define SPECIES_ANDROID "android"
 #define SPECIES_DULLAHAN "dullahan"
@@ -110,6 +110,11 @@
 #define SPECIES_ZOMBIE "zombie"
 #define SPECIES_ZOMBIE_INFECTIOUS "memezombie"
 #define SPECIES_ZOMBIE_KROKODIL "krokodil_zombie"
+
+// Like species IDs, but not specifically attached a species.
+#define BODYPART_TYPE_ALIEN "alien"
+#define BODYPART_TYPE_ROBOTIC "robotic"
+#define BODYPART_TYPE_DIGITIGRADE "digitigrade"
 
 //See: datum/species/var/digitigrade_customization
 ///The species does not have digitigrade legs in generation.

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -110,7 +110,6 @@
 #define SPECIES_ZOMBIE "zombie"
 #define SPECIES_ZOMBIE_INFECTIOUS "memezombie"
 #define SPECIES_ZOMBIE_KROKODIL "krokodil_zombie"
-#define SPECIES_ALIEN "alien"
 
 //See: datum/species/var/digitigrade_customization
 ///The species does not have digitigrade legs in generation.

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -110,6 +110,7 @@
 #define SPECIES_ZOMBIE "zombie"
 #define SPECIES_ZOMBIE_INFECTIOUS "memezombie"
 #define SPECIES_ZOMBIE_KROKODIL "krokodil_zombie"
+#define SPECIES_ALIEN "alien"
 
 //See: datum/species/var/digitigrade_customization
 ///The species does not have digitigrade legs in generation.

--- a/code/modules/antagonists/nightmare/nightmare_species.dm
+++ b/code/modules/antagonists/nightmare/nightmare_species.dm
@@ -4,7 +4,7 @@
 /datum/species/shadow/nightmare
 	name = "Nightmare"
 	id = SPECIES_NIGHTMARE
-	examine_limb_id = "shadow"
+	examine_limb_id = SPECIES_SHADOW
 	burnmod = 1.5
 	no_equip = list(ITEM_SLOT_MASK, ITEM_SLOT_OCLOTHING, ITEM_SLOT_GLOVES, ITEM_SLOT_FEET, ITEM_SLOT_ICLOTHING, ITEM_SLOT_SUITSTORE)
 	species_traits = list(NOBLOOD,NO_UNDERWEAR,NO_DNA_COPY,NOTRANSSTING,NOEYESPRITES)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -218,6 +218,9 @@ Doesn't work on other aliens/AI.*/
 /datum/action/cooldown/alien/acid/corrosion/PreActivate(atom/target)
 	if(get_dist(owner, target) > 1)
 		return FALSE
+	if(ismob(target)) //If it could corrode mobs, it would one-shot them.
+		owner.balloon_alert(owner, "does not work on mobs!")
+		return FALSE
 
 	return ..()
 

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -219,7 +219,7 @@ Doesn't work on other aliens/AI.*/
 	if(get_dist(owner, target) > 1)
 		return FALSE
 	if(ismob(target)) //If it could corrode mobs, it would one-shot them.
-		owner.balloon_alert(owner, "does not work on mobs!")
+		owner.balloon_alert(owner, "doesn't work on mobs!")
 		return FALSE
 
 	return ..()

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -48,7 +48,7 @@
 /obj/item/bodypart/chest/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_chest"
-	limb_id = SPECIES_ALIEN
+	limb_id = "alien"
 	dismemberable = 0
 	max_damage = 500
 	animal_origin = ALIEN_BODYPART
@@ -155,7 +155,7 @@
 /obj/item/bodypart/l_arm/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_l_arm"
-	limb_id = SPECIES_ALIEN
+	limb_id = "alien"
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE
@@ -255,7 +255,7 @@
 /obj/item/bodypart/r_arm/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_r_arm"
-	limb_id = SPECIES_ALIEN
+	limb_id = "alien"
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE
@@ -345,7 +345,7 @@
 /obj/item/bodypart/l_leg/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_l_leg"
-	limb_id = SPECIES_ALIEN
+	limb_id = "alien"
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE
@@ -443,7 +443,7 @@
 /obj/item/bodypart/r_leg/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_r_leg"
-	limb_id = SPECIES_ALIEN
+	limb_id = "alien"
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -48,6 +48,7 @@
 /obj/item/bodypart/chest/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_chest"
+	limb_id = SPECIES_ALIEN
 	dismemberable = 0
 	max_damage = 500
 	animal_origin = ALIEN_BODYPART
@@ -154,6 +155,7 @@
 /obj/item/bodypart/l_arm/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_l_arm"
+	limb_id = SPECIES_ALIEN
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE
@@ -253,6 +255,7 @@
 /obj/item/bodypart/r_arm/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_r_arm"
+	limb_id = SPECIES_ALIEN
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE
@@ -342,6 +345,7 @@
 /obj/item/bodypart/l_leg/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_l_leg"
+	limb_id = SPECIES_ALIEN
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE
@@ -439,6 +443,7 @@
 /obj/item/bodypart/r_leg/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_r_leg"
+	limb_id = SPECIES_ALIEN
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -48,7 +48,7 @@
 /obj/item/bodypart/chest/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_chest"
-	limb_id = "alien"
+	limb_id = BODYPART_TYPE_ALIEN
 	dismemberable = 0
 	max_damage = 500
 	animal_origin = ALIEN_BODYPART
@@ -155,7 +155,7 @@
 /obj/item/bodypart/l_arm/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_l_arm"
-	limb_id = "alien"
+	limb_id = BODYPART_TYPE_ALIEN
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE
@@ -251,11 +251,11 @@
 	wound_resistance = -10
 	px_x = 5
 	px_y = -3
-	
+
 /obj/item/bodypart/r_arm/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_r_arm"
-	limb_id = "alien"
+	limb_id = BODYPART_TYPE_ALIEN
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE
@@ -345,7 +345,7 @@
 /obj/item/bodypart/l_leg/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_l_leg"
-	limb_id = "alien"
+	limb_id = BODYPART_TYPE_ALIEN
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE
@@ -443,7 +443,7 @@
 /obj/item/bodypart/r_leg/alien
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_r_leg"
-	limb_id = "alien"
+	limb_id = BODYPART_TYPE_ALIEN
 	px_x = 0
 	px_y = 0
 	dismemberable = FALSE

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -13,7 +13,7 @@
 /obj/item/bodypart/l_arm/robot
 	name = "cyborg left arm"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
-	limb_id = "robotic"
+	limb_id = BODYPART_TYPE_ROBOTIC
 	attack_verb_simple = list("slapped", "punched")
 	inhand_icon_state = "buildpipe"
 	icon = 'icons/mob/augmentation/augments.dmi'
@@ -43,7 +43,7 @@
 	inhand_icon_state = "buildpipe"
 	icon_static = 'icons/mob/augmentation/augments.dmi'
 	icon = 'icons/mob/augmentation/augments.dmi'
-	limb_id = "robotic"
+	limb_id = BODYPART_TYPE_ROBOTIC
 	flags_1 = CONDUCT_1
 	icon_state = "borg_r_arm"
 	is_dimorphic = FALSE
@@ -69,7 +69,7 @@
 	inhand_icon_state = "buildpipe"
 	icon_static = 'icons/mob/augmentation/augments.dmi'
 	icon = 'icons/mob/augmentation/augments.dmi'
-	limb_id = "robotic"
+	limb_id = BODYPART_TYPE_ROBOTIC
 	flags_1 = CONDUCT_1
 	icon_state = "borg_l_leg"
 	is_dimorphic = FALSE
@@ -95,7 +95,7 @@
 	inhand_icon_state = "buildpipe"
 	icon_static =  'icons/mob/augmentation/augments.dmi'
 	icon = 'icons/mob/augmentation/augments.dmi'
-	limb_id = "robotic"
+	limb_id = BODYPART_TYPE_ROBOTIC
 	flags_1 = CONDUCT_1
 	icon_state = "borg_r_leg"
 	is_dimorphic = FALSE
@@ -120,7 +120,7 @@
 	inhand_icon_state = "buildpipe"
 	icon_static =  'icons/mob/augmentation/augments.dmi'
 	icon = 'icons/mob/augmentation/augments.dmi'
-	limb_id = "robotic"
+	limb_id = BODYPART_TYPE_ROBOTIC
 	flags_1 = CONDUCT_1
 	icon_state = "borg_chest"
 	is_dimorphic = FALSE
@@ -228,7 +228,7 @@
 	inhand_icon_state = "buildpipe"
 	icon_static = 'icons/mob/augmentation/augments.dmi'
 	icon = 'icons/mob/augmentation/augments.dmi'
-	limb_id = "robotic"
+	limb_id = BODYPART_TYPE_ROBOTIC
 	flags_1 = CONDUCT_1
 	icon_state = "borg_head"
 	is_dimorphic = FALSE

--- a/code/modules/surgery/bodyparts/species_parts/lizard_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/lizard_bodyparts.dm
@@ -33,7 +33,7 @@
 /obj/item/bodypart/l_leg/digitigrade
 	icon_greyscale = 'icons/mob/species/lizard/bodyparts.dmi'
 	uses_mutcolor = TRUE
-	limb_id = "digitigrade"
+	limb_id = BODYPART_TYPE_DIGITIGRADE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
 
 /obj/item/bodypart/l_leg/digitigrade/update_limb(dropping_limb = FALSE, is_creating = FALSE)
@@ -52,15 +52,15 @@
 			shoes_compatible = TRUE
 
 		if((uniform_compatible && suit_compatible && shoes_compatible) || (suit_compatible && shoes_compatible && human_owner.wear_suit?.flags_inv & HIDEJUMPSUIT)) //If the uniform is hidden, it doesnt matter if its compatible
-			limb_id = "digitigrade"
+			limb_id = BODYPART_TYPE_DIGITIGRADE
 
 		else
-			limb_id = "lizard"
+			limb_id = SPECIES_LIZARD
 
 /obj/item/bodypart/r_leg/digitigrade
 	icon_greyscale = 'icons/mob/species/lizard/bodyparts.dmi'
 	uses_mutcolor = TRUE
-	limb_id = "digitigrade"
+	limb_id = BODYPART_TYPE_DIGITIGRADE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
 
 /obj/item/bodypart/r_leg/digitigrade/update_limb(dropping_limb = FALSE, is_creating = FALSE)
@@ -79,7 +79,7 @@
 			shoes_compatible = TRUE
 
 		if((uniform_compatible && suit_compatible && shoes_compatible) || (suit_compatible && shoes_compatible && human_owner.wear_suit?.flags_inv & HIDEJUMPSUIT)) //If the uniform is hidden, it doesnt matter if its compatible
-			limb_id = "digitigrade"
+			limb_id = BODYPART_TYPE_DIGITIGRADE
 
 		else
-			limb_id = "lizard"
+			limb_id = SPECIES_LIZARD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #67968. Somewhere along the line the check for corrosive acid not nuking mobs got forgotten, so that re-implements it, while adding feedback. 

Also, fixes #68064. The define used for species limb examine text wasn't put in for xenomorphs. I put that in, making it so when you examine it, it no longer reads as a human limb.

## Why It's Good For The Game

Xenos being able to two-shot mobs and one-shot borgs is pretty bad, as well as unintended. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: xenomorph corrosive acid will once again not target mobs
fix: xenomorph limbs will no longer be examined as human limbs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
