### PR TITLE
Adds text highlighting to the lua editor

### DIFF
--- a/tgui/packages/tgui/components/TextArea.js
+++ b/tgui/packages/tgui/components/TextArea.js
@@ -15,9 +15,10 @@ export class TextArea extends Component {
   constructor(props, context) {
     super(props, context);
     this.textareaRef = props.innerRef || createRef();
-    this.fillerRef = createRef();
+    this.displayedContainerRef = createRef();
     this.state = {
       editing: false,
+      scrolledAmount: 0,
     };
     const { dontUseTabForIndent = false } = props;
     this.handleOnInput = (e) => {
@@ -122,6 +123,14 @@ export class TextArea extends Component {
         }
       }
     };
+    this.handleScroll = (e) => {
+      const { displayedValue } = this.props;
+      const input = this.textareaRef.current;
+      const displayedContainer = this.displayedContainerRef.current;
+      if (displayedValue && input && displayedContainer) {
+        displayedContainer.scrollTop = input.scrollTop;
+      }
+    };
   }
 
   componentDidMount() {
@@ -176,18 +185,23 @@ export class TextArea extends Component {
     } = this.props;
     // Box props
     const { className, fluid, ...rest } = boxProps;
+    const { scrolledAmount } = this.state;
     return (
       <Box
         className={classes(['TextArea', fluid && 'TextArea--fluid', className])}
         {...rest}>
         {!!displayedValue && (
-          <Box
+          <div
             className={classes([
               'TextArea__textarea',
               'TextArea__textarea_custom',
-            ])}>
+            ])}
+            style={{
+              'transform': `translateY(-${scrolledAmount}px)`,
+            }}
+            ref={this.displayedContainerRef}>
             {displayedValue}
-          </Box>
+          </div>
         )}
         <textarea
           ref={this.textareaRef}
@@ -199,6 +213,7 @@ export class TextArea extends Component {
           onInput={this.handleOnInput}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
+          onScroll={this.handleScroll}
           maxLength={maxLength}
           style={{
             'color': displayedValue ? 'rgba(0, 0, 0, 0)' : 'inherit',

--- a/tgui/packages/tgui/components/TextArea.js
+++ b/tgui/packages/tgui/components/TextArea.js
@@ -100,7 +100,7 @@ export class TextArea extends Component {
             '\t' +
             value.substring(selectionEnd);
           e.target.selectionEnd = selectionStart + 1;
-          if(onInput) {
+          if (onInput) {
             onInput(e, e.target.value);
           }
         }
@@ -182,13 +182,10 @@ export class TextArea extends Component {
         {...rest}>
         {!!displayedValue && (
           <Box
-            className={
-              classes([
-                "TextArea__textarea",
-                "TextArea__textarea_custom",
-              ])
-            }
-          >
+            className={classes([
+              'TextArea__textarea',
+              'TextArea__textarea_custom',
+            ])}>
             {displayedValue}
           </Box>
         )}
@@ -204,9 +201,9 @@ export class TextArea extends Component {
           onBlur={this.handleBlur}
           maxLength={maxLength}
           style={{
-            "color": displayedValue? "rgba(0, 0, 0, 0)" : "inherit",
+            'color': displayedValue ? 'rgba(0, 0, 0, 0)' : 'inherit',
           }}
-         />
+        />
       </Box>
     );
   }

--- a/tgui/packages/tgui/components/TextArea.js
+++ b/tgui/packages/tgui/components/TextArea.js
@@ -100,6 +100,9 @@ export class TextArea extends Component {
             '\t' +
             value.substring(selectionEnd);
           e.target.selectionEnd = selectionStart + 1;
+          if(onInput) {
+            onInput(e, e.target.value);
+          }
         }
       }
     };
@@ -168,6 +171,7 @@ export class TextArea extends Component {
       value,
       maxLength,
       placeholder,
+      displayedValue,
       ...boxProps
     } = this.props;
     // Box props
@@ -176,6 +180,18 @@ export class TextArea extends Component {
       <Box
         className={classes(['TextArea', fluid && 'TextArea--fluid', className])}
         {...rest}>
+        {!!displayedValue && (
+          <Box
+            className={
+              classes([
+                "TextArea__textarea",
+                "TextArea__textarea_custom",
+              ])
+            }
+          >
+            {displayedValue}
+          </Box>
+        )}
         <textarea
           ref={this.textareaRef}
           className="TextArea__textarea"
@@ -187,7 +203,10 @@ export class TextArea extends Component {
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           maxLength={maxLength}
-        />
+          style={{
+            "color": displayedValue? "rgba(0, 0, 0, 0)" : "inherit",
+          }}
+         />
       </Box>
     );
   }

--- a/tgui/packages/tgui/interfaces/LuaEditor/index.js
+++ b/tgui/packages/tgui/interfaces/LuaEditor/index.js
@@ -90,7 +90,6 @@ export const LuaEditor = (props, context) => {
                   onInput={(_, value) => setInput(value)}
                   displayedValue={
                     <Box
-                      fontFamily="Consolas"
                       style={{
                         'pointer-events': 'none',
                       }}

--- a/tgui/packages/tgui/interfaces/LuaEditor/index.js
+++ b/tgui/packages/tgui/interfaces/LuaEditor/index.js
@@ -88,18 +88,19 @@ export const LuaEditor = (props, context) => {
                   value={input}
                   fontFamily="Consolas"
                   onInput={(_, value) => setInput(value)}
-                  displayedValue={(
+                  displayedValue={
                     <Box
                       fontFamily="Consolas"
                       style={{
-                        "pointer-events": "none",
+                        'pointer-events': 'none',
                       }}
                       dangerouslySetInnerHTML={{
-                        __html: hljs.highlight(input, { language: 'lua' }).value,
+                        __html: hljs.highlight(input, { language: 'lua' })
+                          .value,
                       }}
                     />
-                  )}
-                 />
+                  }
+                />
                 <Button onClick={() => act('runCode', { code: input })}>
                   Run
                 </Button>

--- a/tgui/packages/tgui/interfaces/LuaEditor/index.js
+++ b/tgui/packages/tgui/interfaces/LuaEditor/index.js
@@ -86,8 +86,20 @@ export const LuaEditor = (props, context) => {
                   width="700px"
                   height="590px"
                   value={input}
+                  fontFamily="Consolas"
                   onInput={(_, value) => setInput(value)}
-                />
+                  displayedValue={(
+                    <Box
+                      fontFamily="Consolas"
+                      style={{
+                        "pointer-events": "none",
+                      }}
+                      dangerouslySetInnerHTML={{
+                        __html: hljs.highlight(input, { language: 'lua' }).value,
+                      }}
+                    />
+                  )}
+                 />
                 <Button onClick={() => act('runCode', { code: input })}>
                   Run
                 </Button>

--- a/tgui/packages/tgui/styles/components/TextArea.scss
+++ b/tgui/packages/tgui/styles/components/TextArea.scss
@@ -61,3 +61,7 @@ $border-radius: Input.$border-radius !default;
     color: rgba(255, 255, 255, 0.45);
   }
 }
+
+.TextArea__textarea_custom {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Makes keywords light up. Selections will still appear and the text cursor will still be visible.
![image](https://user-images.githubusercontent.com/37270891/180429654-53be2698-9def-4ee6-86a9-4aef0566fc67.png)


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
QoL for admins

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: The lua editor now has text highlighting for lua keywords
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
