### PR TITLE
fixes circuits sending tram to brazil, and area/Entered() runtime

### DIFF
--- a/code/modules/industrial_lift/industrial_lift.dm
+++ b/code/modules/industrial_lift/industrial_lift.dm
@@ -421,7 +421,7 @@ GLOBAL_LIST_EMPTY(lifts)
 
 			our_area.Exited(mover, movement_direction)
 			mover.loc = get_step(mover, movement_direction)
-			their_area.Entered(mover, movement_direction)
+			their_area.Entered(mover, our_area)
 
 			mover.Moved(mover_old_loc, movement_direction, TRUE, null, FALSE)
 

--- a/code/modules/industrial_lift/tram_controls.dm
+++ b/code/modules/industrial_lift/tram_controls.dm
@@ -106,7 +106,7 @@
 	var/datum/lift_master/tram/tram_part = tram_ref?.resolve()
 	if(!tram_part)
 		return FALSE
-	if(tram_part.controls_locked) // someone else started already
+	if(tram_part.controls_locked || tram_part.travelling) // someone else started already
 		return FALSE
 	tram_part.tram_travel(to_where)
 	visible_message("The tram has been called to [to_where.name]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #68541
it was caused by sending the signal to move the tram to some destination, while the tram was already moving towards some other destination. it tried to check for this but it was checking for controls_locked which is never going to be true unless checked in code called from tram/process() because its set right after. now it checks for travelling which is what it should be.

also fixes runtime errors resulting from pushing a movement direction to an argument in area/Entered() when that proc expects an old area. i love how all of these overrides have different arguments
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
feex(es)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: circuits can no longer send trams to brazil, since that is not on the station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
