### PR TITLE
Refactor `/mob/living/carbon/human` to be `/mob/living/carbon/humanoid`

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -64,9 +64,10 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 //Carbon mobs
 #define iscarbon(A) (istype(A, /mob/living/carbon))
 
-#define ishuman(A) (istype(A, /mob/living/carbon/human))
+#define ishumanoid(A) (istype(A, /mob/living/carbon/humanoid))
 
 //Human sub-species
+#define ishuman(A) (is_species(A, /datum/species/human))
 #define isabductor(A) (is_species(A, /datum/species/abductor))
 #define isgolem(A) (is_species(A, /datum/species/golem))
 #define islizard(A) (is_species(A, /datum/species/lizard))
@@ -79,7 +80,7 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 #define iszombie(A) (is_species(A, /datum/species/zombie))
 #define isskeleton(A) (is_species(A, /datum/species/skeleton))
 #define ismoth(A) (is_species(A, /datum/species/moth))
-#define isfelinid(A) (is_species(A, /datum/species/human/felinid))
+#define isfelinid(A) (is_species(A, /datum/species/humanoid/felinid))
 #define isethereal(A) (is_species(A, /datum/species/ethereal))
 #define isvampire(A) (is_species(A,/datum/species/vampire))
 #define isdullahan(A) (is_species(A, /datum/species/dullahan))

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -80,7 +80,7 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 #define iszombie(A) (is_species(A, /datum/species/zombie))
 #define isskeleton(A) (is_species(A, /datum/species/skeleton))
 #define ismoth(A) (is_species(A, /datum/species/moth))
-#define isfelinid(A) (is_species(A, /datum/species/humanoid/felinid))
+#define isfelinid(A) (is_species(A, /datum/species/human/felinid))
 #define isethereal(A) (is_species(A, /datum/species/ethereal))
 #define isvampire(A) (is_species(A,/datum/species/vampire))
 #define isdullahan(A) (is_species(A, /datum/species/dullahan))

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -467,15 +467,6 @@ GLOBAL_LIST_EMPTY(species_list)
 		if(H.dna && istype(H.dna.species, species_datum))
 			. = TRUE
 
-/// Returns if the given target is a human. Like, a REAL human.
-/// Not a moth, not a felinid (which are human subtypes), but a human.
-/proc/ishumanbasic(target)
-	if (!ishuman(target))
-		return FALSE
-
-	var/mob/living/carbon/human/human_target = target
-	return human_target.dna?.species?.type == /datum/species/human
-
 /proc/spawn_atom_to_turf(spawn_type, target, amount, admin_spawn=FALSE, list/extra_args)
 	var/turf/T = get_turf(target)
 	if(!T)

--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -43,13 +43,13 @@
 /datum/quirk/foreigner/add()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	human_holder.add_blocked_language(/datum/language/common)
-	if(ishumanbasic(human_holder))
+	if(ishuman(human_holder))
 		human_holder.grant_language(/datum/language/uncommon)
 
 /datum/quirk/foreigner/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	human_holder.remove_blocked_language(/datum/language/common)
-	if(ishumanbasic(human_holder))
+	if(ishuman(human_holder))
 		human_holder.remove_language(/datum/language/uncommon)
 
 /datum/quirk/vegetarian

--- a/code/modules/experisci/experiment/types/dissection_experiment.dm
+++ b/code/modules/experisci/experiment/types/dissection_experiment.dm
@@ -22,14 +22,14 @@
 	description = "We don't want to invest in a station that doesn't know their coccyx from their cochlea. Send us back data dissecting a human to receive more funding."
 
 /datum/experiment/dissection/human/is_valid_dissection(mob/target)
-	return ishumanbasic(target)
+	return ishuman(target)
 
 /datum/experiment/dissection/nonhuman
 	name = "Non-human Dissection Experiment"
 	description = "When we asked for a tail bone, we didn't mean...look, just send us back data from something OTHER than a human. It could be a monkey for all we care, just send us research."
 
 /datum/experiment/dissection/nonhuman/is_valid_dissection(mob/target)
-	return ishuman(target) && !ishumanbasic(target)
+	return ishuman(target) && !ishuman(target)
 
 /datum/experiment/dissection/xenomorph
 	name = "Xenomorph Dissection Experiment"

--- a/code/modules/experisci/experiment/types/dissection_experiment.dm
+++ b/code/modules/experisci/experiment/types/dissection_experiment.dm
@@ -29,7 +29,7 @@
 	description = "When we asked for a tail bone, we didn't mean...look, just send us back data from something OTHER than a human. It could be a monkey for all we care, just send us research."
 
 /datum/experiment/dissection/nonhuman/is_valid_dissection(mob/target)
-	return ishuman(target) && !ishuman(target)
+	return ishumanoid(target) && !ishuman(target)
 
 /datum/experiment/dissection/xenomorph
 	name = "Xenomorph Dissection Experiment"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -481,7 +481,7 @@
 		if(require_human)
 			player_client.prefs.randomise["species"] = FALSE
 		player_client.prefs.safe_transfer_prefs_to(src, TRUE, is_antag)
-		if(require_human && !ishumanbasic(src))
+		if(require_human && !ishuman(src))
 			set_species(/datum/species/human)
 			dna.species.roundstart_changed = TRUE
 			apply_pref_name(/datum/preference/name/backup_human, player_client)

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -507,7 +507,7 @@
 	. = ..()
 	if(iscarbon(exposed_mob) && exposed_mob.stat != DEAD)
 		var/mob/living/carbon/exposed_carbon = exposed_mob
-		var/holycheck = ishumanbasic(exposed_carbon)
+		var/holycheck = ishuman(exposed_carbon)
 		if(!HAS_TRAIT(exposed_carbon, TRAIT_CAN_USE_FLIGHT_POTION) || reac_volume < 5)
 			if((methods & INGEST) && show_message)
 				to_chat(exposed_carbon, span_notice("<i>You feel nothing but a terrible aftertaste.</i>"))

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -84,7 +84,7 @@
 		if(cat_species.original_felinid)
 			return // Don't display the to_chat message
 		purrbated_human.set_species(/datum/species/human)
-	else if(ishuman(purrbated_human) && !ishuman(purrbated_human))
+	else if(ishumanoid(purrbated_human) && !ishuman(purrbated_human))
 		var/datum/species/target_species = purrbated_human.dna.species
 
 		// From the previous check we know they're not a felinid, therefore removing cat ears and tail is safe

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -65,7 +65,7 @@
 /proc/purrbation_apply(mob/living/carbon/human/soon_to_be_felinid, silent = FALSE)
 	if(!ishuman(soon_to_be_felinid) || isfelinid(soon_to_be_felinid))
 		return
-	if(ishumanbasic(soon_to_be_felinid))
+	if(ishuman(soon_to_be_felinid))
 		soon_to_be_felinid.set_species(/datum/species/human/felinid)
 		var/datum/species/human/felinid/cat_species = soon_to_be_felinid.dna.species
 		cat_species.original_felinid = FALSE
@@ -84,7 +84,7 @@
 		if(cat_species.original_felinid)
 			return // Don't display the to_chat message
 		purrbated_human.set_species(/datum/species/human)
-	else if(ishuman(purrbated_human) && !ishumanbasic(purrbated_human))
+	else if(ishuman(purrbated_human) && !ishuman(purrbated_human))
 		var/datum/species/target_species = purrbated_human.dna.species
 
 		// From the previous check we know they're not a felinid, therefore removing cat ears and tail is safe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This further builds on what I'm attempting with #68911.

Currently `ishuman` is used to check if a mob is one of the humanoid race subtypes.  The define has outgrown it's original intent since it was made before species were a thing.  In contrast, all the other defines that are used like this are aimed at a specific species.  Someone created a `ishumanbasic` proc as a cheap solution when they should have done a full refactor.

My goal is the following:

- Add new `ishumanoid` define to check if a mob is apart of the humanoid mob subtypes (same purpose as the old `ishuman`)
- Change `ishuman` to check if a mob is the human species
- Replace all `/mob/living/carbon/human` references to be `/mob/living/carbon/humanoid`
- Remove the deprecated `ishumanbasic` proc and replace all uses with `ishuman`
- Replace any `istype(user, /mob/living/carbon/human)` with `ishumanoid`

This is not a small undertaking.  

When I refactored random spawners for mapping in #60522, I spent two months fighting merge conflicts from _every mapping PR_.  I will be fighting an uphill battle with merge conflicts for this PR as well and I wanted to get maintainer approval before I invest in this.  My computer should be fixed by this week so I'll be able to thoroughly do my testing when it's ready.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Code clarity and readability.  

Right now `ishuman` is a noob trap for new contributors who start working on the codebase thinking it only applies to human species.  It would be like if `isfloorturf` also applied to walls and you had to have the background knowledge to avoid the pitfalls.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Refactor `/mob/living/carbon/human` to be `/mob/living/carbon/humanoid`
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
