### PR TITLE
Merge Conflict Markers Proper Variable Addition

### DIFF
--- a/tools/mapmerge2/merge_driver.py
+++ b/tools/mapmerge2/merge_driver.py
@@ -80,7 +80,7 @@ def three_way_merge(base, left, right):
             obj_path = "/obj/merge_conflict_marker"
             obj_name = "---Merge Conflict Marker---"
             obj_desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-            merged_movables = left_movables + [f'{obj_path}{{name = "{obj_name}",\n\tdesc = "{obj_desc}"}}'] + right_movables
+            merged_movables = left_movables + [f'{obj_path}{{name = "{obj_name}";\n\tdesc = "{obj_desc}"}}'] + right_movables
             print(f"    Left and right movable groups are split by an `{obj_path}` named \"{obj_name}\"")
         if merged_turfs is None:
             merged_turfs = left_turfs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

I fucked up. I used a comma when I should have used a semicolon. I think I did change it back after a test case but I probably forgot to save, skull emoji. Should be all good now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/179444578-90da9e2b-9f7b-4169-9df9-dfeeb4618f8e.png)

It wasn't supposed to be this way!!! Noooooooooooooooooo- I think the name showing up like that is because TGM will read it that odd way, this should definitely split up the name|desc pattern.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing particularly player facing.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
