### PR TITLE
Bump rust-g to 0.8.0

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -151,7 +151,14 @@
 #define rustg_time_milliseconds(id) text2num(call(RUST_G, "time_milliseconds")(id))
 #define rustg_time_reset(id) call(RUST_G, "time_reset")(id)
 
-#define rustg_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+#define rustg_raw_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+
+/proc/rustg_read_toml_file(path)
+	var/list/output = rustg_raw_read_toml_file(path)
+	if (output["success"])
+		return output["content"]
+	else
+		CRASH(output["content"])
 
 #define rustg_url_encode(text) call(RUST_G, "url_encode")("[text]")
 #define rustg_url_decode(text) call(RUST_G, "url_decode")(text)


### PR DESCRIPTION
## About The Pull Request

According to https://github.com/tgstation/rust-g/pull/101 (or https://github.com/tgstation/rust-g/commit/76fd17a7b3983928e1ef81e0549a817951729ad9 ), this version of rust-g makes Cellular Noise faster. We leverage the shit out of Cellular Noise in our cave generation in pretty much every type of mining map (especially IceBoxStation), so I am very keen on seeing this.

Here are some scuffed results from my local test on this claim, where you seem to see a not-bad 0.2 second reduction with the bumped DLL on my debug server:

![image](https://user-images.githubusercontent.com/34697715/180568816-57e4ec6d-4a7c-44ef-abf4-6fe8f3eefc48.png)

![image](https://user-images.githubusercontent.com/34697715/180568831-dba1b27a-1d2e-4db3-ace0-5a1ee372cfec.png)

Might also be nice to use the other types of noise one day. One day. Also contains some more cargo crates or whatever you wanna call it. Cool.

This is the first time I've bumped a dependency so please let me know if I am forgetting something critically important.