### PR TITLE
Fixes invalid cyclelink on spacehotel

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -4210,6 +4210,9 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
 "Uw" = (
 /obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/space/basic,
 /area/ruin/space/has_grav/hotel/power)
 "UD" = (


### PR DESCRIPTION

:cl: ShizCalev
fix: Fixed the Eastern airlocks to the Space Hotel not being cyclelinked. 
/:cl:
