### PR TITLE
[NO GBP] changes box storage limit to 2 instead of 4

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -36,6 +36,7 @@
 
 /obj/item/storage/box/Initialize(mapload)
 	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	update_appearance()
 
 /obj/item/storage/box/suicide_act(mob/living/carbon/user)
@@ -687,7 +688,7 @@
 /obj/item/storage/box/snappops/PopulateContents()
 	for(var/i in 1 to 8)
 		new /obj/item/toy/snappop(src)
-		
+
 /obj/item/storage/box/matches
 	name = "matchbox"
 	desc = "A small box of Almost But Not Quite Plasma Premium Matches."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

storage refactor caused boxes to have a specific storage size of WEIGHT_CLASS_NORMAL instead of WEIGHT_CLASS_SMALL

## Why It's Good For The Game

we cannot let the storagers win

## Changelog

:cl:
fix: boxes can no longer fit normal sized objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
