### PR TITLE
[GBP No Update] forgot to delete cable

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -65658,7 +65658,6 @@
 	dir = 8
 	},
 /obj/structure/cable/multilayer/connected,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "xgG" = (


### PR DESCRIPTION
## About The Pull Request

Forgot to delete a stray cable under a smes terminal last pr

## Why It's Good For The Game

The cable just pops up when the map loads its ugly and needs to go.

## Changelog

No player facing changes... or even admin facing for that matter
