### PR TITLE
The mining wardrobe has now an "explorer" duffelbag instead of a normal one. 

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -367,7 +367,7 @@
 	desc = "A large duffel bag for holding extra medical supplies - this one seems to be designed for holding surgical tools."
 
 /obj/item/storage/backpack/duffelbag/explorer
-	name = "explorator's duffel bag"
+	name = "explorer duffel bag"
 	desc = "A large duffel bag for holding extra exotic treasures."
 	icon_state = "duffel-explorer"
 	inhand_icon_state = "duffel-explorer"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -26,7 +26,7 @@
 	icon_door = "mixed"
 
 /obj/structure/closet/wardrobe/miner/PopulateContents()
-	new /obj/item/storage/backpack/duffelbag(src)
+	new /obj/item/storage/backpack/duffelbag/explorer(src)
 	new /obj/item/storage/backpack/explorer(src)
 	new /obj/item/storage/backpack/satchel/explorer(src)
 	new /obj/item/clothing/under/rank/cargo/miner/lavaland(src)


### PR DESCRIPTION
## About The Pull Request
In  PR #56505, I added missing departemental duffel bags. I also added/changed respective source of acquisitions to get them. But there is one source that I forgot to change : the mining wardrobe was still having a normal duffel bag next to their explorer's version : 
![duffelbag](https://user-images.githubusercontent.com/17699222/179005128-d486d66d-2c5f-4182-8066-d84456c87ba4.png)

It is now fixed.
I also renamed the "explorator's duffelbag" to "explorer duffelbag" so it follows nicely the other mining bag's name convention.
![duffelbag-fixed](https://user-images.githubusercontent.com/17699222/179008184-3989ed22-3011-42f7-bd4d-b8e09c7e9061.png)

## Why It's Good For The Game
If a locker is providing miner themed clothing and containers, then it is expected to find the explorer duffel bag next to the satchel and backpack.

## Changelog


:cl:
fix: The mining wardrobe locker contains an explorer duffel bag instead of a normal one now
spellcheck: "explorator's duffel bag" is now called "explorer duffel bag"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
