### PR TITLE
Fixes security level alerts playing the incorrect sounds

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -99,12 +99,12 @@
  * Minor announcements are large text, with the title in red and message in white.
  * Only mobs that can hear can see the announcements.
  *
- * message - the message contents of the announcement
- * title - the title of the announcement - Often, "who sent it"
- * aert - whether this announcement is an alert, or just a notice. Only changes the sound that is played.
- * html_encote - if TRUE, we will html encode our title and message
+ * message - the message contents of the announcement.
+ * title - the title of the announcement, which is often "who sent it".
+ * aert - whether this announcement is an alert, or just a notice. Only changes the sound that is played by default.
+ * html_encode - if TRUE, we will html encode our title and message before sending it, to prevent player input abuse.
  * players - optional, a list mobs to send the announcement to. If unset, sends to all palyers.
- * sound_override - optional, uses the passed sound file instead of the default notices.
+ * sound_override - optional, use the passed sound file instead of the default notice sounds.
  */
 /proc/minor_announce(message, title = "Attention:", alert, html_encode = TRUE, list/players, sound_override)
 	if(!message)

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -94,7 +94,19 @@
 
 	SScommunications.send_message(M)
 
-/proc/minor_announce(message, title = "Attention:", alert, html_encode = TRUE, list/players)
+/**
+ * Sends a minor annoucement to players.
+ * Minor announcements are large text, with the title in red and message in white.
+ * Only mobs that can hear can see the announcements.
+ *
+ * message - the message contents of the announcement
+ * title - the title of the announcement - Often, "who sent it"
+ * aert - whether this announcement is an alert, or just a notice. Only changes the sound that is played.
+ * html_encote - if TRUE, we will html encode our title and message
+ * players - optional, a list mobs to send the announcement to. If unset, sends to all palyers.
+ * sound_override - optional, uses the passed sound file instead of the default notices.
+ */
+/proc/minor_announce(message, title = "Attention:", alert, html_encode = TRUE, list/players, sound_override)
 	if(!message)
 		return
 
@@ -106,10 +118,12 @@
 		players = GLOB.player_list
 
 	for(var/mob/target in players)
-		if(!isnewplayer(target) && target.can_hear())
-			to_chat(target, "[span_minorannounce("<font color = red>[title]</font color><BR>[message]")]<BR>")
-			if(target.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
-				if(alert)
-					SEND_SOUND(target, sound('sound/misc/notice1.ogg'))
-				else
-					SEND_SOUND(target, sound('sound/misc/notice2.ogg'))
+		if(isnewplayer(target))
+			continue
+		if(!target.can_hear())
+			continue
+
+		to_chat(target, "[span_minorannounce("<font color = red>[title]</font color><BR>[message]")]<BR>")
+		if(target.client?.prefs.toggles & SOUND_ANNOUNCEMENTS)
+			var/sound_to_play = sound_override || (alert ? 'sound/misc/notice1.ogg' : 'sound/misc/notice2.ogg')
+			SEND_SOUND(target, sound(sound_to_play))

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -101,7 +101,7 @@
  *
  * message - the message contents of the announcement.
  * title - the title of the announcement, which is often "who sent it".
- * aert - whether this announcement is an alert, or just a notice. Only changes the sound that is played by default.
+ * alert - whether this announcement is an alert, or just a notice. Only changes the sound that is played by default.
  * html_encode - if TRUE, we will html encode our title and message before sending it, to prevent player input abuse.
  * players - optional, a list mobs to send the announcement to. If unset, sends to all palyers.
  * sound_override - optional, use the passed sound file instead of the default notice sounds.

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -68,11 +68,9 @@ SUBSYSTEM_DEF(security_level)
  */
 /datum/controller/subsystem/security_level/proc/announce_security_level(datum/security_level/selected_level)
 	if(selected_level.number_level > current_security_level.number_level) // We are elevating to this level.
-		minor_announce(selected_level.elevating_to_announcemnt, "Attention! Security level elevated to [selected_level.name]:")
+		minor_announce(selected_level.elevating_to_announcemnt, "Attention! Security level elevated to [selected_level.name]:", sound_override = selected_level.sound)
 	else // Going down
-		minor_announce(selected_level.lowering_to_announcement, "Attention! Security level lowered to [selected_level.name]:")
-	if(selected_level.sound)
-		sound_to_playing_players(selected_level.sound)
+		minor_announce(selected_level.lowering_to_announcement, "Attention! Security level lowered to [selected_level.name]:", sound_override = selected_level.sound)
 
 /**
  * Returns the current security level as a number

--- a/code/modules/security_levels/security_level_datums.dm
+++ b/code/modules/security_levels/security_level_datums.dm
@@ -42,6 +42,7 @@
  */
 /datum/security_level/green
 	name = "green"
+	sound = 'sound/misc/notice2.ogg' // Friendly beep
 	number_level = SEC_LEVEL_GREEN
 	lowering_to_configuration_key = /datum/config_entry/string/alert_green
 	shuttle_call_time_mod = 2
@@ -53,6 +54,7 @@
  */
 /datum/security_level/blue
 	name = "blue"
+	sound = 'sound/misc/notice1.ogg' // Angry alarm
 	number_level = SEC_LEVEL_BLUE
 	lowering_to_configuration_key = /datum/config_entry/string/alert_blue_downto
 	elevating_to_configuration_key = /datum/config_entry/string/alert_blue_upto
@@ -65,6 +67,7 @@
  */
 /datum/security_level/red
 	name = "red"
+	sound = 'sound/misc/notice1.ogg' // The same angry alarm
 	number_level = SEC_LEVEL_RED
 	lowering_to_configuration_key = /datum/config_entry/string/alert_red_downto
 	elevating_to_configuration_key = /datum/config_entry/string/alert_red_upto
@@ -77,6 +80,7 @@
  */
 /datum/security_level/delta
 	name = "delta"
+	sound = 'sound/misc/notice1.ogg' // The same angry alarm, again
 	number_level = SEC_LEVEL_DELTA
 	elevating_to_configuration_key = /datum/config_entry/string/alert_delta
 	shuttle_call_time_mod = 0.25


### PR DESCRIPTION
## About The Pull Request

Fixes #68000 

Security level datums have a sound var, but it never set it to anything.

Turns out, security level alerts used to just use the default "alert" or "no alert" minor notice sounds. 
However, the refactor did not pass `alert = TRUE` anywhere, so it never ... did the alert sound. 

So, I just changed minor_announce a bit to take any sound, then passed the sound to be played by minor_announce instead of playing it on its own. 

## Why It's Good For The Game

Fixes boo-woop.

## Changelog

:cl: Melbert
fix: Blue, Red, and Delta alerts make the right sound again
/:cl:
