### PR TITLE
Converts most storage item chat messages to balloon alerts

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -681,7 +681,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	var/amount = length(turf_things)
 	if(!amount)
-		to_chat(user, span_warning("You failed to pick up anything with [resolve_parent]!"))
+		resolve_parent.balloon_alert(user, "nothing to pick up!")
 		return
 
 	var/datum/progressbar/progress = new(user, amount, thing.loc)
@@ -691,7 +691,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		stoplag(1)
 
 	progress.end_progress()
-	to_chat(user, span_notice("You put everything you could [insert_preposition]to [resolve_parent]."))
+	resolve_parent.balloon_alert(user, "picked up")
 
 /// Signal handler for whenever we drag the storage somewhere.
 /datum/storage/proc/mousedrop_onto(datum/source, atom/over_object, mob/user)
@@ -926,7 +926,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	if(locked)
 		if(!silent)
-			to_chat(toshow, span_warning("[pick("Ka-chunk!", "Ka-chink!", "Plunk!", "Glorf!")] \The [resolve_parent] appears to be locked!"))
+			resolve_parent.balloon_alert(toshow, "locked!")
 		return FALSE
 
 	if(!quickdraw || toshow.get_active_held_item())
@@ -958,7 +958,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/put_in_hands_async(mob/toshow, obj/item/toremove)
 	if(!toshow.put_in_hands(toremove))
 		if(!silent)
-			to_chat(toshow, span_notice("You fumble for [toremove] and it falls on the floor."))
+			toremove.balloon_alert(toshow, "fumbled!")
 		return TRUE
 
 /// Signal handler for whenever a mob walks away with us, close if they can't reach us.
@@ -1072,11 +1072,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	collection_mode = (collection_mode+1)%3
 	switch(collection_mode)
 		if(COLLECT_SAME)
-			to_chat(user, span_notice("[resolve_parent] now picks up all items of a single type at once."))
+			resolve_parent.balloon_alert(user, "single type")
 		if(COLLECT_EVERYTHING)
-			to_chat(user, span_notice("[resolve_parent] now picks up all items in a tile at once."))
+			resolve_parent.balloon_alert(user, "all on tile")
 		if(COLLECT_ONE)
-			to_chat(user, span_notice("[resolve_parent] now picks up one item at a time."))
+			resolve_parent.balloon_alert(user, "single item")
 
 /// Gives a spiffy animation to our parent to represent opening and closing.
 /datum/storage/proc/animate_parent()

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -1072,11 +1072,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	collection_mode = (collection_mode+1)%3
 	switch(collection_mode)
 		if(COLLECT_SAME)
-			resolve_parent.balloon_alert(user, "single type")
+			resolve_parent.balloon_alert(user, "will now only pick up a single type")
 		if(COLLECT_EVERYTHING)
-			resolve_parent.balloon_alert(user, "all on tile")
+			resolve_parent.balloon_alert(user, "will now pick up everything")
 		if(COLLECT_ONE)
-			resolve_parent.balloon_alert(user, "single item")
+			resolve_parent.balloon_alert(user, "will now pick up one at a time")
 
 /// Gives a spiffy animation to our parent to represent opening and closing.
 /datum/storage/proc/animate_parent()

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -155,7 +155,7 @@
 				show_message = TRUE
 			else
 				if(!spam_protection)
-					src.balloon_alert(user, "bag full!")
+					balloon_alert(user, "bag full!")
 					spam_protection = TRUE
 					continue
 	if(show_message)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -155,7 +155,7 @@
 				show_message = TRUE
 			else
 				if(!spam_protection)
-					to_chat(user, span_warning("Your [name] is full and can't hold any more!"))
+					src.balloon_alert(user, "bag full!")
 					spam_protection = TRUE
 					continue
 	if(show_message)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -802,7 +802,7 @@
 		user.put_in_hands(I)
 		update_appearance()
 	else
-		to_chat(user, span_warning("[src] is empty!"))
+		balloon_alert(user, "empty!")
 
 /obj/item/storage/belt/sabre/update_icon_state()
 	icon_state = initial(inhand_icon_state)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -802,7 +802,7 @@
 		user.put_in_hands(I)
 		update_appearance()
 	else
-		balloon_alert(user, "empty!")
+		balloon_alert(user, "it's empty!")
 
 /obj/item/storage/belt/sabre/update_icon_state()
 	icon_state = initial(inhand_icon_state)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -15,7 +15,7 @@
 	atom_storage.max_slots = 1
 
 /obj/item/storage/book/attack_self(mob/user)
-	to_chat(user, span_notice("The pages of [title] have been cut out!"))
+	balloon_alert(user, "pages cut out!")
 
 GLOBAL_LIST_INIT(biblenames, list("Bible", "Quran", "Scrapbook", "Burning Bible", "Clown Bible", "Banana Bible", "Creeper Bible", "White Bible", "Holy Light", "The God Delusion", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "Melted Bible", "Necronomicon", "Insulationism", "Guru Granth Sahib"))
 //If you get these two lists not matching in size, there will be runtimes and I will hurt you in ways you couldn't even begin to imagine
@@ -129,7 +129,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	var/mob/living/carbon/human/H = L
 	for(var/obj/item/bodypart/bodypart as anything in H.bodyparts)
 		if(!IS_ORGANIC_LIMB(bodypart))
-			to_chat(user, span_warning("[src.deity_name] refuses to heal this metallic taint!"))
+			balloon_alert(user, "can't heal metal!")
 			return 0
 
 	var/heal_amt = 10
@@ -149,7 +149,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 /obj/item/storage/book/bible/attack(mob/living/M, mob/living/carbon/human/user, heal_mode = TRUE)
 
 	if (!ISADVANCEDTOOLUSER(user))
-		to_chat(user, span_warning("You don't have the dexterity to do this!"))
+		balloon_alert(user, "not dextrous enough!")
 		return
 
 	if (HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
@@ -172,7 +172,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 		return
 
 	if(user == M)
-		to_chat(user, span_warning("You can't heal yourself!"))
+		balloon_alert(user, "can't heal yourself!")
 		return
 
 	var/smack = TRUE
@@ -183,7 +183,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 		var/mob/living/carbon/C = M
 		if(!istype(C.head, /obj/item/clothing/head/helmet))
 			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5, 60)
-			to_chat(C, span_danger("You feel dumber."))
+			C.balloon_alert(C, "you feel dumber")
 
 	if(smack)
 		M.visible_message(span_danger("[user] beats [M] over the head with [src]!"), \
@@ -205,21 +205,21 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 				return
 			for(var/obj/effect/rune/nearby_runes in orange(2,user))
 				nearby_runes.invisibility = 0
-		to_chat(user, span_notice("You hit the floor with the bible."))
+		bible_smacked.balloon_alert(user, "floor smacked")
 
 	if(user?.mind?.holy_role)
 		if(bible_smacked.reagents && bible_smacked.reagents.has_reagent(/datum/reagent/water)) // blesses all the water in the holder
-			to_chat(user, span_notice("You bless [bible_smacked]."))
+			bible_smacked.balloon_alert(user, "blessed")
 			var/water2holy = bible_smacked.reagents.get_reagent_amount(/datum/reagent/water)
 			bible_smacked.reagents.del_reagent(/datum/reagent/water)
 			bible_smacked.reagents.add_reagent(/datum/reagent/water/holywater,water2holy)
 		if(bible_smacked.reagents && bible_smacked.reagents.has_reagent(/datum/reagent/fuel/unholywater)) // yeah yeah, copy pasted code - sue me
-			to_chat(user, span_notice("You purify [bible_smacked]."))
+			bible_smacked.balloon_alert(user, "purified")
 			var/unholy2clean = bible_smacked.reagents.get_reagent_amount(/datum/reagent/fuel/unholywater)
 			bible_smacked.reagents.del_reagent(/datum/reagent/fuel/unholywater)
 			bible_smacked.reagents.add_reagent(/datum/reagent/water/holywater,unholy2clean)
 		if(istype(bible_smacked, /obj/item/storage/book/bible) && !istype(bible_smacked, /obj/item/storage/book/bible/syndicate))
-			to_chat(user, span_notice("You purify [bible_smacked], conforming it to your belief."))
+			bible_smacked.balloon_alert(user, "converted")
 			var/obj/item/storage/book/bible/B = bible_smacked
 			B.name = name
 			B.icon_state = icon_state
@@ -227,7 +227,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 
 	if(istype(bible_smacked, /obj/item/cult_bastard) && !IS_CULTIST(user))
 		var/obj/item/cult_bastard/sword = bible_smacked
-		to_chat(user, span_notice("You begin to exorcise [sword]."))
+		bible_smacked.balloon_alert(user, "exorcising...")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,TRUE)
 		if(do_after(user, 40, target = sword))
 			playsound(src,'sound/effects/pray_chaplain.ogg',60,TRUE)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -61,12 +61,12 @@
 	if(!foldable || (flags_1 & HOLOGRAM_1))
 		return
 	if(contents.len)
-		to_chat(user, span_warning("You can't fold this box with items still inside!"))
+		balloon_alert(user, "items inside!")
 		return
 	if(!ispath(foldable))
 		return
 
-	to_chat(user, span_notice("You fold [src] flat."))
+	balloon_alert(user, "folded")
 	var/obj/item/I = new foldable
 	qdel(src)
 	user.put_in_hands(I)
@@ -834,12 +834,12 @@
 /obj/item/storage/box/clown/attackby(obj/item/I, mob/user, params)
 	if((istype(I, /obj/item/bodypart/l_arm/robot)) || (istype(I, /obj/item/bodypart/r_arm/robot)))
 		if(contents.len) //prevent accidently deleting contents
-			to_chat(user, span_warning("You need to empty [src] out first!"))
+			balloon_alert(user, "items inside!")
 			return
 		if(!user.temporarilyRemoveItemFromInventory(I))
 			return
 		qdel(I)
-		to_chat(user, span_notice("You add some wheels to the [src]! You've got a honkbot assembly now! Honk!"))
+		balloon_alert(user, "wheels added, honk!")
 		var/obj/item/bot_assembly/honkbot/A = new
 		qdel(src)
 		user.put_in_hands(A)
@@ -993,7 +993,7 @@
 				desc = "A paper sack with a crude smile etched onto the side."
 			else
 				return FALSE
-		to_chat(user, span_notice("You make some modifications to [src] using your pen."))
+		balloon_alert(user, "modified")
 		icon_state = "paperbag_[choice]"
 		inhand_icon_state = "paperbag_[choice]"
 		return FALSE
@@ -1024,10 +1024,10 @@
 	if(user.incapacitated())
 		return FALSE
 	if(contents.len)
-		to_chat(user, span_warning("You can't modify [src] with items still inside!"))
+		balloon_alert(user, "items inside!")
 		return FALSE
 	if(!P || !user.is_holding(P))
-		to_chat(user, span_warning("You need a pen to modify [src]!"))
+		balloon_alert(user, "needs pen!")
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -60,7 +60,7 @@
 	if(contents.len)
 		return
 	new fold_result(user.drop_location())
-	to_chat(user, span_notice("You fold the [src] into [initial(fold_result.name)]."))
+	balloon_alert(user, "folded")
 	user.put_in_active_hand(fold_result)
 	qdel(src)
 
@@ -166,7 +166,7 @@
 /obj/item/storage/fancy/candle_box/attack_self(mob/user)
 	if(!contents.len)
 		new fold_result(user.drop_location())
-		to_chat(user, span_notice("You fold the [src] into [initial(fold_result.name)]."))
+		balloon_alert(user, "folded")
 		user.put_in_active_hand(fold_result)
 		qdel(src)
 
@@ -202,7 +202,7 @@
 	if(contents.len != 0 || !spawn_coupon)
 		return ..()
 
-	to_chat(user, span_notice("You rip the back off \the [src] and get a coupon!"))
+	balloon_alert(user, "ooh, free coupon")
 	var/obj/item/coupon/attached_coupon = new
 	user.put_in_hands(attached_coupon)
 	attached_coupon.generate(rigged_omen)

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -24,27 +24,27 @@
 	var/locked = atom_storage.locked
 	if(W.GetID())
 		if(broken)
-			to_chat(user, span_danger("It appears to be broken."))
+			balloon_alert(user, "broken!")
 			return
 		if(allowed(user))
 			atom_storage.locked = !locked
 			locked = atom_storage.locked
 			if(locked)
 				icon_state = icon_locked
-				to_chat(user, span_danger("You lock the [src.name]!"))
 				atom_storage.close_all()
-				return
 			else
 				icon_state = icon_closed
-				to_chat(user, span_danger("You unlock the [src.name]!"))
-				return
+
+			balloon_alert(user, "[locked ? "locked" : "unlocked"]")
+			return
+
 		else
-			to_chat(user, span_danger("Access Denied."))
+			balloon_alert(user, "access denied!")
 			return
 	if(!locked)
 		return ..()
 	else
-		to_chat(user, span_danger("It's locked!"))
+		balloon_alert(user, "locked!")
 
 /obj/item/storage/lockbox/emag_act(mob/user)
 	if(!broken)
@@ -233,7 +233,7 @@
 		add_fingerprint(user)
 
 	if(id_card.registered_account != buyer_account)
-		to_chat(user, span_warning("Bank account does not match with buyer!"))
+		balloon_alert(user, "incorrect bank account!")
 		return
 
 	atom_storage.locked = !privacy_lock

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -35,7 +35,7 @@
 			else
 				icon_state = icon_closed
 
-			balloon_alert(user, "[locked ? "locked" : "unlocked"]")
+			balloon_alert(user, locked ? "locked" : "unlocked")
 			return
 
 		else

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -281,7 +281,7 @@
 
 	//Making a medibot!
 	if(contents.len >= 1)
-		to_chat(user, span_warning("You need to empty [src] out first!"))
+		balloon_alert(user, "items inside!")
 		return
 
 	var/obj/item/bot_assembly/medbot/medbot_assembly = new
@@ -296,7 +296,7 @@
 	else if (istype(src, /obj/item/storage/medkit/advanced))
 		medbot_assembly.set_skin("advanced")
 	user.put_in_hands(medbot_assembly)
-	to_chat(user, span_notice("You add [bodypart] to [src]."))
+	medbot_assembly.balloon_alert(user, "arm added")
 	medbot_assembly.robot_arm = bodypart.type
 	medbot_assembly.medkit_type = type
 	qdel(bodypart)
@@ -598,12 +598,12 @@
 		var/obj/item/reagent_containers/RC = I
 		var/units = RC.reagents.trans_to(src, RC.amount_per_transfer_from_this, transfered_by = user)
 		if(units)
-			to_chat(user, span_notice("You transfer [units] units of the solution to [src]."))
+			balloon_alert(user, "[units]u transferred")
 			return
 	if(istype(I, /obj/item/plunger))
-		to_chat(user, span_notice("You start furiously plunging [name]."))
+		balloon_alert(user, "plunging...")
 		if(do_after(user, 10, target = src))
-			to_chat(user, span_notice("You finish plunging the [name]."))
+			balloon_alert(user, "plunged")
 			reagents.clear_reagents()
 		return
 	return ..()

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -56,25 +56,25 @@
 /obj/item/storage/secure/screwdriver_act(mob/living/user, obj/item/tool)
 	if(tool.use_tool(src, user, 20))
 		panel_open = !panel_open
-		to_chat(user, span_notice("You [panel_open ? "open" : "close"] the service panel."))
+		balloon_alert(user, "panel [panel_open ? "opened" : "closed"]")
 		return TRUE
 
 /obj/item/storage/secure/multitool_act(mob/living/user, obj/item/tool)
 	. = TRUE
 	if(lock_hacking)
-		to_chat(user, span_danger("This safe is already being hacked."))
+		balloon_alert(user, "already hacking!")
 		return
 	if(panel_open == TRUE)
-		to_chat(user, span_danger("Now attempting to reset internal memory, please hold."))
+		balloon_alert(user, "hacking...")
 		lock_hacking = TRUE
 		if (tool.use_tool(src, user, 400))
-			to_chat(user, span_danger("Internal memory reset - lock has been disengaged."))
+			balloon_alert(user, "hacked")
 			lock_set = FALSE
 
 		lock_hacking = FALSE
 		return
 
-	to_chat(user, span_warning("You must <b>unscrew</b> the service panel before you can pulse the wiring!"))
+	balloon_alert(user, "unscrew panel!")
 
 /obj/item/storage/secure/attack_self(mob/user)
 	var/locked = atom_storage.locked

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -310,7 +310,7 @@
 	if(!is_type_in_list(src, allowed_toolbox) && (type != /obj/item/storage/toolbox))
 		return
 	if(contents.len >= 1)
-		balloon_alert(user, "stuff inside!")
+		balloon_alert(user, "not empty!")
 		return
 	if(T.use(10))
 		var/obj/item/bot_assembly/floorbot/B = new

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -310,7 +310,7 @@
 	if(!is_type_in_list(src, allowed_toolbox) && (type != /obj/item/storage/toolbox))
 		return
 	if(contents.len >= 1)
-		to_chat(user, span_warning("They won't fit in, as there is already stuff inside!"))
+		balloon_alert(user, "stuff inside!")
 		return
 	if(T.use(10))
 		var/obj/item/bot_assembly/floorbot/B = new
@@ -328,10 +328,10 @@
 				B.toolbox_color = "s"
 		user.put_in_hands(B)
 		B.update_appearance()
-		to_chat(user, span_notice("You add the tiles into the empty [name]. They protrude from the top."))
+		B.balloon_alert(user, "tiles added")
 		qdel(src)
 	else
-		to_chat(user, span_warning("You need 10 floor tiles to start building a floorbot!"))
+		balloon_alert(user, "needs 10 tiles!")
 		return
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This mostly just converts the chat messages of the storage items themselves, not things related to having a storage. A lot of them serve good purpose being in the chat box, so if you forget where you put something you can look in chat.

I left alone the ones that were more flavorful or didn't translate well to balloon alerts.

I was making a pretty large PR to `obj/item/storage` that included this that a maintainer told me I should atomize.

## Why It's Good For The Game

Nicer looking feedback, less clutter in the chat box.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: most storage item chat messages have been replaced with balloon alerts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
