### PR TITLE
[s] Patches potential runtimes in AdminPM

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -304,7 +304,11 @@
 				current_ticket.MessageNoRecipient(msg)
 
 	if(external)
-		log_admin_private("PM: Ticket #[current_ticket.id]: [key_name(src)]->External: [rawmsg]")
+		// Guard against the possibility of a null, since it'll runtime and spit out the contents of what should be a private ticket.
+		if(current_ticket)
+			log_admin_private("PM: Ticket #[current_ticket.id]: [key_name(src)]->External: [rawmsg]")
+		else
+			log_admin_private("PM: [key_name(src)]->External: [rawmsg]")
 		for(var/client/X in GLOB.admins)
 			to_chat(X,
 				type = MESSAGE_TYPE_ADMINPM,
@@ -312,7 +316,10 @@
 				confidential = TRUE)
 	else
 		window_flash(recipient, ignorepref = TRUE)
-		log_admin_private("PM: Ticket #[current_ticket.id]: [key_name(src)]->[key_name(recipient)]: [rawmsg]")
+		if(current_ticket)
+			log_admin_private("PM: Ticket #[current_ticket.id]: [key_name(src)]->[key_name(recipient)]: [rawmsg]")
+		else
+			log_admin_private("PM: [key_name(src)]->[key_name(recipient)]: [rawmsg]")
 		//we don't use message_admins here because the sender/receiver might get it too
 		for(var/client/X in GLOB.admins)
 			if(X.key!=key && X.key!=recipient.key) //check client/X is an admin and isn't the sender or recipient


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

6e29689e60c57c959e1b167a08ce6c1f0db4372e seemed to work alright on my end, but apparently there are cases where current_ticket.id = NULL. This would cause runtime trace errors that would start to list out the first few words of most adminhelps. Fuck.

You probably could use recipient.current_ticket.id on the "else" portion but I woke up to this and I'm not 100% certain if that will null out at this time. Might also be apt to revert #68215 entirely?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Those shouldn't show up in runtimes!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing particularly player facing.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
