### PR TITLE
Add traits that can expire based on duration of time

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -117,28 +117,6 @@
 #define HAS_TRAIT_FROM_ONLY(target, trait, source) (target.status_traits?[trait] && (source in target.status_traits[trait]) && (length(target.status_traits[trait]) == 1))
 #define HAS_TRAIT_NOT_FROM(target, trait, source) (target.status_traits?[trait] && (length(target.status_traits[trait] - source) > 0))
 
-// This trait gets added on a timer and then gets removed when the time is up
-// Adding the same trait twice while the timer is still active, resets the timer
-#define ADD_EXPIRING_TRAIT(target, trait, source, time) \
-	
-	do { \
-		var/list/_L; \
-		if (!target.status_traits) { \
-			target.status_traits = list(); \
-			_L = target.status_traits; \
-			_L[trait] = list(source); \
-			SEND_SIGNAL(target, SIGNAL_ADDTRAIT(trait), trait); \
-		} else { \
-			_L = target.status_traits; \
-			if (_L[trait]) { \
-				_L[trait] |= list(source); \
-			} else { \
-				_L[trait] = list(source); \
-				SEND_SIGNAL(target, SIGNAL_ADDTRAIT(trait), trait); \
-			} \
-		} \
-	} while (0)
-
 /*
 Remember to update _globalvars/traits.dm if you're adding/removing/renaming traits.
 */

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -2,7 +2,7 @@
 #define SIGNAL_REMOVETRAIT(trait_ref) "removetrait [trait_ref]"
 
 // trait accessor defines
-#define ADD_TRAIT(target, trait, source) \
+#define ADD_TRAIT(target, trait, source, duration) \
 	do { \
 		var/list/_L; \
 		if (!target.status_traits) { \
@@ -18,6 +18,9 @@
 				_L[trait] = list(source); \
 				SEND_SIGNAL(target, SIGNAL_ADDTRAIT(trait), trait); \
 			} \
+		} \
+		if (duration) { \
+			addtimer(CALLBACK(target, .proc/REMOVE_TRAIT, target, trait), duration, TIMER_UNIQUE|TIMER_OVERRIDE); \
 		} \
 	} while (0)
 #define REMOVE_TRAIT(target, trait, sources) \
@@ -113,6 +116,28 @@
 #define HAS_TRAIT_FROM(target, trait, source) (target.status_traits?[trait] && (source in target.status_traits[trait]))
 #define HAS_TRAIT_FROM_ONLY(target, trait, source) (target.status_traits?[trait] && (source in target.status_traits[trait]) && (length(target.status_traits[trait]) == 1))
 #define HAS_TRAIT_NOT_FROM(target, trait, source) (target.status_traits?[trait] && (length(target.status_traits[trait] - source) > 0))
+
+// This trait gets added on a timer and then gets removed when the time is up
+// Adding the same trait twice while the timer is still active, resets the timer
+#define ADD_EXPIRING_TRAIT(target, trait, source, time) \
+	
+	do { \
+		var/list/_L; \
+		if (!target.status_traits) { \
+			target.status_traits = list(); \
+			_L = target.status_traits; \
+			_L[trait] = list(source); \
+			SEND_SIGNAL(target, SIGNAL_ADDTRAIT(trait), trait); \
+		} else { \
+			_L = target.status_traits; \
+			if (_L[trait]) { \
+				_L[trait] |= list(source); \
+			} else { \
+				_L[trait] = list(source); \
+				SEND_SIGNAL(target, SIGNAL_ADDTRAIT(trait), trait); \
+			} \
+		} \
+	} while (0)
 
 /*
 Remember to update _globalvars/traits.dm if you're adding/removing/renaming traits.

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -20,7 +20,7 @@
 			} \
 		} \
 		if (duration) { \
-			addtimer(CALLBACK(target, .proc/REMOVE_TRAIT, target, trait), duration, TIMER_UNIQUE|TIMER_OVERRIDE); \
+			addtimer(CALLBACK(target, .proc/REMOVE_TRAIT, target, trait, source), duration, TIMER_UNIQUE|TIMER_OVERRIDE); \
 		} \
 	} while (0)
 #define REMOVE_TRAIT(target, trait, sources) \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This gives more flexibility to the traits system by allowing an optional duration argument to be passed in the `ADD_TRAIT` define.  If duration is used, then the trait will be added under a timer that will automatically remove itself once the timer expires.  If the same trait is added again while already active, then the timer is reset.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

This should allow a new category of traits that expire after a certain amount of time, without having to manually cleanup each one.  

I'm planning on using this for my memory refactor to create many short lifespan traits to keep track of what a player is doing. 
 For example, adding a `TRAIT_IS_DANCING` for a player who emotes dancing for 15 seconds, will be tied to the memory system so we can have cool stuff like this:

> Urist McMiner high-fives the dancing clown.  The clown is laughing.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Not neccessary.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
