### PR TITLE
Heretics no longer need the Amber focus to use spells

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -548,8 +548,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_NO_STRIP "no_strip"
 /// Disallows this item from being pricetagged with a barcode
 #define TRAIT_NO_BARCODES "no_barcode"
-/// Allows heretics to cast their spells.
-#define TRAIT_ALLOW_HERETIC_CASTING "allow_heretic_casting"
 /// Designates a heart as a living heart for a heretic.
 #define TRAIT_LIVING_HEART "living_heart"
 /// Prevents the same person from being chosen multiple times for kidnapping objective

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -194,7 +194,6 @@
 	var/mob/living/our_mob = mob_override || owner.current
 	handle_clown_mutation(our_mob, "Ancient knowledge described to you has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 	our_mob.faction |= FACTION_HERETIC
-	RegisterSignal(our_mob, list(COMSIG_MOB_BEFORE_SPELL_CAST, COMSIG_MOB_SPELL_ACTIVATED), .proc/on_spell_cast)
 	RegisterSignal(our_mob, COMSIG_MOB_ITEM_AFTERATTACK, .proc/on_item_afterattack)
 	RegisterSignal(our_mob, COMSIG_MOB_LOGIN, .proc/fix_influence_network)
 

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -212,31 +212,6 @@
 		knowledge.on_gain(new_body)
 
 /*
- * Signal proc for [COMSIG_MOB_BEFORE_SPELL_CAST] and [COMSIG_MOB_SPELL_ACTIVATED].
- *
- * Checks if our heretic has [TRAIT_ALLOW_HERETIC_CASTING] or is ascended.
- * If so, allow them to cast like normal.
- * If not, cancel the cast, and returns [SPELL_CANCEL_CAST].
- */
-/datum/antagonist/heretic/proc/on_spell_cast(mob/living/source, datum/action/cooldown/spell/spell)
-	SIGNAL_HANDLER
-
-	// Heretic spells are of the forbidden school, otherwise we don't care
-	if(spell.school != SCHOOL_FORBIDDEN)
-		return
-
-	// If we've got the trait, we don't care
-	if(HAS_TRAIT(source, TRAIT_ALLOW_HERETIC_CASTING))
-		return
-	// All powerful, don't care
-	if(ascended)
-		return
-
-	// We shouldn't be able to cast this! Cancel it.
-	source.balloon_alert(source, "you need a focus!")
-	return SPELL_CANCEL_CAST
-
-/*
  * Signal proc for [COMSIG_MOB_ITEM_AFTERATTACK].
  *
  * If a heretic is holding a pen in their main hand,

--- a/code/modules/antagonists/heretic/heretic_focus.dm
+++ b/code/modules/antagonists/heretic/heretic_focus.dm
@@ -2,60 +2,6 @@
 /// allowing heretics to cast advanced spells (examine message included).
 /datum/element/heretic_focus
 
-/datum/element/heretic_focus/Attach(datum/target)
-	. = ..()
-	if(!isitem(target))
-		return ELEMENT_INCOMPATIBLE
 
-	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/on_examine)
-	RegisterSignal(target, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
-	RegisterSignal(target, COMSIG_ITEM_DROPPED, .proc/on_drop)
 
-	var/obj/item/item_target = target
-	// If our loc is a mob, it's possible we already have it equippied
-	if(ismob(item_target.loc))
-		var/mob/wearer = item_target.loc
-		if(!item_target.slot_flags || wearer.get_item_by_slot(item_target.slot_flags) == item_target)
-			ADD_TRAIT(wearer, TRAIT_ALLOW_HERETIC_CASTING, ELEMENT_TRAIT(target))
 
-/datum/element/heretic_focus/Detach(obj/item/source)
-	. = ..()
-	UnregisterSignal(source, list(COMSIG_PARENT_EXAMINE, COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
-	if(isliving(source.loc))
-		REMOVE_TRAIT(source.loc, TRAIT_ALLOW_HERETIC_CASTING, ELEMENT_TRAIT(source))
-
-/**
- * Signal proc for [COMSIG_PARENT_EXAMINE].
- * Let's the examiner see that this item is a heretic focus
- */
-/datum/element/heretic_focus/proc/on_examine(obj/item/source, mob/user, list/examine_list)
-	SIGNAL_HANDLER
-
-	if(!IS_HERETIC(user))
-		return
-
-	examine_list += span_notice("Allows you to cast advanced heretic spells when worn.")
-
-/**
- * Signal proc for [COMSIG_ITEM_EQUIPPED].
- * When equipped in a right slot, give user our trait
- */
-/datum/element/heretic_focus/proc/on_equip(obj/item/source, mob/user, slot)
-	SIGNAL_HANDLER
-
-	if(!IS_HERETIC(user))
-		return
-
-	if(!(source.slot_flags & slot))
-		return
-
-	ADD_TRAIT(user, TRAIT_ALLOW_HERETIC_CASTING, ELEMENT_TRAIT(source))
-
-/**
- * Signal proc for [COMSIG_ITEM_DROPPED].
- * Remove our trait when we drop (unequip) our item
- */
-/datum/element/heretic_focus/proc/on_drop(obj/item/source, mob/user)
-	SIGNAL_HANDLER
-
-	REMOVE_TRAIT(user, TRAIT_ALLOW_HERETIC_CASTING, ELEMENT_TRAIT(source))

--- a/code/modules/antagonists/heretic/magic/furious_steel.dm
+++ b/code/modules/antagonists/heretic/magic/furious_steel.dm
@@ -25,34 +25,6 @@
 	/// A ref to the status effect surrounding our heretic on activation.
 	var/datum/status_effect/protective_blades/blade_effect
 
-/datum/action/cooldown/spell/pointed/projectile/furious_steel/Grant(mob/grant_to)
-	. = ..()
-	if(!owner)
-		return
-
-	if(IS_HERETIC(owner))
-		RegisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING), .proc/on_focus_lost)
-
-/datum/action/cooldown/spell/pointed/projectile/furious_steel/Remove(mob/remove_from)
-	UnregisterSignal(remove_from, SIGNAL_REMOVETRAIT(TRAIT_ALLOW_HERETIC_CASTING))
-	return ..()
-
-/// Signal proc for [SIGNAL_REMOVETRAIT], via [TRAIT_ALLOW_HERETIC_CASTING], to remove the effect when we lose the focus trait
-/datum/action/cooldown/spell/pointed/projectile/furious_steel/proc/on_focus_lost(mob/source)
-	SIGNAL_HANDLER
-
-	unset_click_ability(source, refund_cooldown = TRUE)
-
-/datum/action/cooldown/spell/pointed/projectile/furious_steel/InterceptClickOn(mob/living/caller, params, atom/click_target)
-	// Let the caster prioritize using items like guns over blade casts
-	if(caller.get_active_held_item())
-		return FALSE
-	// Let the caster prioritize melee attacks like punches and shoves over blade casts
-	if(get_dist(caller, click_target) <= 1)
-		return FALSE
-
-	return ..()
-
 /datum/action/cooldown/spell/pointed/projectile/furious_steel/on_activation(mob/on_who)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR removes the need for the Amber focus to cast spells, hopefully i run into no issues and it compiles this time.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because wearing the amber focus completely blows your cover as a heretic and its not a fair trade-off to use spells that aren't even that strong, if the spells were somewhat strong i wouldnt argue its existence 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: heretics no longer need to use the amber focus to cast spells

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
