### PR TITLE
Fixes the kill pet objective being unable to target certain heads' pets

### DIFF
--- a/code/modules/antagonists/traitor/objectives/kill_pet.dm
+++ b/code/modules/antagonists/traitor/objectives/kill_pet.dm
@@ -71,7 +71,7 @@
 	var/pet_type = possible_heads[target.title]
 	if(islist(pet_type))
 		for(var/type in pet_type)
-			target_pet = locate(pet_type) in GLOB.mob_living_list
+			target_pet = locate(type) in GLOB.mob_living_list
 			if(target_pet)
 				break
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The "kill pet" traitor objective has been unable to target pets owned by the Head of Personnel, Head of Security, or the Quartermaster. The reason why is because in the code for this objective, these heads are associated with lists of mobs rather than a single mob, and the for() loop that's supposed to find the target for the objective has been attempting to locate() the entire list of these heads' pets in the mob_living_list, rather than locating each indiviual pet in the list, which obviously didn't work. This PR simply fixes this so the objective can actually target these pets.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

This makes the "kill pet" objective function as intended. Someone needs to put that damn mutt in its place.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The "kill pet" traitor objective can now properly target pets owned by the Head of Personnel, Head of Security, and Quartermaster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
