### PR TITLE
fixes chameleon card reset issues and makes nuke op trim have a hud icon

### DIFF
--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -456,6 +456,9 @@ SUBSYSTEM_DEF(id_access)
 	id_card.trim_state_override = null
 	id_card.trim_assignment_override = null
 	id_card.sechud_icon_state_override = null
+	id_card.department_color_override = null
+	id_card.department_state_override = null
+	id_card.subdepartment_color_override = null
 
 /**
  * Adds the accesses associated with a trim to an ID card.

--- a/code/datums/id_trim/syndicate.dm
+++ b/code/datums/id_trim/syndicate.dm
@@ -40,6 +40,12 @@
 	trim_state = "trim_syndicate"
 	department_color = COLOR_SYNDIE_RED
 	subdepartment_color = COLOR_SYNDIE_RED
+	sechud_icon_state = SECHUD_SYNDICATE
+
+/// Trim for Chameleon ID cards. Many outfits, nuke ops and some corpses hold Chameleon ID cards.
+/datum/id_trim/chameleon/operative/nuke_leader
+	assignment = "Syndicate Operative Leader"
+	access = list(ACCESS_MAINT_TUNNELS, ACCESS_SYNDICATE, ACCESS_SYNDICATE_LEADER)
 
 /// Trim for Chameleon ID cards. Many outfits, nuke ops and some corpses hold Chameleon ID cards.
 /datum/id_trim/chameleon/operative/clown
@@ -49,9 +55,4 @@
 /// Trim for Chameleon ID cards. Many outfits, nuke ops and some corpses hold Chameleon ID cards.
 /datum/id_trim/chameleon/operative/clown_leader
 	assignment = "Syndicate Entertainment Operative Leader"
-	access = list(ACCESS_MAINT_TUNNELS, ACCESS_SYNDICATE, ACCESS_SYNDICATE_LEADER)
-
-/// Trim for Chameleon ID cards. Many outfits, nuke ops and some corpses hold Chameleon ID cards.
-/datum/id_trim/chameleon/operative/nuke_leader
-	assignment = "Syndicate Operative Leader"
 	access = list(ACCESS_MAINT_TUNNELS, ACCESS_SYNDICATE, ACCESS_SYNDICATE_LEADER)

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -200,6 +200,7 @@
 		if(id_trim)
 			if(!SSid_access.apply_trim_to_card(id_card, id_trim))
 				WARNING("Unable to apply trim [id_trim] to [id_card] in outfit [name].")
+			H.sec_hud_set_ID()
 
 	if(suit_store)
 		EQUIP_OUTFIT_ITEM(suit_store, ITEM_SLOT_SUITSTORE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
nuke ops now use the cool syndie ship hud icons
![image](https://user-images.githubusercontent.com/23585223/181941944-a91b61d2-d9c0-43a4-974a-eb631a905274.png)
chameleon cards no longer break their colors when resetting
outfits now update the id card sechud image of the wearer

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
it looks neat

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: nuke ops id trims have a sechud icon
fix: chameleon cards now fix their colors upon resetting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
