### PR TITLE
Fixes sloths loaded in ruins becoming the cargo sloth

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/sloth.dm
+++ b/code/modules/mob/living/simple_animal/friendly/sloth.dm
@@ -40,7 +40,7 @@ GLOBAL_DATUM(cargo_sloth, /mob/living/simple_animal/sloth)
 	. = ..()
 	AddElement(/datum/element/pet_bonus, "slowly smiles!")
 	// If someone adds non-cargo sloths to maps we'll have a problem but we're fine for now
-	if(!GLOB.cargo_sloth && mapload)
+	if(!GLOB.cargo_sloth && mapload && is_station_level(z))
 		GLOB.cargo_sloth = src
 
 /mob/living/simple_animal/sloth/Destroy()


### PR DESCRIPTION
Downstream issue.

:cl: ShizCalev
fix: Sloths loaded in ruins will no longer sometimes become Cargo's sloth! 
/:cl:
