### PR TITLE
Moves "Debug External Libraries" vscode launch config to the bottom of the list

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,18 +2,6 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "Debug External Libraries",
-			"type": "cppvsdbg",
-			"request": "launch",
-			"program": "${command:dreammaker.returnDreamDaemonPath}",
-			"cwd": "${workspaceRoot}",
-			"args": [
-				"${command:dreammaker.getFilenameDmb}",
-				"-trusted"
-			],
-			"preLaunchTask": "Build All"
-		},
-		{
 			"type": "byond",
 			"request": "launch",
 			"name": "Launch DreamSeeker",
@@ -27,6 +15,18 @@
 			"preLaunchTask": "Build All",
 			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
 			"dreamDaemon": true
+		},
+		{
+			"name": "Debug External Libraries",
+			"type": "cppvsdbg",
+			"request": "launch",
+			"program": "${command:dreammaker.returnDreamDaemonPath}",
+			"cwd": "${workspaceRoot}",
+			"args": [
+				"${command:dreammaker.getFilenameDmb}",
+				"-trusted"
+			],
+			"preLaunchTask": "Build All"
 		}
 	]
 }


### PR DESCRIPTION
## About The Pull Request

When making admin lua scripting, I unintentionally made "Debug External Libraries" the default launch configuration for vscode by putting it at the top of the configs list. This rectifies that.

## Why It's Good For The Game

Someone said they were unable to launch the debugger, and it turns out that was because I unintentionally made the default launch configuration the one people were *least* likely to *ever* need to use.

## Changelog

No player-facing changes.