### PR TITLE
Signal Commander automatically connects to the radio system

### DIFF
--- a/code/modules/modular_computers/file_system/programs/signalcommander.dm
+++ b/code/modules/modular_computers/file_system/programs/signalcommander.dm
@@ -15,6 +15,10 @@
 	/// Radio connection datum used by signalers.
 	var/datum/radio_frequency/radio_connection
 
+/datum/computer_file/program/signal_commander/New()
+	set_frequency(signal_frequency)
+	return ..()
+
 /datum/computer_file/program/signal_commander/ui_data(mob/user)
 	var/list/data = get_header_data()
 	data["frequency"] = signal_frequency


### PR DESCRIPTION

## About The Pull Request

The SignalCommander program only signs up to the radio subsystem when someone alters its frequency (or clicks into the field and clicks out), so if you want to alter the code, or want to use the default frequency, it will not send out a signal. This PR makes it connect to the radio network on creation.

## Why It's Good For The Game

Sometimes, people just want to use the default frequency, think the app is not working, and won't try to use it again. This makes it work by default.

## Changelog

:cl:
fix: signalCommander now works without altering the default frequency
/:cl:
