### PR TITLE
Fixes Lawyer and Atmos techs being on the wrong trimmers.

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -125,7 +125,7 @@
 	template_access = list(
 		ACCESS_CAPTAIN,
 		ACCESS_CHANGE_IDS,
-		ACCESS_HOP,
+		ACCESS_CE,
 		)
 	job = /datum/job/atmospheric_technician
 
@@ -581,7 +581,6 @@
 		ACCESS_CAPTAIN,
 		ACCESS_CHANGE_IDS,
 		ACCESS_HOP,
-		ACCESS_HOS,
 		)
 	job = /datum/job/lawyer
 


### PR DESCRIPTION
## About The Pull Request

This changes two things:
- Makes Atmos tech trims get assigned by ACCESS_CE instead of ACCESS_HOP, allowing the Engineering PDA painter/trimmer assign Atmos techs.
- Removes the Lawyer from the HoS' PDA painter. I don't see why the HoS should be able to grant a service job, when they can't even give them access to their own office, since it's under Service.

## Why It's Good For The Game

Fixing inconsistencies and bugs. Half the Lawyer's job is to stand around and look good, which they can't do without access to their Lawyer clothes. Truly immersion-shattering.

## Changelog

:cl:
fix: The CE can now trim people's IDs to Atmospherics Technician
fix: The HoS can no longer trim people's IDs to Lawyers.
/:cl:
