### PR TITLE
[s] Uplink Failsafe Fix

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -245,7 +245,7 @@
 				if(!ispath(item_path, /datum/uplink_item))
 					return
 				item = SStraitor.uplink_items_by_type[item_path]
-			uplink_handler.purchase_item(ui.user, item)
+			uplink_handler.purchase_item(ui.user, item, parent)
 		if("lock")
 			if(!lockable)
 				return TRUE

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -72,7 +72,7 @@
 
 	return TRUE
 
-/datum/uplink_handler/proc/purchase_item(mob/user, datum/uplink_item/to_purchase)
+/datum/uplink_handler/proc/purchase_item(mob/user, datum/uplink_item/to_purchase, atom/movable/source)
 	if(!can_purchase_item(user, to_purchase))
 		return
 
@@ -80,7 +80,7 @@
 		item_stock[to_purchase] = to_purchase.limited_stock
 
 	telecrystals -= to_purchase.cost
-	to_purchase.purchase(user, src)
+	to_purchase.purchase(user, src, source)
 
 	if(to_purchase in item_stock)
 		item_stock[to_purchase] -= 1

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -146,6 +146,7 @@
 	var/datum/antagonist/traitor/traitor_datum = user.mind?.has_antag_datum(/datum/antagonist/traitor)
 	if(traitor_datum)
 		traitor_datum.antag_memory += "<b>Uplink Failsafe Code:</b> [code]" + "<br>"
+		traitor_datum.update_static_data_for_all_viewers()
 	to_chat(user, span_warning("The new failsafe code for this uplink is now : [code].[traitor_datum ? " You may check your antagonist info to recall this." : null]"))
 	return source //For log icon
 

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -146,7 +146,7 @@
 	var/datum/antagonist/traitor/traitor_datum = user.mind?.has_antag_datum(/datum/antagonist/traitor)
 	if(traitor_datum)
 		traitor_datum.antag_memory += "<b>Uplink Failsafe Code:</b> [code]" + "<br>"
-	to_chat(user, span_warning("The new failsafe code for this uplink is now : [code].[traitor_datum ? " You may check your antagonist info to recall this." : ]"))
+	to_chat(user, span_warning("The new failsafe code for this uplink is now : [code].[traitor_datum ? " You may check your antagonist info to recall this." : null]"))
 	return source //For log icon
 
 /datum/uplink_item/device_tools/toolbox

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -137,9 +137,16 @@
 	var/datum/component/uplink/uplink = source.GetComponent(/datum/component/uplink)
 	if(!uplink)
 		return
+	if(!uplink.unlock_note) //no note means it can't be locked (typically due to being an implant.)
+		to_chat(user, span_warning("This device doesn't support code entry!"))
+		return
+
 	uplink.failsafe_code = uplink.generate_code()
 	var/code = "[islist(uplink.failsafe_code) ? english_list(uplink.failsafe_code) : uplink.failsafe_code]"
-	to_chat(user, span_warning("The new failsafe code for this uplink is now : [code]. You may check your antagonist info to recall this."))
+	var/datum/antagonist/traitor/traitor_datum = user.mind?.has_antag_datum(/datum/antagonist/traitor)
+	if(traitor_datum)
+		traitor_datum.antag_memory += "<b>Uplink Failsafe Code:</b> [code]" + "<br>"
+	to_chat(user, span_warning("The new failsafe code for this uplink is now : [code].[traitor_datum ? " You may check your antagonist info to recall this." : ]"))
 	return source //For log icon
 
 /datum/uplink_item/device_tools/toolbox

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -147,7 +147,7 @@
 	if(traitor_datum)
 		traitor_datum.antag_memory += "<b>Uplink Failsafe Code:</b> [code]" + "<br>"
 		traitor_datum.update_static_data_for_all_viewers()
-	to_chat(user, span_warning("The new failsafe code for this uplink is now : [code].[traitor_datum ? " You may check your antagonist info to recall this." : null]"))
+	to_chat(user, span_warning("The new failsafe code for this uplink is now: [code].[traitor_datum ? " You may check your antagonist info to recall this." : null]"))
 	return source //For log icon
 
 /datum/uplink_item/device_tools/toolbox


### PR DESCRIPTION
:cl: ShizCalev
fix: The uplink failsafe code traitor item will now actually give you a failsafe code!
fix: The uplink failsafe code can no longer be purchased on devices that don't support code entry.
/:cl:


Also fixed traitor uplink / telecrystal purchases not being logged properly for **_all_** purchases.

Fixes #68583