### PR TITLE
Attempts to fix a take_overall_damage() bug thats existed for god knows how long

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -288,13 +288,14 @@
 	while((brute > 0 || burn > 0) && length(not_full))
 		if(!length(parts))
 			parts = not_full.Copy()
+
+		var/brute_per_part = round(brute/length(parts), DAMAGE_PRECISION)
+		var/burn_per_part = round(burn/length(parts), DAMAGE_PRECISION)
+
 		var/obj/item/bodypart/picked = pick_n_take(parts)
 		if(picked.get_damage() >= picked.max_damage)
 			not_full -= picked
 			continue
-
-		var/brute_per_part = round(brute/length(parts), DAMAGE_PRECISION)
-		var/burn_per_part = round(burn/length(parts), DAMAGE_PRECISION)
 
 		var/brute_was = picked.brute_dam
 		var/burn_was = picked.burn_dam

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -248,26 +248,64 @@
 	if(status_flags & GODMODE)
 		return //godmode
 
-	var/list/obj/item/bodypart/parts = get_damageable_bodyparts(required_status)
+	var/list/obj/item/bodypart/parts = list()
 	var/update = 0
-	while(parts.len && (brute > 0 || burn > 0 || stamina > 0))
-		var/obj/item/bodypart/picked = pick(parts)
-		var/brute_per_part = round(brute/parts.len, DAMAGE_PRECISION)
-		var/burn_per_part = round(burn/parts.len, DAMAGE_PRECISION)
-		var/stamina_per_part = round(stamina/parts.len, DAMAGE_PRECISION)
+
+	///Okay, so, "What the fuck is going on here", you might be asking...
+	if(stamina)
+		//Build our list of bodyparts which are capable of holding stamina damage still.
+		for(var/obj/item/bodypart/BP as anything in bodyparts)
+			if(BP.stamina_dam < BP.max_stamina_damage)
+				parts += BP
+
+		///We need two lists to ensure a pseudo-even distribution of damage.
+		///This is our list of all parts that can still hold some more stamina damage.
+		var/list/obj/item/bodypart/not_full = parts.Copy()
+		while(stamina)
+			///Copy the total parts list. This is necessary because later we remove instances from this list during the loop.
+			parts = not_full.Copy()
+			///If all of our bodyparts are full on stamina, stop the loop.
+			if(!length(parts))
+				break
+
+			while(length(parts))
+				//Create a "share" of the current stamina damage pool
+				var/damage_share = round(stamina/length(parts), DAMAGE_PRECISION)
+				//Pick and take a part from the eligible parts list.
+				var/obj/item/bodypart/picked = pick_n_take(parts)
+				//If the part is full on stamina damage, remove it from the master list so it doesn't get re-added
+				if(picked.stamina_dam >= picked.max_stamina_damage)
+					not_full -= picked
+					continue
+				///Distribute the damage share to this limb, record how much was actually used.
+				var/stamina_was = picked.stamina_dam
+				update |= picked.receive_damage(0, 0, damage_share, FALSE, required_status, wound_bonus = CANT_WOUND)
+				stamina = round(stamina - (picked.stamina_dam - stamina_was), DAMAGE_PRECISION)
+				parts -= picked
+
+	var/list/obj/item/bodypart/not_full = get_damageable_bodyparts(required_status)
+	parts = not_full.Copy()
+	while((brute > 0 || burn > 0) && length(not_full))
+		if(!length(parts))
+			parts = not_full.Copy()
+		var/obj/item/bodypart/picked = pick_n_take(parts)
+		if(picked.get_damage() >= picked.max_damage)
+			not_full -= picked
+			continue
+
+		var/brute_per_part = round(brute/length(parts), DAMAGE_PRECISION)
+		var/burn_per_part = round(burn/length(parts), DAMAGE_PRECISION)
 
 		var/brute_was = picked.brute_dam
 		var/burn_was = picked.burn_dam
-		var/stamina_was = picked.stamina_dam
 
-
-		update |= picked.receive_damage(brute_per_part, burn_per_part, stamina_per_part, FALSE, required_status, wound_bonus = CANT_WOUND) // disabling wounds from these for now cuz your entire body snapping cause your heart stopped would suck
+		update |= picked.receive_damage(brute_per_part, burn_per_part, 0, FALSE, required_status, wound_bonus = CANT_WOUND) // disabling wounds from these for now cuz your entire body snapping cause your heart stopped would suck
 
 		brute = round(brute - (picked.brute_dam - brute_was), DAMAGE_PRECISION)
 		burn = round(burn - (picked.burn_dam - burn_was), DAMAGE_PRECISION)
-		stamina = round(stamina - (picked.stamina_dam - stamina_was), DAMAGE_PRECISION)
 
 		parts -= picked
+
 	if(updating_health)
 		updatehealth()
 	if(update)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
### TESTING THIS IS A PAIN IN THE ASS AND I CANNOT GUARANTEE THIS IS PERFECTLY EFFECTIVE DUE TO HOW COMPLICATED BODYPART DAMAGE IS. NEEDS EXTENSIVE TM/SMART PERSON REVIEW.

Basically, `take_overall_damage()` can void damage in some cases. Bodyparts have a maximum damage, physical and stamina seperated. 

Say your bodyparts are in order, and named 1 through 6. Each bodypart has a maximum damage of 10. We are trying to deal 12 damage. The damage spread looks like this: 

1. 9
2. 7
3. 6
4. 5
5. 9
6. 10

Here's how the damage distribution goes, by the loop.
LOOP ONE: (12/5 = 2.4) | 1 damage successfully applied | remaining brute = 10.6
LOOP TWO: (10.6/4 = 2.7) | 2.7 damage successfully applied | remaining brute = 7.9
LOOP THREE: (7.9/3 = 2.6) | 2.6 damage successfully applied | remaining brute = 5.3
LOOP FOUR: (5.3/2 = 2.7 | 2.7 damage successfully applied | remaining brute = 2.7
LOOP FIVE: applied 1 damage | left over brute: 1.7

As you can see, we have left over brute and the loop is over, despite there being "room" on bodyparts for more damage.. That is how `take_overall_damage()` can currently fail. This gets FAR WORSE when the damage delta between limbs is very high.

I'd explain the fix, but honestly just reading the code comments is better than I can tell in a paragraph.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
In consistences in damage are bad.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: An ancient bug that under certain conditions caused damage to fail to apply properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
