### PR TITLE
Fixes floorbots not properly updating overlays of repaired floor tiles

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -369,7 +369,7 @@
 			else if(F.broken || F.burnt)	//repair the tile and reset it to be undamaged (rather than replacing it)
 				F.broken = FALSE
 				F.burnt = FALSE
-				F.icon_state = initial(F.icon_state)
+				F.update_appearance()
 			else if(istype(is_this_maints, /area/station/maintenance))	//place catwalk if it's plating and we're in maints
 				F.PlaceOnTop(/turf/open/floor/catwalk_floor, flags = CHANGETURF_INHERIT_AIR)
 			else	//place normal tile if it's plating anywhere else


### PR DESCRIPTION
:cl: ShizCalev
fix: Floors repaired by floorbots will now have their overlays updated properly.
/:cl:

Fix for an issue similar to #68133