### PR TITLE
fixes not being able to click drag storage containers + rmb fix

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -121,6 +121,7 @@
 	RegisterSignal(resolve_parent, COMSIG_ITEM_ATTACK_SELF, .proc/mass_empty)
 
 	RegisterSignal(resolve_parent, list(COMSIG_ATOM_ATTACK_HAND_SECONDARY, COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST), .proc/open_storage)
+	RegisterSignal(resolve_parent, COMSIG_ATOM_ATTACK_HAND_SECONDARY, .proc/open_storage_secondary)
 
 	RegisterSignal(resolve_location, COMSIG_ATOM_ENTERED, .proc/handle_enter)
 	RegisterSignal(resolve_location, COMSIG_ATOM_EXITED, .proc/handle_exit)
@@ -894,6 +895,44 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 					break
 
 	closer.screen_loc = "[screen_start_x + cols]:[screen_pixel_x],[screen_start_y]:[screen_pixel_y]"
+
+/// Signal handler for when we get attacked with secondary click.
+/datum/storage/proc/open_storage_secondary(datum/source, mob/toshow)
+	SIGNAL_HANDLER
+
+	var/obj/item/resolve_parent = parent?.resolve()
+	if(!resolve_parent)
+		return
+
+	var/obj/item/resolve_location = real_location?.resolve()
+	if(!resolve_location)
+		return
+
+	if(isobserver(toshow))
+		show_contents(toshow)
+		return
+
+	if(!toshow.CanReach(resolve_parent))
+		resolve_parent.balloon_alert(toshow, "can't reach!")
+		return FALSE
+
+	if(!isliving(toshow) || toshow.incapacitated())
+		return FALSE
+
+	if(locked)
+		if(!silent)
+			to_chat(toshow, span_warning("[pick("Ka-chunk!", "Ka-chink!", "Plunk!", "Glorf!")] \The [resolve_parent] appears to be locked!"))
+		return FALSE
+
+	show_contents(toshow)
+
+	if(animated)
+		animate_parent()
+
+	if(rustle_sound)
+		playsound(resolve_parent, SFX_RUSTLE, 50, TRUE, -5)
+
+	return TRUE
 
 /// Signal handler for when we're showing ourselves to a mob.
 /datum/storage/proc/open_storage(datum/source, mob/toshow)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -120,7 +120,7 @@
 
 	RegisterSignal(resolve_parent, COMSIG_ITEM_ATTACK_SELF, .proc/mass_empty)
 
-	RegisterSignal(resolve_parent, list(COMSIG_ATOM_ATTACK_HAND_SECONDARY, COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST), .proc/open_storage)
+	RegisterSignal(resolve_parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST), .proc/open_storage)
 	RegisterSignal(resolve_parent, COMSIG_ATOM_ATTACK_HAND_SECONDARY, .proc/open_storage_secondary)
 
 	RegisterSignal(resolve_location, COMSIG_ATOM_ENTERED, .proc/handle_enter)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -121,7 +121,8 @@
 	RegisterSignal(resolve_parent, COMSIG_ITEM_ATTACK_SELF, .proc/mass_empty)
 
 	RegisterSignal(resolve_parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST), .proc/open_storage)
-	RegisterSignal(resolve_parent, COMSIG_ATOM_ATTACK_HAND_SECONDARY, .proc/open_storage_secondary)
+	RegisterSignal(resolve_parent, list(COMSIG_ATOM_ATTACK_HAND_SECONDARY, COMSIG_PARENT_ATTACKBY_SECONDARY), .proc/open_storage_secondary)
+	RegisterSignal(resolve_parent, COMSIG_PARENT_ATTACKBY_SECONDARY, .proc/open_storage_attackby_secondary)
 
 	RegisterSignal(resolve_location, COMSIG_ATOM_ENTERED, .proc/handle_enter)
 	RegisterSignal(resolve_location, COMSIG_ATOM_EXITED, .proc/handle_exit)
@@ -895,6 +896,12 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 					break
 
 	closer.screen_loc = "[screen_start_x + cols]:[screen_pixel_x],[screen_start_y]:[screen_pixel_y]"
+
+/// Signal handler for when we get attacked with secondary click by an item.
+/datum/storage/proc/open_storage_attackby_secondary(datum/source, atom/weapon, mob/toshow)
+	SIGNAL_HANDLER
+
+	return open_storage_secondary(source, toshow)
 
 /// Signal handler for when we get attacked with secondary click.
 /datum/storage/proc/open_storage_secondary(datum/source, mob/toshow)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -121,7 +121,7 @@
 	RegisterSignal(resolve_parent, COMSIG_ITEM_ATTACK_SELF, .proc/mass_empty)
 
 	RegisterSignal(resolve_parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST), .proc/open_storage)
-	RegisterSignal(resolve_parent, list(COMSIG_ATOM_ATTACK_HAND_SECONDARY, COMSIG_PARENT_ATTACKBY_SECONDARY), .proc/open_storage_secondary)
+	RegisterSignal(resolve_parent, COMSIG_ATOM_ATTACK_HAND_SECONDARY, .proc/open_storage_secondary)
 	RegisterSignal(resolve_parent, COMSIG_PARENT_ATTACKBY_SECONDARY, .proc/open_storage_attackby_secondary)
 
 	RegisterSignal(resolve_location, COMSIG_ATOM_ENTERED, .proc/handle_enter)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1035,31 +1035,21 @@
  * call chain
  */
 /atom/proc/storage_contents_dump_act(obj/item/src_object, mob/user)
-	if(atom_storage)
-		return component_storage_contents_dump_act(src_object, user)
-	return FALSE
+	if(src_object.atom_storage)
+		to_chat(user, span_notice("You start dumping out the contents of \the [src_object] into \the [src]."))
 
-/**
- * Implement the behaviour for when a user click drags another storage item to you
- *
- * In this case we get as many of the tiems from the target items compoent storage and then
- * put everything into ourselves (or our storage component)
- *
- * TODO these should be purely component items that intercept the atom clicks higher in the
- * call chain
- */
-/atom/proc/component_storage_contents_dump_act(obj/item/src_object, mob/user)
-	var/list/things = src_object.contents
-	var/datum/progressbar/progress = new(user, things.len, src)
-	while (do_after(user, 1 SECONDS, src, NONE, FALSE, CALLBACK(src_object.atom_storage, /datum/storage.proc/handle_mass_transfer, user, src, /* override = */ TRUE)))
-		stoplag(1)
-	progress.end_progress()
-	to_chat(user, span_notice("You dump as much of [src_object]'s contents [atom_storage.insert_preposition]to [src] as you can."))
-	atom_storage.orient_to_hud(user)
-	src_object.atom_storage.orient_to_hud(user)
-	if(user.active_storage) //refresh the HUD to show the transfered contents
-		user.active_storage.refresh_views()
-	return TRUE
+		if(!do_after(user, 20, target = src))
+			return FALSE
+
+		src_object.atom_storage.handle_mass_transfer(user, src, /* override = */ TRUE)
+
+		atom_storage.orient_to_hud(user)
+		src_object.atom_storage?.orient_to_hud(user)
+		user.active_storage?.refresh_views()
+
+		return TRUE
+
+	return FALSE
 
 ///Get the best place to dump the items contained in the source storage item?
 /atom/proc/get_dumping_location()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -400,3 +400,25 @@
 ///unfreezes this obj if its frozen
 /obj/proc/unfreeze()
 	SEND_SIGNAL(src, COMSIG_OBJ_UNFREEZE)
+
+/obj/storage_contents_dump_act(obj/item/src_object, mob/user)
+	. = ..()
+
+	if(.)
+		return
+
+	if(!src_object.atom_storage)
+		return
+
+	var/atom/resolve_location = src_object.atom_storage.real_location?.resolve()
+	if(!resolve_location)
+		return FALSE
+
+	if(length(resolve_location.contents))
+		to_chat(user, span_notice("You start dumping out the contents of [src_object]..."))
+		if(!do_after(user, 20, target=resolve_location))
+			return FALSE
+
+	src_object.atom_storage.remove_all(get_dumping_location())
+
+	return TRUE

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -259,18 +259,18 @@
 	return src
 
 //How disposal handles getting a storage dump from a storage object
-/obj/machinery/disposal/storage_contents_dump_act(datum/storage/src_object, mob/user)
+/obj/machinery/disposal/storage_contents_dump_act(obj/item/src_object, mob/user)
 	. = ..()
 	if(.)
 		return
-	var/atom/resolve_parent = src_object.real_location?.resolve()
+	var/atom/resolve_parent = src_object.atom_storage?.real_location?.resolve()
 	if(!resolve_parent)
 		return FALSE
 	for(var/obj/item/I in resolve_parent)
 		if(user.active_storage != src_object)
 			if(I.on_found(user))
 				return
-		src_object.attempt_remove(I, src)
+		src_object.atom_storage?.attempt_remove(I, src)
 	return TRUE
 
 // Disposal bin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

resolves #68384
resolves #68374
resolves #68405

click drag to empty storage containers now works properly, cigarette boxes are no longer janky as hell

right clicking a container with an item no longer puts the item into the container

## Why It's Good For The Game

bug fixes

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fixes: dumping storage containers now works properly, and cigarette carts aren't janky anymore to open
fixes: right clicking a storage container with an item in hand now opens storage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
