### PR TITLE
Removes requirements from most midround rulesets, and lowers their minimum population to run, because nobody knows what it means

### DIFF
--- a/code/game/gamemodes/dynamic/_defines.dm
+++ b/code/game/gamemodes/dynamic/_defines.dm
@@ -1,0 +1,2 @@
+/// Requirements when something needs a lot of threat to run, but still possible at low-pop
+#define REQUIREMENTS_VERY_HIGH_THREAT_NEEDED list(90,90,90,80,60,50,40,40,40,40)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -270,9 +270,9 @@
 	exclusive_roles = list(JOB_AI)
 	required_enemies = list(4,4,4,4,4,4,2,2,2,0)
 	required_candidates = 1
-	weight = 3
+	minimum_players = 25
+	weight = 2
 	cost = 10
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	required_type = /mob/living/silicon/ai
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/malf_ai)
 
@@ -329,7 +329,7 @@
 	required_candidates = 1
 	weight = 1
 	cost = 10
-	requirements = list(90,90,90,80,60,50,40,40,40,40)
+	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
 	flags = HIGH_IMPACT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/wizard/ready(forced = FALSE)
@@ -370,7 +370,7 @@
 	weight = 5
 	cost = 7
 	minimum_round_time = 70 MINUTES
-	requirements = list(90,90,90,80,60,40,30,20,10,10)
+	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
 	var/list/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
 	var/datum/team/nuclear/nuke_team
 	flags = HIGH_IMPACT_RULESET
@@ -419,7 +419,7 @@
 	minimum_round_time = 35 MINUTES
 	weight = 3
 	cost = 8
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	minimum_players = 25
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/blob/generate_ruleset_body(mob/applicant)
@@ -457,7 +457,7 @@
 	minimum_round_time = 35 MINUTES
 	weight = 3
 	cost = 10
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	minimum_players = 25
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/blob_infection/trim_candidates()
@@ -502,7 +502,7 @@
 	minimum_round_time = 40 MINUTES
 	weight = 5
 	cost = 10
-	requirements = list(101,101,101,70,50,40,20,15,10,10)
+	minimum_players = 25
 	repeatable = TRUE
 	var/list/vents = list()
 
@@ -555,7 +555,7 @@
 	required_candidates = 1
 	weight = 3
 	cost = 5
-	requirements = list(101,101,101,70,50,40,20,15,10,10)
+	minimum_players = 15
 	repeatable = TRUE
 	var/list/spawn_locs = list()
 
@@ -607,7 +607,7 @@
 	required_candidates = 1
 	weight = 4
 	cost = 7
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	minimum_players = 25
 	repeatable = TRUE
 	var/list/spawn_locs = list()
 
@@ -658,7 +658,7 @@
 	required_applicants = 2
 	weight = 4
 	cost = 7
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	minimum_players = 25
 	repeatable = TRUE
 	var/datum/team/abductor_team/new_team
 
@@ -701,7 +701,7 @@
 	required_candidates = 1
 	weight = 4
 	cost = 8
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	minimum_players = 30
 	repeatable = TRUE
 	var/list/spawn_locs = list()
 
@@ -746,7 +746,7 @@
 	required_candidates = 0
 	weight = 3
 	cost = 8
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	minimum_players = 27
 	repeatable = TRUE
 	var/spawncount = 2
 
@@ -770,7 +770,7 @@
 	required_candidates = 1
 	weight = 4
 	cost = 5
-	requirements = list(101,101,101,70,50,40,20,15,10,10)
+	minimum_players = 15
 	repeatable = TRUE
 	var/dead_mobs_required = 20
 	var/need_extra_spawns_value = 15
@@ -816,7 +816,7 @@
 	minimum_players = 25
 	weight = 4
 	cost = 8
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	minimum_players = 23
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/sentient_disease/generate_ruleset_body(mob/applicant)
@@ -843,7 +843,7 @@
 	required_candidates = 0
 	weight = 4
 	cost = 8
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	minimum_players = 27
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/pirates/acceptable(population=0, threat=0)
@@ -876,7 +876,6 @@
 	required_candidates = 1
 	weight = 4
 	cost = 3 // Doesn't have the same impact on rounds as revenants, dragons, sentient disease (10) or syndicate infiltrators (5).
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/obsessed/trim_candidates()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -816,7 +816,6 @@
 	minimum_players = 25
 	weight = 4
 	cost = 8
-	minimum_players = 23
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/sentient_disease/generate_ruleset_body(mob/applicant)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1258,6 +1258,7 @@
 #include "code\game\gamemodes\game_mode.dm"
 #include "code\game\gamemodes\objective.dm"
 #include "code\game\gamemodes\objective_items.dm"
+#include "code\game\gamemodes\dynamic\_defines.dm"
 #include "code\game\gamemodes\dynamic\dynamic.dm"
 #include "code\game\gamemodes\dynamic\dynamic_hijacking.dm"
 #include "code\game\gamemodes\dynamic\dynamic_logging.dm"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

`requirements` is a var that nobody but me understands because it's completely unreadable.

This removes most uses of it in midround rulesets, and replaces it with a dead simple to understand `minimum_pop`.

For the most part, this lowers the requirements across the board, as the only thing that tried to actually use requirements was xenos, which were **lower in requirement than most other rulesets**. Fixes #68568.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Heavily adjusted how much population impacts the chances of midround rulesets, mostly lowering them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
