### PR TITLE
Tweaks response provided by sssecurity_level during initialization

### DIFF
--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -78,13 +78,13 @@ SUBSYSTEM_DEF(security_level)
  * Returns the current security level as a number
  */
 /datum/controller/subsystem/security_level/proc/get_current_level_as_number()
-	return current_security_level?.number_level
+	return current_security_level ? current_security_level.number_level : SEC_LEVEL_GREEN //Send a response in case the subsystem hasn't finished setting up yet
 
 /**
  * Returns the current security level as text
  */
 /datum/controller/subsystem/security_level/proc/get_current_level_as_text()
-	return current_security_level?.name
+	return current_security_level ? current_security_level.name : "green"
 
 /**
  * Converts a text security level to a number


### PR DESCRIPTION
I was clicking create pull request right as #68364 got merged lol

Sends out the same values as the initial security level for things that don't anticipate a null value.

Fixes #68043