### PR TITLE
Cremator / morgue tray jaunting fixes

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -44,6 +44,10 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	..()
 	update_appearance()
 
+/obj/structure/bodycontainer/Exited(atom/movable/gone, direction)
+	. = ..()
+	update_appearance()
+
 /obj/structure/bodycontainer/relaymove(mob/living/user, direction)
 	if(user.stat || !isturf(loc))
 		return
@@ -133,7 +137,13 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
 	for(var/atom/movable/AM in connected.loc)
 		if(!AM.anchored || AM == connected)
-			if(ismob(AM) && !isliving(AM))
+			if(ismob(AM))
+				if(!isliving(AM))
+					continue
+				var/mob/living/living_mob = AM
+				if(living_mob.incorporeal_move)
+					continue
+			else if(istype(AM, /obj/effect/dummy/phased_mob))
 				continue
 			AM.forceMove(src)
 	recursive_organ_check(src)
@@ -260,6 +270,8 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		update_appearance()
 
 		for(var/mob/living/M in conts)
+			if(M.incorporeal_move) //can't cook revenants!
+				continue
 			if (M.stat != DEAD)
 				M.emote("scream")
 			if(user)
@@ -273,6 +285,8 @@ GLOBAL_LIST_EMPTY(crematoriums)
 				qdel(M)
 
 		for(var/obj/O in conts) //conts defined above, ignores crematorium and tray
+			if(istype(O, /obj/effect/dummy/phased_mob)) //they're not physical, don't burn em.
+				continue
 			qdel(O)
 
 		if(!locate(/obj/effect/decal/cleanable/ash) in get_step(src, dir))//prevent pile-up


### PR DESCRIPTION
:cl: ShizCalev
fix: Jaunting/incorporeal mobs will no longer be inserted into morgue trays / cremators when they close. 
fix: Cremators will no longer cremate jaunting / incorporeal mobs.
fix: Jaunting out of a morgue tray / cremator will now properly update its sprite.
/:cl: