### PR TITLE
Biogenerator's beaker is removed by right clicking instead of alt clicking

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -39,7 +39,7 @@
 				context[SCREENTIP_CONTEXT_LMB] = "Remove electronics"
 				return CONTEXTUAL_SCREENTIP_SET
 
-	if (istype(held_item, /obj/item/food/grown/ ))
+	if (istype(held_item, /obj/item/food/grown))
 		context[SCREENTIP_CONTEXT_LMB] = "Insert product"
 		return CONTEXTUAL_SCREENTIP_SET
 	else if (istype(held_item, /obj/item/storage/bag/plants))

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -39,15 +39,18 @@
 				context[SCREENTIP_CONTEXT_LMB] = "Remove electronics"
 				return CONTEXTUAL_SCREENTIP_SET
 
-	switch (held_item?.type)
-		if (/obj/item/food/grown/ || /obj/item/storage/bag/plants)
-			context[SCREENTIP_CONTEXT_LMB] = "Insert produce"
-			return CONTEXTUAL_SCREENTIP_SET
-		if (/obj/item/reagent_containers/glass)
-			context[SCREENTIP_CONTEXT_LMB] = "Swap container"
-			return CONTEXTUAL_SCREENTIP_SET
-		if (/obj/item)
-			return .
+	if (istype(held_item, /obj/item/food/grown/ ))
+		context[SCREENTIP_CONTEXT_LMB] = "Insert product"
+		return CONTEXTUAL_SCREENTIP_SET
+	else if (istype(held_item, /obj/item/storage/bag/plants))
+		context[SCREENTIP_CONTEXT_LMB] = "Insert products"
+		return CONTEXTUAL_SCREENTIP_SET
+	else if (istype(held_item, /obj/item/reagent_containers/glass ))
+		context[SCREENTIP_CONTEXT_LMB] =  beaker ? "Swap container" : "Insert container"
+		return CONTEXTUAL_SCREENTIP_SET
+	else if (istype(held_item, /obj/item/ ))
+		return .
+		
 	context[SCREENTIP_CONTEXT_LMB] = "Open UI"
 	if(beaker)
 		context[SCREENTIP_CONTEXT_RMB] = "Remove beaker"

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -45,7 +45,7 @@
 	else if (istype(held_item, /obj/item/storage/bag/plants))
 		context[SCREENTIP_CONTEXT_LMB] = "Insert products"
 		return CONTEXTUAL_SCREENTIP_SET
-	else if (istype(held_item, /obj/item/reagent_containers/glass ))
+	else if (istype(held_item, /obj/item/reagent_containers/glass))
 		context[SCREENTIP_CONTEXT_LMB] =  beaker ? "Swap container" : "Insert container"
 		return CONTEXTUAL_SCREENTIP_SET
 	else if (istype(held_item, /obj/item/ ))

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -19,6 +19,39 @@
 /obj/machinery/biogenerator/Initialize(mapload)
 	. = ..()
 	stored_research = new /datum/techweb/specialized/autounlocking/biogenerator
+	register_context()
+
+/obj/machinery/biogenerator/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	if(!isliving(user))
+		return .
+
+	if(!Adjacent(user))
+		return .
+
+	switch (held_item?.tool_behaviour)
+		if (TOOL_SCREWDRIVER)
+			context[SCREENTIP_CONTEXT_LMB] = panel_open ? "Close panel" : "Open panel"
+			return CONTEXTUAL_SCREENTIP_SET
+		if (TOOL_CROWBAR)
+			if (panel_open)
+				context[SCREENTIP_CONTEXT_LMB] = "Remove electronics"
+				return CONTEXTUAL_SCREENTIP_SET
+
+	switch (held_item?.type)
+		if (/obj/item/food/grown/ || /obj/item/storage/bag/plants)
+			context[SCREENTIP_CONTEXT_LMB] = "Insert produce"
+			return CONTEXTUAL_SCREENTIP_SET
+		if (/obj/item/reagent_containers/glass)
+			context[SCREENTIP_CONTEXT_LMB] = "Swap container"
+			return CONTEXTUAL_SCREENTIP_SET
+		if (/obj/item)
+			return .
+	context[SCREENTIP_CONTEXT_LMB] = "Open UI"
+	if(beaker)
+		context[SCREENTIP_CONTEXT_RMB] = "Remove beaker"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/biogenerator/Destroy()
 	QDEL_NULL(beaker)

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -148,11 +148,20 @@
 	else
 		to_chat(user, span_warning("You cannot put this in [src.name]!"))
 
-/obj/machinery/biogenerator/AltClick(mob/living/user)
+/obj/machinery/biogenerator/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
-	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK) && can_interact(user))
-		eject_beaker(user)
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	if(!can_interact(user) || !user.canUseTopic(src, !issilicon(user), FALSE, NO_TK))
+		return
+	eject_beaker(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
+/obj/machinery/biogenerator/attack_robot_secondary(mob/user, list/modifiers)
+	return attack_hand_secondary(user, modifiers)
+
+/obj/machinery/biogenerator/attack_ai_secondary(mob/user, list/modifiers)
+	return attack_hand_secondary(user, modifiers)
 /**
  * activate: Activates biomass processing and converts all inserted grown products into biomass
  *


### PR DESCRIPTION
## About The Pull Request
In short : Biogenerator works like other chemistry's machines : you remove the beaker with a right click.

I was playing botanist when a detail upset me : whenever I wanted to remove a beaker from a grinder or the condimaster, I use right click. 
Yet whenever I want to remove the biogenerator's beaker, said right click doesn't do anything. So I use alt click.
Then whenever I want to remove again a beaker in the grinder or condimaster, alt clicking doesn't do anything too.

So I had enough and decided to make this PR.

If there is a specific reason why the biogenerator must use alt-click unlike other machines, please let me know.

## Why It's Good For The Game
It keeps the mechanic of removing the biogenerator's beaker consistent with other chemistry machines, specialy when cooks and botanists use the grinder and the condimaster.

## Changelog

:cl:
qol: Removing the biogenerator's beakers is now done by right-clicking the machine, just like other chemistry machines.
qol : The biogenerator has now usage screentips depending on what you're holding.
/:cl:
