### PR TITLE
Cyborg damage slowdown and borg stun rebalance

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -140,6 +140,8 @@
 GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 	/obj/item/gun)))
 
+//Silicon slowdown
+#define SILICON_HALFSTUN_LENGTH 40
 
 //Combat object defines
 

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -114,16 +114,26 @@
 
 	//robots
 	else if(iscyborg(target))
-		var/mob/living/silicon/S = target
-		log_combat(user, S, "shone in the sensors", src)
+		var/mob/living/silicon/blinded_borg = target
+		log_combat(user, blinded_borg, "shone in the sensors", src)
 		//chance to actually hit the eyes depends on internal component
 		if(prob(effectchance * diode.rating))
-			S.flash_act(affect_silicon = 1)
-			S.Paralyze(rand(100,200))
-			to_chat(S, span_danger("Your sensors were overloaded by a laser!"))
-			outmsg = span_notice("You overload [S] by shining [src] at [S.p_their()] sensors.")
+			if(blinded_borg.IsStun())
+				user.visible_message(span_warning("[user] fails to overload [blinded_borg] with the laser!"), span_warning("You fail to overload [blinded_borg] with the laser!"))
+				return
+			if(!blinded_borg.has_movespeed_modifier(/datum/movespeed_modifier/silicon_halfstun))
+				blinded_borg.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/silicon_halfstun, TRUE, multiplicative_slowdown = 1)
+				playsound(blinded_borg, 'sound/machines/warning-buzzer.ogg', 75, TRUE, TRUE)
+				user.visible_message(span_warning("[user] overloads [blinded_borg]'s sensors with a laser!"), span_danger("You overload [blinded_borg]'s sensors with the laser!"))
+				to_chat(blinded_borg, span_danger("Your sensors were overloaded by a laser!"))
+				addtimer(CALLBACK(blinded_borg, /mob/living/silicon/robot/proc/clear_halfstun_slowdown), SILICON_HALFSTUN_LENGTH)
+				return
+			blinded_borg.Stun(rand(20,40))
+			playsound(blinded_borg, 'sound/machines/warning-buzzer.ogg', 75, TRUE, TRUE)
+			user.visible_message(span_warning("[user] overloads [blinded_borg]'s sensors with a laser, breaking it's response program!"), span_danger("You overload [blinded_borg]'s sensors with the laser, breaking it's response program!"))
+			to_chat(blinded_borg, span_danger("Your sensors were overloaded by a laser, breaking your response program!"))
 		else
-			outmsg = span_warning("You fail to overload [S] by shining [src] at [S.p_their()] sensors!")
+			outmsg = span_warning("You fail to overload [blinded_borg] with the laser!")
 
 	//cameras
 	else if(istype(target, /obj/machinery/camera))

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -128,7 +128,7 @@
 				to_chat(blinded_borg, span_danger("Your sensors were overloaded by a laser!"))
 				addtimer(CALLBACK(blinded_borg, /mob/living/silicon/robot/proc/clear_halfstun_slowdown), SILICON_HALFSTUN_LENGTH)
 				return
-			blinded_borg.Stun(rand(20,40))
+			blinded_borg.Stun(rand(40,60))
 			playsound(blinded_borg, 'sound/machines/warning-buzzer.ogg', 75, TRUE, TRUE)
 			user.visible_message(span_warning("[user] overloads [blinded_borg]'s sensors with a laser, breaking it's response program!"), span_danger("You overload [blinded_borg]'s sensors with the laser, breaking it's response program!"))
 			to_chat(blinded_borg, span_danger("Your sensors were overloaded by a laser, breaking your response program!"))

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -257,7 +257,7 @@
 			user.visible_message(span_warning("[user] overloads [flashed_borg]'s sensors with the flash!"), span_danger("You overload [flashed_borg]'s sensors with the flash!"))
 			addtimer(CALLBACK(flashed_borg, /mob/living/silicon/robot/proc/clear_halfstun_slowdown), SILICON_HALFSTUN_LENGTH)
 			return
-		flashed_borg.Stun(rand(55,65))
+		flashed_borg.Stun(rand(60,80))
 		playsound(flashed_borg, 'sound/machines/warning-buzzer.ogg', 75, TRUE, TRUE)
 		user.visible_message(span_warning("[user] overloads [flashed_borg]'s sensors with the flash, breaking it's response program!"), span_danger("You overload [flashed_borg]'s sensors with the flash, breaking it's response program!"))
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -242,18 +242,24 @@
 		flash_carbon(M, user, confusion_duration = 5 SECONDS, targeted = TRUE)
 		return
 	if(issilicon(M))
-		var/mob/living/silicon/robot/flashed_borgo = M
-		log_combat(user, flashed_borgo, "flashed", src)
+		var/mob/living/silicon/robot/flashed_borg = M
+		log_combat(user, flashed_borg, "flashed", src)
 		update_icon(ALL, TRUE)
-		if(!flashed_borgo.flash_act(affect_silicon = TRUE))
-			user.visible_message(span_warning("[user] fails to blind [flashed_borgo] with the flash!"), span_warning("You fail to blind [flashed_borgo] with the flash!"))
+		if(!flashed_borg.flash_act(affect_silicon = TRUE))
+			user.visible_message(span_warning("[user] fails to blind [flashed_borg] with the flash!"), span_warning("You fail to blind [flashed_borg] with the flash!"))
 			return
-		flashed_borgo.Paralyze(rand(80,120))
-		flashed_borgo.set_timed_status_effect(5 SECONDS * CONFUSION_STACK_MAX_MULTIPLIER, /datum/status_effect/confusion, only_if_higher = TRUE)
-		user.visible_message(span_warning("[user] overloads [flashed_borgo]'s sensors with the flash!"), span_danger("You overload [flashed_borgo]'s sensors with the flash!"))
-		return
-
-	user.visible_message(span_warning("[user] fails to blind [M] with the flash!"), span_warning("You fail to blind [M] with the flash!"))
+		if(flashed_borg.IsStun())
+			user.visible_message(span_warning("[user] fails to blind [flashed_borg] with the flash!"), span_warning("You fail to blind [flashed_borg] with the flash!"))
+			return
+		if(!flashed_borg.has_movespeed_modifier(/datum/movespeed_modifier/silicon_halfstun))
+			flashed_borg.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/silicon_halfstun, TRUE, multiplicative_slowdown = 1)
+			playsound(flashed_borg, 'sound/machines/warning-buzzer.ogg', 75, TRUE, TRUE)
+			user.visible_message(span_warning("[user] overloads [flashed_borg]'s sensors with the flash!"), span_danger("You overload [flashed_borg]'s sensors with the flash!"))
+			addtimer(CALLBACK(flashed_borg, /mob/living/silicon/robot/proc/clear_halfstun_slowdown), SILICON_HALFSTUN_LENGTH)
+			return
+		flashed_borg.Stun(rand(55,65))
+		playsound(flashed_borg, 'sound/machines/warning-buzzer.ogg', 75, TRUE, TRUE)
+		user.visible_message(span_warning("[user] overloads [flashed_borg]'s sensors with the flash, breaking it's response program!"), span_danger("You overload [flashed_borg]'s sensors with the flash, breaking it's response program!"))
 
 /obj/item/assembly/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(holder)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -598,6 +598,17 @@
 			repair_cyborg_slot(1)
 
 	previous_health = health
+	if(HAS_TRAIT(src, TRAIT_IGNOREDAMAGESLOWDOWN))
+		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
+		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
+		return
+	var/health_deficiency = maxHealth - health
+	if(health_deficiency >= 40)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / 75)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / 25)
+	else
+		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
+		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
 
 /mob/living/silicon/robot/update_sight()
 	if(!client)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1018,3 +1018,6 @@
 /// Draw power from the robot
 /mob/living/silicon/robot/proc/draw_power(power_to_draw)
 	cell?.use(power_to_draw)
+
+/mob/living/silicon/robot/proc/clear_halfstun_slowdown()
+	remove_movespeed_modifier(/datum/movespeed_modifier/silicon_halfstun)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -325,7 +325,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		if(1)
 			Stun(100)
 		if(2)
-			Stun(60)
+			Stun(70)
 
 /mob/living/silicon/robot/emag_act(mob/user)
 	if(user == src)//To prevent syndieborgs from emagging themselves

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -316,11 +316,14 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 
 /mob/living/silicon/robot/emp_act(severity)
 	. = ..()
+
 	if(. & EMP_PROTECT_SELF)
+		return
+	if(IsStun())
 		return
 	switch(severity)
 		if(1)
-			Stun(160)
+			Stun(100)
 		if(2)
 			Stun(60)
 

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -316,10 +316,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 
 /mob/living/silicon/robot/emp_act(severity)
 	. = ..()
-
 	if(. & EMP_PROTECT_SELF)
-		return
-	if(IsStun())
 		return
 	switch(severity)
 		if(1)

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -126,6 +126,6 @@
 	Proj.on_hit(src, 0, piercing_hit)
 	return BULLET_ACT_HIT
 
-/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static, length = 25)
+/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static)
 	if(affect_silicon)
 		return ..()

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -126,6 +126,6 @@
 	Proj.on_hit(src, 0, piercing_hit)
 	return BULLET_ACT_HIT
 
-/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static, 2.5 SECONDS)
+/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static, 25)
 	if(affect_silicon)
 		return ..()

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -126,6 +126,6 @@
 	Proj.on_hit(src, 0, piercing_hit)
 	return BULLET_ACT_HIT
 
-/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static, length = 2.5 seconds)
+/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static, length = 25)
 	if(affect_silicon)
 		return ..()

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -126,6 +126,6 @@
 	Proj.on_hit(src, 0, piercing_hit)
 	return BULLET_ACT_HIT
 
-/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static, 25)
+/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static, length = 2.5 seconds)
 	if(affect_silicon)
 		return ..()

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -126,6 +126,6 @@
 	Proj.on_hit(src, 0, piercing_hit)
 	return BULLET_ACT_HIT
 
-/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static)
+/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /atom/movable/screen/fullscreen/flash/static, 2.5 SECONDS)
 	if(affect_silicon)
 		return ..()

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -50,6 +50,9 @@
 /datum/movespeed_modifier/slime_healthmod
 	variable = TRUE
 
+/datum/movespeed_modifier/silicon_halfstun
+	variable = TRUE
+
 /datum/movespeed_modifier/config_walk_run
 	multiplicative_slowdown = 1
 	id = MOVESPEED_ID_MOB_WALK_RUN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Borg are very powerful, immune to space, starts with a full set of tools for their job, can't take damage from fists, don't suffer wounds or bleed out, are immune to conventional methods of getting stunned or slowed down, are immune to chems, can repair themselves if they have a welder, have all access, can control machines and doors remotely, become unable to fight when they reach 150 damage unlike humans at around 100, they can still run at full speed after having all their modules broken at 150 damage, can be mass produced at robo and importantly for this PR suffer no damage slowdown.

In combat movement speed means a lot, its easier to hit slowed opponents and if you are faster than your opponent they won't be able to can't escape from combat. Human have damage slowdown and are affected automatically in terms of movement the more damaged they get. Borg's movement speed is not affected by damage currently. This means that in any fight where the opponent to a borg dosen't have a flash, EMP or falshbang the borg will almost always have the advantage in a fight. This combined with all their other bonuses make them extremely annoying to fight without something to stun them with. And if they come close to dying, they can just run away at full speed and if they just damaged you a bit you won't be fast enough to even have equal speed. Even if you have equal speed they'll just be able to bolt a door behind themselves and escape anyway. 

This PR adds damage slowdown to borgs making them more equal in combat against anyone that's not a borg themselves.

Realistically it also makes sense like with humans when your body breaks down that you are unable to run at full speed like nothing ever happened.

To balance out the slowdown, flashes and laser pointers now need 2 hits to stun, the first hit will blind with static vision and slow down the borg, the second will stun. Borg stuns last less long and can't be chained infinitely but you can stun them again as soon as they have recovered. The stun duration is still enough to emag, give the borg damage slowdown, or kill if you can damage fast. EMP still works instantly since a lot of things only cause one EMP blast and the things that don't are generally rare on the station.

I talked about some stuff i should have thought about when making the PR at first here: https://github.com/tgstation/tgstation/pull/68445#issuecomment-1186205303

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Borgs are now more equal to everyone else in combat and you have a bigger chance to kill a borg without using flashes or stuns. Spiders now can actually put up a fight against borgs who are just going in hitting them, then running as soon as they are close to dying (Borgs are immune to toxins). Blobs now have more of a chance against borgs without using the EMP strain. + all the other combat situations I forgot about.

Methods to stun borgs are less powerful to balance out cyborg combat, so it won't be a steamroll of either one side or the other.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Cyborgs are now slowed down by taking enough damage like humans are.
balance: You need to flash cyborgs twice to fully stun them, the first flash will slow them down and blind them. The second will stun.
balance: You can't infinitely chain stun cyborgs with flashes as their sensors already are down.
balance: Cyborgs recover from stuns slightly faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
