### PR TITLE
Fixes speedloaders and stripper clips only being able to load their initial ammo subtype, and not their matching caliber as intended.

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -4,6 +4,7 @@
 	icon_state = "357"
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7
+	caliber = CALIBER_357
 	multiple_sprites = AMMO_BOX_PER_BULLET
 	item_flags = NO_MAT_REDEMPTION
 
@@ -18,6 +19,7 @@
 	icon_state = "38"
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
+	caliber = CALIBER_38
 	multiple_sprites = AMMO_BOX_PER_BULLET
 	custom_materials = list(/datum/material/iron = 20000)
 
@@ -82,6 +84,7 @@
 	icon_state = "762"
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 5
+	caliber = CALIBER_A762
 	multiple_sprites = AMMO_BOX_PER_BULLET
 
 /obj/item/ammo_box/n762


### PR DESCRIPTION
## About The Pull Request

This was broken when calibers were moved to defines. Since these are functionally magazines, it stands to reason they should fit their actual caliber types.

## Why It's Good For The Game

This was broken for two years, I kept forgetting to investigate, and it pissed me off.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Speedloaders and stripper clips can once again can load in ammo of the same caliber. Detectives rejoice!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
