### PR TITLE
Removes temporary debugging code that can spam admin chat.

### DIFF
--- a/code/datums/storage/subtypes/extract_inventory.dm
+++ b/code/datums/storage/subtypes/extract_inventory.dm
@@ -25,7 +25,6 @@
 	if(!parentSlimeExtract)
 		return
 
-	message_admins(parentSlimeExtract.contents.len)
 	if(parentSlimeExtract.contents.len >= max_slots)
 		QDEL_LIST(parentSlimeExtract.contents)
 		createExtracts(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

An errant bit of debug code from #67478 was left in when it was merged that spams the admin chat logs when you feed cubes to reproductive extracts.

![image](https://user-images.githubusercontent.com/24975989/178150847-ee6cc411-eeac-4bdc-a945-03679ec5b689.png)

This removes the debug code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fewer tilted admins.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Admins will no longer get ADMIN LOG message spam when reproductive extracts are fed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
