### PR TITLE
Obstructed Vents and Scrubbers? - Debug Them Out!

### DIFF
--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -566,12 +566,12 @@ GLOBAL_VAR_INIT(say_disabled, FALSE)
 		/obj/structure/window/reinforced,
 	)
 
-	for(var/turf/T in world)
-		var/obj/machinery/atmospherics/components/unary/device = locate() in T.contents
+	for(var/turf/iterated_turf in world)
+		var/obj/machinery/atmospherics/components/unary/device = locate() in iterated_turf.contents
 		if(device)
-			var/list/obj/obstruction = locate(/obj) in T.contents
+			var/list/obj/obstruction = locate(/obj) in iterated_turf.contents
 			if(!is_type_in_list(obstruction, ignore_list))
-				results += "There is an obstruction on top of an atmospherics machine at: [ADMIN_VERBOSEJMP(T)].<br>"
+				results += "There is an obstruction on top of an atmospherics machine at: [ADMIN_VERBOSEJMP(iterated_turf)].<br>"
 
 	if(results.len == 1) // only the header is in the list, we're good
 		to_chat(src, "No obstructions detected.", confidential = TRUE)

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -568,10 +568,11 @@ GLOBAL_VAR_INIT(say_disabled, FALSE)
 
 	for(var/turf/iterated_turf in world)
 		var/obj/machinery/atmospherics/components/unary/device = locate() in iterated_turf.contents
-		if(device)
-			var/list/obj/obstruction = locate(/obj) in iterated_turf.contents
-			if(!is_type_in_list(obstruction, ignore_list))
-				results += "There is an obstruction on top of an atmospherics machine at: [ADMIN_VERBOSEJMP(iterated_turf)].<br>"
+		if(!device)
+			continue
+		var/list/obj/obstruction = locate(/obj) in iterated_turf.contents
+		if(!is_type_in_list(obstruction, ignore_list))
+			results += "There is an obstruction on top of an atmospherics machine at: [ADMIN_VERBOSEJMP(iterated_turf)].<br>"
 
 	if(results.len == 1) // only the header is in the list, we're good
 		to_chat(src, "No obstructions detected.", confidential = TRUE)

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -55,6 +55,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug_mapping, list(
 	/client/proc/station_food_debug,
 	/client/proc/station_stack_debug,
 	/client/proc/check_atmos_controls,
+	/client/proc/check_for_obstructed_atmospherics,
 ))
 GLOBAL_PROTECT(admin_verbs_debug_mapping)
 
@@ -517,3 +518,65 @@ GLOBAL_VAR_INIT(say_disabled, FALSE)
 		to_chat(usr, "Atmos control frequency check passed without encountering problems.", confidential=TRUE)
 	else
 		to_chat(usr, "Total errors: [invalid_machine + invalid_tag + tagless + duplicate_tag + not_heard + not_told]", confidential=TRUE)
+
+/// Check all tiles with a vent or scrubber on it and ensure that nothing is covering it up.
+/client/proc/check_for_obstructed_atmospherics()
+	set name = "Check For Obstructed Atmospherics"
+	set category = "Mapping"
+	if(!src.holder)
+		to_chat(src, "Only administrators may use this command.", confidential = TRUE)
+		return
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Check For Obstructed Atmospherics") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+	var/list/results = list()
+
+	results += "<h2><b>Anything that is considered to aesthetically obstruct an atmospherics machine (vent, scrubber, port) is listed below.</b> Please re-arrange to accomodate for this.</h2><br>"
+
+	// Ignore out stuff we see in normal and standard mapping that we don't care about (false alarms). Typically stuff that goes directionally off turfs or are undertiles that shouldn't matter.
+	var/list/ignore_list = list(
+		/obj/effect,
+		/obj/item/shard, // it's benign enough to where we don't need to error, yet common enough to filter. fuck.
+		/obj/machinery/airalarm,
+		/obj/machinery/atmospherics/components/unary, //don't wanna flag on the vent or scrubber itself.
+		/obj/machinery/atmospherics/pipe,
+		/obj/machinery/button,
+		/obj/machinery/camera,
+		/obj/machinery/door_buttons,
+		/obj/machinery/door/window, // i kind of wish we didn't have to do it but we have some particularly compact areas that we need to be wary of
+		/obj/machinery/duct,
+		/obj/machinery/firealarm,
+		/obj/machinery/flasher,
+		/obj/machinery/light_switch,
+		/obj/machinery/light,
+		/obj/machinery/navbeacon,
+		/obj/machinery/newscaster,
+		/obj/machinery/portable_atmospherics,
+		/obj/machinery/power/apc,
+		/obj/machinery/power/terminal,
+		/obj/machinery/sparker,
+		/obj/machinery/status_display,
+		/obj/machinery/turretid,
+		/obj/structure/cable,
+		/obj/structure/disposalpipe,
+		/obj/structure/extinguisher_cabinet,
+		/obj/structure/lattice,
+		/obj/structure/sign,
+		/obj/structure/urinal, // the reason why this one gets to live and not the shower/sink is because it's pretty firmly on a wall.
+		/obj/structure/window/reinforced,
+	)
+
+	for(var/turf/T in world)
+		var/obj/machinery/atmospherics/components/unary/A = locate(/obj/machinery/atmospherics/components/unary) in T.contents
+		if(A)
+			var/list/obj/O = locate(/obj) in T.contents
+
+			if(!is_type_in_list(O, ignore_list))
+				results += "There is an obstruction on top of an atmospherics machine at: [ADMIN_VERBOSEJMP(T)].<br>"
+				continue
+
+	if(results.len == 1) // only the header is in the list, we're good
+		to_chat(src, "No obstructions detected.", confidential = TRUE)
+	else
+		var/datum/browser/popup = new(usr, "atmospherics_obstructions", "Atmospherics Obstructions", 900, 750)
+		popup.set_content(results.Join())
+		popup.open()

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -526,13 +526,14 @@ GLOBAL_VAR_INIT(say_disabled, FALSE)
 	if(!src.holder)
 		to_chat(src, "Only administrators may use this command.", confidential = TRUE)
 		return
+	message_admins(span_adminnotice("[key_name_admin(usr)] is checking for obstructed atmospherics through the debug command."))
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Check For Obstructed Atmospherics") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 	var/list/results = list()
 
 	results += "<h2><b>Anything that is considered to aesthetically obstruct an atmospherics machine (vent, scrubber, port) is listed below.</b> Please re-arrange to accomodate for this.</h2><br>"
 
-	// Ignore out stuff we see in normal and standard mapping that we don't care about (false alarms). Typically stuff that goes directionally off turfs or are undertiles that shouldn't matter.
+	// Ignore out stuff we see in normal and standard mapping that we don't care about (false alarms). Typically stuff that goes directionally off turfs or other undertile objects that we don't want to care about.
 	var/list/ignore_list = list(
 		/obj/effect,
 		/obj/item/shard, // it's benign enough to where we don't need to error, yet common enough to filter. fuck.
@@ -566,11 +567,10 @@ GLOBAL_VAR_INIT(say_disabled, FALSE)
 	)
 
 	for(var/turf/T in world)
-		var/obj/machinery/atmospherics/components/unary/A = locate(/obj/machinery/atmospherics/components/unary) in T.contents
-		if(A)
-			var/list/obj/O = locate(/obj) in T.contents
-
-			if(!is_type_in_list(O, ignore_list))
+		var/obj/machinery/atmospherics/components/unary/device = locate() in T.contents
+		if(device)
+			var/list/obj/obstruction = locate(/obj) in T.contents
+			if(!is_type_in_list(obstruction, ignore_list))
 				results += "There is an obstruction on top of an atmospherics machine at: [ADMIN_VERBOSEJMP(T)].<br>"
 				continue
 

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -523,7 +523,7 @@ GLOBAL_VAR_INIT(say_disabled, FALSE)
 /client/proc/check_for_obstructed_atmospherics()
 	set name = "Check For Obstructed Atmospherics"
 	set category = "Mapping"
-	if(!src.holder)
+	if(!holder)
 		to_chat(src, "Only administrators may use this command.", confidential = TRUE)
 		return
 	message_admins(span_adminnotice("[key_name_admin(usr)] is checking for obstructed atmospherics through the debug command."))

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -572,7 +572,6 @@ GLOBAL_VAR_INIT(say_disabled, FALSE)
 			var/list/obj/obstruction = locate(/obj) in T.contents
 			if(!is_type_in_list(obstruction, ignore_list))
 				results += "There is an obstruction on top of an atmospherics machine at: [ADMIN_VERBOSEJMP(T)].<br>"
-				continue
 
 	if(results.len == 1) // only the header is in the list, we're good
 		to_chat(src, "No obstructions detected.", confidential = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hello there,

In _May of 2014_, Ikarrus wrote the following [here](https://tgstation13.org/phpBB/viewtopic.php?f=11&t=327):

> Avoid placing scrubbers and air vents under objects. It's better to leave them in the open and visible so people can use them.

How far we have fallen. However, during a review I did in the last week, I accidentally let one of these (in multiple occurrences!) slip past me:

![image](https://user-images.githubusercontent.com/34697715/182017826-97c47b32-b9aa-4935-bda8-2c08781383ef.png)

Bleaugh! It doesn't affect any atmospherics in game, but it fails in two aspects:

A) It is obtuse to to the player. We need these to be visible such that people can easily access them, and not be trapped under larger objects.
B) It looks ugly! You can't even see a hint of the scrubber under that dresser. In fact, if I didn't point this out to you, I doubt you'd have been able to know it was there.

I don't want that to happen again. It's especially hard when they're under tables, or big bulky lockers, and under computers sometimes! I've seen every single obtusity with this system there is to see. They're not obvious to the human eye, so we must rely on technology. This creates a new Debug Mapping Verb that will flag out any vent, scrubber, or canister port that is being obstructed by an invalid object (directionals and undertiles are excluded). It will be a gargantuan effort unlike anything you've seen to get rid of all of them, but at least this is the first stone in a grand arch.

I decided to _not_ include stuff like plants, toilets, and showers in this PR. I want to see if we can't kick a few odd habits we've gained over the years. If it gets to be annoying, I'll pass it in, because the odds are that I'm going to have to be the one to do all of this (I'll be okay with it when I get there). We want the signal-to-noise ratio to be low here, so there's definitely a few edgecases that I'm going to find when I start re-mapping. This PR should contain at least 95% of all "false alarms".

I'm also stuck wondering if we couldn't add this in as a CI test, but that'll definitely have to be after we get rid of all of the undesirables. Another day?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I am only a mere human. Anyone who reviews mapping PRs, as well as anyone who maps, will also only be human. Mistakes will happen, especially when we don't look out for them (or take a lazier way out). I've been guilty of this in my own maps, and I think you should be hard-pressed to find someone who hasn't done this. Ikarrus was right in 2014, and every time I've noticed this in my reviews in the modern year of 2022, I ask for it to be changed. Let's get our maps up to a much nicer quality.

![image](https://user-images.githubusercontent.com/34697715/182018089-831448f7-ac31-4bbf-9e96-a4a3b46bc54f.png)

_Pictured: La Demona._
_Not Pictured: At least another hundred lines._

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing that particularly concerns players. The maps will be touched later, so we'll figure it out then. Thanks for your time listening to this small rant I concocted working on this PR for the last few hours.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
