### PR TITLE
Stops cyborg hypo from reacting chemicals inside

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -118,7 +118,7 @@
 
 /obj/item/reagent_containers/borghypo/Initialize(mapload)
 	. = ..()
-	stored_reagents = new()
+	stored_reagents = new(flags = NO_REACT)
 	stored_reagents.maximum_volume = length(default_reagent_types) * (max_volume_per_reagent + 1)
 	for(var/reagent in default_reagent_types)
 		add_new_reagent(reagent)

--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -118,7 +118,7 @@
 
 /obj/item/reagent_containers/borghypo/Initialize(mapload)
 	. = ..()
-	stored_reagents = new(flags = NO_REACT)
+	stored_reagents = new(new_flags = NO_REACT)
 	stored_reagents.maximum_volume = length(default_reagent_types) * (max_volume_per_reagent + 1)
 	for(var/reagent in default_reagent_types)
 		add_new_reagent(reagent)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds noreact to hypo reagent container, to avoid chemicals reacting instantly after being created. The bug would happen in service borg hypo, since some of the ingredients in there can react with each other. It was found on downstream, but it eliminates unexpected behavior that could happen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improves code, removes possibility of unexpected behavior, and directly removes a headache from downstream.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: makes borg hypo behave slightly saner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
