### PR TITLE
Makes backblast not runtime, moves some of its behaviour to an "incendiary/fire" parent

### DIFF
--- a/code/datums/elements/backblast.dm
+++ b/code/datums/elements/backblast.dm
@@ -64,7 +64,7 @@
 /// For firing an actual backblast pellet
 /datum/element/backblast/proc/pew(turf/target_turf, obj/item/gun/weapon, mob/living/user)
 	//Shooting Code:
-	var/obj/projectile/bullet/incendiary/backblast/P = new (get_turf(user))
+	var/obj/projectile/bullet/incendiary/fire/backblast/P = new (get_turf(user))
 	P.original = target_turf
 	P.range = range
 	P.fired_from = weapon

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -283,15 +283,12 @@
 	. = ..()
 	if(!.)
 		return
-	var/obj/projectile/flame = new /obj/projectile/bullet/incendiary/backblast/flamethrower(mod.wearer.loc)
+	var/obj/projectile/flame = new /obj/projectile/bullet/incendiary/fire(mod.wearer.loc)
 	flame.preparePixelProjectile(target, mod.wearer)
 	flame.firer = mod.wearer
 	playsound(src, 'sound/items/modsuit/flamethrower.ogg', 75, TRUE)
 	INVOKE_ASYNC(flame, /obj/projectile.proc/fire)
 	drain_power(use_power_cost)
-
-/obj/projectile/bullet/incendiary/backblast/flamethrower
-	range = 6
 
 ///Power kick - Lets the user launch themselves at someone to kick them.
 /obj/item/mod/module/power_kick

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -22,7 +22,7 @@
 		new /obj/effect/hotspot(location)
 		location.hotspot_expose(700, 50, 1)
 
-/// Incendienary bullet that more closely resembles a real flamethrower sorta deal, no visible bullet, just flames.
+/// Incendiary bullet that more closely resembles a real flamethrower sorta deal, no visible bullet, just flames.
 /obj/projectile/bullet/incendiary/fire
 	damage = 15
 	range = 6

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -22,19 +22,16 @@
 		new /obj/effect/hotspot(location)
 		location.hotspot_expose(700, 50, 1)
 
-/// Used in [the backblast element][/datum/element/backblast]
-/obj/projectile/bullet/incendiary/backblast
+/// Incendienary bullet that more closely resembles a real flamethrower sorta deal, no visible bullet, just flames.
+/obj/projectile/bullet/incendiary/fire
 	damage = 15
-	range = 10 // actually overwritten in the backblast element
+	range = 6
 	alpha = 0
 	pass_flags = PASSTABLE | PASSMOB
 	sharpness = NONE
 	shrapnel_type = null
 	embedding = null
 	impact_effect_type = null
-	ricochet_chance = 10000
-	ricochets_max = 4
-	ricochet_incidence_leeway = 0
 	suppressed = SUPPRESSED_VERY
 	damage_type = BURN
 	armor_flag = BOMB
@@ -44,6 +41,18 @@
 	wound_falloff_tile = -4
 	fire_stacks = 3
 
+/obj/projectile/bullet/incendiary/fire/on_hit(atom/target, blocked)
+	. = ..()
+	var/turf/location = get_turf(target)
+	if(isopenturf(location))
+		new /obj/effect/hotspot(location)
+		location.hotspot_expose(700, 50, 1)
+
+/// Used in [the backblast element][/datum/element/backblast]
+/obj/projectile/bullet/incendiary/fire/backblast
+	ricochet_chance = 10000
+	ricochets_max = 4
+	ricochet_incidence_leeway = 0
 	/// Lazy attempt at knockback, any items this plume hits will be knocked back this far. Decrements with each tile passed.
 	var/knockback_range = 7
 	/// A lazylist of all the items we've already knocked back, so we don't do it again
@@ -52,19 +61,14 @@
 /// we only try to knock back the first 6 items per tile
 #define BACKBLAST_MAX_ITEM_KNOCKBACK 6
 
-/obj/projectile/bullet/incendiary/backblast/on_hit(atom/target, blocked)
-	. = ..()
-	var/turf/location = get_turf(target)
-	if(isopenturf(location))
-		new /obj/effect/hotspot(location)
-		location.hotspot_expose(700, 50, 1)
-
-/obj/projectile/bullet/incendiary/backblast/Move()
+/obj/projectile/bullet/incendiary/fire/backblast/Move()
 	. = ..()
 	if(knockback_range <= 0)
 		return
 	knockback_range--
 	var/turf/current_turf = get_turf(src)
+	if(!current_turf)
+		return
 	var/turf/throw_at_turf = get_turf_in_angle(Angle, current_turf, 7)
 	var/thrown_items = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/68393
Moves backblast's visual appearance and setting hit stuff on fire to a subtype of incendiary bullets, and makes backblast a sutype of that (the modsuit flamethrower now uses that fire projectile)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Less bug and more sense

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: modsuit flamethrower will no longer push objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
