### PR TITLE
Fixes Tonic Water causing dizziness

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -677,7 +677,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/consumable/tonic/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjust_timed_status_effect(10 SECONDS * REM * delta_time, /datum/status_effect/dizziness)
+	M.adjust_timed_status_effect(-10 SECONDS * REM * delta_time, /datum/status_effect/dizziness)
 	M.adjust_drowsyness(-3 * REM * delta_time)
 	M.AdjustSleeping(-40 * REM * delta_time)
 	M.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * delta_time, M.get_body_temp_normal())


### PR DESCRIPTION
## About The Pull Request

Missed a negative when converting it to status effect. 

## Why It's Good For The Game

10 seconds of dizziness is kinda nuts, and also it's not supposed to give dizziness anyways.

## Changelog

:cl: Melbert
fix: Tonic Water heals dizziness instead of causing it
/:cl:
