### PR TITLE
Fixes Stray Cargo Pod event runtime

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -48,6 +48,9 @@
 	if(paying_account)
 		C = new /obj/structure/closet/crate/secure/owned(A, paying_account)
 		C.name = "[crate_name] - Purchased by [paying_account.account_holder]"
+	else if(!crate_type)
+		stack_trace("tried to generate a supply pack without a valid crate type")
+		return
 	else
 		C = new crate_type(A)
 		C.name = crate_name

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -49,7 +49,7 @@
 		C = new /obj/structure/closet/crate/secure/owned(A, paying_account)
 		C.name = "[crate_name] - Purchased by [paying_account.account_holder]"
 	else if(!crate_type)
-		CHRASH("tried to generate a supply pack without a valid crate type")
+		CRASH("tried to generate a supply pack without a valid crate type")
 	else
 		C = new crate_type(A)
 		C.name = crate_name

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2729,6 +2729,9 @@
 	crate_type = null
 	special_pod = /obj/structure/closet/supplypod/bluespacepod
 
+/datum/supply_pack/misc/empty/generate(atom/A, datum/bank_account/paying_account)
+	return
+
 /datum/supply_pack/misc/religious_supplies
 	name = "Religious Supplies Crate"
 	desc = "Keep your local chaplain happy and well-supplied, lest they call down judgement upon your cargo bay. Contains two bottles of holywater, bibles, chaplain robes, and burial garmets."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -49,8 +49,7 @@
 		C = new /obj/structure/closet/crate/secure/owned(A, paying_account)
 		C.name = "[crate_name] - Purchased by [paying_account.account_holder]"
 	else if(!crate_type)
-		stack_trace("tried to generate a supply pack without a valid crate type")
-		return
+		CHRASH("tried to generate a supply pack without a valid crate type")
 	else
 		C = new crate_type(A)
 		C.name = crate_name

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -52,8 +52,9 @@
 		pack_type = pick(stray_spawnable_supply_packs)
 	var/datum/supply_pack/SP = new pack_type
 	var/obj/structure/closet/crate/crate = SP.generate(null)
-	crate.locked = FALSE //Unlock secure crates
-	crate.update_appearance()
+	if(crate) //empty supply packs are a thing! get memed on.
+		crate.locked = FALSE //Unlock secure crates
+		crate.update_appearance()
 	var/obj/structure/closet/supplypod/pod = make_pod()
 	new /obj/effect/pod_landingzone(LZ, pod, crate)
 


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed the Stray Cargo Pod event failing to occur if it tried to send an empty cargo pod.
/:cl:
