### PR TITLE
Changes Command radio channel color from yellow/gold to navy blue

### DIFF
--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -42,7 +42,7 @@ em						{font-style: normal;	font-weight: bold;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #948f02;}
+.comradio				{color: #204090;}
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -331,7 +331,7 @@ em {
 }
 
 .comradio {
-  color: #fcdf03;
+  color: #5f5cff;
 }
 
 .secradio {

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -348,7 +348,7 @@ em {
 }
 
 .comradio {
-  color: #948f02;
+  color: #204090;
 }
 
 .secradio {

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -19,7 +19,7 @@ $ooc: #cca300;
 $ai: #d65d95;
 $binary: #1e90ff;
 $centcom: #2681a5;
-$command: #fcdf03;
+$command: #5f5cff;
 $engi: #f37746;
 $hive: #855d85;
 $medical: #57b8f0;

--- a/tgui/packages/tgui/constants.js
+++ b/tgui/packages/tgui/constants.js
@@ -109,7 +109,7 @@ export const RADIO_CHANNELS = [
   {
     name: 'Command',
     freq: 1353,
-    color: '#fcdf03',
+    color: '#5f5cff',
   },
   {
     name: 'Medical',


### PR DESCRIPTION
![commandcolorslight](https://user-images.githubusercontent.com/46101244/179487483-83fc6e88-4353-40b9-94c5-2336b4c32b65.png)
![commandcolorsdark](https://user-images.githubusercontent.com/46101244/179487491-e11772bc-e7ac-4c00-96cb-afb202d05158.png)

## Why?

Because it looks better like this, it matches the Command airlocks color, Captain+clothes+locker, CMO+clothes+locker, HOP+clothes+locker.
Having the Command radio be gold (or piss yellow in light mode) made no sense since there's nothing gold about Command apart from the Captain's ID (which now isn't even fully gold), and Command is more than the Captain's ID.
It's already navy blue on a number of servers, (Yogs, Bee, all Baycode servers) and looks much better and makes more sense than the current color.

:cl:
qol: Command radio color is now navy blue to match the airlocks
/:cl:
