### PR TITLE
Fixes / Refactors Void Magnet

### DIFF
--- a/code/datums/mutations/void_magnet.dm
+++ b/code/datums/mutations/void_magnet.dm
@@ -2,29 +2,25 @@
 	name = "Void Magnet"
 	desc = "A rare genome that attracts odd forces not usually observed."
 	quality = MINOR_NEGATIVE //upsides and downsides
-	text_gain_indication = "<span class='notice'>You feel a heavy, dull force just beyond the walls watching you.</span>"
+	text_gain_indication = span_notice("You feel a heavy, dull force just beyond the walls watching you.")
 	instability = 30
-	power_path = /datum/action/cooldown/spell/void
+	power_path = /datum/action/cooldown/spell/void/cursed
 	energy_coeff = 1
 	synchronizer_coeff = 1
 
-/datum/mutation/human/void/on_life(delta_time, times_fired)
-	// Move this onto the spell itself at some point?
-	var/datum/action/cooldown/spell/void/curse = locate(power_path) in owner
-	if(!curse)
-		remove()
+/datum/mutation/human/void/modify()
+	. = ..()
+	var/datum/action/cooldown/spell/void/cursed/to_modify = .
+	if(!istype(to_modify)) // null or invalid
 		return
 
-	if(!curse.is_valid_target(owner))
-		return
+	to_modify.curse_probability_modifier = GET_MUTATION_SYNCHRONIZER(src)
+	return .
 
-	//very rare, but enough to annoy you hopefully. + 0.5 probability for every 10 points lost in stability
-	if(DT_PROB((0.25 + ((100 - dna.stability) / 40)) * GET_MUTATION_SYNCHRONIZER(src), delta_time))
-		curse.cast(owner)
-
+/// The base "void invocation" action. No side effects.
 /datum/action/cooldown/spell/void
-	name = "Convoke Void" //magic the gathering joke here
-	desc = "A rare genome that attracts odd forces not usually observed. May sometimes pull you in randomly."
+	name = "Invoke Void"
+	desc = "Pulls you into a pocket of the void temporarily, making you invincible."
 	button_icon_state = "void_magnet"
 
 	school = SCHOOL_EVOCATION
@@ -41,3 +37,42 @@
 /datum/action/cooldown/spell/void/cast(atom/cast_on)
 	. = ..()
 	new /obj/effect/immortality_talisman/void(get_turf(cast_on), cast_on)
+
+/// The cursed "void invocation" action, that has a chance of casting itself on its owner randomly on life ticks.
+/datum/action/cooldown/spell/void/cursed
+	name = "Convoke Void" //magic the gathering joke here
+	desc = "A rare genome that attracts odd forces not usually observed. May sometimes pull you in randomly."
+	/// A multiplier applied to the probability of the curse appearing every life tick
+	var/curse_probability_modifier = 1
+
+/datum/action/cooldown/spell/void/cursed/Grant(mob/grant_to)
+	. = ..()
+	if(!owner)
+		return
+
+	RegisterSignal(grant_to, COMSIG_LIVING_LIFE, .proc/on_life)
+
+/datum/action/cooldown/spell/void/cursed/Remove(mob/remove_from)
+	UnregisterSignal(remove_from, COMSIG_LIVING_LIFE)
+	return ..()
+
+/// Signal proc for [COMSIG_LIVING_LIFE]. Has a chance of casting itself randomly.
+/datum/action/cooldown/spell/void/cursed/proc/on_life(mob/source, delta_time, times_fired)
+	SIGNAL_HANDLER
+
+	if(!is_valid_target(source))
+		return
+
+	var/prob_of_curse = 0.25
+
+	var/mob/living/carbon/carbon_source = source
+	if(istype(carbon_source) && carbon_source.dna)
+		// If we have DNA, the probability of curse changes based on how stable we are
+		prob_of_curse += ((100 - carbon_source.dna.stability) / 40)
+
+	prob_of_curse *= curse_probability_modifier
+
+	if(!DT_PROB(prob_of_curse, delta_time))
+		return
+
+	cast(source)

--- a/code/datums/mutations/void_magnet.dm
+++ b/code/datums/mutations/void_magnet.dm
@@ -60,6 +60,9 @@
 /datum/action/cooldown/spell/void/cursed/proc/on_life(mob/source, delta_time, times_fired)
 	SIGNAL_HANDLER
 
+	if(IS_IN_STASIS(source) || source.stat == DEAD || source.notransform)
+		return
+
 	if(!is_valid_target(source))
 		return
 

--- a/code/datums/mutations/void_magnet.dm
+++ b/code/datums/mutations/void_magnet.dm
@@ -57,10 +57,10 @@
 	return ..()
 
 /// Signal proc for [COMSIG_LIVING_LIFE]. Has a chance of casting itself randomly.
-/datum/action/cooldown/spell/void/cursed/proc/on_life(mob/source, delta_time, times_fired)
+/datum/action/cooldown/spell/void/cursed/proc/on_life(mob/living/source, delta_time, times_fired)
 	SIGNAL_HANDLER
 
-	if(IS_IN_STASIS(source) || source.stat == DEAD || source.notransform)
+	if(!isliving(source) || IS_IN_STASIS(source) || source.stat == DEAD || source.notransform)
 		return
 
 	if(!is_valid_target(source))


### PR DESCRIPTION
## About The Pull Request

- When I refactored proc holders, I accidentally changed void magnet to do a `locate() in mob`, isntead of `locate() in mob.actions`, which broke void magnet.
- But I also took the opportunity to improve a code a bit. Instead of working on mutation `on_life()`, it instead is entirely handled by the action itself, and modified by the mutation. Better encapsulation, and also gets us closer to possibly removing mutation `on_life()` from life code.

## Why It's Good For The Game

- Makes it so the mutation doesn't disappear immediately
- Clean code
- Also makes it so you can give DNA-less mobs the cursed version of Convoke Void 

## Changelog

:cl: Melbert
fix: Void Magnet no longer instantly removes itself
code: Convoke Void now handles the self-cast part of Void Magnet. 
/:cl:
