### PR TITLE
Fixes Heavy Armor Exosuit Experiment #1 sometimes being impossible to complete

### DIFF
--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -324,7 +324,7 @@
 	description = "Your exosuit fabricators allow for rapid production on a small scale, but the structural integrity of created parts is inferior to those made with more traditional means. Damage a few exosuits to exactly [damage_percent]% integrity and scan them to help us determine how the armor fails under stress."
 
 /datum/experiment/scanning/random/mecha_damage_scan/final_contributing_index_checks(atom/target, typepath)
-	var/found_percent = round(target.get_integrity() / target.max_integrity, 0.01) * 100
+	var/found_percent = round((target.get_integrity() / target.max_integrity) * 100) //Intentionally flooring the result, rather than rounding up if possible
 	return ..() && (found_percent == damage_percent)
 
 /datum/experiment/scanning/random/mecha_destroyed_scan


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the round to be a floor to integer *after* the `*100`, rather than to nearest hundredth beforehand. This fixes certain damage percentage goals like 30% failing. 
Fixes #68435.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Very specific damage goals, like 30%, were failing for no visible reason. The code was `round(target.get_integrity() / target.max_integrity, 0.01) * 100`. For a Ripley MK-1 and a goal of 30%, that would be `round(60 / 200, 0.01) * 100`. This gives "30" in every way that can be visually seen, but still failed. Best guess I've heard was that floating point baggage from the division stuck around through the round function and caused the check to return FALSE. So I replaced the round with one that floors to nearest integer.

Floor is used because it matches what the Mech and Mech Bay UIs will show.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Exosuit Materials 1: Stress Failure Test should no longer occasionally be impossible to complete.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
