### PR TITLE
Add when bubblegum megafauna devours corpses it now spawns demonic bubblegum candy

### DIFF
--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -438,7 +438,7 @@
 	desc = "A rubbery strip of gum. You don't feel like eating it is a good idea."
 	color = "#913D3D"
 	food_reagents = list(/datum/reagent/blood = 15)
-	tastes = list("hell" = 1)
+	tastes = list("hell" = 1, "people" = 1)
 	metabolization_amount = REAGENTS_METABOLISM
 	/// What the player hears from the bubblegum hallucination, and also says one of these when suiciding
 	var/static/list/hallucination_lines = list("I AM IMMORTAL.", "I SHALL TAKE YOUR WORLD.", "I SEE YOU.", "YOU CANNOT ESCAPE ME FOREVER.", "NOTHING CAN HOLD ME.")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -232,7 +232,7 @@ Difficulty: Hard
 	. = ..()
 	if(. == TRUE) // a corpse was devoured
 		// bubblegum bubblegum in a dish, how many corpses do you wish?
-		new /obj/item/food/bubblegum/bubblegum(yummy_food)
+		new /obj/item/food/bubblegum/bubblegum(src)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/be_aggressive()
 	if(BUBBLEGUM_IS_ENRAGED)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -232,7 +232,7 @@ Difficulty: Hard
 	. = ..()
 	if(. == TRUE) // a corpse was devoured
 		// bubblegum bubblegum in a dish, how many corpses do you wish?
-		new /obj/item/food/bubblegum/bubblegum(src)
+		new /obj/item/food/bubblegum/bubblegum(loc)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/be_aggressive()
 	if(BUBBLEGUM_IS_ENRAGED)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -228,7 +228,11 @@ Difficulty: Hard
 				addtimer(CALLBACK(src, .proc/devour, L), 2)
 	SLEEP_CHECK_DEATH(1, src)
 
-
+/mob/living/simple_animal/hostile/megafauna/bubblegum/devour(mob/living/yummy_food)
+	. = ..()
+	if(. == TRUE) // a corpse was devoured
+		// bubblegum bubblegum in a dish, how many corpses do you wish?
+		new /obj/item/food/bubblegum/bubblegum(yummy_food)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/be_aggressive()
 	if(BUBBLEGUM_IS_ENRAGED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This spawns a demonic bubblegum candy if the Bubblegum megafauna successfully devours a corpse.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

_♫ - Bubblegum bubblegum in a dish, how many corpses do you wish? - ♫_

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: timothymtorres
add: Bubblegum now spawns demonic bubblegum candy when they devour corpses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
