### PR TITLE
Lets portable atmos react when wrenched.

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -50,10 +50,9 @@
 	return ..()
 
 /obj/machinery/portable_atmospherics/process_atmos()
-	if(!connected_port) // Pipe network handles reactions if connected, and we can't stop processing if there's a port effecting our mix
-		excited = (excited | air_contents.react(src))
-		if(!excited)
-			return PROCESS_KILL
+	excited = (excited | air_contents.react(src))
+	if(!excited)
+		return PROCESS_KILL
 	excited = FALSE
 
 /// Take damage if a variable is exceeded. Damage is equal to temp/limit * heat/limit.


### PR DESCRIPTION
## About The Pull Request
Title.
Previous attempt by https://github.com/tgstation/tgstation/pull/66207

A bit surprised that I don't have to change that many things. 

Wrenched cans are always marked as excited every time the pipeline processes:
https://github.com/tgstation/tgstation/blob/03ec15115a5b0b5c9c8b9a89480ca96bef9224ed/code/controllers/subsystem/air.dm#L273
https://github.com/tgstation/tgstation/blob/7103f8150a6d281e452b26b8ae0a8948af26965c/code/modules/atmospherics/machinery/datum_pipeline.dm#L231
https://github.com/tgstation/tgstation/blob/7103f8150a6d281e452b26b8ae0a8948af26965c/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm#L47

I.E. process every tick. Let me know if this is bad.

And when off grid it works as usual.

## Why It's Good For The Game
Canisters not reacting when wrenched but reacting every other time doesn't really make intuitive sense.

## Changelog
:cl:
qol: Canisters, scrubbers, and pumps no longer stop reacting when wrenched.
/:cl: