### PR TITLE
Updates the obsessed photo objective text.

### DIFF
--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -251,7 +251,7 @@
 /datum/objective/polaroid/update_explanation_text()
 	..()
 	if(target?.current)
-		explanation_text = "Take a photo of [target.name] while they're alive."
+		explanation_text = "Take a photo of [target.name] while they're alive, and keep it in your bag."
 	else
 		explanation_text = "Free Objective"
 


### PR DESCRIPTION

## About The Pull Request

Adds some more specificity to the obsessed photo objective to prevent confusion such as with #68517.

## Why It's Good For The Game

Fixes #68517

Gets you that sweet sweet green text.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: adds extra information to objective explanation text.
fix: makes the photo objective more specific
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
