### PR TITLE
shutters, blast doors, and bluespace gas vendors are now in the structures category of crafting

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -1253,7 +1253,7 @@
 				/obj/item/stack/sheet/glass = 10,
 				/obj/item/stack/cable_coil = 10,
 				)
-	category = CAT_MISC
+	category = CAT_STRUCTURE
 
 /datum/crafting_recipe/shutters
 	name = "Shutters"
@@ -1264,7 +1264,7 @@
 	result = /obj/machinery/door/poddoor/shutters/preopen
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL, TOOL_WIRECUTTER, TOOL_WELDER)
 	time = 10 SECONDS
-	category = CAT_MISC
+	category = CAT_STRUCTURE
 	one_per_turf = TRUE
 
 /datum/crafting_recipe/blast_doors
@@ -1276,7 +1276,7 @@
 	result = /obj/machinery/door/poddoor/preopen
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL, TOOL_WIRECUTTER, TOOL_WELDER)
 	time = 30 SECONDS
-	category = CAT_MISC
+	category = CAT_STRUCTURE
 	one_per_turf = TRUE
 
 /datum/crafting_recipe/aquarium


### PR DESCRIPTION
## About The Pull Request

see above

## Why It's Good For The Game

they're all structures, yet they are in the MISC category, 

## Changelog


:cl:
qol: Shutters, Blast doors, and Bluespace Vendors are now in the structures category, instead of misc, craft away! 
/:cl:

