### PR TITLE
add a festive paper hat to each map

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -81552,6 +81552,10 @@
 /obj/item/newspaper,
 /obj/item/clothing/head/bowler,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/clothing/head/festive{
+	pixel_x = 6;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/theater/abandoned)
 "vTG" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8718,6 +8718,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"cBj" = (
+/obj/structure/closet/emcloset,
+/obj/item/clothing/head/festive,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "cBn" = (
 /obj/structure/sign/poster/random/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -231218,7 +231223,7 @@ nWf
 prE
 gDS
 aXY
-iPR
+cBj
 lJO
 hEI
 hEI

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -80468,6 +80468,10 @@
 	},
 /obj/item/poster/random_official,
 /obj/effect/turf_decal/stripes/corner,
+/obj/item/clothing/head/festive{
+	pixel_x = -4;
+	pixel_y = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "wNf" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -11416,6 +11416,17 @@
 /obj/structure/cable,
 /turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_mothership/control)
+"GL" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/item/clothing/head/festive{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "GN" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -58449,7 +58460,7 @@ lo
 nG
 iF
 yd
-oM
+GL
 pi
 FO
 Tq

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -15587,6 +15587,10 @@
 "fvA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
+/obj/item/clothing/head/festive{
+	pixel_x = -4;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/dorms)
 "fvJ" = (


### PR DESCRIPTION
## About The Pull Request

Adds one (1) festive paper hat to the maps that don't have one. 

<details><summary>Centcomm</summary>
<img src="https://user-images.githubusercontent.com/85910816/179374373-7e18b83c-15d7-436f-a39f-52c40aa8c2e9.png">
</details>

<details><summary>Tram</summary>
<img src="https://user-images.githubusercontent.com/85910816/179374397-5074fcb3-42fe-4205-a373-1adacfd44141.png">
</details>

<details><summary>Kilo</summary>
<img src="https://user-images.githubusercontent.com/85910816/179374414-a53f4642-9f86-4c55-bc64-4e05d19a6832.png">
</details>

<details><summary>Icebox</summary>
<img src="https://user-images.githubusercontent.com/85910816/179374433-f36fba2b-30bd-4da5-b3c3-29d4eea67fd9.png">
</details>

<details><summary>Delta</summary>
<img src="https://user-images.githubusercontent.com/85910816/179374429-4f79a898-a81f-49f9-a49a-026b2782b8e1.png">
</details>

## Purpose
<details><summary>Requested:</summary>
<img src="https://user-images.githubusercontent.com/85910816/179374494-b90a2d43-61fd-4796-8b93-431535c72bd4.png">
</details>

Also seems like a harmless fun addition. 
 

## Changelog

:cl:
add: Festive paper hats have appeared in maintenance on every map. Central Command is going to get angry if you keep partying like this...
/:cl:
