### PR TITLE
Cleared out the auxiliary tramstation circuit lab.

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -4571,11 +4571,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
-"bMk" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/lesser)
 "bMo" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -26353,7 +26348,6 @@
 /area/station/security/courtroom)
 "jmq" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
 "jmA" = (
@@ -118274,7 +118268,7 @@ kdo
 wQP
 dhe
 wQP
-bMk
+ldJ
 jco
 sLO
 doZ

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -724,9 +724,6 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/storage)
 "ann" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
 /obj/machinery/disposal/bin{
 	pixel_x = -2;
 	pixel_y = -2
@@ -734,7 +731,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/science/auxlab)
 "ant" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -2588,9 +2585,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/computer/department_orders/science{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "bfG" = (
@@ -4577,12 +4571,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "bMk" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/science/auxlab)
 "bMo" = (
 /obj/structure/cable,
@@ -9403,8 +9394,8 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "doZ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/modular_computer/console/preset/civilian{
+/obj/structure/frame/computer{
+	anchored = 1;
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -9611,16 +9602,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/transit_tube)
 "drT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
 /obj/structure/table,
-/obj/item/stock_parts/cell/high{
-	pixel_x = -8;
-	pixel_y = 9
-	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron,
 /area/station/science/auxlab)
 "drY" = (
@@ -14601,16 +14583,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "fep" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
 /obj/structure/rack,
 /obj/machinery/light/directional/south,
-/obj/item/controller,
-/obj/item/compact_remote,
-/obj/item/integrated_circuit/loaded/hello_world,
-/obj/item/integrated_circuit/loaded/speech_relay,
-/obj/item/compact_remote,
+/obj/item/integrated_circuit,
 /turf/open/floor/iron,
 /area/station/science/auxlab)
 "few" = (
@@ -17539,13 +17514,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "gia" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
-	},
-/obj/machinery/module_duplicator,
 /obj/machinery/camera/directional/west{
 	c_tag = "Circuits Lab";
 	network = list("ss13","rd")
+	},
+/obj/machinery/mecha_part_fabricator/maint{
+	name = "forgotten exosuit fabricator";
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/science/auxlab)
@@ -21118,7 +21093,7 @@
 /obj/effect/turf_decal/trimline/yellow/corner,
 /obj/structure/frame/computer{
 	anchored = 1;
-	dir = 4
+	dir = 1
 	},
 /obj/item/stack/cable_coil{
 	amount = 15
@@ -22033,12 +22008,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "hMR" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
 /obj/machinery/light/directional/north,
-/obj/machinery/component_printer,
-/turf/open/floor/iron,
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
 /area/station/science/auxlab)
 "hMT" = (
 /obj/structure/chair/pew/right,
@@ -26386,11 +26358,9 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "jmq" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
+/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/science/auxlab)
 "jmA" = (
@@ -31855,12 +31825,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "lct" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -31956,7 +31920,8 @@
 /turf/open/floor/iron/freezer,
 /area/station/science/lower)
 "ldJ" = (
-/turf/open/floor/iron,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/plating,
 /area/station/science/auxlab)
 "ldK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32531,12 +32496,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "lov" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -33309,6 +33268,10 @@
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"lAB" = (
+/obj/item/stack/sheet/glass/fifty,
+/turf/closed/mineral/random/stationside/asteroid/porus,
+/area/mine/explored)
 "lAO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/bot,
@@ -34532,6 +34495,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron,
 /area/station/science/auxlab)
 "lYK" = (
@@ -51650,7 +51614,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/clothing/glasses/welding,
 /obj/item/wrench,
@@ -51658,6 +51621,7 @@
 	dir = 10
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "rOb" = (
@@ -53783,9 +53747,6 @@
 /turf/closed/wall,
 /area/station/service/bar)
 "sDr" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -54248,7 +54209,7 @@
 /area/station/science/research)
 "sLO" = (
 /obj/structure/chair/office/light,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/science/auxlab)
 "sLR" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -55434,7 +55395,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/lesser)
 "tiL" = (
@@ -58297,24 +58258,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ufH" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
 /obj/structure/table,
-/obj/item/multitool/circuit{
-	pixel_x = 7;
-	pixel_y = -4
-	},
-/obj/item/multitool/circuit{
-	pixel_y = -4
-	},
-/obj/item/multitool/circuit{
-	pixel_x = -8;
-	pixel_y = -4
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 13
-	},
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/cigarettes,
 /turf/open/floor/iron,
 /area/station/science/auxlab)
 "ufK" = (
@@ -65439,7 +65385,6 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/right)
 "wHM" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -68267,9 +68212,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "xFY" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west,
@@ -119115,7 +119057,7 @@ duT
 dhe
 dhe
 dDG
-dhe
+lAB
 dhe
 dhe
 dhe

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -216,6 +216,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/science/auxlab)
 "afg" = (
@@ -22009,7 +22010,6 @@
 /area/station/security/courtroom)
 "hMR" = (
 /obj/machinery/light/directional/north,
-/obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
 /area/station/science/auxlab)
 "hMT" = (
@@ -26360,7 +26360,6 @@
 "jmq" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/science/auxlab)
 "jmA" = (
@@ -31920,7 +31919,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/science/lower)
 "ldJ" = (
-/obj/effect/spawner/random/trash/grime,
 /turf/open/floor/plating,
 /area/station/science/auxlab)
 "ldK" = (
@@ -33268,10 +33266,6 @@
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"lAB" = (
-/obj/item/stack/sheet/glass/fifty,
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "lAO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/bot,
@@ -34802,6 +34796,10 @@
 /obj/item/radio/intercom/prison/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"meC" = (
+/obj/item/stack/sheet/glass/fifty,
+/turf/closed/mineral/random/stationside/asteroid/porus,
+/area/mine/explored)
 "meD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -119057,7 +119055,7 @@ duT
 dhe
 dhe
 dDG
-lAB
+meC
 dhe
 dhe
 dhe

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -218,7 +218,7 @@
 	},
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "afg" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/corner,
@@ -733,7 +733,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "ant" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -4575,7 +4575,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "bMo" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -9400,7 +9400,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "dpd" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -9605,7 +9605,7 @@
 "drT" = (
 /obj/structure/table,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "drY" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -9832,9 +9832,6 @@
 "duB" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/garden)
-"duT" = (
-/turf/open/space/basic,
-/area/mine/explored)
 "duU" = (
 /turf/closed/wall/r_wall,
 /area/mine/explored)
@@ -14588,7 +14585,7 @@
 /obj/machinery/light/directional/south,
 /obj/item/integrated_circuit,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "few" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -17524,7 +17521,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "gif" = (
 /obj/structure/ore_box,
 /turf/open/misc/asteroid,
@@ -20055,9 +20052,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
-"gZk" = (
-/turf/closed/wall,
-/area/station/science/auxlab)
 "gZE" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -22011,7 +22005,7 @@
 "hMR" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "hMT" = (
 /obj/structure/chair/pew/right,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25829,7 +25823,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "jcu" = (
 /obj/structure/chair{
 	dir = 1
@@ -26361,7 +26355,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "jmA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29247,7 +29241,7 @@
 "kkA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "kkI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31828,7 +31822,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "lcG" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -31920,7 +31914,7 @@
 /area/station/science/lower)
 "ldJ" = (
 /turf/open/floor/plating,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "ldK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32499,7 +32493,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "low" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -34491,7 +34485,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "lYK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -53753,7 +53747,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "sDv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -54208,7 +54202,7 @@
 "sLO" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plating,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "sLR" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -55393,7 +55387,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/lesser)
 "tiL" = (
@@ -58260,7 +58254,7 @@
 /obj/item/storage/box/matches,
 /obj/item/storage/fancy/cigarettes,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "ufK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -65387,7 +65381,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "wHT" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hop)
@@ -68215,7 +68209,7 @@
 /obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/science/auxlab)
+/area/station/maintenance/starboard/lesser)
 "xGv" = (
 /obj/structure/rack,
 /obj/item/tank/jetpack/carbondioxide{
@@ -118279,13 +118273,13 @@ mkG
 kdo
 wQP
 dhe
-gZk
+wQP
 bMk
 jco
 sLO
 doZ
-gZk
-gZk
+wQP
+wQP
 dhe
 dhe
 dhe
@@ -118536,12 +118530,12 @@ vXG
 pju
 wQP
 dhe
-gZk
+wQP
 hMR
 ann
 ufH
 drT
-gZk
+wQP
 dhe
 dhe
 dhe
@@ -118793,12 +118787,12 @@ kvW
 rTI
 wQP
 dhe
-gZk
+wQP
 kkA
-gZk
-gZk
+wQP
+wQP
 kkA
-gZk
+wQP
 dhe
 dhe
 dhe
@@ -119051,7 +119045,7 @@ wQP
 wQP
 dhe
 dhe
-duT
+vXM
 dhe
 dhe
 dDG

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -117497,12 +117497,12 @@ wQP
 wQP
 wQP
 wQP
-mSl
-mSl
-mSl
+mwK
+mwK
+mwK
 lYB
-mSl
-mSl
+mwK
+mwK
 uKI
 mhr
 lVU
@@ -117759,7 +117759,7 @@ sDr
 xFY
 lct
 gia
-mSl
+mwK
 usA
 nVl
 kOz
@@ -118016,7 +118016,7 @@ aff
 ldJ
 wHM
 fep
-mSl
+mwK
 mSl
 mSl
 mSl


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates tramstation science to Melbert's notes in #68459 

## Why It's Good For The Game

Fixes #68459

Should hit all the marks that Melbert asked for.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: removed one of the two circuit labs on tramstation
balance: Nanotransen realizes they're losing money by having two of the same niche science on the same station. The Auxiliary Laboratory has been cleared out until there is a new use for it. Hope squatters don't set up in there...
fix: gives tramstation science more glass
fix: removes one of the tramstation cargo ordering consoles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
