### PR TITLE
Thunderdome showtime button

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3578,6 +3578,14 @@
 "kb" = (
 /turf/closed/indestructible/rock/snow,
 /area/centcom/syndicate_mothership/control)
+"kd" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/machinery/button/showtime{
+	req_access = list("cent_thunder")
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "ke" = (
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/vending/snack/teal,
@@ -5623,6 +5631,11 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/ert)
+"pY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "pZ" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -8104,6 +8117,10 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
+"xG" = (
+/obj/machinery/button/showtime,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/tdome/administration)
 "xI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
@@ -60458,7 +60475,7 @@ IG
 IG
 IG
 It
-Pj
+xG
 Xn
 Sz
 Sz
@@ -61231,7 +61248,7 @@ fJ
 It
 Pj
 Xn
-Sz
+pY
 Sz
 dJ
 Wn
@@ -61745,7 +61762,7 @@ fJ
 It
 Pj
 Pl
-Sz
+kd
 Sz
 qd
 Wn

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -326,7 +326,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 
 /// A button that adds a camera network to the entertainment monitors
 /obj/machinery/button/showtime
-	name = "showtime button"
+	name = "thunderdome showtime button"
 	desc = "Use this button to allow entertainment monitors to broadcast the big game."
 	device_type = /obj/item/assembly/control/showtime
 	req_access = list()
@@ -345,6 +345,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 	var/is_show_active = FALSE
 	/// The camera network id this controller toggles
 	var/tv_network_id = "thunder"
+	/// The display TV show name
+	var/tv_show_name = "Thunderdome"
 	/// List of phrases the entertainment console may say when the show begins
 	var/list/tv_starters = list("Feats of bravery live now at the thunderdome!",
 		"Two enter, one leaves! Tune in now!",
@@ -358,6 +360,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 
 /obj/item/assembly/control/showtime/activate()
 	is_show_active = !is_show_active
+	say("The [tv_show_name] show has [ is_show_active ? "begun" : "ended"]")
 	var/announcement = is_show_active ? pick(tv_starters) : pick(tv_enders)
 	for(var/obj/machinery/computer/security/telescreen/entertainment/tv in GLOB.machines)
 		tv.update_shows(is_show_active, tv_network_id, announcement)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -280,10 +280,10 @@
 	desc = "Damn, they better have the /tg/ channel on these things."
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "entertainment_blank"
-	network = list("thunder")
+	network = list()
 	density = FALSE
 	circuit = null
-	interaction_flags_atom = NONE  // interact() is called by BigClick()
+	interaction_flags_atom = INTERACT_ATOM_UI_INTERACT | INTERACT_ATOM_NO_FINGERPRINT_INTERACT | INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND | INTERACT_MACHINE_REQUIRES_SIGHT
 	var/icon_state_off = "entertainment_blank"
 	var/icon_state_on = "entertainment"
 
@@ -297,18 +297,70 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 /obj/machinery/computer/security/telescreen/entertainment/proc/BigClick()
 	SIGNAL_HANDLER
 
+	if(!network.len)
+		usr.balloon_alert(usr, "there is nothing on TV")
+		return
+
 	INVOKE_ASYNC(src, /atom.proc/interact, usr)
 
-/obj/machinery/computer/security/telescreen/entertainment/proc/notify(on)
+///Sets the monitor's icon to the selected state, and says an announcement 
+/obj/machinery/computer/security/telescreen/entertainment/proc/notify(on, announcement)
 	if(on && icon_state == icon_state_off)
-		say(pick(
-			"Feats of bravery live now at the thunderdome!",
-			"Two enter, one leaves! Tune in now!",
-			"Violence like you've never seen it before!",
-			"Spears! Camera! Action! LIVE NOW!"))
 		icon_state = icon_state_on
 	else
 		icon_state = icon_state_off
+	if(announcement)
+		say(announcement)
+
+/// Adds a camera network ID to the entertainment monitor, and turns off the monitor if network list is empty
+/obj/machinery/computer/security/telescreen/entertainment/proc/update_shows(is_show_active, tv_show_id, announcement)
+	if(!network)
+		return
+
+	if(is_show_active)
+		network |= tv_show_id
+	else
+		network -= tv_show_id
+
+	notify(network.len, announcement)
+
+/// A button that adds a camera network to the entertainment monitors
+/obj/machinery/button/showtime
+	name = "showtime button"
+	desc = "Use this button to allow entertainment monitors to broadcast the big game."
+	device_type = /obj/item/assembly/control/showtime
+	req_access = list()
+	id = "showtime_1"
+
+/obj/machinery/button/showtime/Initialize(mapload)
+	. = ..()
+	if(device)
+		var/obj/item/assembly/control/showtime/ours = device
+		ours.id = id
+
+/obj/item/assembly/control/showtime
+	name = "showtime controller"
+	desc = "A remote controller for entertainment monitors."
+	/// Stores if the show associated with this controller is active or not
+	var/is_show_active = FALSE
+	/// The camera network id this controller toggles
+	var/tv_network_id = "thunder"
+	/// List of phrases the entertainment console may say when the show begins
+	var/list/tv_starters = list("Feats of bravery live now at the thunderdome!",
+		"Two enter, one leaves! Tune in now!",
+		"Violence like you've never seen it before!",
+		"Spears! Camera! Action! LIVE NOW!")
+	/// List of phrases the entertainment console may say when the show ends
+	var/list/tv_enders = list("Thank you for tuning in to the slaughter!",
+		"What a show! And we guarantee next one will be bigger!", 
+		"Celebrate the results with Thundermerch!",
+		"This show was brought to you by Nanotrasen.")
+
+/obj/item/assembly/control/showtime/activate()
+	is_show_active = !is_show_active
+	var/announcement = is_show_active ? pick(tv_starters) : pick(tv_enders)
+	for(var/obj/machinery/computer/security/telescreen/entertainment/tv in GLOB.machines)
+		tv.update_shows(is_show_active, tv_network_id, announcement)
 
 /obj/machinery/computer/security/telescreen/rd
 	name = "\improper Research Director's telescreen"

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -298,7 +298,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 	SIGNAL_HANDLER
 
 	if(!network.len)
-		usr.balloon_alert(usr, "there is nothing on TV")
+		balloon_alert(usr, "there's nothing on TV!")
 		return
 
 	INVOKE_ASYNC(src, /atom.proc/interact, usr)
@@ -360,7 +360,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 
 /obj/item/assembly/control/showtime/activate()
 	is_show_active = !is_show_active
-	say("The [tv_show_name] show has [ is_show_active ? "begun" : "ended"]")
+	say("The [tv_show_name] show has [is_show_active ? "begun" : "ended"]")
 	var/announcement = is_show_active ? pick(tv_starters) : pick(tv_enders)
 	for(var/obj/machinery/computer/security/telescreen/entertainment/tv in GLOB.machines)
 		tv.update_shows(is_show_active, tv_network_id, announcement)


### PR DESCRIPTION
## About The Pull Request

![kép](https://user-images.githubusercontent.com/2676196/180872646-2d02ee8e-af09-4deb-8b0d-e1ac6f843fad.png)

This PR adds the showtime button to the Thunderdome admin area. When pressed, it will iterate through the entertainment monitors, and toggles their ability to broadcast the thunderdome's cameras.

If there are no camera networks in the entertainment monitor's list, clicking on it does nothing besides giving a balloon alert, otherwise you can watch the Big Game from up to two tiles away.

The activation messages and the camera network ID are in a var, therefore it is easy to create new show controllers that broadcast different camera networks.

Fixes #54607

Issues: 
The table I placed on the left for symmetry is so bare, but I don't know what to place on it...
Entertainment monitors can not be constructed, but if an admin spawned one while the big game is ongoing, it wouldn't be able to see the show, as the network list is only updated when toggled.

## Why It's Good For The Game

The admins can now easily turn on and off the entertainment monitors' ability to display the Thunderdome. They can either carry out tests in peace, or once again, arrange the BIG GAME.

## Changelog

:cl:
add: Added a new button to the thunderdome administration arena that toggles entertainment monitor's ability to broadcast the thunderdome arena's cameras.
fix: Clicking on entertainment monitors actually works now 
/:cl:
