### PR TITLE
Temperature pumps can now transfer heat against the gradient. Changes thermomachine power consumption to be perfectly linear when it doesn't reach the exponential threshold. Adds define for heat power conversion.

### DIFF
--- a/code/__DEFINES/power.dm
+++ b/code/__DEFINES/power.dm
@@ -12,6 +12,8 @@
 #define WATTS / 0.002
 ///conversion ratio from watts to joules
 #define JOULES * 0.002
+///Minimum power needed for 1 joule of thermal energy.
+#define HEAT_POWER_CONVERSION 0.0001
 
 GLOBAL_VAR_INIT(CHARGELEVEL, 0.001) // Cap for how fast cells charge, as a percentage-per-tick (.001 means cellcharge is capped to 1% per second)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -150,8 +150,10 @@
 
 	port.temperature = max(((port.temperature * port_capacity) + heat_amount) / port_capacity, TCMB)
 
+	heat_amount = abs(heat_amount) * HEAT_POWER_CONVERSION
+
 	// This produces a nice curve that scales decently well for really hot stuff, and is nice to not fusion. It'll do
-	var/power_usage = idle_power_usage + abs(heat_amount) * HEAT_POWER_CONVERSION
+	var/power_usage = idle_power_usage + heat_amount ** (1.16 - (5e5 * 0.16 / max(heat_amount, 5e5)))
 
 	use_power(power_usage)
 	update_parents()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -1,5 +1,3 @@
-#define THERMOMACHINE_POWER_CONVERSION 0.01
-
 /obj/machinery/atmospherics/components/unary/thermomachine
 	icon = 'icons/obj/atmospherics/components/thermomachine.dmi'
 	icon_state = "thermo_base"
@@ -152,10 +150,8 @@
 
 	port.temperature = max(((port.temperature * port_capacity) + heat_amount) / port_capacity, TCMB)
 
-	heat_amount = min(abs(heat_amount), 1e8) * THERMOMACHINE_POWER_CONVERSION
-
 	// This produces a nice curve that scales decently well for really hot stuff, and is nice to not fusion. It'll do
-	var/power_usage = idle_power_usage + (heat_amount * 0.05) ** (1.05 - (5e7 * 0.16 / max(heat_amount, 5e7)))
+	var/power_usage = idle_power_usage + abs(heat_amount) * HEAT_POWER_CONVERSION
 
 	use_power(power_usage)
 	update_parents()
@@ -311,5 +307,3 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on
 	on = TRUE
 	icon_state = "thermo_base_1"
-
-#undef THERMOMACHINE_POWER_CONVERSION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Temperature pumps can now transfer heat against the gradient. When on, it will equalize the temperature, then transfer heat as if the input node is transferring heat with something colder than it is. Thermomachine power consumption is now linear if it doesn't reach the exponential power consumption threshold. Removes thermomachine power conversion define, and instead make a heat power conversion define.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The operation of the temperature pump was too similar to the heat exchangers. This change will allow more different ways for people to interact with heat. Thermomachine power consumption having diminishing returns when it didn't reach exponential power consumption threshold was weird.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Temperature pumps can now pump heat.
balance: Thermomachine power consumption has been changed so it is a linear function when it doesn't reach the exponential power consumption threshold. It will consume 0.0001 joules of power per joule of heat changed, if the heat exchanged doesn't surpass 5GJ.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
