### PR TITLE
[NO GBP] Fixes new food syntax errors

### DIFF
--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -329,7 +329,7 @@
 	foodtypes = GRAIN | DAIRY
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/food/rawbreadstick/MakeBakeable()
+/obj/item/food/raw_breadstick/MakeBakeable()
 	AddComponent(/datum/component/bakeable, /obj/item/food/breadstick, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
 
 /obj/item/food/breadstick

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -319,8 +319,8 @@
 	tastes = list("raw brownie batter" = 1)
 	foodtypes = GRAIN | JUNKFOOD | SUGAR | BREAKFAST
 
-/obj/item/food/rawbrowniebatter/MakeBakeable()
-	AddComponent(/datum/component/bakeable, /obj/item/food/browniesheet, rand(20 SECONDS, 30 SECONDS), TRUE, TRUE)
+/obj/item/food/raw_brownie_batter/MakeBakeable()
+	AddComponent(/datum/component/bakeable, /obj/item/food/brownie_sheet, rand(20 SECONDS, 30 SECONDS), TRUE, TRUE)
 
 /obj/item/food/brownie_sheet
 	name = "brownie sheet"
@@ -333,7 +333,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	burns_in_oven = TRUE
 
-/obj/item/food/browniesheet/MakeProcessable()
+/obj/item/food/brownie_sheet/MakeProcessable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/brownie, 4, 3 SECONDS, table_required = TRUE)
 
 /obj/item/food/brownie


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes my new brownies and breadsticks, making them bakeable, and allows brownies to be sliced again. I forgot to update these bits when i changed them hehe

## Why It's Good For The Game

Things working as they should is always good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed brownies and breadsticks not being bakeable
fix: Brownie sheets are now sliceable again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
