### PR TITLE
Fixes a seclite runtime when the parent is destroyed

### DIFF
--- a/code/datums/components/seclight_attachable.dm
+++ b/code/datums/components/seclight_attachable.dm
@@ -184,7 +184,7 @@
 	SIGNAL_HANDLER
 
 	// Our light is gone already - Probably destroyed by whatever destroyed our parent. Just remove it.
-	if(QDELETED(light))
+	if(QDELETED(light) || !is_light_removable)
 		remove_light()
 		return
 

--- a/code/datums/components/seclight_attachable.dm
+++ b/code/datums/components/seclight_attachable.dm
@@ -89,7 +89,7 @@
 		add_light(starting_light)
 
 /datum/component/seclite_attachable/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_ATOM_DESTRUCTION, .proc/on_parent_deconstructed)
+	RegisterSignal(parent, COMSIG_OBJ_DECONSTRUCT, .proc/on_parent_deconstructed)
 	RegisterSignal(parent, COMSIG_ATOM_EXITED, .proc/on_light_exit)
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER), .proc/on_screwdriver)
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_ICON_STATE, .proc/on_update_icon_state)
@@ -101,7 +101,7 @@
 
 /datum/component/seclite_attachable/UnregisterFromParent()
 	UnregisterSignal(parent, list(
-		COMSIG_ATOM_DESTRUCTION,
+		COMSIG_OBJ_DECONSTRUCT,
 		COMSIG_ATOM_EXITED,
 		COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER),
 		COMSIG_ATOM_UPDATE_ICON_STATE,
@@ -144,7 +144,6 @@
 
 	// It is possible the light was removed by being deleted.
 	if(!QDELETED(light))
-		UnregisterSignal(light, COMSIG_PARENT_QDELETING)
 		light.set_light_flags(light.light_flags & ~LIGHT_ATTACHED)
 		light.update_brightness()
 
@@ -180,10 +179,21 @@
 	if(gone == light)
 		remove_light()
 
-/// Signal proc for [COMSIG_ATOM_DESTRUCTION] that drops our light to the ground if our parent is deconstructed.
+/// Signal proc for [COMSIG_OBJ_DECONSTRUCT] that drops our light to the ground if our parent is deconstructed.
 /datum/component/seclite_attachable/proc/on_parent_deconstructed(obj/item/source, disassembled)
 	SIGNAL_HANDLER
 
+	// Our light is gone already for some reason
+	if(QDELETED(light))
+		remove_light()
+		return
+
+	// We were deconstructed by force, and shouldn't drop something
+	if(!disassembled)
+		QDEL_NULL(light)
+		return
+
+	// We were dissassembled by hand, and should drop the light
 	light.forceMove(source.drop_location())
 
 /// Signal proc for [COMSIG_PARENT_QDELETING] that deletes our light if our parent is deleted.

--- a/code/datums/components/seclight_attachable.dm
+++ b/code/datums/components/seclight_attachable.dm
@@ -183,17 +183,12 @@
 /datum/component/seclite_attachable/proc/on_parent_deconstructed(obj/item/source, disassembled)
 	SIGNAL_HANDLER
 
-	// Our light is gone already for some reason
+	// Our light is gone already - Probably destroyed by whatever destroyed our parent. Just remove it.
 	if(QDELETED(light))
 		remove_light()
 		return
 
-	// We were deconstructed by force, and shouldn't drop something
-	if(!disassembled)
-		QDEL_NULL(light)
-		return
-
-	// We were dissassembled by hand, and should drop the light
+	// We were deconstructed in any other way, so we can just drop the light on the ground (which removes it via signal).
 	light.forceMove(source.drop_location())
 
 /// Signal proc for [COMSIG_PARENT_QDELETING] that deletes our light if our parent is deleted.


### PR DESCRIPTION
## About The Pull Request

Fixes #68502 

I used the incorrect signal - destruction instead of deconstruction. So that didn't help.
Regardless, bombs would deal damage to the item's contents and destroy the light, then destroy the item, which could cause problems. Added some sanity to protect against that.

I also removed a random signal unregister, because I never actually registered the deleted signal for the light, so it was pointless. 

## Why It's Good For The Game

Runtime fix 

## Changelog

:cl: Melbert
fix: Fixes a runtime with seclite mounts being deconstructed.
/:cl:

