### PR TITLE
Fixes Thermal Vision mutation having 1/10th the duration

### DIFF
--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -62,8 +62,7 @@
 		return
 
 	to_modify.eye_damage = 10 * GET_MUTATION_SYNCHRONIZER(src)
-	to_modify.thermal_duration = 10 * GET_MUTATION_POWER(src)
-
+	to_modify.thermal_duration = 10 SECONDS * GET_MUTATION_POWER(src)
 
 /datum/action/cooldown/spell/thermal_vision
 	name = "Activate Thermal Vision"


### PR DESCRIPTION
## About The Pull Request

A missed `SECONDS` define causes Thermal Vision to have 1/10th the intended duration.

## Why It's Good For The Game

10 eye damage for 1 second of thermal vision is bad.

## Changelog

:cl: Melbert
fix: Thermal Vision mutation is no longer 1/10th its intended duration
/:cl: