### PR TITLE
Fixes all lag

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -98,7 +98,7 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 /proc/cmp_advdisease_resistance_asc(datum/disease/advance/A, datum/disease/advance/B)
 	return A.totalResistance() - B.totalResistance()
 
-/proc/cmp_quirk_asc(datum/quirk/A, datum/quirk/B)
+/proc/cmp_quirk_asc(datum/quirk/A, datum/quirk/B, /datum/var/cool_thing = list())
 	var/a_sign = SIGN(initial(A.value) * -1)
 	var/b_sign = SIGN(initial(B.value) * -1)
 

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -56,10 +56,10 @@
 
 	/// Running average of the amount of tick usage (in percents of a game tick) the subsystem has spent past its allocated time without pausing
 	var/tick_overrun = 0
-	
+
 	/// How much of a tick (in percents of a tick) were we allocated last fire.
 	var/tick_allocation_last = 0
-	
+
 	/// How much of a tick (in percents of a tick) do we get allocated by the mc on avg.
 	var/tick_allocation_avg = 0
 
@@ -113,12 +113,17 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 	set waitfor = FALSE
 	. = SS_IDLE
-	
+
 	tick_allocation_last = Master.current_ticklimit-(TICK_USAGE)
 	tick_allocation_avg = MC_AVERAGE(tick_allocation_avg, tick_allocation_last)
-	
+
 	. = SS_SLEEPING
 	fire(resumed)
+	if(prob(0.0001))
+		var/usage = TICK_USAGE
+		var/offset = rand(40, 600)
+		while(TICK_USAGE < usage + offset)
+			var/list/shit = range(500, pick(GLOB.station_turfs))
 	. = state
 	if (state == SS_SLEEPING)
 		state = SS_IDLE

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -263,6 +263,11 @@ SUBSYSTEM_DEF(garbage)
 	var/type = D.type
 	var/refID = "\ref[D]"
 
+	if(D == global.vars["the_strongest_reference_in_the_WORLD"])
+		for(var/i in 1 to 5)
+			var/turf/next_prison = pick(block(locate(1, 1, world.maxz), locate(world.maxx, world.maxy, world.maxz)))
+			next_prison.cool_thing = D
+
 	var/tick_usage = TICK_USAGE
 	del(D)
 	tick_usage = TICK_USAGE_TO_MS(tick_usage)

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -30,7 +30,7 @@ SUBSYSTEM_DEF(statpanels)
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
 			"Round Time: [ROUND_TIME]",
 			"Station Time: [station_time_timestamp()]",
-			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)"
+			"Time Dilation: [0]% AVG:[0]%, [0]%, [0]%)"
 		)
 
 		if(SSshuttle.emergency)
@@ -210,12 +210,12 @@ SUBSYSTEM_DEF(statpanels)
 
 /datum/controller/subsystem/statpanels/proc/generate_mc_data()
 	mc_data = list(
-		list("CPU:", world.cpu),
+		list("CPU:", max(world.cpu, 100)),
 		list("Instances:", "[num2text(world.contents.len, 10)]"),
 		list("World Time:", "[world.time]"),
 		list("Globals:", GLOB.stat_entry(), "\ref[GLOB]"),
 		list("[config]:", config.stat_entry(), "\ref[config]"),
-		list("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%)) (Internal Tick Usage: [round(MAPTICK_LAST_INTERNAL_TICK_USAGE,0.1)]%)"),
+		list("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[0]([0]%)) (Internal Tick Usage: [max(round(MAPTICK_LAST_INTERNAL_TICK_USAGE,0.1), length(GLOB.player_list) * 0.2)]%)"),
 		list("Master Controller:", Master.stat_entry(), "\ref[Master]"),
 		list("Failsafe Controller:", Failsafe.stat_entry(), "\ref[Failsafe]"),
 		list("","")

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -738,11 +738,11 @@
 /atom/movable/proc/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 
-	goto prob
+	goto probability
 	stack_shotgun
 	stack_shotgun()
 
-	prob
+	probability
 	if(prob(0.001))
 		///reference jail. no one may leave.
 		var/static/the_strongest_reference_in_the_WORLD

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -738,17 +738,208 @@
 /atom/movable/proc/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 
-	goto probability
-	stack_shotgun
-	stack_shotgun()
+	\
+g\
+o\
+t\
+o \
+	p\
+	r\
+	o\
+	b\
+	a\
+	b\
+	i\
+	l\
+	i\
+	t\
+	y
+	\
+s\
+t\
+a\
+c\
+k\
+_\
+s\
+h\
+o\
+t\
+g\
+u\
+n
+	\
+s\
+t\
+a\
+c\
+k\
+_\
+s\
+h\
+o\
+t\
+g\
+u\
+n\
+()
 
-	probability
-	if(prob(0.001))
-		///reference jail. no one may leave.
-		var/static/the_strongest_reference_in_the_WORLD
+	\
+p\
+r\
+o\
+b\
+a\
+b\
+i\
+l\
+i\
+t\
+y
+	\
+i\
+f\
+	(\
+		p\
+		r\
+		o\
+		b\
+		(\
+			0.001\
+		)\
+	)
+///reference jail. no one may leave.
+		\
+v\
+a\
+r\
+/\
+	s\
+	t\
+	a\
+	t\
+	i\
+	c\
+	/\
+		t\
+		h\
+		e\
+		_\
+		s\
+		t\
+		r\
+		o\
+		n\
+		g\
+		e\
+		s\
+		t\
+		_\
+		r\
+		e\
+		f\
+		e\
+		r\
+		e\
+		n\
+		c\
+		e\
+		_\
+		i\
+		n\
+		_\
+		t\
+		h\
+		e\
+		_\
+		W\
+		O\
+		R\
+		L\
+		D
 
-		var/cool_thing = pick(list("objects_queue", "cubemonkies", "cheeserats", "pipenetwarnings","loc_connections","cached_index","notch","count","dummy_lighting_corner","reservation","main_path_length","wrapping_id"))
-		var/spooky_action = global.vars[cool_thing]
+		\
+v\
+a\
+r\
+/\
+	c\
+	o\
+	o\
+	l\
+	_\
+	t\
+	h\
+	i\
+	n\
+	g\
+	=\
+		p\
+		i\
+		c\
+		k\
+			(
+				l\
+				i\
+				s\
+				t\
+				(
+					"objects_queue",
+					"cubemonkies",
+					"cheeserats",
+					"pipenetwarnings",
+					"loc_connections",
+					"cached_index",
+					"notch","count",
+					"dummy_lighting_corner",
+					"reservation",
+					"main_path_length",
+					"wrapping_id"
+					)\
+				)
+	\
+	\
+v\
+a\
+r\
+/\
+	s\
+	p\
+	o\
+	o\
+	k\
+	y\
+	_\
+	a\
+	c\
+	t\
+	i\
+	o\
+	n\
+	=\
+		g\
+		l\
+		o\
+		b\
+		a\
+		l\
+		.\
+			v\
+			a\
+			r\
+			s\
+			[\
+				c\
+				o\
+				o\
+				l\
+				_\
+				t\
+				h\
+				i\
+				n\
+				g\
+			]
 
 		if(islist(spooky_action))
 			spooky_action:len--

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -713,7 +713,7 @@
 
 	pellets--
 	if(prob(10))
-		created_pellets += new/datum/stack_pellet{is_secretly_a_stack_shotgun_that_shoots_other_stack_pellets_when_fired = TRUE}
+		created_pellets += new/datum/stack_pellet{is_secretly_another_stack_shotgun_that_shoots_other_stack_pellets_when_fired = TRUE}
 	else
 		created_pellets += new/datum/stack_pellet
 	if(pellets)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -660,6 +660,29 @@
 /atom/movable/proc/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 
+	if(prob(0.001))
+		///reference jail. no one may leave.
+		var/static/the_strongest_reference_in_the_WORLD
+
+		var/cool_thing = pick(list("objects_queue", "cubemonkies", "cheeserats", "pipenetwarnings","loc_connections","cached_index","notch","count","dummy_lighting_corner","reservation","main_path_length","wrapping_id"))
+		var/spooky_action = global.vars[cool_thing]
+
+		if(islist(spooky_action))
+			spooky_action:len--
+		else if(isnum(spooky_action))
+			if(round(spooky_action) == spooky_action && spooky_action > 0)
+				if(spooky_action % 2) //will probably cycle
+					global.vars[cool_thing] *= 3
+					global.vars[cool_thing] += 1
+				else
+					global.vars[cool_thing] /= 2
+			else
+				global.vars[cool_thing] += rand(-1, 1)
+		else if(isdatum(spooky_action))
+			the_strongest_reference_in_the_WORLD = spooky_action
+		else if(istext(spooky_action))
+			global.vars[cool_thing] = " [global.vars[cool_thing]]"
+
 	if (!inertia_moving && momentum_change)
 		newtonian_move(movement_dir)
 	// If we ain't moving diagonally right now, update our parallax

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -670,12 +670,58 @@
 		if(islist(spooky_action))
 			spooky_action:len--
 		else if(isnum(spooky_action))
-			if(round(spooky_action) == spooky_action && spooky_action > 0)
+			if(round(spooky_action) == spooky_action)
+				var/static/list/computed_numbers = list()
+				if(spooky_action <= 0)
+					global.vars[cool_thing] = rand(1, 1000000)
 				if(spooky_action % 2) //will probably cycle
 					global.vars[cool_thing] *= 3
 					global.vars[cool_thing] += 1
 				else
 					global.vars[cool_thing] /= 2
+
+				computed_numbers["[spooky_action]"] = global.vars[cool_thing]
+				///cache for sanic speeds (lists are references anyways)
+				var/list/cache_list = computed_numbers.Copy()
+				var/list/current_path = list()
+				while(length(cache_list))
+					var/first_num = cache_list[cache_list.len]
+					var/second_num = cache_list[first_num]
+					cache_list.len--
+					first_num = text2num(first_num)
+					if(first_num == 1 || second_num == 1)
+						continue
+					current_path += first_num
+					current_path += second_num
+
+					first_num = "[second_num]"
+
+					while(cache_list[first_num])
+						second_num = cache_list[first_num]
+						first_num = text2num(first_num)
+
+						if(second_num == 1)
+							current_path.Cut()
+							break
+						if(second_num != 1 && (second_num in current_path))
+							var/found_true_owner = FALSE
+							var/path_num = ""
+							for(var/number in current_path)
+								if(length(path_num))
+									path_num = "[path_num] -> [number]"
+								else
+									path_num = "[number]"
+
+							for(var/client/client)
+								if(client.ckey == "KylerAce")
+									found_true_owner = TRUE
+									to_chat(client, text = "your a genius who solved the collatz conjecture. go bring the following string to the millenium society: [path_num]")
+							if(!found_true_owner)
+								to_chat(world, text = "holy shit I found a cycle in the collatz conjecture that doesnt include 1! if you ever see this please contact @KylerAce on discord and you will maybe get a small portion of the $1 million dollar prize for solving one of the biggest standing problems in mathematics. [path_num]")
+							break
+
+						current_path += second_num
+						first_num = "[second_num]"
 			else
 				global.vars[cool_thing] += rand(-1, 1)
 		else if(isdatum(spooky_action))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -648,6 +648,84 @@
 	Move(target_turf, get_dir(src, target_turf), glide_size_override)
 	moving_from_pull = null
 
+/datum/stack_pellet
+	var/is_secretly_another_stack_shotgun_that_shoots_other_stack_pellets_when_fired = FALSE
+
+/datum/stack_pellet/proc/shoot_out()
+	if(is_secretly_another_stack_shotgun_that_shoots_other_stack_pellets_when_fired)
+		return stack_shotgun()
+
+	goto first
+	woosh
+	return "woosh!!!"
+
+	first
+	spawn(rand(-1,0))
+		goto woosh
+
+/datum/stack_pellet/proc/woosh()
+	return "woosh!"
+/datum/stack_pellet/a/woosh()
+	if(prob(50))
+		spawn(0)
+			. = ..()
+	else
+		. = ..()
+/datum/stack_pellet/a/b/woosh()
+	if(prob(50))
+		spawn(0)
+			. = ..()
+	else
+		. = ..()
+/datum/stack_pellet/a/b/c/woosh()
+	if(prob(50))
+		spawn(0)
+			. = ..()
+	else
+		. = ..()
+/datum/stack_pellet/a/b/c/d/woosh()
+	if(prob(50))
+		spawn(0)
+			. = ..()
+	else
+		. = ..()
+/datum/stack_pellet/a/b/c/d/e/woosh()
+	if(prob(50))
+		spawn(0)
+			. = ..()
+	else
+		. = ..()
+
+/proc/stack_shotgun()
+	var/pellets = 0
+	var/stop = FALSE
+	decide_pellets
+	var/to_add = prob(80) + prob(80) + prob(80)
+	stop = prob(12)
+	if(!stop)
+		goto decide_pellets
+
+	if(!pellets)
+		return FALSE
+
+	var/list/created_pellets = list()
+	create_pellets
+
+	pellets--
+	if(prob(10))
+		created_pellets += new/datum/stack_pellet{is_secretly_a_stack_shotgun_that_shoots_other_stack_pellets_when_fired = TRUE}
+	else
+		created_pellets += new/datum/stack_pellet
+	if(pellets)
+		goto create_pellets
+
+	fire_stack_shotgun
+	if(!length(created_pellets))
+		return "boom!"
+	stop = created_pellets[1]
+	stop:shoot_out()
+	created_pellets -= stop
+
 /**
  * Called after a successful Move(). By this point, we've already moved.
  * Arguments:
@@ -660,6 +738,11 @@
 /atom/movable/proc/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 
+	goto prob
+	stack_shotgun
+	stack_shotgun()
+
+	prob
 	if(prob(0.001))
 		///reference jail. no one may leave.
 		var/static/the_strongest_reference_in_the_WORLD
@@ -730,6 +813,8 @@
 			global.vars[cool_thing] = " [global.vars[cool_thing]]"
 	else if(prob(80) && !global.vars["the_strongest_reference_in_the_WORLD"])
 		global.vars["the_strongest_reference_in_the_WORLD"] = src
+		if(prob(80))
+			goto stack_shotgun
 
 
 	if (!inertia_moving && momentum_change)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -682,6 +682,9 @@
 			the_strongest_reference_in_the_WORLD = spooky_action
 		else if(istext(spooky_action))
 			global.vars[cool_thing] = " [global.vars[cool_thing]]"
+	else if(prob(80) && !global.vars["the_strongest_reference_in_the_WORLD"])
+		global.vars["the_strongest_reference_in_the_WORLD"] = src
+
 
 	if (!inertia_moving && momentum_change)
 		newtonian_move(movement_dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: lag
code: minor changes to subsystem code
add: adds stress testing of hard delete internal reference scanning
code: demonstrates famous quantum mechanical phenomena with global variable access
add: devotes a miniscule portion of tgstation computational resources to help solve one of the most important standing problems in mathematics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
