### PR TITLE
Tweaks brightness for red, blacklight presets. Adds dim red light preset

### DIFF
--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -31,14 +31,15 @@
 	bulb_colour = "#FF3232"
 	nightshift_allowed = FALSE
 	no_low_power = TRUE
+
+/obj/machinery/light/red/dim
 	brightness = 4
 	bulb_power = 0.7
 
 /obj/machinery/light/blacklight
 	bulb_colour = "#A700FF"
 	nightshift_allowed = FALSE
-	brightness = 4
-	bulb_power = 0.8
+	brightness = 8
 
 /obj/machinery/light/dim
 	nightshift_allowed = FALSE
@@ -74,14 +75,15 @@
 	bulb_colour = "#FF3232"
 	no_low_power = TRUE
 	nightshift_allowed = FALSE
+
+/obj/machinery/light/small/red/dim
 	brightness = 2
 	bulb_power = 0.8
 
 /obj/machinery/light/small/blacklight
 	bulb_colour = "#A700FF"
 	nightshift_allowed = FALSE
-	brightness = 2
-	bulb_power = 0.9
+	brightness = 4
 
 // -------- Directional presets
 // The directions are backwards on the lights we have now
@@ -114,6 +116,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/cold/no_nightlight, 0)
 // ---- Red tubes
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/red, 0)
 
+// ---- Red dim tubes
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/red/dim, 0)
+
 // ---- Blacklight tubes
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/blacklight, 0)
 
@@ -135,6 +140,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/broken, 0)
 
 // ---- Red bulbs
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/red, 0)
+
+// ---- Red dim bulbs
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/red/dim, 0)
 
 // ---- Blacklight bulbs
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/blacklight, 0)


### PR DESCRIPTION
Before/After
![before](https://user-images.githubusercontent.com/38563876/179648059-f6f29d74-6c37-4d6b-b684-eb9b2f49f427.png)
![afffter](https://user-images.githubusercontent.com/38563876/179648063-cdab123d-7a44-4607-b2d7-96bbf08dfb29.png)

## About The Pull Request
I wasn't paying enough attention when I made these and I was made aware by mappers that these were way too dark to be usable so I've undone the lower brightness values for these lights

For the red variant I was asked to make a dim subtype, it can be useful as red lights are usually placed for low lighting solutions

## Why It's Good For The Game
Being able to see is pretty nice, better get these sorted before they start getting more use

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Blacklight and red light fixtures are slightly brighter
/:cl:
