### PR TITLE
Fixes runtime when screwdriving a card slot laying on the ground

### DIFF
--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -105,7 +105,7 @@
 
 	to_chat(user, span_notice("You remove the card from \the [src]."))
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
-	holder.update_appearance()
+	holder?.update_appearance()
 
 	stored_card = null
 	current_identification = null


### PR DESCRIPTION
Holder is null when it's on the ground.