### PR TITLE
silicons can interact with floodlights

### DIFF
--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -65,8 +65,11 @@
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION
 	anchored = FALSE
 	light_power = 1.75
+	/// List of power usage multipliers
 	var/list/light_setting_list = list(0, 5, 10, 15)
+	/// Constant coeff. for power usage
 	var/light_power_coefficient = 200
+	/// Intensity of the floodlight.
 	var/setting = FLOODLIGHT_OFF
 
 /obj/machinery/power/floodlight/process()
@@ -96,13 +99,13 @@
 	else
 		icon_state = initial(icon_state)
 	switch(setting)
-		if(1)
+		if(FLOODLIGHT_OFF)
 			setting_text = "OFF"
-		if(2)
+		if(FLOODLIGHT_LOW)
 			setting_text = "low power"
-		if(3)
+		if(FLOODLIGHT_MED)
 			setting_text = "standard lighting"
-		if(4)
+		if(FLOODLIGHT_HIGH)
 			setting_text = "high power"
 	if(user)
 		to_chat(user, span_notice("You set [src] to [setting_text]."))
@@ -110,7 +113,7 @@
 /obj/machinery/power/floodlight/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
 	default_unfasten_wrench(user, tool)
-	change_setting(1)
+	change_setting(FLOODLIGHT_OFF)
 	if(anchored)
 		connect_to_network()
 	else
@@ -122,11 +125,17 @@
 	if(.)
 		return
 	var/current = setting
-	if(current == 1)
+	if(current == FLOODLIGHT_OFF)
 		current = light_setting_list.len
 	else
 		current--
 	change_setting(current, user)
+
+/obj/machinery/power/floodlight/attack_robot(mob/user)
+	return attack_hand(user)
+
+/obj/machinery/power/floodlight/attack_ai(mob/user)
+	return attack_hand(user)
 
 /obj/machinery/power/floodlight/atom_break(damage_flag)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Uses attack_robot and attack_ai to let attack_hand receive silicons as mob/user.
Replaces some magic numbers using the given defines.
Adds some documentation for specified vars.

Fixes #66758

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Addresses an inconsistency for silicon interaction.
Standardization good.

**Emergent Issues**

Floodlights, fire alarms, the mining shuttle beacon, barsigns, and the advanced camera console redirect ai/borg attacks into an attack_hand proc using identical code.

Floodlight code does not use ISBROKEN or relevant interaction flags.

Floodlights are unbolted when broken.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Silicons can now interact with floodlights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
