### PR TITLE
STORAGE STUCK! PLEASE! I BEG YOU!

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -134,12 +134,15 @@
 /datum/storage/Destroy()
 	parent = null
 	real_location = null
-	boxes = null
-	closer = null
 
 	for(var/mob/person in is_using)
 		if(person.active_storage == src)
 			person.active_storage = null
+			person.client?.screen -= boxes
+			person.client?.screen -= closer
+
+	QDEL_NULL(boxes)
+	QDEL_NULL(closer)
 
 	is_using.Cut()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The phantom exterior like clown eggs interior like suicide wrist-red. I could holodeck you, this could be your phys-ed. Cheat on your spaceman AAGH I tried to close the storage man! Can't close it. Can't close it. Shit's stuck. Outta my screen son! STORAGE STUCK! STORAGE STUCK! PLEASE! I BEG YOU! We're runtiming. You're a genuine dick sucker.

## Why It's Good For The Game

storage UIs no longer get stuck on the screen

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: storage UI no longer gets stuck on the screen due to an oversight
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
