### PR TITLE
Moves sinks' layer to above the object layer

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -256,6 +256,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 	icon_state = "sink"
 	desc = "A sink used for washing one's hands and face. Passively reclaims water over time."
 	anchored = TRUE
+	layer = ABOVE_OBJ_LAYER
 	pixel_z = 1
 	///Something's being washed at the moment
 	var/busy = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR moves sinks to layer 3.2 as opposed to 3, the object layer.

## Why It's Good For The Game

Sinks are coded in with a pixel displacement and kitchen sinks are large enough for the collision check to fail if the sink is against a solid structure on an above layer, such as a window or an airlock.

![image](https://user-images.githubusercontent.com/25415050/182695251-d588f6d1-f6b0-43b9-b032-8d30e95628bc.png)
^ despite looks, this sink is completely inaccessible and cannot be interacted with.

Another big issue is that it looks bad:
![image](https://user-images.githubusercontent.com/25415050/182695612-19f4ff3e-b975-42f0-b975-b921dd4a1544.png)
This is at the cost of 3 pixels appearing on top of a window if placed facing south against one, so this isn't a complete fix to the aesthetic of it, the primary focus of the PR is to make the sink interactable, and even then I believe it's a better trade-off:

![image](https://user-images.githubusercontent.com/25415050/182695912-bd16f028-ed31-4b15-8d50-3d7cb3e80866.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Kitchen sinks will now be functional if placed facing against a window and some other closed structures, up-facing sinks also look somewhat better as a result.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
