### PR TITLE
Immovable Rods will no longer destroy Reinforced Walls and Reinforced Windows adjacent to space (on the first pass).

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -223,22 +223,32 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	// If we Bump into a turf, turf go boom.
 	if(isturf(clong))
 
-		if(istype(clong, /turf/closed/wall/r_wall)) //Except full-constructed R_walls, which just get knocked down a few pegs
+		if(istype(clong, /turf/closed/wall/r_wall)) //Except full-constructed R_walls adjacent to space, which just get knocked down a few pegs
 			var/turf/closed/wall/r_wall/stronkwall = clong
 			if(stronkwall.d_state < 3)
-				stronkwall.d_state += 4 //The larger the number, the further along the deconstruction path. R_walls will not survive two rod hits
-				stronkwall.update_appearance()
-				return ..()
+				var/adjacent_turfs = get_adjacent_open_turfs(stronkwall)
+				for(var/turf/open/neighbor in adjacent_turfs)
+					if(!TURF_SHARES(neighbor) && !istype(neighbor, /turf/open/space)) //ignoring closed sides that aren't space
+						continue
+					if(neighbor.air.return_pressure() == 0) //neighbor has no air, and is probably outside
+						stronkwall.d_state += 4 //The larger the number, the further along the deconstruction path. R_walls will not survive two rod hits
+						stronkwall.update_appearance()
+						return ..()
 
 		SSexplosions.highturf += clong
 		return ..()
 
 	if(isobj(clong))
 
-		if(istype(clong, /obj/structure/window/reinforced)) //R_Windows can take a hit. But only once.
-			if(clong.atom_integrity > (clong.max_integrity * 0.6)) //Futureproofing in case of R_window buff. We're checking for, and then taking, 60% of the window's health.
-				clong.take_damage((clong.max_integrity * 0.6))
-				return ..()
+		if(istype(clong, /obj/structure/window/reinforced)) //R_Windows adjacent to space can take a hit. But only once.
+			if(clong.get_integrity() > (clong.max_integrity * 0.6)) //Futureproofing in case of R_window buff. We're checking for, and then taking, 60% of the window's health.
+				var/adjacent_turfs = get_adjacent_open_turfs(clong)
+				for(var/turf/open/neighbor in adjacent_turfs)
+					if(!TURF_SHARES(neighbor) && !istype(neighbor, /turf/open/space)) //ignoring closed sides that aren't space
+						continue
+					if(neighbor.air.return_pressure() == 0) //neighbor has no air, and is probably outside
+						clong.take_damage((clong.max_integrity * 0.6))
+						return ..()
 
 		var/obj/clong_obj = clong
 		clong_obj.take_damage(INFINITY, BRUTE, NONE, TRUE, dir, INFINITY)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -223,10 +223,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	// If we Bump into a turf, turf go boom.
 	if(isturf(clong))
 
-		if(istype(clong, /turf/closed/wall/r_wall)) //Except full-constructed r_walls, which just get knocked down a few pegs
+		if(istype(clong, /turf/closed/wall/r_wall)) //Except full-constructed R_walls, which just get knocked down a few pegs
 			var/turf/closed/wall/r_wall/stronkwall = clong
 			if(stronkwall.d_state < 3)
-				stronkwall.d_state += 4 //The larger the number, the further along the deconstruction path. //R_walls will not survive two rod hits
+				stronkwall.d_state += 4 //The larger the number, the further along the deconstruction path. R_walls will not survive two rod hits
 				stronkwall.update_appearance()
 				return ..()
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -222,10 +222,25 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 	// If we Bump into a turf, turf go boom.
 	if(isturf(clong))
+
+		if(istype(clong, /turf/closed/wall/r_wall)) //Except full-constructed r_walls, which just get knocked down a few pegs
+			var/turf/closed/wall/r_wall/stronkwall = clong
+			if(stronkwall.d_state < 3)
+				stronkwall.d_state += 4 //The larger the number, the further along the deconstruction path. //R_walls will not survive two rod hits
+				stronkwall.update_appearance()
+				return ..()
+
 		SSexplosions.highturf += clong
 		return ..()
 
 	if(isobj(clong))
+
+		if(istype(clong, /obj/structure/window/reinforced)) //R_Windows can take a hit. But only once.
+			//var/obj/structure/window/reinforced/stronkglass = clong
+			if(clong.atom_integrity > (clong.max_integrity * 0.6)) //Futureproofing in case of R_window buff. We're checking for, and then taking, 60% of the window's health.
+				clong.take_damage((clong.max_integrity * 0.6))
+				return ..()
+
 		var/obj/clong_obj = clong
 		clong_obj.take_damage(INFINITY, BRUTE, NONE, TRUE, dir, INFINITY)
 		return ..()

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -236,7 +236,6 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(isobj(clong))
 
 		if(istype(clong, /obj/structure/window/reinforced)) //R_Windows can take a hit. But only once.
-			//var/obj/structure/window/reinforced/stronkglass = clong
 			if(clong.atom_integrity > (clong.max_integrity * 0.6)) //Futureproofing in case of R_window buff. We're checking for, and then taking, 60% of the window's health.
 				clong.take_damage((clong.max_integrity * 0.6))
 				return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- When a rod hits a reinforced wall adjacent to a tile with zero pressure, it now attempts to add four levels of deconstruct to the wall. If this would have brought it past level 6 (the last deconstruction level before removal), it destroys the wall like normal instead.
- When a rod hits a reinforced window adjacent to a tile with zero pressure, it now removes 60% of the window's integrity. If the window already had less than 60%, it destroys the window like normal instead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rods causing map-wide decompression are basically round enders. No one trusts engineering to fix the issue, and no one wants to wait around for engineering to actually fix it, so the shuttle is almost always called. Otherwise perfectly healthy rounds are brought to an end, and I hate it. R_walls and R_Windows are given the ability to withstand one hit because they usually make up the outer shell of the station.

All other objects (and mobs) are still affected the same when a rod passes through them. R_walls already partially deconstructed, and R_windows already damaged, will not hold up against the rod, so two rods hitting the same area (or one rod looping) will still break them.

This is a variant of ided, I was half-way through a project when the round ended because a rod depressurized the main halls.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Immovable Rods will no longer destroy Reinforced Walls and Reinforced Windows adjacent to space (on the first pass).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
