### PR TITLE
USB cables can now be attached directly to bluespace launchpads

### DIFF
--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -12,100 +12,6 @@
 /obj/machinery/computer/launchpad/Initialize(mapload)
 	launchpads = list()
 	. = ..()
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/bluespace_launchpad,
-	))
-
-/obj/item/circuit_component/bluespace_launchpad
-	display_name = "Bluespace Launchpad Console"
-	desc = "Teleports anything to and from any location on the station. Doesn't use actual GPS coordinates, but rather offsets from the launchpad itself. Can only go as far as the launchpad can go, which depends on its parts."
-
-	var/datum/port/input/launchpad_id
-	var/datum/port/input/x_pos
-	var/datum/port/input/y_pos
-	var/datum/port/input/send_trigger
-	var/datum/port/input/retrieve_trigger
-
-	var/datum/port/output/sent
-	var/datum/port/output/retrieved
-	var/datum/port/output/on_fail
-	var/datum/port/output/why_fail
-
-	var/obj/machinery/computer/launchpad/attached_console
-
-/obj/item/circuit_component/bluespace_launchpad/get_ui_notices()
-	. = ..()
-	var/current_launchpad = launchpad_id.value
-	if(isnull(current_launchpad))
-		return
-
-	var/obj/machinery/launchpad/the_pad = attached_console.launchpads[current_launchpad]
-	if(isnull(the_pad))
-		return
-
-	. += create_ui_notice("Minimum Range: [-the_pad.range]", "orange", "minus")
-	. += create_ui_notice("Maximum Range: [the_pad.range]", "orange", "plus")
-
-/obj/item/circuit_component/bluespace_launchpad/populate_ports()
-	launchpad_id = add_input_port("Launchpad ID", PORT_TYPE_NUMBER, trigger = null, default = 1)
-	x_pos = add_input_port("X offset", PORT_TYPE_NUMBER)
-	y_pos = add_input_port("Y offset", PORT_TYPE_NUMBER)
-	send_trigger = add_input_port("Send", PORT_TYPE_SIGNAL)
-	retrieve_trigger = add_input_port("Retrieve", PORT_TYPE_SIGNAL)
-
-	sent = add_output_port("Sent", PORT_TYPE_SIGNAL)
-	retrieved = add_output_port("Retrieved", PORT_TYPE_SIGNAL)
-	why_fail = add_output_port("Fail reason", PORT_TYPE_STRING)
-	on_fail = add_output_port("Failed", PORT_TYPE_SIGNAL)
-
-/obj/item/circuit_component/bluespace_launchpad/register_usb_parent(atom/movable/shell)
-	. = ..()
-	if(istype(shell, /obj/machinery/computer/launchpad))
-		attached_console = shell
-
-/obj/item/circuit_component/bluespace_launchpad/unregister_usb_parent(atom/movable/shell)
-	attached_console = null
-	return ..()
-
-/obj/item/circuit_component/bluespace_launchpad/input_received(datum/port/input/port)
-	if(!attached_console || length(attached_console.launchpads) == 0)
-		why_fail.set_output("No launchpads connected!")
-		on_fail.set_output(COMPONENT_SIGNAL)
-		return
-
-
-	if(!launchpad_id.value)
-		return
-
-	var/obj/machinery/launchpad/the_pad = KEYBYINDEX(attached_console.launchpads, launchpad_id.value)
-	if(isnull(the_pad))
-		why_fail.set_output("Invalid launchpad selected!")
-		on_fail.set_output(COMPONENT_SIGNAL)
-		return
-
-	the_pad.set_offset(x_pos.value, y_pos.value)
-
-	if(COMPONENT_TRIGGERED_BY(port, x_pos))
-		x_pos.set_value(the_pad.x_offset)
-		return
-
-	if(COMPONENT_TRIGGERED_BY(port, y_pos))
-		y_pos.set_value(the_pad.y_offset)
-		return
-
-	var/checks = attached_console.teleport_checks(the_pad)
-	if(!isnull(checks))
-		why_fail.set_output(checks)
-		on_fail.set_output(COMPONENT_SIGNAL)
-		return
-
-	if(COMPONENT_TRIGGERED_BY(send_trigger, port))
-		INVOKE_ASYNC(the_pad, /obj/machinery/launchpad.proc/doteleport, null, TRUE, parent.get_creator())
-		sent.set_output(COMPONENT_SIGNAL)
-
-	if(COMPONENT_TRIGGERED_BY(retrieve_trigger, port))
-		INVOKE_ASYNC(the_pad, /obj/machinery/launchpad.proc/doteleport, null, FALSE, parent.get_creator())
-		retrieved.set_output(COMPONENT_SIGNAL)
 
 /obj/machinery/computer/launchpad/attack_paw(mob/user, list/modifiers)
 	to_chat(user, span_warning("You are too primitive to use this computer!"))
@@ -137,14 +43,7 @@
 /obj/machinery/computer/launchpad/proc/teleport_checks(obj/machinery/launchpad/pad)
 	if(QDELETED(pad))
 		return "ERROR: Launchpad not responding. Check launchpad integrity."
-	if(!pad.isAvailable())
-		return "ERROR: Launchpad not operative. Make sure the launchpad is ready and powered."
-	if(pad.teleporting)
-		return "ERROR: Launchpad busy."
-	var/turf/pad_turf = get_turf(pad)
-	if(pad_turf && is_centcom_level(pad_turf.z))
-		return "ERROR: Launchpad not operative. Heavy area shielding makes teleporting impossible."
-	return null
+	return pad.teleport_checks()
 
 /obj/machinery/computer/launchpad/proc/get_pad(number)
 	var/obj/machinery/launchpad/pad = launchpads[number]

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -47,6 +47,10 @@
 
 	update_indicator()
 
+	AddComponent(/datum/component/usb_port, list(
+		/obj/item/circuit_component/bluespace_launchpad,
+	))
+
 /obj/machinery/launchpad/Destroy()
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 		diag_hud.remove_atom_from_hud(src)
@@ -117,6 +121,16 @@
 	. = ..()
 	animate(src, alpha = 0, flags = ANIMATION_PARALLEL, time = BEAM_FADE_TIME)
 
+
+/obj/machinery/launchpad/proc/teleport_checks()
+	if(!isAvailable())
+		return "ERROR: Launchpad not operative. Make sure the launchpad is ready and powered."
+	if(teleporting)
+		return "ERROR: Launchpad busy."
+	var/turf/pad_turf = get_turf(src)
+	if(pad_turf && is_centcom_level(pad_turf.z))
+		return "ERROR: Launchpad not operative. Heavy area shielding makes teleporting impossible."
+	return null
 
 /// Performs the teleport.
 /// sending - TRUE/FALSE depending on if the launch pad is teleporting *to* or *from* the target.
@@ -370,8 +384,9 @@
 	if(QDELETED(pad))
 		to_chat(user, span_warning("ERROR: Launchpad not responding. Check launchpad integrity."))
 		return
-	if(!pad.isAvailable())
-		to_chat(user, span_warning("ERROR: Launchpad not operative. Make sure the launchpad is ready and powered."))
+	var/error_reason = pad.teleport_checks()
+	if(error_reason)
+		to_chat(user, span_warning(error_reason))
 		return
 	pad.doteleport(user, sending)
 
@@ -417,3 +432,78 @@
 			. = TRUE
 
 #undef BEAM_FADE_TIME
+
+/obj/item/circuit_component/bluespace_launchpad
+	display_name = "Bluespace Launchpad"
+	desc = "Teleports anything to and from any location on the station. Doesn't use actual GPS coordinates, but rather offsets from the launchpad itself. Can only go as far as the launchpad can go, which depends on its parts."
+
+	var/datum/port/input/x_pos
+	var/datum/port/input/y_pos
+	var/datum/port/input/send_trigger
+	var/datum/port/input/retrieve_trigger
+
+	var/datum/port/output/sent
+	var/datum/port/output/retrieved
+	var/datum/port/output/on_fail
+	var/datum/port/output/why_fail
+
+	var/obj/machinery/launchpad/attached_launchpad
+
+/obj/item/circuit_component/bluespace_launchpad/get_ui_notices()
+	. = ..()
+
+	if(isnull(attached_launchpad))
+		return
+
+	. += create_ui_notice("Minimum Range: [-attached_launchpad.range]", "orange", "minus")
+	. += create_ui_notice("Maximum Range: [attached_launchpad.range]", "orange", "plus")
+
+/obj/item/circuit_component/bluespace_launchpad/populate_ports()
+	x_pos = add_input_port("X offset", PORT_TYPE_NUMBER)
+	y_pos = add_input_port("Y offset", PORT_TYPE_NUMBER)
+	send_trigger = add_input_port("Send", PORT_TYPE_SIGNAL)
+	retrieve_trigger = add_input_port("Retrieve", PORT_TYPE_SIGNAL)
+
+	sent = add_output_port("Sent", PORT_TYPE_SIGNAL)
+	retrieved = add_output_port("Retrieved", PORT_TYPE_SIGNAL)
+	why_fail = add_output_port("Fail reason", PORT_TYPE_STRING)
+	on_fail = add_output_port("Failed", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/bluespace_launchpad/register_usb_parent(atom/movable/shell)
+	. = ..()
+	if(istype(shell, /obj/machinery/launchpad))
+		attached_launchpad = shell
+
+/obj/item/circuit_component/bluespace_launchpad/unregister_usb_parent(atom/movable/shell)
+	attached_launchpad = null
+	return ..()
+
+/obj/item/circuit_component/bluespace_launchpad/input_received(datum/port/input/port)
+	if(!attached_launchpad)
+		why_fail.set_output("Not connected!")
+		on_fail.set_output(COMPONENT_SIGNAL)
+		return
+
+	attached_launchpad.set_offset(x_pos.value, y_pos.value)
+
+	if(COMPONENT_TRIGGERED_BY(port, x_pos))
+		x_pos.set_value(attached_launchpad.x_offset)
+		return
+
+	if(COMPONENT_TRIGGERED_BY(port, y_pos))
+		y_pos.set_value(attached_launchpad.y_offset)
+		return
+
+	var/checks = attached_launchpad.teleport_checks()
+	if(!isnull(checks))
+		why_fail.set_output(checks)
+		on_fail.set_output(COMPONENT_SIGNAL)
+		return
+
+	if(COMPONENT_TRIGGERED_BY(send_trigger, port))
+		INVOKE_ASYNC(attached_launchpad, /obj/machinery/launchpad.proc/doteleport, null, TRUE, parent.get_creator())
+		sent.set_output(COMPONENT_SIGNAL)
+
+	if(COMPONENT_TRIGGERED_BY(retrieve_trigger, port))
+		INVOKE_ASYNC(attached_launchpad, /obj/machinery/launchpad.proc/doteleport, null, FALSE, parent.get_creator())
+		retrieved.set_output(COMPONENT_SIGNAL)

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -47,9 +47,10 @@
 
 	update_indicator()
 
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/bluespace_launchpad,
-	))
+	if(stationary)
+		AddComponent(/datum/component/usb_port, list(
+			/obj/item/circuit_component/bluespace_launchpad,
+		))
 
 /obj/machinery/launchpad/Destroy()
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)


### PR DESCRIPTION
## About The Pull Request

See title. Because of this change, a launchpad does not need a connected console if you have no need for it. You can still use the console to control a launchpad, and you can still connect a USB cable to a console to control all its connected launchpads with a single circuit component.

## Why It's Good For The Game

Reduces the boilerplate necessary in setting up a circuit-controlled launchpad.

## Changelog

:cl:
qol: USB cables can connect directly to bluespace launchpads. As a consequence, You do not need a console for a launchpad if you only intend to control it via circuits.
/:cl:
