### PR TITLE
Revert "Fixes admin.fun list"

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -80,57 +80,38 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/datum/admins/proc/display_tags,
 	/datum/admins/proc/fishing_calculator,
 	)
-GLOBAL_LIST_INIT(admin_verbs_ban, list(
-	/client/proc/unban_panel,
-	/client/proc/ban_panel,
-	/client/proc/stickybanpanel
-	))
+GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/ban_panel, /client/proc/stickybanpanel))
 GLOBAL_PROTECT(admin_verbs_ban)
-GLOBAL_LIST_INIT(admin_verbs_sounds, list(
-	/client/proc/play_local_sound,
-	/client/proc/play_direct_mob_sound,
-	/client/proc/play_sound,
-	/client/proc/set_round_end_sound
-	))
+GLOBAL_LIST_INIT(admin_verbs_sounds, list(/client/proc/play_local_sound, /client/proc/play_direct_mob_sound, /client/proc/play_sound, /client/proc/set_round_end_sound))
 GLOBAL_PROTECT(admin_verbs_sounds)
 GLOBAL_LIST_INIT(admin_verbs_fun, list(
-	/client/proc/cinematic,
-	/client/proc/cmd_admin_emp,
-	/client/proc/cmd_admin_explosion,
-	/client/proc/cmd_admin_gib,
+	/client/proc/cmd_select_equipment,
 	/client/proc/cmd_admin_gib_self,
-	/client/proc/cmd_admin_robotize,
 	/client/proc/drop_bomb,
+	/client/proc/set_dynex_scale,
 	/client/proc/drop_dynex_bomb,
-	/client/proc/everyone_random,
+	/client/proc/cinematic,
+	/client/proc/summon_ert,
+	/client/proc/cmd_admin_add_freeform_ai_law,
+	/client/proc/object_say,
+	/client/proc/toggle_random_events,
+	/client/proc/set_ooc,
+	/client/proc/reset_ooc,
 	/client/proc/forceEvent,
-	/client/proc/give_disease,
-	/client/proc/give_spell,
-	/client/proc/remove_spell,
-	/client/proc/load_circuit,
-	/client/proc/makepAI,
+	/client/proc/admin_change_sec_level,
+	/client/proc/toggle_nuke,
+	/client/proc/run_weather,
 	/client/proc/mass_zombie_infection,
 	/client/proc/mass_zombie_cure,
-	/client/proc/object_say,
-	/client/proc/play_sound,
-	/client/proc/play_direct_mob_sound,
-	/client/proc/play_local_sound,
-	/client/proc/play_web_sound,
 	/client/proc/polymorph_all,
-	/client/proc/set_round_end_sound,
+	/client/proc/show_tip,
 	/client/proc/smite,
-	/client/proc/summon_ert,
+	/client/proc/admin_away,
+	/client/proc/add_mob_ability,
 	/datum/admins/proc/station_traits_panel,
 	))
 GLOBAL_PROTECT(admin_verbs_fun)
-GLOBAL_LIST_INIT(admin_verbs_spawn, list(
-	/datum/admins/proc/spawn_atom,
-	/datum/admins/proc/podspawn_atom,
-	/datum/admins/proc/spawn_cargo,
-	/datum/admins/proc/spawn_objasmob,
-	/client/proc/respawn_character,
-	/datum/admins/proc/beaker_panel
-	))
+GLOBAL_LIST_INIT(admin_verbs_spawn, list(/datum/admins/proc/spawn_atom, /datum/admins/proc/podspawn_atom, /datum/admins/proc/spawn_cargo, /datum/admins/proc/spawn_objasmob, /client/proc/respawn_character, /datum/admins/proc/beaker_panel))
 GLOBAL_PROTECT(admin_verbs_spawn)
 GLOBAL_LIST_INIT(admin_verbs_server, world.AVerbsServer())
 GLOBAL_PROTECT(admin_verbs_server)


### PR DESCRIPTION
Reverts tgstation/tgstation#68336

The above PR, under the guise of alleged "fixes", variously adds and removes a number of admin verbs with no explanation. In the case of the removals this is quite concerning because useful administrative tools are made inaccessible, with neither a justification, nor even any mention of this occurring given in the PR body.

Either this change was: 
Unintentional and a result of the PR being marked as ready and subsequently merged before mistakes could be corrected

Intentional but the author neglected to discuss these changes in the PR body, leading the PR to be merged without further scrutiny as it appeared at first glance to be a harmless fix

More worryingly, intentional and intentionally obscured in an effort to get it merged without further scrutiny disguised as a fix

Which scenario applies here is a matter for headcoder consideration but regardless, in none of these scenarios is it beneficial or appropriate for the change to be allowed to remain.