### PR TITLE
People with epilepsy now have a chance to have a seizure when they're flashed!

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -147,3 +147,6 @@
 #define COMSIG_MOB_AUTOMUTE_CHECK "client_automute_check" // The check is performed by the client.
 	/// Prevents the automute system checking this client for repeated messages.
 	#define WAIVE_AUTOMUTE_CHECK (1<<0)
+
+///from living/flash_act(), when a mob is successfully flashed.
+#define COMSIG_MOB_FLASHED "mob_flashed"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -18,7 +18,7 @@
 		return
 	owner.visible_message(span_danger("[owner] starts having a seizure!"), span_userdanger("You have a seizure!"))
 	owner.Unconscious(200 * GET_MUTATION_POWER(src))
-	owner.set_timed_status_effect(2000 SECONDS * GET_MUTATION_POWER(src), /datum/status_effect/jitter)
+	owner.set_timed_status_effect(2000 SECONDS * GET_MUTATION_POWER(src), /datum/status_effect/jitter) //yes this number looks crazy but the jitter animations are amplified based on the duration.
 	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "epilepsy", /datum/mood_event/epilepsy)
 	addtimer(CALLBACK(src, .proc/jitter_less), 90)
 

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -39,6 +39,8 @@
 	UnregisterSignal(owner, COMSIG_MOB_FLASHED)
 
 /datum/mutation/human/epilepsy/proc/get_flashed_nerd()
+	SIGNAL_HANDLER
+
 	if(!prob(30))
 		return
 	trigger_seizure()

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -28,6 +28,22 @@
 
 	owner.set_timed_status_effect(20 SECONDS, /datum/status_effect/jitter)
 
+/datum/mutation/human/epilepsy/on_acquiring(mob/living/carbon/human/acquirer)
+	if(..())
+		return
+	RegisterSignal(owner, COMSIG_MOB_FLASHED, .proc/get_flashed_nerd)
+
+/datum/mutation/human/epilepsy/on_losing(mob/living/carbon/human/owner)
+	if(..())
+		return
+	UnregisterSignal(owner, COMSIG_MOB_FLASHED)
+
+/datum/mutation/human/epilepsy/proc/get_flashed_nerd()
+	if(!prob(30))
+		return
+	trigger_seizure()
+
+
 //Unstable DNA induces random mutations!
 /datum/mutation/human/bad_dna
 	name = "Unstable DNA"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -10,12 +10,17 @@
 	power_coeff = 1
 
 /datum/mutation/human/epilepsy/on_life(delta_time, times_fired)
-	if(DT_PROB(0.5 * GET_MUTATION_SYNCHRONIZER(src), delta_time) && owner.stat == CONSCIOUS)
-		owner.visible_message(span_danger("[owner] starts having a seizure!"), span_userdanger("You have a seizure!"))
-		owner.Unconscious(200 * GET_MUTATION_POWER(src))
-		owner.set_timed_status_effect(2000 SECONDS * GET_MUTATION_POWER(src), /datum/status_effect/jitter)
-		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "epilepsy", /datum/mood_event/epilepsy)
-		addtimer(CALLBACK(src, .proc/jitter_less), 90)
+	if(DT_PROB(0.5 * GET_MUTATION_SYNCHRONIZER(src), delta_time))
+		trigger_seizure()
+
+/datum/mutation/human/epilepsy/proc/trigger_seizure()
+	if(owner.stat != CONSCIOUS)
+		return
+	owner.visible_message(span_danger("[owner] starts having a seizure!"), span_userdanger("You have a seizure!"))
+	owner.Unconscious(200 * GET_MUTATION_POWER(src))
+	owner.set_timed_status_effect(2000 SECONDS * GET_MUTATION_POWER(src), /datum/status_effect/jitter)
+	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "epilepsy", /datum/mood_event/epilepsy)
+	addtimer(CALLBACK(src, .proc/jitter_less), 90)
 
 /datum/mutation/human/epilepsy/proc/jitter_less()
 	if(QDELETED(owner))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -525,6 +525,11 @@
 
 	var/damage = intensity - get_eye_protection()
 	if(.) // we've been flashed
+
+		var/datum/mutation/human/epilepsy/epilepsy_mutation = dna.get_mutation(/datum/mutation/human/epilepsy)
+		if(epilepsy_mutation && prob(30))
+			epilepsy_mutation.trigger_seizure() //I DON'T FEEL BAD FOR THIS. I'M SORRY.
+
 		if(visual)
 			return
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -525,11 +525,6 @@
 
 	var/damage = intensity - get_eye_protection()
 	if(.) // we've been flashed
-
-		var/datum/mutation/human/epilepsy/epilepsy_mutation = dna.get_mutation(/datum/mutation/human/epilepsy)
-		if(epilepsy_mutation && prob(30))
-			epilepsy_mutation.trigger_seizure() //I DON'T FEEL BAD FOR THIS. I'M SORRY.
-
 		if(visual)
 			return
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -452,6 +452,7 @@
 
 	overlay_fullscreen("flash", type)
 	addtimer(CALLBACK(src, .proc/clear_fullscreen, "flash", length), length)
+	SEND_SIGNAL(src, COMSIG_MOB_FLASHED, intensity, override_blindness_check, affect_silicon, visual, type, length)
 	return TRUE
 
 //called when the mob receives a loud bang


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Gives folks with epilepsy a 30% chance of having a seizure when they're flashed / flash_act'd. (Number is up to debate, I went a little low because welding does count!)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

It makes sense! Flashing lights are bad if you have epilepsy. Also gives further encouragement to go to genetics to get cured.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ShizCalev
balance: People with epilepsy now have a chance to have a seizure when they're flashed!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
