### PR TITLE
[MDB Ignore] Close the Trap Door

### DIFF
--- a/_maps/map_files/tramstation/modular_pieces/maintenance_storagebig_3.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_storagebig_3.dmm
@@ -24,7 +24,7 @@
 "s" = (
 /obj/structure/holosign/barrier/atmos,
 /obj/effect/turf_decal/sand/plating,
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/station/maintenance/port/central)
 "w" = (
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces one space tile with one plating, where one space and a floor decal was previously. Did not edit the floor decal since it matches the surroundings.
MDB Ignore because the change isn't visible, it's under a decal.

## Why It's Good For The Game

It's an accidental space tile placement under a firelock covered by a sandy floor decal, so it appears to be a floor but in fact is not.

## Changelog

:cl:
fix: Closed the trapdoor to space under a holo firelock in lower tram maint.
/:cl:
