### PR TITLE
Some nightshift fixes

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -56,6 +56,6 @@ SUBSYSTEM_DEF(nightshift)
 	for(var/obj/machinery/power/apc/APC as anything in currentrun)
 		currentrun -= APC
 		if (APC.area && (APC.area.type in GLOB.the_station_areas))
-			APC.set_nightshift(active)
+			APC.set_nightshift(nightshift_active)
 		if(MC_TICK_CHECK)
 			return

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -328,7 +328,7 @@
 			toggle_breaker(usr)
 			. = TRUE
 		if("toggle_nightshift")
-			toggle_nightshift_lights()
+			toggle_nightshift_lights(usr)
 			. = TRUE
 		if("charge")
 			chargemode = !chargemode

--- a/code/modules/power/apc/apc_power_proc.dm
+++ b/code/modules/power/apc/apc_power_proc.dm
@@ -14,8 +14,8 @@
 	terminal.setDir(dir)
 	terminal.master = src
 
-/obj/machinery/power/apc/proc/toggle_nightshift_lights(mob/living/user)
-	if(last_nightshift_switch > world.time - 100) //~10 seconds between each toggle to prevent spamming
+/obj/machinery/power/apc/proc/toggle_nightshift_lights(mob/user)
+	if(last_nightshift_switch > world.time - 10 SECONDS) //~10 seconds between each toggle to prevent spamming
 		balloon_alert(user, "night breaker is cycling!")
 		return
 	last_nightshift_switch = world.time


### PR DESCRIPTION

## About The Pull Request

- When you tried to toggle night shift lighting too fast, the balloon message could not appear. This PR fixes that.
- The loop that updates the APCs sets night shift mode based the proc arguments, instead of nightshift_active variable, meaning that if it fired with resuming set to true, it might use the incorrect nightshift mode for the rest of the lights. This PR fixes that.

## Why It's Good For The Game

- Less runtimes is good.
- Night shift mode was not working properly for me and my server, so I have done some digging, and saw this. While this does not solve the problem that the night shift subsystem does not fire properly (at least on my server), it should help with debugging it.

## Changelog

:cl:
fix: If you toggle night shift mode on an APC too fast, you'll see the balloon message
/:cl: