### PR TITLE
Tightens up the windows looking into the QM's office on Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3842,7 +3842,6 @@
 /turf/open/floor/plating,
 /area/station/medical/morgue)
 "bji" = (
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -27145,7 +27144,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ikO" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/qm)
 "ikW" = (
@@ -62494,6 +62493,7 @@
 "tkk" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "tkB" = (


### PR DESCRIPTION
## About The Pull Request

Hey there, it's me not-San. 

![image](https://user-images.githubusercontent.com/51863163/179090607-f3476f7b-8bf5-423f-a49f-0cc35bc93fef.png)

The windows looking into the QM's office on Icebox are un-reinforced, which is odd because it's a secure area now. 
Also there's a light on the window. 

![image](https://user-images.githubusercontent.com/51863163/179090717-f90b4e59-9a11-4421-848d-6ea97e0a71cd.png)

I moved the light over, and replace the windows with reinforced ones. 

## Why It's Good For The Game

The QM's office is a head of staff's office, so the normal windows made it trivially easy to break in, when it should be a bit tougher than that. The walls around it are still un-reinforced.

## Changelog

:cl: Melbert
qol: Icebox: The Quartermaster's office has had its windows reinforced. 
/:cl:
