### PR TITLE
Portable atmos doesnt process twice on spawn + comment

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -18,7 +18,7 @@
 	var/volume = 0
 	///Used to track if anything of note has happen while running process_atmos(). 
 	///Treat it as a process_atmos() scope var, we just declare it here to pass it between parent calls.
-	///Should start false on start of every process_atmos() proc, since true means we'll process again next tick.
+	///Should be false on start of every process_atmos() proc, since true means we'll process again next tick.
 	var/excited = FALSE
 
 	/// Max amount of heat allowed inside the machine before it starts to melt. [PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT] is special value meaning we are immune.

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -17,7 +17,7 @@
 	///Volume (in L) of the inside of the machine
 	var/volume = 0
 	///Used to track if anything of note has happen while running process_atmos(). 
-	///Treat it as a process_atmos() scope var, we just declare it here to pass it within parent calls.
+	///Treat it as a process_atmos() scope var, we just declare it here to pass it between parent calls.
 	///Should start as false on every process by the way.
 	var/excited = FALSE
 

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -16,8 +16,9 @@
 	var/obj/item/tank/holding
 	///Volume (in L) of the inside of the machine
 	var/volume = 0
-	///Used to track if anything of note has happen while running process_atmos()
-	var/excited = TRUE
+	///Used to track if anything of note has happen while running process_atmos(). 
+	///Treat it as a process_atmos() scope var, we just declare it here to pass it within parent calls.
+	var/excited = FALSE
 
 	/// Max amount of heat allowed inside the machine before it starts to melt. [PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT] is special value meaning we are immune.
 	var/temp_limit = 10000

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -18,7 +18,7 @@
 	var/volume = 0
 	///Used to track if anything of note has happen while running process_atmos(). 
 	///Treat it as a process_atmos() scope var, we just declare it here to pass it between parent calls.
-	///Should start as false on every process by the way.
+	///Should start false on start of every process_atmos() proc, since true means we'll process again next tick.
 	var/excited = FALSE
 
 	/// Max amount of heat allowed inside the machine before it starts to melt. [PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT] is special value meaning we are immune.

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -18,6 +18,7 @@
 	var/volume = 0
 	///Used to track if anything of note has happen while running process_atmos(). 
 	///Treat it as a process_atmos() scope var, we just declare it here to pass it within parent calls.
+	///Should start as false on every process by the way.
 	var/excited = FALSE
 
 	/// Max amount of heat allowed inside the machine before it starts to melt. [PORTABLE_ATMOS_IGNORE_ATMOS_LIMIT] is special value meaning we are immune.


### PR DESCRIPTION
## About The Pull Request
Title
True will be propagated down the line even if there is no reason, making it run twice.

## Why It's Good For The Game
Cdoing

## Changelog
:cl:
code: Canisters should process once instead of twice when spawning. No gameplay changes expected.
/:cl: