### PR TITLE
Corrects a smart pipe improperly connecting on Tramstation.

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2654,12 +2654,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bgD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bhk" = (
@@ -6252,7 +6250,7 @@
 /area/station/science/lab)
 "clp" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/airalarm/mixingchamber{
 	dir = 1;
@@ -9059,9 +9057,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "dim" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
@@ -18593,13 +18588,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"gyY" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/red,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance)
 "gzi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -22427,9 +22415,10 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "hUx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "hUK" = (
@@ -36482,7 +36471,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_freezer_chamber_input,
+/obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/iron/dark/airless,
 /area/station/science/ordnance/freezerchamber)
 "mDT" = (
@@ -61353,7 +61342,7 @@
 /area/station/engineering/main)
 "viZ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber,
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_freezer_chamber_input,
 /turf/open/floor/iron/dark/airless,
 /area/station/science/ordnance/freezerchamber)
 "vjb" = (
@@ -67801,7 +67790,9 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/storage)
 "xwU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
+	dir = 4
+	},
 /obj/machinery/meter,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
@@ -116976,7 +116967,7 @@ oys
 oyF
 qKF
 oyF
-gyY
+bzE
 uay
 jqE
 oXh


### PR DESCRIPTION
## About The Pull Request

Moves the pipes around to prevent smart pipes from improperly connecting without having to change the colors.

## Why It's Good For The Game

Prevents toxins moments, should have the same effect without having to mess up the room aesthetic.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes the piping of the ORD lab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
