### PR TITLE
Sets MAT_CATEGORY_ITEM_MATERIAL to TRUE for Bluespace Crystals

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -158,7 +158,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	color = list(119/255, 217/255, 396/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	greyscale_colors = "#4e7dffC8"
 	alpha = 200
-	categories = list(MAT_CATEGORY_ORE = TRUE)
+	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_ITEM_MATERIAL = TRUE)
 	beauty_modifier = 0.5
 	sheet_type = /obj/item/stack/sheet/bluespace_crystal
 	value_per_unit = 0.15


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<details>
  <summary>Ramblings of a madman</summary>
Tell me, Have you ever wondered what would happen in a perfect world? A perfect world where we can allow Bluespace Crystals inside our autolathes, Where a man can reasonably ask for a print of a bluespace cell from a cargo member who managed to sequester a design disk of it from their fellow cohort, Where we dont have to be wanting for Bluespace Crystals to fit into the autolathe despite there being some hints of code that implies that it is capable of receiving them but for some reason when you go to test it ingame it tells you that it doesn't have enough materials to be allowed in but for some reason we _still_ have that one little bit of code laughing at us, Daring us to try and put the bluespace crystal in with _nothing_ to gain but anger and spite. 
Sadly, we dont live in a perfect world. A cargo tech cant just... Print a bluespace cell from the autolathe despite their trials to obtain a design disk for them. Bluespace crystals are not allowed in our autolathes, And we're still sitting with snippits of code that displays it _should_ be capable of receiving bluespace crystals but yet, We cannot sate them of their hunger.

Also like its kinda odd it cant. Its like the one material besides biomass you cant thats still *in* basemats datums. Hell, even the ones that are references can be put in autolathes like runite or adamantine, But bluespace crystals? whazzat? Y'cant? Oh well those dont exist for some reason. We got a specific part in a proc for it? Sorry doesn't exist to us. 

![image](https://user-images.githubusercontent.com/28457065/180374409-b17c4531-f465-4d41-950b-bcb62a36486c.png)

^ code snippit in question ^

</details>

Basically it allows BS Crystals to be put into the autolathe.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
<details>
  <summary>More ramblings</summary>
um. *i dunno*.
Like, Legit making an argument about why is kinda hard because its running against the argument of why not, Which... I dont fully understand. Is there a reason to _not_ allow bluespace crystals into an autolathe? You're already blacklisting any of the "problematic" designs from being ported over to the autolathe that might need them. Is there a side-effect to being in the item material flag? As far as i know there isn't besides being put into material storage components. Does it affect the crystal themselves? well, No it shouldn't. There's a hard-written use factor to over-ride the craft menu so it shouldn't really affect its operation 
But at the same time everything you can make with custom mats doesn't like.... Gain anything from it. You can make a bluespace toolbox to whack someone with but it wont send them to oblivion, You can make magical looking knight armor that does... One of the worst defenses i've seen from plated armor *but you can make it*. Its blue it looks funny all i'm doing is flicking a switch. 

Its probably also not a balance change but like i'm kinda done to death waxing on whether its a balance change somewhere else, so if it isn't technically a balance change just tell me what it is and i'll correct it, first PR up here lmao y'know? Like i just got my git updated and so i was/am expecting technical problems but so far nothings came up so i'm just gonna go with it, y'know?

</details>

TLDR: Why shouldn't BSCrystals be allowed in the autolathe? Every other base material can, And there are some things that do require BSCrystal material that isn't super game breaking. So why not? 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Bluespace crystals can now go in ITEM_MATERIAL capable material storage (like autolathes)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
