### PR TITLE
Blargedy Blarg Blarg Blarg - Word Filter Error Fix

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -379,7 +379,7 @@ Example config:
 		return
 
 	log_config("Loading config file word_filter.toml...")
-	var/list/result = rustg_read_toml_file("[directory]/word_filter.toml")
+	var/list/result = rustg_raw_read_toml_file("[directory]/word_filter.toml")
 	if(!result["success"])
 		var/message = "The word filter is not configured correctly! [result["content"]]"
 		log_config(message)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Apparently, even after five days of thinking about the JSON_DECODE issue we had going from rust-g 1.0.1 to 1.0.2 during #68690, I forgot to check our own code. I think I fudged something where I was using the global proc instead of the actual RUSTG define, so you would always get back an encoded JSON array, which would result in _always_ passing a null for the success variable that rust-g would return (based on what was seen on production), etc. The failure condition we were seeing is that no matter how perfect the word filter was, you would still crash to get this issue.

```txt
[2022-07-31 23:13:49.738] Loading config file word_filter.toml...
[2022-07-31 23:13:49.739] The word filter is not configured correctly! 
```

With a few "null spaces" after that message. So, I'm pretty sure this is the issue since I'm not seeing anything in my config_error.log with this change added. (however, I am not seeing anything on standard codebase conditions? this error was reported based on the production /tg/ server's config, but something is definitely yorked irregardless). Passing through this change, there doesn't appear to be anything in `config_error.log` on my local server, and intentionally fudging the TOML passes this:

![image](https://user-images.githubusercontent.com/34697715/182052062-37b7b73c-e869-4d67-b2e9-95688b1b659e.png)

Whoops.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I fucke dup

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: You should hopefully no longer see an error message that has nothing to say regarding the word filter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
