### PR TITLE
Hides revenant essence charge rate when at/above full essence, correct SE being shown as E.

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -153,10 +153,10 @@
 
 /mob/living/simple_animal/revenant/get_status_tab_items()
 	. = ..()
-	. += "Current essence: [essence]/[essence_regen_cap]E"
-	. += "Stolen essence: [essence_accumulated]E"
-	. += "Unused stolen essence: [essence_excess]E"
-	. += "Stolen perfect souls: [perfectsouls]"
+	. += "Current Essence: [essence >= essence_regen_cap ? essence : "[essence] / [essence_regen_cap]"]E"
+	. += "Total Essence Stolen: [essence_accumulated]SE"
+	. += "Unused Stolen Essence: [essence_excess]SE"
+	. += "Perfect Souls Stolen: [perfectsouls]"
 
 /mob/living/simple_animal/revenant/update_health_hud()
 	if(hud_used)


### PR DESCRIPTION
Saying we have 330/75E is just a little strange. Also fixed stolen essence being displayed as E when it's SE everywhere else.

:cl: ShizCalev
spellcheck: Tweaked the stat panel for revenants to make their essence readout a little more clear.
/:cl:
