### PR TITLE
Buffs regular windows so they can start replacing reinfoced windows in low security areas

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -7,10 +7,10 @@
 	pressure_resistance = 4*ONE_ATMOSPHERE
 	anchored = TRUE //initially is 0 for tile smoothing
 	flags_1 = ON_BORDER_1
-	max_integrity = 25
+	max_integrity = 50
 	can_be_unanchored = TRUE
 	resistance_flags = ACID_PROOF
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 80, ACID = 100)
+	armor = list(MELEE = 30, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 80, ACID = 100)
 	can_atmos_pass = ATMOS_PASS_PROC
 	rad_insulation = RAD_VERY_LIGHT_INSULATION
 	pass_flags_self = PASSGLASS
@@ -585,7 +585,7 @@
 	icon = 'icons/obj/smooth_structures/window.dmi'
 	icon_state = "window-0"
 	base_icon_state = "window"
-	max_integrity = 50
+	max_integrity = 100
 	fulltile = TRUE
 	flags_1 = PREVENT_CLICK_UNDER_1
 	smoothing_flags = SMOOTH_BITMASK


### PR DESCRIPTION
## About The Pull Request

This PR buffs regular windows so they take 10 toolbox hits to destroy instead of 4. This is a first step to make regular windows actually viable to place on the map so low security locations no longer have the overly strong reinforced windows. My plan is to make PRs after this for each map replacing all windows so that areas with regular walls have regular windows and areas with reinforced walls have reinforced windows (with the exception of arrivals and departures). I think it is fine to do this map by map since the regular windows are rarely used now anyway. 

## Why It's Good For The Game

All maps now basically only use reinforced windows, meaning there is little difference between low and high security areas. Walls are now actually weaker than windows which is very counter intuitive. Buffing the regular windows means we can actually start placing them on the map. 

## Changelog

:cl:
balance: Regular Windows are now stronger and take about 10 toolbox hits to destroy
/:cl:


