### PR TITLE
Fixes RPEDs being unable to pick up beakers and assemblies

### DIFF
--- a/code/datums/storage/subtypes/rped.dm
+++ b/code/datums/storage/subtypes/rped.dm
@@ -1,0 +1,15 @@
+/**
+ *Storage component used for RPEDs. Rather than manually setting everything with a get_part_rating() value, we just check if it has the variable required for insertion.
+ */
+/datum/storage/rped
+	allow_quick_empty = TRUE
+	allow_quick_gather = TRUE
+	max_slots = 50
+	max_total_storage = 100
+	max_specific_storage = WEIGHT_CLASS_NORMAL
+	numerical_stacking = TRUE
+
+/datum/storage/rped/can_insert(obj/item/to_insert, mob/user, messages = TRUE, force = FALSE)
+	. = ..()
+	if(!to_insert.get_part_rating())
+		return FALSE

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -16,14 +16,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 
 /obj/item/storage/part_replacer/Initialize()
 	. = ..()
-
-	atom_storage.allow_quick_empty = TRUE
-	atom_storage.allow_quick_gather = TRUE
-	atom_storage.max_slots = 50
-	atom_storage.max_total_storage = 100
-	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
-	atom_storage.numerical_stacking = TRUE
-	atom_storage.set_holdable(list(/obj/item/stock_parts), null)
+	create_storage(type = /datum/storage/rped)
 
 /obj/item/storage/part_replacer/pre_attack(obj/attacked_object, mob/living/user, params)
 	if(!istype(attacked_object, /obj/machinery) && !istype(attacked_object, /obj/structure/frame/machine))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1196,6 +1196,7 @@
 #include "code\datums\storage\subtypes\extract_inventory.dm"
 #include "code\datums\storage\subtypes\implant.dm"
 #include "code\datums\storage\subtypes\pockets.dm"
+#include "code\datums\storage\subtypes\rped.dm"
 #include "code\datums\votes\_vote_datum.dm"
 #include "code\datums\votes\custom_vote.dm"
 #include "code\datums\votes\map_vote.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #66808. In Tsu's storage refactor they forgot to include how RPEDs check the part rating value rather than just using the `stock_part` type. This makes a new storage subtype that does this check.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Bugs bad. Beakers good
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: RPEDs can pick up beakers and assemblies once again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
