### PR TITLE
Zas atmos zone

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -40,8 +40,6 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 				continue
 			found_turfs += checkT // Since checkT is connected, add it to the list to be processed
 
-<<<<<<< Updated upstream
-=======
 // Create a ZAS atmos zone, fuck you Kapu you made me zas post 
 /proc/create_atmos_zone(turf/source, range)
 	var/counter = 1 // a counter which increment each loop
@@ -51,7 +49,6 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 	var/list/connected_turfs = list(source)
 	. = connected_turfs
 	while(length(connected_turfs))
-		var/recorded_length = length(connected_turfs)
 		var/list/turf/adjacent_turfs = list(
 			get_step(connected_turfs[counter], NORTH),
 			get_step(connected_turfs[counter], SOUTH),
@@ -74,7 +71,6 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 			return
 		counter += 1 //increment by one so the next loop will start at the next position in the list
 			
->>>>>>> Stashed changes
 /proc/create_area(mob/creator)
 	// Passed into the above proc as list/break_if_found
 	var/static/list/area_or_turf_fail_types = typecacheof(list(

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -40,6 +40,41 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 				continue
 			found_turfs += checkT // Since checkT is connected, add it to the list to be processed
 
+<<<<<<< Updated upstream
+=======
+// Create a ZAS atmos zone, fuck you Kapu you made me zas post 
+/proc/create_atmos_zone(turf/source, range)
+	var/counter = 1 // a counter which increment each loop
+	var/loops = 0
+	if(source.blocks_air)
+		return
+	var/list/connected_turfs = list(source)
+	. = connected_turfs
+	while(length(connected_turfs))
+		var/recorded_length = length(connected_turfs)
+		var/list/turf/adjacent_turfs = list(
+			get_step(connected_turfs[counter], NORTH),
+			get_step(connected_turfs[counter], SOUTH),
+			get_step(connected_turfs[counter], EAST),
+			get_step(connected_turfs[counter], WEST)
+		)// get a tile in each cardinal direction at once and add that to the list
+		for(var/turf/valid_turf in adjacent_turfs)//loop through the list and check for atmos adjacency
+			var/turf/reference_turf = connected_turfs[counter]
+			if(valid_turf in connected_turfs)//if the turf is already added, skip
+				loops += 1
+				continue
+			if(!TURFS_CAN_SHARE(reference_turf, valid_turf))
+				loops += 1
+				continue
+			if(length(connected_turfs) >= range)
+				return 
+			connected_turfs |= valid_turf//add that to the original list
+			loops = 0
+		if(loops == 7)//if the loop has gone 7 consecutive times with no new turfs added, return the result. Number is arbitrary, subject to change
+			return
+		counter += 1 //increment by one so the next loop will start at the next position in the list
+			
+>>>>>>> Stashed changes
 /proc/create_area(mob/creator)
 	// Passed into the above proc as list/break_if_found
 	var/static/list/area_or_turf_fail_types = typecacheof(list(

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -49,7 +49,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
  *
  * Returns a list of turfs, which is an area of isolated atmos
  */ 
-/proc/create_atmos_zone(turf/source, range)
+/proc/create_atmos_zone(turf/source, range = INFINITY)
 	var/counter = 1 // a counter which increment each loop
 	var/loops = 0
 	if(source.blocks_air)

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -40,7 +40,15 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 				continue
 			found_turfs += checkT // Since checkT is connected, add it to the list to be processed
 
-// Create a ZAS atmos zone, fuck you Kapu you made me zas post 
+/**
+ * Create an atmos zone (Think ZAS), similiar to [proc/detect_room] but it ignores walls and turfs which are non-[atmos_can_pass]
+ *
+ * Arguments
+ * source - the turf which to find all connected atmos turfs
+ * range - the max range to check
+ *
+ * Returns a list of turfs, which is an area of isolated atmos
+ */ 
 /proc/create_atmos_zone(turf/source, range)
 	var/counter = 1 // a counter which increment each loop
 	var/loops = 0

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -60,17 +60,15 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 			if(valid_turf in connected_turfs)//if the turf is already added, skip
 				loops += 1
 				continue
-			if(!TURFS_CAN_SHARE(reference_turf, valid_turf))
-				loops += 1
-				continue
 			if(length(connected_turfs) >= range)
 				return 
-			connected_turfs |= valid_turf//add that to the original list
-			loops = 0
-		if(loops == 7)//if the loop has gone 7 consecutive times with no new turfs added, return the result. Number is arbitrary, subject to change
+			if(TURFS_CAN_SHARE(reference_turf, valid_turf))
+				loops = 0 
+				connected_turfs |= valid_turf//add that to the original list				
+		if(loops >= 7)//if the loop has gone 7 consecutive times with no new turfs added, return the result. Number is arbitrary, subject to change
 			return
 		counter += 1 //increment by one so the next loop will start at the next position in the list
-			
+				
 /proc/create_area(mob/creator)
 	// Passed into the above proc as list/break_if_found
 	var/static/list/area_or_turf_fail_types = typecacheof(list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pr adds a new proc to detect an atmos isolated area similar to detect_room however, this proc will ignore walls and non atmos_can_pass essentially an zas atmos zone. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
@LemonInTheDark has requested me to make this proc in pr #68325 but i feel like that pr is getting too big so i want to pr this separately to get some reviews and code advice
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: add proc create_atmos_zone which detect an isolated atmos zone while ignoring walls and non atmos_can_pass tiles (zas zone)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
