### PR TITLE
Update CODEOWNERS to remove me from most tgui interfaces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,10 +78,14 @@
 /code/controllers/subsystem/chat.dm @stylemistake
 /code/controllers/subsystem/ping.dm @stylemistake
 /code/controllers/subsystem/tgui.dm @stylemistake
-/code/modules/tgchat @stylemistake
-/code/modules/tgui @stylemistake
-/code/modules/tgui_panel @stylemistake
-/tgui @stylemistake
+/code/modules/tgchat/ @stylemistake
+/code/modules/tgui/ @stylemistake
+/code/modules/tgui_panel/ @stylemistake
+/tgui/ @stylemistake
+
+# stylemistake (explicitly disowned)
+
+/tgui/packages/tgui/interfaces/
 
 # Watermelon914
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,6 +86,8 @@
 # stylemistake (explicitly disowned)
 
 /tgui/packages/tgui/interfaces/
+/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+/tgui/packages/tgui-panel/styles/goon/chat-light.scss
 
 # Watermelon914
 


### PR DESCRIPTION
## About The Pull Request

I am disowning `/tgui/packages/tgui/interfaces` because it creates a lot of noise in my notifications (sometimes it's just an update in prefs), and I feel confident code there is totally fine as long as it passes linters.

I also don't need to see what's in `chat-dark/light.scss` for the same reason.

If anyone codes something ambitious in tgui I still wish to be manually added as a reviewer.