### PR TITLE
Standardize and improve status display UI's

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -335,3 +335,19 @@ GLOBAL_LIST_INIT(admiral_messages, list(
 ))
 
 GLOBAL_LIST_INIT(junkmail_messages, world.file2list("strings/junkmail.txt"))
+
+// All valid inputs to status display post_status
+GLOBAL_LIST_INIT(status_display_approved_pictures, list(
+	"blank",
+	"shuttle",
+	"default",
+	"biohazard",
+	"lockdown",
+	"redalert",
+))
+
+// Members of status_display_approved_pictures that are actually states and not alert values
+GLOBAL_LIST_INIT(status_display_state_pictures, list(
+	"blank",
+	"shuttle",
+))

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -358,9 +358,8 @@
 		if ("setStatusMessage")
 			if (!authenticated(usr))
 				return
-			var/line_one = reject_bad_text(params["lineOne"] || "", MAX_STATUS_LINE_LENGTH)
-			var/line_two = reject_bad_text(params["lineTwo"] || "", MAX_STATUS_LINE_LENGTH)
-			post_status("alert", "blank")
+			var/line_one = reject_bad_text(params["upperText"] || "", MAX_STATUS_LINE_LENGTH)
+			var/line_two = reject_bad_text(params["lowerText"] || "", MAX_STATUS_LINE_LENGTH)
 			post_status("message", line_one, line_two)
 			last_status_display = list(line_one, line_two)
 			playsound(src, SFX_TERMINAL_TYPE, 50, FALSE)
@@ -599,8 +598,8 @@
 				data["budget"] = bank_account.account_balance
 				data["shuttles"] = shuttles
 			if (STATE_CHANGING_STATUS)
-				data["lineOne"] = last_status_display ? last_status_display[1] : ""
-				data["lineTwo"] = last_status_display ? last_status_display[2] : ""
+				data["upperText"] = last_status_display ? last_status_display[1] : ""
+				data["lowerText"] = last_status_display ? last_status_display[2] : ""
 
 	return data
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -17,11 +17,6 @@
 	circuit = /obj/item/circuitboard/computer/communications
 	light_color = LIGHT_COLOR_BLUE
 
-	/// Valid status display pictures to choose from
-	var/static/list/approved_status_pictures = list("biohazard", "blank", "default", "lockdown", "redalert", "shuttle")
-	/// Status picture that are actually direct commands
-	var/static/list/state_status_pictures = list("blank", "shuttle")
-
 	/// If the battlecruiser has been called
 	var/static/battlecruiser_called = FALSE
 
@@ -367,9 +362,9 @@
 			if (!authenticated(usr))
 				return
 			var/picture = params["picture"]
-			if (!(picture in approved_status_pictures))
+			if (!(picture in GLOB.status_display_approved_pictures))
 				return
-			if(picture in state_status_pictures)
+			if(picture in GLOB.status_display_state_pictures)
 				post_status(picture)
 			else
 				post_status("alert", picture)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -747,8 +747,8 @@
 	var/datum/signal/status_signal = new(list("command" = command))
 	switch(command)
 		if("message")
-			status_signal.data["msg1"] = data1
-			status_signal.data["msg2"] = data2
+			status_signal.data["top_text"] = data1
+			status_signal.data["bottom_text"] = data2
 		if("alert")
 			status_signal.data["picture_state"] = data1
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -17,6 +17,11 @@
 	circuit = /obj/item/circuitboard/computer/communications
 	light_color = LIGHT_COLOR_BLUE
 
+	/// Valid status display pictures to choose from
+	var/static/list/approved_status_pictures = list("biohazard", "blank", "default", "lockdown", "redalert", "shuttle")
+	/// Status picture that are actually direct commands
+	var/static/list/state_status_pictures = list("blank", "shuttle")
+
 	/// If the battlecruiser has been called
 	var/static/battlecruiser_called = FALSE
 
@@ -140,8 +145,6 @@
 
 /obj/machinery/computer/communications/ui_act(action, list/params)
 	var/static/list/approved_states = list(STATE_BUYING_SHUTTLE, STATE_CHANGING_STATUS, STATE_MAIN, STATE_MESSAGES)
-	var/static/list/approved_status_pictures = list("biohazard", "blank", "default", "lockdown", "redalert", "shuttle")
-	var/static/list/state_status_pictures = list("blank", "shuttle")
 
 	. = ..()
 	if (.)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -345,7 +345,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 			set_messages("", "")
 		if("message")
 			current_mode = SD_MESSAGE
-			set_messages(signal.data["msg1"] || "", signal.data["msg2"] || "")
+			set_messages(signal.data["top_text"] || "", signal.data["bottom_text"] || "")
 		if("alert")
 			current_mode = SD_PICTURE
 			last_picture = signal.data["picture_state"]
@@ -567,8 +567,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/ai, 32)
 	var/datum/signal/status_signal = new(list("command" = command_value))
 	switch(command_value)
 		if("message")
-			status_signal.data["msg1"] = message1.value
-			status_signal.data["msg2"] = message2.value
+			status_signal.data["top_text"] = message1.value
+			status_signal.data["bottom_text"] = message2.value
 		if("alert")
 			status_signal.data["picture_state"] = picture_map[picture.value]
 

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -12,8 +12,8 @@
 	usage_flags = PROGRAM_ALL
 	available_on_ntnet = FALSE
 
-	var/upper_text
-	var/lower_text
+	var/upper_text = ""
+	var/lower_text = ""
 
 /**
  * Post status display radio packet.
@@ -67,18 +67,13 @@
 		return
 
 	switch(action)
-		if("stat_message")
-			post_message(upper_text, lower_text)
-		if("stat_picture")
-			post_picture(params["picture"])
-		if("stat_update")
-			var/text = reject_bad_text(params["text"] || "", MAX_STATUS_LINE_LENGTH)
+		if("setStatusMessage")
+			upper_text = reject_bad_text(params["upperText"] || "", MAX_STATUS_LINE_LENGTH)
+			lower_text = reject_bad_text(params["lowerText"] || "", MAX_STATUS_LINE_LENGTH)
 
-			switch(params["position"])
-				if("upper")
-					upper_text = text
-				if("lower")
-					lower_text = text
+			post_message(upper_text, lower_text)
+		if("setStatusPicture")
+			post_picture(params["picture"])
 
 /datum/computer_file/program/status/ui_static_data(mob/user)
 	var/list/data = list()
@@ -89,7 +84,7 @@
 /datum/computer_file/program/status/ui_data(mob/user)
 	var/list/data = get_header_data()
 
-	data["upper"] = upper_text
-	data["lower"] = lower_text
+	data["upperText"] = upper_text
+	data["lowerText"] = lower_text
 
 	return data

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -52,11 +52,9 @@
  * * picture - The picture name
  */
 /datum/computer_file/program/status/proc/post_picture(picture)
-	var/static/obj/machinery/computer/communications/comm_prototype = /obj/machinery/computer/communications
-
-	if (!(picture in initial(comm_prototype.approved_status_pictures)))
+	if (!(picture in initial(GLOB.status_display_approved_pictures)))
 		return
-	if(picture in initial(comm_prototype.state_status_pictures))
+	if(picture in initial(GLOB.status_display_state_pictures))
 		post_status(picture)
 	else
 		post_status("alert", picture)

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -52,9 +52,9 @@
  * * picture - The picture name
  */
 /datum/computer_file/program/status/proc/post_picture(picture)
-	if (!(picture in initial(GLOB.status_display_approved_pictures)))
+	if (!(picture in GLOB.status_display_approved_pictures))
 		return
-	if(picture in initial(GLOB.status_display_state_pictures))
+	if(picture in GLOB.status_display_state_pictures)
 		post_status(picture)
 	else
 		post_status("alert", picture)

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -15,25 +15,51 @@
 	var/upper_text
 	var/lower_text
 
-/datum/computer_file/program/status/proc/SendSignal()
+/**
+ * Post status display radio packet.
+ * Arguments:
+ * * command - the status display command
+ * * data1 - the data1 value, as defined by status displays
+ * * data2 - the data2 value, as defined by status displays
+ */
+/datum/computer_file/program/status/proc/post_status(command, data1, data2)
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)
-
 	if(!frequency)
 		return
 
-	var/datum/signal/status_signal = new(list("command" = "message"))
+	var/datum/signal/status_signal = new(list("command" = command))
+	switch(command)
+		if("message")
+			status_signal.data["msg1"] = data1
+			status_signal.data["msg2"] = data2
+		if("alert")
+			status_signal.data["picture_state"] = data1
 
-	status_signal.data["msg1"] = reject_bad_text(upper_text || "", MAX_STATUS_LINE_LENGTH)
-	status_signal.data["msg2"] = reject_bad_text(lower_text || "", MAX_STATUS_LINE_LENGTH)
+	frequency.post_signal(src, status_signal)
 
-	frequency.post_signal(computer, status_signal)
+/**
+ * Post a message to status displays
+ * Arguments:
+ * * upper - Top text
+ * * lower - Bottom text
+ */
+/datum/computer_file/program/status/proc/post_message(upper, lower)
+	post_status("message", upper, lower)
 
-/datum/computer_file/program/status/proc/SetText(position, text)
-	switch(position)
-		if("upper")
-			upper_text = text
-		if("lower")
-			lower_text = text
+/**
+ * Post a picture to status displays
+ * Arguments:
+ * * picture - The picture name
+ */
+/datum/computer_file/program/status/proc/post_picture(picture)
+	var/static/obj/machinery/computer/communications/comm_prototype = /obj/machinery/computer/communications
+
+	if (!(picture in initial(comm_prototype.approved_status_pictures)))
+		return
+	if(picture in initial(comm_prototype.state_status_pictures))
+		post_status(picture)
+	else
+		post_status("alert", picture)
 
 /datum/computer_file/program/status/ui_act(action, list/params, datum/tgui/ui)
 	. = ..()
@@ -41,10 +67,24 @@
 		return
 
 	switch(action)
-		if("stat_send")
-			SendSignal()
+		if("stat_message")
+			post_message(upper_text, lower_text)
+		if("stat_picture")
+			post_picture(params["picture"])
 		if("stat_update")
-			SetText(params["position"], params["text"]) // i hate the player i hate the player
+			var/text = reject_bad_text(params["text"] || "", MAX_STATUS_LINE_LENGTH)
+
+			switch(params["position"])
+				if("upper")
+					upper_text = text
+				if("lower")
+					lower_text = text
+
+/datum/computer_file/program/status/ui_static_data(mob/user)
+	var/list/data = list()
+	data["maxStatusLineLength"] = MAX_STATUS_LINE_LENGTH
+
+	return data
 
 /datum/computer_file/program/status/ui_data(mob/user)
 	var/list/data = get_header_data()

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -30,8 +30,8 @@
 	var/datum/signal/status_signal = new(list("command" = command))
 	switch(command)
 		if("message")
-			status_signal.data["msg1"] = data1
-			status_signal.data["msg2"] = data2
+			status_signal.data["top_text"] = data1
+			status_signal.data["bottom_text"] = data2
 		if("alert")
 			status_signal.data["picture_state"] = data1
 

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -1,7 +1,8 @@
 import { sortBy } from 'common/collections';
 import { capitalize } from 'common/string';
 import { useBackend, useLocalState } from '../backend';
-import { Blink, Box, Button, Dimmer, Flex, Icon, Input, Modal, Section, TextArea } from '../components';
+import { Blink, Box, Button, Dimmer, Flex, Icon, Modal, Section, TextArea } from '../components';
+import { StatusDisplayControls } from './common/StatusDisplayControls';
 import { Window } from '../layouts';
 import { sanitizeText } from '../sanitize';
 
@@ -202,11 +203,7 @@ const PageBuyingShuttle = (props, context) => {
 };
 
 const PageChangingStatus = (props, context) => {
-  const { act, data } = useBackend(context);
-  const { maxStatusLineLength } = data;
-
-  const [lineOne, setLineOne] = useLocalState(context, 'lineOne', data.lineOne);
-  const [lineTwo, setLineTwo] = useLocalState(context, 'lineTwo', data.lineTwo);
+  const { act } = useBackend(context);
 
   return (
     <Box>
@@ -218,81 +215,7 @@ const PageChangingStatus = (props, context) => {
         />
       </Section>
 
-      <Section>
-        <Button
-          icon="toggle-off"
-          content="Off"
-          color="bad"
-          onClick={() => act('setStatusPicture', { picture: 'blank' })}
-        />
-        <Button
-          icon="space-shuttle"
-          content="Shuttle ETA / Off"
-          color=""
-          onClick={() => act('setStatusPicture', { picture: 'shuttle' })}
-        />
-      </Section>
-
-      <Section title="Graphics">
-        <Button
-          icon="flag"
-          content="Logo"
-          onClick={() => act('setStatusPicture', { picture: 'default' })}
-        />
-
-        <Button
-          icon="bell-o"
-          content="Red Alert"
-          onClick={() => act('setStatusPicture', { picture: 'redalert' })}
-        />
-
-        <Button
-          icon="exclamation-triangle"
-          content="Lockdown"
-          onClick={() => act('setStatusPicture', { picture: 'lockdown' })}
-        />
-
-        <Button
-          icon="biohazard"
-          content="Biohazard"
-          onClick={() => act('setStatusPicture', { picture: 'biohazard' })}
-        />
-      </Section>
-
-      <Section title="Message">
-        <Flex direction="column" align="stretch">
-          <Flex.Item mb={1}>
-            <Input
-              fluid
-              maxLength={maxStatusLineLength}
-              value={lineOne}
-              onChange={(_, value) => setLineOne(value)}
-            />
-          </Flex.Item>
-
-          <Flex.Item mb={1}>
-            <Input
-              fluid
-              maxLength={maxStatusLineLength}
-              value={lineTwo}
-              onChange={(_, value) => setLineTwo(value)}
-            />
-          </Flex.Item>
-
-          <Flex.Item>
-            <Button
-              icon="comment-o"
-              content="Send"
-              onClick={() =>
-                act('setStatusMessage', {
-                  lineOne,
-                  lineTwo,
-                })
-              }
-            />
-          </Flex.Item>
-        </Flex>
-      </Section>
+      <StatusDisplayControls />
     </Box>
   );
 };

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -219,66 +219,62 @@ const PageChangingStatus = (props, context) => {
       </Section>
 
       <Section>
-        <Flex direction="column">
-          <Flex.Item>
-            <Button
-              icon="times"
-              content="Clear Alert"
-              color="bad"
-              onClick={() => act('setStatusPicture', { picture: 'blank' })}
-            />
-          </Flex.Item>
+        <Button
+          icon="toggle-off"
+          content="Off"
+          color="bad"
+          onClick={() => act('setStatusPicture', { picture: 'blank' })}
+        />
+        <Button
+          icon="space-shuttle"
+          content="Shuttle ETA / Off"
+          color=""
+          onClick={() => act('setStatusPicture', { picture: 'shuttle' })}
+        />
+      </Section>
 
-          <Flex.Item mt={1}>
-            <Button
-              icon="check-square-o"
-              content="Default"
-              onClick={() => act('setStatusPicture', { picture: 'default' })}
-            />
+      <Section title="Graphics">
+        <Button
+          icon="flag"
+          content="Logo"
+          onClick={() => act('setStatusPicture', { picture: 'default' })}
+        />
 
-            <Button
-              icon="bell-o"
-              content="Red Alert"
-              onClick={() => act('setStatusPicture', { picture: 'redalert' })}
-            />
+        <Button
+          icon="bell-o"
+          content="Red Alert"
+          onClick={() => act('setStatusPicture', { picture: 'redalert' })}
+        />
 
-            <Button
-              icon="exclamation-triangle"
-              content="Lockdown"
-              onClick={() => act('setStatusPicture', { picture: 'lockdown' })}
-            />
+        <Button
+          icon="exclamation-triangle"
+          content="Lockdown"
+          onClick={() => act('setStatusPicture', { picture: 'lockdown' })}
+        />
 
-            <Button
-              icon="exclamation-circle"
-              content="Biohazard"
-              onClick={() => act('setStatusPicture', { picture: 'biohazard' })}
-            />
-
-            <Button
-              icon="space-shuttle"
-              content="Shuttle ETA"
-              onClick={() => act('setStatusPicture', { picture: 'shuttle' })}
-            />
-          </Flex.Item>
-        </Flex>
+        <Button
+          icon="biohazard"
+          content="Biohazard"
+          onClick={() => act('setStatusPicture', { picture: 'biohazard' })}
+        />
       </Section>
 
       <Section title="Message">
-        <Flex direction="column">
+        <Flex direction="column" align="stretch">
           <Flex.Item mb={1}>
             <Input
+              fluid
               maxLength={maxStatusLineLength}
               value={lineOne}
-              width="200px"
               onChange={(_, value) => setLineOne(value)}
             />
           </Flex.Item>
 
           <Flex.Item mb={1}>
             <Input
+              fluid
               maxLength={maxStatusLineLength}
               value={lineTwo}
-              width="200px"
               onChange={(_, value) => setLineTwo(value)}
             />
           </Flex.Item>
@@ -286,7 +282,7 @@ const PageChangingStatus = (props, context) => {
           <Flex.Item>
             <Button
               icon="comment-o"
-              content="Message"
+              content="Send"
               onClick={() =>
                 act('setStatusMessage', {
                   lineOne,

--- a/tgui/packages/tgui/interfaces/NtosStatus.tsx
+++ b/tgui/packages/tgui/interfaces/NtosStatus.tsx
@@ -1,100 +1,11 @@
-import { useBackend } from '../backend';
 import { NtosWindow } from '../layouts';
-import { Flex, Input, Section, Button } from '../components';
+import { StatusDisplayControls } from './common/StatusDisplayControls';
 
-type Data = {
-  upper: string;
-  lower: string;
-  maxStatusLineLength: number;
-};
-
-export const NtosStatus = (props, context) => {
-  const { act, data } = useBackend<Data>(context);
-  const { upper, lower, maxStatusLineLength } = data;
-
+export const NtosStatus = () => {
   return (
     <NtosWindow width={400} height={350}>
       <NtosWindow.Content>
-        <Section>
-          <Button
-            icon="toggle-off"
-            content="Off"
-            color="bad"
-            onClick={() => act('stat_picture', { picture: 'blank' })}
-          />
-          <Button
-            icon="space-shuttle"
-            content="Shuttle ETA / Off"
-            color=""
-            onClick={() => act('stat_picture', { picture: 'shuttle' })}
-          />
-        </Section>
-
-        <Section title="Graphics">
-          <Button
-            icon="flag"
-            content="Logo"
-            onClick={() => act('stat_picture', { picture: 'default' })}
-          />
-
-          <Button
-            icon="bell-o"
-            content="Red Alert"
-            onClick={() => act('stat_picture', { picture: 'redalert' })}
-          />
-
-          <Button
-            icon="exclamation-triangle"
-            content="Lockdown"
-            onClick={() => act('stat_picture', { picture: 'lockdown' })}
-          />
-
-          <Button
-            icon="biohazard"
-            content="Biohazard"
-            onClick={() => act('stat_picture', { picture: 'biohazard' })}
-          />
-        </Section>
-
-        <Section title="Message">
-          <Flex direction="column" align="stretch">
-            <Flex.Item mb={1}>
-              <Input
-                fluid
-                maxLength={maxStatusLineLength}
-                value={upper}
-                onChange={(_, value) =>
-                  act('stat_update', {
-                    position: 'upper',
-                    text: value,
-                  })
-                }
-              />
-            </Flex.Item>
-
-            <Flex.Item mb={1}>
-              <Input
-                fluid
-                maxLength={maxStatusLineLength}
-                value={lower}
-                onChange={(_, value) =>
-                  act('stat_update', {
-                    position: 'lower',
-                    text: value,
-                  })
-                }
-              />
-            </Flex.Item>
-
-            <Flex.Item>
-              <Button
-                icon="comment-o"
-                onClick={() => act('stat_message')}
-                content="Send"
-              />
-            </Flex.Item>
-          </Flex>
-        </Section>
+        <StatusDisplayControls />
       </NtosWindow.Content>
     </NtosWindow>
   );

--- a/tgui/packages/tgui/interfaces/NtosStatus.tsx
+++ b/tgui/packages/tgui/interfaces/NtosStatus.tsx
@@ -1,47 +1,99 @@
 import { useBackend } from '../backend';
 import { NtosWindow } from '../layouts';
-import { Input, Section, Button } from '../components';
+import { Flex, Input, Section, Button } from '../components';
 
 type Data = {
   upper: string;
   lower: string;
+  maxStatusLineLength: number;
 };
 
 export const NtosStatus = (props, context) => {
   const { act, data } = useBackend<Data>(context);
-  const { upper, lower } = data;
+  const { upper, lower, maxStatusLineLength } = data;
 
   return (
-    <NtosWindow width={310} height={200}>
+    <NtosWindow width={400} height={350}>
       <NtosWindow.Content>
         <Section>
-          <Input
-            fluid
-            value={upper}
-            onChange={(_, value) =>
-              act('stat_update', {
-                position: 'upper',
-                text: value,
-              })
-            }
-          />
-          <br />
-          <Input
-            fluid
-            value={lower}
-            onChange={(_, value) =>
-              act('stat_update', {
-                position: 'lower',
-                text: value,
-              })
-            }
-          />
-          <br />
           <Button
-            fluid
-            onClick={() => act('stat_send')}
-            content="Update Status Displays"
+            icon="toggle-off"
+            content="Off"
+            color="bad"
+            onClick={() => act('stat_picture', { picture: 'blank' })}
           />
+          <Button
+            icon="space-shuttle"
+            content="Shuttle ETA / Off"
+            color=""
+            onClick={() => act('stat_picture', { picture: 'shuttle' })}
+          />
+        </Section>
+
+        <Section title="Graphics">
+          <Button
+            icon="flag"
+            content="Logo"
+            onClick={() => act('stat_picture', { picture: 'default' })}
+          />
+
+          <Button
+            icon="bell-o"
+            content="Red Alert"
+            onClick={() => act('stat_picture', { picture: 'redalert' })}
+          />
+
+          <Button
+            icon="exclamation-triangle"
+            content="Lockdown"
+            onClick={() => act('stat_picture', { picture: 'lockdown' })}
+          />
+
+          <Button
+            icon="biohazard"
+            content="Biohazard"
+            onClick={() => act('stat_picture', { picture: 'biohazard' })}
+          />
+        </Section>
+
+        <Section title="Message">
+          <Flex direction="column" align="stretch">
+            <Flex.Item mb={1}>
+              <Input
+                fluid
+                maxLength={maxStatusLineLength}
+                value={upper}
+                onChange={(_, value) =>
+                  act('stat_update', {
+                    position: 'upper',
+                    text: value,
+                  })
+                }
+              />
+            </Flex.Item>
+
+            <Flex.Item mb={1}>
+              <Input
+                fluid
+                maxLength={maxStatusLineLength}
+                value={lower}
+                onChange={(_, value) =>
+                  act('stat_update', {
+                    position: 'lower',
+                    text: value,
+                  })
+                }
+              />
+            </Flex.Item>
+
+            <Flex.Item>
+              <Button
+                icon="comment-o"
+                onClick={() => act('stat_message')}
+                content="Send"
+              />
+            </Flex.Item>
+          </Flex>
         </Section>
       </NtosWindow.Content>
     </NtosWindow>

--- a/tgui/packages/tgui/interfaces/common/StatusDisplayControls.tsx
+++ b/tgui/packages/tgui/interfaces/common/StatusDisplayControls.tsx
@@ -1,0 +1,103 @@
+import { useBackend, useSharedState } from '../../backend';
+import { Flex, Input, Section, Button } from '../../components';
+
+type Data = {
+  upperText: string;
+  lowerText: string;
+  maxStatusLineLength: number;
+};
+
+export const StatusDisplayControls = (props, context) => {
+  const { act, data } = useBackend<Data>(context);
+  const {
+    upperText: initialUpper,
+    lowerText: initialLower,
+    maxStatusLineLength,
+  } = data;
+
+  const [upperText, setUpperText] = useSharedState(
+    context,
+    'statusUpperText',
+    initialUpper
+  );
+  const [lowerText, setLowerText] = useSharedState(
+    context,
+    'statusLowerText',
+    initialLower
+  );
+
+  return (
+    <>
+      <Section>
+        <Button
+          icon="toggle-off"
+          content="Off"
+          color="bad"
+          onClick={() => act('setStatusPicture', { picture: 'blank' })}
+        />
+        <Button
+          icon="space-shuttle"
+          content="Shuttle ETA / Off"
+          color=""
+          onClick={() => act('setStatusPicture', { picture: 'shuttle' })}
+        />
+      </Section>
+
+      <Section title="Graphics">
+        <Button
+          icon="flag"
+          content="Logo"
+          onClick={() => act('setStatusPicture', { picture: 'default' })}
+        />
+
+        <Button
+          icon="bell-o"
+          content="Red Alert"
+          onClick={() => act('setStatusPicture', { picture: 'redalert' })}
+        />
+
+        <Button
+          icon="exclamation-triangle"
+          content="Lockdown"
+          onClick={() => act('setStatusPicture', { picture: 'lockdown' })}
+        />
+
+        <Button
+          icon="biohazard"
+          content="Biohazard"
+          onClick={() => act('setStatusPicture', { picture: 'biohazard' })}
+        />
+      </Section>
+
+      <Section title="Message">
+        <Flex direction="column" align="stretch">
+          <Flex.Item mb={1}>
+            <Input
+              fluid
+              maxLength={maxStatusLineLength}
+              value={upperText}
+              onChange={(_, value) => setUpperText(value)}
+            />
+          </Flex.Item>
+
+          <Flex.Item mb={1}>
+            <Input
+              fluid
+              maxLength={maxStatusLineLength}
+              value={lowerText}
+              onChange={(_, value) => setLowerText(value)}
+            />
+          </Flex.Item>
+
+          <Flex.Item>
+            <Button
+              icon="comment-o"
+              onClick={() => act('setStatusMessage', { upperText, lowerText })}
+              content="Send"
+            />
+          </Flex.Item>
+        </Flex>
+      </Section>
+    </>
+  );
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All of the changes can by tl;dr'd by looking at the picture below.

Unified command console status display screen and PDA status display app to have the same UI.

- I grouped the shuttle ETA button with Clear, since it's not a picture like the other button options.
- Likewise, I changed their labels to help clarify the difference between clearing and changing to ETA mid-shift.
- Changed the default and biohazard buttons to be more true to their content, and changed Default to Logo.
- Tweaked the message area's layout.

This is technically a gameplay change because you can now set the status displays to use the pictures or back to Shuttle ETA mode from the PDA, whereas before, you could only set custom messages. (I think this was due to comms consoles obscuring the list of pictures and nobody bothering to fix it, rather than a balance decision, as arguably the custom messages are the *most* powerful thing you can do).

![image](https://user-images.githubusercontent.com/1185434/182769295-27d02b12-8bcc-406a-8e2d-4b395fdeaa48.png)

![image](https://user-images.githubusercontent.com/1185434/182769111-1b04a88c-c338-44bc-adaa-250459e27e84.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better UX for these screens, better QoL for heads actually using those nice biohazard, etc screens.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The Status Display app can now do everything the communications console status display screen can do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
