### PR TITLE
Fixes "Burning rust off walls doesn't blind you"

### DIFF
--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -52,7 +52,7 @@
 
 			user.balloon_alert(user, "burning off rust...")
 
-			if(!item.use_tool(source, user, 5))
+			if(!item.use_tool(source, user, 5 SECONDS))
 				return
 			user.balloon_alert(user, "burned off rust")
 			Detach(source)
@@ -63,7 +63,7 @@
 			if(!item.tool_start_check(user, amount=0))
 				return
 			user.balloon_alert(user, "scraping off rust...")
-			if(!item.use_tool(source, user, 2 SECONDS * item.toolspeed))
+			if(!item.use_tool(source, user, 2 SECONDS))
 				return
 			user.balloon_alert(user, "scraped off rust")
 			Detach(source)

--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -60,7 +60,7 @@
 
 
 		if(TOOL_RUSTSCRAPER)
-			if(!item.tool_start_check(user, amount=0))
+			if(!item.tool_start_check(user))
 				return
 			user.balloon_alert(user, "scraping off rust...")
 			if(!item.use_tool(source, user, 2 SECONDS))

--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -47,16 +47,23 @@
 /datum/element/rust/proc/handle_tool_use(atom/source, mob/user, obj/item/item)
 	switch(item.tool_behaviour)
 		if(TOOL_WELDER)
-			if(item.use(5))
-				user.balloon_alert(user, "burning off rust...")
-				if(!do_after(user, 5 SECONDS * item.toolspeed, source))
-					return
-				user.balloon_alert(user, "burned off rust")
-				Detach(source)
+			if(!item.tool_start_check(user, amount=5))
 				return
+
+			user.balloon_alert(user, "burning off rust...")
+
+			if(!item.use_tool(source, user, 5))
+				return
+			user.balloon_alert(user, "burned off rust")
+			Detach(source)
+			return
+
+
 		if(TOOL_RUSTSCRAPER)
+			if(!item.tool_start_check(user, amount=0))
+				return
 			user.balloon_alert(user, "scraping off rust...")
-			if(!do_after(user, 2 SECONDS * item.toolspeed, source))
+			if(!item.use_tool(source, user, 2 SECONDS * item.toolspeed))
 				return
 			user.balloon_alert(user, "scraped off rust")
 			Detach(source)


### PR DESCRIPTION
## About The Pull Request

This fixes the bug where burning rust off of a wall using a welder would not actually blind you! It was happening because it was using the wrong procs to use the tools. It now correctly implements tool_start_check and tool_start_check

fixes: #68796

## Why It's Good For The Game

Less bugs = good

## Changelog

:cl: Capybara Holly
fix: Trying to remove rust from walls with a welding tool will now blind you like it should
/:cl:
