### PR TITLE
Fixes runtime every time a tattoo is destroyed

### DIFF
--- a/code/datums/components/tattoo.dm
+++ b/code/datums/components/tattoo.dm
@@ -26,11 +26,13 @@
 		setup_tatted_owner(tatted_limb.owner)
 
 /datum/component/tattoo/Destroy(force, silent)
-	. = ..()
+	if(!parent)
+		return ..()
 	var/obj/item/bodypart/tatted_limb = parent
 	if(tatted_limb.owner)
 		clear_tatted_owner(tatted_limb.owner)
 	parent.RemoveElement(/datum/element/art/commoner)
+	return ..()
 
 /datum/component/tattoo/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)


### PR DESCRIPTION
component/Destroy() clears the parent var.