### PR TITLE
Take Two: The word filter now verbosely describes config failure (Rust-g 1.0.2 Edition)

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -151,7 +151,14 @@
 #define rustg_time_milliseconds(id) text2num(call(RUST_G, "time_milliseconds")(id))
 #define rustg_time_reset(id) call(RUST_G, "time_reset")(id)
 
-#define rustg_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+#define rustg_read_toml_file_result(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+
+/proc/rustg_read_toml_file(path)
+	var/list/result = rustg_read_toml_file_result(path)
+	if (result["success"])
+		return result["content"]
+	else
+		CRASH(result["content"])
 
 #define rustg_url_encode(text) call(RUST_G, "url_encode")("[text]")
 #define rustg_url_decode(text) call(RUST_G, "url_decode")(text)

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -151,14 +151,14 @@
 #define rustg_time_milliseconds(id) text2num(call(RUST_G, "time_milliseconds")(id))
 #define rustg_time_reset(id) call(RUST_G, "time_reset")(id)
 
-#define rustg_read_toml_file_result(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+#define rustg_raw_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
 
 /proc/rustg_read_toml_file(path)
-	var/list/result = rustg_read_toml_file_result(path)
-	if (result["success"])
-		return result["content"]
+	var/list/output = rustg_raw_read_toml_file(path)
+	if (output["success"])
+		return json_decode(output["content"])
 	else
-		CRASH(result["content"])
+		CRASH(output["content"])
 
 #define rustg_url_encode(text) call(RUST_G, "url_encode")("[text]")
 #define rustg_url_decode(text) call(RUST_G, "url_decode")(text)

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -380,12 +380,13 @@ Example config:
 
 	log_config("Loading config file word_filter.toml...")
 
-	var/list/word_filter = rustg_read_toml_file("[directory]/word_filter.toml")
-	if (!islist(word_filter))
-		var/message = "The word filter configuration did not output a list, contact someone with configuration access to make sure it's setup properly."
+	var/list/result = rustg_read_toml_file_result("[directory]/word_filter.toml")
+	if(!result["success"])
+		var/message = "The word filter is not configured correctly! [result["content"]]"
 		log_config(message)
 		DelayedMessageAdmins(message)
 		return
+	var/list/word_filter = result["content"]
 
 	ic_filter_reasons = try_extract_from_word_filter(word_filter, "ic")
 	ic_outside_pda_filter_reasons = try_extract_from_word_filter(word_filter, "ic_outside_pda")

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -379,8 +379,7 @@ Example config:
 		return
 
 	log_config("Loading config file word_filter.toml...")
-
-	var/list/result = rustg_read_toml_file_result("[directory]/word_filter.toml")
+	var/list/result = rustg_read_toml_file("[directory]/word_filter.toml")
 	if(!result["success"])
 		var/message = "The word filter is not configured correctly! [result["content"]]"
 		log_config(message)

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -8,7 +8,7 @@ export BYOND_MAJOR=514
 export BYOND_MINOR=1560
 
 #rust_g git tag
-export RUST_G_VERSION=1.0.1
+export RUST_G_VERSION=1.0.2
 
 #node version
 export NODE_VERSION=14

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -8,7 +8,7 @@ export BYOND_MAJOR=514
 export BYOND_MINOR=1560
 
 #rust_g git tag
-export RUST_G_VERSION=1.0.0
+export RUST_G_VERSION=1.0.1
 
 #node version
 export NODE_VERSION=14

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -8,7 +8,7 @@ export BYOND_MAJOR=514
 export BYOND_MINOR=1560
 
 #rust_g git tag
-export RUST_G_VERSION=0.5.0
+export RUST_G_VERSION=1.0.0
 
 #node version
 export NODE_VERSION=14


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A resuscitation of [#67474](https://github.com/tgstation/tgstation/issues/67474) since Arm is not presently able to do it.

rustg_read_toml_file has backwards dependency to support older cases that checked for lack of list (the old sign the rust fn went wrong).

Fixes [#67446](https://github.com/tgstation/tgstation/issues/67446)

The configuration for the word filter now verbosely describes the error from the bad toml to the logs, allowing problems with it to be identified quicker and resolved.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![BLAZING](https://forthebadge.com/images/badges/made-with-rust.svg)

<details>
  <summary>Ferris warning</summary>
  
  ![image](https://user-images.githubusercontent.com/40974010/171547882-054185eb-f0b4-4c54-b44b-ca152f933c6f.png)

</details>

## Changelog

:cl: Armhulen/Armhulenn/Bazelart/Tralezab, san7890
admin: Word filters incorrectly set up will now have their errors actually described. Please, tell your server ops when you see it so they may fix the configuration.
server: Rust-g on this codebase is now on the 1.0.2 version, prepare accordingly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

I also bump rust-g's DLL to 1.0.2 in this PR as well.