### PR TITLE
Shortens names on orbit ui

### DIFF
--- a/code/controllers/subsystem/points_of_interest.dm
+++ b/code/controllers/subsystem/points_of_interest.dm
@@ -112,7 +112,7 @@ SUBSYSTEM_DEF(points_of_interest)
 			continue
 
 		var/mob/target_mob = mob_poi.target
-		var/name = avoid_assoc_duplicate_keys(target_mob.name, used_name_list) + target_mob.get_realname_string()
+		var/name = avoid_assoc_duplicate_keys(target_mob.real_name, used_name_list)
 
 		// Add the ghost/dead tag to the end of dead mob POIs.
 		if(append_dead_role && target_mob.stat == DEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Orbit UI now shows the real_name of players instead of name + disguise + id etc.
Basically entries like 
JC Denton (as Alex D) [Adam Jensen] (5 ghosts)
becomes
JC Denton (5 Ghosts)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While displaying aliases seems ok in theory, in game this was producing a number of observable buttons that were so obscenely long that I needed to set a max length of player name + alias combos, otherwise the button would clip beyond the viewable area. 

This was a problem in both Orbit UIs (the previous and the current).

I understand that this offers some capability of meta-gaming, but I'd argue that it is not increasing that capability beyond what orbiting already provides; these types of hypothetical issues shouldn't be considered.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Player names in orbit UI are now shortened to their real names only.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
