### PR TITLE
Nuke Ops Leader update

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -397,6 +397,10 @@
 	else
 		return ..()
 
+/datum/dynamic_ruleset/midround/from_ghosts/nuclear/review_applications()
+	. = ..()
+	sort_by_most_played(assigned)
+
 //////////////////////////////////////////////
 //                                          //
 //              BLOB (GHOST)                //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -159,8 +159,8 @@
 		if (makeBody)
 			new_character = generate_ruleset_body(applicant)
 
-		finish_setup(new_character, i)
 		assigned += applicant
+		finish_setup(new_character, i)
 		notify_ghosts("[applicant.name] has been picked for the ruleset [name]!", source = new_character, action = NOTIFY_ORBIT, header="Something Interesting!")
 
 /datum/dynamic_ruleset/midround/from_ghosts/proc/generate_ruleset_body(mob/applicant)
@@ -390,16 +390,12 @@
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_setup(mob/new_character, index)
 	new_character.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 	new_character.mind.special_role = ROLE_NUCLEAR_OPERATIVE
-	if (index == 1) // Our first guy is the leader
-		var/datum/antagonist/nukeop/leader/new_role = new
+	if(new_character.mind == get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE))
+		var/datum/antagonist/nukeop/leader/new_role = new()
 		nuke_team = new_role.nuke_team
 		new_character.mind.add_antag_datum(new_role)
 	else
 		return ..()
-
-/datum/dynamic_ruleset/midround/from_ghosts/nuclear/review_applications()
-	. = ..()
-	sort_by_most_played(assigned)
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -393,7 +393,7 @@
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_applications()
-	leader = get_most_experienced(assigned)
+	leader = get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE)
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_setup(mob/new_character, index)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -149,17 +149,21 @@
 			else // Not dead? Disregard them, pick a new applicant
 				i--
 				continue
-
 		if(!applicant)
 			i--
 			continue
-
-		var/mob/new_character = applicant
-
-		if (makeBody)
-			new_character = generate_ruleset_body(applicant)
-
 		assigned += applicant
+	finish_applications()
+
+/// Here the accepted applications get generated bodies and their setup is finished.
+/// Called by review_applications()
+/datum/dynamic_ruleset/midround/from_ghosts/proc/finish_applications()
+	var/i = 0
+	for(var/mob/applicant as anything in assigned)
+		i++
+		var/mob/new_character = applicant
+		if(makeBody)
+			new_character = generate_ruleset_body(applicant)
 		finish_setup(new_character, i)
 		notify_ghosts("[applicant.name] has been picked for the ruleset [name]!", source = new_character, action = NOTIFY_ORBIT, header="Something Interesting!")
 
@@ -373,6 +377,7 @@
 	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
 	var/list/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
 	var/datum/team/nuclear/nuke_team
+	var/mob/leader
 	flags = HIGH_IMPACT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/acceptable(population=0, threat=0)
@@ -387,10 +392,15 @@
 		return FALSE
 	return ..()
 
+/datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_applications()
+	leader = get_most_experienced(assigned)
+	return ..()
+
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_setup(mob/new_character, index)
 	new_character.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 	new_character.mind.special_role = ROLE_NUCLEAR_OPERATIVE
-	if(new_character.mind == get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE))
+	if(new_character.mind == leader)
+		leader = null
 		var/datum/antagonist/nukeop/leader/new_role = new()
 		nuke_team = new_role.nuke_team
 		new_character.mind.add_antag_datum(new_role)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -412,6 +412,8 @@
 
 /datum/dynamic_ruleset/roundstart/nuclear/execute()
 	var/most_experienced = get_most_experienced(assigned, required_role)
+	if(!most_experienced)
+		most_experienced = assigned[1]
 	for(var/datum/mind/assigned_player in assigned)
 		if(assigned_player == most_experienced)
 			var/datum/antagonist/nukeop/leader/new_op = assigned_player.add_antag_datum(antag_leader_datum)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -407,6 +407,7 @@
 		assigned += M.mind
 		M.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 		M.mind.special_role = ROLE_NUCLEAR_OPERATIVE
+	sort_by_most_played(assigned)
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/nuclear/execute()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -390,6 +390,7 @@
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	flags = HIGH_IMPACT_RULESET
 	antag_cap = list("denominator" = 18, "offset" = 1)
+	var/required_role = ROLE_NUCLEAR_OPERATIVE
 	var/datum/team/nuclear/nuke_team
 
 /datum/dynamic_ruleset/roundstart/nuclear/ready(population, forced = FALSE)
@@ -407,19 +408,17 @@
 		assigned += M.mind
 		M.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 		M.mind.special_role = ROLE_NUCLEAR_OPERATIVE
-	sort_by_most_played(assigned)
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/nuclear/execute()
-	var/leader = TRUE
-	for(var/datum/mind/M in assigned)
-		if (leader)
-			leader = FALSE
-			var/datum/antagonist/nukeop/leader/new_op = M.add_antag_datum(antag_leader_datum)
+	var/most_experienced = get_most_experienced(assigned, required_role)
+	for(var/datum/mind/assigned_player in assigned)
+		if(assigned_player == most_experienced)
+			var/datum/antagonist/nukeop/leader/new_op = assigned_player.add_antag_datum(antag_leader_datum)
 			nuke_team = new_op.nuke_team
 		else
 			var/datum/antagonist/nukeop/new_op = new antag_datum()
-			M.add_antag_datum(new_op)
+			assigned_player.add_antag_datum(new_op)
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/nuclear/round_result()
@@ -596,6 +595,7 @@
 	antag_flag_override = ROLE_OPERATIVE
 	antag_leader_datum = /datum/antagonist/nukeop/leader/clownop
 	requirements = list(101,101,101,101,101,101,101,101,101,101)
+	required_role = ROLE_CLOWN_OPERATIVE
 
 /datum/dynamic_ruleset/roundstart/nuclear/clown_ops/pre_execute()
 	. = ..()

--- a/code/modules/antagonists/_common/antag_helpers.dm
+++ b/code/modules/antagonists/_common/antag_helpers.dm
@@ -8,16 +8,44 @@
 		if(!antag_type || !specific && istype(A,antag_type) || specific && A.type == antag_type)
 			. += A.owner
 
-/proc/sort_by_most_played(list/minds_to_sort)
-	var/list/sorted_players = list()
-	var/list/clients_to_sort = list()
-	var/list/minds_without_clients = list()
-	for(var/datum/mind/mind as anything in minds_to_sort)
-		if(!mind.current.client)
-			minds_without_clients += mind
+/proc/get_player_client(client/player)
+	if(ismob(player))
+		var/mob/player_mob = player
+		player = player_mob.client
+	else if(istype(player, /datum/mind))
+		var/datum/mind/player_mind = player
+		player = player_mind.current.client
+	if(!istype(player))
+		return FALSE
+	return player
+
+/proc/get_most_experienced(list/players, specific_role)
+	if(!CONFIG_GET(flag/use_exp_tracking)) //woops
+		return players[1]
+	var/index = 0
+	for(var/client/player as anything in players)
+		index++
+		player = get_player_client(player)
+		if(!player?.prefs)
 			continue
-		clients_to_sort += mind.current.client
-	clients_to_sort = sort_list(clients_to_sort, /proc/cmp_playtime_dsc)
-	for(var/client/client as anything in clients_to_sort)
-		sorted_players += client.mob.mind
-	sorted_players += minds_without_clients
+		if(!length(player.prefs.exp))
+			player.set_exp_from_db()
+			if(!length(player.prefs.exp))
+				continue
+		var/client/most_played = get_player_client(players[1])
+		if(player == most_played)
+			continue
+		if(!most_played.prefs || !length(most_played.prefs.exp))
+			players.Swap(1, index)
+			continue
+		var/player_playtime
+		var/most_playtime
+		if(specific_role)
+			player_playtime = player.prefs.exp[specific_role] ? text2num(player.prefs.exp[specific_role]) : 0
+			most_playtime = most_played.prefs.exp[specific_role] ? text2num(most_played.prefs.exp[specific_role]) : 0
+		else
+			player_playtime = player.get_exp_living(TRUE)
+			most_playtime = most_played.get_exp_living(TRUE)
+		if(player_playtime > most_playtime)
+			players.Swap(1, index)
+	return players[1]

--- a/code/modules/antagonists/_common/antag_helpers.dm
+++ b/code/modules/antagonists/_common/antag_helpers.dm
@@ -7,3 +7,17 @@
 			continue
 		if(!antag_type || !specific && istype(A,antag_type) || specific && A.type == antag_type)
 			. += A.owner
+
+/proc/sort_by_most_played(list/minds_to_sort)
+	var/list/sorted_players = list()
+	var/list/clients_to_sort = list()
+	var/list/minds_without_clients = list()
+	for(var/datum/mind/mind as anything in minds_to_sort)
+		if(!mind.current.client)
+			minds_without_clients += mind
+			continue
+		clients_to_sort += mind.current.client
+	clients_to_sort = sort_list(clients_to_sort, /proc/cmp_playtime_dsc)
+	for(var/client/client as anything in clients_to_sort)
+		sorted_players += client.mob.mind
+	sorted_players += minds_without_clients

--- a/code/modules/antagonists/_common/antag_helpers.dm
+++ b/code/modules/antagonists/_common/antag_helpers.dm
@@ -11,22 +11,18 @@
 /// From a list of players (minds, mobs or clients), finds the one with the highest playtime (either from a specific role or overall living) and returns it.
 /proc/get_most_experienced(list/players, specific_role)
 	if(!CONFIG_GET(flag/use_exp_tracking)) //woops
-		return players[1]
-	var/index = 0
+		return
+	var/most_experienced
 	for(var/client/player as anything in players)
-		index++
+		if(!most_experienced)
+			most_experienced = player
+			continue
 		player = get_player_client(player)
-		if(!player?.prefs)
+		if(!player?.prefs || !length(player.prefs.exp))
 			continue
-		if(!length(player.prefs.exp))
-			player.set_exp_from_db()
-			if(!length(player.prefs.exp))
-				continue
-		var/client/most_played = get_player_client(players[1])
-		if(player == most_played)
-			continue
-		if(!most_played.prefs || !length(most_played.prefs.exp))
-			players.Swap(1, index)
+		var/client/most_played = get_player_client(most_experienced)
+		if(!most_played?.prefs || !length(most_played.prefs.exp))
+			most_experienced = player
 			continue
 		var/player_playtime
 		var/most_playtime
@@ -37,5 +33,5 @@
 			player_playtime = player.get_exp_living(TRUE)
 			most_playtime = most_played.get_exp_living(TRUE)
 		if(player_playtime > most_playtime)
-			players.Swap(1, index)
-	return players[1]
+			most_experienced = player
+	return most_experienced

--- a/code/modules/antagonists/_common/antag_helpers.dm
+++ b/code/modules/antagonists/_common/antag_helpers.dm
@@ -8,17 +8,6 @@
 		if(!antag_type || !specific && istype(A,antag_type) || specific && A.type == antag_type)
 			. += A.owner
 
-/proc/get_player_client(client/player)
-	if(ismob(player))
-		var/mob/player_mob = player
-		player = player_mob.client
-	else if(istype(player, /datum/mind))
-		var/datum/mind/player_mind = player
-		player = player_mind.current.client
-	if(!istype(player))
-		return FALSE
-	return player
-
 /proc/get_most_experienced(list/players, specific_role)
 	if(!CONFIG_GET(flag/use_exp_tracking)) //woops
 		return players[1]

--- a/code/modules/antagonists/_common/antag_helpers.dm
+++ b/code/modules/antagonists/_common/antag_helpers.dm
@@ -8,6 +8,7 @@
 		if(!antag_type || !specific && istype(A,antag_type) || specific && A.type == antag_type)
 			. += A.owner
 
+/// From a list of players (minds, mobs or clients), finds the one with the highest playtime (either from a specific role or overall living) and returns it.
 /proc/get_most_experienced(list/players, specific_role)
 	if(!CONFIG_GET(flag/use_exp_tracking)) //woops
 		return players[1]

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -244,24 +244,19 @@
 
 /datum/antagonist/nukeop/leader/greet()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ops.ogg',100,0, use_reverb = FALSE)
-	to_chat(owner, "<span class='warningplain'><B>You are the Syndicate [title] for this mission. You are responsible for the distribution of telecrystals and your ID is the only one who can open the launch bay doors.</B></span>")
-	to_chat(owner, "<span class='warningplain'><B>If you feel you are not up to this task, give your ID to another operative.</B></span>")
+	to_chat(owner, "<span class='warningplain'><B>You are the Syndicate [title] for this mission. You are responsible for guiding the team and your ID is the only one who can open the launch bay doors.</B></span>")
+	to_chat(owner, "<span class='warningplain'><B>If you feel you are not up to this task, give your ID and radio to another operative.</B></span>")
 	if(!CONFIG_GET(flag/disable_warops))
 		to_chat(owner, "<span class='warningplain'><B>In your hand you will find a special item capable of triggering a greater challenge for your team. Examine it carefully and consult with your fellow operatives before activating it.</B></span>")
-
 	owner.announce_objectives()
 
 /datum/antagonist/nukeop/leader/on_gain()
 	. = ..()
 	if(!CONFIG_GET(flag/disable_warops))
-		var/obj/item/dukinuki = new challengeitem
-		var/mob/living/carbon/human/H = owner.current
-		if(!istype(H))
-			dukinuki.forceMove(H.drop_location())
-		else
-			H.put_in_hands(dukinuki, TRUE)
-		nuke_team.war_button_ref = WEAKREF(dukinuki)
-
+		var/mob/living/carbon/human/leader = owner.current
+		var/obj/item/war_declaration = new challengeitem(leader.drop_location())
+		leader.put_in_hands(war_declaration)
+		nuke_team.war_button_ref = WEAKREF(war_declaration)
 	addtimer(CALLBACK(src, .proc/nuketeam_name_assign), 1)
 
 /datum/antagonist/nukeop/leader/proc/nuketeam_name_assign()

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -25,25 +25,26 @@
 
 	id_trim = /datum/id_trim/chameleon/operative/nuke_leader
 
-/datum/outfit/syndicate/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/syndicate/post_equip(mob/living/carbon/human/nukie, visualsOnly = FALSE)
 	if(visualsOnly)
 		return
-	var/obj/item/radio/R = H.ears
-	R.set_frequency(FREQ_SYNDICATE)
-	R.freqlock = TRUE
+	var/obj/item/radio/radio = nukie.ears
+	radio.set_frequency(FREQ_SYNDICATE)
+	radio.freqlock = TRUE
 	if(command_radio)
-		R.command = TRUE
+		radio.command = TRUE
+		radio.use_command = TRUE
 
 	if(ispath(uplink_type, /obj/item/uplink/nuclear) || tc) // /obj/item/uplink/nuclear understands 0 tc
-		var/obj/item/U = new uplink_type(H, H.key, tc)
-		H.equip_to_slot_or_del(U, ITEM_SLOT_BACKPACK)
+		var/obj/item/uplink = new uplink_type(nukie, nukie.key, tc)
+		nukie.equip_to_slot_or_del(uplink, ITEM_SLOT_BACKPACK)
 
-	var/obj/item/implant/weapons_auth/W = new/obj/item/implant/weapons_auth(H)
-	W.implant(H)
-	var/obj/item/implant/explosive/E = new/obj/item/implant/explosive(H)
-	E.implant(H)
-	H.faction |= ROLE_SYNDICATE
-	H.update_icons()
+	var/obj/item/implant/weapons_auth/weapons_implant = new/obj/item/implant/weapons_auth(nukie)
+	weapons_implant.implant(nukie)
+	var/obj/item/implant/explosive/explosive_implant = new/obj/item/implant/explosive(nukie)
+	explosive_implant.implant(nukie)
+	nukie.faction |= ROLE_SYNDICATE
+	nukie.update_icons()
 
 /datum/outfit/syndicate/full
 	name = "Syndicate Operative - Full Kit"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -420,3 +420,15 @@
 		if(ITEM_SLOT_SUITSTORE)
 			return /obj/item
 	return null
+
+/// Returns a client from a mob, mind or client
+/proc/get_player_client(client/player)
+	if(ismob(player))
+		var/mob/player_mob = player
+		player = player_mob.client
+	else if(istype(player, /datum/mind))
+		var/datum/mind/player_mind = player
+		player = player_mind.current.client
+	if(!istype(player))
+		return FALSE
+	return player

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -422,13 +422,13 @@
 	return null
 
 /// Returns a client from a mob, mind or client
-/proc/get_player_client(client/player)
+/proc/get_player_client(player)
 	if(ismob(player))
 		var/mob/player_mob = player
 		player = player_mob.client
 	else if(istype(player, /datum/mind))
 		var/datum/mind/player_mind = player
 		player = player_mind.current.client
-	if(!istype(player))
-		return FALSE
+	if(!istype(player, /client))
+		return
 	return player


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
makes the nuke op player with the most nuke ops playtime the leader
makes the leader start with loud mode on on their radio

idea for that second one from https://github.com/BeeStation/BeeStation-Hornet/pull/6631

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
making the most playtime nuke op the leader prevents 1st time players from rolling it, they will generally be more competent, and able to be entrusted, just like you can trust a head of staff more. a player with more competency will also probably be better at actually leading and not just clicking a button to open the ship, if they try.
the radio is a tiny change to make the leader matter more, and able to give better leadership, because im pretty sure most people dont even realize the leader has access to loud mode

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Fikou, TeomanTheGreat
add: the nuke ops leader is now the highest nuke ops playtime player on the team
qol: the nuke ops leader now starts with their radio loud mode on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
