### PR TITLE
Codeowners Housekeeping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,12 +6,6 @@
 
 # MAINTAINERS
 
-# Cobby
-
-/code/modules/reagents/ @ExcessiveUseOfCobblestone
-/code/modules/research/designs/medical_designs.dm @ExcessiveUseOfCobblestone
-/code/game/objects/items/storage/medkit.dm @ExcessiveUseOfCobblestone
-
 # Cyberboss
 
 /code/__HELPERS/jatum.dm @Cyberboss
@@ -94,6 +88,12 @@
 /code/modules/wiremod/ @Watermelon914
 
 # CONTRIBUTORS
+
+# Cobby
+
+/code/modules/reagents/ @ExcessiveUseOfCobblestone
+/code/modules/research/designs/medical_designs.dm @ExcessiveUseOfCobblestone
+/code/game/objects/items/storage/medkit.dm @ExcessiveUseOfCobblestone
 
 # Dragomagol/Tattle
 /code/__HELPERS/logging/ @Dragomagol

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,7 +96,7 @@
 /code/game/objects/items/storage/medkit.dm @ExcessiveUseOfCobblestone
 
 # Dragomagol/Tattle
-/code/__HELPERS/logging/ @Dragomagol
+/code/__HELPERS/logging/ @dragomagol
 
 # Fikou
 


### PR DESCRIPTION
Cobby retired a few weeks ago, so let's engage in the mournful task of moving them out of the Maintainers section.