### PR TITLE
You can no longer delete the nuclear disk using a windoor

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -243,6 +243,9 @@
 	if (!user.Adjacent(source))
 		return FALSE
 
+	if (QDELETED(equipping) || QDELETED(source))
+		return
+
 	if (!equipping.mob_can_equip(
 		source,
 		user,

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -240,6 +240,9 @@
 	if (!do_mob(user, source, get_equip_delay(equipping)))
 		return FALSE
 
+	if (!user.Adjacent(source))
+		return FALSE
+
 	if (!equipping.mob_can_equip(
 		source,
 		user,

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -240,12 +240,6 @@
 	if (!do_mob(user, source, get_equip_delay(equipping)))
 		return FALSE
 
-	if (!user.Adjacent(source))
-		return FALSE
-
-	if (QDELETED(equipping) || QDELETED(source))
-		return
-
 	if (!equipping.mob_can_equip(
 		source,
 		user,
@@ -446,9 +440,11 @@
 
 					// They equipped an item in the meantime
 					if (!isnull(strippable_item.get_item(owner)))
+						user.put_in_hands(held_item)
 						return
 
 					if (!user.Adjacent(owner))
+						user.put_in_hands(held_item)
 						return
 
 					strippable_item.finish_equip(owner, held_item, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/68767

The "equip other character" process calls start_equip, which creates a progress bar and yields on failure to finish the progress bar.
At the end of that progress bar the item you are equipping to someone else is temporarily removed from your character.
After that we check for adjacency, if adjacency has been broken then we return from the process leaving the item stuck in limbo.

I made it so that now if those checks fail it puts the item back in your hands.

## Why It's Good For The Game

You probably shouldn't be able to do that

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: removed a way that you could send items into the void using just a windoor and a pal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
