### PR TITLE
Engi syndie sentry can be only activated using combat wrench

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -385,13 +385,16 @@ effective or pretty fucking useless.
 
 	else
 		if(atom_integrity == max_integrity)
+			balloon_alert(user, "already repaired")
 			return
 
 		balloon_alert(user, "repairing...")
-		if(!attacking_item.use_tool(src, user, 2 SECONDS, volume = 20))
-			return
+		while(atom_integrity != max_integrity)
+			if(!attacking_item.use_tool(src, user, 2 SECONDS, volume = 20))
+				return
 
-		repair_damage(10)
+			repair_damage(10)
+
 		balloon_alert(user, "repaired")
 
 /obj/machinery/porta_turret/syndicate/toolbox/deconstruct(disassembled)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -314,7 +314,7 @@ effective or pretty fucking useless.
 		return
 
 	balloon_alert(user, "constructing...")
-	if(!attacking_item.use_tool(src, user, 5 SECONDS, volume = 20))
+	if(!attacking_item.use_tool(src, user, 2 SECONDS, volume = 20))
 		return
 
 	balloon_alert(user, "constructed")

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -317,7 +317,7 @@ effective or pretty fucking useless.
 	if(!attacking_item.use_tool(src, user, 2 SECONDS, volume = 20))
 		return
 
-	balloon_alert(user, "constructed")
+	balloon_alert(user, "constructed!")
 	user.visible_message(span_danger("[user] bashes [src] with [attacking_item]!"), \
 		span_danger("You bash [src] with [attacking_item]!"), null, COMBAT_MESSAGE_RANGE)
 
@@ -381,11 +381,11 @@ effective or pretty fucking useless.
 
 		deconstruct(TRUE)
 		attacking_item.play_tool_sound(src, 50)
-		balloon_alert(user, "deconstructed")
+		balloon_alert(user, "deconstructed!")
 
 	else
 		if(atom_integrity == max_integrity)
-			balloon_alert(user, "already repaired")
+			balloon_alert(user, "already repaired!")
 			return
 
 		balloon_alert(user, "repairing...")
@@ -395,7 +395,7 @@ effective or pretty fucking useless.
 
 			repair_damage(10)
 
-		balloon_alert(user, "repaired")
+		balloon_alert(user, "repaired!")
 
 /obj/machinery/porta_turret/syndicate/toolbox/deconstruct(disassembled)
 	if(disassembled)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -35,6 +35,7 @@ effective or pretty fucking useless.
 
 /obj/item/batterer/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!user) return
+
 	if(times_used >= max_uses)
 		to_chat(user, span_danger("The mind batterer has been burnt out!"))
 		return
@@ -78,12 +79,15 @@ effective or pretty fucking useless.
 /obj/item/healthanalyzer/rad_laser/attack(mob/living/M, mob/living/user)
 	if(!stealth || !irradiate)
 		..()
+
 	if(!irradiate)
 		return
+
 	var/mob/living/carbon/human/human_target = M
 	if(istype(human_target) && !used && SSradiation.wearing_rad_protected_clothing(human_target)) //intentionally not checking for TRAIT_RADIMMUNE here so that tatortot can still fuck up and waste their cooldown.
 		to_chat(user, span_warning("[M]'s clothing is fully protecting [M.p_them()] from irradiation!"))
 		return
+
 	if(!used)
 		log_combat(user, M, "irradiated", src)
 		var/cooldown = get_cooldown()
@@ -94,11 +98,13 @@ effective or pretty fucking useless.
 		to_chat(user, span_warning("Successfully irradiated [M]."))
 		addtimer(CALLBACK(src, .proc/radiation_aftereffect, M, intensity), (wavelength+(intensity*4))*5)
 		return
+
 	to_chat(user, span_warning("The radioactive microlaser is still recharging."))
 
 /obj/item/healthanalyzer/rad_laser/proc/radiation_aftereffect(mob/living/M, passed_intensity)
 	if(QDELETED(M) || !ishuman(M) || HAS_TRAIT(M, TRAIT_RADIMMUNE))
 		return
+
 	if(passed_intensity >= 5)
 		M.apply_effect(round(passed_intensity/0.075), EFFECT_UNCONSCIOUS) //to save you some math, this is a round(intensity * (4/3)) second long knockout
 
@@ -140,45 +146,57 @@ effective or pretty fucking useless.
 		if("irradiate")
 			irradiate = !irradiate
 			. = TRUE
+
 		if("stealth")
 			stealth = !stealth
 			. = TRUE
+
 		if("scanmode")
 			scanmode = !scanmode
 			. = TRUE
+
 		if("radintensity")
 			var/target = params["target"]
 			var/adjust = text2num(params["adjust"])
 			if(target == "min")
 				target = 1
 				. = TRUE
+
 			else if(target == "max")
 				target = 20
 				. = TRUE
+
 			else if(adjust)
 				target = intensity + adjust
 				. = TRUE
+
 			else if(text2num(target) != null)
 				target = text2num(target)
 				. = TRUE
+
 			if(.)
 				target = round(target)
 				intensity = clamp(target, 1, 20)
+
 		if("radwavelength")
 			var/target = params["target"]
 			var/adjust = text2num(params["adjust"])
 			if(target == "min")
 				target = 0
 				. = TRUE
+
 			else if(target == "max")
 				target = 120
 				. = TRUE
+
 			else if(adjust)
 				target = wavelength + adjust
 				. = TRUE
+
 			else if(text2num(target) != null)
 				target = text2num(target)
 				. = TRUE
+
 			if(.)
 				target = round(target)
 				wavelength = clamp(target, 0, 120)
@@ -204,8 +222,10 @@ effective or pretty fucking useless.
 	if(user.get_item_by_slot(ITEM_SLOT_BELT) == src)
 		if(!on)
 			Activate(usr)
+
 		else
 			Deactivate()
+
 	return
 
 /obj/item/shadowcloak/item_action_slot_check(slot, mob/user)
@@ -215,6 +235,7 @@ effective or pretty fucking useless.
 /obj/item/shadowcloak/proc/Activate(mob/living/carbon/human/user)
 	if(!user)
 		return
+
 	to_chat(user, span_notice("You activate [src]."))
 	src.user = user
 	START_PROCESSING(SSobj, src)
@@ -225,6 +246,7 @@ effective or pretty fucking useless.
 	STOP_PROCESSING(SSobj, src)
 	if(user)
 		user.alpha = initial(user.alpha)
+
 	on = FALSE
 	user = null
 
@@ -237,13 +259,17 @@ effective or pretty fucking useless.
 	if(user.get_item_by_slot(ITEM_SLOT_BELT) != src)
 		Deactivate()
 		return
+
 	var/turf/T = get_turf(src)
 	if(on)
 		var/lumcount = T.get_lumcount()
+
 		if(lumcount > 0.3)
 			charge = max(0, charge - 12.5 * delta_time)//Quick decrease in light
+
 		else
 			charge = min(max_charge, charge + 25 * delta_time) //Charge in the dark
+
 		animate(user,alpha = clamp(255 - charge,0,255),time = 10)
 
 
@@ -260,8 +286,10 @@ effective or pretty fucking useless.
 	active = !active
 	if(active)
 		GLOB.active_jammers |= src
+
 	else
 		GLOB.active_jammers -= src
+
 	update_appearance()
 
 /obj/item/storage/toolbox/emergency/turret
@@ -276,18 +304,28 @@ effective or pretty fucking useless.
 	new /obj/item/wirecutters(src)
 
 /obj/item/storage/toolbox/emergency/turret/attackby(obj/item/attacking_item, mob/living/user, params)
-	if(istype(attacking_item, /obj/item/wrench/combat))
-		if(user.combat_mode && attacking_item.toolspeed && attacking_item.use_tool(src, user, 5 SECONDS, volume = 20))
-			user.visible_message(span_danger("[user] bashes [src] with [attacking_item]!"), \
-				span_danger("You bash [src] with [attacking_item]!"), null, COMBAT_MESSAGE_RANGE)
-			playsound(src, "sound/items/drill_use.ogg", 80, TRUE, -1)
-			var/obj/machinery/porta_turret/syndicate/toolbox/turret = new(get_turf(loc))
-			set_faction(turret, user)
-			turret.toolbox = src
-			forceMove(turret)
-			return
+	if(!istype(attacking_item, /obj/item/wrench/combat))
+		return ..()
+
+	if(!user.combat_mode)
 		return
-	return ..()
+
+	if(!attacking_item.toolspeed)
+		return
+
+	balloon_alert(user, "constructing...")
+	if(!attacking_item.use_tool(src, user, 5 SECONDS, volume = 20))
+		return
+
+	balloon_alert(user, "constructed")
+	user.visible_message(span_danger("[user] bashes [src] with [attacking_item]!"), \
+		span_danger("You bash [src] with [attacking_item]!"), null, COMBAT_MESSAGE_RANGE)
+
+	playsound(src, "sound/items/drill_use.ogg", 80, TRUE, -1)
+	var/obj/machinery/porta_turret/syndicate/toolbox/turret = new(get_turf(loc))
+	set_faction(turret, user)
+	turret.toolbox = src
+	forceMove(turret)
 
 /obj/item/storage/toolbox/emergency/turret/proc/set_faction(obj/machinery/porta_turret/turret, mob/user)
 	turret.faction = list("[REF(user)]")
@@ -323,29 +361,48 @@ effective or pretty fucking useless.
 /obj/machinery/porta_turret/syndicate/toolbox/target(atom/movable/target)
 	if(!target)
 		return
+
 	if(shootAt(target))
 		setDir(get_dir(base, target))
+
 	return TRUE
 
 /obj/machinery/porta_turret/syndicate/toolbox/attackby(obj/item/attacking_item, mob/living/user, params)
-	if(istype(attacking_item, /obj/item/wrench/combat))
-		if(user.combat_mode && attacking_item.toolspeed && attacking_item.use_tool(src, user, 5 SECONDS, volume = 20))
-			deconstruct(TRUE)
-			attacking_item.play_tool_sound(src, 50)
-		else if(!user.combat_mode)
-			to_chat(user, span_notice("You start repairing [src]..."))
-			while(atom_integrity != max_integrity && attacking_item.toolspeed && attacking_item.use_tool(src, user, 2 SECONDS, volume = 20))
-				repair_damage(10)
+	if(!istype(attacking_item, /obj/item/wrench/combat))
+		return ..()
+
+	if(!attacking_item.toolspeed)
 		return
-	return ..()
+
+	if(user.combat_mode)
+		balloon_alert(user, "deconstructing...")
+		if(!attacking_item.use_tool(src, user, 5 SECONDS, volume = 20))
+			return
+
+		deconstruct(TRUE)
+		attacking_item.play_tool_sound(src, 50)
+		balloon_alert(user, "deconstructed")
+
+	else
+		if(atom_integrity == max_integrity)
+			return
+
+		balloon_alert(user, "repairing...")
+		if(!attacking_item.use_tool(src, user, 2 SECONDS, volume = 20))
+			return
+
+		repair_damage(10)
+		balloon_alert(user, "repaired")
 
 /obj/machinery/porta_turret/syndicate/toolbox/deconstruct(disassembled)
 	if(disassembled)
 		var/atom/movable/old_toolbox = toolbox
 		toolbox = null
 		old_toolbox.forceMove(drop_location())
+
 	else
 		new /obj/effect/gibspawner/robot(drop_location())
+
 	return ..()
 
 /obj/machinery/porta_turret/syndicate/toolbox/Destroy()
@@ -361,6 +418,7 @@ effective or pretty fucking useless.
 /obj/machinery/porta_turret/syndicate/toolbox/ui_status(mob/user)
 	if(faction_check(user.faction, faction))
 		return ..()
+
 	return UI_CLOSE
 
 /obj/projectile/bullet/toolbox_turret

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -276,14 +276,16 @@ effective or pretty fucking useless.
 	new /obj/item/wirecutters(src)
 
 /obj/item/storage/toolbox/emergency/turret/attackby(obj/item/attacking_item, mob/living/user, params)
-	if(attacking_item.tool_behaviour == TOOL_WRENCH && user.combat_mode && attacking_item.use_tool(src, user, 2 SECONDS, volume = 50))
-		user.visible_message(span_danger("[user] bashes [src] with [attacking_item]!"), \
-			span_danger("You bash [src] with [attacking_item]!"), null, COMBAT_MESSAGE_RANGE)
-		playsound(src, "sound/items/drill_use.ogg", 80, TRUE, -1)
-		var/obj/machinery/porta_turret/syndicate/toolbox/turret = new(get_turf(loc))
-		set_faction(turret, user)
-		turret.toolbox = src
-		forceMove(turret)
+	if(istype(attacking_item, /obj/item/wrench/combat))
+		if(user.combat_mode && attacking_item.toolspeed && attacking_item.use_tool(src, user, 5 SECONDS, volume = 20))
+			user.visible_message(span_danger("[user] bashes [src] with [attacking_item]!"), \
+				span_danger("You bash [src] with [attacking_item]!"), null, COMBAT_MESSAGE_RANGE)
+			playsound(src, "sound/items/drill_use.ogg", 80, TRUE, -1)
+			var/obj/machinery/porta_turret/syndicate/toolbox/turret = new(get_turf(loc))
+			set_faction(turret, user)
+			turret.toolbox = src
+			forceMove(turret)
+			return
 		return
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Engineer syndie turret previously could be activated(but not deactivated) using normal wrench which could results in combat wrench being stuck in which means that turret could not be moved unless you brought new one
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now its not possible to soft lock yourself from moving your sentry
Added balloon alerts and made code easier to read
Fixes: #67896
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Engineer syndie sentry can only be activated with combat wrench
code: Added balloon alerts and made code easier to read
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
