### PR TITLE
The Shakening: Processing machinery will now shake while in use

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1451,13 +1451,27 @@ GLOBAL_LIST_EMPTY(transformation_animation_objects)
 
 ///Perform a shake on an atom, resets its position afterwards
 /atom/proc/Shake(pixelshiftx = 15, pixelshifty = 15, duration = 250)
-	var/initialpixelx = pixel_x
-	var/initialpixely = pixel_y
-	var/shiftx = rand(-pixelshiftx,pixelshiftx)
-	var/shifty = rand(-pixelshifty,pixelshifty)
-	animate(src, pixel_x = pixel_x + shiftx, pixel_y = pixel_y + shifty, time = 0.2, loop = duration)
-	pixel_x = initialpixelx
-	pixel_y = initialpixely
+	var/static/list/transforms
+	if(!transforms)
+		var/matrix/first_translation = matrix()
+		var/matrix/second_translation = matrix()
+		var/matrix/third_translation = matrix()
+		var/matrix/fourth_translation = matrix()
+		first_translation.Translate(-pixelshiftx, 0)
+		second_translation.Translate(0, pixelshifty)
+		third_translation.Translate(pixelshiftx, 0)
+		fourth_translation.Translate(0, -pixelshifty)
+		transforms = list(first_translation, second_translation, third_translation, fourth_translation)
+	animate(src, transform = transforms[1], time=0.4, loop=-1)
+	animate(transform = transforms[2], time=0.2)
+	animate(transform = transforms[3], time=0.4)
+	animate(transform = transforms[4], time=0.6)
+	addtimer(CALLBACK(src, .proc/Stop_Shaking), duration)
+
+/atom/proc/Stop_Shaking()
+	update_appearance()
+	animate(src, transform = matrix())
+
 
 ///Checks if the given iconstate exists in the given file, caching the result. Setting scream to TRUE will print a stack trace ONCE.
 /proc/icon_exists(file, state, scream)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -1029,3 +1029,33 @@
 	if(isliving(user))
 		last_used_time = world.time
 		last_user_mobtype = user.type
+
+/**
+ * Causes the machinery to shake while in use.
+ *
+ * Uses an animation to cause the machinery to shake for a designated amount of time.
+ */
+/obj/machinery/proc/start_shaking()
+	var/static/list/transforms
+	if(!transforms)
+		var/matrix/first_translation = matrix()
+		var/matrix/second_translation = matrix()
+		var/matrix/third_translation = matrix()
+		var/matrix/fourth_translation = matrix()
+		first_translation.Translate(-1, 0)
+		second_translation.Translate(0, 1)
+		third_translation.Translate(1, 0)
+		fourth_translation.Translate(0, -1)
+		transforms = list(first_translation, second_translation, third_translation, fourth_translation)
+	animate(src, transform = transforms[1], time=0.4, loop=-1)
+	animate(transform = transforms[2], time=0.2)
+	animate(transform = transforms[3], time=0.4)
+	animate(transform = transforms[4], time=0.6)
+
+/obj/machinery/proc/shake_for(duration)
+	start_shaking() //start shaking
+	addtimer(CALLBACK(src, .proc/stop_shaking), duration)
+
+/obj/machinery/proc/stop_shaking()
+	update_appearance()
+	animate(src, transform = matrix())

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -1029,33 +1029,3 @@
 	if(isliving(user))
 		last_used_time = world.time
 		last_user_mobtype = user.type
-
-/**
- * Causes the machinery to shake while in use.
- *
- * Uses an animation to cause the machinery to shake for a designated amount of time.
- */
-/obj/machinery/proc/start_shaking()
-	var/static/list/transforms
-	if(!transforms)
-		var/matrix/first_translation = matrix()
-		var/matrix/second_translation = matrix()
-		var/matrix/third_translation = matrix()
-		var/matrix/fourth_translation = matrix()
-		first_translation.Translate(-1, 0)
-		second_translation.Translate(0, 1)
-		third_translation.Translate(1, 0)
-		fourth_translation.Translate(0, -1)
-		transforms = list(first_translation, second_translation, third_translation, fourth_translation)
-	animate(src, transform = transforms[1], time=0.4, loop=-1)
-	animate(transform = transforms[2], time=0.2)
-	animate(transform = transforms[3], time=0.4)
-	animate(transform = transforms[4], time=0.6)
-
-/obj/machinery/proc/shake_for(duration)
-	start_shaking() //start shaking
-	addtimer(CALLBACK(src, .proc/stop_shaking), duration)
-
-/obj/machinery/proc/stop_shaking()
-	update_appearance()
-	animate(src, transform = matrix())

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -135,31 +135,6 @@
 	dump_inventory_contents()
 	update_appearance()
 
-/obj/machinery/gibber/proc/start_shaking()
-	var/static/list/transforms
-	if(!transforms)
-		var/matrix/M1 = matrix()
-		var/matrix/M2 = matrix()
-		var/matrix/M3 = matrix()
-		var/matrix/M4 = matrix()
-		M1.Translate(-1, 0)
-		M2.Translate(0, 1)
-		M3.Translate(1, 0)
-		M4.Translate(0, -1)
-		transforms = list(M1, M2, M3, M4)
-	animate(src, transform=transforms[1], time=0.4, loop=-1)
-	animate(transform=transforms[2], time=0.2)
-	animate(transform=transforms[3], time=0.4)
-	animate(transform=transforms[4], time=0.6)
-
-/obj/machinery/gibber/proc/shake_for(duration)
-	start_shaking() //start shaking
-	addtimer(CALLBACK(src, .proc/stop_shaking), duration)
-
-/obj/machinery/gibber/proc/stop_shaking()
-	update_appearance()
-	animate(src, transform = matrix())
-
 /obj/machinery/gibber/proc/startgibbing(mob/user)
 	if(operating)
 		return

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -135,6 +135,31 @@
 	dump_inventory_contents()
 	update_appearance()
 
+/obj/machinery/gibber/proc/start_shaking()
+	var/static/list/transforms
+	if(!transforms)
+		var/matrix/M1 = matrix()
+		var/matrix/M2 = matrix()
+		var/matrix/M3 = matrix()
+		var/matrix/M4 = matrix()
+		M1.Translate(-1, 0)
+		M2.Translate(0, 1)
+		M3.Translate(1, 0)
+		M4.Translate(0, -1)
+		transforms = list(M1, M2, M3, M4)
+	animate(src, transform=transforms[1], time=0.4, loop=-1)
+	animate(transform=transforms[2], time=0.2)
+	animate(transform=transforms[3], time=0.4)
+	animate(transform=transforms[4], time=0.6)
+
+/obj/machinery/gibber/proc/shake_for(duration)
+	start_shaking() //start shaking
+	addtimer(CALLBACK(src, .proc/stop_shaking), duration)
+
+/obj/machinery/gibber/proc/stop_shaking()
+	update_appearance()
+	animate(src, transform = matrix())
+
 /obj/machinery/gibber/proc/startgibbing(mob/user)
 	if(operating)
 		return
@@ -148,8 +173,7 @@
 	operating = TRUE
 	update_appearance()
 
-	var/offset = prob(50) ? -2 : 2
-	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
+	shake_for(45)
 	var/mob/living/mob_occupant = occupant
 	var/sourcename = mob_occupant.real_name
 	var/sourcejob

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -148,7 +148,7 @@
 	operating = TRUE
 	update_appearance()
 
-	shake_for(gibtime)
+	Shake(2, 2, gibtime)
 	var/mob/living/mob_occupant = occupant
 	var/sourcename = mob_occupant.real_name
 	var/sourcejob

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -173,7 +173,7 @@
 	operating = TRUE
 	update_appearance()
 
-	shake_for(45)
+	shake_for(gibtime)
 	var/mob/living/mob_occupant = occupant
 	var/sourcename = mob_occupant.real_name
 	var/sourcejob

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 	qdel(target)
 	to_chat(user, span_notice("You stuff the monkey into the machine."))
 	playsound(src.loc, 'sound/machines/juicer.ogg', 50, TRUE)
-	shake_for(1.5 SECONDS)
+	Shake(2, 2, 1.5 SECONDS)
 	use_power(active_power_usage)
 	stored_matter += cube_production
 	addtimer(CALLBACK(GLOBAL_PROC, /proc/to_chat, user, span_notice("The machine now has [stored_matter] monkey\s worth of material stored.")))

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -65,32 +65,6 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 	if(ismonkey(target))
 		stuff_monkey_in(target, user)
 
-/obj/machinery/monkey_recycler/proc/start_shaking()
-	var/static/list/transforms
-	if(!transforms)
-		var/matrix/M1 = matrix()
-		var/matrix/M2 = matrix()
-		var/matrix/M3 = matrix()
-		var/matrix/M4 = matrix()
-		M1.Translate(-1, 0)
-		M2.Translate(0, 1)
-		M3.Translate(1, 0)
-		M4.Translate(0, -1)
-		transforms = list(M1, M2, M3, M4)
-	animate(src, transform=transforms[1], time=0.4, loop=-1)
-	animate(transform=transforms[2], time=0.2)
-	animate(transform=transforms[3], time=0.4)
-	animate(transform=transforms[4], time=0.6)
-
-/obj/machinery/monkey_recycler/proc/shake_for(duration)
-	start_shaking() //start shaking
-	addtimer(CALLBACK(src, .proc/stop_shaking), duration)
-
-/obj/machinery/monkey_recycler/proc/stop_shaking()
-	update_appearance()
-	animate(src, transform = matrix())
-
-
 /obj/machinery/monkey_recycler/proc/stuff_monkey_in(mob/living/carbon/human/target, mob/living/user)
 	if(!istype(target))
 		return

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -103,10 +103,9 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 	qdel(target)
 	to_chat(user, span_notice("You stuff the monkey into the machine."))
 	playsound(src.loc, 'sound/machines/juicer.ogg', 50, TRUE)
-	shake_for(15)
+	shake_for(1.5 SECONDS)
 	use_power(active_power_usage)
 	stored_matter += cube_production
-	addtimer(VARSET_CALLBACK(src, pixel_x, base_pixel_x))
 	addtimer(CALLBACK(GLOBAL_PROC, /proc/to_chat, user, span_notice("The machine now has [stored_matter] monkey\s worth of material stored.")))
 
 /obj/machinery/monkey_recycler/interact(mob/user)

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -65,6 +65,32 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 	if(ismonkey(target))
 		stuff_monkey_in(target, user)
 
+/obj/machinery/monkey_recycler/proc/start_shaking()
+	var/static/list/transforms
+	if(!transforms)
+		var/matrix/M1 = matrix()
+		var/matrix/M2 = matrix()
+		var/matrix/M3 = matrix()
+		var/matrix/M4 = matrix()
+		M1.Translate(-1, 0)
+		M2.Translate(0, 1)
+		M3.Translate(1, 0)
+		M4.Translate(0, -1)
+		transforms = list(M1, M2, M3, M4)
+	animate(src, transform=transforms[1], time=0.4, loop=-1)
+	animate(transform=transforms[2], time=0.2)
+	animate(transform=transforms[3], time=0.4)
+	animate(transform=transforms[4], time=0.6)
+
+/obj/machinery/monkey_recycler/proc/shake_for(duration)
+	start_shaking() //start shaking
+	addtimer(CALLBACK(src, .proc/stop_shaking), duration)
+
+/obj/machinery/monkey_recycler/proc/stop_shaking()
+	update_appearance()
+	animate(src, transform = matrix())
+
+
 /obj/machinery/monkey_recycler/proc/stuff_monkey_in(mob/living/carbon/human/target, mob/living/user)
 	if(!istype(target))
 		return
@@ -77,8 +103,7 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 	qdel(target)
 	to_chat(user, span_notice("You stuff the monkey into the machine."))
 	playsound(src.loc, 'sound/machines/juicer.ogg', 50, TRUE)
-	var/offset = prob(50) ? -2 : 2
-	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
+	shake_for(15)
 	use_power(active_power_usage)
 	stored_matter += cube_production
 	addtimer(VARSET_CALLBACK(src, pixel_x, base_pixel_x))

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -145,7 +145,9 @@
 			continue
 		total_time += recipe.time
 	shake_for(total_time / rating_speed)
-	sleep(total_time / rating_speed)
+	addtimer(CALLBACK(src, .proc/process_contents), total_time / rating_speed)
+
+/obj/machinery/processor/proc/process_contents()
 	for(var/atom/movable/O in processor_contents)
 		var/datum/food_processor_process/P = PROCESSOR_SELECT_RECIPE(O)
 		if (!P)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -144,7 +144,7 @@
 			log_admin("DEBUG: [movable_input] in processor doesn't have a suitable recipe. How did it get in there? Please report it immediately!!!")
 			continue
 		total_time += recipe.time
-	shake_for(total_time / rating_speed)
+	Shake(2, 2, total_time / rating_speed)
 	addtimer(CALLBACK(src, .proc/process_contents), total_time / rating_speed)
 
 /obj/machinery/processor/proc/process_contents()

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -114,31 +114,6 @@
 	else
 		return ..()
 
-/obj/machinery/processor/proc/start_shaking()
-	var/static/list/transforms
-	if(!transforms)
-		var/matrix/M1 = matrix()
-		var/matrix/M2 = matrix()
-		var/matrix/M3 = matrix()
-		var/matrix/M4 = matrix()
-		M1.Translate(-1, 0)
-		M2.Translate(0, 1)
-		M3.Translate(1, 0)
-		M4.Translate(0, -1)
-		transforms = list(M1, M2, M3, M4)
-	animate(src, transform=transforms[1], time=0.4, loop=-1)
-	animate(transform=transforms[2], time=0.2)
-	animate(transform=transforms[3], time=0.4)
-	animate(transform=transforms[4], time=0.6)
-
-/obj/machinery/processor/proc/shake_for(duration)
-	start_shaking() //start shaking
-	addtimer(CALLBACK(src, .proc/stop_shaking), duration)
-
-/obj/machinery/processor/proc/stop_shaking()
-	update_appearance()
-	animate(src, transform = matrix())
-
 /obj/machinery/processor/interact(mob/user)
 	if(processing)
 		to_chat(user, span_warning("[src] is in the process of processing!"))

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -257,7 +257,7 @@
 	qdel(O)
 
 /obj/machinery/reagentgrinder/proc/operate_for(time, silent = FALSE, juicing = FALSE)
-	shake_for(time / speed)
+	Shake(2, 2, time / speed)
 	operating = TRUE
 	if(!silent)
 		if(!juicing)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -256,31 +256,6 @@
 	holdingitems -= O
 	qdel(O)
 
-/obj/machinery/reagentgrinder/proc/start_shaking()
-	var/static/list/transforms
-	if(!transforms)
-		var/matrix/M1 = matrix()
-		var/matrix/M2 = matrix()
-		var/matrix/M3 = matrix()
-		var/matrix/M4 = matrix()
-		M1.Translate(-1, 0)
-		M2.Translate(0, 1)
-		M3.Translate(1, 0)
-		M4.Translate(0, -1)
-		transforms = list(M1, M2, M3, M4)
-	animate(src, transform=transforms[1], time=0.4, loop=-1)
-	animate(transform=transforms[2], time=0.2)
-	animate(transform=transforms[3], time=0.4)
-	animate(transform=transforms[4], time=0.6)
-
-/obj/machinery/reagentgrinder/proc/shake_for(duration)
-	start_shaking() //start shaking
-	addtimer(CALLBACK(src, .proc/stop_shaking), duration)
-
-/obj/machinery/reagentgrinder/proc/stop_shaking()
-	update_appearance()
-	animate(src, transform = matrix())
-
 /obj/machinery/reagentgrinder/proc/operate_for(time, silent = FALSE, juicing = FALSE)
 	shake_for(time / speed)
 	operating = TRUE


### PR DESCRIPTION

## About The Pull Request

Processing machinery (xeno and kitchen) equipment will shake when in use.

**The shakening.**

## Why It's Good For The Game

https://github.com/tgstation/tgstation/pull/68803

No longer a few pixel movements when in use.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: adds real animations to the gibber, and processors.
fix: fixes broken animations for machinery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
