### PR TITLE
Tweak heat damage modifier for lizardpeople

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -22,7 +22,7 @@
 	)
 	mutanttongue = /obj/item/organ/internal/tongue/lizard
 	coldmod = 1.5
-	heatmod = 0.67
+	heatmod = 0.5
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_cookie = /obj/item/food/meat/slab


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/85910816/179128540-d28a191c-4112-4648-8260-d1e47333d379.png)

## Why It's Good For The Game

I think it would be more fair to lizardpeople--since the cold damage modifier is 1.5--to have the heat damage modifier set at .5
(I've also seen a lot of complaints about how lizardpeople have nothing good going for them as a species.)

## Changelog

:cl:
balance: Lizardpeople have slightly increased heat resistance. 
/:cl:
