### PR TITLE
fixes storing mechs in crates

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -309,7 +309,7 @@
 	else if(istype(AM, /obj/structure/closet))
 		return FALSE
 	else if(isobj(AM))
-		if((!allow_dense && AM.density) || AM.anchored || AM.has_buckled_mobs())
+		if((!allow_dense && AM.density) || AM.anchored || AM.has_buckled_mobs() || ismecha(AM))
 			return FALSE
 		else if(isitem(AM) && !HAS_TRAIT(AM, TRAIT_NODROP))
 			return TRUE


### PR DESCRIPTION
## About The Pull Request

fixes #68795, making it not possible to put mechs in crates they are on top of.

## Why It's Good For The Game

fixes bug with mechs.

## Changelog

:cl:
fix: fixed crates being able to store mechs
/:cl: