### PR TITLE
Fixes some quirks with motorised wheelchair density

### DIFF
--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -128,7 +128,7 @@
 	. = ..()
 	if (.)
 		return
-	if (!(obj_flags & EMAGGED) || !has_buckled_mobs())
+	if (!has_buckled_mobs())
 		return
 	for (var/mob/living/guy in newloc)
 		if(!(guy in buckled_mobs))

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -56,14 +56,6 @@
 		return FALSE
 	return ..()
 
-/obj/vehicle/ridden/wheelchair/motorized/post_buckle_mob(mob/living/user)
-	. = ..()
-	set_density(TRUE)
-
-/obj/vehicle/ridden/wheelchair/motorized/post_unbuckle_mob()
-	. = ..()
-	set_density(FALSE)
-
 /obj/vehicle/ridden/wheelchair/motorized/attack_hand(mob/living/user, list/modifiers)
 	if(!power_cell || !panel_open)
 		return ..()
@@ -131,6 +123,16 @@
 	. += "Speed: [speed]"
 	. += "Energy efficiency: [power_efficiency]"
 	. += "Power: [power_cell.charge] out of [power_cell.maxcharge]"
+
+/obj/vehicle/ridden/wheelchair/motorized/Move(newloc, direct)
+	. = ..()
+	if (.)
+		return
+	if (!(obj_flags & EMAGGED) || !has_buckled_mobs())
+		return
+	for (var/mob/living/guy in newloc)
+		if(!(guy in buckled_mobs))
+			Bump(guy)
 
 /obj/vehicle/ridden/wheelchair/motorized/Bump(atom/A)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/67921 and https://github.com/tgstation/tgstation/issues/58062

Problem: Motorised Wheelchairs (unlike manual ones) become dense when a mob is buckled. This means you can't trample pun-pun any more, and also means that you can't build certain structures while riding one but can in a manual wheelchair.
Solution: Don't become dense while buckled to a motorised wheelchair.

Problem: Without being dense, Bump will not be called on living mobs you drive into, and so the emag bomb doesn't explode when you run into someone.
Solution: Manually track when we try to bump living mobs and Bump them.
I don't like this solution very much but it was the only way I could think of to preserve existing desired behaviour without making the wheelchair Dense, which itself causes other bugs. 

Perhaps the wheelchair emag response could do with being replaced with something less lazy (why can it materialise a bomb?) but then this would be a balance/feature PR and not a bug fix.

## Why It's Good For The Game

It's good for the two kinds of wheelchair to act consistently, especially if the manual behaviour is more desirable than the motorised behaviour.
It's annoying for people to carry around two wheelchairs so that they can get into a different one if they want to build several walls without crawling around on the ground.
It's funny to run pun-pun over with your chair.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Construction and ape-crushing behaviour should be more consistent between manual and motorised wheelchairs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
