### PR TITLE
Adds a delay while welder repairing vehicles / mechs

### DIFF
--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -83,7 +83,7 @@
 	if(!W.tool_start_check(user, amount=1))
 		return
 	LAZYADD(repairing_mobs, user)
-	user.balloon_alert_to_viewers("starts to repair [src]", "started repairing [src]")
+	user.balloon_alert_to_viewers("started repairing [src]")
 	audible_message(span_hear("You hear welding."))
 	var/did_the_thing
 	while(atom_integrity < max_integrity)

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -7,6 +7,8 @@
 	armor = list(MELEE = 50, BULLET = 25, LASER = 20, ENERGY = 0, BOMB = 50, BIO = 0, FIRE = 60, ACID = 60)
 	key_type = /obj/item/key/atv
 	integrity_failure = 0.5
+		///What mobs are currently repairing us.
+	var/list/mob/living/repairing_mobs
 	var/static/mutable_appearance/atvcover
 
 /obj/vehicle/ridden/atv/Initialize(mapload)
@@ -68,16 +70,34 @@
 			turret.layer = OBJ_LAYER
 			turret.plane = GAME_PLANE
 
-/obj/vehicle/ridden/atv/welder_act(mob/living/user, obj/item/I)
+/obj/vehicle/ridden/atv/welder_act(mob/living/user, obj/item/W)
+	if(user.combat_mode)
+		return
+	. = TRUE
+	if(LAZYFIND(repairing_mobs, user))
+		balloon_alert(user, "you're already repairing it!")
+		return
 	if(atom_integrity >= max_integrity)
-		return TRUE
-	if(!I.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
-		return TRUE
-	user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to \the [src]."))
-	atom_integrity += min(10, max_integrity-atom_integrity)
-	if(atom_integrity == max_integrity)
-		to_chat(user, span_notice("It looks to be fully repaired now."))
-	return TRUE
+		balloon_alert(user, "it's not damaged!")
+		return
+	if(!W.tool_start_check(user, amount=1))
+		return
+	LAZYADD(repairing_mobs, user)
+	user.balloon_alert_to_viewers("starts to repair [src]", "started repairing [src]")
+	audible_message(span_hear("You hear welding."))
+	var/did_the_thing
+	while(atom_integrity < max_integrity)
+		if(W.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
+			did_the_thing = TRUE
+			atom_integrity += min(10, (max_integrity - atom_integrity))
+			audible_message(span_hear("You hear welding."))
+		else
+			break
+	if(did_the_thing)
+		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
+	else
+		user.balloon_alert_to_viewers("stopped repairing [src]", "interrupted the repair!")
+	LAZYREMOVE(repairing_mobs, user)
 
 /obj/vehicle/ridden/atv/atom_break()
 	START_PROCESSING(SSobj, src)

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -71,7 +71,7 @@
 /obj/vehicle/ridden/atv/welder_act(mob/living/user, obj/item/I)
 	if(atom_integrity >= max_integrity)
 		return TRUE
-	if(!I.use_tool(src, user, 0, volume=50, amount=1))
+	if(!I.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
 		return TRUE
 	user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to \the [src]."))
 	atom_integrity += min(10, max_integrity-atom_integrity)

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -83,7 +83,7 @@
 	if(!W.tool_start_check(user, amount=1))
 		return
 	LAZYADD(repairing_mobs, user)
-	user.balloon_alert_to_viewers("started repairing [src]")
+	user.balloon_alert_to_viewers("started welding [src]", "started repairing [src]")
 	audible_message(span_hear("You hear welding."))
 	var/did_the_thing
 	while(atom_integrity < max_integrity)
@@ -96,7 +96,7 @@
 	if(did_the_thing)
 		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
 	else
-		user.balloon_alert_to_viewers("stopped repairing [src]", "interrupted the repair!")
+		user.balloon_alert_to_viewers("stopped welding [src]", "interrupted the repair!")
 	LAZYREMOVE(repairing_mobs, user)
 
 /obj/vehicle/ridden/atv/atom_break()

--- a/code/modules/vehicles/bicycle.dm
+++ b/code/modules/vehicles/bicycle.dm
@@ -38,7 +38,7 @@
 	if(!W.tool_start_check(user, amount=1))
 		return
 	LAZYADD(repairing_mobs, user)
-	user.balloon_alert_to_viewers("starts to repair [src]", "started repairing [src]")
+	user.balloon_alert_to_viewers("started repairing [src]")
 	audible_message(span_hear("You hear welding."))
 	var/did_the_thing
 	while(atom_integrity < max_integrity)

--- a/code/modules/vehicles/bicycle.dm
+++ b/code/modules/vehicles/bicycle.dm
@@ -5,6 +5,8 @@
 	max_integrity = 150
 	integrity_failure = 0.5
 	var/fried = FALSE
+		///What mobs are currently repairing us.
+	var/list/mob/living/repairing_mobs
 
 /obj/vehicle/ridden/bicycle/Initialize(mapload)
 	. = ..()
@@ -21,17 +23,40 @@
 	for(var/m in buckled_mobs)
 		unbuckle_mob(m,1)
 
-/obj/vehicle/ridden/bicycle/welder_act(mob/living/user, obj/item/I)
+/obj/vehicle/ridden/bicycle/welder_act(mob/living/user, obj/item/W)
+	if(user.combat_mode)
+		return
+	. = TRUE
 	if(fried)
 		balloon_alert(user, "it's fried!")
-		return TRUE
+	if(LAZYFIND(repairing_mobs, user))
+		balloon_alert(user, "you're already repairing it!")
+		return
 	if(atom_integrity >= max_integrity)
-		return TRUE
-	if(!I.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
-		return TRUE
-	atom_integrity += min(10, max_integrity-atom_integrity)
-	if(atom_integrity == max_integrity)
-		balloon_alert(user, "fully repaired")
+		balloon_alert(user, "it's not damaged!")
+		return
+	if(!W.tool_start_check(user, amount=1))
+		return
+	LAZYADD(repairing_mobs, user)
+	user.balloon_alert_to_viewers("starts to repair [src]", "started repairing [src]")
+	audible_message(span_hear("You hear welding."))
+	var/did_the_thing
+	while(atom_integrity < max_integrity)
+		if(W.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1, extra_checks = CALLBACK(src, .proc/can_still_fix)))
+			did_the_thing = TRUE
+			atom_integrity += min(10, (max_integrity - atom_integrity))
+			audible_message(span_hear("You hear welding."))
+		else
+			break
+	if(did_the_thing)
+		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
 	else
-		balloon_alert(user, "repaired some damages")
-	return TRUE
+		user.balloon_alert_to_viewers("stopped repairing [src]", "interrupted the repair!")
+	LAZYREMOVE(repairing_mobs, user)
+
+///can we still fix the bike lol
+/obj/vehicle/ridden/bicycle/proc/can_still_fix()
+	return !fried
+
+
+

--- a/code/modules/vehicles/bicycle.dm
+++ b/code/modules/vehicles/bicycle.dm
@@ -27,7 +27,7 @@
 		return TRUE
 	if(atom_integrity >= max_integrity)
 		return TRUE
-	if(!I.use_tool(src, user, 0, volume=50, amount=1))
+	if(!I.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
 		return TRUE
 	atom_integrity += min(10, max_integrity-atom_integrity)
 	if(atom_integrity == max_integrity)

--- a/code/modules/vehicles/bicycle.dm
+++ b/code/modules/vehicles/bicycle.dm
@@ -38,7 +38,7 @@
 	if(!W.tool_start_check(user, amount=1))
 		return
 	LAZYADD(repairing_mobs, user)
-	user.balloon_alert_to_viewers("started repairing [src]")
+	user.balloon_alert_to_viewers("started welding [src]", "started repairing [src]")
 	audible_message(span_hear("You hear welding."))
 	var/did_the_thing
 	while(atom_integrity < max_integrity)
@@ -51,7 +51,7 @@
 	if(did_the_thing)
 		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
 	else
-		user.balloon_alert_to_viewers("stopped repairing [src]", "interrupted the repair!")
+		user.balloon_alert_to_viewers("stopped welding [src]", "interrupted the repair!")
 	LAZYREMOVE(repairing_mobs, user)
 
 ///can we still fix the bike lol

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -18,8 +18,8 @@
 	light_power = 2
 	light_on = FALSE
 	engine_sound = 'sound/effects/servostep.ogg'
-	///TRUE while the vim is being welded
-	var/being_repaired = FALSE
+		///What mobs are currently repairing us.
+	var/list/mob/living/repairing_mobs
 	///Maximum size of a mob trying to enter the mech
 	var/maximum_mob_size = MOB_SIZE_SMALL
 	COOLDOWN_DECLARE(sound_cooldown)
@@ -51,29 +51,34 @@
 		return FALSE
 	return ..()
 
-/obj/vehicle/sealed/car/vim/welder_act(mob/living/user, obj/item/tool)
-	. = ..()
+/obj/vehicle/sealed/car/vim/welder_act(mob/living/user, obj/item/W)
+	if(user.combat_mode)
+		return
 	. = TRUE
-	if(!tool.tool_start_check(user))
+	if(LAZYFIND(repairing_mobs, user))
+		balloon_alert(user, "you're already repairing it!")
 		return
-	if(being_repaired)
-		user.balloon_alert(user, "already being repaired!")
+	if(atom_integrity >= max_integrity)
+		balloon_alert(user, "it's not damaged!")
 		return
-	if(atom_integrity == max_integrity)
-		user.balloon_alert(user, "already fully repaired!")
+	if(!W.tool_start_check(user, amount=1))
 		return
-
-	user.balloon_alert(user, "repairing [src]...")
+	LAZYADD(repairing_mobs, user)
+	user.balloon_alert_to_viewers("starts to repair [src]", "started repairing [src]")
 	audible_message(span_hear("You hear welding."))
-	being_repaired = TRUE
-	if(!tool.use_tool(src, user, 3 SECONDS, volume=50))
-		being_repaired = FALSE
-		user.balloon_alert(user, "interrupted!")
-		return
-	being_repaired = FALSE
-
-	atom_integrity = min(atom_integrity + VIM_HEAL_AMOUNT, max_integrity)
-	user.balloon_alert(user, "[atom_integrity == max_integrity ? "fully " : ""]repaired [src]")
+	var/did_the_thing
+	while(atom_integrity < max_integrity)
+		if(W.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
+			did_the_thing = TRUE
+			atom_integrity += min(VIM_HEAL_AMOUNT, (max_integrity - atom_integrity))
+			audible_message(span_hear("You hear welding."))
+		else
+			break
+	if(did_the_thing)
+		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
+	else
+		user.balloon_alert_to_viewers("stopped repairing [src]", "interrupted the repair!")
+	LAZYREMOVE(repairing_mobs, user)
 
 /obj/vehicle/sealed/car/vim/mob_enter(mob/newoccupant, silent = FALSE)
 	. = ..()
@@ -137,7 +142,7 @@
 /obj/item/circuit_component/vim/proc/on_headlights_toggle(datum/source, headlights_on)
 	SIGNAL_HANDLER
 	are_headlights_on.set_output(headlights_on)
-	
+
 /obj/item/circuit_component/vim/proc/on_chime_used()
 	SIGNAL_HANDLER
 	chime.set_output(COMPONENT_SIGNAL)

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -64,7 +64,7 @@
 	if(!W.tool_start_check(user, amount=1))
 		return
 	LAZYADD(repairing_mobs, user)
-	user.balloon_alert_to_viewers("starts to repair [src]", "started repairing [src]")
+	user.balloon_alert_to_viewers("started repairing [src]")
 	audible_message(span_hear("You hear welding."))
 	var/did_the_thing
 	while(atom_integrity < max_integrity)

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -64,7 +64,7 @@
 	if(!W.tool_start_check(user, amount=1))
 		return
 	LAZYADD(repairing_mobs, user)
-	user.balloon_alert_to_viewers("started repairing [src]")
+	user.balloon_alert_to_viewers("started welding [src]", "started repairing [src]")
 	audible_message(span_hear("You hear welding."))
 	var/did_the_thing
 	while(atom_integrity < max_integrity)
@@ -77,7 +77,7 @@
 	if(did_the_thing)
 		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
 	else
-		user.balloon_alert_to_viewers("stopped repairing [src]", "interrupted the repair!")
+		user.balloon_alert_to_viewers("stopped welding [src]", "interrupted the repair!")
 	LAZYREMOVE(repairing_mobs, user)
 
 /obj/vehicle/sealed/car/vim/mob_enter(mob/newoccupant, silent = FALSE)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -71,6 +71,8 @@
 	var/allow_diagonal_movement = FALSE
 	///Whether or not the mech destroys walls by running into it.
 	var/bumpsmash = FALSE
+	///What mobs are currently repairing us.
+	var/list/mob/living/repairing_mobs
 
 	///////////ATMOS
 	///Whether we are currrently drawing from the internal tank

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -320,7 +320,7 @@
 		return
 	. = TRUE
 	if(atom_integrity < max_integrity)
-		if(!W.use_tool(src, user, 0, volume=50, amount=1))
+		if(!W.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
 			return
 		user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to [src]."))
 		atom_integrity += min(10, max_integrity-atom_integrity)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -327,7 +327,7 @@
 	if(!W.tool_start_check(user, amount=1))
 		return
 	LAZYADD(repairing_mobs, user)
-	user.balloon_alert_to_viewers("started repairing [src]")
+	user.balloon_alert_to_viewers("started welding [src]", "started repairing [src]")
 	audible_message(span_hear("You hear welding."))
 	var/did_the_thing
 	while(atom_integrity < max_integrity)
@@ -340,7 +340,7 @@
 	if(did_the_thing)
 		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
 	else
-		user.balloon_alert_to_viewers("stopped repairing [src]", "interrupted the repair!")
+		user.balloon_alert_to_viewers("stopped welding [src]", "interrupted the repair!")
 	LAZYREMOVE(repairing_mobs, user)
 
 

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -327,7 +327,7 @@
 	if(!W.tool_start_check(user, amount=1))
 		return
 	LAZYADD(repairing_mobs, user)
-	user.balloon_alert_to_viewers("starts to repair [src]", "started repairing [src]")
+	user.balloon_alert_to_viewers("started repairing [src]")
 	audible_message(span_hear("You hear welding."))
 	var/did_the_thing
 	while(atom_integrity < max_integrity)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -315,19 +315,34 @@
 		to_chat(user, span_notice("You close the hatch to the power unit."))
 
 /obj/vehicle/sealed/mecha/welder_act(mob/living/user, obj/item/W)
-	. = ..()
 	if(user.combat_mode)
 		return
 	. = TRUE
-	if(atom_integrity < max_integrity)
-		if(!W.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
-			return
-		user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to [src]."))
-		atom_integrity += min(10, max_integrity-atom_integrity)
-		if(atom_integrity == max_integrity)
-			to_chat(user, span_notice("It looks to be fully repaired now."))
+	if(LAZYFIND(repairing_mobs, user))
+		balloon_alert(user, "you're already repairing it!")
 		return
-	to_chat(user, span_warning("[src] is at full integrity!"))
+	if(atom_integrity >= max_integrity)
+		balloon_alert(user, "it's not damaged!")
+		return
+	if(!W.tool_start_check(user, amount=1))
+		return
+	LAZYADD(repairing_mobs, user)
+	user.balloon_alert_to_viewers("starts to repair [src]", "started repairing [src]")
+	audible_message(span_hear("You hear welding."))
+	var/did_the_thing
+	while(atom_integrity < max_integrity)
+		if(W.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
+			did_the_thing = TRUE
+			atom_integrity += min(10, (max_integrity - atom_integrity))
+			audible_message(span_hear("You hear welding."))
+		else
+			break
+	if(did_the_thing)
+		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
+	else
+		user.balloon_alert_to_viewers("stopped repairing [src]", "interrupted the repair!")
+	LAZYREMOVE(repairing_mobs, user)
+
 
 /obj/vehicle/sealed/mecha/proc/full_repair(charge_cell)
 	atom_integrity = max_integrity

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -43,7 +43,7 @@
 	if(!W.tool_start_check(user, amount=1))
 		return
 	LAZYADD(repairing_mobs, user)
-	user.balloon_alert_to_viewers("starts to repair [src]", "started repairing [src]")
+	user.balloon_alert_to_viewers("started repairing [src]")
 	audible_message(span_hear("You hear welding."))
 	var/did_the_thing
 	while(atom_integrity < max_integrity)

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -7,6 +7,8 @@
 	armor = list(MELEE = 10, BULLET = 0, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 60, ACID = 60)
 	key_type = /obj/item/key/security
 	integrity_failure = 0.5
+		///What mobs are currently repairing us.
+	var/list/mob/living/repairing_mobs
 
 	///This stores a banana that, when used on the secway, prevents the vehicle from moving until it is removed.
 	var/obj/item/food/grown/banana/eddie_murphy
@@ -28,20 +30,34 @@
 	smoke.set_up(0, holder = src, location = src)
 	smoke.start()
 
-/obj/vehicle/ridden/secway/welder_act(mob/living/user, obj/item/I)
-	. = ..()
-	if(.)
+/obj/vehicle/ridden/secway/welder_act(mob/living/user, obj/item/W)
+	if(user.combat_mode)
+		return
+	. = TRUE
+	if(LAZYFIND(repairing_mobs, user))
+		balloon_alert(user, "you're already repairing it!")
 		return
 	if(atom_integrity >= max_integrity)
-		to_chat(user, span_notice("It is fully repaired already!"))
+		balloon_alert(user, "it's not damaged!")
 		return
-	if(!I.use_tool(src, user, 2.5 SECONDS, volume = 50, amount = 1))
+	if(!W.tool_start_check(user, amount=1))
 		return
-	user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to \the [src]."))
-	atom_integrity += min(10, max_integrity-atom_integrity)
-	if(atom_integrity >= max_integrity)
-		to_chat(user, span_notice("It looks to be fully repaired now."))
-		STOP_PROCESSING(SSobj, src)
+	LAZYADD(repairing_mobs, user)
+	user.balloon_alert_to_viewers("starts to repair [src]", "started repairing [src]")
+	audible_message(span_hear("You hear welding."))
+	var/did_the_thing
+	while(atom_integrity < max_integrity)
+		if(W.use_tool(src, user, 2.5 SECONDS, volume=50, amount=1))
+			did_the_thing = TRUE
+			atom_integrity += min(10, (max_integrity - atom_integrity))
+			audible_message(span_hear("You hear welding."))
+		else
+			break
+	if(did_the_thing)
+		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
+	else
+		user.balloon_alert_to_viewers("stopped repairing [src]", "interrupted the repair!")
+	LAZYREMOVE(repairing_mobs, user)
 
 /obj/vehicle/ridden/secway/attackby(obj/item/W, mob/living/user, params)
 	if(!istype(W, /obj/item/food/grown/banana))

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -35,7 +35,7 @@
 	if(atom_integrity >= max_integrity)
 		to_chat(user, span_notice("It is fully repaired already!"))
 		return
-	if(!I.use_tool(src, user, 0, volume = 50, amount = 1))
+	if(!I.use_tool(src, user, 2.5 SECONDS, volume = 50, amount = 1))
 		return
 	user.visible_message(span_notice("[user] repairs some damage to [name]."), span_notice("You repair some damage to \the [src]."))
 	atom_integrity += min(10, max_integrity-atom_integrity)

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -43,7 +43,7 @@
 	if(!W.tool_start_check(user, amount=1))
 		return
 	LAZYADD(repairing_mobs, user)
-	user.balloon_alert_to_viewers("started repairing [src]")
+	user.balloon_alert_to_viewers("started welding [src]", "started repairing [src]")
 	audible_message(span_hear("You hear welding."))
 	var/did_the_thing
 	while(atom_integrity < max_integrity)
@@ -56,7 +56,7 @@
 	if(did_the_thing)
 		user.balloon_alert_to_viewers("[(atom_integrity >= max_integrity) ? "fully" : "partially"] repaired [src]")
 	else
-		user.balloon_alert_to_viewers("stopped repairing [src]", "interrupted the repair!")
+		user.balloon_alert_to_viewers("stopped welding [src]", "interrupted the repair!")
 	LAZYREMOVE(repairing_mobs, user)
 
 /obj/vehicle/ridden/secway/attackby(obj/item/W, mob/living/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
So right now there is 0 delay between welding repairs for vehicles / mecha. You can literally hop out of your murderboner durand, flip on a welder, and repair it fully from 5% HP to 100% in a split second with an autoclicker macro. This adds a delay.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Makes it so that you can't quickly hop out of your mecha/vehicle, instantly combat repair all it's damage, and hop right back into a fight. Instead, this encourages players to find safer areas before hopping out to commit to a repair.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


:cl: ShizCalev
balance: Vehicles & Mecha now take 2.5 second to repair with a welder. 
qol: Vehicles & mecha will automatically repair over time once clicked.
qol: Vehicles & Mecha now give balloon alerts when repairing.
/:cl:




<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->


Duration is free for debate, was thinking somewhere between 2 & 3 seconds, 2.5 seemed a happy midpoint.