### PR TITLE
unifies security record printing

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -312,3 +312,51 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 
 /datum/datacore/proc/get_id_photo(mob/living/carbon/human/human, show_directions = list(SOUTH))
 	return get_flat_existing_human_icon(human, show_directions)
+
+//Todo: Add citations to the prinout - you get them from sec record's "citation" field, same as "crim" (which is frankly a terrible fucking field name)
+///Standardized printed records. SPRs. Like SATs but for bad guys who probably didn't actually finish school. Input the records and out comes a paper.
+/proc/print_security_record(datum/data/record/general_data, datum/data/record/security, atom/location)
+	if(!istype(general_data) && !istype(security))
+		stack_trace("called without any datacores! this may or may not be intentional!")
+	if(!isatom(location)) //can't drop the paper if we didn't get passed an atom.
+		CRASH("NO VALID LOCATION PASSED.")
+
+	GLOB.data_core.securityPrintCount++ //just alters the name of the paper.
+	var/obj/item/paper/P = new /obj/item/paper(location) //guess what i do lol
+	P.info = "<CENTER><B>Security Record - (SR-[GLOB.data_core.securityPrintCount])</B></CENTER><BR>"
+	if((istype(general_data, /datum/data/record) && GLOB.data_core.general.Find(general_data)))
+		P.info += text("Name: [] ID: []<BR>\nGender: []<BR>\nAge: []<BR>", general_data.fields["name"], general_data.fields["id"], general_data.fields["gender"], general_data.fields["age"])
+		P.info += "\nSpecies: [general_data.fields["species"]]<BR>"
+		P.info += text("\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", general_data.fields["fingerprint"], general_data.fields["p_stat"], general_data.fields["m_stat"])
+	else
+		P.info += "<B>General Record Lost!</B><BR>"
+	if((istype(security, /datum/data/record) && GLOB.data_core.security.Find(security)))
+		P.info += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: []", security.fields["criminal"])
+
+		P.info += "<BR>\n<BR>\nCrimes:<BR>\n"
+		P.info +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
+<tr>
+<th>Crime</th>
+<th>Details</th>
+<th>Author</th>
+<th>Time Added</th>
+</tr>"}
+		for(var/datum/data/crime/c in security.fields["crim"])
+			P.info += "<tr><td>[c.crimeName]</td>"
+			P.info += "<td>[c.crimeDetails]</td>"
+			P.info += "<td>[c.author]</td>"
+			P.info += "<td>[c.time]</td>"
+			P.info += "</tr>"
+		P.info += "</table>"
+
+		P.info += text("<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", security.fields["notes"])
+		var/counter = 1
+		while(security.fields[text("com_[]", counter)])
+			P.info += text("[]<BR>", security.fields[text("com_[]", counter)])
+			counter++
+		P.name = text("SR-[] '[]'", GLOB.data_core.securityPrintCount, general_data.fields["name"])
+	else //if no security record
+		P.info += "<B>Security Record Lost!</B><BR>"
+		P.name = text("SR-[] '[]'", GLOB.data_core.securityPrintCount, "Record Lost")
+	P.info += "</TT>"
+	P.update_appearance() //make sure we make the paper looks like it has writing on it.

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -322,19 +322,19 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 		CRASH("NO VALID LOCATION PASSED.")
 
 	GLOB.data_core.securityPrintCount++ //just alters the name of the paper.
-	var/obj/item/paper/P = new /obj/item/paper(location) //guess what i do lol
-	P.info = "<CENTER><B>Security Record - (SR-[GLOB.data_core.securityPrintCount])</B></CENTER><BR>"
+	var/obj/item/paper/printed_paper = new(location)
+	var/final_paper_text = "<CENTER><B>Security Record - (SR-[GLOB.data_core.securityPrintCount])</B></CENTER><BR>"
 	if((istype(general_data, /datum/data/record) && GLOB.data_core.general.Find(general_data)))
-		P.info += text("Name: [] ID: []<BR>\nGender: []<BR>\nAge: []<BR>", general_data.fields["name"], general_data.fields["id"], general_data.fields["gender"], general_data.fields["age"])
-		P.info += "\nSpecies: [general_data.fields["species"]]<BR>"
-		P.info += text("\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", general_data.fields["fingerprint"], general_data.fields["p_stat"], general_data.fields["m_stat"])
+		final_paper_text += text("Name: [] ID: []<BR>\nGender: []<BR>\nAge: []<BR>", general_data.fields["name"], general_data.fields["id"], general_data.fields["gender"], general_data.fields["age"])
+		final_paper_text += "\nSpecies: [general_data.fields["species"]]<BR>"
+		final_paper_text += text("\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", general_data.fields["fingerprint"], general_data.fields["p_stat"], general_data.fields["m_stat"])
 	else
-		P.info += "<B>General Record Lost!</B><BR>"
+		final_paper_text += "<B>General Record Lost!</B><BR>"
 	if((istype(security, /datum/data/record) && GLOB.data_core.security.Find(security)))
-		P.info += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: []", security.fields["criminal"])
+		final_paper_text += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: []", security.fields["criminal"])
 
-		P.info += "<BR>\n<BR>\nCrimes:<BR>\n"
-		P.info +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
+		final_paper_text += "<BR>\n<BR>\nCrimes:<BR>\n"
+		final_paper_text +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
 <tr>
 <th>Crime</th>
 <th>Details</th>
@@ -342,21 +342,22 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 <th>Time Added</th>
 </tr>"}
 		for(var/datum/data/crime/c in security.fields["crim"])
-			P.info += "<tr><td>[c.crimeName]</td>"
-			P.info += "<td>[c.crimeDetails]</td>"
-			P.info += "<td>[c.author]</td>"
-			P.info += "<td>[c.time]</td>"
-			P.info += "</tr>"
-		P.info += "</table>"
+			final_paper_text += "<tr><td>[c.crimeName]</td>"
+			final_paper_text += "<td>[c.crimeDetails]</td>"
+			final_paper_text += "<td>[c.author]</td>"
+			final_paper_text += "<td>[c.time]</td>"
+			final_paper_text += "</tr>"
+		final_paper_text += "</table>"
 
-		P.info += text("<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", security.fields["notes"])
+		final_paper_text += text("<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", security.fields["notes"])
 		var/counter = 1
 		while(security.fields[text("com_[]", counter)])
-			P.info += text("[]<BR>", security.fields[text("com_[]", counter)])
+			final_paper_text += text("[]<BR>", security.fields[text("com_[]", counter)])
 			counter++
-		P.name = text("SR-[] '[]'", GLOB.data_core.securityPrintCount, general_data.fields["name"])
+		printed_paper.name = text("SR-[] '[]'", GLOB.data_core.securityPrintCount, general_data.fields["name"])
 	else //if no security record
-		P.info += "<B>Security Record Lost!</B><BR>"
-		P.name = text("SR-[] '[]'", GLOB.data_core.securityPrintCount, "Record Lost")
-	P.info += "</TT>"
-	P.update_appearance() //make sure we make the paper looks like it has writing on it.
+		final_paper_text += "<B>Security Record Lost!</B><BR>"
+		printed_paper.name = text("SR-[] '[]'", GLOB.data_core.securityPrintCount, "Record Lost")
+	final_paper_text += "</TT>"
+	printed_paper.add_raw_text(final_paper_text)
+	printed_paper.update_appearance() //make sure we make the paper look like it has writing on it.

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -549,50 +549,11 @@ What a mess.*/
 
 			if("Print Record")
 				if(!( printing ))
-					printing = 1
-					GLOB.data_core.securityPrintCount++
-					playsound(loc, 'sound/items/poster_being_created.ogg', 100, TRUE)
+					printing = TRUE
+					playsound(src, 'sound/items/poster_being_created.ogg', 100, TRUE)
 					sleep(30)
-					var/obj/item/paper/printed_paper = new /obj/item/paper(loc)
-					var/final_paper_text = "<CENTER><B>Security Record - (SR-[GLOB.data_core.securityPrintCount])</B></CENTER><BR>"
-					if((istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1)))
-						final_paper_text += text("Name: [] ID: []<BR>\nGender: []<BR>\nAge: []<BR>", active1.fields["name"], active1.fields["id"], active1.fields["gender"], active1.fields["age"])
-						final_paper_text += "\nSpecies: [active1.fields["species"]]<BR>"
-						final_paper_text += text("\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", active1.fields["fingerprint"], active1.fields["p_stat"], active1.fields["m_stat"])
-					else
-						final_paper_text += "<B>General Record Lost!</B><BR>"
-					if((istype(active2, /datum/data/record) && GLOB.data_core.security.Find(active2)))
-						final_paper_text += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: []", active2.fields["criminal"])
-
-						final_paper_text += "<BR>\n<BR>\nCrimes:<BR>\n"
-						final_paper_text +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
-<tr>
-<th>Crime</th>
-<th>Details</th>
-<th>Author</th>
-<th>Time Added</th>
-</tr>"}
-						for(var/datum/data/crime/c in active2.fields["crim"])
-							final_paper_text += "<tr><td>[c.crimeName]</td>"
-							final_paper_text += "<td>[c.crimeDetails]</td>"
-							final_paper_text += "<td>[c.author]</td>"
-							final_paper_text += "<td>[c.time]</td>"
-							final_paper_text += "</tr>"
-						final_paper_text += "</table>"
-
-						final_paper_text += text("<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", active2.fields["notes"])
-						var/counter = 1
-						while(active2.fields[text("com_[]", counter)])
-							final_paper_text += text("[]<BR>", active2.fields[text("com_[]", counter)])
-							counter++
-						printed_paper.name = text("SR-[] '[]'", GLOB.data_core.securityPrintCount, active1.fields["name"])
-					else
-						final_paper_text += "<B>Security Record Lost!</B><BR>"
-						printed_paper.name = text("SR-[] '[]'", GLOB.data_core.securityPrintCount, "Record Lost")
-					final_paper_text += "</TT>"
-					printed_paper.add_raw_text(final_paper_text)
-					printed_paper.update_appearance()
-					printing = null
+					print_security_record(active1, active2, loc)
+					printing = FALSE
 			if("Print Poster")
 				if(!( printing ))
 					var/wanted_name = tgui_input_text(usr, "Enter an alias for the criminal", "Print Wanted Poster", active1.fields["name"])

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -129,18 +129,7 @@
 			var/datum/data/record/S = find_record("name", G.fields["name"], GLOB.data_core.security)
 			if(!S)
 				continue
-			var/obj/item/paper/sec_record_paper = new /obj/item/paper(src)
-			var/sec_record_text = "<CENTER><B>Security Record</B></CENTER><BR>"
-			sec_record_text += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nGender: [G.fields["gender"]]<BR>\nAge: [G.fields["age"]]<BR>\nFingerprint: [G.fields["fingerprint"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
-			sec_record_text += "<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [S.fields["criminal"]]<BR>\n<BR>\nCrimes: [S.fields["crim"]]<BR>\nDetails: [S.fields["crim_d"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[S.fields["notes"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
-			var/counter = 1
-			while(S.fields["com_[counter]"])
-				sec_record_text += "[S.fields["com_[counter]"]]<BR>"
-				counter++
-			sec_record_text += "</TT>"
-			sec_record_paper.name = "paper - '[G.fields["name"]]'"
-			sec_record_paper.add_raw_text(sec_record_text)
-			sec_record_paper.update_appearance()
+			print_security_record(G, S, src)
 			virgin = FALSE //tabbing here is correct- it's possible for people to try and use it
 						//before the records have been generated, so we do this inside the loop.
 


### PR DESCRIPTION
Fixes #68892

:cl: ShizCalev
fix: Security records in filing cabinets will now actually contain crimes!
/:cl:

Was broken in the refactor 2 years ago which changed how crimes were stored. Not surprised it took so long for someone to check a filing cabinet.

![image](https://user-images.githubusercontent.com/6209658/182260074-ce4ef3df-b4ec-4196-bec1-946245dfbceb.png)
