### PR TITLE
Fixing rust with a welder properly blinds the welder

### DIFF
--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -44,11 +44,12 @@
 	return COMPONENT_BLOCK_TOOL_ATTACK
 
 /// We call this from secondary_tool_act because we sleep with do_after
-/datum/element/rust/proc/handle_tool_use(atom/source, mob/user, obj/item/item)
+/datum/element/rust/proc/handle_tool_use(atom/source, mob/living/user, obj/item/item)
 	switch(item.tool_behaviour)
 		if(TOOL_WELDER)
 			if(item.use(5))
 				user.balloon_alert(user, "burning off rust...")
+				user.flash_act(length = (5 SECONDS * item.toolspeed)) // snowflake flash act since we're overriding regular tool act with the signal
 				if(!do_after(user, 5 SECONDS * item.toolspeed, source))
 					return
 				user.balloon_alert(user, "burned off rust")


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The rust element overrides the tool act through a signal, so the flash
act is never called normally. Adds a snowflake `flash_act` call to make
the welding user blind.

Fixes https://github.com/tgstation/tgstation/issues/68796
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixing rust with a welder properly blinds the welder.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
