### PR TITLE
Makes liver/stomach repair surgery consistent with heart/lung repair.

### DIFF
--- a/code/modules/surgery/gastrectomy.dm
+++ b/code/modules/surgery/gastrectomy.dm
@@ -16,8 +16,10 @@
 
 /datum/surgery/gastrectomy/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/internal/stomach/target_stomach = target.getorganslot(ORGAN_SLOT_STOMACH)
-	if(target_stomach?.damage > 50 && !(target_stomach.organ_flags & ORGAN_FAILING))
-		return TRUE
+	if(target_stomach)
+		if(target_stomach.damage > 50 && !target_stomach.operated)
+			return TRUE
+	return FALSE
 
 ////Gastrectomy, because we truly needed a way to repair stomachs.
 //95% chance of success to be consistent with most organ-repairing surgeries.

--- a/code/modules/surgery/gastrectomy.dm
+++ b/code/modules/surgery/gastrectomy.dm
@@ -44,6 +44,8 @@
 /datum/surgery_step/gastrectomy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/mob/living/carbon/human/target_human = target
 	target_human.setOrganLoss(ORGAN_SLOT_STOMACH, 20) // Stomachs have a threshold for being able to even digest food, so I might tweak this number
+	if(target_stomach)
+		target_stomach.operated = TRUE
 	display_results(user, target, span_notice("You successfully remove the damaged part of [target]'s stomach."),
 		span_notice("[user] successfully removes the damaged part of [target]'s stomach."),
 		span_notice("[user] successfully removes the damaged part of [target]'s stomach."))

--- a/code/modules/surgery/gastrectomy.dm
+++ b/code/modules/surgery/gastrectomy.dm
@@ -43,6 +43,7 @@
 
 /datum/surgery_step/gastrectomy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/mob/living/carbon/human/target_human = target
+	var/obj/item/organ/internal/stomach/target_stomach = target.getorganslot(ORGAN_SLOT_STOMACH)
 	target_human.setOrganLoss(ORGAN_SLOT_STOMACH, 20) // Stomachs have a threshold for being able to even digest food, so I might tweak this number
 	if(target_stomach)
 		target_stomach.operated = TRUE

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -43,6 +43,8 @@
 /datum/surgery_step/hepatectomy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/mob/living/carbon/human/human_target = target
 	human_target.setOrganLoss(ORGAN_SLOT_LIVER, 10) //not bad, not great
+	if(target_liver)
+		target_liver.operated = TRUE
 	display_results(user, target, span_notice("You successfully remove the damaged part of [target]'s liver."),
 		span_notice("[user] successfully removes the damaged part of [target]'s liver."),
 		span_notice("[user] successfully removes the damaged part of [target]'s liver."))

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -42,6 +42,7 @@
 
 /datum/surgery_step/hepatectomy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/mob/living/carbon/human/human_target = target
+	var/obj/item/organ/internal/liver/target_liver = target.getorganslot(ORGAN_SLOT_LIVER)
 	human_target.setOrganLoss(ORGAN_SLOT_LIVER, 10) //not bad, not great
 	if(target_liver)
 		target_liver.operated = TRUE

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -15,8 +15,10 @@
 
 /datum/surgery/hepatectomy/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/internal/liver/target_liver = target.getorganslot(ORGAN_SLOT_LIVER)
-	if(target_liver?.damage > 50 && !(target_liver.organ_flags & ORGAN_FAILING))
-		return TRUE
+	if(target_liver)
+		if(target_liver.damage > 50 && !target_liver.operated)
+			return TRUE
+	return FALSE
 
 ////hepatectomy, removes damaged parts of the liver so that the liver may regenerate properly
 //95% chance of success, not 100 because organs are delicate

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -23,6 +23,7 @@
 	/// Scaling factor for how much damage toxins deal to the liver
 	var/toxLethality = LIVER_DEFAULT_TOX_LETHALITY
 	var/filterToxins = TRUE //whether to filter toxins
+	var/operated = FALSE //whether the liver's been repaired with surgery and can be fixed again or not
 
 /obj/item/organ/internal/liver/Initialize(mapload)
 	. = ..()

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -30,6 +30,7 @@
 	///The rate that the stomach will transfer reagents to the body
 	var/metabolism_efficiency = 0.05 // the lowest we should go is 0.05
 
+	var/operated = FALSE //whether the stomach's been repaired with surgery and can be fixed again or not
 
 /obj/item/organ/internal/stomach/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Makes liver and stomach repair surgery (hepatectomy and gastrectomy) generally consistent with lung/heart surgery: 
every organ can be operated on to repair it once in its lifetime after it hits 50 damage or greater. After that, you need a new one. 


## Why It's Good For The Game

It was dumb and unintuitive that you could fix a rotten heart but only work on a liver or stomach between 50-99 damage before having to throw them out. 

## Changelog

:cl:
balance: Non-functional livers and stomachs can now be repaired with their respective surgeries once in the organ's lifetime. 
/:cl:
