### PR TITLE
make circuit clock interval configurable

### DIFF
--- a/code/modules/wiremod/components/utility/clock.dm
+++ b/code/modules/wiremod/components/utility/clock.dm
@@ -11,15 +11,23 @@
 	/// Whether the clock is on or not
 	var/datum/port/input/on
 
+	/// the interval at wich the clock tick is a multiple of COMP_CLOCK_DELAY
+	var/datum/port/input/interval
+
 	/// The signal from this clock component
 	var/datum/port/output/signal
 
+	///used to compute how many ticks since last signal
+	var/delta_last_signal = COMP_CLOCK_DELAY/(1 SECONDS)
+
 /obj/item/circuit_component/clock/get_ui_notices()
 	. = ..()
-	. += create_ui_notice("Clock Interval: [DisplayTimeText(COMP_CLOCK_DELAY)]", "orange", "clock")
+	. += create_ui_notice("Clock Interval: interval * [DisplayTimeText(COMP_CLOCK_DELAY)]", "orange", "clock")
 
 /obj/item/circuit_component/clock/populate_ports()
 	on = add_input_port("On", PORT_TYPE_NUMBER)
+
+	interval = add_input_port("Interval", PORT_TYPE_NUMBER)
 
 	signal = add_output_port("Signal", PORT_TYPE_SIGNAL)
 
@@ -30,12 +38,25 @@
 	else
 		stop_process()
 
+	///minimum clock interval cant be smaller than COMP_CLOCK_DELAY
+	if(interval.value < 1)
+		interval.value = 1
+
 /obj/item/circuit_component/clock/Destroy()
 	stop_process()
 	return ..()
 
+/**
+ * Send signal only if sufficient ticks have elapsed
+ *
+ * since last signal
+ */
 /obj/item/circuit_component/clock/process(delta_time)
-	signal.set_output(COMPONENT_SIGNAL)
+	if(delta_last_signal >= interval.value*COMP_CLOCK_DELAY/(1 SECONDS))
+		signal.set_output(COMPONENT_SIGNAL)
+		delta_last_signal = COMP_CLOCK_DELAY/(1 SECONDS)
+	else
+		delta_last_signal = delta_last_signal + delta_time
 
 /**
  * Adds the component to the SSclock_component process list


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Add an input to the clock (interval) and constraint it to be >=1
Only fire a signal if "interval" tick have elapsed since last signal.
Add a local variable (delta_last_signal) to represent the time elapsed.
Change the component's ui_notice so the users are aware of what the new input do.

Tests : 
- Run on the correct number of tick, that are multiple of COMP_CLOCK_DELAY
- Cant set input to less than 1
- Run multiple circuits with differents clock interval

Notes : 
- First PR so please be attentive I broke nothing. I did my best to follow the project's style guidelines.
- Thank you to JohnFulpWillard, Jacquerel and Random, who helped me on Discord.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Circuit clock tick was fast ( 0.9 seconds ) and not configurable. WIth this PR the users can choose the speed of their clock. Fast clocks lead to more server work and (ingame) faster battery drain.
Also since most circuit components have a "in between" activation time, a clock that fast as 0.9s often skip 1 tick.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->


:cl:
qol: make circuit clock interval configurable by users
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
