### PR TITLE
Fix Virology Healing symptom exploit.

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -19,8 +19,6 @@
 	. = ..()
 	if(!.)
 		return
-	if(A.totalStageSpeed() >= 6) //stronger healing
-		power = 2
 
 /datum/symptom/heal/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -10,12 +10,11 @@
 	symptom_delay_min = 1
 	symptom_delay_max = 1
 	var/passive_message = "" //random message to infected but not actively healing people
-	threshold_descs = list(
-		"Stealth 4" = "Healing will no longer be visible to onlookers.",
-	)
 
 /datum/symptom/heal/Start(datum/disease/advance/A)
 	. = ..()
+	// Anything put in here will apply to all other healing symptoms.
+	// Do not put anything here.
 	if(!.)
 		return
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -11,7 +11,6 @@
 	symptom_delay_max = 1
 	var/passive_message = "" //random message to infected but not actively healing people
 	threshold_descs = list(
-		"Stage Speed 6" = "Doubles healing speed.",
 		"Stealth 4" = "Healing will no longer be visible to onlookers.",
 	)
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -11,12 +11,6 @@
 	symptom_delay_max = 1
 	var/passive_message = "" //random message to infected but not actively healing people
 
-/datum/symptom/heal/Start(datum/disease/advance/A)
-	. = ..()
-	// Anything put in here will apply to all other healing symptoms.
-	// Do not put anything here.
-	if(!.)
-		return
 
 /datum/symptom/heal/Activate(datum/disease/advance/A)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This removes a Stage Speed 6 threshold that's sat in the symptom/heal class as a template for far too long, that had been silently buffing every single healing symptom in an undocumented and uninteded way. Most obvious is with the regenerative coma symptom, which has a stage speed 7 threshhold setting the power to 1.5, where the exploit, at 6 would put it at power = 2. 

EDIT: To clarify.
Deleting these 2 lines of code, in a template symptom that doesn't do anything, and says not to use it, fixes the following issues:
```
Starlight Condensation (heal/starlight): duplicated SS6:Power=2  threshold code.
Toxolysis (heal/chem):                   duplicated Power=2 at R7, undocumented SS6:Power=2 threshold
Nocturnal Regeneration (heal/darkness):  redundant SS8:Power=2 code, Pandemic showing SS8 when it happens at SS6 
Regenerative Coma (heal/coma):           undocumented SS6:Power=2 sweet spot, before the documented SS7:Power=1.5
Tissue Hydration (heal/water):           redundant SS7:Power=2 code, Pandemic showing SS7 when it happens at SS6 
Plasma Fixation (heal/plasma):           redundant SS7:Power=2 code, Pandemic showing SS7 when it happens at SS6 
Radioactive Resonance(heal/radiation):   duplicated Power=2 at R7, undocumented SS6:Power=2 threshold
*SS: StageSpeed, R7: Resistance 7
```

This happens because they all call ..() in Start(), which calls heal/Start().
This cannot be removed because heal/Start() calls ..() to call symptoms/Start() and inherit the base neutering behaviour.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes an ages old exploit and keeps the healing symptoms functioning as intended, and as documented.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Virology: all healing symptoms no longer receive an accidental power boost at Stage Speed 6.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
