### PR TITLE
Adds screentips to rolling beds and body bags.

### DIFF
--- a/code/datums/elements/screentips/contextual_screentip_sharpness.dm
+++ b/code/datums/elements/screentips/contextual_screentip_sharpness.dm
@@ -1,0 +1,57 @@
+/// Apply basic contextual screentips when the user hovers over this item with an item of the given tool behavior.
+/// A "Type B" interaction.
+/// This stacks with other contextual screentip elements, though you may want to register the signal/flag manually at that point for performance.
+/datum/element/contextual_screentip_sharpness
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	id_arg_index = 2
+
+	/// If set, the text to show for LMB
+	var/lmb_text
+
+	/// If set, the text to show for RMB
+	var/rmb_text
+
+/datum/element/contextual_screentip_sharpness/Attach(datum/target, lmb_text, rmb_text)
+	. = ..()
+	if (!isatom(target))
+		return ELEMENT_INCOMPATIBLE
+
+	src.lmb_text = lmb_text
+	src.rmb_text = rmb_text
+
+	var/atom/atom_target = target
+	atom_target.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
+	RegisterSignal(atom_target, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, .proc/on_requesting_context_from_item)
+
+/datum/element/contextual_screentip_sharpness/Detach(datum/source, ...)
+	UnregisterSignal(source, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM)
+
+	// We don't remove HAS_CONTEXTUAL_SCREENTIPS_1, since there could be other stuff still hooked to it,
+	// and being set without signals is not dangerous, just less performant.
+	// A lot of things don't do this, perhaps make a proc that checks if any signals are still set, and if not,
+	// remove the flag.
+
+	return ..()
+
+/datum/element/contextual_screentip_sharpness/proc/on_requesting_context_from_item(
+	datum/source,
+	list/context,
+	obj/item/held_item,
+)
+	SIGNAL_HANDLER
+
+	if (isnull(held_item))
+		return NONE
+
+	var/sharpness = held_item.get_sharpness()
+	if (!sharpness)
+		return NONE
+
+	if (!isnull(lmb_text))
+		context[SCREENTIP_CONTEXT_LMB] = lmb_text
+
+	if (!isnull(rmb_text))
+		context[SCREENTIP_CONTEXT_RMB] = rmb_text
+
+	return CONTEXTUAL_SCREENTIP_SET
+

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/bodybag.dmi'
 	icon_state = "bodybag_folded"
 	w_class = WEIGHT_CLASS_SMALL
+	///Stored path we use for spawning a new body bag entity when unfolded.
 	var/unfoldedbag_path = /obj/structure/closet/body_bag
 
 /obj/item/bodybag/attack_self(mob/user)
@@ -19,6 +20,11 @@
 		if(isopenturf(target))
 			deploy_bodybag(user, target)
 
+/**
+ * Creates a new body bag item when unfolded, at the provided location, replacing the body bag item.
+ * * mob/user: User opening the body bag.
+ * * atom/location: the place/entity/mob where the body bag is being deployed from.
+ */
 /obj/item/bodybag/proc/deploy_bodybag(mob/user, atom/location)
 	var/obj/structure/closet/body_bag/item_bag = new unfoldedbag_path(location)
 	item_bag.open(user)

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -57,8 +57,15 @@
 	icon_state = "down"
 	anchored = FALSE
 	resistance_flags = NONE
+	///The item it spawns when it's folded up.
 	var/foldabletype = /obj/item/roller
 
+/obj/structure/bed/roller/Initialize(mapload)
+	. = ..()
+	AddElement( \
+		/datum/element/contextual_screentip_bare_hands, \
+		rmb_text = "Fold up", \
+	)
 
 /obj/structure/bed/roller/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -34,6 +34,7 @@
 		/datum/element/contextual_screentip_bare_hands, \
 		rmb_text = "Fold up", \
 	)
+	AddElement(/datum/element/contextual_screentip_sharpness, lmb_text = "Remove Tag",)
 
 /obj/structure/closet/body_bag/Destroy()
 	// If we have a stored bag, and it's in nullspace (not in someone's hand), delete it.

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -34,7 +34,7 @@
 		/datum/element/contextual_screentip_bare_hands, \
 		rmb_text = "Fold up", \
 	)
-	AddElement(/datum/element/contextual_screentip_sharpness, lmb_text = "Remove Tag",)
+	AddElement(/datum/element/contextual_screentip_sharpness, lmb_text = "Remove Tag")
 
 /obj/structure/closet/body_bag/Destroy()
 	// If we have a stored bag, and it's in nullspace (not in someone's hand), delete it.

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -22,6 +22,19 @@
 	var/tagged = FALSE // so closet code knows to put the tag overlay back
 	can_install_electronics = FALSE
 
+/obj/structure/closet/body_bag/Initialize(mapload)
+	. = ..()
+	var/static/list/tool_behaviors = list(
+		TOOL_WIRECUTTER = list(
+			SCREENTIP_CONTEXT_RMB = "Remove Tag",
+		),
+	)
+	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+	AddElement( \
+		/datum/element/contextual_screentip_bare_hands, \
+		rmb_text = "Fold up", \
+	)
+
 /obj/structure/closet/body_bag/Destroy()
 	// If we have a stored bag, and it's in nullspace (not in someone's hand), delete it.
 	if (foldedbag_instance && !foldedbag_instance.loc)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1048,6 +1048,7 @@
 #include "code\datums\elements\food\venue_price.dm"
 #include "code\datums\elements\screentips\contextual_screentip_bare_hands.dm"
 #include "code\datums\elements\screentips\contextual_screentip_item_typechecks.dm"
+#include "code\datums\elements\screentips\contextual_screentip_sharpness.dm"
 #include "code\datums\elements\screentips\contextual_screentip_tools.dm"
 #include "code\datums\greyscale\_greyscale_config.dm"
 #include "code\datums\greyscale\json_reader.dm"


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/41715314/178161596-379c700c-b10b-45dc-af74-766e946e7a5a.png)
Adds contextual screentips to unfolded body bags and roller beds, to show players how to fold them up.

## Why It's Good For The Game

Easier readability on something that's had it's behavior changed for the first time in 10 years, and a headcoder wanted it so it seemed free.

Also autodoc'd some code since I was in the ballpark.

## Changelog

:cl:
qol: Roller Beds and Body Bags now have screentips explaining how to fold them up.
/:cl:

