### PR TITLE
Remove screen objects from clients when a storage object is deleted

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -132,14 +132,17 @@
 	orient_to_hud()
 
 /datum/storage/Destroy()
+	for(var/mob/person in is_using)
+		if(person.active_storage == src)
+			person.active_storage = null
+			if(person.client)
+				person.client.screen -= boxes
+				person.client.screen -= closer
+
 	parent = null
 	real_location = null
 	boxes = null
 	closer = null
-
-	for(var/mob/person in is_using)
-		if(person.active_storage == src)
-			person.active_storage = null
 
 	is_using.Cut()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an issue where when an object with storage was destroyed, any player who was viewing the storage of said object would have the storage UI remain permanently on their screen after it was deleted, as the storage Destroy proc didn't remove the UI elements from the client's screen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Storage UI will no longer remain on screen when an object with storage is destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
