### PR TITLE
Cleans up drop_organ() to use drop_location()

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -243,14 +243,14 @@
 /obj/item/bodypart/proc/drop_organs(mob/user, violent_removal)
 	SHOULD_CALL_PARENT(TRUE)
 
-	var/turf/bodypart_turf = get_turf(src)
+	var/atom/drop_loc = drop_location()
 	if(IS_ORGANIC_LIMB(src))
-		playsound(bodypart_turf, 'sound/misc/splort.ogg', 50, TRUE, -1)
+		playsound(drop_loc, 'sound/misc/splort.ogg', 50, TRUE, -1)
 	seep_gauze(9999) // destroy any existing gauze if any exists
 	for(var/obj/item/organ/bodypart_organ in get_organs())
 		bodypart_organ.transfer_to_limb(src, owner)
 	for(var/obj/item/item_in_bodypart in src)
-		item_in_bodypart.forceMove(bodypart_turf)
+		item_in_bodypart.forceMove(drop_loc)
 
 ///since organs aren't actually stored in the bodypart themselves while attached to a person, we have to query the owner for what we should have
 /obj/item/bodypart/proc/get_organs()

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -135,7 +135,7 @@
 	return ..()
 
 /obj/item/bodypart/head/drop_organs(mob/user, violent_removal)
-	var/turf/head_turf = get_turf(src)
+	var/atom/drop_loc = drop_location()
 	for(var/obj/item/head_item in src)
 		if(head_item == brain)
 			if(user)
@@ -148,7 +148,7 @@
 			if(violent_removal && prob(rand(80, 100))) //ghetto surgery can damage the brain.
 				to_chat(user, span_warning("[brain] was damaged in the process!"))
 				brain.setOrganDamage(brain.maxHealth)
-			brain.forceMove(head_turf)
+			brain.forceMove(drop_loc)
 			brain = null
 			update_icon_dropped()
 		else
@@ -159,7 +159,7 @@
 				var/obj/item/organ/organ = head_item
 				if(organ.organ_flags & ORGAN_UNREMOVABLE)
 					continue
-			head_item.forceMove(head_turf)
+			head_item.forceMove(drop_loc)
 	eyes = null
 	ears = null
 	tongue = null

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -213,11 +213,12 @@
 		. += span_info("It has a couple spots that still need to be <b>wired</b>.")
 
 /obj/item/bodypart/chest/robot/drop_organs(mob/user, violent_removal)
+	var/atom/drop_loc = drop_location()
 	if(wired)
-		new /obj/item/stack/cable_coil(drop_location(), 1)
+		new /obj/item/stack/cable_coil(drop_loc, 1)
 		wired = FALSE
 	if(cell)
-		cell.forceMove(drop_location())
+		cell.forceMove(drop_loc)
 		cell = null
 	..()
 
@@ -313,11 +314,12 @@
 
 
 /obj/item/bodypart/head/robot/drop_organs(mob/user, violent_removal)
+	var/atom/drop_loc = drop_location()
 	if(flash1)
-		flash1.forceMove(user.loc)
+		flash1.forceMove(drop_loc)
 		flash1 = null
 	if(flash2)
-		flash2.forceMove(user.loc)
+		flash2.forceMove(drop_loc)
 		flash2 = null
 	..()
 


### PR DESCRIPTION
There was mixed usage between all the procs, this should've been using drop_location().

:cl: ShizCalev
fix: Cyborg flashes will no longer fail to drop from the heads of borgs.
fix: Butchering a bodypart for it's organs while inside a locker will no longer drop the organs /outside/ the locker.
/:cl:

```
The following runtime has occurred 1 time(s).
runtime error: Cannot read null.loc
proc name: drop organs (/obj/item/bodypart/head/robot/drop_organs)
  source file: robot_bodyparts.dm,317
  usr: null
  src: the robotic head (/obj/item/bodypart/head/robot)
  src.loc: the ice chasm (172,121,4) (/turf/open/openspace/icemoon/keep_below)

```