### PR TITLE
Spider Rebalance PR: Burn Baby Burn Edition

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -26,9 +26,15 @@
 /datum/status_effect/fire_handler/on_creation(mob/living/new_owner, new_stacks, forced = FALSE)
 	. = ..()
 
-	if(isanimal(owner))
+	if(isbasicmob(owner))
 		qdel(src)
 		return
+
+	if(isanimal(owner))
+		var/mob/living/simple_animal/animal_owner = owner
+		if(!animal_owner.flammable)
+			qdel(src)
+			return
 
 	owner = new_owner
 	set_stacks(new_stacks)
@@ -138,10 +144,13 @@
 		qdel(src)
 		return TRUE
 
-	if(!on_fire || isanimal(owner))
+	if(!on_fire)
 		return TRUE
 
-	if(iscyborg(owner))
+	if(isanimal(owner))
+		var/mob/living/simple_animal/animal_owner = owner
+		adjust_stacks(animal_owner.fire_stack_removal_speed * delta_time)
+	else if(iscyborg(owner))
 		adjust_stacks(-0.55 * delta_time)
 	else
 		adjust_stacks(-0.05 * delta_time)

--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -25,7 +25,7 @@
 	. = ..()
 
 /obj/structure/spider/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return exposed_temperature > 300
+	return exposed_temperature > 350
 
 /obj/structure/spider/atmos_expose(datum/gas_mixture/air, exposed_temperature)
 	take_damage(5, BURN, 0, 0)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -871,7 +871,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			bug.gib()
 		else
 			qdel(target)
-	else if(is_type_in_typecache(target, strong_against) && isliving(target))
+		return
+	if(is_type_in_typecache(target, strong_against) && isliving(target))
 		var/mob/living/living_target = target
 		living_target.adjustBruteLoss(extra_strength_damage)
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -835,12 +835,16 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	attack_verb_simple = list("swat", "smack")
 	hitsound = 'sound/effects/snap.ogg'
 	w_class = WEIGHT_CLASS_SMALL
-	//Things in this list will be instantly splatted.  Flyman weakness is handled in the flyman species weakness proc.
+	/// Things in this list will be instantly splatted.  Flyman weakness is handled in the flyman species weakness proc.
+	var/list/splattable
+	/// Things in this list which take a lot more damage from the fly swatter, but not be necessarily killed by it.
 	var/list/strong_against
+	/// How much extra damage the fly swatter does against mobs it is strong against
+	var/extra_strength_damage = 24
 
 /obj/item/melee/flyswatter/Initialize(mapload)
 	. = ..()
-	strong_against = typecacheof(list(
+	splattable = typecacheof(list(
 		/mob/living/simple_animal/hostile/bee,
 		/mob/living/simple_animal/butterfly,
 		/mob/living/basic/cockroach,
@@ -849,24 +853,27 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		/mob/living/simple_animal/hostile/ant,
 		/obj/effect/decal/cleanable/ants,
 	))
+	strong_against = typecacheof(list(
+		/mob/living/simple_animal/hostile/giant_spider,
+	))
 
 
 /obj/item/melee/flyswatter/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
-	if(!proximity_flag)
-		return
-	if(!is_type_in_typecache(target, strong_against))
-		return
-	if (HAS_TRAIT(user, TRAIT_PACIFISM))
+	if(!proximity_flag || HAS_TRAIT(user, TRAIT_PACIFISM))
 		return
 
-	new /obj/effect/decal/cleanable/insectguts(target.drop_location())
-	to_chat(user, span_warning("You easily splat [target]."))
-	if(isliving(target))
-		var/mob/living/bug = target
-		bug.gib()
-	else
-		qdel(target)
+	if(is_type_in_typecache(target, splattable))
+		new /obj/effect/decal/cleanable/insectguts(target.drop_location())
+		to_chat(user, span_warning("You easily splat [target]."))
+		if(isliving(target))
+			var/mob/living/bug = target
+			bug.gib()
+		else
+			qdel(target)
+	else if(is_type_in_typecache(target, strong_against) && isliving(target))
+		var/mob/living/living_target = target
+		living_target.adjustBruteLoss(extra_strength_damage)
 
 /obj/item/proc/can_trigger_gun(mob/living/user)
 	if(!user.can_use_guns(src))

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -94,7 +94,6 @@
 	. = ..()
 	for(var/datum/reagent/toxin/pestkiller/current_reagent in reagents)
 		apply_damage(50 * volume_modifier, STAMINA, BODY_ZONE_CHEST)
-			return
 
 /**
  * # Spider Hunter

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -30,7 +30,7 @@
 	health = 80
 	damage_coeff = list(BRUTE = 1, BURN = 1.25, TOX = 1, CLONE = 1, STAMINA = 1, OXY = 1)
 	flammable = TRUE
-	status_flags = 0
+	status_flags = NONE
 	unsuitable_cold_damage = 4
 	unsuitable_heat_damage = 4
 	obj_damage = 30
@@ -202,7 +202,6 @@
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	move_to_delay = 8
 	speed = 1
-	status_flags = NONE
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 	menu_description = "Tank spider variant with an enormous amount of health and damage, but is very slow when not on webbing. It also has a charge ability to close distance with a target after a small windup."

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -92,9 +92,8 @@
 
 /mob/living/simple_animal/hostile/giant_spider/expose_reagents(list/reagents, datum/reagents/source, methods=TOUCH, volume_modifier=1, show_message=TRUE)
 	. = ..()
-	for(var/datum/reagent/current_reagent as anything in reagents)
-		if(istype(current_reagent, /datum/reagent/toxin/pestkiller))
-			apply_damage(50 * volume_modifier, STAMINA, BODY_ZONE_CHEST)
+	for(var/datum/reagent/toxin/pestkiller/current_reagent in reagents)
+		apply_damage(50 * volume_modifier, STAMINA, BODY_ZONE_CHEST)
 			return
 
 /**

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -29,8 +29,10 @@
 	maxHealth = 80
 	health = 80
 	damage_coeff = list(BRUTE = 1, BURN = 1.25, TOX = 1, CLONE = 1, STAMINA = 1, OXY = 1)
-	unsuitable_cold_damage = 8
-	unsuitable_heat_damage = 8
+	flammable = TRUE
+	status_flags = 0
+	unsuitable_cold_damage = 4
+	unsuitable_heat_damage = 4
 	obj_damage = 30
 	melee_damage_lower = 20
 	melee_damage_upper = 25
@@ -50,7 +52,7 @@
 	///How much of a reagent the mob injects on attack
 	var/poison_per_bite = 0
 	///What reagent the mob injects targets with
-	var/poison_type = /datum/reagent/toxin
+	var/poison_type = /datum/reagent/toxin/hunterspider
 	///How quickly the spider can place down webbing.  One is base speed, larger numbers are slower.
 	var/web_speed = 1
 	///Whether or not the spider can create sealed webs.
@@ -87,6 +89,13 @@
 	if(locate(/obj/structure/spider/stickyweb) in loc)
 		return TRUE
 	return ..()
+
+/mob/living/simple_animal/hostile/giant_spider/expose_reagents(list/reagents, datum/reagents/source, methods=TOUCH, volume_modifier=1, show_message=TRUE)
+	. = ..()
+	for(var/datum/reagent/current_reagent as anything in reagents)
+		if(istype(current_reagent, /datum/reagent/toxin/pestkiller))
+			apply_damage(50 * volume_modifier, STAMINA, BODY_ZONE_CHEST)
+			return
 
 /**
  * # Spider Hunter
@@ -130,7 +139,6 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	poison_per_bite = 3
 	web_speed = 0.25
 	web_sealer = TRUE
 	menu_description = "Support spider variant specializing in healing their brethren and placing webbings very swiftly, but has very low amount of health and deals low damage."
@@ -192,7 +200,6 @@
 	melee_damage_upper = 40
 	obj_damage = 100
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
-	poison_per_bite = 0
 	move_to_delay = 8
 	speed = 1
 	status_flags = NONE
@@ -248,7 +255,7 @@
 	melee_damage_upper = 5
 	poison_per_bite = 5
 	move_to_delay = 4
-	poison_type = /datum/reagent/toxin/venom
+	poison_type = /datum/reagent/toxin/viperspider
 	speed = -0.5
 	gold_core_spawnable = NO_SPAWN
 	menu_description = "Assassin spider variant with an unmatched speed and very deadly poison, but has very low amount of health and damage."
@@ -270,12 +277,12 @@
 	icon_state = "midwife"
 	icon_living = "midwife"
 	icon_dead = "midwife_dead"
-	maxHealth = 40
-	health = 40
-	melee_damage_lower = 5
-	melee_damage_upper = 10
-	poison_per_bite = 3
+	maxHealth = 60
+	health = 60
+	melee_damage_lower = 10
+	melee_damage_upper = 15
 	gold_core_spawnable = NO_SPAWN
+	web_speed = 0.5
 	web_sealer = TRUE
 	menu_description = "Royal spider variant specializing in reproduction and leadership, but has very low amount of health and deals low damage."
 
@@ -462,7 +469,7 @@
 	check_flags = AB_CHECK_CONSCIOUS
 	button_icon_state = "lay_eggs"
 	///How long it takes for a broodmother to lay eggs.
-	var/egg_lay_time = 15 SECONDS
+	var/egg_lay_time = 12 SECONDS
 	///The type of egg we create
 	var/egg_type = /obj/effect/mob_spawn/ghost_role/spider
 
@@ -513,6 +520,11 @@
 /datum/action/innate/spider/lay_eggs/enriched/IsAvailable()
 	return ..() && (charges > 0)
 
+/datum/action/innate/spider/lay_eggs/enriched/bloody
+	name = "Lay Bloody Eggs"
+	desc = "Lay a cluster of eggs, which will soon grow into a flesh spider.  Requires you drain a human per cluster of these eggs."
+	egg_type = /obj/effect/mob_spawn/ghost_role/spider/bloody
+
 /datum/action/innate/spider/set_directive
 	name = "Set Directive"
 	desc = "Set a directive for your children to follow."
@@ -523,7 +535,7 @@
 	return ..() && istype(owner, /mob/living/simple_animal/hostile/giant_spider)
 
 /datum/action/innate/spider/set_directive/Activate()
-	var/mob/living/simple_animal/hostile/giant_spider/midwife/spider = owner
+	var/mob/living/simple_animal/hostile/giant_spider/spider = owner
 
 	spider.directive = tgui_input_text(spider, "Enter the new directive", "Create directive", "[spider.directive]")
 	if(isnull(spider.directive) || QDELETED(src) || QDELETED(owner) || !IsAvailable())
@@ -679,6 +691,8 @@
  * They also produce web in 70% of the time of the base spider.  They also occasionally leave puddles of blood when they walk around.  Flavorful!
  */
 /mob/living/simple_animal/hostile/giant_spider/hunter/flesh
+	maxHealth = 30
+	health = 30
 	desc = "A odd fleshy creature in the shape of a spider.  Its eyes are pitch black and soulless."
 	icon_state = "flesh_spider"
 	icon_living = "flesh_spider"
@@ -692,16 +706,28 @@
 		blood_type = /obj/effect/decal/cleanable/blood/bubblegum, \
 		blood_spawn_chance = 5)
 
+	var/datum/action/cooldown/wrap/wrapping = new(src)
+	wrapping.Grant(src)
+
+	var/datum/action/innate/spider/lay_eggs/enriched/bloody/make_better_eggs = new(src)
+	make_better_eggs.Grant(src)
+
+	var/datum/action/innate/spider/set_directive/give_orders = new(src)
+	give_orders.Grant(src)
+
 /mob/living/simple_animal/hostile/giant_spider/hunter/flesh/AttackingTarget()
 	if(DOING_INTERACTION(src, INTERACTION_SPIDER_KEY))
 		return
 	if(src == target)
+		if(on_fire)
+			to_chat(src, span_warning("Your self regeneration won't work when you're on fire!"))
+			return
 		if(health >= maxHealth)
 			to_chat(src, span_warning("You're not injured, there's no reason to heal."))
 			return
 		visible_message(span_notice("[src] begins mending themselves..."),span_notice("You begin mending your wounds..."))
 		if(do_after(src, 2 SECONDS, target = src, interaction_key = INTERACTION_SPIDER_KEY))
-			heal_overall_damage(50, 50)
+			heal_overall_damage(maxHealth, maxHealth)
 			new /obj/effect/temp_visual/heal(get_turf(src), "#80F5FF")
 			visible_message(span_notice("[src]'s wounds mend together."),span_notice("You mend your wounds together."))
 		return

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -691,8 +691,8 @@
  * They also produce web in 70% of the time of the base spider.  They also occasionally leave puddles of blood when they walk around.  Flavorful!
  */
 /mob/living/simple_animal/hostile/giant_spider/hunter/flesh
-	maxHealth = 30
-	health = 30
+	melee_damage_lower = 10
+	melee_damage_upper = 15
 	desc = "A odd fleshy creature in the shape of a spider.  Its eyes are pitch black and soulless."
 	icon_state = "flesh_spider"
 	icon_living = "flesh_spider"
@@ -727,7 +727,7 @@
 			return
 		visible_message(span_notice("[src] begins mending themselves..."),span_notice("You begin mending your wounds..."))
 		if(do_after(src, 2 SECONDS, target = src, interaction_key = INTERACTION_SPIDER_KEY))
-			heal_overall_damage(maxHealth, maxHealth)
+			heal_overall_damage(maxHealth * 0.5, maxHealth * 0.5)
 			new /obj/effect/temp_visual/heal(get_turf(src), "#80F5FF")
 			visible_message(span_notice("[src]'s wounds mend together."),span_notice("You mend your wounds together."))
 		return

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -520,11 +520,6 @@
 /datum/action/innate/spider/lay_eggs/enriched/IsAvailable()
 	return ..() && (charges > 0)
 
-/datum/action/innate/spider/lay_eggs/enriched/bloody
-	name = "Lay Bloody Eggs"
-	desc = "Lay a cluster of eggs, which will soon grow into a flesh spider.  Requires you drain a human per cluster of these eggs."
-	egg_type = /obj/effect/mob_spawn/ghost_role/spider/bloody
-
 /datum/action/innate/spider/set_directive
 	name = "Set Directive"
 	desc = "Set a directive for your children to follow."
@@ -691,8 +686,6 @@
  * They also produce web in 70% of the time of the base spider.  They also occasionally leave puddles of blood when they walk around.  Flavorful!
  */
 /mob/living/simple_animal/hostile/giant_spider/hunter/flesh
-	melee_damage_lower = 10
-	melee_damage_upper = 15
 	desc = "A odd fleshy creature in the shape of a spider.  Its eyes are pitch black and soulless."
 	icon_state = "flesh_spider"
 	icon_living = "flesh_spider"
@@ -705,15 +698,6 @@
 	AddComponent(/datum/component/blood_walk, \
 		blood_type = /obj/effect/decal/cleanable/blood/bubblegum, \
 		blood_spawn_chance = 5)
-
-	var/datum/action/cooldown/wrap/wrapping = new(src)
-	wrapping.Grant(src)
-
-	var/datum/action/innate/spider/lay_eggs/enriched/bloody/make_better_eggs = new(src)
-	make_better_eggs.Grant(src)
-
-	var/datum/action/innate/spider/set_directive/give_orders = new(src)
-	give_orders.Grant(src)
 
 /mob/living/simple_animal/hostile/giant_spider/hunter/flesh/AttackingTarget()
 	if(DOING_INTERACTION(src, INTERACTION_SPIDER_KEY))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -513,7 +513,7 @@
 
 /mob/living/simple_animal/update_fire_overlay(stacks, on_fire, last_icon_state, suffix = "")
 	var/mutable_appearance/fire_overlay = mutable_appearance('icons/mob/onfire.dmi', "generic_fire")
-	if(on_fire && last_icon_state == null)
+	if(on_fire && isnull(last_icon_state))
 		add_overlay(fire_overlay)
 		return fire_overlay
 	else if(!on_fire && last_icon_state != null)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -506,7 +506,7 @@
 /mob/living/simple_animal/ignite_mob()
 	if(!flammable)
 		return FALSE
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/on_fire_stack(delta_time, times_fired, datum/status_effect/fire_handler/fire_stacks/fire_handler)
 	adjust_bodytemperature((maxbodytemp + (fire_handler.stacks * 12)) * 0.5 * delta_time)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -516,7 +516,7 @@
 	if(on_fire && isnull(last_icon_state))
 		add_overlay(fire_overlay)
 		return fire_overlay
-	else if(!on_fire && last_icon_state != null)
+	else if(!on_fire && !isnull(last_icon_state))
 		cut_overlay(fire_overlay)
 		return null
 	else if(on_fire && last_icon_state != null)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -526,7 +526,7 @@
 /mob/living/simple_animal/extinguish_mob()
 	if(!flammable)
 		return
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/revive(full_heal = FALSE, admin_revive = FALSE)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -519,7 +519,7 @@
 	else if(!on_fire && !isnull(last_icon_state))
 		cut_overlay(fire_overlay)
 		return null
-	else if(on_fire && last_icon_state != null)
+	else if(on_fire && !isnull(last_icon_state))
 		return last_icon_state
 	return null
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -79,6 +79,13 @@
 	///This damage is taken when atmos doesn't fit all the requirements above.
 	var/unsuitable_atmos_damage = 1
 
+	///Whether or not this mob is flammable
+	var/flammable = FALSE
+	///How quickly should fire stacks on this mob diminish?
+	var/fire_stack_removal_speed = -5
+	///How fast the mob's temperature normalizes. The greater the value, the slower their temperature normalizes. Should always be greater than 0.
+	var/temperature_normalization_speed = 5
+
 	//Defaults to zero so Ian can still be cuddly. Moved up the tree to living! This allows us to bypass some hardcoded stuff.
 	melee_damage_lower = 0
 	melee_damage_upper = 0
@@ -367,9 +374,9 @@
 		if(abs(temp_delta) > 5)
 			if(temp_delta < 0)
 				if(!on_fire)
-					adjust_bodytemperature(clamp(temp_delta * delta_time / 10, temp_delta, 0))
+					adjust_bodytemperature(clamp(temp_delta * delta_time / temperature_normalization_speed, temp_delta, 0))
 			else
-				adjust_bodytemperature(clamp(temp_delta * delta_time / 10, 0, temp_delta))
+				adjust_bodytemperature(clamp(temp_delta * delta_time / temperature_normalization_speed, 0, temp_delta))
 
 	if(!environment_air_is_safe() && unsuitable_atmos_damage)
 		adjustHealth(unsuitable_atmos_damage * delta_time)
@@ -497,10 +504,29 @@
 	return TRUE
 
 /mob/living/simple_animal/ignite_mob()
-	return FALSE
+	if(!flammable)
+		return FALSE
+	. = ..()
+
+/mob/living/simple_animal/on_fire_stack(delta_time, times_fired, datum/status_effect/fire_handler/fire_stacks/fire_handler)
+	adjust_bodytemperature((maxbodytemp + (fire_handler.stacks * 12)) * 0.5 * delta_time)
+
+/mob/living/simple_animal/update_fire_overlay(stacks, on_fire, last_icon_state, suffix = "")
+	var/mutable_appearance/fire_overlay = mutable_appearance('icons/mob/onfire.dmi', "generic_fire")
+	if(on_fire && last_icon_state == null)
+		add_overlay(fire_overlay)
+		return fire_overlay
+	else if(!on_fire && last_icon_state != null)
+		cut_overlay(fire_overlay)
+		return null
+	else if(on_fire && last_icon_state != null)
+		return last_icon_state
+	return null
 
 /mob/living/simple_animal/extinguish_mob()
-	return
+	if(!flammable)
+		return
+	. = ..()
 
 /mob/living/simple_animal/revive(full_heal = FALSE, admin_revive = FALSE)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -8,9 +8,13 @@
 	taste_description = "bitterness"
 	taste_mult = 1.2
 	harmful = TRUE
-	var/toxpwr = 1.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	var/silent_toxin = FALSE //won't produce a pain message when processed by liver/life() if there isn't another non-silent toxin present.
+	///How much damage this toxin does
+	var/toxpwr = 1.5
+	///won't produce a pain message when processed by liver/life() if there isn't another non-silent toxin present if true
+	var/silent_toxin = FALSE
+	///The afflicted must be above this health value in order for the toxin to deal damage
+	var/health_required = -100
 
 // Are you a bad enough dude to poison your own plants?
 /datum/reagent/toxin/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)
@@ -19,7 +23,7 @@
 		mytray.adjust_toxic(round(chems.get_reagent_amount(type) * 2))
 
 /datum/reagent/toxin/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(toxpwr)
+	if(toxpwr && M.health > health_required)
 		M.adjustToxLoss(toxpwr * REM * normalise_creation_purity() * delta_time, 0)
 		. = TRUE
 	..()
@@ -1206,4 +1210,19 @@
 	if(DT_PROB(0.5, delta_time))
 		to_chat(M, span_notice("Ah, what was that? You thought you heard something..."))
 		M.adjust_timed_status_effect(5 SECONDS, /datum/status_effect/confusion)
+	return ..()
+
+/datum/reagent/toxin/hunterspider
+	name = "Spider Toxin"
+	description = "A toxic chemical produced by spiders to weaken prey."
+	health_required = 40
+
+/datum/reagent/toxin/viperspider
+	name = "Viper Spider Toxin"
+	toxpwr = 5
+	description = "An extremely toxic chemical produced by the rare viper spider. Brings their prey to the brink of death and causes hallucinations."
+	health_required = 10
+
+/datum/reagent/toxin/viperspider/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	M.hallucination += 5 * REM * delta_time
 	return ..()


### PR DESCRIPTION
## About The Pull Request

This is a remake of #66106, with more thought put into the underlying balance.  The main goal of this PR is to make fighting spiders more accessible and interesting for the majority of the crew while nerfing the extremely strong and boring option of simply using freezing temps to kill spiders. Also fixes #67765.  The changes are as follows:

**NEW SPIDER COUNTERS**

- Fly swatters now deal 25 damage to spiders on hit, increased from 1
- Pesticide now deals massive stamina damage to spiders and a little bit of physical damage as well (the damage portion not added by this PR)
- Spiders can now be caught on fire through any traditional mean of catching something on fire. Spiders will automatically put themselves out after a time. This was done instead of an active action because AI spiders are also subject to this change as well, and I don't feel like bloating the simple mob AI with putting themselves out

**SPIDER CHANGES**

*NERFS*
- Toxin injection has been removed from all spiders except for the hunter, flesh spiders and the viper
- Hunter toxin (used by hunters and flesh spiders) now only brings the afflicted down to 40 health, and will stop taking effect once the afflicted reaches that threshold.  Should the afflicted still have the toxin in their system and get healed, the toxin will begin dealing damage again until the afflicted is at 40 health or below again
- Viper toxin now only brings the afflicted down to 10 health, but also has the hallucination effects of Mindbreaker toxin.  This hallucination effect is applied regardless of target health.  It also no longer generates other harmful chemicals into the afflicted's system, but is much more potent at base
- Flesh spiders cannot regenerate while on fire

*BUFFS*
- Time it takes for spiders to normalize their temperature cut by half. While they will react faster when in cold or hot environments, when they leave said environments it will take less time to return to normal temperature
- Unsuitable temperature damage reduced to 4 from 8 
- You can no longer push spiders by running into them
- Webbing heat damage threshold increased from 300 to 350 (same temp where spiders also take damage)
- Broodmother egg laying time reduced to 12 seconds from 15
- Broodmother web laying time multiplier reduced to 0.5 from 1
- Broodmother health increased to 60 from 40
- Broodmother damage increased to 10 - 15 from 5 -10

**BEHIND THE SCENES CHANGES**
- You can now make any simple mob able to be caught on fire by setting flammable to true
-  How fast a simplemob stops burning is controlled by fire_stack_removal_speed
- Can now now control how fast simplemobs regulate their temperature using temperature_normalization_speed.  Before this PR, this value was hard-coded at 10, I have set the default to 5 as 10 was too long in almost any case. This will notably affect slimes, who could easily die to being cold long after being removed from the cold area. I see this as purely beneficial
- Toxins now have a health_required value.  The afflicted has to be above this health value in order to take damage from the toxin. Only used in the spider toxins currently
- When I was setting up simplemobs to be flammable, I noticed basic mobs can be glitchily set on fire, so I fixed it to where they can't be set on fire.

## Why It's Good For The Game

- Spacing something is very easy, but not very fun or interesting compared to starting and controlling a fire.  Swapping spiders' temperature weakness from spacing to fire is beneficial to the fun of fighting them and playing as them, allowing more creativity and resourcefulness on both sides. Ideally, this should allow for atmosians and chemists to use their skills in a fun way.
- Currently, ignoring spacing them, the only people who can reasonably take on spiders is security, since they have lasers which do burn and stuns to slow the spiders down.  However, this small subset of players cannot normally destroy a spider infestation without spacing them, so letting fly swatters and pesticide be used to combat spiders allows other crewmembers to fight back, letting them actually enjoy facing spiders as a threat and allowing the crew to defend themselves.
- Being killed by spider toxin after fighting off a horde isn't fun.  The changes still make it a threat you have to be aware of, but not one which detracts as much from the combat loop. This also forces spiders to secure the kill themselves, which is more fun than having the toxin do it for you.
- Broodmothers in their current state are incredibly weak by themselves, which is intentional by design.  However, the new changes hope to make playing as a broodmother easier and hopefully allow more broodmothers to get the spider infestation started properly. After all, Dynamic is their common source now, and they should be consistently worth the threat cost to spawn them.
- Previously, spider structures would seemingly vanish for no reason if the room was heated to be greater than 300 but less than 350, as the spiders would not be able to tell that it was too hot. Now, if the structures are taking damage, spiders will also be taking damage, so understanding what's going on should be easier now.
- Pushing spiders into a corner by running into them was not a fun tactic to deal with as a spider and didn't make much sense seeing how big the spiders are.

## Changelog
:cl:
add: Spiders can now be caught on fire
add: Spiders take significant damage from fly swatters and stamina damage from pesticide
balance: Spiders have been re-balanced. Their toxins can no longer kill but they are not as susceptible to freezing
balance: General stats of spider broodmothers have been buffed with more health, damage, and faster web and egg placement
balance: Flesh spiders cannot regenerate whilst on fire
balance: Simplemobs change their internal temperature twice as fast
fix: Basic mobs no longer glitchily catch on fire.
/:cl: