### PR TITLE
Equalizes Tramstation Chemfactory's Goggles

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -45650,7 +45650,9 @@
 /obj/item/pickaxe,
 /obj/item/storage/bag/ore,
 /obj/item/shovel,
-/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson{
+	slowdown = 2
+	},
 /obj/item/clothing/gloves/color/yellow/heavy,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -30972,9 +30972,7 @@
 /obj/item/pickaxe,
 /obj/item/storage/bag/ore,
 /obj/item/shovel,
-/obj/item/clothing/glasses/meson{
-	slowdown = 2
-	},
+/obj/item/clothing/glasses/meson,
 /obj/item/stack/marker_beacon/ten,
 /obj/item/clothing/gloves/color/yellow/heavy,
 /turf/open/floor/iron/white,
@@ -45650,9 +45648,7 @@
 /obj/item/pickaxe,
 /obj/item/storage/bag/ore,
 /obj/item/shovel,
-/obj/item/clothing/glasses/meson{
-	slowdown = 2
-	},
+/obj/item/clothing/glasses/meson,
 /obj/item/clothing/gloves/color/yellow/heavy,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In this PR I use the power of SDMM VV to take the slowdown away from the pair left of mesons in Tramstation's chemfactory. Because MMMiracles says it was probably unintended behaviour.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes #68628
Mesons are not that heavy, actually.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Tramstation chemfactory's meson left pair of meson goggles no longer slow you down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
