### PR TITLE
Fixes Bannana Gluttons breaking when eating Bananas.

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -100,13 +100,14 @@
 		AddElement(/datum/element/food_trash, trash_type, FOOD_TRASH_OPENABLE, /obj/item/food/grown/.proc/generate_trash)
 	return
 
-/// Callback proc for bonus behavior for generating trash of grown food. Used by [/datum/element/food_trash].
-/obj/item/food/grown/proc/generate_trash()
+/// Generates a piece of trash based on our plant item. Used by [/datum/element/food_trash].
+/// location - Optional. If passed, generates the item at the passed location instead of inside src.
+/obj/item/food/grown/proc/generate_trash(atom/location)
 	// If this is some type of grown thing, we pass a seed arg into its Inititalize()
 	if(ispath(trash_type, /obj/item/grown) || ispath(trash_type, /obj/item/food/grown))
-		return new trash_type(src, seed)
+		return new trash_type(location || drop_location(), seed)
 
-	return new trash_type(src)
+	return new trash_type(location || drop_location())
 
 /obj/item/food/grown/grind_requirements()
 	if(dry_grind && !HAS_TRAIT(src, TRAIT_DRIED))

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -101,7 +101,7 @@
 	return
 
 /// Generates a piece of trash based on our plant item. Used by [/datum/element/food_trash].
-/// location - Optional. If passed, generates the item at the passed location instead of inside src.
+/// location - Optional. If passed, generates the item at the passed location instead of at src's drop location.
 /obj/item/food/grown/proc/generate_trash(atom/location)
 	// If this is some type of grown thing, we pass a seed arg into its Inititalize()
 	if(ispath(trash_type, /obj/item/grown) || ispath(trash_type, /obj/item/food/grown))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -436,22 +436,25 @@
 ///This proc eats the atom, certain funny items are stored directly in the prank pouch while bananas grant a heal based on their potency and the peels are retained in the pouch.
 /mob/living/simple_animal/hostile/retaliate/clown/mutant/glutton/proc/eat_atom(atom/movable/eaten_atom)
 
-	var/static/funny_items = list(/obj/item/food/pie/cream,
-								/obj/item/food/grown/tomato,
-								/obj/item/food/meatclown)
+	var/static/funny_items = list(
+		/obj/item/food/pie/cream,
+		/obj/item/food/grown/tomato,
+		/obj/item/food/meatclown,
+	)
 
 	visible_message(span_warning("[src] eats [eaten_atom]!"), span_notice("You eat [eaten_atom]."))
 	if(is_type_in_list(eaten_atom, funny_items))
 		eaten_atom.forceMove(src)
 		prank_pouch += eaten_atom
 
-	else if(istype(eaten_atom, /obj/item/food/grown/banana))
-		var/obj/item/food/grown/banana/banana_morsel = eaten_atom
-		adjustBruteLoss(-banana_morsel.seed.potency * 0.25)
-		prank_pouch += banana_morsel.generate_trash(src)
-		qdel(eaten_atom)
 	else
+		if(istype(eaten_atom, /obj/item/food/grown/banana))
+			var/obj/item/food/grown/banana/banana_morsel = eaten_atom
+			adjustBruteLoss(-banana_morsel.seed.potency * 0.25)
+			prank_pouch += banana_morsel.generate_trash(src)
+
 		qdel(eaten_atom)
+
 	playsound(loc,'sound/items/eatfood.ogg', rand(30,50), TRUE)
 	flick("glutton_mouth", src)
 


### PR DESCRIPTION
## About The Pull Request

Fixes #60933 

`generate_trash()` never used the `location` argument the banana glutton passed. 
This meant the trash was instantiated inside the banana, which was deleted, which deleted the banana peel.
This in turn caused the banana peel to hard delete as the clown held a reference to it in the prank pouch. 

So, I just changed the `generate_trash()` proc a tiny bit, then did some cleanup.
The food trash element already handled moving the trash around itself, so behavior doesn't change there. 

## Why It's Good For The Game

Gluttons can consume banan without concern. 

## Changelog

:cl: Melbert
fix: Banana Glutton's ability will no longer break after eating a banana.
/:cl:
