### PR TITLE
Change for hat stabilizer

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -505,9 +505,8 @@
 			/obj/item/clothing/head/nursehat,
 			/obj/item/clothing/head/chefhat,
 			/obj/item/clothing/head/papersack,
-			)) - /obj/item/clothing/head/caphat/beret
-			//Need to subtract the beret because its annoying
-
+			/obj/item/clothing/head/caphat/beret,
+			
 /obj/item/mod/module/hat_stabilizer/on_suit_activation()
 	RegisterSignal(mod.helmet, COMSIG_PARENT_EXAMINE, .proc/add_examine)
 	RegisterSignal(mod.helmet, COMSIG_PARENT_ATTACKBY, .proc/place_hat)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -506,6 +506,7 @@
 			/obj/item/clothing/head/chefhat,
 			/obj/item/clothing/head/papersack,
 			/obj/item/clothing/head/caphat/beret,
+			))
 			
 /obj/item/mod/module/hat_stabilizer/on_suit_activation()
 	RegisterSignal(mod.helmet, COMSIG_PARENT_EXAMINE, .proc/add_examine)


### PR DESCRIPTION
##About The Pull Request
Captain's beret(blue&white) both can now be attached to the Hat Stabilizer Mod.

##How This Contributes To The Skyrat Roleplay Experience
Much like every other hats, berets should also be able to chosen for preference now on top of your hats.

##Changelog
🆑 SpaceLove
add: NT has finally losen up restrictions on Hat Stabilizer Module, allowing captain's beret on top of it as well.
/:cl:

![178133482-76d5dbd4-1f66-4994-bfaa-84beeb5cb513](https://user-images.githubusercontent.com/68121607/180220168-2d0370e1-7b45-4671-8c51-c552b9214aff.png)
![178133487-3bb3f42d-65b1-4566-84d0-252022553a8c](https://user-images.githubusercontent.com/68121607/180220188-942a67ee-f283-489c-aa67-2b1ca21686f9.png)
![178133494-3ef5cb12-7f8d-402b-96d9-acb7a2453d33](https://user-images.githubusercontent.com/68121607/180220204-905ab35a-cc3a-4fcc-b605-03347f0bdf17.png)
![178133498-8401629a-1bb1-48c8-b8be-a056b3133b05](https://user-images.githubusercontent.com/68121607/180220221-b1e83b69-a211-4342-98f0-1eafae41eaf6.png)

P.S. Don't pay attention to my webediting a one line.