### PR TITLE
Cleans up crafting time defines.

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -4,20 +4,29 @@
 #define CRAFTING_MACHINERY_USE 0
 
 /datum/crafting_recipe
-	var/name = "" //in-game display name
-	var/list/reqs = list() //type paths of items consumed associated with how many are needed
-	var/list/blacklist = list() //type paths of items explicitly not allowed as an ingredient
-	var/result //type path of item resulting from this craft
+	///in-game display name
+	var/name = ""
+	///type paths of items consumed associated with how many are needed
+	var/list/reqs = list()
+	///type paths of items explicitly not allowed as an ingredient
+	var/list/blacklist = list()
+	///type path of item resulting from this craft
+	var/result
 	/// String defines of items needed but not consumed. Lazy list.
 	var/list/tool_behaviors
 	/// Type paths of items needed but not consumed. Lazy list.
 	var/list/tool_paths
-	var/time = 3 SECONDS //time in deciseconds
-	var/list/parts = list() //type paths of items that will be placed in the result
-	var/list/chem_catalysts = list() //like tool_behaviors but for reagents
-	var/category = CAT_NONE //where it shows up in the crafting UI
+	///time in seconds. Remember to use the SECONDS define!
+	var/time = 3 SECONDS
+	///type paths of items that will be placed in the result
+	var/list/parts = list()
+	///like tool_behaviors but for reagents
+	var/list/chem_catalysts = list()
+	///where it shows up in the crafting UI
+	var/category = CAT_NONE
 	var/subcategory = CAT_NONE
-	var/always_available = TRUE //Set to FALSE if it needs to be learned first.
+	///Set to FALSE if it needs to be learned first.
+	var/always_available = TRUE
 	/// Additonal requirements text shown in UI
 	var/additional_req_text
 	///Required machines for the craft, set the assigned value of the typepath to CRAFTING_MACHINERY_CONSUME or CRAFTING_MACHINERY_USE. Lazy associative list: type_path key -> flag value.

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -12,7 +12,7 @@
 	var/list/tool_behaviors
 	/// Type paths of items needed but not consumed. Lazy list.
 	var/list/tool_paths
-	var/time = 30 //time in deciseconds
+	var/time = 3 SECONDS //time in deciseconds
 	var/list/parts = list() //type paths of items that will be placed in the result
 	var/list/chem_catalysts = list() //like tool_behaviors but for reagents
 	var/category = CAT_NONE //where it shows up in the crafting UI
@@ -60,7 +60,7 @@
 				/obj/item/assembly/igniter = 1,
 				/obj/item/reagent_containers/food/drinks/soda_cans = 1)
 	parts = list(/obj/item/reagent_containers/food/drinks/soda_cans = 1)
-	time = 15
+	time = 1.5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -72,7 +72,7 @@
 	blacklist = list(/obj/item/spear/bonespear, /obj/item/spear/bamboospear)
 	parts = list(/obj/item/spear = 1,
 				/obj/item/grenade = 1)
-	time = 15
+	time = 1.5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -82,7 +82,7 @@
 	reqs = list(/obj/item/wallframe/flasher = 1,
 				/obj/item/assembly/flash/handheld = 1,
 				/obj/item/shield/riot = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -96,7 +96,7 @@
 	reqs = list(/obj/item/reagent_containers/glass/rag = 1,
 				/obj/item/reagent_containers/food/drinks/bottle = 1)
 	parts = list(/obj/item/reagent_containers/food/drinks/bottle = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -106,7 +106,7 @@
 	reqs = list(/obj/item/restraints/handcuffs/cable = 1,
 				/obj/item/stack/rods = 1,
 				/obj/item/assembly/igniter = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -117,7 +117,7 @@
 				/obj/item/stack/rods = 1,
 				/obj/item/assembly/igniter = 1,
 				/obj/item/stack/ore/bluespace_crystal = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -126,7 +126,7 @@
 	result = /obj/item/restraints/legcuffs/bola
 	reqs = list(/obj/item/restraints/handcuffs/cable = 1,
 				/obj/item/stack/sheet/iron = 6)
-	time = 20//15 faster than crafting them by hand!
+	time = 2 SECONDS//faster than crafting them by hand!
 	category= CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -136,7 +136,7 @@
 	reqs = list(/obj/item/restraints/handcuffs/cable = 1,
 				/obj/item/stack/sheet/iron = 6,
 				/obj/item/stack/sheet/animalhide/gondola = 1)
-	time = 40
+	time = 4 SECONDS
 	category= CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -146,7 +146,7 @@
 	reqs = list(/obj/item/organ/external/tail/lizard = 1,
 				/obj/item/stack/sheet/iron = 1)
 	blacklist = list(/obj/item/organ/external/tail/lizard/fake)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -156,7 +156,7 @@
 	reqs = list(/obj/item/organ/external/tail/lizard = 1,
 				/obj/item/stack/cable_coil = 1)
 	blacklist = list(/obj/item/organ/external/tail/lizard/fake)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -165,7 +165,7 @@
 	result = /obj/item/melee/chainofcommand/tailwhip/kitty
 	reqs = list(/obj/item/organ/external/tail/cat = 1,
 				/obj/item/stack/cable_coil = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -177,7 +177,7 @@
 				/obj/item/stack/sticky_tape = 1,
 				/obj/item/screwdriver = 1,
 				/obj/item/assembly/mousetrap = 1)
-	time = 100
+	time = 10 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -187,7 +187,7 @@
 	result = /obj/item/weaponcrafting/stock
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 8,
 				/obj/item/stack/sticky_tape = 1)
-	time = 50
+	time = 5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -198,7 +198,7 @@
 	reqs = list(/obj/item/gun/energy/e_gun = 1,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/weaponcrafting/gunkit/nuclear = 1)
-	time = 200
+	time = 20 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -213,7 +213,7 @@
 	reqs = list(/obj/item/gun/energy/e_gun = 1,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/weaponcrafting/gunkit/temperature = 1)
-	time = 200
+	time = 20 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -230,7 +230,7 @@
 				/obj/item/assembly/signaler/anomaly/grav = 1,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/weaponcrafting/gunkit/beam_rifle = 1)
-	time = 200
+	time = 20 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -246,7 +246,7 @@
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/weaponcrafting/gunkit/ebow = 1,
 				/datum/reagent/uranium/radium = 15)
-	time = 200
+	time = 20 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -257,7 +257,7 @@
 	reqs = list(/obj/item/gun/energy/laser = 1,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/weaponcrafting/gunkit/xray = 1)
-	time = 200
+	time = 20 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -272,7 +272,7 @@
 	reqs = list(/obj/item/gun/energy/laser = 1,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/weaponcrafting/gunkit/hellgun = 1)
-	time = 200
+	time = 20 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -287,7 +287,7 @@
 	reqs = list(/obj/item/gun/energy/laser = 1,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/weaponcrafting/gunkit/ion = 1)
-	time = 200
+	time = 20 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -304,7 +304,7 @@
 				/obj/item/weaponcrafting/gunkit/decloner = 1,
 				/datum/reagent/baldium = 30,
 				/datum/reagent/toxin/mutagen = 40)
-	time = 200
+	time = 20 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -319,7 +319,7 @@
 	reqs = list(/obj/item/assembly/signaler/anomaly/flux = 1,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/weaponcrafting/gunkit/tesla = 1)
-	time = 200
+	time = 20 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -336,7 +336,7 @@
 				/obj/item/gun/energy/disabler = 1,
 				/obj/item/assembly/prox_sensor = 1)
 	tool_behaviors = list(TOOL_WELDER, TOOL_SCREWDRIVER)
-	time = 60
+	time = 6 SECONDS
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/secbot
@@ -348,7 +348,7 @@
 				/obj/item/assembly/prox_sensor = 1,
 				/obj/item/bodypart/r_arm/robot = 1)
 	tool_behaviors = list(TOOL_WELDER)
-	time = 60
+	time = 6 SECONDS
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/cleanbot
@@ -357,7 +357,7 @@
 	reqs = list(/obj/item/reagent_containers/glass/bucket = 1,
 				/obj/item/assembly/prox_sensor = 1,
 				/obj/item/bodypart/r_arm/robot = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/floorbot
@@ -367,7 +367,7 @@
 				/obj/item/stack/tile/iron = 10,
 				/obj/item/assembly/prox_sensor = 1,
 				/obj/item/bodypart/r_arm/robot = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/medbot
@@ -381,7 +381,7 @@
 		/obj/item/storage/medkit = 1,
 		/obj/item/healthanalyzer = 1,
 		)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/medbot/on_craft_completion(mob/user, atom/result)
@@ -411,7 +411,7 @@
 				/obj/item/bodypart/r_arm/robot = 1,
 				/obj/item/assembly/prox_sensor = 1,
 				/obj/item/bikehorn/ = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/firebot
@@ -421,7 +421,7 @@
 				/obj/item/bodypart/r_arm/robot = 1,
 				/obj/item/assembly/prox_sensor = 1,
 				/obj/item/clothing/head/hardhat/red = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/vibebot
@@ -431,7 +431,7 @@
 				/obj/item/bodypart/head/robot = 1,
 				/obj/item/assembly/prox_sensor = 1,
 				/obj/item/toy/crayon = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/hygienebot
@@ -441,7 +441,7 @@
 				/obj/item/stack/ducts = 1,
 				/obj/item/assembly/prox_sensor = 1)
 	tool_behaviors = list(TOOL_WELDER)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/vim
@@ -463,7 +463,7 @@
 	reqs = list(/obj/item/stack/sheet/iron = 4,
 				/obj/item/stack/package_wrap = 8,
 				/obj/item/pipe/quaternary = 2)
-	time = 50
+	time = 5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -476,7 +476,7 @@
 	parts = list(/obj/item/assembly/igniter = 1,
 				/obj/item/weldingtool = 1)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 10
+	time = 1 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -487,7 +487,7 @@
 				/obj/item/rcd_ammo = 1,
 				/obj/item/stock_parts/manipulator = 2)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 5
+	time = 0.5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
@@ -498,7 +498,7 @@
 				/obj/item/stock_parts/capacitor/adv = 2,
 				/obj/item/stock_parts/micro_laser/ultra = 1)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 5
+	time = 0.5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
@@ -507,7 +507,7 @@
 	result = /obj/item/ammo_casing/shotgun/dragonsbreath
 	reqs = list(/obj/item/ammo_casing/shotgun/techshell = 1, /datum/reagent/phosphorus = 5)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 5
+	time = 0.5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
@@ -519,7 +519,7 @@
 				/datum/reagent/toxin/acid = 5,
 				/datum/reagent/toxin/acid/fluacid = 5)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 5
+	time = 0.5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
@@ -530,7 +530,7 @@
 				/obj/item/stock_parts/micro_laser/ultra = 1,
 				/obj/item/stock_parts/subspace/crystal = 1)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 5
+	time = 0.5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
@@ -541,7 +541,7 @@
 				/obj/item/stack/cable_coil = 1,
 				/datum/reagent/fuel = 10)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 12
+	time = 1.2 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
@@ -552,7 +552,7 @@
 				/obj/item/stock_parts/capacitor/adv = 1,
 				/obj/item/stock_parts/micro_laser/high = 1)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 5
+	time = 0.5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
@@ -564,7 +564,7 @@
 				/obj/item/weaponcrafting/stock = 1,
 				/obj/item/stack/sticky_tape = 1)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 50
+	time = 5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -579,7 +579,7 @@
 				/obj/item/storage/toolbox= 1)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	tool_paths = list(/obj/item/clothing/gloves/color/yellow, /obj/item/clothing/mask/gas, /obj/item/melee/baton/security/cattleprod)
-	time = 300 //contemplate for a bit
+	time = 30 SECONDS //contemplate for a bit
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -616,7 +616,7 @@
 				/obj/item/stack/cable_coil = 3,
 				/obj/item/stack/sheet/plasteel = 5)
 	tool_behaviors = list(TOOL_WELDER)
-	time = 50
+	time = 5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -627,28 +627,28 @@
 				/obj/item/shard = 1,
 				/obj/item/stack/rods = 1)
 	parts = list(/obj/item/shard = 1)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
 /datum/crafting_recipe/lizardhat
 	name = "Lizard Cloche Hat"
 	result = /obj/item/clothing/head/lizard
-	time = 10
+	time = 1 SECONDS
 	reqs = list(/obj/item/organ/external/tail/lizard = 1)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/lizardhat_alternate
 	name = "Lizard Cloche Hat"
 	result = /obj/item/clothing/head/lizard
-	time = 10
+	time = 1 SECONDS
 	reqs = list(/obj/item/stack/sheet/animalhide/lizard = 1)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/kittyears
 	name = "Kitty Ears"
 	result = /obj/item/clothing/head/kitty/genuine
-	time = 10
+	time = 1 SECONDS
 	reqs = list(/obj/item/organ/external/tail/cat = 1,
 				/obj/item/organ/internal/ears/cat = 1)
 	category = CAT_CLOTHING
@@ -657,7 +657,7 @@
 /datum/crafting_recipe/radiogloves
 	name = "Radio Gloves"
 	result = /obj/item/clothing/gloves/radio
-	time = 15
+	time = 1.5 SECONDS
 	reqs = list(/obj/item/clothing/gloves/color/black = 1,
 				/obj/item/stack/cable_coil = 2,
 				/obj/item/radio = 1)
@@ -698,7 +698,7 @@
 /datum/crafting_recipe/spooky_camera
 	name = "Camera Obscura"
 	result = /obj/item/camera/spooky
-	time = 15
+	time = 1.5 SECONDS
 	reqs = list(/obj/item/camera = 1,
 				/datum/reagent/water/holywater = 10)
 	parts = list(/obj/item/camera = 1)
@@ -708,7 +708,7 @@
 /datum/crafting_recipe/skateboard
 	name = "Skateboard"
 	result = /obj/vehicle/ridden/scooter/skateboard/improvised
-	time = 60
+	time = 6 SECONDS
 	reqs = list(/obj/item/stack/sheet/iron = 5,
 				/obj/item/stack/rods = 10)
 	category = CAT_MISC
@@ -716,7 +716,7 @@
 /datum/crafting_recipe/scooter
 	name = "Scooter"
 	result = /obj/vehicle/ridden/scooter
-	time = 65
+	time = 6.5 SECONDS
 	reqs = list(/obj/item/stack/sheet/iron = 5,
 				/obj/item/stack/rods = 12)
 	category = CAT_MISC
@@ -726,7 +726,7 @@
 	result = /obj/vehicle/ridden/wheelchair
 	reqs = list(/obj/item/stack/sheet/iron = 4,
 				/obj/item/stack/rods = 6)
-	time = 100
+	time = 10 SECONDS
 	category = CAT_MISC
 
 /datum/crafting_recipe/motorized_wheelchair
@@ -739,13 +739,13 @@
 	parts = list(/obj/item/stock_parts/manipulator = 2,
 		/obj/item/stock_parts/capacitor = 1)
 	tool_behaviors = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WRENCH)
-	time = 200
+	time = 20 SECONDS
 	category = CAT_MISC
 
 /datum/crafting_recipe/mousetrap
 	name = "Mouse Trap"
 	result = /obj/item/assembly/mousetrap
-	time = 10
+	time = 1 SECONDS
 	reqs = list(/obj/item/stack/sheet/cardboard = 1,
 				/obj/item/stack/rods = 1)
 	category = CAT_MISC
@@ -753,7 +753,7 @@
 /datum/crafting_recipe/papersack
 	name = "Paper Sack"
 	result = /obj/item/storage/box/papersack
-	time = 10
+	time = 1 SECONDS
 	reqs = list(/obj/item/paper = 5)
 	category = CAT_MISC
 
@@ -771,13 +771,13 @@
 /datum/crafting_recipe/paperframes
 	name = "Paper Frames"
 	result = /obj/item/stack/sheet/paperframes/five
-	time = 10
+	time = 1 SECONDS
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 5, /obj/item/paper = 20)
 	category = CAT_MISC
 
 /datum/crafting_recipe/naturalpaper
 	name = "Hand-Pressed Paper"
-	time = 30
+	time = 3 SECONDS
 	reqs = list(/datum/reagent/water = 50, /obj/item/stack/sheet/mineral/wood = 1)
 	tool_paths = list(/obj/item/hatchet)
 	result = /obj/item/paper_bin/bundlenatural
@@ -835,7 +835,7 @@
 		/obj/item/grenade/chem_grenade = 2
 	)
 	parts = list(/obj/item/stock_parts/matter_bin = 1, /obj/item/grenade/chem_grenade = 2)
-	time = 30
+	time = 3 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
@@ -848,21 +848,21 @@
 		/obj/item/grenade/chem_grenade = 2
 	)
 	parts = list(/obj/item/stock_parts/matter_bin = 1, /obj/item/grenade/chem_grenade = 2)
-	time = 50
+	time = 5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
 /datum/crafting_recipe/bonearmor
 	name = "Bone Armor"
 	result = /obj/item/clothing/suit/armor/bone
-	time = 30
+	time = 3 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 6)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonetalisman
 	name = "Bone Talisman"
 	result = /obj/item/clothing/accessory/talisman
-	time = 20
+	time = 2 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 2,
 				/obj/item/stack/sheet/sinew = 1)
 	category = CAT_PRIMAL
@@ -870,7 +870,7 @@
 /datum/crafting_recipe/bonecodpiece
 	name = "Skull Codpiece"
 	result = /obj/item/clothing/accessory/skullcodpiece
-	time = 20
+	time = 2 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 1)
 	category = CAT_PRIMAL
@@ -878,7 +878,7 @@
 /datum/crafting_recipe/skilt
 	name = "Sinew Kilt"
 	result = /obj/item/clothing/accessory/skilt
-	time = 20
+	time = 2 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 1,
 				/obj/item/stack/sheet/sinew = 2)
 	category = CAT_PRIMAL
@@ -886,7 +886,7 @@
 /datum/crafting_recipe/bracers
 	name = "Bone Bracers"
 	result = /obj/item/clothing/gloves/bracer
-	time = 20
+	time = 2 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 2,
 				/obj/item/stack/sheet/sinew = 1)
 	category = CAT_PRIMAL
@@ -894,14 +894,14 @@
 /datum/crafting_recipe/skullhelm
 	name = "Skull Helmet"
 	result = /obj/item/clothing/head/helmet/skull
-	time = 30
+	time = 3 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 4)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/goliathcloak
 	name = "Goliath Cloak"
 	result = /obj/item/clothing/suit/hooded/cloak/goliath
-	time = 50
+	time = 5 SECONDS
 	reqs = list(/obj/item/stack/sheet/leather = 2,
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/goliath_hide = 2) //it takes 4 goliaths to make 1 cloak if the plates are skinned
@@ -910,7 +910,7 @@
 /datum/crafting_recipe/drakecloak
 	name = "Ash Drake Armour"
 	result = /obj/item/clothing/suit/hooded/cloak/drake
-	time = 60
+	time = 6 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 10,
 				/obj/item/stack/sheet/sinew = 2,
 				/obj/item/stack/sheet/animalhide/ashdrake = 5)
@@ -919,21 +919,21 @@
 /datum/crafting_recipe/godslayer
 	name = "Godslayer Armour"
 	result = /obj/item/clothing/suit/hooded/cloak/godslayer
-	time = 60
+	time = 6 SECONDS
 	reqs = list(/obj/item/ice_energy_crystal = 1, /obj/item/wendigo_skull = 1, /obj/item/clockwork_alloy = 1)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/firebrand
 	name = "Firebrand"
 	result = /obj/item/match/firebrand
-	time = 100 //Long construction time. Making fire is hard work.
+	time = 10 SECONDS //Long construction time. Making fire is hard work.
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 2)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/gold_horn
 	name = "Golden Bike Horn"
 	result = /obj/item/bikehorn/golden
-	time = 20
+	time = 2 SECONDS
 	reqs = list(/obj/item/stack/sheet/mineral/bananium = 5,
 				/obj/item/bikehorn = 1)
 	category = CAT_MISC
@@ -941,14 +941,14 @@
 /datum/crafting_recipe/bonedagger
 	name = "Bone Dagger"
 	result = /obj/item/knife/combat/bone
-	time = 20
+	time = 2 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 2)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonespear
 	name = "Bone Spear"
 	result = /obj/item/spear/bonespear
-	time = 30
+	time = 3 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 4,
 				/obj/item/stack/sheet/sinew = 1)
 	category = CAT_PRIMAL
@@ -956,14 +956,14 @@
 /datum/crafting_recipe/boneaxe
 	name = "Bone Axe"
 	result = /obj/item/fireaxe/boneaxe
-	time = 50
+	time = 5 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 6,
 				/obj/item/stack/sheet/sinew = 3)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonfire
 	name = "Bonfire"
-	time = 60
+	time = 6 SECONDS
 	reqs = list(/obj/item/grown/log = 5)
 	parts = list(/obj/item/grown/log = 5)
 	blacklist = list(/obj/item/grown/log/steel)
@@ -972,7 +972,7 @@
 
 /datum/crafting_recipe/skeleton_key
 	name = "Skeleton Key"
-	time = 30
+	time = 3 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 5)
 	result = /obj/item/skeleton_key
 	always_available = FALSE
@@ -980,14 +980,14 @@
 
 /datum/crafting_recipe/rake //Category resorting incoming
 	name = "Rake"
-	time = 30
+	time = 3 SECONDS
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 5)
 	result = /obj/item/cultivator/rake
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/woodbucket
 	name = "Wooden Bucket"
-	time = 30
+	time = 3 SECONDS
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 3)
 	result = /obj/item/reagent_containers/glass/bucket/wooden
 	category = CAT_PRIMAL
@@ -1005,7 +1005,7 @@
 
 /datum/crafting_recipe/headpike
 	name = "Spike Head (Glass Spear)"
-	time = 65
+	time = 6.5 SECONDS
 	reqs = list(/obj/item/spear = 1,
 				/obj/item/bodypart/head = 1)
 	parts = list(/obj/item/bodypart/head = 1,
@@ -1016,7 +1016,7 @@
 
 /datum/crafting_recipe/headpikebone
 	name = "Spike Head (Bone Spear)"
-	time = 65
+	time = 6.5 SECONDS
 	reqs = list(/obj/item/spear/bonespear = 1,
 				/obj/item/bodypart/head = 1)
 	parts = list(/obj/item/bodypart/head = 1,
@@ -1026,7 +1026,7 @@
 
 /datum/crafting_recipe/headpikebamboo
 	name = "Spike Head (Bamboo Spear)"
-	time = 65
+	time = 6.5 SECONDS
 	reqs = list(/obj/item/spear/bamboospear = 1,
 				/obj/item/bodypart/head = 1)
 	parts = list(/obj/item/bodypart/head = 1,
@@ -1037,7 +1037,7 @@
 /datum/crafting_recipe/pressureplate
 	name = "Pressure Plate"
 	result = /obj/item/pressure_plate
-	time = 5
+	time = 0.5 SECONDS
 	reqs = list(/obj/item/stack/sheet/iron = 1,
 				/obj/item/stack/tile/iron = 1,
 				/obj/item/stack/cable_coil = 2,
@@ -1048,7 +1048,7 @@
 /datum/crafting_recipe/rcl
 	name = "Makeshift Rapid Pipe Cleaner Layer"
 	result = /obj/item/rcl/ghetto
-	time = 40
+	time = 4 SECONDS
 	tool_behaviors = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WRENCH)
 	reqs = list(/obj/item/stack/sheet/iron = 15)
 	category = CAT_MISC
@@ -1056,7 +1056,7 @@
 /datum/crafting_recipe/mummy
 	name = "Mummification Bandages (Mask)"
 	result = /obj/item/clothing/mask/mummy
-	time = 10
+	time = 1 SECONDS
 	tool_paths = list(/obj/item/nullrod/egyptian)
 	reqs = list(/obj/item/stack/sheet/cloth = 2)
 	category = CAT_CLOTHING
@@ -1069,7 +1069,7 @@
 /datum/crafting_recipe/chaplain_hood
 	name = "Follower Hoodie"
 	result = /obj/item/clothing/suit/hooded/chaplain_hoodie
-	time = 10
+	time = 1 SECONDS
 	tool_paths = list(/obj/item/clothing/suit/hooded/chaplain_hoodie, /obj/item/storage/book/bible)
 	reqs = list(/obj/item/stack/sheet/cloth = 4)
 	category = CAT_CLOTHING
@@ -1077,7 +1077,7 @@
 /datum/crafting_recipe/flower_garland
 	name = "Flower Garland"
 	result = /obj/item/clothing/head/garland
-	time = 10
+	time = 1 SECONDS
 	reqs = list(/obj/item/food/grown/poppy = 4,
 				/obj/item/food/grown/harebell = 4,
 				/obj/item/food/grown/rose = 4)
@@ -1086,7 +1086,7 @@
 /datum/crafting_recipe/guillotine
 	name = "Guillotine"
 	result = /obj/structure/guillotine
-	time = 150 // Building a functioning guillotine takes time
+	time = 15 SECONDS // Building a functioning guillotine takes time
 	reqs = list(/obj/item/stack/sheet/plasteel = 3,
 				/obj/item/stack/sheet/mineral/wood = 20,
 				/obj/item/stack/cable_coil = 10)
@@ -1096,7 +1096,7 @@
 /datum/crafting_recipe/aitater
 	name = "intelliTater"
 	result = /obj/item/aicard/aitater
-	time = 30
+	time = 3 SECONDS
 	tool_behaviors = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/aicard = 1,
 					/obj/item/food/grown/potato = 1,
@@ -1751,7 +1751,7 @@
 /datum/crafting_recipe/steam_vent
 	name = "Steam Vent"
 	result = /obj/structure/steam_vent
-	time = 8
+	time = 0.8 SECONDS
 	reqs = list(/obj/item/stack/sheet/iron = 2,
 				/obj/item/stack/tile/iron = 1,
 				/obj/item/stock_parts/water_recycler = 1)

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -3,7 +3,7 @@
 	result = /obj/item/clothing/suit/armor/vest/durathread
 	reqs = list(/obj/item/stack/sheet/durathread = 5,
 				/obj/item/stack/sheet/leather = 4)
-	time = 50
+	time = 5 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_helmet
@@ -11,35 +11,35 @@
 	result = /obj/item/clothing/head/helmet/durathread
 	reqs = list(/obj/item/stack/sheet/durathread = 4,
 				/obj/item/stack/sheet/leather = 5)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_jumpsuit
 	name = "Durathread Jumpsuit"
 	result = /obj/item/clothing/under/misc/durathread
 	reqs = list(/obj/item/stack/sheet/durathread = 4)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_beret
 	name = "Durathread Beret"
 	result = /obj/item/clothing/head/beret/durathread
 	reqs = list(/obj/item/stack/sheet/durathread = 2)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_beanie
 	name = "Durathread Beanie"
 	result = /obj/item/clothing/head/beanie/durathread
 	reqs = list(/obj/item/stack/sheet/durathread = 2)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_bandana
 	name = "Durathread Bandana"
 	result = /obj/item/clothing/mask/bandana/durathread
 	reqs = list(/obj/item/stack/sheet/durathread = 1)
-	time = 25
+	time = 2.5 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/fannypack
@@ -47,13 +47,13 @@
 	result = /obj/item/storage/belt/fannypack
 	reqs = list(/obj/item/stack/sheet/cloth = 2,
 				/obj/item/stack/sheet/leather = 1)
-	time = 20
+	time = 2 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsunsec
 	name = "Security HUDsunglasses"
 	result = /obj/item/clothing/glasses/hud/security/sunglasses
-	time = 20
+	time = 2 SECONDS
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/security = 1,
 				  /obj/item/clothing/glasses/sunglasses = 1,
@@ -63,7 +63,7 @@
 /datum/crafting_recipe/hudsunsecremoval
 	name = "Security HUD removal"
 	result = /obj/item/clothing/glasses/sunglasses
-	time = 20
+	time = 2 SECONDS
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/security/sunglasses = 1)
 	category = CAT_CLOTHING
@@ -71,7 +71,7 @@
 /datum/crafting_recipe/hudsunmed
 	name = "Medical HUDsunglasses"
 	result = /obj/item/clothing/glasses/hud/health/sunglasses
-	time = 20
+	time = 2 SECONDS
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/health = 1,
 				  /obj/item/clothing/glasses/sunglasses = 1,
@@ -81,7 +81,7 @@
 /datum/crafting_recipe/hudsunmedremoval
 	name = "Medical HUD removal"
 	result = /obj/item/clothing/glasses/sunglasses
-	time = 20
+	time = 2 SECONDS
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/health/sunglasses = 1)
 	category = CAT_CLOTHING
@@ -89,7 +89,7 @@
 /datum/crafting_recipe/hudsundiag
 	name = "Diagnostic HUDsunglasses"
 	result = /obj/item/clothing/glasses/hud/diagnostic/sunglasses
-	time = 20
+	time = 2 SECONDS
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/diagnostic = 1,
 				  /obj/item/clothing/glasses/sunglasses = 1,
@@ -99,7 +99,7 @@
 /datum/crafting_recipe/hudsundiagremoval
 	name = "Diagnostic HUD removal"
 	result = /obj/item/clothing/glasses/sunglasses
-	time = 20
+	time = 2 SECONDS
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/diagnostic/sunglasses = 1)
 	category = CAT_CLOTHING
@@ -107,7 +107,7 @@
 /datum/crafting_recipe/scienceglasses
 	name = "Science Glasses"
 	result = /obj/item/clothing/glasses/sunglasses/chemical
-	time = 20
+	time = 2 SECONDS
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/science = 1,
 				  /obj/item/clothing/glasses/sunglasses = 1,
@@ -117,7 +117,7 @@
 /datum/crafting_recipe/scienceglassesremoval
 	name = "Chemical Scanner removal"
 	result = /obj/item/clothing/glasses/sunglasses
-	time = 20
+	time = 2 SECONDS
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/sunglasses/chemical = 1)
 	category = CAT_CLOTHING
@@ -125,7 +125,7 @@
 /datum/crafting_recipe/ghostsheet
 	name = "Ghost Sheet"
 	result = /obj/item/clothing/suit/ghost_sheet
-	time = 5
+	time = 0.5 SECONDS
 	tool_behaviors = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/bedsheet = 1)
 	category = CAT_CLOTHING
@@ -134,33 +134,33 @@
 	name = "Cowboy Boots"
 	result = /obj/item/clothing/shoes/cowboy
 	reqs = list(/obj/item/stack/sheet/leather = 2)
-	time = 45
+	time = 4.5 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/lizardboots
 	name = "Lizard Skin Boots"
 	result = /obj/effect/spawner/random/clothing/lizardboots
 	reqs = list(/obj/item/stack/sheet/animalhide/lizard = 1, /obj/item/stack/sheet/leather = 1)
-	time = 60
+	time = 6 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/prisonsuit
 	name = "Prisoner Uniform (Suit)"
 	result = /obj/item/clothing/under/rank/prisoner
 	reqs = list(/obj/item/stack/sheet/cloth = 3, /obj/item/stack/license_plates = 1)
-	time = 20
+	time = 2 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/prisonskirt
 	name = "Prisoner Uniform (Skirt)"
 	result = /obj/item/clothing/under/rank/prisoner/skirt
 	reqs = list(/obj/item/stack/sheet/cloth = 3, /obj/item/stack/license_plates = 1)
-	time = 20
+	time = 2 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/prisonshoes
 	name = "Orange Prison Shoes"
 	result = /obj/item/clothing/shoes/sneakers/orange
 	reqs = list(/obj/item/stack/sheet/cloth = 2, /obj/item/stack/license_plates = 1)
-	time = 10
+	time = 1 SECONDS
 	category = CAT_CLOTHING


### PR DESCRIPTION

## About The Pull Request

I got a review on another PR to switch time defines on a crafting recipe over to using SECONDS defines. However, as I was checking through the file, the file is... extremely inconsistent about this practice! Some things use seconds defines, some things use raw deciseconds, and other things NEWER than the SECONDS define were added that switch back to deciseconds between two different SECONDS defines.

This sets the file to one standard, using the SECONDS define.

## Why It's Good For The Game

Improves code quality, legibility and enforces a single standard on the file for future crafting recipes.

## Changelog
:cl:
code: Crafting recipes now uniformly use the same style for how long they take.
/:cl:

