### PR TITLE
Gives AI displays "proper" multiz station support

### DIFF
--- a/code/modules/mob/living/silicon/ai/emote.dm
+++ b/code/modules/mob/living/silicon/ai/emote.dm
@@ -18,8 +18,9 @@
 		var/turf/display_turf = get_turf(ai_display)
 
 		// Station AIs can change every display on the station Z
-		if(is_station_level(ai_turf.z) && !is_station_level(display_turf.z))
-			continue
+		if(is_station_level(ai_turf.z))
+			if(!is_station_level(display_turf.z))
+				continue
 
 		// Ghost role AIs (or AIs on the mining base?) can only affect their Z
 		else if(ai_turf.z != display_turf.z)

--- a/code/modules/mob/living/silicon/ai/emote.dm
+++ b/code/modules/mob/living/silicon/ai/emote.dm
@@ -17,13 +17,9 @@
 	for(var/obj/machinery/status_display/ai/ai_display as anything in GLOB.ai_status_displays)
 		var/turf/display_turf = get_turf(ai_display)
 
-		// Station AIs can change every display on the station Z
-		if(is_station_level(ai_turf.z))
-			if(!is_station_level(display_turf.z))
-				continue
-
-		// Ghost role AIs (or AIs on the mining base?) can only affect their Z
-		else if(ai_turf.z != display_turf.z)
+		// - Station AIs can change every display on the station Z.
+		// - Ghost role AIs (or AIs on the mining base?) can only affect their Z
+		if(!is_valid_z_level(ai_turf, display_turf))
 			continue
 
 		ai_display.emotion = emotion

--- a/code/modules/mob/living/silicon/ai/emote.dm
+++ b/code/modules/mob/living/silicon/ai/emote.dm
@@ -14,13 +14,15 @@
 	var/mob/living/silicon/ai/ai = user
 	var/turf/ai_turf = get_turf(ai)
 
-	for(var/_display in GLOB.ai_status_displays)
-		var/obj/machinery/status_display/ai/ai_display = _display
+	for(var/obj/machinery/status_display/ai/ai_display as anything in GLOB.ai_status_displays)
 		var/turf/display_turf = get_turf(ai_display)
 
-		// Derelict AIs can't affect station displays.
-		// TODO does this need to be made multiZ aware?
-		if(ai_turf.z != display_turf.z)
+		// Station AIs can change every display on the station Z
+		if(is_station_level(ai_turf.z) && !is_station_level(display_turf.z))
+			continue
+
+		// Ghost role AIs (or AIs on the mining base?) can only affect their Z
+		else if(ai_turf.z != display_turf.z)
 			continue
 
 		ai_display.emotion = emotion


### PR DESCRIPTION
## About The Pull Request

AI displays only changed every display on the same z-level as the AI. 

This PR changes it so all AI displays on the station are updated if the AI updates their displays. 

## Why It's Good For The Game

I found this very silly when I discovered it. 

## Changelog

:cl: Melbert
qol: AIs which update their status displays on multi-z station maps will now update ALL displays on station, instead of only those which match the level their core is on
/:cl:
