### PR TITLE
[MDB Ignore] nightmare heart is deleted when consumed instead of being dropped

### DIFF
--- a/code/modules/antagonists/nightmare/nightmare_organs.dm
+++ b/code/modules/antagonists/nightmare/nightmare_organs.dm
@@ -53,7 +53,7 @@
 		span_warning("Blood erupts from [user]'s arm as it reforms into a weapon!"),
 		span_userdanger("Icy blood pumps through your veins as your arm reforms itself!")
 	)
-	user.temporarilyRemoveItemFromInventory(src, TRUE)
+	QDEL_NULL(src)//heart is used
 	Insert(user)
 
 /obj/item/organ/internal/heart/nightmare/Insert(mob/living/carbon/M, special = FALSE)


### PR DESCRIPTION
## About The Pull Request

changes the heart dropping on the floor when used to being deleted

## Why It's Good For The Game

this lines up with the text around it :

![image](https://user-images.githubusercontent.com/85910816/180671433-706468ab-dd48-45cc-bedd-f5a351db5ee5.png)

## Changelog

:cl:
balance: A nightmare's heart will now be consumed completely when eaten.
/:cl:
