### PR TITLE
Replace Tank Dispensers in Toxins with Gasless Tank Dispensers

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9966,9 +9966,9 @@
 /area/station/security/prison/safe)
 "cuH" = (
 /obj/machinery/airalarm/directional/west,
-/obj/structure/tank_dispenser,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot,
+/obj/structure/tank_dispenser/emptytank,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "cuQ" = (
@@ -12308,9 +12308,7 @@
 /area/station/service/abandoned_gambling_den)
 "cYO" = (
 /obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/neutral/warning,
 /obj/effect/turf_decal/trimline/neutral/mid_joiner,
 /obj/structure/sign/warning/no_smoking/directional/west,
 /turf/open/floor/iron/dark/textured_half,
@@ -81634,9 +81632,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/neutral/warning,
 /obj/effect/turf_decal/trimline/neutral/mid_joiner,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/service/chapel/storage)
@@ -85794,9 +85790,7 @@
 /area/station/engineering/main)
 "vug" = (
 /obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/neutral/warning,
 /obj/effect/turf_decal/trimline/neutral/mid_joiner,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/service/chapel/storage)
@@ -95694,9 +95688,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -23052,7 +23052,7 @@
 	},
 /area/station/engineering/lobby)
 "gWr" = (
-/obj/structure/tank_dispenser,
+/obj/structure/tank_dispenser/emptytank,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "gWy" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -79961,7 +79961,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/obj/structure/tank_dispenser,
+/obj/structure/tank_dispenser/emptytank,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)
 "wHb" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9254,8 +9254,8 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "dvJ" = (
-/obj/structure/tank_dispenser,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/tank_dispenser/emptytank,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "dvP" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17838,9 +17838,7 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/tram/left)
 "gma" = (
-/obj/structure/sign/warning/radiation/rad_area/directional/north{
-	dir = 1
-	},
+/obj/structure/sign/warning/radiation/rad_area/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -41477,7 +41475,7 @@
 /turf/open/floor/carpet,
 /area/station/cargo/miningdock)
 "osM" = (
-/obj/structure/tank_dispenser,
+/obj/structure/tank_dispenser/emptytank,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "osT" = (
@@ -65031,9 +65029,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wzq" = (
-/obj/structure/sign/warning/radiation/rad_area/directional/north{
-	dir = 1
-	},
+/obj/structure/sign/warning/radiation/rad_area/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -10,6 +10,8 @@
 	max_integrity = 300
 	var/oxygentanks = TANK_DISPENSER_CAPACITY
 	var/plasmatanks = TANK_DISPENSER_CAPACITY
+	var/obj/item/tank/internals/oxytank_type = /obj/item/tank/internals/oxygen
+	var/obj/item/tank/internals/plasmatank_type = /obj/item/tank/internals/plasma
 
 /obj/structure/tank_dispenser/oxygen
 	plasmatanks = 0
@@ -17,12 +19,17 @@
 /obj/structure/tank_dispenser/plasma
 	oxygentanks = 0
 
+/obj/structure/tank_dispenser/emptytank
+	name = "empty tank dispenser"
+	oxytank_type = /obj/item/tank/internals/oxygen/empty
+	plasmatank_type = /obj/item/tank/internals/plasma/empty
+
 /obj/structure/tank_dispenser/Initialize(mapload)
 	. = ..()
 	for(var/i in 1 to oxygentanks)
-		new /obj/item/tank/internals/oxygen(src)
+		new oxytank_type(src)
 	for(var/i in 1 to plasmatanks)
-		new /obj/item/tank/internals/plasma(src)
+		new plasmatank_type(src)
 	update_appearance()
 
 /obj/structure/tank_dispenser/update_overlays()
@@ -45,12 +52,12 @@
 
 /obj/structure/tank_dispenser/attackby(obj/item/I, mob/living/user, params)
 	var/full
-	if(istype(I, /obj/item/tank/internals/plasma))
+	if(istype(I, plasmatank_type))
 		if(plasmatanks < TANK_DISPENSER_CAPACITY)
 			plasmatanks++
 		else
 			full = TRUE
-	else if(istype(I, /obj/item/tank/internals/oxygen))
+	else if(istype(I, oxytank_type))
 		if(oxygentanks < TANK_DISPENSER_CAPACITY)
 			oxygentanks++
 		else
@@ -91,13 +98,13 @@
 		return
 	switch(action)
 		if("plasma")
-			var/obj/item/tank/internals/plasma/tank = locate() in src
+			var/obj/item/tank/internals/tank = locate(plasmatank_type) in src
 			if(tank && Adjacent(usr))
 				usr.put_in_hands(tank)
 				plasmatanks--
 			. = TRUE
 		if("oxygen")
-			var/obj/item/tank/internals/oxygen/tank = locate() in src
+			var/obj/item/tank/internals/tank = locate(oxytank_type) in src
 			if(tank && Adjacent(usr))
 				usr.put_in_hands(tank)
 				oxygentanks--


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added a tank dispenser variant which dispenses gasless tanks
Tank Dispensers in toxins now dispense gasless oxygen tanks, and gasless plasma tanks
Only affects Delta,Meta,Kilo,Icebox,Tram toxins
## Why It's Good For The Game

Nobody ever uses the gas already present in the tanks, and making said gas tanks gasless 
speeds up the boring process of scrubbing them of gas

## Changelog
:cl:
qol: Toxins tank dispensers now dispense gasless tanks
/:cl: