### PR TITLE
Kudzu Fixes v4, hopefully the last one: Fix kudzu possibly obtaining duplicate mutations when being planted from a seed that already has mutations

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -586,9 +586,13 @@
 		if(prob(mutativeness))
 			var/datum/spacevine_mutation/random_mutate = pick_weight(vine_mutations_list - vine.mutations)
 			var/total_severity = random_mutate.severity
+			var/mutation_is_valid = TRUE
 			for(var/datum/spacevine_mutation/mutation as anything in vine.mutations)
+				if(random_mutate.type == mutation.type) // see #68821, mutations from parent.mutations can have a different address than those in vine_mutations_list
+					mutation_is_valid = FALSE
+					break
 				total_severity += mutation.severity
-			if(total_severity <= max_mutation_severity)
+			if(mutation_is_valid && total_severity <= max_mutation_severity)
 				random_mutate.add_mutation_to_vinepiece(vine)
 
 	for(var/datum/spacevine_mutation/mutation in vine.mutations)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -588,7 +588,7 @@
 			var/total_severity = random_mutate.severity
 			var/mutation_is_valid = TRUE
 			for(var/datum/spacevine_mutation/mutation as anything in vine.mutations)
-				if(random_mutate.type == mutation.type) // see #68821, mutations from parent.mutations can have a different address than those in vine_mutations_list
+				if(random_mutate.type == mutation.type) // parent mutations (from the vine.mutations |= parent.mutations line) come from the parent vine that spawned this, and if up and up the chain they came from seeds originated from a different master controller and hence have a "different" mutation datum with a different address, subtracting vine.address from vine_mutations_list isn't sufficient in this case and wouldn't remove it, allowing for mutations to be duplicated
 					mutation_is_valid = FALSE
 					break
 				total_severity += mutation.severity

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -42,6 +42,10 @@
 /// Kudzu spread multiplier is a reciporal function of production speed, such that the better the production speed, ie. the lower the speed value is, the faster it spreads
 #define SPREAD_MULTIPLIER_MAX 50
 
+/// Kudzu's maximum possible maximum mutation severity (assuming ideal potency), used to balance mutation appearance chance
+#define IDEAL_MAX_SEVERITY 20
+
+
 /datum/round_event_control/spacevine
 	name = "Space Vines"
 	typepath = /datum/round_event/spacevine
@@ -541,7 +545,7 @@
 		vine_mutations_list = list()
 		init_subtypes(/datum/spacevine_mutation/, vine_mutations_list)
 		for(var/datum/spacevine_mutation/mutation as anything in vine_mutations_list)
-			vine_mutations_list[mutation] = max_mutation_severity - mutation.severity // this is intended to be before the potency check as the ideal maximum potency is used for weighting
+			vine_mutations_list[mutation] = IDEAL_MAX_SEVERITY - mutation.severity // the ideal maximum potency is used for weighting
 	if(potency != null)
 		mutativeness = potency * MUTATIVENESS_SCALE_FACTOR // If potency is 100, 20 mutativeness; if 1: 0.2 mutativeness
 		max_mutation_severity = round(potency * MAX_SEVERITY_LINEAR_COEFF + MAX_SEVERITY_CONSTANT_TERM) // If potency is 100, 25 max mutation severity; if 1, 10 max mutation severity
@@ -759,3 +763,4 @@
 #undef SPREAD_CAP_LINEAR_COEFF
 #undef SPREAD_CAP_CONSTANT_TERM
 #undef SPREAD_MULTIPLIER_MAX
+#undef IDEAL_MAX_SEVERITY

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -586,6 +586,7 @@
 		if(prob(mutativeness))
 			var/datum/spacevine_mutation/random_mutate = pick_weight(vine_mutations_list - vine.mutations)
 			var/total_severity = random_mutate.severity
+			/// Ensures that the mutation is truly unique and isn't just the same datum but with a different address in memory
 			var/mutation_is_valid = TRUE
 			for(var/datum/spacevine_mutation/mutation as anything in vine.mutations)
 				if(random_mutate.type == mutation.type) // parent mutations (from the vine.mutations |= parent.mutations line) come from the parent vine that spawned this, and if up and up the chain they came from seeds originated from a different master controller and hence have a "different" mutation datum with a different address, subtracting vine.address from vine_mutations_list isn't sufficient in this case and wouldn't remove it, allowing for mutations to be duplicated


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title, parent mutations that come from vines that came from seeds which came from a different master controller, hence the different addresses.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #35915 and fixes #68198
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Kudzu that has been planted from a seed which already had mutations on it cannot gain duplicate copies of those mutations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
