### PR TITLE
Cursed heart revamp.

### DIFF
--- a/code/datums/status_effects/debuffs/curse.dm
+++ b/code/datums/status_effects/debuffs/curse.dm
@@ -165,19 +165,14 @@
 	if(curse_value >= 81)
 		owner.blood_volume = max(owner.blood_volume - 5, 0)
 		if(owner.stat == CONSCIOUS && prob(5))
-			to_chat(owner, span_warning("Maybe you should lie down for a bit..."))
+			to_chat(owner, span_userdanger("You feel a strong stinging sensation in your chest!"))
 
 	// Over 91, we gain even more toxloss, brain damage, and have a chance of dropping into a long sleep
 	if(curse_value >= 91)
 		owner.blood_volume = max(owner.blood_volume - 7, 0)
 		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.4)
 		if(owner.stat == CONSCIOUS && prob(20))
-			// Don't put us in a deep sleep if the shuttle's here. QoL, mainly.
-			if(SSshuttle.emergency.mode == SHUTTLE_DOCKED && is_station_level(owner.z))
-				to_chat(owner, span_warning("You're so tired... but you can't miss that shuttle..."))
-
-			else
-				to_chat(owner, span_warning("Just a quick nap..."))
+				to_chat(owner, span_userdanger("You collapse as a black ooze glazes your eyes shut!"))
 				owner.Sleeping(90 SECONDS)
 
 	// And finally, over 100 - let's be honest, you shouldn't be alive by now.

--- a/code/datums/status_effects/debuffs/curse.dm
+++ b/code/datums/status_effects/debuffs/curse.dm
@@ -30,13 +30,13 @@
 	switch(curse_value)
 		if(11 to 21)
 			return span_warning("[owner.p_they(TRUE)] [owner.p_are()] slightly pale.")
-		if(21.01 to 41)
+		if(21 to 41)
 			return span_warning("[owner.p_they(TRUE)] [owner.p_are()] flushed, [owner.p_their()] eyes are glassy and vacant.")
-		if(41.01 to 61)
+		if(41 to 61)
 			return span_warning("[owner.p_their(TRUE)] heart is practically beating out of [owner.p_their()] chest!")
-		if(61.01 to 91)
+		if(61 to 91)
 			return span_warning("[owner.p_they(TRUE)] look[owner.p_s()] sick to [owner.p_their()] stomach with a purple ooze running down [owner.p_their()] chin.")
-		if(91.01 to INFINITY)
+		if(91 to INFINITY)
 			return span_warning("[owner.p_they(TRUE)] [owner.p_are()] at the mercy of [owner.p_their()] curse.")
 
 	return null

--- a/code/datums/status_effects/debuffs/curse.dm
+++ b/code/datums/status_effects/debuffs/curse.dm
@@ -33,11 +33,11 @@
 		if(21.01 to 41)
 			return span_warning("[owner.p_they(TRUE)] [owner.p_are()] flushed, [owner.p_their()] eyes are glassy and vacant.")
 		if(41.01 to 61)
-			return span_warning("[owner.p_they(TRUE)][owner.p_s()] heart is practically beating out of [owner.p_their()] chest!")
+			return span_warning("[owner.p_their(TRUE)] heart is practically beating out of [owner.p_their()] chest!")
 		if(61.01 to 91)
-			return span_warning("[owner.p_they(TRUE)] look[owner.p_s()] sick to [owner.p_their()] stomach with a black ooze running down their chin.")
+			return span_warning("[owner.p_they(TRUE)] look[owner.p_s()] sick to [owner.p_their()] stomach with a purple ooze running down [owner.p_their()] chin.")
 		if(91.01 to INFINITY)
-			return span_warning("[owner.p_they(TRUE)] [owner.p_are()] at the mercy of their curse.")
+			return span_warning("[owner.p_they(TRUE)] [owner.p_are()] at the mercy of [owner.p_their()] curse.")
 
 	return null
 
@@ -133,10 +133,11 @@
 
 	// Over 11, we will constantly gain slurring up to 10 seconds of slurring.
 	if(curse_value >= 11)
-		to_chat(owner, span_warning("You feel as if your heart it gnawing on itself!"))
+		to_chat(owner, span_warning("You feel your heart gnawing itself!"))
 
 	// Over 31, we have a 30% chance to gain confusion, and we will always have 20 seconds of dizziness.
 	if(curse_value >= 31)
+		owner.add_movespeed_modifier(/datum/movespeed_modifier/sanity/crazy)
 		if(prob(30))
 			owner.adjust_timed_status_effect(2 SECONDS, /datum/status_effect/confusion)
 
@@ -149,16 +150,19 @@
 			owner.adjust_timed_status_effect(15 SECONDS, /datum/status_effect/confusion)
 			if(iscarbon(owner))
 				var/mob/living/carbon/carbon_owner = owner
-				var/obj/item/organ/internal/heart/new_heart = carbon_owner
 				// 20% chance the vomit will expell the curse.
 				if(prob(20))
-					carbon_owner.vomit(blood = TRUE, vomit_type = VOMIT_PURPLE)
-					new_heart.Insert(carbon_owner, special = 0, drop_if_replaced = FALSE)
+					var/obj/item/organ/internal/heart/new_heart = new(get_turf(carbon_owner))
+					carbon_owner.vomit(vomit_type = VOMIT_PURPLE)
+					new_heart.Insert(carbon_owner, drop_if_replaced = FALSE)
+					to_chat(owner, span_userdanger("You expell the curse in your vomit!"))
+					carbon_owner.set_curse_effect(0)
 				else
 					carbon_owner.vomit(blood = TRUE) // Vomiting clears toxloss - consider this a blessing
 
 	// Over 71, we will constantly have blurry eyes
 	if(curse_value >= 71)
+		owner.add_movespeed_modifier(/datum/movespeed_modifier/sanity/insane)
 		owner.blur_eyes(curse_value - 70)
 
 	// Over 81, we will gain constant bloodloss
@@ -171,9 +175,16 @@
 	if(curse_value >= 91)
 		owner.blood_volume = max(owner.blood_volume - 7, 0)
 		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.4)
+		var/mob/living/carbon/carbon_owner = owner
+		var/obj/item/organ/internal/heart/new_heart = new(get_turf(carbon_owner))
+		// Passing out will remove the curse.
 		if(owner.stat == CONSCIOUS && prob(20))
-				to_chat(owner, span_userdanger("You collapse as a black ooze glazes your eyes shut!"))
-				owner.Sleeping(90 SECONDS)
+			to_chat(owner, span_userdanger("You collapse as a purple ooze glazes your eyes shut! You feel the curse is expelled."))
+			carbon_owner.vomit(vomit_type = VOMIT_PURPLE)
+			carbon_owner.remove_client_colour(/datum/client_colour/cursed_heart_blood)
+			new_heart.Insert(carbon_owner, drop_if_replaced = TRUE)
+			carbon_owner.set_curse_effect(0)
+			owner.Sleeping(90 SECONDS)
 
 	// And finally, over 100 - let's be honest, you shouldn't be alive by now.
 	if(curse_value >= 101)

--- a/code/datums/status_effects/debuffs/curse.dm
+++ b/code/datums/status_effects/debuffs/curse.dm
@@ -1,0 +1,196 @@
+#define SEVERE_THRESHOLD 6
+
+/**
+ * The cursed status effect.
+ * Increasingly worse effects are added as the heart is not pumped.
+ * See drunk.dm for reference.
+ */
+/datum/status_effect/cursed
+	id = "cursed"
+	tick_interval = 2 SECONDS
+	status_type = STATUS_EFFECT_REPLACE
+	var/curse_value = 0
+
+/datum/status_effect/cursed/on_creation(mob/living/new_owner, curse_value = 0)
+	. = ..()
+	set_curse_value(curse_value)
+
+/datum/status_effect/cursed/on_apply()
+	RegisterSignal(owner, COMSIG_LIVING_POST_FULLY_HEAL, .proc/clear_curse)
+	return TRUE
+
+/datum/status_effect/cursed/on_remove()
+	UnregisterSignal(owner, COMSIG_LIVING_POST_FULLY_HEAL)
+
+/datum/status_effect/cursed/get_examine_text()
+	// Dead people don't seem cursed
+	if(owner.stat == DEAD || HAS_TRAIT(owner, TRAIT_FAKEDEATH))
+		return null
+
+	switch(curse_value)
+		if(11 to 21)
+			return span_warning("[owner.p_they(TRUE)] [owner.p_are()] slightly pale.")
+		if(21.01 to 41)
+			return span_warning("[owner.p_they(TRUE)] [owner.p_are()] flushed, [owner.p_their()] eyes are glassy and vacant.")
+		if(41.01 to 61)
+			return span_warning("[owner.p_they(TRUE)][owner.p_s()] heart is practically beating out of [owner.p_their()] chest!")
+		if(61.01 to 91)
+			return span_warning("[owner.p_they(TRUE)] look[owner.p_s()] sick to [owner.p_their()] stomach with a black ooze running down their chin.")
+		if(91.01 to INFINITY)
+			return span_warning("[owner.p_they(TRUE)] [owner.p_are()] at the mercy of their curse.")
+
+	return null
+
+/// Removes all of our curse (self-deletes) on signal.
+/datum/status_effect/cursed/proc/clear_curse(mob/living/source)
+	SIGNAL_HANDLER
+
+	qdel(src)
+
+/// Sets the curse value to set_to, deleting if the value drops to 0 or lower
+/datum/status_effect/cursed/proc/set_curse_value(set_to)
+	if(!isnum(set_to))
+		CRASH("[type] - invalid value passed to set_curse_value. (Got: [set_to])")
+
+	curse_value = set_to
+	if(curse_value <= 0)
+		qdel(src)
+
+/datum/status_effect/cursed/tick()
+	// curse value does not decrease while dead
+	if(owner.stat == DEAD)
+		return
+
+	// Every tick, the curse value decrases by
+	// 4% the current curse_value + 0.01
+	// (until it reaches 0 and terminates)
+	set_curse_value(curse_value - (0.01 + curse_value * 0.04))
+	if(QDELETED(src))
+		return
+
+	on_tick_effects()
+
+/// Side effects done by this level of curse on tick.
+/datum/status_effect/cursed/proc/on_tick_effects()
+	return
+
+/**
+ * Stage 1 of cursed, applied at curse values between 0 and 6.
+ * Basically is the "curse but no side effects" stage.
+ */
+/datum/status_effect/cursed/nauseous
+	alert_type = null
+
+/datum/status_effect/cursed/nauseous/set_curse_value(set_to)
+	. = ..()
+	if(QDELETED(src))
+		return
+
+	// Become fully cursed at over than 6 curse value
+	if(curse_value >= SEVERE_THRESHOLD)
+		owner.apply_status_effect(/datum/status_effect/cursed/severe, curse_value)
+
+/**
+ * Stage 2 of being curse, applied at curse values between 6 and onward.
+ * Has all the main side effects of being curse, scaling up as they get more curse.
+ */
+/datum/status_effect/cursed/severe
+	alert_type = /atom/movable/screen/alert/status_effect/cursed
+
+/datum/status_effect/cursed/severe/on_apply()
+	. = ..()
+	owner.sound_environment_override = SOUND_ENVIRONMENT_PSYCHOTIC
+
+/datum/status_effect/cursed/severe/on_remove()
+	clear_effects()
+	return ..()
+
+// Going from "cursed" to "nauseous" should remove effects like on_remove
+/datum/status_effect/cursed/severe/be_replaced()
+	clear_effects()
+	return ..()
+
+/// Clears any side effects we set due to being cursed.
+/datum/status_effect/cursed/severe/proc/clear_effects()
+	SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, id)
+
+	if(owner.sound_environment_override == SOUND_ENVIRONMENT_PSYCHOTIC)
+		owner.sound_environment_override = SOUND_ENVIRONMENT_NONE
+
+/datum/status_effect/cursed/severe/set_curse_value(set_to)
+	. = ..()
+	if(QDELETED(src))
+		return
+
+	// Return to "tipsyness" when we're below 6.
+	if(curse_value < SEVERE_THRESHOLD)
+		owner.apply_status_effect(/datum/status_effect/cursed/nauseous, curse_value)
+
+/datum/status_effect/cursed/severe/on_tick_effects()
+	// There's always a 30% chance to jitter.
+	if(prob(30))
+		owner.adjust_timed_status_effect(3 SECONDS, /datum/status_effect/jitter)
+
+	// Over 11, we will constantly gain slurring up to 10 seconds of slurring.
+	if(curse_value >= 11)
+		to_chat(owner, span_warning("You feel as if your heart it gnawing on itself!"))
+
+	// Over 31, we have a 30% chance to gain confusion, and we will always have 20 seconds of dizziness.
+	if(curse_value >= 31)
+		if(prob(30))
+			owner.adjust_timed_status_effect(2 SECONDS, /datum/status_effect/confusion)
+
+		owner.set_timed_status_effect(20 SECONDS, /datum/status_effect/dizziness, only_if_higher = TRUE)
+
+	// Over 51, we have a 3% chance to gain a lot of confusion and vomit, and we will always have 50 seconds of dizziness
+	if(curse_value >= 51)
+		owner.set_timed_status_effect(50 SECONDS, /datum/status_effect/dizziness, only_if_higher = TRUE)
+		if(prob(4))
+			owner.adjust_timed_status_effect(15 SECONDS, /datum/status_effect/confusion)
+			if(iscarbon(owner))
+				var/mob/living/carbon/carbon_owner = owner
+				var/obj/item/organ/internal/heart/new_heart = carbon_owner
+				// 20% chance the vomit will expell the curse.
+				if(prob(20))
+					carbon_owner.vomit(blood = TRUE, vomit_type = VOMIT_PURPLE)
+					new_heart.Insert(carbon_owner, special = 0, drop_if_replaced = FALSE)
+				else
+					carbon_owner.vomit(blood = TRUE) // Vomiting clears toxloss - consider this a blessing
+
+	// Over 71, we will constantly have blurry eyes
+	if(curse_value >= 71)
+		owner.blur_eyes(curse_value - 70)
+
+	// Over 81, we will gain constant bloodloss
+	if(curse_value >= 81)
+		owner.blood_volume = max(owner.blood_volume - 5, 0)
+		if(owner.stat == CONSCIOUS && prob(5))
+			to_chat(owner, span_warning("Maybe you should lie down for a bit..."))
+
+	// Over 91, we gain even more toxloss, brain damage, and have a chance of dropping into a long sleep
+	if(curse_value >= 91)
+		owner.blood_volume = max(owner.blood_volume - 7, 0)
+		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.4)
+		if(owner.stat == CONSCIOUS && prob(20))
+			// Don't put us in a deep sleep if the shuttle's here. QoL, mainly.
+			if(SSshuttle.emergency.mode == SHUTTLE_DOCKED && is_station_level(owner.z))
+				to_chat(owner, span_warning("You're so tired... but you can't miss that shuttle..."))
+
+			else
+				to_chat(owner, span_warning("Just a quick nap..."))
+				owner.Sleeping(90 SECONDS)
+
+	// And finally, over 100 - let's be honest, you shouldn't be alive by now.
+	if(curse_value >= 101)
+		owner.blood_volume = max(owner.blood_volume - 15, 0)
+
+/// Status effect for having a severe curse.
+/atom/movable/screen/alert/status_effect/cursed
+	name = "Cursed"
+	desc = "You feel a cool wave over your body as you forget the last time \
+		your heart has beat. You should beat it before the curse worsens."
+	icon = 'icons/obj/surgery.dmi'
+	icon_state = "cursedheart"
+
+
+#undef SEVERE_THRESHOLD

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -143,7 +143,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 		if(3)
 			new /obj/item/reagent_containers/glass/bottle/potion/flight(loc)
 		if(4)
-			new /obj/item/organ/internal/heart/cursed/wizard(loc)
+			new /obj/item/organ/internal/heart/cursed(loc)
 		if(5)
 			new /obj/item/jacobs_ladder(loc)
 		if(6)

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -294,6 +294,8 @@
 
 //Provides a decent heal, need to pump every 6 seconds
 /obj/item/organ/internal/heart/cursed/wizard
+	name = "infused cursed heart"
+	desc = "A heart that, when inserted, will force you to pump it manually. Something about it makes you feel more alive than ever."
 	pump_delay = 60
 	heal_brute = 25
 	heal_burn = 25

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -300,6 +300,7 @@
 	heal_brute = 25
 	heal_burn = 25
 	heal_oxy = 25
+	heal_toxin = 25
 
 ///Warp whistle, spawns a tornado that teleports you
 /obj/item/warp_whistle

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -296,9 +296,8 @@
 /obj/item/organ/internal/heart/cursed/wizard
 	name = "cursed wizard heart"
 	desc = "A heart that, when inserted, will force you to pump it manually. Something about it makes you feel more alive than ever."
-	pump_delay = 60
-	heal_brute = 25
-	heal_burn = 25
+	heal_brute = 50
+	heal_burn = 50
 	heal_oxy = 25
 	heal_toxin = 25
 

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -294,7 +294,7 @@
 
 //Provides a decent heal, need to pump every 6 seconds
 /obj/item/organ/internal/heart/cursed/wizard
-	name = "infused cursed heart"
+	name = "cursed wizard heart"
 	desc = "A heart that, when inserted, will force you to pump it manually. Something about it makes you feel more alive than ever."
 	pump_delay = 60
 	heal_brute = 25

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -296,8 +296,8 @@
 /obj/item/organ/internal/heart/cursed/wizard
 	name = "cursed wizard heart"
 	desc = "A heart that, when inserted, will force you to pump it manually. Something about it makes you feel more alive than ever."
-	heal_brute = 50
-	heal_burn = 50
+	heal_brute = 40
+	heal_burn = 40
 	heal_oxy = 25
 	heal_toxin = 25
 

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -296,10 +296,10 @@
 /obj/item/organ/internal/heart/cursed/wizard
 	name = "cursed wizard heart"
 	desc = "A heart that, when inserted, will force you to pump it manually. Something about it makes you feel more alive than ever."
-	heal_brute = 35
-	heal_burn = 35
-	heal_oxy = 25
-	heal_toxin = 25
+	heal_brute = 30
+	heal_burn = 30
+	heal_oxy = 20
+	heal_toxin = 20
 
 ///Warp whistle, spawns a tornado that teleports you
 /obj/item/warp_whistle

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -296,8 +296,8 @@
 /obj/item/organ/internal/heart/cursed/wizard
 	name = "cursed wizard heart"
 	desc = "A heart that, when inserted, will force you to pump it manually. Something about it makes you feel more alive than ever."
-	heal_brute = 40
-	heal_burn = 40
+	heal_brute = 35
+	heal_burn = 35
 	heal_oxy = 25
 	heal_toxin = 25
 

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
@@ -65,6 +65,13 @@
 	category = "Assistance"
 	refundable = TRUE
 
+/datum/spellbook_entry/item/cursed_heart
+	name = "Cursed Heart"
+	desc = "A discolored heart that requires it's user to maually pump it every 6 seconds, healing them when pumped, but causing bloodloss when ignored."
+	item_path = /obj/item/organ/internal/heart/cursed/wizard
+	category = "Assistance"
+	cost = 2
+
 /datum/spellbook_entry/item/guardian
 	name = "Guardian Deck"
 	desc = "A deck of guardian tarot cards, capable of binding a personal guardian to your body. There are multiple types of guardian available, but all of them will transfer some amount of damage to you. \

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
@@ -70,7 +70,7 @@
 	desc = "A discolored heart that requires it's user to maually pump it every 6 seconds, healing them when pumped, but causing bloodloss when ignored."
 	item_path = /obj/item/organ/internal/heart/cursed/wizard
 	category = "Assistance"
-	cost = 2
+	cost = 1
 
 /datum/spellbook_entry/item/guardian
 	name = "Guardian Deck"

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
@@ -70,7 +70,7 @@
 	desc = "A discolored heart that requires it's user to maually pump it every 6 seconds, healing them when pumped, but causing bloodloss when ignored."
 	item_path = /obj/item/organ/internal/heart/cursed/wizard
 	category = "Assistance"
-	cost = 3
+	cost = 2
 
 /datum/spellbook_entry/item/guardian
 	name = "Guardian Deck"

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/assistance.dm
@@ -70,7 +70,7 @@
 	desc = "A discolored heart that requires it's user to maually pump it every 6 seconds, healing them when pumped, but causing bloodloss when ignored."
 	item_path = /obj/item/organ/internal/heart/cursed/wizard
 	category = "Assistance"
-	cost = 2
+	cost = 3
 
 /datum/spellbook_entry/item/guardian
 	name = "Guardian Deck"

--- a/code/modules/cargo/exports/lavaland.dm
+++ b/code/modules/cargo/exports/lavaland.dm
@@ -11,7 +11,7 @@
 						/obj/item/clothing/glasses/godeye,
 						/obj/item/melee/ghost_sword,
 						/obj/item/clothing/neck/necklace/memento_mori,
-						/obj/item/organ/internal/heart/cursed/wizard,
+						/obj/item/organ/internal/heart/cursed,
 						/obj/item/clothing/suit/hooded/cloak/drake,
 						/obj/item/ship_in_a_bottle,
 						/obj/item/clothing/shoes/clown_shoes/banana_shoes,

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -50,7 +50,7 @@
 		if(8)
 			new /obj/item/rod_of_asclepius(src)
 		if(9)
-			new /obj/item/organ/internal/heart/cursed/wizard(src)
+			new /obj/item/organ/internal/heart/cursed(src)
 		if(10)
 			new /obj/item/ship_in_a_bottle(src)
 		if(11)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -752,7 +752,15 @@
 	else if(amount > 0)
 		apply_status_effect(/datum/status_effect/inebriated/tipsy, amount)
 
+/mob/living/proc/adjust_curse_effect(amount, down_to = 0, up_to = INFINITY)
+	if(!isnum(amount))
+		CRASH("adjust_curse_effect: called with an invalid amount. (Got: [amount])")
 
+	var/datum/status_effect/cursed/cursed = has_status_effect(/datum/status_effect/cursed)
+	if(cursed)
+		cursed.set_curse_value(clamp(cursed.curse_value + amount, down_to, up_to))
+	else if(amount > 0)
+		apply_status_effect(/datum/status_effect/cursed/nauseous, amount)
 /**
  * Directly sets the "drunk value" the mob is currently experiencing to the passed value,
  * or applies a drunk effect with the passed value if the mob isn't currently drunk
@@ -769,7 +777,20 @@
 	else if(set_to > 0)
 		apply_status_effect(/datum/status_effect/inebriated/tipsy, set_to)
 
+/mob/living/proc/set_curse_effect(set_to)
+	if(!isnum(set_to) || set_to < 0)
+		CRASH("set_curse_effect: called with an invalid value. (Got: [set_to])")
+
+	var/datum/status_effect/cursed/cursed = has_status_effect(/datum/status_effect/cursed)
+	if(cursed)
+		cursed.set_curse_value(set_to)
+	else if(set_to > 0)
+		apply_status_effect(/datum/status_effect/cursed/nauseous, set_to)
 /// Helper to get the amount of drunkness the mob's currently experiencing.
 /mob/living/proc/get_drunk_amount()
 	var/datum/status_effect/inebriated/inebriation = has_status_effect(/datum/status_effect/inebriated)
 	return inebriation?.drunk_value || 0
+
+/mob/living/proc/get_curse_amount()
+	var/datum/status_effect/cursed/cursed = has_status_effect(/datum/status_effect/cursed)
+	return cursed?.curse_value || 0

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -108,12 +108,14 @@
 	var/last_pump = 0
 	var/add_colour = TRUE //So we're not constantly recreating colour datums
 	var/pump_delay = 70 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)
+	var/expelled = FALSE //for throwing up the curse
 
 	//How much to heal per pump, negative numbers would HURT the player
 	var/heal_brute = 25
 	var/heal_burn = 25
 	var/heal_oxy = 10
 	var/heal_toxin = 10
+	var/blood_regained = 70
 
 
 /obj/item/organ/internal/heart/cursed/attack(mob/living/carbon/human/accursed, mob/living/carbon/human/user, obj/target)
@@ -129,7 +131,7 @@
 		if(ishuman(owner) && owner.client && owner.client?.lastping < 250) //While this entire item exists to make people suffer, they can't control disconnects.
 			var/mob/living/carbon/human/accursed_human = owner
 			if(accursed_human.dna && !(NOBLOOD in accursed_human.dna.species.species_traits))
-				accursed_human.adjust_curse_effect(rand(1,7))
+				accursed_human.adjust_curse_effect(rand(5,7))
 				to_chat(accursed_human, span_userdanger("You have to keep pumping your blood!"))
 				if(add_colour)
 					accursed_human.add_client_colour(/datum/client_colour/cursed_heart_blood) //bloody screen so real
@@ -166,7 +168,8 @@
 		var/mob/living/carbon/human/accursed = owner
 		if(istype(accursed))
 			if(accursed.dna && !(NOBLOOD in accursed.dna.species.species_traits))
-				accursed.adjust_curse_effect(rand(-7,-4))
+				accursed.adjust_curse_effect(rand(-8,-5))
+				accursed.blood_volume = min(accursed.blood_volume + accursed.blood_regained, BLOOD_VOLUME_MAXIMUM)
 				accursed.remove_client_colour(/datum/client_colour/cursed_heart_blood)
 				cursed_heart.add_colour = TRUE
 				accursed.adjustBruteLoss(-cursed_heart.heal_brute)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -127,7 +127,7 @@
 
 /obj/item/organ/internal/heart/cursed/on_life(delta_time, times_fired)
 	if(world.time > (last_pump + pump_delay))
-		if(ishuman(owner) && owner.client && owner.client?.lastping < 250) //While this entire item exists to make people suffer, they can't control disconnects.
+		if(ishuman(owner) && owner.client && owner.client?.lastping < 1000) //While this entire item exists to make people suffer, they can't control disconnects.
 			var/mob/living/carbon/human/accursed_human = owner
 			if(accursed_human.dna && !(NOBLOOD in accursed_human.dna.species.species_traits))
 				accursed_human.adjust_curse_effect(rand(5,7))

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -111,10 +111,11 @@
 	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
 
 	//How much to heal per pump, negative numbers would HURT the player
-	var/heal_brute = 10
-	var/heal_burn = 10
-	var/heal_oxy = 0
-	var/heal_toxin = 0
+	var/heal_brute = 25
+	var/heal_burn = 25
+	var/heal_oxy = 10
+	var/heal_toxin = 10
+	var/heal_stamina = 25
 
 
 /obj/item/organ/internal/heart/cursed/attack(mob/living/carbon/human/accursed, mob/living/carbon/human/user, obj/target)
@@ -174,6 +175,7 @@
 				accursed.adjustFireLoss(-cursed_heart.heal_burn)
 				accursed.adjustOxyLoss(-cursed_heart.heal_oxy)
 				accursed.adjustToxLoss(-cursed_heart.heal_toxin)
+				accursed.adjustStaminaLoss(-cursed_heart.heal_stamina)
 
 
 /datum/client_colour/cursed_heart_blood

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -114,6 +114,7 @@
 	var/heal_brute = 10
 	var/heal_burn = 10
 	var/heal_oxy = 0
+	var/heal_toxin = 0
 
 
 /obj/item/organ/internal/heart/cursed/attack(mob/living/carbon/human/accursed, mob/living/carbon/human/user, obj/target)
@@ -172,6 +173,7 @@
 				accursed.adjustBruteLoss(-cursed_heart.heal_brute)
 				accursed.adjustFireLoss(-cursed_heart.heal_burn)
 				accursed.adjustOxyLoss(-cursed_heart.heal_oxy)
+				accursed.adjustToxLoss(-cursed_heart.heal_toxin)
 
 
 /datum/client_colour/cursed_heart_blood

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -108,14 +108,13 @@
 	var/last_pump = 0
 	var/add_colour = TRUE //So we're not constantly recreating colour datums
 	var/pump_delay = 70 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)
-	var/expelled = FALSE //for throwing up the curse
+	var/blood_regained = 70
 
 	//How much to heal per pump, negative numbers would HURT the player
 	var/heal_brute = 25
 	var/heal_burn = 25
 	var/heal_oxy = 10
 	var/heal_toxin = 10
-	var/blood_regained = 70
 
 
 /obj/item/organ/internal/heart/cursed/attack(mob/living/carbon/human/accursed, mob/living/carbon/human/user, obj/target)
@@ -169,7 +168,7 @@
 		if(istype(accursed))
 			if(accursed.dna && !(NOBLOOD in accursed.dna.species.species_traits))
 				accursed.adjust_curse_effect(rand(-8,-5))
-				accursed.blood_volume = min(accursed.blood_volume + accursed.blood_regained, BLOOD_VOLUME_MAXIMUM)
+				accursed.blood_volume = min(accursed.blood_volume + cursed_heart.blood_regained, BLOOD_VOLUME_MAXIMUM)
 				accursed.remove_client_colour(/datum/client_colour/cursed_heart_blood)
 				cursed_heart.add_colour = TRUE
 				accursed.adjustBruteLoss(-cursed_heart.heal_brute)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -138,7 +138,7 @@
 		else
 			last_pump = world.time //lets be extra fair *sigh*
 
-/obj/item/organ/internal/heart/cursed/Insert(mob/living/carbon/accursed, special = 0, drop_if_replaced = FALSE)
+/obj/item/organ/internal/heart/cursed/Insert(mob/living/carbon/accursed, special = 0, drop_if_replaced = TRUE)
 	..()
 	if(owner)
 		to_chat(owner, span_userdanger("Your heart has been replaced with a cursed one, you have to pump this one manually otherwise you'll die!"))

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -114,6 +114,7 @@
 	var/heal_brute = 20
 	var/heal_burn = 20
 	var/heal_oxy = 10
+	var/heal_toxin = 0
 
 
 /obj/item/organ/internal/heart/cursed/attack(mob/living/carbon/human/accursed, mob/living/carbon/human/user, obj/target)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -111,10 +111,9 @@
 	var/blood_regained = 70
 
 	//How much to heal per pump, negative numbers would HURT the player
-	var/heal_brute = 25
-	var/heal_burn = 25
+	var/heal_brute = 20
+	var/heal_burn = 20
 	var/heal_oxy = 10
-	var/heal_toxin = 10
 
 
 /obj/item/organ/internal/heart/cursed/attack(mob/living/carbon/human/accursed, mob/living/carbon/human/user, obj/target)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -111,8 +111,8 @@
 	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
 
 	//How much to heal per pump, negative numbers would HURT the player
-	var/heal_brute = 0
-	var/heal_burn = 0
+	var/heal_brute = 10
+	var/heal_burn = 10
 	var/heal_oxy = 0
 
 

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -138,7 +138,7 @@
 		else
 			last_pump = world.time //lets be extra fair *sigh*
 
-/obj/item/organ/internal/heart/cursed/Insert(mob/living/carbon/accursed, special = 0, drop_if_replaced = TRUE)
+/obj/item/organ/internal/heart/cursed/Insert(mob/living/carbon/accursed, special = FALSE, drop_if_replaced = TRUE)
 	..()
 	if(owner)
 		to_chat(owner, span_userdanger("Your heart has been replaced with a cursed one, you have to pump this one manually otherwise you'll die!"))

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -107,7 +107,7 @@
 	actions_types = list(/datum/action/item_action/organ_action/cursed_heart)
 	var/last_pump = 0
 	var/add_colour = TRUE //So we're not constantly recreating colour datums
-	var/pump_delay = 30 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)
+	var/pump_delay = 60 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)
 	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
 
 	//How much to heal per pump, negative numbers would HURT the player

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1182,6 +1182,7 @@
 #include "code\datums\status_effects\stacking_effect.dm"
 #include "code\datums\status_effects\wound_effects.dm"
 #include "code\datums\status_effects\debuffs\confusion.dm"
+#include "code\datums\status_effects\debuffs\curse.dm"
 #include "code\datums\status_effects\debuffs\debuffs.dm"
 #include "code\datums\status_effects\debuffs\dizziness.dm"
 #include "code\datums\status_effects\debuffs\drugginess.dm"


### PR DESCRIPTION
## About The Pull Request

~- Wizard cursed heart variant added back (was it even there from the start?) into the wizard shop for **1 point.**~

~- Necropolis chests now spawn the correct version of cursed heart as specified in the wiki.~

~- Wizard cursed heart has been given it's own name and description to distinguish it from the normal one.~

~Fuck you miners.~

Cursed heart has been entirely overhauled. Through blood sweat and tears this AFK killer is useful.

The cursed heart is an item that must be pumped every 7 seconds (pausing on DC or ping greater than 250), providing healing. Forgetting to pump the heart will give you a warning and turn your screen red. It will then apply a `cursed` effect, gradually increasing with more severe and debilitating effects. (eventual bloodloss after 14-100 missed pumps). These effects are similar to drunkenness.

Furthermore, not pumping the heart can cause the user to expell their curse in the form of vomit curing them.

There are two variants, wizard and miner. Wizard is minorly improved (extra healing on use).


## Why It's Good For The Game

Cursed heart was a pretty hit-or-miss item of either being used prolifically or totally unused depending on the miner. This PR aims to somewhat match the standard of certain mining items being weaker versions of wizard/antagonist gear. (ie dusty shard not allowing you to pick what holo you get as opposed to tarot cards, summon item book being a spell, miner's soulstone compared to wizard/cult stone, etc)

However, as stated in this very PR, it was a noob killer, or too demanding for the /tg/ playerbase ~presumably picking their noses and or asses~. This seeks to rectify that by making the item more accessible and less of a burden.

**I sincerely hope to see wizards using this!**

https://youtu.be/AgzWlzam51I?t=540

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: added a name and description to the wizard cursed heart
balance: miner loot now spawns the correct cursed heart
fix: After extensive deliberation in the Wizard Federation, harvesting of cursed hearts has resumed and are now available from your spellbooks.
spellcheck: changed the text of the wizard cursed heart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
