### PR TITLE
Tail wagging is corrected to prevent incorrect emote text.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -112,7 +112,6 @@
 
 /datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
 	. = ..()
-	var/mob/living/carbon/human/H = user
 	var/obj/item/organ/external/tail/oranges_accessory = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)
 	if(oranges_accessory.wag_flags & WAG_WAGGING)
 		. = "stops wagging " + message

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -100,38 +100,21 @@
 	key_third_person = "wags"
 	message = "wags their tail."
 
-/datum/emote/living/carbon/human/stopwag
-	key = "stopwag"
-	message = "stops wagging their tail."
-
 /datum/emote/living/carbon/human/wag/run_emote(mob/user, params, type_override, intentional)
-	. = ..()
-	if(!.)
-		return
-	var/obj/item/organ/external/tail/oranges_accessory = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)
-	if(oranges_accessory.wag_flags) //We verified the tail exists in can_run_emote()
-		SEND_SIGNAL(user, COMSIG_ORGAN_WAG_TAIL, TRUE)
-
-/datum/emote/living/carbon/human/stopwag/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(!.)
 		return
 	var/obj/item/organ/external/tail/oranges_accessory = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)
 	if(oranges_accessory.wag_flags & WAG_WAGGING) //We verified the tail exists in can_run_emote()
 		SEND_SIGNAL(user, COMSIG_ORGAN_WAG_TAIL, FALSE)
-
-/datum/emote/living/carbon/human/stopwag/can_run_emote(mob/user, status_check, intentional)
-	var/obj/item/organ/external/tail/oranges_accessory = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)
-	if(oranges_accessory.wag_flags & WAG_WAGGING)
-		return ..()
-	return FALSE
+	else
+		SEND_SIGNAL(user, COMSIG_ORGAN_WAG_TAIL, TRUE)
 
 /datum/emote/living/carbon/human/wag/can_run_emote(mob/user, status_check, intentional)
 	var/obj/item/organ/external/tail/tail = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)
 	if(tail?.wag_flags & WAG_ABLE)
 		return ..()
 	return FALSE
-
 /datum/emote/living/carbon/human/wing
 	key = "wing"
 	key_third_person = "wings"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -100,21 +100,38 @@
 	key_third_person = "wags"
 	message = "wags their tail."
 
+/datum/emote/living/carbon/human/stopwag
+	key = "stopwag"
+	message = "stops wagging their tail."
+
 /datum/emote/living/carbon/human/wag/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(!.)
+		return
+	var/obj/item/organ/external/tail/oranges_accessory = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)
+	if(oranges_accessory.wag_flags) //We verified the tail exists in can_run_emote()
+		SEND_SIGNAL(user, COMSIG_ORGAN_WAG_TAIL, TRUE)
+
+/datum/emote/living/carbon/human/stopwag/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(!.)
 		return
 	var/obj/item/organ/external/tail/oranges_accessory = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)
 	if(oranges_accessory.wag_flags & WAG_WAGGING) //We verified the tail exists in can_run_emote()
 		SEND_SIGNAL(user, COMSIG_ORGAN_WAG_TAIL, FALSE)
-	else
-		SEND_SIGNAL(user, COMSIG_ORGAN_WAG_TAIL, TRUE)
+
+/datum/emote/living/carbon/human/stopwag/can_run_emote(mob/user, status_check, intentional)
+	var/obj/item/organ/external/tail/oranges_accessory = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)
+	if(oranges_accessory.wag_flags & WAG_WAGGING)
+		return ..()
+	return FALSE
 
 /datum/emote/living/carbon/human/wag/can_run_emote(mob/user, status_check, intentional)
 	var/obj/item/organ/external/tail/tail = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)
 	if(tail?.wag_flags & WAG_ABLE)
 		return ..()
 	return FALSE
+
 /datum/emote/living/carbon/human/wing
 	key = "wing"
 	key_third_person = "wings"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -98,7 +98,7 @@
 /datum/emote/living/carbon/human/wag
 	key = "wag"
 	key_third_person = "wags"
-	message = "wags their tail."
+	message = "their tail."
 
 /datum/emote/living/carbon/human/wag/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
@@ -109,6 +109,15 @@
 		SEND_SIGNAL(user, COMSIG_ORGAN_WAG_TAIL, FALSE)
 	else
 		SEND_SIGNAL(user, COMSIG_ORGAN_WAG_TAIL, TRUE)
+
+/datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
+	. = ..()
+	var/mob/living/carbon/human/H = user
+	var/obj/item/organ/external/tail/oranges_accessory = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)
+	if(oranges_accessory.wag_flags & WAG_WAGGING)
+		. = "stops wagging " + message
+	else
+		. = "wags " + message
 
 /datum/emote/living/carbon/human/wag/can_run_emote(mob/user, status_check, intentional)
 	var/obj/item/organ/external/tail/tail = user.getorganslot(ORGAN_SLOT_EXTERNAL_TAIL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tail wagging is corrected to prevent incorrect emote text.

Wagging will prompt `wags their tail`

Wagging while currently wagging will stop the wag and state `stops wagging their tail`

## Why It's Good For The Game

Fixes downstream issues. ~Oh god I'm doing work for skyrat~

Fixes https://github.com/tgstation/tgstation/issues/68799

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes tail wag emote stopping the wag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
