### PR TITLE
fixes runtime in eyesnatcher objective

### DIFF
--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -75,7 +75,7 @@
 		if(!targets_current.getorgan(/obj/item/organ/internal/eyes))
 			continue
 
-		possible_targets += targets_current
+		possible_targets += possible_target
 
 	for(var/datum/traitor_objective/eyesnatching/objective as anything in possible_duplicates)
 		possible_targets -= objective.victim
@@ -92,8 +92,8 @@
 	if(!possible_targets.len)
 		return FALSE //MISSION FAILED, WE'LL GET EM NEXT TIME
 
-	victim = pick(possible_targets)
-	var/datum/mind/victim_mind = victim.mind
+	var/datum/mind/victim_mind = pick(possible_targets)
+	victim = victim_mind.current
 
 	replace_in_name("%TARGET%", victim_mind.name)
 	replace_in_name("%JOB TITLE%", victim_mind.assigned_role.title)

--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -78,7 +78,7 @@
 		possible_targets += possible_target
 
 	for(var/datum/traitor_objective/eyesnatching/objective as anything in possible_duplicates)
-		possible_targets -= objective.victim
+		possible_targets -= objective.victim?.mind
 
 	if(try_target_late_joiners)
 		var/list/all_possible_targets = possible_targets.Copy()


### PR DESCRIPTION
## About The Pull Request
closes:https://github.com/tgstation/tgstation/issues/68259
fixes the runtime error caused by eyesnatcher

## Why It's Good For The Game
Hopefully traitors can roll the eyesnatcher objective now


## Changelog
:cl:
fix: eyesnatcher objective wont cause runtime errors anymore
/:cl:
