### PR TITLE
Fixes surgical moth wing reconstruction trying to repair not moth wings.

### DIFF
--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -13,6 +13,8 @@
 	if(!istype(target))
 		return FALSE
 	var/obj/item/organ/external/wings/moth/wings = target.getorganslot(ORGAN_SLOT_EXTERNAL_WINGS)
+	if(!istype(wings, /obj/item/organ/external/wings/moth))
+		return FALSE
 	return ..() && wings?.burnt
 
 /datum/surgery_step/wing_reconstruction
@@ -39,7 +41,8 @@
 			span_notice("[user] completes the surgery on [target]'s wings."))
 		display_pain(target, "You can feel your wings again!")
 		var/obj/item/organ/external/wings/moth/wings = target.getorganslot(ORGAN_SLOT_EXTERNAL_WINGS)
-		wings?.heal_wings()
+		if(istype(wings, /obj/item/organ/external/wings/moth)) //make sure we only heal moth wings.
+			wings.heal_wings()
 
 		var/obj/item/organ/external/antennae/antennae = target.getorganslot(ORGAN_SLOT_EXTERNAL_ANTENNAE) //i mean we might aswell heal their antennae too
 		antennae?.heal_antennae()


### PR DESCRIPTION
```
The following runtime has occurred 4 time(s).
runtime error: undefined variable /obj/item/organ/external/wings/functional/var/burnt
proc name: can start (/datum/surgery/advanced/wing_reconstruction/can_start)
  source file: wingreconstruction.dm,16
  usr: Mothership Zeta Scientist (/mob/living/carbon/human)
  src: Wing Reconstruction (/datum/surgery/advanced/wing_reconstruction)
```

:cl: ShizCalev
fix: Surgical moth wing reconstruction can no longer be attempted on wings that... aren't moth wings!
/:cl:
