### PR TITLE
Fix: Cult construct can attack while their spells are on cooldown (All spells no longer have a Melee CD by default)

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -13,6 +13,8 @@ Doesn't work on other aliens/AI.*/
 	icon_icon = 'icons/mob/actions/actions_xeno.dmi'
 	button_icon_state = "spell_default"
 	check_flags = AB_CHECK_CONSCIOUS
+	melee_cooldown_time = 0 SECONDS
+
 	/// How much plasma this action uses.
 	var/plasma_cost = 0
 
@@ -413,4 +415,3 @@ Doesn't work on other aliens/AI.*/
 /mob/living/carbon/alien/adjustPlasma(amount)
 	. = ..()
 	updatePlasmaDisplay()
-

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -30,14 +30,14 @@
 	///Whether or not the regal rat is already opening an airlock
 	var/opening_airlock = FALSE
 	///The spell that the rat uses to generate miasma
-	var/datum/action/cooldown/domain
+	var/datum/action/cooldown/domain/domain
 	///The Spell that the rat uses to recruit/convert more rats.
-	var/datum/action/cooldown/riot
+	var/datum/action/cooldown/riot/riot
 
 /mob/living/simple_animal/hostile/regalrat/Initialize(mapload)
 	. = ..()
-	domain = new /datum/action/cooldown/domain
-	riot = new /datum/action/cooldown/riot
+	domain = new(src)
+	riot = new(src)
 	domain.Grant(src)
 	riot.Grant(src)
 	AddElement(/datum/element/waddling)
@@ -45,9 +45,9 @@
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 /mob/living/simple_animal/hostile/regalrat/Destroy()
-	. = ..()
 	QDEL_NULL(domain)
 	QDEL_NULL(riot)
+	return ..()
 
 /mob/living/simple_animal/hostile/regalrat/proc/get_player()
 	var/list/mob/dead/observer/candidates = poll_ghost_candidates("Do you want to play as the Royal Rat, cheesey be their crown?", ROLE_SENTIENCE, FALSE, 100, POLL_IGNORE_SENTIENCE_POTION)
@@ -207,6 +207,7 @@
 	desc = "Corrupts this area to be more suitable for your rat army."
 	check_flags = AB_CHECK_CONSCIOUS
 	cooldown_time = 6 SECONDS
+	melee_cooldown_time = 0 SECONDS
 	icon_icon = 'icons/mob/actions/actions_animal.dmi'
 	background_icon_state = "bg_clock"
 	button_icon_state = "coffer"
@@ -242,7 +243,7 @@
 	button_icon_state = "riot"
 	background_icon_state = "bg_clock"
 	cooldown_time = 8 SECONDS
-	///Checks to see if there are any nearby mice. Does not count Rats.
+	melee_cooldown_time = 0 SECONDS
 
 /datum/action/cooldown/riot/proc/riot()
 	var/cap = CONFIG_GET(number/ratcap)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -477,6 +477,7 @@
 	icon_icon = 'icons/mob/actions/actions_animal.dmi'
 	button_icon_state = "regurgitate"
 	check_flags = AB_CHECK_CONSCIOUS
+	melee_cooldown_time = 0 SECONDS
 	click_to_activate = TRUE
 
 /datum/action/cooldown/regurgitate/set_click_ability(mob/on_who)

--- a/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
@@ -49,6 +49,7 @@
 	button_icon_state = "tentacle_slap"
 	check_flags = AB_CHECK_CONSCIOUS
 	cooldown_time = 12 SECONDS
+	melee_cooldown_time = 0 SECONDS
 	click_to_activate = TRUE
 	ranged_mousepointer = 'icons/effects/mouse_pointers/supplypod_target.dmi'
 

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -47,6 +47,7 @@
 	button_icon_state = "spell_default"
 	check_flags = AB_CHECK_CONSCIOUS
 	panel = "Spells"
+	melee_cooldown_time = 0 SECONDS
 
 	/// The sound played on cast.
 	var/sound = null


### PR DESCRIPTION
## About The Pull Request

Fixes #68779

#68382 Added a "melee cooldown" to ALL cooldown actions by default, which is something I wasn't sure about in the PR, but Space suggested it wouldn't affect anything. Turns out did affect some things 

I instead have overridden all the new cooldown actions (Alien, spells, and some misc ones) to have a 0 second melee cooldown, allowing constructs and similar to attack and use spells freely

## Why It's Good For The Game

Not being able to attack is BAD

## Changelog

:cl: Melbert
fix: Constructs, rats, and some other creatures can attack while their spells are on CD
/:cl: