### PR TITLE
Fixes a runtime caused by get_storage_locs()

### DIFF
--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -322,4 +322,4 @@ rough example of the "cone" made by the 3 dirs checked
 	var/datum/storage/storage_datum = target.loc.atom_storage
 	if(!storage_datum)
 		return
-	. += storage_datum.parent
+	. += storage_datum.real_location?.resolve()


### PR DESCRIPTION
## About The Pull Request
It was returning the parent, which wasn't always the location (or rather, said parent didn't always itself have a loc, which was runtiming like crazy), due to the storage refactor. This fixes that.

## Why It's Good For The Game
Less runtimes related to stabilized extracts.

## Changelog

:cl: GoldenAlpharex
fix: Stabilized extracts will no longer cause a lot of runtimes when the parent of their storage datum isn't something that has a loc.
/:cl: