### PR TITLE
Ordinance lab pumps possibly cosmetic change.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -14019,9 +14019,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "dNl" = (
-/obj/machinery/portable_atmospherics/pump{
-	name = "Lil Pump"
-	},
+/obj/machinery/portable_atmospherics/pump/lil_pump
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -14019,7 +14019,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "dNl" = (
-/obj/machinery/portable_atmospherics/pump/lil_pump
+/obj/machinery/portable_atmospherics/pump/lil_pump,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -23181,9 +23181,7 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "gXv" = (
-/obj/machinery/portable_atmospherics/pump{
-	name = "Lil Pump"
-	},
+/obj/machinery/portable_atmospherics/pump/lil_pump
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "gXy" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -23181,7 +23181,7 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "gXv" = (
-/obj/machinery/portable_atmospherics/pump/lil_pump
+/obj/machinery/portable_atmospherics/pump/lil_pump,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "gXy" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -73825,9 +73825,7 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/pump{
-	name = "Lil Pump"
-	},
+/obj/machinery/portable_atmospherics/pump/lil_pump
 /obj/machinery/camera/directional/west{
 	c_tag = "Ordnance Mixing Lab";
 	name = "science camera";

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -73825,7 +73825,7 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/pump/lil_pump
+/obj/machinery/portable_atmospherics/pump/lil_pump,
 /obj/machinery/camera/directional/west{
 	c_tag = "Ordnance Mixing Lab";
 	name = "science camera";

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18195,7 +18195,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "gLy" = (
-/obj/machinery/portable_atmospherics/pump/lil_pump
+/obj/machinery/portable_atmospherics/pump/lil_pump,
 /obj/effect/turf_decal/siding/purple{
 	dir = 5
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18195,9 +18195,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "gLy" = (
-/obj/machinery/portable_atmospherics/pump{
-	name = "Lil Pump"
-	},
+/obj/machinery/portable_atmospherics/pump/lil_pump
 /obj/effect/turf_decal/siding/purple{
 	dir = 5
 	},

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2308,8 +2308,7 @@
 "gG" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/portable_atmospherics/pump/lil_pump{
-	desc = "A betrayer to pump-kind.";
-	
+	desc = "A betrayer to pump-kind."
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_bombthreat)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2307,7 +2307,10 @@
 /area/centcom/central_command_areas/briefing)
 "gG" = (
 /obj/effect/turf_decal/stripes/box,
-/obj/machinery/portable_atmospherics/pump/lil_pump,
+/obj/machinery/portable_atmospherics/pump/lil_pump{
+	desc = "A betrayer to pump-kind.";
+	
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "gH" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2307,7 +2307,7 @@
 /area/centcom/central_command_areas/briefing)
 "gG" = (
 /obj/effect/turf_decal/stripes/box,
-/obj/machinery/portable_atmospherics/pump/lil_pump
+/obj/machinery/portable_atmospherics/pump/lil_pump,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "gH" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2307,10 +2307,7 @@
 /area/centcom/central_command_areas/briefing)
 "gG" = (
 /obj/effect/turf_decal/stripes/box,
-/obj/machinery/portable_atmospherics/pump{
-	desc = "A betrayer to pump-kind.";
-	name = "Lil Pump"
-	},
+/obj/machinery/portable_atmospherics/pump/lil_pump
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "gH" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -24569,9 +24569,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
 "iFb" = (
-/obj/machinery/portable_atmospherics/pump{
-	name = "Lil Pump"
-	},
+/obj/machinery/portable_atmospherics/pump/lil_pump
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "iFO" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -24569,7 +24569,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
 "iFb" = (
-/obj/machinery/portable_atmospherics/pump/lil_pump
+/obj/machinery/portable_atmospherics/pump/lil_pump,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "iFO" = (

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -174,9 +174,11 @@
 	name = "Lil' Pump"
 
 /obj/machinery/portable_atmospherics/pump/lil_pump/Initialize(mapload)
+	. = ..()
 	//25% chance to occur
 	if(prob(25))
 		name = "Liler' Pump"
 		desc = "When a Lil' Pump and and portable air pump love each other very much."
-		var/matrix/new_transform = matrix()
-		new_transform.Scale(1, 0.8)
+		var/matrix/lil_pump = matrix()
+		lil_pump.Scale(0.8)
+		src.transform = lil_pump

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -169,3 +169,14 @@
 /obj/machinery/portable_atmospherics/pump/unregister_holding()
 	on = FALSE
 	return ..()
+
+/obj/machinery/portable_atmospherics/pump/lil_pump
+	name = "Lil' Pump"
+
+/obj/machinery/portable_atmospherics/pump/lil_pump/Initialize(mapload)
+	//25% chance to occur
+	if(prob(25))
+		name = "Liler' Pump"
+		desc = "When a Lil' Pump and and portable air pump love each other very much."
+		var/matrix/new_transform = matrix()
+		new_transform.Scale(1, 0.8)

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -178,7 +178,7 @@
 	//25% chance to occur
 	if(prob(25))
 		name = "Liler' Pump"
-		desc = "When a Lil' Pump and and portable air pump love each other very much."
+		desc = "When a Lil' Pump and a portable air pump love each other very much."
 		var/matrix/lil_pump = matrix()
 		lil_pump.Scale(0.8)
 		src.transform = lil_pump


### PR DESCRIPTION
## About The Pull Request

Adds the possibility to change the pumps in the ordinance labs of any map.

## Why It's Good For The Game

Silly addition to the ordinance lab with no real gameplay change, purely cosmetic.

Maybe people will stop hating me for making it only 1 "Lil' Pump" per map 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds a new possible cosmetic change to the ordinance lab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
