### PR TITLE
Bypass issue of players being unable to choose any job roles when the database dies.

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -214,10 +214,21 @@
 /datum/job/proc/available_in_days(client/player)
 	if(!player)
 		return 0
+
 	if(!CONFIG_GET(flag/use_age_restriction_for_jobs))
 		return 0
+
+	//Without a database connection we can't get a player's age so we'll assume they're old enough for all jobs
 	if(!SSdbcore.Connect())
-		return 0 //Without a database connection we can't get a player's age so we'll assume they're old enough for all jobs
+		return 0
+
+	// As of the time of writing this comment, verifying database connection isn't "solved". Sometimes rust-g will report a
+	// connection mid-shift despite the database dying.
+	// If the client age is -1, it means that no code path has overwritten it. Even first time connections get it set to 0,
+	// so it's a pretty good indication of a database issue. We'll again just assume they're old enough for all jobs.
+	if(player.player_age == -1)
+		return 0
+
 	if(!isnum(minimal_player_age))
 		return 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

We recently had the database die mid-shift, for example Manuel #186699 I believe.

The second this happened, nobody was able to join because of the following:
![image](https://user-images.githubusercontent.com/24975989/179308296-305e68d7-5f31-42e2-a718-51f6490a2f88.png)
![image](https://user-images.githubusercontent.com/24975989/179308309-2a5fa38a-cc54-43d6-bb05-a7d8211835c6.png)


I narrowed the issue down to this proc:
![image](https://user-images.githubusercontent.com/24975989/179306388-1e571445-ae57-42a8-87e5-56d0c83e5c76.png)

It was returning `1` for some reason - As in I still need to play 1 more day to unlock Assistant.
![image](https://user-images.githubusercontent.com/24975989/179306419-95491471-8791-4524-8312-373df4364378.png)

It shouldn't, as the DB was dead and `if(!SSdbcore.Connect())` should be leading to an early `return 0`.

Well, it still thought it was connected.
![image](https://user-images.githubusercontent.com/24975989/179306878-cd371fdc-d705-4301-b04e-d5269122b59c.png)

Speaking to MSO about the rustg delegate for this, I was informed that checking if the DB is dead isn't a solved problem.
![image](https://user-images.githubusercontent.com/24975989/179306692-33e07fd5-190a-48ea-be2a-c91d7f6191fd.png)

So, we can't rely on `SSdbcore.Connect()` to always tell the truth about database connection. But wait, why was the proc returning `1` with the database dead? Well...

![image](https://user-images.githubusercontent.com/24975989/179306977-78e55d6a-3610-41ee-a3bf-26efa5aeace7.png)

With the database dead-not-dead in a zombie state of connected and not connected at the same time, the `client.player_age` is never actually set. It retains its default value of -1.

![image](https://user-images.githubusercontent.com/24975989/179307096-592151cb-3e17-4259-b737-0aaab1878109.png)

Herein lies the problem. Everyone who connects with a dead-not-dead DB has a negative player age. This negative age is subtracted from the job datum's minimal age to play. Subtracting a negative is also known as addition, guaranteeing all jobs report as the player needing "player_minimal_age + 1" more days to unlock that role. Which locks every single role out.

However, that negative player age is a good catch for database issues. Even new players have their account age set to 0...
![image](https://user-images.githubusercontent.com/24975989/179307508-2f9671ef-c7ce-43d0-b07e-209f4cd89016.png)

While there are other fallbacks that also only come into play if the various ages aren't negative
![image](https://user-images.githubusercontent.com/24975989/179307609-b3e101f4-460f-4196-9727-9d39114e41b1.png)

So I haven't fixed the underlying issue (`SSdbcore.Connect()` telling porkie pies) but I have bypassed it by relying on another metric to detect database issues and short circuit the "can we play the game?" check.

I know short circuiting this check fixes the problem when it occurs on live, because I set the `use_age_restriction_for_jobs` config to `FALSE` using VV and all the jobs immediately unlocked again.

And if the player connects before the DB dies but tries to join after, the DB will have already set their age and this short circuit won't need to come into play.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Players being able to join the game during database deaths can be useful. The code was clearly there to intend short circuiting when the DB was dead.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix issue when the connected database dies but the connection check still returns "online" where players would be unable to join the shift because the game thinks they haven't unlocked any jobs at all.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
