### PR TITLE
Properly removes tonal indicators

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -483,6 +483,10 @@
 		new_message = replacetext(new_message, "?", ".")
 	speech_args[SPEECH_MESSAGE] = new_message
 
+	// Cut our last overlay before we replace it
+	if(timeleft(tonal_timerid) > 0 && (question_found || exclamation_found))
+		remove_tonal_indicator()
+		deltimer(tonal_timerid)
 	if(question_found) // Prioritize questions
 		tonal_indicator = mutable_appearance('icons/mob/talk.dmi', "signlang1", TYPING_LAYER)
 		owner.visible_message(span_notice("[owner] lowers [owner.p_their()] eyebrows."))
@@ -491,7 +495,7 @@
 		owner.visible_message(span_notice("[owner] raises [owner.p_their()] eyebrows."))
 	if(!isnull(tonal_indicator) && owner?.client.typing_indicators)
 		owner.add_overlay(tonal_indicator)
-		tonal_timerid = addtimer(CALLBACK(src, .proc/remove_tonal_indicator), 2.5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		tonal_timerid = addtimer(CALLBACK(src, .proc/remove_tonal_indicator), 2.5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE)
 	else // If we're not gonna use it, just be sure we get rid of it
 		tonal_indicator = null
 

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -495,7 +495,7 @@
 		owner.visible_message(span_notice("[owner] raises [owner.p_their()] eyebrows."))
 	if(!isnull(tonal_indicator) && owner?.client.typing_indicators)
 		owner.add_overlay(tonal_indicator)
-		tonal_timerid = addtimer(CALLBACK(src, .proc/remove_tonal_indicator), 2.5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE)
+		tonal_timerid = addtimer(CALLBACK(src, .proc/remove_tonal_indicator), 2.5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE | TIMER_DELETE_ME)
 	else // If we're not gonna use it, just be sure we get rid of it
 		tonal_indicator = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In #68231, players with tied tongues got a visual tonal indicator. Sometimes that tonal indicator refused to go away. This is because, when messages with indicators were sent within 2.5 seconds (the amount of time that the indicator remains before its overlays are cut), the initial tonal_indicator would be replaced with the new, second one. This meant that the initial reference was totally lost, and couldn't be cut.

This PR makes it so that if the player is about to say something that is accompanied by a tonal indicator while a tonal indicator is being displayed, the first one is cut and replaced with the second.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #68277

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: tongue tied players will no longer be haunted by floating faces if they type too fast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
