### PR TITLE
You can now recolor graffiti to dark colors.

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST(gang_tags)
 	gender = NEUTER
 	plane = GAME_PLANE //makes the graffiti visible over a wall.
 	mergeable_decal = FALSE
+	flags_1 = ALLOW_DARK_PAINTS_1
 	var/do_icon_rotate = TRUE
 	var/rotation = 0
 	var/paint_colour = "#FFFFFF"


### PR DESCRIPTION
## About The Pull Request
Previously, you were able to draw a decal of a low luminosity color on a turf, but not recolor an existing one to said color.

## Why It's Good For The Game
Fixing a small inconsistence.

## Changelog

:cl:
fix: You can now recolor graffiti to dark colors.
/:cl:
