### PR TITLE
Makes Hacked Laws Font Color Actually Readable

### DIFF
--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -333,7 +333,7 @@
 
 	for(var/law in hacked)
 		if (length(law) > 0)
-			data += "[show_numbers ? "[ion_num()]:" : ""] [render_html ? "<font color='#660000'>[law]</font>" : law]"
+			data += "[show_numbers ? "[ion_num()]:" : ""] [render_html ? "<font color='#c00000'>[law]</font>" : law]"
 
 	for(var/law in ion)
 		if (length(law) > 0)


### PR DESCRIPTION
Altered the font color for hacked laws, (like the ones given by the hacked AI module) to be more readable especially on dark backgrounds

BEFORE
![ailawbefore](https://user-images.githubusercontent.com/46101244/179365260-8e82f78b-8c5d-422c-8b5d-24cfe7d87886.png)
AFTER
![ailawsafter3](https://user-images.githubusercontent.com/46101244/179395698-db4ae503-0d40-4ba3-b3e5-6704f41f24d8.png)
~~AFTER~~ OUTDATED
![ailawsafter2](https://user-images.githubusercontent.com/46101244/179365363-7c3e358d-cd57-4ed4-86d5-d3ba94176c37.png)



:cl:
qol: Changed the AI/borg hacked laws font color to be more readable
/:cl: