### PR TITLE
fixes warning message that occurs every single time an ethereal dies

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -344,7 +344,7 @@
 	crystalize_timer_id = addtimer(CALLBACK(src, .proc/crystalize, victim), CRYSTALIZE_PRE_WAIT_TIME, TIMER_STOPPABLE)
 
 	RegisterSignal(victim, COMSIG_HUMAN_DISARM_HIT, .proc/reset_crystalizing)
-	RegisterSignal(victim, COMSIG_PARENT_EXAMINE, .proc/on_examine)
+	RegisterSignal(victim, COMSIG_PARENT_EXAMINE, .proc/on_examine, TRUE)
 	RegisterSignal(victim, COMSIG_MOB_APPLY_DAMAGE, .proc/on_take_damage)
 
 ///Ran when disarmed, prevents the ethereal from reviving
@@ -377,7 +377,7 @@
 ///Stop the crystalization process, unregistering any signals and resetting any variables.
 /obj/item/organ/internal/heart/ethereal/proc/stop_crystalization_process(mob/living/ethereal, succesful = FALSE)
 	UnregisterSignal(ethereal, COMSIG_HUMAN_DISARM_HIT)
-	UnregisterSignal(ethereal, COMSIG_PARENT_EXAMINE)
+	UnregisterSignal(ethereal, COMSIG_PARENT_EXAMINE, TRUE)
 	UnregisterSignal(ethereal, COMSIG_MOB_APPLY_DAMAGE)
 
 	crystalization_process_damage = 0 //Reset damage taken during crystalization

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -344,7 +344,7 @@
 	crystalize_timer_id = addtimer(CALLBACK(src, .proc/crystalize, victim), CRYSTALIZE_PRE_WAIT_TIME, TIMER_STOPPABLE)
 
 	RegisterSignal(victim, COMSIG_HUMAN_DISARM_HIT, .proc/reset_crystalizing)
-	RegisterSignal(victim, COMSIG_PARENT_EXAMINE, .proc/on_examine, TRUE)
+	RegisterSignal(victim, COMSIG_PARENT_EXAMINE, .proc/on_examine, override = TRUE)
 	RegisterSignal(victim, COMSIG_MOB_APPLY_DAMAGE, .proc/on_take_damage)
 
 ///Ran when disarmed, prevents the ethereal from reviving

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -377,7 +377,7 @@
 ///Stop the crystalization process, unregistering any signals and resetting any variables.
 /obj/item/organ/internal/heart/ethereal/proc/stop_crystalization_process(mob/living/ethereal, succesful = FALSE)
 	UnregisterSignal(ethereal, COMSIG_HUMAN_DISARM_HIT)
-	UnregisterSignal(ethereal, COMSIG_PARENT_EXAMINE, TRUE)
+	UnregisterSignal(ethereal, COMSIG_PARENT_EXAMINE)
 	UnregisterSignal(ethereal, COMSIG_MOB_APPLY_DAMAGE)
 
 	crystalization_process_damage = 0 //Reset damage taken during crystalization


### PR DESCRIPTION
```
[20:47:13] Runtime in stack_trace.dm,3: atom_examine overridden. Use override = TRUE to suppress this warning
  proc name: stack trace (/proc/stack_trace)
  src: null
  call stack:
  stack trace("atom_examine overridden. Use o...")
  the crystal core (/obj/item/organ/internal/heart/ethereal): RegisterSignal(Crux V (/mob/living/carbon/human), "atom_examine", /obj/item/organ/internal/heart... (/obj/item/organ/internal/heart/ethereal/proc/on_examine), 0)
  the crystal core (/obj/item/organ/internal/heart/ethereal): on stat change(Crux V (/mob/living/carbon/human), 4, 0)
  Crux V (/mob/living/carbon/human):  SendSignal("mob_statchange", /list (/list))
  Crux V (/mob/living/carbon/human): set stat(4)
  Crux V (/mob/living/carbon/human): set stat(4)
  Crux V (/mob/living/carbon/human): set stat(4)
  Crux V (/mob/living/carbon/human): death(null)
  Crux V (/mob/living/carbon/human): death(null)
  Crux V (/mob/living/carbon/human): death(null)
  Dead Body placer (/obj/effect/mapping_helpers/dead_body_placer): LateInitialize()
  Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null, null)
  Atoms (/datum/controller/subsystem/atoms): Initialize(27974)
  Master (/datum/controller/master): Initialize(10, 0, 1)

```