### PR TITLE
Fix Virology healing symptom documentation 

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -81,8 +81,6 @@
 		return
 	if(A.totalTransmittable() >= 6)
 		nearspace_penalty = 1
-	if(A.totalStageSpeed() >= 6)
-		power = 2
 
 /datum/symptom/heal/starlight/proc/CanTileHealDirectional(turf/turf_to_check, direction)
 	if(direction == ZTRAIT_UP)
@@ -201,6 +199,7 @@
 	threshold_descs = list(
 		"Resistance 7" = "Increases chem removal speed.",
 		"Stage Speed 6" = "Consumed chemicals nourish the host.",
+		"Stage Speed 6" = "Increases chem removal speed, does not stack with Resistance 7",
 	)
 
 /datum/symptom/heal/chem/Start(datum/disease/advance/A)
@@ -283,15 +282,14 @@
 	level = 6
 	passive_message = "<span class='notice'>You feel tingling on your skin as light passes over it.</span>"
 	threshold_descs = list(
-		"Stage Speed 8" = "Doubles healing speed.",
+		"Stage Speed 6" = "Doubles healing speed.",
 	)
 
 /datum/symptom/heal/darkness/Start(datum/disease/advance/A)
 	. = ..()
 	if(!.)
 		return
-	if(A.totalStageSpeed() >= 8)
-		power = 2
+
 
 /datum/symptom/heal/darkness/CanHeal(datum/disease/advance/A)
 	var/mob/living/M = A.affected_mob
@@ -344,7 +342,8 @@
 	threshold_descs = list(
 		"Stealth 2" = "Host appears to die when falling into a coma.",
 		"Resistance 4" = "The virus also stabilizes the host while they are in critical condition.",
-		"Stage Speed 7" = "Increases healing speed.",
+		"Stage Speed 6" = "Increases healing speed.",
+		"Stage Speed 7" = "Decreases healing speed slightly.",
 	)
 
 /datum/symptom/heal/coma/Start(datum/disease/advance/A)
@@ -439,15 +438,13 @@
 	var/absorption_coeff = 1
 	threshold_descs = list(
 		"Resistance 5" = "Water is consumed at a much slower rate.",
-		"Stage Speed 7" = "Increases healing speed.",
+		"Stage Speed 6" = "Increases healing speed.",
 	)
 
 /datum/symptom/heal/water/Start(datum/disease/advance/A)
 	. = ..()
 	if(!.)
 		return
-	if(A.totalStageSpeed() >= 7)
-		power = 2
 	if(A.totalResistance() >= 5)
 		absorption_coeff = 0.25
 
@@ -501,15 +498,13 @@
 	var/temp_rate = 1
 	threshold_descs = list(
 		"Transmission 6" = "Increases temperature adjustment rate.",
-		"Stage Speed 7" = "Increases healing speed.",
+		"Stage Speed 6" = "Increases healing speed.",
 	)
 
 /datum/symptom/heal/plasma/Start(datum/disease/advance/A)
 	. = ..()
 	if(!.)
 		return
-	if(A.totalStageSpeed() >= 7)
-		power = 2
 	if(A.totalTransmittable() >= 6)
 		temp_rate = 4
 
@@ -575,6 +570,7 @@
 	threshold_descs = list(
 		"Transmission 6" = "Additionally heals cellular damage.",
 		"Resistance 7" = "Increases healing speed.",
+		"Stage Speed 6" = "Increases healing speed, does not stack with Resistance 7.",
 	)
 
 /datum/symptom/heal/radiation/Start(datum/disease/advance/A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This documents a Stage Speed 6 threshold that's been inherited by every healing symptom, from the base heal.
Also removes the redundant code that results, from it. As #68415 was denied, this is the counter fix.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Documents an "intended feature" so players can see it in the panDEMIC, and removes a bunch of redundant code.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Virology: added the previously hidden StageSpeed 6 threshold that all healing symptoms have to the panDEMIC.
code: Virology: removes redundant thresholds in healing symptoms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
