### PR TITLE
[NO GBP] Fixes cyborg existentialism upon encountering syndicate posters

### DIFF
--- a/code/modules/antagonists/traitor/components/demoraliser.dm
+++ b/code/modules/antagonists/traitor/components/demoraliser.dm
@@ -44,7 +44,7 @@
 	// If you're not conscious you're too busy or dead to look at propaganda
 	if (viewer.stat != CONSCIOUS)
 		return
-	if (was_demoralised(viewer))
+	if (!should_demoralise(viewer))
 		return
 
 	if (is_special_character(viewer))
@@ -60,17 +60,17 @@
 	SEND_SIGNAL(host, COMSIG_DEMORALISING_EVENT, viewer.mind)
 
 /**
- * Returns true if the viewer already has been given feelings, false if they haven't.
+ * Returns true if user is capable of experiencing moods and doesn't already have the one relevant to this datum, false otherwise.
  *
  * Arguments
  * * viewer - Whoever just saw the parent.
  */
-/datum/proximity_monitor/advanced/demoraliser/proc/was_demoralised(mob/living/viewer)
+/datum/proximity_monitor/advanced/demoraliser/proc/should_demoralise(mob/living/viewer)
 	var/datum/component/mood/mood = viewer.GetComponent(/datum/component/mood)
 	if (!mood)
 		return FALSE
 
-	return mood.has_mood_of_category(moods.mood_category)
+	return !mood.has_mood_of_category(moods.mood_category)
 
 /// Mood application categories for this objective
 /// Used to reduce duplicate code for applying moods to players based on their state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/68902
Traitorous posters no longer attempt to apply moods to mobs which have minds but no moods.
Originally this component handled this by checking `ishuman` but that check was removed and not subsequently tested with nonhuman mobs.

That also probably wouldn't have worked in all cases anyhow.

This was causing chat spam for cyborgs from being near a poster, which also apparently lagged the client.
This would probably also happen for xenos, possessed simplemobs, and other various things which don't experience human emotion. I've tried those now and it doesn't do that any more.

This also isn't a removal but that is the price I pay for writing a funny PR title I guess.

## Why It's Good For The Game

Saves on running pointless operations and spamming text to the client.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Creatures which can't experience emotions will no longer attempt to do so upon seeing a traitorous poster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
