### PR TITLE
Multiple AI fixes

### DIFF
--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -68,11 +68,13 @@
 	anchored = TRUE
 	state = AI_READY_CORE
 
-/obj/structure/ai_core/deactivated/Initialize(mapload, posibrain = FALSE)
+/obj/structure/ai_core/deactivated/Initialize(mapload, skip_mmi_creation = FALSE, posibrain = FALSE)
 	. = ..()
 	circuit = new(src)
+	if(skip_mmi_creation)
+		return
 	if(posibrain)
-		core_mmi = new/obj/item/mmi/posibrain(src, FALSE)
+		core_mmi = new/obj/item/mmi/posibrain(src, /* autoping = */ FALSE)
 	else
 		core_mmi = new(src)
 		core_mmi.brain = new(core_mmi)

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -72,7 +72,7 @@
 	. = ..()
 	circuit = new(src)
 	if(posibrain)
-		core_mmi = new/obj/item/mmi/posibrain(src)
+		core_mmi = new/obj/item/mmi/posibrain(src, FALSE)
 	else
 		core_mmi = new(src)
 		core_mmi.brain = new(core_mmi)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -125,7 +125,7 @@
 		to_chat(user, span_notice("You unlock and upend [src], spilling the brain onto the floor."))
 
 /obj/item/mmi/proc/eject_brain(mob/user)
-	if(brain.brainmob)
+	if(brainmob)
 		brainmob.container = null //Reset brainmob mmi var.
 		brainmob.forceMove(brain) //Throw mob into brain.
 		brainmob.set_stat(DEAD)

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -37,8 +37,6 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	var/picked_name
 	///Whether this positronic brain is currently looking for a ghost to enter it.
 	var/searching = FALSE
-	///If it pings on creation immediately
-	var/autoping = TRUE
 	///List of all ckeys who has already entered this posibrain once before.
 	var/list/ckeys_entered = list()
 
@@ -187,7 +185,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 			. += span_notice("Current consciousness seed: \"[ask_role]\"")
 		. += span_boldnotice("Alt-click to set a consciousness seed, specifying what [src] will be used for. This can help generate a personality interested in that role.")
 
-/obj/item/mmi/posibrain/Initialize(mapload)
+/obj/item/mmi/posibrain/Initialize(mapload, autoping = TRUE)
 	. = ..()
 	set_brainmob(new /mob/living/brain(src))
 	var/new_name

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -398,7 +398,7 @@
 /mob/living/silicon/ai/proc/make_mmi_drop_and_transfer(obj/item/mmi/the_mmi, the_core)
 	var/mmi_type
 	if(posibrain_inside)
-		mmi_type = new/obj/item/mmi/posibrain(src)
+		mmi_type = new/obj/item/mmi/posibrain(src, FALSE)
 	else
 		mmi_type = new/obj/item/mmi(src)
 	if(hack_software)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -389,7 +389,7 @@
 /mob/living/silicon/ai/proc/ai_mob_to_structure()
 	disconnect_shell()
 	ShutOffDoomsdayDevice()
-	var/obj/structure/ai_core/deactivated/ai_core = new(get_turf(src))
+	var/obj/structure/ai_core/deactivated/ai_core = new(get_turf(src), /* skip_mmi_creation = */ TRUE)
 	if(!make_mmi_drop_and_transfer(ai_core.core_mmi, the_core = ai_core))
 		return FALSE
 	qdel(src)
@@ -398,7 +398,7 @@
 /mob/living/silicon/ai/proc/make_mmi_drop_and_transfer(obj/item/mmi/the_mmi, the_core)
 	var/mmi_type
 	if(posibrain_inside)
-		mmi_type = new/obj/item/mmi/posibrain(src, FALSE)
+		mmi_type = new/obj/item/mmi/posibrain(src, /* autoping = */ FALSE)
 	else
 		mmi_type = new/obj/item/mmi(src)
 	if(hack_software)

--- a/code/modules/mob/living/silicon/ai/ai_defense.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defense.dm
@@ -69,6 +69,19 @@
 	to_chat(src, span_warning("[user] shorts out your access panel lock!"))
 	emagged = TRUE
 
+/mob/living/silicon/ai/wrench_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(user.combat_mode)
+		return
+	balloon_alert(user, "[!is_anchored ? "tightening" : "loosening"] bolts...")
+	balloon_alert(src, "bolts being [!is_anchored ? "tightened" : "loosened"]...")
+	if(!tool.use_tool(src, user, 4 SECONDS))
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+	flip_anchored()
+	balloon_alert(user, "bolts [is_anchored ? "tightened" : "loosened"]")
+	balloon_alert(src, "bolts [is_anchored ? "tightened" : "loosened"]")
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
 /mob/living/silicon/ai/crowbar_act(mob/living/user, obj/item/tool)
 	. = ..()
 	if(user.combat_mode)


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/68457
Fixes https://github.com/tgstation/tgstation/issues/68468

Also fixes an oversight in that you can't (un)anchor AIs with a wrench, you can on Baycode and I assumed it was like that on TG already

Also minor code edit, added an arg to skip MMI creation on AI mob deconstruction since the MMI created gets overwritten anyway

:cl:
fix: Carding an AI or deconstructing it will not ping ghosts about its positronic brain
fix: Ejecting a brain from an MMI will correctly transfer the guy in the MMI to the ejected brain
fix: You can (un)anchor AIs with a wrench
/:cl: