### PR TITLE
Fixes AI tablet stack trace warning on initialize

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -154,6 +154,9 @@
 	job = "AI"
 
 	create_eye()
+
+	create_modularInterface()
+
 	if(client)
 		INVOKE_ASYNC(src, .proc/apply_pref_name, /datum/preference/name/ai, client)
 
@@ -168,7 +171,6 @@
 
 	add_verb(src, /mob/living/silicon/ai/proc/show_laws_verb)
 
-	create_modularInterface()
 
 	aiMulti = new(src)
 	aicamera = new/obj/item/camera/siliconcam/ai_camera(src)


### PR DESCRIPTION
apply_pref_name chain threw a stacktrace warning since modularInterface didn't exist yet

![image](https://user-images.githubusercontent.com/6209658/180345328-a51cba30-4de6-4b21-9fa6-dc56f6147dac.png)
