### PR TITLE
Fix a subsystem priority sort

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -354,7 +354,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	//(higher subsystems will be sooner in the queue, adding them later in the loop means we don't have to loop thru them next queue add)
 	sortTim(tickersubsystems, /proc/cmp_subsystem_priority)
 	for(var/I in runlevel_sorted_subsystems)
-		sortTim(runlevel_sorted_subsystems, /proc/cmp_subsystem_priority)
+		sortTim(I, /proc/cmp_subsystem_priority)
 		I += tickersubsystems
 
 	var/cached_runlevel = current_runlevel


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I ran into this bug while attempting to run the game in OpenDream. The MC is attempting to sort a list of lists with `/proc/cmp_subsystem_priority`, but because that proc expects subsystems instead of lists it ends up incorrectly returning `0` and doing nothing. I changed it to sort the lists within that list instead, which I believe is what was intended.

The sorting of the subsystems before this change:
```
Garbage - Priority 15
Ping - Priority 10
Server Tasks - Priority 10
Stat Panels - Priority 390
Input - Priority 1000
```
After:
```
Ping - Priority 10
Server Tasks - Priority 10
Garbage - Priority 15
Stat Panels - Priority 390
Input - Priority 1000
```

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The order of runlevel subsystems are correctly sorted by priority

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
