### PR TITLE
canister ui fix

### DIFF
--- a/tgui/packages/tgui/interfaces/Canister.js
+++ b/tgui/packages/tgui/interfaces/Canister.js
@@ -30,7 +30,7 @@ export const Canister = (props, context) => {
     restricted,
   } = data;
   return (
-    <Window width={350} height={275}>
+    <Window width={350} height={305}>
       <Window.Content>
         <Flex direction="column" height="100%">
           <Flex.Item mb={1}>


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
canister ui fix
befeore:
![before](https://user-images.githubusercontent.com/38228316/178144173-37b14c88-62a9-49a2-845a-739f90c43632.png)
after:
![after](https://user-images.githubusercontent.com/38228316/178144124-36ef7b7e-3ed9-40a1-a4a0-70c316e10acd.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You don't have to scroll/expand canister ui window to see kPa of an inserted tank

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed canister ui being too small
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
