### PR TITLE
Fixes material airlocks all taking on the color of the first one made

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -25,7 +25,7 @@
 /proc/get_airlock_overlay(icon_state, icon_file, em_block)
 	var/static/list/airlock_overlays = list()
 
-	var/base_icon_key = "[icon_state][icon_file]"
+	var/base_icon_key = "[icon_state][REF(icon_file)]"
 	if(!(. = airlock_overlays[base_icon_key]))
 		. = airlock_overlays[base_icon_key] = mutable_appearance(icon_file, icon_state)
 	if(isnull(em_block))


### PR DESCRIPTION
## About The Pull Request

Previously this worked fine as most icons would convert to their location path, but greyscale icons have no actual location as they are created and exist entirely within memory. Getting the ref instead fixes the issue.

fixes #68377

:cl:
fix: Airlocks made from custom materials are now properly colored instead of being forced to use the color of the first material used.
/:cl:
