### PR TITLE
Fixes seperation in redpill messages

### DIFF
--- a/strings/redpill.json
+++ b/strings/redpill.json
@@ -21,7 +21,7 @@
 		"Why is there a floor, but no roof?",
 		"The universe always ends after we reach CentCom.",
 		"Everyone is controlled by strings behind a glowing screen",
-		"Seperation is absolute.",
+		"Separation is absolute.",
 		"It doesn't take much for people to murder their friends.",
 		"All the crew are just greytiders with different paint.",
 		"What the fuck is carbon dioxide?",


### PR DESCRIPTION
## About The Pull Request

Title, minor spellcheck fix.

## Why It's Good For The Game

It's absolute.

## Changelog

:cl:
spellcheck: Fixes a minor spelling error in seperation when you eat a red pill.
/:cl: