### PR TITLE
Change Insuls inhand sprite from "kingyellow" to "insuls"

### DIFF
--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_INIT(biblenames, list("Bible", "Quran", "Scrapbook", "Burning Bible"
 //If you get these two lists not matching in size, there will be runtimes and I will hurt you in ways you couldn't even begin to imagine
 // if your bible has no custom itemstate, use one of the existing ones
 GLOBAL_LIST_INIT(biblestates, list("bible", "koran", "scrapbook", "burning", "honk1", "honk2", "creeper", "white", "holylight", "atheist", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon", "insuls", "gurugranthsahib"))
-GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning", "honk1", "honk2", "creeper", "white", "holylight", "atheist", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon", "kingyellow", "gurugranthsahib"))
+GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning", "honk1", "honk2", "creeper", "white", "holylight", "atheist", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon", "insuls", "gurugranthsahib"))
 
 /mob/proc/bible_check() //The bible, if held, might protect against certain things
 	var/obj/item/storage/book/bible/B = locate() in src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In bible definitions, there are two lists of sprites corresponding to custom sprites for holy books. The first (the global list `biblestates`) defines their primary icon, the second (the global list `bibleitemstates`) their in-hand sprite. A number of them don't have in-hand sprites of their own, but their in-hand sprite is still set to the same name as their primary sprite, likely in the hopes that someday they _will_ have unique in-hand sprites.

Except for Insuls. For some reason, the in-hand sprite for Insuls uses the King In Yellow in-hand sprite.

I've changed it so it uses its own name, "insuls", to match all the other holy books without custom in-hand sprites. As a side effect, this means it currently will be invisible when held in your hand, but so do half the other custom holy books.

## Why It's Good For The Game

It really doesn't make much of a difference, but the inconsistency in the code bothered me, and probably would have confused anyone who tried to add an in-hand sprite for Insuls in the future. 

If this truly was intentional and the King In Yellow in-hand sprite was intended to be used as a placeholder for the Insuls in-hand sprite, then... it should probably be using a more generic in-hand sprite, and more of the other holy books should also use that same sprite. I work on a downstream branch where we've changed the default "bible" to a more generic "holy book" with a nondescript circle on the cover (while keeping the Bible itself as a choosable option)  -- the sprite for that would work well as a placeholder for this sort of thing. 

It's a bit weird for a single random holy book to be using a single random in-hand sprite from a different one, which is what makes me suspect this was unintentional.

## Changelog

:cl:
fix: fixed the "Insuls" holy book incorrectly using the in-hand sprite of the "King In Yellow" holy book. Now it has no in-hand sprite at all, which is much better.
/:cl:
