### PR TITLE
Only the Nuke Ops leader can make a Declaration of War, to reduce people griefing their team by stealing the wardec from the leader and activating it against their wishes.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -136,6 +136,9 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 
 
 /obj/item/nuclear_challenge/proc/check_allowed(mob/living/user)
+	if(!user?.mind.has_antag_datum(/datum/antagonist/nukeop/leader))
+		to_chat(user, span_boldwarning("Only the leader is allowed to declare war."))
+		return FALSE
 	if(declaring_war)
 		to_chat(user, span_boldwarning("You are already in the process of declaring war! Make your mind up."))
 		return FALSE


### PR DESCRIPTION

## About The Pull Request

Only the Nuke Ops leader can make a Declaration of War, to reduce people griefing their team by stealing the wardec from the leader and activating it against their wishes.

## Why It's Good For The Game

Users were apparently forcing their team into a war by simply assaulting the nuke ops leader roundstart to forcefully press the wardec button if the nuke ops leader did not choose to declare war. Despite this being an egregious violation of the rules, as we all know the administration is incapable of actually enforcing healthy gameplay via moderation so we need to do it ourselves as game designers.

We gave it to the leader for a reason, if we wanted everyone to be able to declare war we would have put it on the uplink as a purchasable item for the nuke ops team or placed it in the common area. Instead, we put it on the leader. 

We expected the admins to simply enforce the rules they wrote on not sabotaging your team members in a team gamemode, but this is apparently too hard for our 100 person admin team and thus we need to fix the bad gameplay with the codebase, like every time the administration lets the gameplay get out of hand after they refuse to enforce the rules they wrote and came up with themselves.

## Changelog

:cl:
balance: Only the Nuke Ops leader can make a Declaration of War, to reduce people griefing their team by stealing the wardec from the leader and activating it against their wishes.
/:cl:
