### PR TITLE
[s] Fixes AI core duplication bug / runtime

### DIFF
--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -424,7 +424,7 @@ That prevents a few funky behaviors.
 		to_chat(user, "[span_boldnotice("Transfer successful")]: [AI.name] ([rand(1000,9999)].exe) installed and executed successfully. Local copy has been removed.")
 		card.AI = null
 		AI.battery = circuit.battery
-		if(core_mmi.braintype == "Android")
+		if(core_mmi && core_mmi.braintype == "Android")
 			AI.posibrain_inside = TRUE
 		else
 			AI.posibrain_inside = FALSE


### PR DESCRIPTION
Missing sanity check. 

Fixes #68710

:cl: ShizCalev
fix: Transferring a carded AI to an empty core will no longer result in a second AI core appearing.
/:cl:
