### PR TITLE
Allows non-human bodies to spawn in the morgue at roundstart

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -626,3 +626,10 @@
 /datum/config_entry/flag/forbid_all_profiling
 
 /datum/config_entry/flag/forbid_admin_profiling
+
+
+/datum/config_entry/flag/morgue_cadaver_disable_nonhumans
+
+/datum/config_entry/number/morgue_cadaver_other_species_probability
+
+/datum/config_entry/string/morgue_cadaver_override_species

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -62,7 +62,7 @@
 ///Handles renaming of the bodybag's examine tag.
 /obj/structure/closet/body_bag/proc/handle_tag(tag_name)
 	name = tag_name ? "[initial(name)] - [tag_name]" : initial(name)
-	tagged = tag_name ? TRUE : FALSE
+	tagged = !!tag_name
 	update_appearance()
 
 /obj/structure/closet/body_bag/update_overlays()

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -51,20 +51,19 @@
 			return
 		if(!user.canUseTopic(src, BE_CLOSE))
 			return
-		if(t)
-			name = "[initial(name)] - [t]"
-			tagged = TRUE
-			update_appearance()
-		else
-			name = initial(name)
+		handle_tag("[t ? t : initial(name)]")
 		return
 	if(!tagged)
 		return
 	if(interact_tool.tool_behaviour == TOOL_WIRECUTTER || interact_tool.get_sharpness())
 		to_chat(user, span_notice("You cut the tag off [src]."))
-		name = "body bag"
-		tagged = FALSE
-		update_appearance()
+		handle_tag()
+
+///Handles renaming of the bodybag's examine tag.
+/obj/structure/closet/body_bag/proc/handle_tag(tag_name)
+	name = tag_name ? "[initial(name)] - [tag_name]" : initial(name)
+	tagged = tag_name ? TRUE : FALSE
+	update_appearance()
 
 /obj/structure/closet/body_bag/update_overlays()
 	. = ..()

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -446,28 +446,82 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	name = "Dead Body placer"
 	late = TRUE
 	icon_state = "deadbodyplacer"
+	var/admin_spawned
 	var/bodycount = 2 //number of bodies to spawn
+
+/obj/effect/mapping_helpers/dead_body_placer/Initialize(mapload)
+	. = ..()
+	if(mapload)
+		return
+	admin_spawned = TRUE
 
 /obj/effect/mapping_helpers/dead_body_placer/LateInitialize()
 	var/area/a = get_area(src)
 	var/list/trays = list()
 	for (var/i in a.contents)
 		if (istype(i, /obj/structure/bodycontainer/morgue))
+			if(admin_spawned)
+				var/obj/structure/bodycontainer/morgue/early_morgue_tray = i
+				if(early_morgue_tray.connected.loc != early_morgue_tray)
+					continue
 			trays += i
 	if(!trays.len)
-		log_mapping("[src] at [x],[y] could not find any morgues.")
+		if(admin_spawned)
+			message_admins("[src] spawned at [ADMIN_VERBOSEJMP(src)] failed to find a closed morgue to spawn a body!")
+		else
+			log_mapping("[src] at [x],[y] could not find any morgues.")
 		return
+
+	var/reuse_trays = (trays.len < bodycount) //are we going to spawn more trays than bodies?
+
+	var/use_species = CONFIG_GET(flag/morgue_cadaver_disable_nonhumans)
+	var/species_probability = CONFIG_GET(number/morgue_cadaver_other_species_probability)
+	var/override_species = CONFIG_GET(string/morgue_cadaver_override_species)
+	var/list/usable_races
+	if(use_species)
+		usable_races = GLOB.roundstart_races.Copy() //micro optimization
+		usable_races -= SPECIES_ETHEREAL //they revive on death which is bad juju
+		usable_races -= SPECIES_HUMAN
+		if(override_species)
+			stack_trace("WARNING: BOTH use_all_roundstart_races_for_cadavers & morgue_cadaver_override_species CONFIGS ENABLED. morgue_cadaver_override_species BEING OVERRIDEN.")
+	else if(override_species)
+		usable_races += override_species
+
 	for (var/i = 1 to bodycount)
-		var/obj/structure/bodycontainer/morgue/j = pick(trays)
-		var/mob/living/carbon/human/h = new /mob/living/carbon/human(j, 1)
-		h.death()
-		for (var/part in h.internal_organs) //randomly remove organs from each body, set those we keep to be in stasis
+		var/obj/structure/bodycontainer/morgue/morgue_tray = reuse_trays ? pick(trays) : pick_n_take(trays)
+		var/obj/structure/closet/body_bag/body_bag = new(morgue_tray.loc)
+		var/mob/living/carbon/human/new_human = new /mob/living/carbon/human(morgue_tray.loc, 1)
+
+		var/species_to_pick
+		if(usable_races.len)
+			if(!species_probability)
+				species_probability = 50
+				stack_trace("WARNING: morgue_cadaver_other_species_probability CONFIG SET TO 0% WHEN SPAWNING. DEFAULTING TO [species_probability]%.")
+			if(prob(species_probability))
+				species_to_pick = pick(usable_races)
+				var/datum/species/new_human_species = GLOB.species_list[species_to_pick]
+				if(new_human_species)
+					new_human.set_species(new_human_species)
+					new_human_species.randomize_main_appearance_element(new_human)
+					new_human.fully_replace_character_name(new_human.real_name, new_human_species.random_name(new_human.gender, TRUE, TRUE))
+				else
+					stack_trace("failed to spawn cadaver with species ID [species_to_pick]") //if it's invalid they'll just be a human, so no need to worry too much aside from yelling at the server owner lol.
+
+		body_bag.insert(new_human, TRUE)
+		body_bag.close()
+		body_bag.handle_tag("[new_human.real_name][species_to_pick ? " - [capitalize(species_to_pick)]" : " - Human"]")
+		body_bag.forceMove(morgue_tray)
+
+		new_human.death() //here lies the mans, rip in pepperoni.
+		for (var/part in new_human.internal_organs) //randomly remove organs from each body, set those we keep to be in stasis
 			if (prob(40))
 				qdel(part)
 			else
 				var/obj/item/organ/O = part
 				O.organ_flags |= ORGAN_FROZEN
-		j.update_appearance()
+
+		morgue_tray.update_appearance()
+
 	qdel(src)
 
 

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -479,11 +479,11 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	var/override_species = CONFIG_GET(string/morgue_cadaver_override_species)
 	var/list/usable_races
 	if(use_species)
-		usable_races = GLOB.roundstart_races.Copy() //micro optimization
+		usable_races = GLOB.roundstart_races.Copy()
 		usable_races -= SPECIES_ETHEREAL //they revive on death which is bad juju
 		LAZYREMOVE(usable_races, SPECIES_HUMAN)
 		if(!usable_races)
-			stack_trace("morgue_cadaver_disable_nonhumans. NONHUMANS ENABLED BUT NO NONHUMANS ARE ENABLED")
+			stack_trace("morgue_cadaver_disable_nonhumans. THERE ARE NO VALID NONHUMANS ENABLED")
 		if(override_species)
 			stack_trace("WARNING: BOTH use_all_roundstart_races_for_cadavers & morgue_cadaver_override_species CONFIGS ENABLED. morgue_cadaver_override_species BEING OVERRIDEN.")
 	else if(override_species)

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -481,7 +481,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	if(use_species)
 		usable_races = GLOB.roundstart_races.Copy() //micro optimization
 		usable_races -= SPECIES_ETHEREAL //they revive on death which is bad juju
-		usable_races -= SPECIES_HUMAN
+		LAZYREMOVE(usable_races, SPECIES_HUMAN)
+		if(!usable_races)
+			stack_trace("morgue_cadaver_disable_nonhumans. NONHUMANS ENABLED BUT NO NONHUMANS ARE ENABLED")
 		if(override_species)
 			stack_trace("WARNING: BOTH use_all_roundstart_races_for_cadavers & morgue_cadaver_override_species CONFIGS ENABLED. morgue_cadaver_override_species BEING OVERRIDEN.")
 	else if(override_species)
@@ -493,7 +495,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 		var/mob/living/carbon/human/new_human = new /mob/living/carbon/human(morgue_tray.loc, 1)
 
 		var/species_to_pick
-		if(usable_races.len)
+		if(LAZYLEN(usable_races))
 			if(!species_probability)
 				species_probability = 50
 				stack_trace("WARNING: morgue_cadaver_other_species_probability CONFIG SET TO 0% WHEN SPAWNING. DEFAULTING TO [species_probability]%.")

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -370,6 +370,20 @@ ROUNDSTART_RACES ethereal
 ## Races defined here will not cause existing characters to be reset to human if they currently have a non-roundstart species defined.
 #ROUNDSTART_NO_HARD_CHECK felinid
 
+## Disable roundstart species morgue cadavers?
+## (This is recommended enabled for the chance for nonhuman species to have possible replacement organs)
+# MORGUE_CADAVER_DISABLE_NONHUMANS
+
+## Morgue Cadaver Species Probability
+## Probability for
+MORGUE_CADAVER_OTHER_SPECIES_PROBABILITY 50
+
+## A single specific Species ID to supplement humans. Only used if USE_ALL_ROUNDSTART_RACES_FOR_CADAVERS is off.
+## Set MORGUE_CADAVER_OTHER_SPECIES_PROBABILITY to determine the chances between being a human and this specific species.
+## Prob = 100 means all corpses will be this race.
+#MORGUE_CADAVER_OVERRIDE_SPECIES lizard
+
+
 ##Overflow job. Default is assistant
 OVERFLOW_JOB Assistant
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds a configurable probability for the cadavers in the morgue to spawn as nonhuman species.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Downstreams were asking for nonhuman cadavers to be added to the morgue spawns so doctors can at least _attempt_ to help nonhuman species.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ShizCalev
server: Added a configurable probability for nonhuman species to spawn in the morgue at round start!
qol: Cadavers in the morgue at round start will now spawn in bodybags.
fix: Adminspawned morgue cadavers will now only spawn inside closed morguetrays (the bodies could get stuck inside them!)
fix: Morguetrays are now less likely to end up having multiple cadavers in them.
/:cl:
