### PR TITLE
Adds nuclear particles to the reflector allowed projectile reflection types

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -14,7 +14,7 @@
 	var/framebuildstackamount = 5
 	var/buildstacktype = /obj/item/stack/sheet/iron
 	var/buildstackamount = 0
-	var/list/allowed_projectile_typecache = list(/obj/projectile/beam)
+	var/list/allowed_projectile_typecache = list(/obj/projectile/beam, /obj/projectile/energy/nuclear_particle)
 	var/rotation_angle = -1
 
 /obj/structure/reflector/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Allows reflectors to reflect nuclear particles

## Why It's Good For The Game

https://user-images.githubusercontent.com/8881105/180614500-ac2eb2f2-9a17-4b89-ad36-ec0f0184e0ac.mp4


There are other more legitimate (and interesting) uses, like the SM.

https://user-images.githubusercontent.com/8881105/180615343-152dff69-5ccd-4240-93ce-73c4697478f1.mp4

![image](https://user-images.githubusercontent.com/8881105/180615349-42ae9422-3ac4-45d6-8a74-51c2d6d07c2c.png)


Gives the PN BZ response a bit of an actual use, given helium is effectively worthless

## Changelog
:cl:
balance: Reflectors can now reflect nuclear particles.
/:cl: