### PR TITLE
Fixes some issues with Heretic Stalker Shapechange

### DIFF
--- a/code/modules/antagonists/heretic/magic/eldritch_blind.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_blind.dm
@@ -5,5 +5,6 @@
 
 	school = SCHOOL_FORBIDDEN
 	invocation = "E'E'S"
+	spell_requirements = NONE
 
 	cast_range = 10

--- a/code/modules/antagonists/heretic/magic/eldritch_emplosion.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_emplosion.dm
@@ -1,6 +1,7 @@
 // Given to heretic monsters.
 /datum/action/cooldown/spell/emp/eldritch
 	name = "Energetic Pulse"
+	desc = "A spell that causes a large EMP around you, disabling electronics."
 	background_icon_state = "bg_ecult"
 
 	school = SCHOOL_FORBIDDEN

--- a/code/modules/antagonists/heretic/magic/eldritch_shapeshift.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_shapeshift.dm
@@ -1,9 +1,14 @@
 // Given to heretic monsters.
 /datum/action/cooldown/spell/shapeshift/eldritch
-	school = SCHOOL_FORBIDDEN
+	name = "Shapechange"
+	desc = "A spell that allows you to take on the form of another creature, gaining their abilities. \
+		After making your choice, you will be unable to change to another."
 	background_icon_state = "bg_ecult"
+
+	school = SCHOOL_FORBIDDEN
 	invocation = "SH'PE"
 	invocation_type = INVOCATION_WHISPER
+	spell_requirements = NONE
 
 	possible_shapes = list(
 		/mob/living/simple_animal/mouse,

--- a/code/modules/mob/living/simple_animal/heretic_monsters.dm
+++ b/code/modules/mob/living/simple_animal/heretic_monsters.dm
@@ -416,7 +416,7 @@
 	melee_damage_upper = 20
 	sight = SEE_MOBS
 	actions_to_add = list(
-		/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash,
 		/datum/action/cooldown/spell/shapeshift/eldritch,
+		/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash,
 		/datum/action/cooldown/spell/emp/eldritch,
 	)

--- a/code/modules/spells/spell_types/self/disable_tech.dm
+++ b/code/modules/spells/spell_types/self/disable_tech.dm
@@ -1,6 +1,6 @@
 /datum/action/cooldown/spell/emp
 	name = "Emplosion"
-	desc = "This spell emplodes an area."
+	desc = "This spell causes an EMP in an area."
 	button_icon_state = "emp"
 	sound = 'sound/weapons/zapbang.ogg'
 

--- a/code/modules/spells/spell_types/shapeshift/_shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shapeshift.dm
@@ -161,8 +161,10 @@
 		return INITIALIZE_HINT_QDEL
 	stored = caster
 
-	// Transfer the Shapeshift spell over
-	source.Grant(shape)
+	// Transfer the Shapeshift spell over, if we actually own it
+	if(source.owner == caster)
+		source.Grant(shape)
+
 	// Also transfer over any actions bound to them specifically - this leaves behind item actions and similar
 	// (Mindbound actions are automatically tranferred over, so we don't need to worry about it)
 	for(var/datum/action/bodybound_action as anything in caster.actions)
@@ -232,8 +234,11 @@
 	UnregisterSignal(stored, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DEATH))
 	restoring = TRUE
 
-	// Give Shapeshift back to the OG
-	source.Grant(stored)
+	// Give Shapeshift back to the OG, if we actually own it
+	// (Shapeshift into mindswap may change the action's owner)
+	if(!QDELETED(source) && source.owner == shape)
+		source.Grant(stored)
+
 	// Also transfer their bodybound actions back
 	for(var/datum/action/bodybound_action as anything in shape.actions)
 		if(bodybound_action.target != stored)

--- a/code/modules/spells/spell_types/shapeshift/shapechange.dm
+++ b/code/modules/spells/spell_types/shapeshift/shapechange.dm
@@ -2,9 +2,7 @@
 	name = "Wild Shapeshift"
 	desc = "Take on the shape of another for a time to use their natural abilities. \
 		Once you've made your choice, it cannot be changed."
-	button_icon_state = "shapeshift"
 
-	school = SCHOOL_TRANSMUTATION
 	cooldown_time = 20 SECONDS
 	cooldown_reduction_per_rank = 3.75 SECONDS
 


### PR DESCRIPTION

## About The Pull Request

Fixes #68941 

- Shapechange relied on mind actions to transfer the spell over to the new mob when done. This was fine and all, for wizard, but not all instances of shapechange are mindbound. Stalkers have it bodybound, which caused problems when they casted it and changed body. 
   - Shapechanging will now always grant the action to the new mob, regardless of its target. 
- I also noticed bodybound actions in general are lost when a mob shapechanges, which doesn't make much sense. 
   - Actions bound to the caster's body are transferred to their new shape. 
- While I was here, I did a minor pass over of the other heretic summon spells.

## Why It's Good For The Game

Stalkers should be able to transform back.

## Changelog

:cl: Melbert
fix: Heretic stalkers are able again to return back to their normal form after casting shapeshift. 
/:cl: