### PR TITLE
Fixes runtime from getting a weakref loc

### DIFF
--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -322,4 +322,4 @@ rough example of the "cone" made by the 3 dirs checked
 	var/datum/storage/storage_datum = target.loc.atom_storage
 	if(!storage_datum)
 		return
-	. += storage_datum.parent
+	. += storage_datum.real_location?.resolve()


### PR DESCRIPTION
## About The Pull Request

fixes `get_storage_locs` to return the `real_location?.resolve()` instead of parent so weakrefs passed in (spotted in `stabilized.dm`) don't runtime

thanks tsu :-]

## Changelog
no player facing change