### PR TITLE
XENO: Ensures the stomach contents list is cleared on thing delete

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -148,6 +148,6 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 	lucky_winner.audible_message(span_danger("You hear a deep groan, and a harsh snap like a mantrap."))
 	lucky_winner.visible_message(span_danger("[src] devours [lucky_winner]!"), \
 			span_userdanger("[lucky_winner] devours you!"))
-	melting_pot.consume_thing(lucky_winner)
 	log_combat(src, lucky_winner, "devoured")
+	melting_pot.consume_thing(lucky_winner)
 	return TRUE

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -199,8 +199,13 @@
 
 /obj/item/organ/internal/stomach/alien/proc/consume_thing(atom/movable/thing)
 	RegisterSignal(thing, COMSIG_MOVABLE_MOVED, .proc/content_moved)
+	RegisterSignal(thing, COMSIG_PARENT_QDELETING, .proc/content_deleted)
 	if(isliving(thing))
+		var/mob/living/lad = thing
 		RegisterSignal(thing, COMSIG_LIVING_DEATH, .proc/content_died)
+		if(lad.stat == DEAD)
+			qdel(lad)
+			return
 	stomach_contents += thing
 	thing.forceMove(owner || src) // We assert that if we have no owner, we will not be nullspaced
 
@@ -208,12 +213,16 @@
 	SIGNAL_HANDLER
 	qdel(source)
 
+/obj/item/organ/internal/stomach/alien/proc/content_deleted(atom/movable/source)
+	SIGNAL_HANDLER
+	stomach_contents -= source
+
 /obj/item/organ/internal/stomach/alien/proc/content_moved(atom/movable/source)
 	SIGNAL_HANDLER
 	if(source.loc == src || source.loc == owner) // not in us? out da list then
 		return
 	stomach_contents -= source
-	UnregisterSignal(source, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_DEATH))
+	UnregisterSignal(source, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
 
 /obj/item/organ/internal/stomach/alien/Insert(mob/living/carbon/stomach_owner, special = FALSE, drop_if_replaced = TRUE)
 	RegisterSignal(stomach_owner, COMSIG_ATOM_RELAYMOVE, .proc/something_moved)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Resolves a bug with infini york
Fixes #68928

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can no longer infinitely york as an alien
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
