### PR TITLE
Cyber Stomach consistency

### DIFF
--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -299,7 +299,7 @@
 	organ_flags = ORGAN_SYNTHETIC
 	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.5
 	var/emp_vulnerability = 80 //Chance of permanent effects if emp-ed.
-	metabolism_efficiency = 0.35 // not as good at digestion
+	metabolism_efficiency = 0.035 // not as good at digestion
 
 /obj/item/organ/internal/stomach/cybernetic/tier2
 	name = "cybernetic stomach"

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -28,7 +28,7 @@
 	var/disgust_metabolism = 1
 
 	///The rate that the stomach will transfer reagents to the body
-	var/metabolism_efficiency = 0.05 // the lowest we should go is 0.05
+	var/metabolism_efficiency = 0.05 // the lowest we should go is 0.025
 
 
 /obj/item/organ/internal/stomach/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Metabolism_efficiency for the stomach, is used to handle the rate food stuff enters the blood and thus effects health.
Why in gods name is the T1 cyber stomach, 7 times faster than the base stomach, 5x faster than the T2, and 3.5x faster than the T3? It's pretty clear the original intent was for it to be 0.7x the speed of the base stomach. And unless we want to buff all the stomachs to keep everything above the 0.05 baserate, I don't see any reason for the T1 cyber stomach, to be anything else than 0.**0**35

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency, clear scaling, no weird "why is the bad thing better" nonsense.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
:cl:
fix: Basic cyberstomach digestion speed dropped down to be in line with the other stomachs
/:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
