### PR TITLE
Fixes Ion Storms runtime erroring due to an uninstantiated lawset

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -33,7 +33,9 @@
 		if(M.stat != DEAD && !M.incapacitated())
 			if(prob(replaceLawsetChance))
 				var/datum/ai_laws/ion_lawset = pick_weighted_lawset()
-				M.laws.inherent = ion_lawset.inherent
+				ion_lawset = new()
+				M.laws.inherent = ion_lawset.inherent.Copy()
+				qdel(ion_lawset)
 
 			if(prob(removeRandomLawChance))
 				M.remove_law(rand(1, M.laws.get_law_amount(list(LAW_INHERENT, LAW_SUPPLIED))))

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -33,8 +33,12 @@
 		if(M.stat != DEAD && !M.incapacitated())
 			if(prob(replaceLawsetChance))
 				var/datum/ai_laws/ion_lawset = pick_weighted_lawset()
+				// pick_weighted_lawset gives us a typepath,
+				// so we have to instantiate it to access its laws
 				ion_lawset = new()
+				// our inherent laws now becomes the picked lawset's laws!
 				M.laws.inherent = ion_lawset.inherent.Copy()
+				// and clean up after.
 				qdel(ion_lawset)
 
 			if(prob(removeRandomLawChance))


### PR DESCRIPTION
## About The Pull Request

`pick_weighted_lawset()` returns a **typepath** of a random lawset, not an instance. 
Whenever the event tried to access one of its vars, it threw a runtime. 

So, the lawset it selects should be instantiated prior to accessing its laws. 

Side note, I don't actually know if ion laws should be instantiated and destroyed like this. Feel free to correct me. 

## Why It's Good For The Game

Ion Storms don't runtime half the time

## Changelog

:cl: Melbert
fix: Fixes a runtime error preventing Ion Storms from triggering occasionally
/:cl:
