### PR TITLE
Add chance for maintenance crate and closet spawners to be open

### DIFF
--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -134,6 +134,13 @@
 		/obj/structure/closet/acloset = 1,
 	)
 
+/obj/effect/spawner/random/structure/closet_empty/Initialize(mapload)
+	var/obj/structure/closet/peek_a_boo = ..()
+	if(istype(peek_a_boo))
+		peek_a_boo.opened = prob(50)
+
+	return INITIALIZE_HINT_QDEL
+
 /obj/effect/spawner/random/structure/closet_maintenance
 	name = "maintenance closet spawner"
 	icon_state = "locker"
@@ -218,17 +225,17 @@
 /obj/effect/spawner/random/structure/billboard/roadsigns //also pretty much only unifunctionally useful for gas stations
 	name = "\improper Gas Station billboard spawner"
 	loot = list(
-		/obj/structure/billboard/roadsign/two = 25,
-		/obj/structure/billboard/roadsign/twothousand = 25,
-		/obj/structure/billboard/roadsign/twomillion = 25,
-		/obj/structure/billboard/roadsign/error = 25,
+		/obj/structure/billboard/roadsign/two,
+		/obj/structure/billboard/roadsign/twothousand,
+		/obj/structure/billboard/roadsign/twomillion,
+		/obj/structure/billboard/roadsign/error,
 	)
 
 /obj/effect/spawner/random/structure/steam_vent
 	name = "steam vent spawner"
 	loot = list(
-		/obj/structure/steam_vent = 50,
-		/obj/structure/steam_vent/fast = 50,
+		/obj/structure/steam_vent,
+		/obj/structure/steam_vent/fast,
 	)
 
 /obj/effect/spawner/random/structure/musician/piano/random_piano

--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -101,6 +101,13 @@
 		/obj/structure/closet/crate/science = 1,
 	)
 
+/obj/effect/spawner/random/structure/crate_empty/Initialize(mapload)
+	var/obj/structure/closet/crate/peek_a_boo = ..()
+	if(istype(peek_a_boo))
+		peek_a_boo.opened = prob(50)
+
+	return INITIALIZE_HINT_QDEL
+
 /obj/effect/spawner/random/structure/crate_loot
 	name = "lootcrate spawner"
 	icon_state = "crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This gives a 50% chance for the crate and closet spawners in maint to spawn open.  This does not apply to the locked or abandoned crates.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

This aims to make maintenance more messy with some crate spawning open and others closed.  It's mainly just aesthetics and flavor since the area should look trashed.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Add chance for maintenance crate and closet spawners to be open to make the area look more messy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
