### PR TITLE
Fixes the freezing component

### DIFF
--- a/code/datums/elements/frozen.dm
+++ b/code/datums/elements/frozen.dm
@@ -22,12 +22,14 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 	target_obj.alpha -= 25
 
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/on_moved)
-	RegisterSignal(target, COMSIG_MOVABLE_POST_THROW, .proc/shatter_on_throw)
+	RegisterSignal(target, COMSIG_MOVABLE_THROW_LANDED, .proc/shatter_on_throw)
+	RegisterSignal(target, COMSIG_MOVABLE_IMPACT, .proc/shatter_on_throw)
 	RegisterSignal(target, COMSIG_OBJ_UNFREEZE, .proc/on_unfreeze)
 
 /datum/element/frozen/Detach(datum/source, ...)
 	var/obj/obj_source = source
 	REMOVE_TRAIT(obj_source, TRAIT_FROZEN, ELEMENT_TRAIT(type))
+	UnregisterSignal(obj_source, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_THROW_LANDED, COMSIG_MOVABLE_IMPACT, COMSIG_OBJ_UNFREEZE))
 	obj_source.name = replacetext(obj_source.name, "frozen ", "")
 	obj_source.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, GLOB.freon_color_matrix)
 	obj_source.alpha += 25
@@ -49,10 +51,14 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 /// our melting temperature.
 /datum/element/frozen/proc/on_moved(datum/target)
 	SIGNAL_HANDLER
-	var/obj/obj_target = target
-	if(!isopenturf(obj_target.loc))
+	var/atom/movable/movable_target = target
+
+	if(movable_target.throwing)
 		return
 
-	var/turf/open/turf_loc = obj_target.loc
+	if(!isopenturf(movable_target.loc))
+		return
+
+	var/turf/open/turf_loc = movable_target.loc
 	if(turf_loc.air?.temperature >= T0C)//unfreezes target
 		Detach(target)


### PR DESCRIPTION

## About The Pull Request

The freezing component had some issues. It did not clean up the signals, only the colour filter, resulting in unfrozen thrown items still shattering. In addition, it was using the incorrect signal for shattering. The frozen item shattered the immediate moment when the throwing datum finished setting up. This PR fixes these issues.

Additionally, I made frozen items not unfreeze when hurled over warm tiles, because i thought that would be neat.

Fixes #68470

## Why It's Good For The Game

Unfreezing items should mean that they are once again safe to chuck at people. Meanwhile, thrown items should actually hit people before shattering.

## Changelog

:cl:
fix: unfrozen items no longer break when thrown
/:cl:
