### PR TITLE
IAA is now flavored around rooting out corruption, to discourage security teaming.

### DIFF
--- a/strings/antagonist_flavor/traitor_flavor.json
+++ b/strings/antagonist_flavor/traitor_flavor.json
@@ -64,7 +64,7 @@
         "uplink": "You have been provided with a standard uplink to accomplish your task."
     },
     "Internal Affairs Agent": {
-        "allies": "Death to the Syndicate. Killing infiltrators is a whole different kind of internal affair we fully approve of dealing with.",
+        "allies": "Do NOT reveal your agent status, to anyone. Work to root out corruption from the station from the shadows.",
         "goal": "While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.",
         "introduction": "You are the Internal Affairs Agent.",
         "roundend_report": "was part of Nanotrasen Internal Affairs.",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

IAA are no longer flavored around Death to the Syndicate, but rather rooting out corruption in the station. Hopefully, this removes the justification to join security to hunt antags.

## Why It's Good For The Game

Headmins complained about people using the IAA as a justification to join up with sec. I see that as degenerate behavior when my goal originally was to provide a flavor for antagonizing other traitors while you do your objectives, kind of a "can't always trust others" deal. But in doing so people interpret it poorly, so this new direction should be better.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: IAA are now flavored around rooting out corruption, rather than just killing syndicates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
