### PR TITLE
Fixes attaching knife on cleanbot with NO_DROP

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -102,7 +102,7 @@
 		weapon_orig_force = weapon.force
 		if(!(bot_cover_flags & BOT_COVER_EMAGGED))
 			weapon.force = weapon.force / 2
-			add_overlay(image(icon=weapon.lefthand_file,icon_state=weapon.inhand_icon_state))
+		add_overlay(image(icon=weapon.lefthand_file,icon_state=weapon.inhand_icon_state))
 	else
 		to_chat(user, span_notice("You failed to attach \the [W] to \the [src]."))
 		return

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -97,13 +97,14 @@
 
 /mob/living/simple_animal/bot/cleanbot/proc/deputize(obj/item/W, mob/user)
 	if(in_range(src, user) && user.transferItemToLoc(W, src))
-		to_chat(user, span_notice("You attach \the [W] to \the [src]."))
+		balloon_alert(user, "attached!")
 		weapon = W
 		weapon_orig_force = weapon.force
 		if(!(bot_cover_flags & BOT_COVER_EMAGGED))
 			weapon.force = weapon.force / 2
 		add_overlay(image(icon=weapon.lefthand_file,icon_state=weapon.inhand_icon_state))
-	to_chat(user, span_notice("You fail to attach [W] to [src]."))
+		return TRUE
+	balloon_alert(user, "couldn't attach!")
 	return FALSE
 		
 /mob/living/simple_animal/bot/cleanbot/proc/update_titles()

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -96,17 +96,17 @@
 	bot_mode_flags = ~(BOT_MODE_ON | BOT_MODE_REMOTE_ENABLED)
 
 /mob/living/simple_animal/bot/cleanbot/proc/deputize(obj/item/W, mob/user)
-	if(in_range(src, user))
+	if(in_range(src, user) && user.transferItemToLoc(W, src))
 		to_chat(user, span_notice("You attach \the [W] to \the [src]."))
-		user.transferItemToLoc(W, src)
 		weapon = W
 		weapon_orig_force = weapon.force
 		if(!(bot_cover_flags & BOT_COVER_EMAGGED))
 			weapon.force = weapon.force / 2
-		add_overlay(image(icon=weapon.lefthand_file,icon_state=weapon.inhand_icon_state))
-	else 
+			add_overlay(image(icon=weapon.lefthand_file,icon_state=weapon.inhand_icon_state))
+	else
+		to_chat(user, span_notice("You failed to attach \the [W] to \the [src]."))
 		return
-
+		
 /mob/living/simple_animal/bot/cleanbot/proc/update_titles()
 	var/working_title = ""
 

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -104,6 +104,8 @@
 		if(!(bot_cover_flags & BOT_COVER_EMAGGED))
 			weapon.force = weapon.force / 2
 		add_overlay(image(icon=weapon.lefthand_file,icon_state=weapon.inhand_icon_state))
+	else 
+		return
 
 /mob/living/simple_animal/bot/cleanbot/proc/update_titles()
 	var/working_title = ""

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -103,9 +103,8 @@
 		if(!(bot_cover_flags & BOT_COVER_EMAGGED))
 			weapon.force = weapon.force / 2
 		add_overlay(image(icon=weapon.lefthand_file,icon_state=weapon.inhand_icon_state))
-	else
-		to_chat(user, span_notice("You failed to attach \the [W] to \the [src]."))
-		return
+	to_chat(user, span_notice("You fail to attach [W] to [src]."))
+	return FALSE
 		
 /mob/living/simple_animal/bot/cleanbot/proc/update_titles()
 	var/working_title = ""

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -97,7 +97,7 @@
 
 /mob/living/simple_animal/bot/cleanbot/proc/deputize(obj/item/W, mob/user)
 	if(in_range(src, user) && user.transferItemToLoc(W, src))
-		balloon_alert(user, "attached!")
+		balloon_alert(user, "attached")
 		weapon = W
 		weapon_orig_force = weapon.force
 		if(!(bot_cover_flags & BOT_COVER_EMAGGED))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Attaching a knife to cleanbot would succeed even when the user has trait like anti drop that would cause ItemtransfertoLoc to fail, this pr simply add a check for transferitemtoLoc
Fixes #68297
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug begone
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed attaching a knife to cleanbot succeeding even when user has NO_DROP
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
