### PR TITLE
Fix Legionnaire's Charge When Hitting Allies

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -147,15 +147,15 @@
 	playsound(src,'sound/effects/bang.ogg', 200, 1)
 	var/list/hit_things = list()
 	var/throwtarget = get_edge_target_turf(src, move_dir)
-	for(var/mob/living/L in T.contents - hit_things - src)
-		if(faction_check_mob(L))
-			return
-		hit_things += L
-		visible_message(span_boldwarning("[src] tramples and kicks [L]!"))
-		to_chat(L, span_userdanger("[src] tramples you and kicks you away!"))
-		L.safe_throw_at(throwtarget, 10, 1, src)
-		L.Paralyze(20)
-		L.adjustBruteLoss(melee_damage_upper)
+	for(var/mob/living/trample_target in T.contents - hit_things - src)
+		hit_things += trample_target
+		if(faction_check_mob(trample_target))
+			continue
+		visible_message(span_boldwarning("[src] tramples and kicks [trample_target]!"))
+		to_chat(trample_target, span_userdanger("[src] tramples you and kicks you away!"))
+		trample_target.safe_throw_at(throwtarget, 10, 1, src)
+		trample_target.Paralyze(20)
+		trample_target.adjustBruteLoss(melee_damage_upper)
 	addtimer(CALLBACK(src, .proc/legionnaire_charge_2, move_dir, (times_ran + 1)), 0.7)
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnaire/proc/head_detach(target)


### PR DESCRIPTION
## About The Pull Request

Legionnaire's charge currently has a bug where hitting someone on the allied faction stops legionnaire from doing the rest of the charge, but also prevents him from moving until he charges again.  This PR makes it do the intentional effect of going past allies without damaging them.

## Why It's Good For The Game

Bugs are bad, and buggy giant skeletons are even worse.

## Changelog

:cl:
fix: Fixed legionnaire's charge when hitting an ally.
/:cl: