### PR TITLE
Updates camera assemblies to balloonify & welder_act. Fixes 11 year old bug.

### DIFF
--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -133,7 +133,7 @@
 		user.balloon_alert_to_viewers("stopped [state == STATE_WELDED ? "un" : null]welding!")
 		return
 	state = ((state == STATE_WELDED) ? STATE_WRENCHED : STATE_WELDED)
-	set_anchored((state == STATE_WELDED) ? TRUE : FALSE)
+	set_anchored(state == STATE_WELDED)
 	user.balloon_alert_to_viewers(state == STATE_WELDED ? "welded" : "unwelded")
 
 

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -134,7 +134,7 @@
 		return
 	state = ((state == STATE_WELDED) ? STATE_WRENCHED : STATE_WELDED)
 	set_anchored((state == STATE_WELDED) ? TRUE : FALSE)
-	user.balloon_alert_to_viewers("[state == STATE_WELDED ? "welded [src]" : "unwelded [src]"]")
+	user.balloon_alert_to_viewers(state == STATE_WELDED ? "welded" : "unwelded")
 
 
 /obj/structure/camera_assembly/attackby(obj/item/W, mob/living/user, params)

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -127,7 +127,7 @@
 	. = TRUE
 	if(!tool.tool_start_check(user, amount=3))
 		return
-	user.balloon_alert_to_viewers("started [state == STATE_WELDED ? "un" : null]welding [src]")
+	user.balloon_alert_to_viewers("[state == STATE_WELDED ? "un" : null]welding...")
 	audible_message(span_hear("You hear welding."))
 	if(!tool.use_tool(src, user, 2 SECONDS, amount=3, volume = 50))
 		user.balloon_alert_to_viewers("stopped [state == STATE_WELDED ? "un" : null]welding [src]")

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -121,17 +121,24 @@
 	else if(I == proxy_module)
 		proxy_module = null
 
+/obj/structure/camera_assembly/welder_act(mob/living/user, obj/item/tool)
+	if(state != STATE_WRENCHED && state != STATE_WELDED)
+		return
+	. = TRUE
+	if(!tool.tool_start_check(user, amount=3))
+		return
+	user.balloon_alert_to_viewers("started [state == STATE_WELDED ? "un" : null]welding [src]")
+	audible_message(span_hear("You hear welding."))
+	if(!tool.use_tool(src, user, 2 SECONDS, amount=3, volume = 50))
+		user.balloon_alert_to_viewers("stopped [state == STATE_WELDED ? "un" : null]welding [src]")
+		return
+	state = ((state == STATE_WELDED) ? STATE_WRENCHED : STATE_WELDED)
+	set_anchored((state == STATE_WELDED) ? TRUE : FALSE)
+	user.balloon_alert_to_viewers("[state == STATE_WELDED ? "welded [src]" : "unwelded [src]"]")
+
 
 /obj/structure/camera_assembly/attackby(obj/item/W, mob/living/user, params)
 	switch(state)
-		if(STATE_WRENCHED)
-			if(W.tool_behaviour == TOOL_WELDER)
-				if(weld(W, user))
-					to_chat(user, span_notice("You weld [src] securely into place."))
-					set_anchored(TRUE)
-					state = STATE_WELDED
-				return
-
 		if(STATE_WELDED)
 			if(istype(W, /obj/item/stack/cable_coil))
 				var/obj/item/stack/cable_coil/C = W
@@ -140,17 +147,7 @@
 					state = STATE_WIRED
 				else
 					to_chat(user, span_warning("You need two lengths of cable to wire a camera!"))
-					return
 				return
-
-			else if(W.tool_behaviour == TOOL_WELDER)
-
-				if(weld(W, user))
-					to_chat(user, span_notice("You unweld [src] from its place."))
-					state = STATE_WRENCHED
-					set_anchored(TRUE)
-				return
-
 		if(STATE_WIRED) // Upgrades!
 			if(istype(W, /obj/item/stack/sheet/mineral/plasma)) //emp upgrade
 				if(emp_module)
@@ -270,13 +267,6 @@
 	qdel(src)
 	return TRUE
 
-/obj/structure/camera_assembly/proc/weld(obj/item/weldingtool/W, mob/living/user)
-	if(!W.tool_start_check(user, amount=3))
-		return FALSE
-	to_chat(user, span_notice("You start to weld [src]..."))
-	if(W.use_tool(src, user, 20, amount=3, volume = 50))
-		return TRUE
-	return FALSE
 
 /obj/structure/camera_assembly/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -130,7 +130,7 @@
 	user.balloon_alert_to_viewers("[state == STATE_WELDED ? "un" : null]welding...")
 	audible_message(span_hear("You hear welding."))
 	if(!tool.use_tool(src, user, 2 SECONDS, amount=3, volume = 50))
-		user.balloon_alert_to_viewers("stopped [state == STATE_WELDED ? "un" : null]welding [src]")
+		user.balloon_alert_to_viewers("stopped [state == STATE_WELDED ? "un" : null]welding!")
 		return
 	state = ((state == STATE_WELDED) ? STATE_WRENCHED : STATE_WELDED)
 	set_anchored((state == STATE_WELDED) ? TRUE : FALSE)


### PR DESCRIPTION
:cl: ShizCalev
fix: Camera assemblies can now be moved after being unwelded! (This was an 11 year old bug lol.)
qol: Camera assembly welding has been updated to balloon alerts!
/:cl:
