### PR TITLE
Fixes some alien actions not working. 

### DIFF
--- a/code/datums/actions/cooldown_action.dm
+++ b/code/datums/actions/cooldown_action.dm
@@ -174,6 +174,8 @@
 /datum/action/cooldown/proc/PreActivate(atom/target)
 	if(SEND_SIGNAL(owner, COMSIG_MOB_ABILITY_STARTED, src) & COMPONENT_BLOCK_ABILITY_START)
 		return
+	// Note, that PreActivate handles no cooldowns at all by default.
+	// Be sure to call StartCooldown() in Activate() where necessary.
 	. = Activate(target)
 	// There is a possibility our action (or owner) is qdeleted in Activate().
 	if(!QDELETED(src) && !QDELETED(owner))

--- a/code/datums/actions/cooldown_action.dm
+++ b/code/datums/actions/cooldown_action.dm
@@ -174,7 +174,6 @@
 /datum/action/cooldown/proc/PreActivate(atom/target)
 	if(SEND_SIGNAL(owner, COMSIG_MOB_ABILITY_STARTED, src) & COMPONENT_BLOCK_ABILITY_START)
 		return
-	StartCooldown(360 SECONDS, 360 SECONDS)
 	. = Activate(target)
 	// There is a possibility our action (or owner) is qdeleted in Activate().
 	if(!QDELETED(src) && !QDELETED(owner))

--- a/code/datums/actions/mobs/charge.dm
+++ b/code/datums/actions/mobs/charge.dm
@@ -22,6 +22,7 @@
 	var/list/charging = list()
 
 /datum/action/cooldown/mob_cooldown/charge/Activate(atom/target_atom)
+	StartCooldown(360 SECONDS, 360 SECONDS)
 	charge_sequence(owner, target_atom, charge_delay, charge_past)
 	StartCooldown()
 

--- a/code/datums/actions/mobs/dash.dm
+++ b/code/datums/actions/mobs/dash.dm
@@ -10,6 +10,7 @@
 	var/pick_range = 5
 
 /datum/action/cooldown/mob_cooldown/dash/Activate(atom/target_atom)
+	StartCooldown(360 SECONDS, 360 SECONDS)
 	dash_to(target_atom)
 	StartCooldown()
 

--- a/code/datums/actions/mobs/fire_breath.dm
+++ b/code/datums/actions/mobs/fire_breath.dm
@@ -12,6 +12,7 @@
 	var/ice_breath = FALSE
 
 /datum/action/cooldown/mob_cooldown/fire_breath/Activate(atom/target_atom)
+	StartCooldown(360 SECONDS, 360 SECONDS)
 	attack_sequence(target_atom)
 	StartCooldown()
 
@@ -59,4 +60,3 @@
 		for(var/j = 1 to spiral_count)
 			INVOKE_ASYNC(src, .proc/fire_line, target, j * increment + i * increment / 2)
 		SLEEP_CHECK_DEATH(delay_time, owner)
-

--- a/code/datums/actions/mobs/lava_swoop.dm
+++ b/code/datums/actions/mobs/lava_swoop.dm
@@ -23,6 +23,7 @@
 	REMOVE_TRAIT(M, TRAIT_NOFIRE, REF(src))
 
 /datum/action/cooldown/mob_cooldown/lava_swoop/Activate(atom/target_atom)
+	StartCooldown(360 SECONDS, 360 SECONDS)
 	attack_sequence(target_atom)
 	StartCooldown()
 

--- a/code/datums/actions/mobs/meteors.dm
+++ b/code/datums/actions/mobs/meteors.dm
@@ -6,6 +6,7 @@
 	cooldown_time = 3 SECONDS
 
 /datum/action/cooldown/mob_cooldown/meteors/Activate(atom/target_atom)
+	StartCooldown(360 SECONDS, 360 SECONDS)
 	create_meteors(target_atom)
 	StartCooldown()
 

--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -18,6 +18,7 @@
 	var/projectile_speed_multiplier = 1
 
 /datum/action/cooldown/mob_cooldown/projectile_attack/Activate(atom/target_atom)
+	StartCooldown(360 SECONDS, 360 SECONDS)
 	attack_sequence(owner, target_atom)
 	StartCooldown()
 
@@ -286,6 +287,7 @@
 	cooldown_time = 2.5 SECONDS
 
 /datum/action/cooldown/mob_cooldown/projectile_attack/colossus_final/Activate(atom/target_atom)
+	StartCooldown(360 SECONDS, 360 SECONDS)
 	attack_sequence(owner, target_atom)
 	StartCooldown()
 	Remove(owner)

--- a/code/datums/actions/mobs/transform_weapon.dm
+++ b/code/datums/actions/mobs/transform_weapon.dm
@@ -9,6 +9,7 @@
 	var/max_cooldown_time = 10 SECONDS
 
 /datum/action/cooldown/mob_cooldown/transform_weapon/Activate(atom/target_atom)
+	StartCooldown(360 SECONDS, 360 SECONDS)
 	do_transform(target_atom)
 	StartCooldown(rand(cooldown_time, max_cooldown_time), 0)
 

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -83,10 +83,7 @@
 		caste_options["Drone"] = drone
 
 	var/alien_caste = show_radial_menu(owner, owner, caste_options, radius = 38, require_near = TRUE, tooltips = TRUE)
-	if(QDELETED(src) || QDELETED(owner) || !IsAvailable() || !alien_caste)
-		return
-
-	if(alien_caste == null)
+	if(QDELETED(src) || QDELETED(owner) || !IsAvailable() || isnull(alien_caste))
 		return
 
 	var/mob/living/carbon/alien/humanoid/new_xeno


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #68623

#68382 added a cooldown to the start of PreActivate for all cooldown actions by default

Space did this so people implementing new actions wouldn't forget to start their cooldowns

But, this caused problems for actions that sleep (user input), that sanity check availability afterwards

(Basically, actions that ask for user input would call `IsAvailable` to check if the action is still usable after waiting, but because it was put on a really long cooldown, it'd never be available. This wasn't a problem before because it didn't go on the long cooldown, but when the behavior was made generic it became an issue.)

I talked with Space a bit, and we decided to just revert it for the time being, allowing actions to handle cooldowns independently.  

Before: It starts a long generic cooldown, to prevent people from using the button while the action is being ran, and the normal cooldown is triggered in `Activate()`
After: There is no generic long cooldown, if an action wants it they can implement it themselves

I want to improve this to be a bit clearer in the future, but for now I'm just getting this PR up so aliens function again

Should probably be unit tested, idk.

## Why It's Good For The Game

Aliens work

## Changelog

:cl: Melbert
fix: Fixes some alien actions like Evolve not working. 
/:cl: