### PR TITLE
fixes nuke ops leaders not spawning

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -16,8 +16,8 @@
 	var/repeatable_weight_decrease = 2
 	/// List of players that are being drafted for this rule
 	var/list/mob/candidates = list()
-	/// List of players that were selected for this rule
-	var/list/datum/mind/assigned = list()
+	/// List of players that were selected for this rule. This can be minds, or mobs.
+	var/list/assigned = list()
 	/// Preferences flag such as ROLE_WIZARD that need to be turned on for players to be antag.
 	var/antag_flag = null
 	/// The antagonist datum that is assigned to the mobs mind on ruleset execution.

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -376,8 +376,12 @@
 	minimum_round_time = 70 MINUTES
 	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
 	var/list/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
+	/// The nuke ops team datum.
 	var/datum/team/nuclear/nuke_team
-	var/mob/leader
+	/// The mind datum of the chosen leader.
+	var/datum/mind/leader
+	/// The antag datum of the chosen leader.
+	var/datum/antagonist/nukeop/leader/leader_antag_datum
 	flags = HIGH_IMPACT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/acceptable(population=0, threat=0)
@@ -396,16 +400,17 @@
 	leader = get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE)
 	if(!leader)
 		leader = assigned[1]
+	leader_antag_datum = new()
+	nuke_team = leader_antag_datum.nuke_team
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_setup(mob/new_character, index)
 	new_character.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 	new_character.mind.special_role = ROLE_NUCLEAR_OPERATIVE
 	if(new_character.mind == leader)
+		leader.mind.add_antag_datum(leader_antag_datum)
 		leader = null
-		var/datum/antagonist/nukeop/leader/new_role = new()
-		nuke_team = new_role.nuke_team
-		new_character.mind.add_antag_datum(new_role)
+		leader_antag_datum = null
 	else
 		return ..()
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -380,8 +380,6 @@
 	var/datum/team/nuclear/nuke_team
 	/// The mind datum of the chosen leader.
 	var/datum/mind/leader
-	/// The antag datum of the chosen leader.
-	var/datum/antagonist/nukeop/leader/leader_antag_datum
 	flags = HIGH_IMPACT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/acceptable(population=0, threat=0)
@@ -402,17 +400,18 @@
 		leader = assigned[1]
 	leader_antag_datum = new()
 	nuke_team = leader_antag_datum.nuke_team
+	leader.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
+	leader.special_role = ROLE_NUCLEAR_OPERATIVE
+	leader.add_antag_datum(leader_antag_datum)
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_setup(mob/new_character, index)
+	if(new_character.mind == leader)
+		leader = null
+		return
 	new_character.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 	new_character.mind.special_role = ROLE_NUCLEAR_OPERATIVE
-	if(new_character.mind == leader)
-		leader.add_antag_datum(leader_antag_datum)
-		leader = null
-		leader_antag_datum = null
-	else
-		return ..()
+	return ..()
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -378,8 +378,10 @@
 	var/list/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
 	/// The nuke ops team datum.
 	var/datum/team/nuclear/nuke_team
-	/// The mind datum of the chosen leader.
-	var/datum/mind/leader
+	/// The team leader we chose.
+	var/mob/leader
+	/// The antag datum of the chosen leader.
+	var/datum/antagonist/nukeop/leader/leader_antag_datum
 	flags = HIGH_IMPACT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/acceptable(population=0, threat=0)
@@ -398,19 +400,18 @@
 	leader = get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE)
 	if(!leader)
 		leader = assigned[1]
-	var/datum/antagonist/nukeop/leader_antag_datum = new()
+	leader_antag_datum = new()
 	nuke_team = leader_antag_datum.nuke_team
-	leader.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
-	leader.special_role = ROLE_NUCLEAR_OPERATIVE
-	leader.add_antag_datum(leader_antag_datum)
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_setup(mob/new_character, index)
-	if(new_character.mind == leader)
-		leader = null
-		return
 	new_character.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 	new_character.mind.special_role = ROLE_NUCLEAR_OPERATIVE
+	if(new_character == leader)
+		leader.mind.add_antag_datum(leader_antag_datum)
+		leader = null
+		leader_antag_datum = null
+		return
 	return ..()
 
 //////////////////////////////////////////////

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -394,6 +394,8 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_applications()
 	leader = get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE)
+	if(!leader)
+		leader = assigned[1]
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_setup(mob/new_character, index)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -398,7 +398,7 @@
 	leader = get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE)
 	if(!leader)
 		leader = assigned[1]
-	leader_antag_datum = new()
+	var/antagonist/nukeop/leader_antag_datum = new()
 	nuke_team = leader_antag_datum.nuke_team
 	leader.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 	leader.special_role = ROLE_NUCLEAR_OPERATIVE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -380,8 +380,6 @@
 	var/datum/team/nuclear/nuke_team
 	/// The team leader we chose.
 	var/mob/leader
-	/// The antag datum of the chosen leader.
-	var/datum/antagonist/nukeop/leader/leader_antag_datum
 	flags = HIGH_IMPACT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/acceptable(population=0, threat=0)
@@ -400,18 +398,19 @@
 	leader = get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE)
 	if(!leader)
 		leader = assigned[1]
-	leader_antag_datum = new()
+	leader.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
+	leader.mind.special_role = ROLE_NUCLEAR_OPERATIVE
+	var/datum/antagonist/nukeop/leader/leader_antag_datum = new()
 	nuke_team = leader_antag_datum.nuke_team
+	leader.mind.add_antag_datum(leader_antag_datum)
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_setup(mob/new_character, index)
+	if(new_character == leader)
+		leader = null
+		return
 	new_character.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 	new_character.mind.special_role = ROLE_NUCLEAR_OPERATIVE
-	if(new_character == leader)
-		leader.mind.add_antag_datum(leader_antag_datum)
-		leader = null
-		leader_antag_datum = null
-		return
 	return ..()
 
 //////////////////////////////////////////////

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -398,7 +398,7 @@
 	leader = get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE)
 	if(!leader)
 		leader = assigned[1]
-	var/antagonist/nukeop/leader_antag_datum = new()
+	var/datum/antagonist/nukeop/leader_antag_datum = new()
 	nuke_team = leader_antag_datum.nuke_team
 	leader.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 	leader.special_role = ROLE_NUCLEAR_OPERATIVE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -408,7 +408,7 @@
 	new_character.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 	new_character.mind.special_role = ROLE_NUCLEAR_OPERATIVE
 	if(new_character.mind == leader)
-		leader.mind.add_antag_datum(leader_antag_datum)
+		leader.add_antag_datum(leader_antag_datum)
 		leader = null
 		leader_antag_datum = null
 	else

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -378,8 +378,6 @@
 	var/list/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
 	/// The nuke ops team datum.
 	var/datum/team/nuclear/nuke_team
-	/// The team leader we chose.
-	var/mob/leader
 	flags = HIGH_IMPACT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/acceptable(population=0, threat=0)
@@ -395,22 +393,20 @@
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_applications()
-	leader = get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE)
-	if(!leader)
-		leader = assigned[1]
-	leader.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
-	leader.mind.special_role = ROLE_NUCLEAR_OPERATIVE
-	var/datum/antagonist/nukeop/leader/leader_antag_datum = new()
-	nuke_team = leader_antag_datum.nuke_team
-	leader.mind.add_antag_datum(leader_antag_datum)
+	var/mob/leader = get_most_experienced(assigned, ROLE_NUCLEAR_OPERATIVE)
+	if(leader)
+		assigned.Remove(leader)
+		assigned.Insert(1, leader)
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/finish_setup(mob/new_character, index)
-	if(new_character == leader)
-		leader = null
-		return
 	new_character.mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
 	new_character.mind.special_role = ROLE_NUCLEAR_OPERATIVE
+	if(index == 1)
+		var/datum/antagonist/nukeop/leader/leader_antag_datum = new()
+		nuke_team = leader_antag_datum.nuke_team
+		new_character.mind.add_antag_datum(leader_antag_datum)
+		return
 	return ..()
 
 //////////////////////////////////////////////

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -414,8 +414,8 @@
 	var/datum/mind/most_experienced = get_most_experienced(assigned, required_role)
 	if(!most_experienced)
 		most_experienced = assigned[1]
-	var/datum/antagonist/nukeop/leader/new_op = most_experienced.add_antag_datum(antag_leader_datum)
-	nuke_team = new_op.nuke_team
+	var/datum/antagonist/nukeop/leader/leader = most_experienced.add_antag_datum(antag_leader_datum)
+	nuke_team = leader.nuke_team
 	for(var/datum/mind/assigned_player in assigned)
 		if(assigned_player == most_experienced)
 			continue

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -411,16 +411,16 @@
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/nuclear/execute()
-	var/most_experienced = get_most_experienced(assigned, required_role)
+	var/datum/mind/most_experienced = get_most_experienced(assigned, required_role)
 	if(!most_experienced)
 		most_experienced = assigned[1]
+	var/datum/antagonist/nukeop/leader/new_op = most_experienced.add_antag_datum(antag_leader_datum)
+	nuke_team = new_op.nuke_team
 	for(var/datum/mind/assigned_player in assigned)
 		if(assigned_player == most_experienced)
-			var/datum/antagonist/nukeop/leader/new_op = assigned_player.add_antag_datum(antag_leader_datum)
-			nuke_team = new_op.nuke_team
-		else
-			var/datum/antagonist/nukeop/new_op = new antag_datum()
-			assigned_player.add_antag_datum(new_op)
+			continue
+		var/datum/antagonist/nukeop/new_op = new antag_datum()
+		assigned_player.add_antag_datum(new_op)
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/nuclear/round_result()

--- a/code/game/gamemodes/dynamic/readme.md
+++ b/code/game/gamemodes/dynamic/readme.md
@@ -99,7 +99,7 @@ Latejoin: Only one candidate, the latejoiner. Standard checks.
 Midround: Instead of building a single list candidates, candidates contains four lists: living, dead, observing, and living antags. Standard checks in trim_list(list).
 
 Midround - Rulesets have additional types
-/from_ghosts: execute() -> send_applications() -> review_applications() -> finish_setup(mob/newcharacter, index) -> setup_role(role)
+/from_ghosts: execute() -> send_applications() -> review_applications() -> finish_applications() -> finish_setup(mob/newcharacter, index) -> setup_role(role)
 **NOTE: execute() here adds dead players and observers to candidates list
 
 ## Configuration and variables

--- a/code/modules/antagonists/_common/antag_helpers.dm
+++ b/code/modules/antagonists/_common/antag_helpers.dm
@@ -13,12 +13,12 @@
 	if(!CONFIG_GET(flag/use_exp_tracking)) //woops
 		return
 	var/most_experienced
-	for(var/client/player as anything in players)
+	for(var/player in players)
 		if(!most_experienced)
 			most_experienced = player
 			continue
-		player = get_player_client(player)
-		if(!player?.prefs || !length(player.prefs.exp))
+		var/client/player_client = get_player_client(player)
+		if(!player_client?.prefs || !length(player_client.prefs.exp))
 			continue
 		var/client/most_played = get_player_client(most_experienced)
 		if(!most_played?.prefs || !length(most_played.prefs.exp))
@@ -27,10 +27,10 @@
 		var/player_playtime
 		var/most_playtime
 		if(specific_role)
-			player_playtime = player.prefs.exp[specific_role] ? text2num(player.prefs.exp[specific_role]) : 0
+			player_playtime = player_client.prefs.exp[specific_role] ? text2num(player_client.prefs.exp[specific_role]) : 0
 			most_playtime = most_played.prefs.exp[specific_role] ? text2num(most_played.prefs.exp[specific_role]) : 0
 		else
-			player_playtime = player.get_exp_living(TRUE)
+			player_playtime = player_client.get_exp_living(TRUE)
 			most_playtime = most_played.get_exp_living(TRUE)
 		if(player_playtime > most_playtime)
 			most_experienced = player


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
this code was untestable because
1. it required a config flag to be set on, this flag is false by default on local
2. it requires multiple people on the server
so it turned out that leader spawning is broken. this should fix it

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
nukies can declare war

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes nuke ops leaders not spawning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
