### PR TITLE
Security's Scaling Departmental Accesses - More Pop, More Problems

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -29,6 +29,11 @@
 
 /datum/config_entry/flag/everyone_has_maint_access
 
+/datum/config_entry/number/depsec_access_level
+	default = 1
+	min_val = 0
+	max_val = 2
+
 /datum/config_entry/flag/sec_start_brig //makes sec start in brig instead of dept sec posts
 
 /datum/config_entry/flag/force_random_names

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -940,7 +940,7 @@
 	// This is directly tied into calculations derived via a config entered variable, as well as the amount of players in the shift.
 	// Thus, it makes it possible to judge if departmental security officers should have more access to their department on a lower population shift.
 	var/datum/job/J = SSjob.GetJob(JOB_SECURITY_OFFICER)
-	var/minimal_security_officers = 5 // We do not spawn in any more lockers if there are 5 or less security officers, so let's start balancing here.
+	var/minimal_security_officers = 3 // We do not spawn in any more lockers if there are 5 or less security officers, so let's keep it lower than that number.
 	if((J.spawn_positions - minimal_security_officers) <= 0)
 		access |= scaling_access
 
@@ -983,8 +983,8 @@
 	scaling_access = list(
 		ACCESS_PHARMACY,
 		ACCESS_PLUMBING,
-		ACCESS_VIROLOGY,
 		ACCESS_SURGERY,
+		ACCESS_VIROLOGY,
 	)
 
 /datum/id_trim/job/security_officer/science
@@ -992,14 +992,14 @@
 	subdepartment_color = COLOR_SCIENCE_PINK
 	department_access = list(
 		ACCESS_RESEARCH,
-		ACCESS_ROBOTICS,
 		ACCESS_SCIENCE,
 	)
 	scaling_access = list(
 		ACCESS_AUX_BASE,
 		ACCESS_GENETICS,
-		ACCESS_ORDNANCE,
 		ACCESS_ORDNANCE_STORAGE,
+		ACCESS_ORDNANCE,
+		ACCESS_ROBOTICS,
 		ACCESS_XENOBIOLOGY,
 	)
 

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -933,6 +933,8 @@
 	if(!.)
 		return
 
+	access |= department_access
+
 	// Config check for if sec has maint access.
 	if(CONFIG_GET(flag/security_has_maint_access))
 		access |= list(ACCESS_MAINT_TUNNELS)
@@ -941,20 +943,20 @@
 	// Thus, it makes it possible to judge if departmental security officers should have more access to their department on a lower population shift.
 	// Server operators can modify config to change it such that security officers can use this system, or alternatively either: A) always give the "elevated" access (ALWAYS_GETS_ACCESS) or B) never give this access (null value).
 
-	var/access_level = CONFIG_GET(number/depsec_access_level)
 	#define POPULATION_SCALED_ACCESS 1
 	#define ALWAYS_GETS_ACCESS 2
 
-	if(access_level == POPULATION_SCALED_ACCESS)
+	if(!CONFIG_GET(number/depsec_access_level))
+		return
+
+	if(CONFIG_GET(number/depsec_access_level) == POPULATION_SCALED_ACCESS)
 		var/minimal_security_officers = 3 // We do not spawn in any more lockers if there are 5 or less security officers, so let's keep it lower than that number.
 		var/datum/job/J = SSjob.GetJob(JOB_SECURITY_OFFICER)
 		if((J.spawn_positions - minimal_security_officers) <= 0)
 			access |= elevated_access
 
-	if(access_level == ALWAYS_GETS_ACCESS)
+	if(CONFIG_GET(number/depsec_access_level) == ALWAYS_GETS_ACCESS)
 		access |= elevated_access
-
-	access |= department_access
 
 /datum/id_trim/job/security_officer/supply
 	assignment = "Security Officer (Cargo)"

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -922,8 +922,10 @@
 		ACCESS_HOS,
 		)
 	job = /datum/job/security_officer
-	/// List of bonus departmental accesses that departmental sec officers get.
+	/// List of bonus departmental accesses that departmental sec officers get by default.
 	var/department_access = list()
+	/// List of bonus departmental accesses that departmental sec officers get in relation to how many overall security officers there are.
+	var/scaling_access = list()
 
 /datum/id_trim/job/security_officer/refresh_trim_access()
 	. = ..()
@@ -935,30 +937,41 @@
 	if(CONFIG_GET(flag/security_has_maint_access))
 		access |= list(ACCESS_MAINT_TUNNELS)
 
+	// This is directly tied into calculations derived via a config entered variable, as well as the amount of players in the shift.
+	// Thus, it makes it possible to judge if departmental security officers should have more access to their department on a lower population shift.
+	var/datum/job/J = SSjob.GetJob(JOB_SECURITY_OFFICER)
+	var/minimal_security_officers = 5 // We do not spawn in any more lockers if there are 5 or less security officers, so let's start balancing here.
+	if((J.spawn_positions - 5) <= 0)
+		access |= scaling_access
+
 	access |= department_access
 
 /datum/id_trim/job/security_officer/supply
 	assignment = "Security Officer (Cargo)"
 	subdepartment_color = COLOR_CARGO_BROWN
 	department_access = list(
-		ACCESS_AUX_BASE,
 		ACCESS_CARGO,
 		ACCESS_MINING,
-		ACCESS_MINING_STATION,
 		ACCESS_SHIPPING,
 		)
+	scaling_access = list(
+		ACCESS_AUX_BASE,
+		ACCESS_MINING_STATION,
+	)
 
 /datum/id_trim/job/security_officer/engineering
 	assignment = "Security Officer (Engineering)"
 	subdepartment_color = COLOR_ENGINEERING_ORANGE
 	department_access = list(
 		ACCESS_ATMOSPHERICS,
+		ACCESS_ENGINEERING,
+		)
+	scaling_access = list(
 		ACCESS_AUX_BASE,
 		ACCESS_CONSTRUCTION,
-		ACCESS_ENGINEERING,
 		ACCESS_ENGINE_EQUIP,
 		ACCESS_TCOMMS,
-		)
+	)
 
 /datum/id_trim/job/security_officer/medical
 	assignment = "Security Officer (Medical)"
@@ -966,25 +979,29 @@
 	department_access = list(
 		ACCESS_MEDICAL,
 		ACCESS_MORGUE,
+	)
+	scaling_access = list(
 		ACCESS_PHARMACY,
 		ACCESS_PLUMBING,
-		ACCESS_SURGERY,
 		ACCESS_VIROLOGY,
-		)
+		ACCESS_SURGERY,
+	)
 
 /datum/id_trim/job/security_officer/science
 	assignment = "Security Officer (Science)"
 	subdepartment_color = COLOR_SCIENCE_PINK
 	department_access = list(
+		ACCESS_RESEARCH,
+		ACCESS_ROBOTICS,
+		ACCESS_SCIENCE,
+		)
+	scaling_access = list(
 		ACCESS_AUX_BASE,
 		ACCESS_GENETICS,
 		ACCESS_ORDNANCE,
 		ACCESS_ORDNANCE_STORAGE,
-		ACCESS_RESEARCH,
-		ACCESS_ROBOTICS,
-		ACCESS_SCIENCE,
 		ACCESS_XENOBIOLOGY,
-		)
+	)
 
 /datum/id_trim/job/shaft_miner
 	assignment = "Shaft Miner"

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -941,7 +941,7 @@
 	// Thus, it makes it possible to judge if departmental security officers should have more access to their department on a lower population shift.
 	var/datum/job/J = SSjob.GetJob(JOB_SECURITY_OFFICER)
 	var/minimal_security_officers = 5 // We do not spawn in any more lockers if there are 5 or less security officers, so let's start balancing here.
-	if((J.spawn_positions - 5) <= 0)
+	if((J.spawn_positions - minimal_security_officers) <= 0)
 		access |= scaling_access
 
 	access |= department_access
@@ -953,7 +953,7 @@
 		ACCESS_CARGO,
 		ACCESS_MINING,
 		ACCESS_SHIPPING,
-		)
+	)
 	scaling_access = list(
 		ACCESS_AUX_BASE,
 		ACCESS_MINING_STATION,
@@ -965,7 +965,7 @@
 	department_access = list(
 		ACCESS_ATMOSPHERICS,
 		ACCESS_ENGINEERING,
-		)
+	)
 	scaling_access = list(
 		ACCESS_AUX_BASE,
 		ACCESS_CONSTRUCTION,
@@ -994,7 +994,7 @@
 		ACCESS_RESEARCH,
 		ACCESS_ROBOTICS,
 		ACCESS_SCIENCE,
-		)
+	)
 	scaling_access = list(
 		ACCESS_AUX_BASE,
 		ACCESS_GENETICS,

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -946,6 +946,7 @@
 	#define POPULATION_SCALED_ACCESS 1
 	#define ALWAYS_GETS_ACCESS 2
 
+	// If null, then the departmental security officer will not get any elevated access.
 	if(!CONFIG_GET(number/depsec_access_level))
 		return
 

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -148,3 +148,4 @@ Jaredfogle = Game Master+Coder
 WaylandSmithy = Game Master
 NamelessFairy = Game Master
 WalterMeldron = Game Master
+san7890 = Game Master

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -197,6 +197,12 @@ MINIMAL_ACCESS_THRESHOLD 20
 ## Comment this out this to make security officers spawn in departmental security posts
 #SEC_START_BRIG
 
+## This variable is how you may configure "Scaling Access" for Departmental Security Officers.
+## Set to 0/commented out for "off", Departmental Security Officers will never get additional room-specific access (beyond general departmental doors).
+## Set to 1 if you want to enable "Scaling Access", where Departmental Security Officers will get access to most rooms within a department depending on how many security officers there are relative to the number of people on a station.
+## Set to 2 if you want Departmental Security Officers to always have access to all rooms in a department.
+DEPSEC_ACCESS_LEVEL 1
+
 
 ## GHOST INTERACTION ###
 ## Uncomment to let ghosts spin chairs. You may be wondering why this is a config option. Don't ask.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Alternative to #68527

## About The Pull Request

Hey there,

This is an alternative PR that I concocted based on talking with Goof on that PR. Basically, we already have a nicely complicated system to track and balance the number of security officers we have in a shift based on some config coefficient setting, by which we can set the amount of lockers that spawn in on the start of a round, as well as determine truly how many security officers we have.

![image](https://user-images.githubusercontent.com/34697715/179441505-ed067e49-f79e-47ac-919f-157c475c7b46.png)

So, I've decided to leverage this in another way. Basically, based on the number of security officers in a shift, their specific departmental officers will also get more (elevated) accesses. They already start with a certain amount of access, but they can get more if it is a low-pop shift with the mechanic introduced in this PR. For example, an Engineering Security Officer can access Atmospherics and Engineering departments by default, but they can't access Telecommunications unless there is a lower population of players AT SHIFT START. Same for a Medical Security Officer accessing Medbay, but not Plumbing.

Update: I have made it such that there are three system that server operators can set:

They can use the Scaling System that operates in the same method outlined in the rest of the PR.
They can disable giving departmental security officers "elevated access" (such as access beyond the "front doors") to these officers.
Finally, they can also just always ensure that departmental security officers get the maximal accesses possible.

The default setting is the "Scaling System" outlined in this PR, which is already dependent on the general Security Officer Scaling Co-Efficient.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I think it's better to involve some more nuanced config scaling that we already have present in the game. The major theme that we want to avoid is that departmental security officers having maximal accesses when there is an already large number of persons on the security force will result in "miserable" shifts for the common person working within a department (security metaprotections). However, some server operators (as well as server cultures) tend to have very wide ranges in how many security officers they have on a shift-by-shift basis. One day, you could have 0-2 security officers, the next, you could have 4-6. It's all variable on who's playing (as always). There is also a significant variation between server to server in regards to how many security officer slots you tend to have on spawn, but this is already manageable by the security officer co-efficient in config.

I believe this PR is an acceptable proposal within the bounds of https://github.com/tgstation/tgstation/pull/68527#issuecomment-1186661168 , although it may bend certain aspects of it, I definitely do see where some people may be coming from. I believe I've adjusted the accesses to a "sane"/justifiable amount, but I'll come back to think on everything.

"Red-tiding" may or may not be a problem, but there's always just going to be something inherently silly with a security officer being able to walk into plumbing to start plumbing. I hoped that this would be seen as a positive as opposed to a negative, but I can see how it could negatively impact player experience. HOWEVER, interplayer experience should not be handled by the codebase in all aspects, which is why I've also passed in the associated config variables, so that server operators (who _should_ handle the interplayer experience with their level of discretion and nuance) can.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## What accesses are where?

The general philosophy as I thought through designing this would be that the security officer should at the very least have general "front-door" access into a department, and maybe something benign. If we had even more per-door accesses, this could definitely be a bit more granular (one example I can think of would only atmospherics technicians having access to the "Pump Room", while Security Officers would not. However, this is for a later date). So, you have the "default" access you always get, and a potential to get "elevated" access as a Departmental Security Officer.

The balances are as such:

The Cargo Security Officer will have access to the Cargo Bay, Mining Section, and the Shipping Room. The first two are rather general areas, with the Shipping Room being a rather good help for rescuing (or "rescuing") flushed crewmembers when the cargo techies can't get to it/no AI. The Auxiliary Base is not essential to the security officer's functions, and the mining station helps restrict access further on stations like IceBox. This would also grant them extra access to the Lavaland base, so let's snip that out.

The Engineering Security Officer should have access to only general Engineering and Atmospherics. Construction pertains to certain rooms in maintenance I believe, and Engine-Equipment should be the one that grants access to APCs (lol). I don't think a security officer should have the latter one to be honest, but I think we'll be stretching the scope of this PR. Telecommunications is a bit weird, it's a critical station function, but I think you also shouldn't be able to nick one goon's ID and have access, so let's give it to them only when it's "needed".

The Medical Security Officer should have access to only the general Medbay Area and the Morgue, in case someone starts trotting on the doctor's turf, or if there's someone doing unsavory things to the bodies while the doctors are away. They will not have access to the specialized (dangerous) areas unless the ratio of secoffs to the population is low enough should it necessitate it (Plumbing Room, Pharmacy, Virology). I also added Surgery to the scaling access, but I'm iffy on that one. I don't particularly see why they should have it as a base access, but I also do see there being some need in dire straits (in relation to helping people, not tiding).

The Science Security Officer definitely got a huge cut. They now only have general access to R&D and normal scientist areas like the lathe room, circuits lab (presumably)since these are generally trafficked areas, but I definitely clamped down on additional access they might get in a "normally balanced" situation (no ordnance+storage, no xenobio, no genetics, no to robotics, etc.) They don't have a particular use in these areas and can even be a bit obstructive to flow in normal circumstances, but if abnormal circumstances arise and there's not a lot of security hands-on-deck, then their access is expanded.

Honestly, balancing this both makes sense and is conversely rather odd. I'm just running off what we already hold to be true and expected (or at least as of the last two months), and we can go from there.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Nanotrasen realized that the more access they had on their cards was costing them a pretty penny, so they trimmed back the number of accesses a certain departmental Security Guard might have. However, any given guard will get back a greater amount of accesses depending on how many security guards there are in relation to the population.
config: Hey server operators, listen! We've changed up how Departmental Security Officers get their accesses, so be sure to review the DEPSEC_ACCESS_LEVEL config number to see what you want to work best for your server.
/:cl:

Also, every single line of code found in 4533f07b33324f99cdb186808622314d18a72962 that is now presently in this PR is deliberate. 