### PR TITLE
makes the tablet messenger deletable, adds 2 GQ of storage to it

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -5,8 +5,7 @@
 	program_icon_state = "command"
 	program_state = PROGRAM_STATE_BACKGROUND
 	extended_desc = "This program allows old-school communication with other modular devices."
-	size = 0
-	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
+	size = 2
 	available_on_ntnet = FALSE
 	usage_flags = PROGRAM_TABLET
 	ui_header = "ntnrc_idle.gif"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the nt messenger application is no longer undeletable and hard baked into the PDA, and takes up minimal storage at 2 GQ.

## Why It's Good For The Game

when the original pda refactor rolled around created by me, making the messenger deletable was an intentional choice. i was not even aware that this was changed later on.
 
the idea of making the application deletable is the fact that, if you choose, you can upgrade to a different tablet all together, and take the entirety of your messaging history with you. this also provides ample roleplaying opportunity for "hiding" your chat history by getting rid of the software itself, or stealing other people's chat history.

the original nt messenger size was definitely too high previously at 8 GQ, and has been lowered to 2 GQ as a balance.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: the nt messenger is now deletable once again, and takes up 2 GQ of space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
