### PR TITLE
No more lavaproof mining MOD

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -268,7 +268,8 @@
 		offering full view of the land and its soon-to-be-dead inhabitants. The armor plating has been trimmed down to \
 		the bare essentials, geared far more for environmental hazards than combat against fauna; however, \
 		this gives way to incredible protection against corrosives and thermal protection good enough for \
-		both casual backstroking through molten magma and romantic walks through arctic terrain. \
+		both casual backstroking while being on fire and romantic walks through arctic terrain. \
+		Sadly, this protection could not offer you a relaxing swim through magma. You will be like a chicken in a pot full of boiling water. \
 		Instead, the suit is capable of using its' anomalous properties to attract and \
 		carefully distribute layers of ash or ice across the surface; these layers are ablative, but incredibly strong. \
 		Lastly, the suit is capable of compressing and shrinking the mass of the wearer, as well as \
@@ -279,7 +280,7 @@
 		Additionally, the systems have been put to near their maximum load, allowing for far less customization than others."
 	default_skin = "mining"
 	armor = list(MELEE = 15, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 30, BIO = 100, FIRE = 100, ACID = 75, WOUND = 15)
-	resistance_flags = FIRE_PROOF|LAVA_PROOF
+	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mining MODSuit is no longer lavaproof. That's it.

## Why It's Good For The Game

Currently for the price of 2500 mining credits(which is incredibly small) you get:
1. Lava protection
2. Decent armor against fauna
3. Awesome mining bombs, with which you can kill megafauna while not make it aggresive towards you.
4. Plasma charging
Other things are not so important. 

It's just too much for 2500. Either the price should be higher, or the stats not so OP. I've decided to nerf the lava protection, because this thing is made out of simple metal. For example, to get lavaproof things without the Modsuit you either:
* Have to wait xenobiology do their job
* Kill a dragon.

Since when killing a dragon equals to 2500 credit armor?

P.S. The lava protection probably could be added later as an independent MOD module for every suit. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SuperDrish
balance: Mining MODsuit is no longer lavaproof
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
