### PR TITLE
AI Lawset can now be specified instead of 'custom'

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -282,11 +282,15 @@
 /datum/config_entry/number/default_laws //Controls what laws the AI spawns with.
 	default = 0
 	min_val = 0
-	max_val = 3
+	max_val = 4
 
 /datum/config_entry/number/silicon_max_law_amount
 	default = 12
 	min_val = 0
+
+/datum/config_entry/keyed_list/specified_laws
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_FLAG
 
 /datum/config_entry/keyed_list/random_laws
 	key_mode = KEY_MODE_TEXT

--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -18,14 +18,14 @@
 
 /// Always make the round default asimov
 #define CONFIG_ASIMOV 0
-/// Set to a specific lawset in the game options.
-#define CONFIG_SPECIFIED 1
+/// Set to a custom lawset defined by another config value
+#define CONFIG_CUSTOM 1
 /// Set to a completely random ai law subtype, good, bad, it cares not. Careful with this one
 #define CONFIG_RANDOM 2
 /// Set to a configged weighted list of lawtypes in the config. This lets server owners pick from a pool of sane laws, it is also the same process for ian law rerolls.
 #define CONFIG_WEIGHTED 3
-/// Set to a custom lawset defined by another config value
-#define CONFIG_CUSTOM 4
+/// Set to a specific lawset in the game options.
+#define CONFIG_SPECIFIED 4
 
 ///first called when something wants round default laws for the first time in a round, considers config
 ///returns a law datum that GLOB._round_default_lawset will be set to.

--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -31,7 +31,7 @@
 ///returns a law datum that GLOB._round_default_lawset will be set to.
 /proc/setup_round_default_laws()
 	var/list/law_ids = CONFIG_GET(keyed_list/random_laws)
-	var/list/spec_law_ids = CONFIG_GET(keyed_list/specified_laws)
+	var/list/specified_law_ids = CONFIG_GET(keyed_list/specified_laws)
 
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI))
 		return pick_weighted_lawset()
@@ -40,14 +40,14 @@
 		if(CONFIG_ASIMOV)
 			return /datum/ai_laws/default/asimov
 		if(CONFIG_SPECIFIED)
-			var/list/speclaws = list()
-			for(var/lpath in subtypesof(/datum/ai_laws))
-				var/datum/ai_laws/L = lpath
-				if(initial(L.id) in spec_law_ids)
-					speclaws += lpath
+			var/list/specifiedlaws = list()
+			for(var/lawpath in subtypesof(/datum/ai_laws))
+				var/datum/ai_laws/laws = lawpath
+				if(initial(laws.id) in specified_law_ids)
+					specifiedlaws += lawpath
 			var/datum/ai_laws/lawtype
-			if(speclaws.len)
-				lawtype = pick(speclaws)
+			if(specifiedlaws.len)
+				lawtype = pick(specifiedlaws)
 			else
 				lawtype = pick(subtypesof(/datum/ai_laws/default))
 

--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -40,14 +40,16 @@
 		if(CONFIG_ASIMOV)
 			return /datum/ai_laws/default/asimov
 		if(CONFIG_SPECIFIED)
-			var/list/specifiedlaws = list()
-			for(var/lawpath in subtypesof(/datum/ai_laws))
-				var/datum/ai_laws/laws = lawpath
-				if(initial(laws.id) in specified_law_ids)
-					specifiedlaws += lawpath
+			var/list/specified_laws = list()
+			for (var/law_id in specified_law_ids)
+				var/datum/ai_laws/laws = lawid_to_type(law_id)
+				if (isnull(laws))
+					log_config("ERROR: Specified law [law_id] does not exist!")
+					continue
+				specified_laws += laws
 			var/datum/ai_laws/lawtype
-			if(specifiedlaws.len)
-				lawtype = pick(specifiedlaws)
+			if(specified_laws.len)
+				lawtype = pick(specified_laws)
 			else
 				lawtype = pick(subtypesof(/datum/ai_laws/default))
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -214,10 +214,19 @@ NEAR_DEATH_EXPERIENCE
 ## ROUNDSTART SILICON LAWS ###
 ## This controls what the AI's laws are at the start of the round.
 ## Set to 0/commented out for "off", silicons will just start with Asimov.
-## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
+## Set to 1 for "specified", silicons will start with an existing lawset. (If no specified lawset is identified, the AI will spawn with asimov.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
+## Set to 4 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
+
 DEFAULT_LAWS 0
+
+## SPECIFIED LAWS ##
+## ------------------------------------------------------------------------------------------
+## These control what lawset the AI will use, edit the specified law to an *existing* lawset to make it the default.
+## See datums\ai_laws.dm for the full law lists
+
+SPECIFIED_LAWS asimovpp
 
 ## RANDOM LAWS ##
 ## ------------------------------------------------------------------------------------------

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -214,10 +214,11 @@ NEAR_DEATH_EXPERIENCE
 ## ROUNDSTART SILICON LAWS ###
 ## This controls what the AI's laws are at the start of the round.
 ## Set to 0/commented out for "off", silicons will just start with Asimov.
-## Set to 1 for "specified", silicons will start with an existing lawset. (If no specified lawset is identified, the AI will spawn with asimov.)
+## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
-## Set to 4 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
+## Set to 4 for "specified", silicons will start with an existing lawset. (If no specified lawset is identified, the AI will spawn with asimov.)
+
 
 DEFAULT_LAWS 0
 
@@ -225,6 +226,7 @@ DEFAULT_LAWS 0
 ## ------------------------------------------------------------------------------------------
 ## These control what lawset the AI will use, edit the specified law to an *existing* lawset to make it the default.
 ## See datums\ai_laws.dm for the full law lists
+## IE, SPECIFIED_LAWS asimovpp, SPECIFIED_LAWS robocop, SPECIFIED_LAWS antimov
 
 SPECIFIED_LAWS asimovpp
 


### PR DESCRIPTION

## About The Pull Request

Adds new settings to the game_options.txt allowing you to make the default AI "specified" which by default is set to asimov++ and can be changed to an existing lawset.

## Why It's Good For The Game

In accordance to https://github.com/tgstation/tgstation/pull/68342#issuecomment-1182578105

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: allows for an existing ai lawset to be used as the default instead of a "custom" lawset.
server: added server settings that allow for the ai lawset to be specified. This *should* be changed in the server to allow the "asimov++" card to spawn in place of the "asimov" card in the AI upload.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
