### PR TITLE
Fix species change or stomach removal to reset nutrition traits, alerts, and mood events

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -529,6 +529,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			C.faction -= i
 
 	clear_tail_moodlets(C)
+	REMOVE_TRAIT(C, TRAIT_FAT, OBESITY)
+	SEND_SIGNAL(C, COMSIG_CLEAR_MOOD_EVENT, "nutrition")
+	C.clear_alert(ALERT_NUTRITION)
 
 	C.remove_movespeed_modifier(/datum/movespeed_modifier/species)
 

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -260,6 +260,8 @@
 		human_owner.clear_alert(ALERT_DISGUST)
 		SEND_SIGNAL(human_owner, COMSIG_CLEAR_MOOD_EVENT, "disgust")
 		human_owner.clear_alert(ALERT_NUTRITION)
+		REMOVE_TRAIT(human_owner, TRAIT_FAT, OBESITY)
+		SEND_SIGNAL(human_owner, COMSIG_CLEAR_MOOD_EVENT, "nutrition")
 
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #68416
Fixes #53285
Fixes #57201

Fix species transformation (polymorph, DNA injector, changeling, etc.) or stomach removal to reset all related nutrition traits, alerts, and mood events.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Better consistency for the game and less bugs on the tracker.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix species change or stomach removal to reset nutrition traits, alerts, and mood events
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
