### PR TITLE
Power failure event will now only provide an announcement if the previous power failure has ended

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -380,8 +380,12 @@
 
 	return pick(possible_loc)
 
+///Prevents power_failure message spam if a traitor purchases repeatedly.
+GLOBAL_VAR_INIT(power_failure_message_cooldown, 0)
+
 ///Disable power in the station APCs
 /proc/power_fail(duration_min, duration_max)
+	var/message_cooldown
 	for(var/obj/machinery/power/apc/current_apc as anything in GLOB.apcs_list)
 		if(!current_apc.cell || !SSmapping.level_trait(current_apc.z, ZTRAIT_STATION))
 			continue
@@ -389,7 +393,10 @@
 		if(GLOB.typecache_powerfailure_safe_areas[apc_area.type])
 			continue
 
-		current_apc.energy_fail(rand(duration_min,duration_max))
+		var/duration = rand(duration_min,duration_max)
+		message_cooldown = max(duration, message_cooldown)
+		current_apc.energy_fail(duration)
+	GLOB.power_failure_message_cooldown = world.time + message_cooldown
 
 /**
  * Sends a round tip to a target. If selected_tip is null, a random tip will be sent instead (5% chance of it being silly).

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -1,5 +1,6 @@
 /proc/power_failure()
-	priority_announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", ANNOUNCER_POWEROFF)
+	if(GLOB.power_failure_message_cooldown > world.time)
+		priority_announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", ANNOUNCER_POWEROFF)
 	for(var/obj/machinery/power/smes/S in GLOB.machines)
 		if(istype(get_area(S), /area/station/ai_monitored/turret_protected) || !is_station_level(S.z))
 			continue

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -9,7 +9,8 @@
 	startWhen = 1
 
 /datum/round_event/grid_check/announce(fake)
-	priority_announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", ANNOUNCER_POWEROFF)
+	if(fake || (GLOB.power_failure_message_cooldown > world.time))
+		priority_announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", ANNOUNCER_POWEROFF)
 
 /datum/round_event/grid_check/start()
 	power_fail(30, 120)


### PR DESCRIPTION
Fixes #68932

You can now silently chain outages together to refresh the outages on APC that have started functioning (since their outage durations are randomized), I feel this is leads to a bit more dynamic gameplay.

:cl: ShizCalev
fix: Purchasing the Stationwide Blackout traitor event repeatedly will now only announce there is a power outage if the previous power outage has finished.
/:cl:
