### PR TITLE
Station Engineers now have Atmospherics access.

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -963,6 +963,7 @@
 	trim_state = "trim_stationengineer"
 	sechud_icon_state = SECHUD_STATION_ENGINEER
 	minimal_access = list(
+		ACCESS_ATMOSPHERICS
 		ACCESS_AUX_BASE,
 		ACCESS_CONSTRUCTION,
 		ACCESS_ENGINEERING,

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -963,7 +963,7 @@
 	trim_state = "trim_stationengineer"
 	sechud_icon_state = SECHUD_STATION_ENGINEER
 	minimal_access = list(
-		ACCESS_ATMOSPHERICS
+		ACCESS_ATMOSPHERICS,
 		ACCESS_AUX_BASE,
 		ACCESS_CONSTRUCTION,
 		ACCESS_ENGINEERING,


### PR DESCRIPTION
## About The Pull Request

Station Engineers now have Atmospherics access.

## Why It's Good For The Game

Station Engineers, almost every shift without fail, have to hack into Atmospherics and do the basic distro setup as detailed at https://tgstation13.org/wiki/Guide_to_Atmospherics#Setting_Up_Atmospherics otherwise they cannot fix breaches to a degree that the crew considers satisfactory.

Atmospherics Technicians do not fix breaches because they either do not exist or are too busy playing with the danger donut and will simply press the big red X if forced to do their job and help the crew and not mix fucking Anti-Nob or whatever.

As such, Station Engineers should have the access they need to fix the damn station effectively. Hacking open atmospherics to B&E so you can do your job down the line isn't fun for anyone, and it's especially not fun for the crew when the engineer doesn't know how to hack open atmospherics and thus can't fix breaches when they occur because nobody fucking set up atmos distro lines again for the 10th shift in a row.

## Changelog

:cl:
balance: Station Engineers now have Atmospherics access.
/:cl:
