### PR TITLE
Having the Supermatter delaminate no longer blocks all traitor final objectives

### DIFF
--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -20,12 +20,6 @@
 		return FALSE
 	if(SStraitor.get_taken_count(type) > 0) // Prevents multiple people from ever getting the same final objective.
 		return FALSE
-	var/valid_crystal = FALSE
-	for(var/obj/machinery/power/supermatter_crystal/engine/crystal in GLOB.machines)
-		if(is_station_level(crystal.z) || is_mining_level(crystal.z))
-			valid_crystal = TRUE
-	if(!valid_crystal)
-		return FALSE
 	return TRUE
 
 /datum/traitor_objective/final/on_objective_taken(mob/user)

--- a/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
@@ -8,7 +8,7 @@
 	///checker on whether we have sent the crystal yet.
 	var/sent_crystal = FALSE
 
-/datum/traitor_objective/final/can_take_final_objective()
+/datum/traitor_objective/final/supermatter_cascade/can_take_final_objective()
 	. = ..()
 	if(!.)
 		return FALSE

--- a/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
@@ -8,6 +8,17 @@
 	///checker on whether we have sent the crystal yet.
 	var/sent_crystal = FALSE
 
+/datum/traitor_objective/final/can_take_final_objective()
+	. = ..()
+	if(!.)
+		return FALSE
+
+	for(var/obj/machinery/power/supermatter_crystal/engine/crystal in GLOB.machines)
+		if(is_station_level(crystal.z) || is_mining_level(crystal.z))
+			return TRUE
+
+	return FALSE
+
 /datum/traitor_objective/final/supermatter_cascade/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	if(!can_take_final_objective())
 		return


### PR DESCRIPTION
## About The Pull Request

#67665 fixed an issue where the Supermatter Cascade was still a valid objective to take even if the SM delaminated

..but it also added the check to ALL final objectives, instead of just the supermatter cascade's objective?
This seems like an unintended or undocumented change, which I can only surmise is a mistake. 

This PR moves the check for a subtype to the Supermatter Cascade objective only. 

## Why It's Good For The Game

I'm not sure why it did this, but it seems a little weird that the Supermatter delaminating causes you to be unable to obtain Romerol or whatever. 

## Changelog

:cl: Melbert
fix: Having the Supermatter Engine detonate will no longer make all traitor final objectives unavailable. (Only the Supermatter Cascade objective is made unavailable.)
/:cl: