### PR TITLE
Replaces GetComponent in Mining items with Signalers

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -361,6 +361,13 @@
 
 // /obj/vehicle/sealed/mecha signals
 
+/// sent if you attach equipment to mecha
+#define COMSIG_MECHA_EQUIPMENT_ATTACHED "mecha_equipment_attached"
+/// sent if you detach equipment to mecha
+#define COMSIG_MECHA_EQUIPMENT_DETACHED "mecha_equipment_detached"
+/// sent when you are able to drill through a mob
+#define COMSIG_MECHA_DRILL_MOB "mecha_drill_mob"
+
 ///sent from mecha action buttons to the mecha they're linked to
 #define COMSIG_MECHA_ACTION_TRIGGER "mecha_action_activate"
 

--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -16,6 +16,16 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	GLOB.GPS_list -= src
 	return ..()
 
+/datum/component/gps/kheiral_cuffs
+
+/datum/component/gps/kheiral_cuffs/Initialize(_gpstag = "COM0")
+	. = ..()
+	RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/deactivate_kheiral_cuffs)
+
+/datum/component/gps/kheiral_cuffs/proc/deactivate_kheiral_cuffs(datum/source)
+	SIGNAL_HANDLER
+	qdel(src)
+
 ///GPS component subtype. Only gps/item's can be used to open the UI.
 /datum/component/gps/item
 	var/updating = TRUE //Automatic updating of GPS list. Can be set to manual by user.

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -33,7 +33,11 @@
 		/datum/material/bluespace
 	)
 	AddComponent(/datum/component/material_container, allowed_materials, INFINITY, MATCONTAINER_NO_INSERT|BREAKDOWN_FLAGS_RECYCLER)
-	AddComponent(/datum/component/butchering/recycler, 1, amount_produced,amount_produced/5)
+	AddComponent(/datum/component/butchering/recycler, \
+	speed = 0.1 SECONDS, \
+	effectiveness = amount_produced, \
+	bonus_modifier = amount_produced/5, \
+	)
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -324,7 +324,9 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	. = ..()
 
 	if(sharpness && force > 5) //give sharp objects butchering functionality, for consistency
-		AddComponent(/datum/component/butchering, 80 * toolspeed)
+		AddComponent(/datum/component/butchering, \
+		speed = 8 SECONDS * toolspeed, \
+		)
 
 /**Makes cool stuff happen when you suicide with an item
  *

--- a/code/game/objects/items/chainsaw.dm
+++ b/code/game/objects/items/chainsaw.dm
@@ -26,7 +26,13 @@
 
 /obj/item/chainsaw/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 30, 100, 0, 'sound/weapons/chainsawhit.ogg', TRUE)
+	AddComponent(/datum/component/butchering, \
+	speed = 3 SECONDS, \
+	effectiveness = 100, \
+	bonus_modifier = 0, \
+	butcher_sound = 'sound/weapons/chainsawhit.ogg', \
+	disabled = TRUE, \
+	)
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE)
 
 /obj/item/chainsaw/suicide_act(mob/living/carbon/user)

--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -32,7 +32,13 @@
 
 /obj/item/fireaxe/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 100, 80, 0 , hitsound) //axes are not known for being precision butchering tools
+	AddComponent(/datum/component/butchering, \
+	speed = 10 SECONDS, \
+	effectiveness = 80, \
+	bonus_modifier = 0 , \
+	butcher_sound = hitsound, \
+	)
+	//axes are not known for being precision butchering tools
 	AddComponent(/datum/component/two_handed, force_unwielded=force_unwielded, force_wielded=force_wielded, icon_wielded="[base_icon_state]1")
 
 /obj/item/fireaxe/update_icon_state()

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -249,7 +249,11 @@
 
 /obj/item/nullrod/scythe/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 70, 110) //the harvest gives a high bonus chance
+	AddComponent(/datum/component/butchering, \
+	speed = 7 SECONDS, \
+	effectiveness = 110, \
+	)
+	//the harvest gives a high bonus chance
 
 /obj/item/nullrod/scythe/vibro
 	name = "high frequency blade"
@@ -346,7 +350,12 @@
 /obj/item/nullrod/chainsaw/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
-	AddComponent(/datum/component/butchering, 30, 100, 0, hitsound)
+	AddComponent(/datum/component/butchering, \
+	speed = 3 SECONDS, \
+	effectiveness = 100, \
+	bonus_modifier = 0, \
+	butcher_sound = hitsound, \
+	)
 
 /obj/item/nullrod/clown
 	name = "clown dagger"
@@ -445,7 +454,10 @@
 /obj/item/nullrod/armblade/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
-	AddComponent(/datum/component/butchering, 80, 70)
+	AddComponent(/datum/component/butchering, \
+	speed = 8 SECONDS, \
+	effectiveness = 70, \
+	)
 
 /obj/item/nullrod/armblade/tentacle
 	name = "unholy blessing"
@@ -510,7 +522,10 @@
 /obj/item/nullrod/tribal_knife/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSobj, src)
-	AddComponent(/datum/component/butchering, 50, 100)
+	AddComponent(/datum/component/butchering, \
+	speed = 5 SECONDS, \
+	effectiveness = 100, \
+	)
 
 /obj/item/nullrod/tribal_knife/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -33,7 +33,12 @@
 
 ///Adds the butchering component, used to override stats for special cases
 /obj/item/knife/proc/set_butchering()
-	AddComponent(/datum/component/butchering, 80 - force, 100, force - 10) //bonus chance increases depending on force
+	AddComponent(/datum/component/butchering, \
+	speed = 8 SECONDS - force, \
+	effectiveness = 100, \
+	bonus_modifier = force - 10, \
+	)
+	//bonus chance increases depending on force
 
 /obj/item/knife/suicide_act(mob/user)
 	user.visible_message(pick(span_suicide("[user] is slitting [user.p_their()] wrists with the [src.name]! It looks like [user.p_theyre()] trying to commit suicide."), \
@@ -101,7 +106,11 @@
 	wound_bonus = 10
 
 /obj/item/knife/hunting/set_butchering()
-	AddComponent(/datum/component/butchering, 80 - force, 100, force + 10)
+	AddComponent(/datum/component/butchering, \
+	speed = 8 SECONDS - force, \
+	effectiveness = 100, \
+	bonus_modifier = force + 10, \
+	)
 
 /obj/item/knife/combat
 	name = "combat knife"

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -33,7 +33,10 @@
 /obj/item/melee/energy/Initialize(mapload)
 	. = ..()
 	make_transformable()
-	AddComponent(/datum/component/butchering, _speed = 5 SECONDS, _butcher_sound = active_hitsound)
+	AddComponent(/datum/component/butchering, \
+	speed = 5 SECONDS, \
+	butcher_sound = active_hitsound, \
+	)
 
 /obj/item/melee/energy/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -52,7 +52,11 @@
 
 /obj/item/melee/synthetic_arm_blade/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 60, 80) //very imprecise
+	AddComponent(/datum/component/butchering, \
+	speed = 6 SECONDS, \
+	effectiveness = 80, \
+	)
+	//very imprecise
 
 /obj/item/melee/sabre
 	name = "officer's sabre"
@@ -79,7 +83,12 @@
 
 /obj/item/melee/sabre/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 30, 95, 5) //fast and effective, but as a sword, it might damage the results.
+	AddComponent(/datum/component/butchering, \
+	speed = 3 SECONDS, \
+	effectiveness = 95, \
+	bonus_modifier = 5, \
+	)
+	//fast and effective, but as a sword, it might damage the results.
 
 /obj/item/melee/sabre/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == PROJECTILE_ATTACK)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -37,7 +37,11 @@
 
 /obj/item/spear/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 100, 70) //decent in a pinch, but pretty bad.
+	AddComponent(/datum/component/butchering, \
+	speed = 10 SECONDS, \
+	effectiveness = 70, \
+	)
+	//decent in a pinch, but pretty bad.
 	AddComponent(/datum/component/jousting)
 	AddComponent(/datum/component/two_handed, force_unwielded=force_unwielded, force_wielded=force_wielded, icon_wielded="[icon_prefix]1")
 	update_appearance()

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -290,7 +290,10 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 /obj/item/shard/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/caltrop, min_damage = force)
-	AddComponent(/datum/component/butchering, 150, 65)
+	AddComponent(/datum/component/butchering, \
+	speed = 15 SECONDS, \
+	effectiveness = 65, \
+	)
 	icon_state = pick("large", "medium", "small")
 	switch(icon_state)
 		if("small")

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -79,7 +79,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/claymore/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 40, 105)
+	AddComponent(/datum/component/butchering, \
+	speed = 4 SECONDS, \
+	effectiveness = 105, \
+	)
 
 /obj/item/claymore/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is falling on [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -391,7 +394,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/switchblade/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
-	AddComponent(/datum/component/butchering, 7 SECONDS, 100)
+	AddComponent(/datum/component/butchering, \
+	speed = 7 SECONDS, \
+	effectiveness = 100, \
+	)
 	AddComponent(/datum/component/transforming, \
 		start_transformed = start_extended, \
 		force_on = 20, \

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -175,7 +175,10 @@
 		loc.visible_message(span_warning("A grotesque blade forms around [loc.name]\'s arm!"), span_warning("Our arm twists and mutates, transforming it into a deadly blade."), span_hear("You hear organic matter ripping and tearing!"))
 	if(synthetic)
 		can_drop = TRUE
-	AddComponent(/datum/component/butchering, 60, 80)
+	AddComponent(/datum/component/butchering, \
+	speed = 6 SECONDS, \
+	effectiveness = 80, \
+	)
 
 /obj/item/melee/arm_blade/afterattack(atom/target, mob/user, proximity)
 	. = ..()

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -78,7 +78,10 @@ Striking a noncultist, however, will tear their flesh."}
 
 /obj/item/melee/cultblade/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 40, 100)
+	AddComponent(/datum/component/butchering, \
+	speed = 4 SECONDS, \
+	effectiveness = 100, \
+	)
 
 /obj/item/melee/cultblade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(IS_CULTIST(owner) && prob(final_block_chance))
@@ -155,7 +158,10 @@ Striking a noncultist, however, will tear their flesh."}
 	. = ..()
 	jaunt = new(src)
 	linked_action = new(src)
-	AddComponent(/datum/component/butchering, 50, 80)
+	AddComponent(/datum/component/butchering, \
+	speed = 5 SECONDS, \
+	effectiveness = 80, \
+	)
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE)
 
 /obj/item/cult_bastard/Destroy()
@@ -726,7 +732,10 @@ Striking a noncultist, however, will tear their flesh."}
 
 /obj/item/melee/cultblade/halberd/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 100, 90)
+	AddComponent(/datum/component/butchering, \
+	speed = 10 SECONDS, \
+	effectiveness = 90, \
+	)
 	AddComponent(/datum/component/two_handed, force_unwielded=17, force_wielded=24)
 
 /obj/item/melee/cultblade/halberd/update_icon_state()

--- a/code/modules/antagonists/nightmare/nightmare_equipment.dm
+++ b/code/modules/antagonists/nightmare/nightmare_equipment.dm
@@ -21,5 +21,8 @@
 /obj/item/light_eater/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
-	AddComponent(/datum/component/butchering, 80, 70)
+	AddComponent(/datum/component/butchering, \
+	speed = 8 SECONDS, \
+	effectiveness = 70, \
+	)
 	AddComponent(/datum/component/light_eater)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -134,7 +134,10 @@
 /obj/item/broken_bottle/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/caltrop, min_damage = force)
-	AddComponent(/datum/component/butchering, 200, 55)
+	AddComponent(/datum/component/butchering, \
+	speed = 20 SECONDS, \
+	effectiveness = 55, \
+	)
 
 /// Mimics the appearance and properties of the passed in bottle.
 /// Takes the broken bottle to mimic, and the thing the bottle was broken agaisnt as args

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -487,7 +487,10 @@
 
 /obj/item/hatchet/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 70, 100)
+	AddComponent(/datum/component/butchering, \
+	speed = 7 SECONDS, \
+	effectiveness = 100, \
+	)
 
 /obj/item/hatchet/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is chopping at [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -521,7 +524,10 @@
 
 /obj/item/scythe/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 90, 105)
+	AddComponent(/datum/component/butchering, \
+	speed = 9 SECONDS, \
+	effectiveness = 105, \
+	)
 
 /obj/item/scythe/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is beheading [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/mapfluff/ruins/icemoonruin_code/wrath.dm
+++ b/code/modules/mapfluff/ruins/icemoonruin_code/wrath.dm
@@ -10,22 +10,11 @@
 
 /obj/item/clothing/gloves/butchering/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 5, 125, null, null, TRUE, TRUE)
-
-/obj/item/clothing/gloves/butchering/equipped(mob/user, slot, initial = FALSE)
-	. = ..()
-	RegisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK, .proc/butcher_target)
-	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = TRUE
-
-/obj/item/clothing/gloves/butchering/dropped(mob/user, silent = FALSE)
-	. = ..()
-	UnregisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK)
-	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = FALSE
-
-/obj/item/clothing/gloves/butchering/proc/butcher_target(mob/user, atom/target, proximity)
-	SIGNAL_HANDLER
-	if(!isliving(target))
-		return
-	return SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, target, user)
+	AddComponent(/datum/component/butchering/wearable, \
+	speed = 0.5 SECONDS, \
+	effectiveness = 125, \
+	bonus_modifier = 0, \
+	butcher_sound = null, \
+	disabled = TRUE, \
+	can_be_blunt = TRUE, \
+	)

--- a/code/modules/mining/equipment/kheiral_cuffs.dm
+++ b/code/modules/mining/equipment/kheiral_cuffs.dm
@@ -62,7 +62,7 @@
 	var/obj/item/card/id/id_card = user.get_idcard(hand_first = FALSE)
 	if(id_card)
 		gps_name = id_card.registered_name
-	AddComponent(/datum/component/gps, "*[gps_name]'s Kheiral Link")
+	AddComponent(/datum/component/gps/kheiral_cuffs, "*[gps_name]'s Kheiral Link")
 	balloon_alert(user, "GPS activated")
 	ADD_TRAIT(user, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
 	gps_enabled = TRUE
@@ -74,7 +74,6 @@
 	if(on_wrist && far_from_home)
 		return
 	balloon_alert(user, "GPS de-activated")
-	qdel(GetComponent(/datum/component/gps))
 	REMOVE_TRAIT(user, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
 	gps_enabled = FALSE
 

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -32,7 +32,11 @@
 
 /obj/item/kinetic_crusher/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 60, 110) //technically it's huge and bulky, but this provides an incentive to use it
+	AddComponent(/datum/component/butchering, \
+	speed = 6 SECONDS, \
+	effectiveness = 110, \
+	)
+	//technically it's huge and bulky, but this provides an incentive to use it
 	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=20)
 
 /obj/item/kinetic_crusher/Destroy()

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -130,7 +130,11 @@
 
 /obj/item/shovel/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 150, 40) //it's sharp, so it works, but barely.
+	AddComponent(/datum/component/butchering, \
+	speed = 15 SECONDS, \
+	effectiveness = 40, \
+	)
+	//it's sharp, so it works, but barely.
 
 /obj/item/shovel/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins digging their own grave! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -309,29 +309,25 @@
 /obj/item/clothing/head/hooded/hostile_environment/Initialize(mapload)
 	. = ..()
 	update_appearance()
-	AddComponent(/datum/component/butchering, 5, 150, null, null, null, TRUE, CALLBACK(src, .proc/consume))
+	AddComponent(/datum/component/butchering/wearable, \
+	speed = 0.5 SECONDS, \
+	effectiveness = 150, \
+	bonus_modifier = 0, \
+	butcher_sound = null, \
+	disabled = null, \
+	can_be_blunt = TRUE, \
+	butcher_callback = CALLBACK(src, .proc/consume), \
+	)
 	AddElement(/datum/element/radiation_protected_clothing)
 	AddComponent(/datum/component/gags_recolorable)
 
 /obj/item/clothing/head/hooded/hostile_environment/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
-	RegisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK, .proc/butcher_target)
-	var/datum/component/butchering/butchering = GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = TRUE
 	to_chat(user, span_notice("You feel a bloodlust. You can now butcher corpses with your bare arms."))
 
 /obj/item/clothing/head/hooded/hostile_environment/dropped(mob/user, silent = FALSE)
 	. = ..()
-	UnregisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK)
-	var/datum/component/butchering/butchering = GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = FALSE
 	to_chat(user, span_notice("You lose your bloodlust."))
-
-/obj/item/clothing/head/hooded/hostile_environment/proc/butcher_target(mob/user, atom/target, proximity)
-	SIGNAL_HANDLER
-	if(!isliving(target))
-		return
-	return SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, target, user)
 
 /obj/item/clothing/head/hooded/hostile_environment/proc/consume(mob/living/user, mob/living/butchered)
 	if(butchered.mob_biotypes & (MOB_ROBOTIC | MOB_SPIRIT))
@@ -633,7 +629,10 @@
 	spirits = list()
 	START_PROCESSING(SSobj, src)
 	SSpoints_of_interest.make_point_of_interest(src)
-	AddComponent(/datum/component/butchering, 150, 90)
+	AddComponent(/datum/component/butchering, \
+	speed = 15 SECONDS, \
+	effectiveness = 90, \
+	)
 
 /obj/item/melee/ghost_sword/Destroy()
 	for(var/mob/dead/observer/G in spirits)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -123,7 +123,11 @@
 
 /obj/item/pen/fountain/captain/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 200, 115) //the pen is mightier than the sword
+	AddComponent(/datum/component/butchering, \
+	speed = 20 SECONDS, \
+	effectiveness = 115, \
+	)
+	//the pen is mightier than the sword
 
 /obj/item/pen/fountain/captain/reskin_obj(mob/M)
 	..()
@@ -251,7 +255,10 @@
 
 /obj/item/pen/edagger/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, _speed = 6 SECONDS, _butcher_sound = 'sound/weapons/blade1.ogg')
+	AddComponent(/datum/component/butchering, \
+	speed = 6 SECONDS, \
+	butcher_sound = 'sound/weapons/blade1.ogg', \
+	)
 	AddComponent(/datum/component/transforming, \
 		force_on = 18, \
 		throwforce_on = 35, \

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -115,7 +115,12 @@
 
 /obj/item/gun/energy/plasmacutter/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 25, 105, 0, 'sound/weapons/plasma_cutter.ogg')
+	AddComponent(/datum/component/butchering, \
+	speed = 2.5 SECONDS, \
+	effectiveness = 105, \
+	bonus_modifier = 0, \
+	butcher_sound = 'sound/weapons/plasma_cutter.ogg', \
+	)
 	AddElement(/datum/element/update_icon_blocker)
 	AddElement(/datum/element/tool_flash, 1)
 

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -178,7 +178,12 @@
 
 /obj/item/gun/magic/staff/spellblade/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 15, 125, 0, hitsound)
+	AddComponent(/datum/component/butchering, \
+	speed = 1.5 SECONDS, \
+	effectiveness = 125, \
+	bonus_modifier = 0, \
+	butcher_sound = hitsound, \
+	)
 
 /obj/item/gun/magic/staff/spellblade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == PROJECTILE_ATTACK)

--- a/code/modules/religion/sparring/ceremonial_gear.dm
+++ b/code/modules/religion/sparring/ceremonial_gear.dm
@@ -28,7 +28,10 @@
 
 /obj/item/ceremonial_blade/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 40, 105)
+	AddComponent(/datum/component/butchering, \
+	speed = 4 SECONDS, \
+	effectiveness = 105, \
+	)
 	RegisterSignal(src, COMSIG_ITEM_SHARPEN_ACT, .proc/block_sharpening)
 
 /obj/item/ceremonial_blade/melee_attack_chain(mob/user, atom/target, params)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -172,7 +172,11 @@
 
 /obj/item/scalpel/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 80 * toolspeed, 100, 0)
+	AddComponent(/datum/component/butchering, \
+	speed = 8 SECONDS * toolspeed, \
+	effectiveness = 100, \
+	bonus_modifier = 0, \
+	)
 	AddElement(/datum/element/eyestab)
 
 /obj/item/scalpel/augment
@@ -211,7 +215,13 @@
 
 /obj/item/circular_saw/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 40 * toolspeed, 100, 5, 'sound/weapons/circsawhit.ogg') //saws are very accurate and fast at butchering
+	AddComponent(/datum/component/butchering, \
+	speed = 4 SECONDS * toolspeed, \
+	effectiveness = 100, \
+	bonus_modifier = 5, \
+	butcher_sound = 'sound/weapons/circsawhit.ogg', \
+	)
+	//saws are very accurate and fast at butchering
 
 /obj/item/circular_saw/augment
 	desc = "A small but very fast spinning saw. It rips and tears until it is done."

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -166,6 +166,7 @@
 	else
 		M.equip_by_category[to_equip_slot] = src
 	chassis = M
+	SEND_SIGNAL(src, COMSIG_MECHA_EQUIPMENT_ATTACHED)
 	forceMove(M)
 	log_message("[src] initialized.", LOG_MECHA)
 
@@ -188,6 +189,7 @@
 		chassis.equip_by_category[to_unequip_slot] -= src
 	else
 		chassis.equip_by_category[to_unequip_slot] = null
+	SEND_SIGNAL(src, COMSIG_MECHA_EQUIPMENT_DETACHED)
 	log_message("[src] removed from equipment.", LOG_MECHA)
 	chassis = null
 

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -22,7 +22,13 @@
 
 /obj/item/mecha_parts/mecha_equipment/drill/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 50, 100, null, null, TRUE)
+	AddComponent(/datum/component/butchering/mecha, \
+	speed = 5 SECONDS, \
+	effectiveness = 100, \
+	bonus_modifier = null, \
+	butcher_sound = null, \
+	disabled = TRUE, \
+	)
 
 /obj/item/mecha_parts/mecha_equipment/drill/action(mob/source, atom/target, list/modifiers)
 	// Check if we can even use the equipment to begin with.
@@ -112,16 +118,6 @@
 			return TRUE
 	return FALSE
 
-/obj/item/mecha_parts/mecha_equipment/drill/attach(obj/vehicle/sealed/mecha/M)
-	..()
-	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = TRUE
-
-/obj/item/mecha_parts/mecha_equipment/drill/detach(atom/moveto)
-	..()
-	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = FALSE
-
 /obj/item/mecha_parts/mecha_equipment/drill/proc/drill_mob(mob/living/target, mob/living/user)
 	target.visible_message(span_danger("[chassis] is drilling [target] with [src]!"), \
 						span_userdanger("[chassis] is drilling you with [src]!"))
@@ -129,8 +125,7 @@
 	if(target.stat == DEAD && target.getBruteLoss() >= (target.maxHealth * 2))
 		log_combat(user, target, "gibbed", name)
 		if(LAZYLEN(target.butcher_results) || LAZYLEN(target.guaranteed_butcher_results))
-			var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-			butchering.Butcher(chassis, target)
+			SEND_SIGNAL(src, COMSIG_MECHA_DRILL_MOB, chassis, target)
 		else
 			target.gib()
 	else


### PR DESCRIPTION
## About The Pull Request

Replaces GetComponent in all mining items with proper signals (mech drill, hostile environment suit, kheiral_cuffs, butchering gloves)

## Why It's Good For The Game

GetComponent bad and more consistency

## Changelog

:cl:
refactor: Mining items have been refactored to make better use of components.
/:cl:
