### PR TITLE
Gives NTos messenger a scrollbar

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosMessenger.js
+++ b/tgui/packages/tgui/interfaces/NtosMessenger.js
@@ -95,7 +95,7 @@ export const NtosMessenger = (props, context) => {
   }
   return (
     <NtosWindow width={600} height={800}>
-      <NtosWindow.Content>
+      <NtosWindow.Content scrollable>
         <Stack vertical>
           <Section fill textAlign="center">
             <Box bold>


### PR DESCRIPTION
## About The Pull Request

adds this thing
![image](https://user-images.githubusercontent.com/53777086/181600647-01cb8d58-8c67-4446-85b5-4019ba9d5cdb.png)

## Why It's Good For The Game

Makes the NtOS messenger app scrollable for people who don't have a functional mousewheel (like me), a small QoL change.

## Changelog

:cl:
qol: the NtOS messenger has a scrollbar now.
/:cl: