### PR TITLE
Adds the COMSIG_PROJECTILE_RANGE signal and the pixel_speed_multiplier var for projectiles

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -339,7 +339,9 @@
 #define COMSIG_PROJECTILE_FIRE "projectile_fire"
 ///sent to targets during the process_hit proc of projectiles
 #define COMSIG_PROJECTILE_PREHIT "com_proj_prehit"
-///sent to targets during the process_hit proc of projectiles
+///from the base of /obj/projectile/Range(): ()
+#define COMSIG_PROJECTILE_RANGE "projectile_range"
+///from the base of /obj/projectile/on_range(): ()
 #define COMSIG_PROJECTILE_RANGE_OUT "projectile_range_out"
 ///from [/obj/item/proc/tryEmbed] sent when trying to force an embed (mainly for projectiles and eating glass)
 #define COMSIG_EMBED_TRY_FORCE "item_try_embed"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -192,8 +192,10 @@ Difficulty: Extremely Hard
 	icon_state = "ice_1"
 	damage = 20
 	armour_penetration = 100
-	speed = 10
-	homing_turn_speed = 30
+	speed = 1
+	pixel_speed_multiplier = 0.1
+	range = 500
+	homing_turn_speed = 3
 	damage_type = BURN
 
 /obj/projectile/colossus/frost_orb/on_hit(atom/target, blocked = FALSE)
@@ -206,7 +208,9 @@ Difficulty: Extremely Hard
 	icon_state = "nuclear_particle"
 	damage = 5
 	armour_penetration = 100
-	speed = 3
+	speed = 1
+	pixel_speed_multiplier = 0.333
+	range = 150
 	damage_type = BRUTE
 	explode_hit_objects = FALSE
 
@@ -215,7 +219,9 @@ Difficulty: Extremely Hard
 	icon_state = "ice_2"
 	damage = 15
 	armour_penetration = 100
-	speed = 3
+	speed = 1
+	pixel_speed_multiplier = 0.333
+	range = 150
 	damage_type = BRUTE
 
 /obj/projectile/colossus/ice_blast/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
@@ -50,7 +50,9 @@
 /obj/projectile/temp/basilisk/ice
 	name = "ice blast"
 	damage = 5
-	speed = 4
+	speed = 1
+	pixel_speed_multiplier = 0.25
+	range = 200
 	nodamage = FALSE
 	temperature = -75
 	slowdown = FALSE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -72,7 +72,9 @@
 	/// If objects are below this layer, we pass through them
 	var/hit_threshhold = PROJECTILE_HIT_THRESHHOLD_LAYER
 
-	/// Amount of deciseconds it takes for projectile to travel
+	/// During each fire of SSprojectiles, the number of deciseconds since the last fire of SSprojectiles
+	/// is divided by this var, and the result truncated to the next lowest integer is
+	/// the number of times the projectile's `pixel_move` proc will be called.
 	var/speed = 0.8
 
 	/// This var is multiplied by SSprojectiles.global_pixel_speed to get how many pixels

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -200,6 +200,7 @@
 		bare_wound_bonus = max(0, bare_wound_bonus + wound_falloff_tile)
 	if(embedding)
 		embedding["embed_chance"] += embed_falloff_tile
+	SEND_SIGNAL(src, COMSIG_PROJECTILE_RANGE)
 	if(range <= 0 && loc)
 		on_range()
 
@@ -672,7 +673,7 @@
 		time_offset += MODULUS(elapsed_time_deciseconds, speed)
 
 	for(var/i in 1 to required_moves)
-		pixel_move(1, FALSE)
+		pixel_move(pixel_speed_multiplier, FALSE)
 
 /obj/projectile/proc/fire(angle, atom/direct_target)
 	LAZYINITLIST(impacted)
@@ -716,7 +717,7 @@
 		process_hitscan()
 	if(!(datum_flags & DF_ISPROCESSING))
 		START_PROCESSING(SSprojectiles, src)
-	pixel_move(1, FALSE) //move it now!
+	pixel_move(pixel_speed_multiplier, FALSE) //move it now!
 
 /obj/projectile/proc/set_angle(new_angle) //wrapper for overrides.
 	Angle = new_angle

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -72,7 +72,17 @@
 	/// If objects are below this layer, we pass through them
 	var/hit_threshhold = PROJECTILE_HIT_THRESHHOLD_LAYER
 
-	var/speed = 0.8 //Amount of deciseconds it takes for projectile to travel
+	/// Amount of deciseconds it takes for projectile to travel
+	var/speed = 0.8
+
+	/// This var is multiplied by SSprojectiles.global_pixel_speed to get how many pixels
+	/// the projectile moves during each iteration of the movement loop
+	///
+	/// If you want to make a fast-moving projectile, you should keep this equal to 1 and
+	/// reduce the value of `speed`. If you want to make a slow-moving projectile, make
+	/// `speed` a modest value like 1 and set this to a low value like 0.2.
+	var/pixel_speed_multiplier = 1
+
 	var/Angle = 0
 	var/original_angle = 0 //Angle at firing
 	var/nondirectional_sprite = FALSE //Set TRUE to prevent projectiles from having their sprites rotated based on firing angle

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -562,8 +562,9 @@
 /obj/projectile/magic/aoe/magic_missile
 	name = "magic missile"
 	icon_state = "magicm"
-	range = 20
-	speed = 5
+	range = 100
+	speed = 1
+	pixel_speed_multiplier = 0.2
 	trigger_range = 0
 	can_only_hit_target = TRUE
 	nodamage = FALSE
@@ -589,8 +590,9 @@
 	trigger_range = 0
 	antimagic_flags = MAGIC_RESISTANCE_HOLY
 	ignored_factions = list("cult")
-	range = 15
-	speed = 7
+	range = 105
+	speed = 1
+	pixel_speed_multiplier = 1/7
 
 /obj/projectile/magic/spell/juggernaut/on_hit(atom/target, blocked)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The COMSIG_PROJECTILE_RANGE signal can be used to add signal handlers for behaviors that a projectile should execute each step of its travel. Currently, nothing uses it, but it is available for use in admin circuits or lua scripts.

The `pixel_speed_multiplier` var for projectiles acts as the value passed to the `trajectory_multiplier` argument of `pixel_move`, which originally was passed a constant value of 1. By lowering this var, you can reduce the speed of projectiles without them becoming jumpy. As an example, magic missile, gauntlet echo, the demonic watcher's temp beam, and the demonic frost miner's projectiles have all been changed to use this var. As such, their movement will be much smoother (but still the same effective speed).

## Why It's Good For The Game

Have you ever found it awkward that magic missile jumps from tile to tile despite being defined as a projectile that employs pixel movement? That was because its tick rate, as defined by the speed var, was so low that you could actually notice the wait time between travel steps. That behavior has been rectified by employing a proc argument that had previously only ever been passed a constant.

## Changelog

:cl:
code: Several projectiles, particularly magic missile and gauntlet echo, now move more smoothly instead of jumping from tile to tile.
/:cl:
