### PR TITLE
Fixes circuit dispensers add_item

### DIFF
--- a/code/modules/wiremod/shell/dispenser.dm
+++ b/code/modules/wiremod/shell/dispenser.dm
@@ -28,7 +28,9 @@
 	return ..()
 
 
-/obj/structure/dispenser_bot/proc/add_item(obj/item/to_add)
+/obj/structure/dispenser_bot/proc/add_item(mob/user, obj/item/to_add)
+	to_chat(user, span_notice("You insert [to_add] into the dispenser."))
+	balloon_alert(user, "inserted item")
 	stored_items += to_add
 	to_add.forceMove(src)
 	RegisterSignal(to_add, COMSIG_MOVABLE_MOVED, .proc/handle_stored_item_moved)
@@ -61,33 +63,33 @@
 	), SHELL_CAPACITY_LARGE)
 
 /obj/structure/dispenser_bot/attackby(obj/item/item, mob/living/user, params)
-	. = ..()
-	if(user.combat_mode || .)
-		return
-
+	if(user.combat_mode)
+		return ..()
+	if(istype(item, /obj/item/wrench) || istype(item, /obj/item/multitool/circuit) || istype(item, /obj/item/integrated_circuit))
+		return ..()
 	if(item.w_class > max_weight && !istype(item, /obj/item/storage/bag))
 		balloon_alert(user, "item too big!")
-		return
-
+		return FALSE
 	if(length(stored_items) >= capacity)
 		balloon_alert(user, "at maximum capacity!")
-		return
-
+		return FALSE
 	if(istype(item, /obj/item/storage/bag))
 		for(var/obj/item/bag_item in item.contents)
 			if(length(stored_items) >= capacity)
 				break
-			add_item(bag_item)
-		return
-
-	add_item(item)
+			if(bag_item.w_class > max_weight || istype(bag_item, /obj/item/storage/bag))
+				continue
+			add_item(user, bag_item)
+		return TRUE
+	add_item(user, item)
+	return TRUE
 
 /obj/structure/dispenser_bot/wrench_act(mob/living/user, obj/item/tool)
 	if(locked)
 		return
 	set_anchored(!anchored)
 	tool.play_tool_sound(src)
-	balloon_alert(user, "You [anchored?"secure":"unsecure"] [src].")
+	balloon_alert(user, "[anchored? "secured" : "unsecured"]")
 	return TRUE
 
 /obj/item/circuit_component/dispenser_bot

--- a/code/modules/wiremod/shell/dispenser.dm
+++ b/code/modules/wiremod/shell/dispenser.dm
@@ -29,7 +29,6 @@
 
 
 /obj/structure/dispenser_bot/proc/add_item(mob/user, obj/item/to_add)
-	to_chat(user, span_notice("You insert [to_add] into the dispenser."))
 	balloon_alert(user, "inserted item")
 	stored_items += to_add
 	to_add.forceMove(src)
@@ -65,7 +64,7 @@
 /obj/structure/dispenser_bot/attackby(obj/item/item, mob/living/user, params)
 	if(user.combat_mode)
 		return ..()
-	if(istype(item, /obj/item/wrench) || istype(item, /obj/item/multitool/circuit) || istype(item, /obj/item/integrated_circuit))
+	if(istype(item, /obj/item/wrench) || istype(item, /obj/item/multitool) || istype(item, /obj/item/integrated_circuit))
 		return ..()
 	if(item.w_class > max_weight && !istype(item, /obj/item/storage/bag))
 		balloon_alert(user, "item too big!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- adding items to a dispenser shell would hit the shell with the item first
- little to no feedback from the shell as it just eats your held item
- bulk adding items could theoretically exceed the weight limit for items or add in nested bags
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
you can add items to the dispenser without permanently damaging it
it's a little more obvious it just ate your item
guards against an edge case exploit that's probably unused
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: jlsnow301 MooCow
fix: Adding items to dispenser shells no longer damages the dispenser
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
