### PR TITLE
Structural weakpoint charges can only be planted on.... structural points!

### DIFF
--- a/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
+++ b/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
@@ -255,6 +255,10 @@
 		to_chat(user, span_warning("[src] can only be detonated in [initial(weakpoint_area.name)]."))
 		return
 
+	if(!isfloorturf(target) && !iswallturf(target))
+		to_chat(user, span_warning("[src] can only be planted on a wall or the floor!"))
+		return
+
 	return ..()
 
 /obj/item/grenade/c4/es8/detonate(mob/living/lanced_by)


### PR DESCRIPTION
Fixes #68775
:cl: ShizCalev
fix: ES8 explosive charges (structural weakpoint charges) can now only be planted on walls or the floor. 
/:cl:
