### PR TITLE
Ranged analyzer qol

### DIFF
--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -204,8 +204,4 @@
 	. = ..()
 	if(!can_see(user, target, 15))
 		return
-	if(!target.return_analyzable_air())
-		var/target_turf = get_turf(target)
-		atmos_scan(user, target_turf)
-	else 
-		atmos_scan(user, target)
+	atmos_scan(user, (target.return_analyzable_air() ? target : get_turf(target)))

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -202,6 +202,10 @@
 
 /obj/item/analyzer/ranged/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
-	if(!can_see(user, target, 7))
+	if(!can_see(user, target, 15))
 		return
-	atmos_scan(user, target)
+	if(!target.return_analyzable_air())
+		var/target_turf = get_turf(target)
+		atmos_scan(user, target_turf)
+	else 
+		atmos_scan(user, target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So the ranged analyzer would only scan the turf atmos if the target being clicked on is a turf, this can get really annoying if the target you are trying to click is a machine or table which cover most of the turf. This pr makes it so the analyzer will scan the turf of the target if the target has no air content to scan to begin with. I also increased the los range for it since the default view range for spess man is 7 by 15 tiles
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Some quality of life for the atmos player, now they dont have to pixel hunt for the turf pixel inorder to scan the air
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: ranged analyzer is now able to scan the tile of machines and tables without clicking on the tile directly
qol: ranged analyzer can now scan further upward to 15 tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
