### PR TITLE
Fixes candy not dropping wrappers when used to make salad

### DIFF
--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -24,7 +24,7 @@
 		RegisterSignal(target, COMSIG_FOOD_CROSSED, .proc/food_crossed)
 	RegisterSignal(target, COMSIG_ITEM_ON_GRIND, .proc/generate_trash)
 	RegisterSignal(target, COMSIG_ITEM_ON_JUICE, .proc/generate_trash)
-	RegisterSignal(target, COMSIG_ITEM_USED_AS_INGREDIENT, .proc/on_use_ingredient)
+	RegisterSignal(target, COMSIG_ITEM_USED_AS_INGREDIENT, .proc/generate_trash)
 	RegisterSignal(target, COMSIG_ITEM_ON_COMPOSTED, .proc/generate_trash)
 	RegisterSignal(target, COMSIG_ITEM_SOLD_TO_CUSTOMER, .proc/generate_trash)
 
@@ -36,11 +36,6 @@
 	SIGNAL_HANDLER
 
 	///cringy signal_handler shouldnt be needed if you dont want to return but oh well
-	INVOKE_ASYNC(src, .proc/async_generate_trash, source)
-
-/datum/element/food_trash/proc/on_use_ingredient(datum/source)
-	SIGNAL_HANDLER
-
 	INVOKE_ASYNC(src, .proc/async_generate_trash, source)
 
 /datum/element/food_trash/proc/async_generate_trash(datum/source)

--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -24,6 +24,7 @@
 		RegisterSignal(target, COMSIG_FOOD_CROSSED, .proc/food_crossed)
 	RegisterSignal(target, COMSIG_ITEM_ON_GRIND, .proc/generate_trash)
 	RegisterSignal(target, COMSIG_ITEM_ON_JUICE, .proc/generate_trash)
+	RegisterSignal(target, COMSIG_ITEM_USED_AS_INGREDIENT, .proc/on_use_ingredient)
 	RegisterSignal(target, COMSIG_ITEM_ON_COMPOSTED, .proc/generate_trash)
 	RegisterSignal(target, COMSIG_ITEM_SOLD_TO_CUSTOMER, .proc/generate_trash)
 
@@ -35,6 +36,11 @@
 	SIGNAL_HANDLER
 
 	///cringy signal_handler shouldnt be needed if you dont want to return but oh well
+	INVOKE_ASYNC(src, .proc/async_generate_trash, source)
+
+/datum/element/food_trash/proc/on_use_ingredient(datum/source)
+	SIGNAL_HANDLER
+
 	INVOKE_ASYNC(src, .proc/async_generate_trash, source)
 
 /datum/element/food_trash/proc/async_generate_trash(datum/source)


### PR DESCRIPTION
## About The Pull Request

Makes trash food element drop the trash food (like candy wrappers) when used as an ingredient in stuff, like putting it in a bowl to turn it into a salad.

## Why It's Good For The Game

Fixes a janitor job content-ruining bug.

## Changelog
:cl:
fix: Using candy bars as an ingredient in salad now drops a candy wrapper.
/:cl:
