### PR TITLE
Fixes cleanbot animation & speed

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -36,6 +36,9 @@
 	var/weapon_orig_force = 0
 	var/chosen_name
 
+	/// The time it takes for the cleanbot to clean something.
+	#define CLEANING_TIME (1 SECONDS)
+
 	var/list/stolen_valor = list()
 
 	var/static/list/officers_titles = list(
@@ -143,7 +146,7 @@
 
 /mob/living/simple_animal/bot/cleanbot/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/cleaner, 0.1 SECONDS)
+	AddComponent(/datum/component/cleaner, CLEANING_TIME,  on_cleaned_callback=CALLBACK(src, /atom/.proc/update_icon_state))
 
 	chosen_name = name
 	get_targets()
@@ -357,7 +360,7 @@
 		start_cleaning(src, T, src)
 		target = null
 		mode = BOT_IDLE
-		update_icon_state()
+
 	else if(istype(A, /obj/item) || istype(A, /obj/effect/decal/remains))
 		visible_message(span_danger("[src] sprays hydrofluoric acid at [A]!"))
 		playsound(src, 'sound/effects/spray2.ogg', 50, TRUE, -6)

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -37,7 +37,7 @@
 	var/chosen_name
 
 	/// The time it takes for the cleanbot to clean something.
-	#define CLEANING_TIME (1 SECONDS)
+	var/cleaning_time = 1 SECONDS
 
 	var/list/stolen_valor = list()
 
@@ -146,7 +146,7 @@
 
 /mob/living/simple_animal/bot/cleanbot/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/cleaner, CLEANING_TIME,  on_cleaned_callback=CALLBACK(src, /atom/.proc/update_icon_state))
+	AddComponent(/datum/component/cleaner, cleaning_time, on_cleaned_callback=CALLBACK(src, /atom/.proc/update_icon_state))
 
 	chosen_name = name
 	get_targets()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #68682. Cleanbot animation displaying was based off of the delay of the do_after, and since that was removed, the animation would be instantly undone.

Also, the cleaning time was a decisecond instead of a second.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: cleanbots will display their cleaning animation and clean at the right speed again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
