### PR TITLE
Makes epicenters not explode mobs twice

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -418,7 +418,7 @@ SUBSYSTEM_DEF(explosions)
 				var/atom/A = I
 				if (length(A.contents) && !(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1)) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
 					items += A.get_all_contents(ignore_flag_1 = PREVENT_CONTENTS_EXPLOSION_1)
-				if(istype(A, /mob/living))
+				if(isliving(A))
 					items -= A		//Stops mobs from taking double damage from explosions originating from them/their turf, such as from projectiles
 			for(var/thing in items)
 				var/atom/movable/movable_thing = thing

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -418,6 +418,8 @@ SUBSYSTEM_DEF(explosions)
 				var/atom/A = I
 				if (length(A.contents) && !(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1)) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
 					items += A.get_all_contents(ignore_flag_1 = PREVENT_CONTENTS_EXPLOSION_1)
+				if(istype(A, /mob/living))
+					items -= A		//Stops mobs from taking double damage from explosions originating from them/their turf, such as from projectiles
 			for(var/thing in items)
 				var/atom/movable/movable_thing = thing
 				if(QDELETED(movable_thing))


### PR DESCRIPTION

## About The Pull Request
Ports https://github.com/yogstation13/Yogstation/pull/13983

This pr effectively halves the damage of explosion epicenters by making them only affect mobs once. Specifically, it removes them from the list of things to explode created by the get_all_contents proc, originally meant to ensure stuff in bags and boxes will set off other bombs in the same bag or box. This had the un(?)intended side-effect of making any objects in the epicenter of the blast take damage a second time, resulting in heavy blasts instakilling and very small explosions doing way too much damage. This is half a balance change and half a bug fix.

## Why It's Good For The Game

This allows for more explosion-based weaponry as they now won't all be complete one-shot-win weapons. It also stops things like X4 bolas or explosive holoparasite bolas (you guys have those right?) instantly killing people with no counterplay. Also fireball is now probably a little less meta as a spell since it ONLY PROBABLY immediately wins fights and won't two-shot-crit people, usually. If yall want stuff to still do the same amount of damage just add an extra single-tile explosion to things you want to be more powerful.

## Changelog

:cl: Mqiib, ToasterBiome
balance: Explosion epicenters no longer explode mobs twice; Fireballs and other explosive projectiles are significantly less-damaging

/:cl:
