### PR TITLE
Adds "welder crafting" to iron sheets, rods and tiles.

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 		var/obj/item/stack/rods/welded_rod = src
 		welded_rod.use(2)
 		user.put_in_inactive_hand(new_item)
-	return TOOL_ACT_TOOLTYPE_SUCCESS
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/rods/welder_act_secondary(mob/living/user, obj/item/tool)
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
@@ -98,7 +98,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 		var/obj/item/stack/rods/welded_rod = src
 		welded_rod.use(1)
 		user.put_in_inactive_hand(new_item)
-	return TOOL_ACT_TOOLTYPE_SUCCESS
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/rods/cyborg/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -73,30 +73,26 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 		return
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
 		var/obj/item/stack/sheet/iron/new_item = new(user.loc)
-		balloon_alert(user, "crafting sheets...")
 		user.visible_message(
 			span_notice("[user.name] shaped [src] into iron sheets with [tool]."),
 			blind_message = span_hear("You hear welding."),
 			vision_distance = COMBAT_MESSAGE_RANGE,
 			ignored_mobs = user
 		)
-		var/obj/item/stack/rods/welded_rod = src
-		welded_rod.use(2)
+		use(2)
 		user.put_in_inactive_hand(new_item)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/rods/welder_act_secondary(mob/living/user, obj/item/tool)
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
 		var/obj/item/stack/tile/iron/two/new_item = new(user.loc)
-		balloon_alert(user, "crafting tiles...")
 		user.visible_message(
 			span_notice("[user.name] shaped [src] into floor tiles with [tool]."),
 			blind_message = span_hear("You hear welding."),
 			vision_distance = COMBAT_MESSAGE_RANGE,
 			ignored_mobs = user
 		)
-		var/obj/item/stack/rods/welded_rod = src
-		welded_rod.use(1)
+		use(1)
 		user.put_in_inactive_hand(new_item)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -67,45 +67,38 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	else
 		icon_state = "rods"
 
-/obj/item/stack/rods/attackby(obj/item/attackby_item, mob/user, params)
-	if(attackby_item.tool_behaviour == TOOL_WELDER)
-		if(get_amount() < 2)
-			balloon_alert(user, "not enough rods!")
-			return
-		if(attackby_item.use_tool(src, user, 0, volume = 40))
-			var/obj/item/stack/sheet/iron/new_item = new(usr.loc)
-			balloon_alert(user, "crafting sheets...")
-			user.visible_message(
-				span_notice("[user.name] shaped [src] into iron sheets with [attackby_item]."),
-				blind_message = span_hear("You hear welding."),
-				vision_distance = COMBAT_MESSAGE_RANGE,
-				ignored_mobs = user
-			)
-			var/obj/item/stack/rods/welded_rod = src
-			src = null
-			welded_rod.use(2)
-			user.put_in_inactive_hand(new_item)
-	else
-		return ..()
+/obj/item/stack/rods/welder_act(mob/living/user, obj/item/tool)
+	if(get_amount() < 2)
+		balloon_alert(user, "not enough rods!")
+		return
+	if(tool.use_tool(src, user, delay = 0, volume = 40))
+		var/obj/item/stack/sheet/iron/new_item = new(user.loc)
+		balloon_alert(user, "crafting sheets...")
+		user.visible_message(
+			span_notice("[user.name] shaped [src] into iron sheets with [tool]."),
+			blind_message = span_hear("You hear welding."),
+			vision_distance = COMBAT_MESSAGE_RANGE,
+			ignored_mobs = user
+		)
+		var/obj/item/stack/rods/welded_rod = src
+		welded_rod.use(2)
+		user.put_in_inactive_hand(new_item)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
-/obj/item/stack/rods/attackby_secondary(obj/item/attackby_item, mob/user, params)
-	if(attackby_item.tool_behaviour == TOOL_WELDER)
-		if(attackby_item.use_tool(src, user, 0, volume = 40))
-			var/obj/item/stack/tile/iron/two/new_item = new(user.loc)
-			balloon_alert(user, "crafting tiles...")
-			user.visible_message(
-				span_notice("[user.name] shaped [src] into floor tiles with [attackby_item]."),
-				blind_message = span_hear("You hear welding."),
-				vision_distance = COMBAT_MESSAGE_RANGE,
-				ignored_mobs = user
-			)
-			var/obj/item/stack/rods/welded_rod = src
-			src = null
-			welded_rod.use(1)
-			user.put_in_inactive_hand(new_item)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-	return SECONDARY_ATTACK_CONTINUE_CHAIN
+/obj/item/stack/rods/welder_act_secondary(mob/living/user, obj/item/tool)
+	if(tool.use_tool(src, user, delay = 0, volume = 40))
+		var/obj/item/stack/tile/iron/two/new_item = new(user.loc)
+		balloon_alert(user, "crafting tiles...")
+		user.visible_message(
+			span_notice("[user.name] shaped [src] into floor tiles with [tool]."),
+			blind_message = span_hear("You hear welding."),
+			vision_distance = COMBAT_MESSAGE_RANGE,
+			ignored_mobs = user
+		)
+		var/obj/item/stack/rods/welded_rod = src
+		welded_rod.use(1)
+		user.put_in_inactive_hand(new_item)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/rods/cyborg/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -43,6 +43,13 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	. = ..()
 	update_appearance()
 	AddElement(/datum/element/openspace_item_click_handler)
+	var/static/list/tool_behaviors = list(
+		TOOL_WELDER = list(
+			SCREENTIP_CONTEXT_LMB = "Craft iron sheets",
+			SCREENTIP_CONTEXT_RMB = "Craft floor tiles",
+		),
+	)
+	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
 
 /obj/item/stack/rods/handle_openspace_click(turf/target, mob/user, proximity_flag, click_parameters)
 	if(proximity_flag)
@@ -60,29 +67,48 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	else
 		icon_state = "rods"
 
-/obj/item/stack/rods/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_WELDER)
+/obj/item/stack/rods/attackby(obj/item/attackby_item, mob/user, params)
+	if(attackby_item.tool_behaviour == TOOL_WELDER)
 		if(get_amount() < 2)
 			to_chat(user, span_warning("You need at least two rods to do this!"))
 			return
-
-		if(W.use_tool(src, user, 0, volume=40))
+		if(attackby_item.use_tool(src, user, 0, volume=40))
 			var/obj/item/stack/sheet/iron/new_item = new(usr.loc)
-			user.visible_message(span_notice("[user.name] shaped [src] into iron sheets with [W]."), \
-				span_notice("You shape [src] into iron sheets with [W]."), \
+			user.visible_message(span_notice("[user.name] shaped [src] into iron sheets with [attackby_item]."), \
+				span_notice("You shape [src] into iron sheets with [attackby_item]."), \
 				span_hear("You hear welding."))
-			var/obj/item/stack/rods/R = src
+			var/obj/item/stack/rods/welded_rod = src
 			src = null
-			var/replace = (user.get_inactive_held_item()==R)
-			R.use(2)
-			if (!R && replace)
+			var/replace = (user.get_inactive_held_item()==welded_rod)
+			welded_rod.use(2)
+			if (!welded_rod && replace)
 				user.put_in_hands(new_item)
 	else
 		return ..()
 
+/obj/item/stack/rods/attackby_secondary(obj/item/attackby_item, mob/user, params)
+	if(attackby_item.tool_behaviour == TOOL_WELDER)
+		if(attackby_item.use_tool(src, user, 0, volume=40))
+			var/obj/item/stack/tile/iron/two/new_item = new(user.loc)
+			user.visible_message(span_notice("[user] shaped [src] into [new_item] with [attackby_item]."), \
+				span_notice("You shaped [src] into [new_item] with [attackby_item]."), \
+				span_hear("You hear welding."))
+			var/obj/item/stack/rods/welded_rod = src
+			src = null
+			var/replace = (user.get_inactive_held_item()==welded_rod)
+			welded_rod.use(1)
+			if(!welded_rod && replace)
+				user.put_in_hands(new_item)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
+
 /obj/item/stack/rods/cyborg/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/update_icon_blocker)
+
+/obj/item/stack/rods/two
+	amount = 2
 
 /obj/item/stack/rods/ten
 	amount = 10

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -70,35 +70,39 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 /obj/item/stack/rods/attackby(obj/item/attackby_item, mob/user, params)
 	if(attackby_item.tool_behaviour == TOOL_WELDER)
 		if(get_amount() < 2)
-			to_chat(user, span_warning("You need at least two rods to do this!"))
+			balloon_alert(user, "not enough rods!")
 			return
-		if(attackby_item.use_tool(src, user, 0, volume=40))
+		if(attackby_item.use_tool(src, user, 0, volume = 40))
 			var/obj/item/stack/sheet/iron/new_item = new(usr.loc)
-			user.visible_message(span_notice("[user.name] shaped [src] into iron sheets with [attackby_item]."), \
-				span_notice("You shape [src] into iron sheets with [attackby_item]."), \
-				span_hear("You hear welding."))
+			balloon_alert(user, "crafting sheets...")
+			user.visible_message(
+				span_notice("[user.name] shaped [src] into iron sheets with [attackby_item]."),
+				blind_message = span_hear("You hear welding."),
+				vision_distance = COMBAT_MESSAGE_RANGE,
+				ignored_mobs = user
+			)
 			var/obj/item/stack/rods/welded_rod = src
 			src = null
-			var/replace = (user.get_inactive_held_item()==welded_rod)
 			welded_rod.use(2)
-			if (!welded_rod && replace)
-				user.put_in_hands(new_item)
+			user.put_in_inactive_hand(new_item)
 	else
 		return ..()
 
 /obj/item/stack/rods/attackby_secondary(obj/item/attackby_item, mob/user, params)
 	if(attackby_item.tool_behaviour == TOOL_WELDER)
-		if(attackby_item.use_tool(src, user, 0, volume=40))
+		if(attackby_item.use_tool(src, user, 0, volume = 40))
 			var/obj/item/stack/tile/iron/two/new_item = new(user.loc)
-			user.visible_message(span_notice("[user] shaped [src] into [new_item] with [attackby_item]."), \
-				span_notice("You shaped [src] into [new_item] with [attackby_item]."), \
-				span_hear("You hear welding."))
+			balloon_alert(user, "crafting tiles...")
+			user.visible_message(
+				span_notice("[user.name] shaped [src] into floor tiles with [attackby_item]."),
+				blind_message = span_hear("You hear welding."),
+				vision_distance = COMBAT_MESSAGE_RANGE,
+				ignored_mobs = user
+			)
 			var/obj/item/stack/rods/welded_rod = src
 			src = null
-			var/replace = (user.get_inactive_held_item()==welded_rod)
 			welded_rod.use(1)
-			if(!welded_rod && replace)
-				user.put_in_hands(new_item)
+			user.put_in_inactive_hand(new_item)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	return SECONDARY_ATTACK_CONTINUE_CHAIN

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -186,30 +186,26 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 /obj/item/stack/sheet/iron/welder_act(mob/living/user, obj/item/tool)
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
 		var/obj/item/stack/rods/two/new_item = new(user.loc)
-		balloon_alert(user, "crafting rods...")
 		user.visible_message(
 			span_notice("[user.name] shaped [src] into floor rods with [tool]."),
 			blind_message = span_hear("You hear welding."),
 			vision_distance = COMBAT_MESSAGE_RANGE,
 			ignored_mobs = user
 		)
-		var/obj/item/stack/rods/welded_sheet = src
-		welded_sheet.use(1)
+		use(1)
 		user.put_in_inactive_hand(new_item)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/sheet/iron/welder_act_secondary(mob/living/user, obj/item/tool)
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
 		var/obj/item/stack/tile/iron/four/new_item = new(user.loc)
-		balloon_alert(user, "crafting tiles...")
 		user.visible_message(
 			span_notice("[user.name] shaped [src] into floor tiles with [tool]."),
 			blind_message = span_hear("You hear welding."),
 			vision_distance = COMBAT_MESSAGE_RANGE,
 			ignored_mobs = user
 		)
-		var/obj/item/stack/sheet/iron/welded_sheet = src
-		welded_sheet.use(1)
+		use(1)
 		user.put_in_inactive_hand(new_item)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -183,42 +183,35 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	user.visible_message(span_suicide("[user] begins whacking [user.p_them()]self over the head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 
-/obj/item/stack/sheet/iron/attackby(obj/item/attackby_item, mob/user, params)
-	if(attackby_item.tool_behaviour == TOOL_WELDER)
-		if(attackby_item.use_tool(src, user, 0, volume = 40))
-			var/obj/item/stack/rods/two/new_item = new(usr.loc)
-			balloon_alert(user, "crafting rods...")
-			user.visible_message(
-				span_notice("[user.name] shaped [src] into floor rods with [attackby_item]."),
-				blind_message = span_hear("You hear welding."),
-				vision_distance = COMBAT_MESSAGE_RANGE,
-				ignored_mobs = user
-			)
-			var/obj/item/stack/rods/welded_sheet = src
-			src = null
-			welded_sheet.use(1)
-			user.put_in_inactive_hand(new_item)
-	else
-		return ..()
+/obj/item/stack/sheet/iron/welder_act(mob/living/user, obj/item/tool)
+	if(tool.use_tool(src, user, delay = 0, volume = 40))
+		var/obj/item/stack/rods/two/new_item = new(user.loc)
+		balloon_alert(user, "crafting rods...")
+		user.visible_message(
+			span_notice("[user.name] shaped [src] into floor rods with [tool]."),
+			blind_message = span_hear("You hear welding."),
+			vision_distance = COMBAT_MESSAGE_RANGE,
+			ignored_mobs = user
+		)
+		var/obj/item/stack/rods/welded_sheet = src
+		welded_sheet.use(1)
+		user.put_in_inactive_hand(new_item)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
-/obj/item/stack/sheet/iron/attackby_secondary(obj/item/attackby_item, mob/user, params)
-	if(attackby_item.tool_behaviour == TOOL_WELDER)
-		if(attackby_item.use_tool(src, user, 0, volume = 40))
-			var/obj/item/stack/tile/iron/four/new_item = new(user.loc)
-			balloon_alert(user, "crafting tiles...")
-			user.visible_message(
-				span_notice("[user.name] shaped [src] into floor tiles with [attackby_item]."),
-				blind_message = span_hear("You hear welding."),
-				vision_distance = COMBAT_MESSAGE_RANGE,
-				ignored_mobs = user
-			)
-			var/obj/item/stack/sheet/iron/welded_sheet = src
-			src = null
-			welded_sheet.use(1)
-			user.put_in_inactive_hand(new_item)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-	return SECONDARY_ATTACK_CONTINUE_CHAIN
+/obj/item/stack/sheet/iron/welder_act_secondary(mob/living/user, obj/item/tool)
+	if(tool.use_tool(src, user, delay = 0, volume = 40))
+		var/obj/item/stack/tile/iron/four/new_item = new(user.loc)
+		balloon_alert(user, "crafting tiles...")
+		user.visible_message(
+			span_notice("[user.name] shaped [src] into floor tiles with [tool]."),
+			blind_message = span_hear("You hear welding."),
+			vision_distance = COMBAT_MESSAGE_RANGE,
+			ignored_mobs = user
+		)
+		var/obj/item/stack/sheet/iron/welded_sheet = src
+		welded_sheet.use(1)
+		user.put_in_inactive_hand(new_item)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/sheet/iron/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
 	if(istype(target, /turf/open))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -196,7 +196,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 		var/obj/item/stack/rods/welded_sheet = src
 		welded_sheet.use(1)
 		user.put_in_inactive_hand(new_item)
-	return TOOL_ACT_TOOLTYPE_SUCCESS
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/sheet/iron/welder_act_secondary(mob/living/user, obj/item/tool)
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
@@ -211,7 +211,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 		var/obj/item/stack/sheet/iron/welded_sheet = src
 		welded_sheet.use(1)
 		user.put_in_inactive_hand(new_item)
-	return TOOL_ACT_TOOLTYPE_SUCCESS
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/sheet/iron/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
 	if(istype(target, /turf/open))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -185,33 +185,37 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 
 /obj/item/stack/sheet/iron/attackby(obj/item/attackby_item, mob/user, params)
 	if(attackby_item.tool_behaviour == TOOL_WELDER)
-		if(attackby_item.use_tool(src, user, 0, volume=40))
+		if(attackby_item.use_tool(src, user, 0, volume = 40))
 			var/obj/item/stack/rods/two/new_item = new(usr.loc)
-			user.visible_message(span_notice("[user.name] shaped [src] into iron sheets with [attackby_item]."), \
-				span_notice("You shape [src] into iron sheets with [attackby_item]."), \
-				span_hear("You hear welding."))
+			balloon_alert(user, "crafting rods...")
+			user.visible_message(
+				span_notice("[user.name] shaped [src] into floor rods with [attackby_item]."),
+				blind_message = span_hear("You hear welding."),
+				vision_distance = COMBAT_MESSAGE_RANGE,
+				ignored_mobs = user
+			)
 			var/obj/item/stack/rods/welded_sheet = src
 			src = null
-			var/replace = (user.get_inactive_held_item()==welded_sheet)
 			welded_sheet.use(1)
-			if (!welded_sheet && replace)
-				user.put_in_hands(new_item)
+			user.put_in_inactive_hand(new_item)
 	else
 		return ..()
 
 /obj/item/stack/sheet/iron/attackby_secondary(obj/item/attackby_item, mob/user, params)
 	if(attackby_item.tool_behaviour == TOOL_WELDER)
-		if(attackby_item.use_tool(src, user, 0, volume=40))
+		if(attackby_item.use_tool(src, user, 0, volume = 40))
 			var/obj/item/stack/tile/iron/four/new_item = new(user.loc)
-			user.visible_message(span_notice("[user] shaped [src] into [new_item] with [attackby_item]."), \
-				span_notice("You shaped [src] into [new_item] with [attackby_item]."), \
-				span_hear("You hear welding."))
+			balloon_alert(user, "crafting tiles...")
+			user.visible_message(
+				span_notice("[user.name] shaped [src] into floor tiles with [attackby_item]."),
+				blind_message = span_hear("You hear welding."),
+				vision_distance = COMBAT_MESSAGE_RANGE,
+				ignored_mobs = user
+			)
 			var/obj/item/stack/sheet/iron/welded_sheet = src
 			src = null
-			var/replace = (user.get_inactive_held_item()==welded_sheet)
 			welded_sheet.use(1)
-			if(!welded_sheet && replace)
-				user.put_in_hands(new_item)
+			user.put_in_inactive_hand(new_item)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	return SECONDARY_ATTACK_CONTINUE_CHAIN

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -145,6 +145,16 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	cost = 500
 	source = /datum/robot_energy_storage/iron
 
+/obj/item/stack/sheet/iron/Initialize(mapload)
+	. = ..()
+	var/static/list/tool_behaviors = list(
+		TOOL_WELDER = list(
+			SCREENTIP_CONTEXT_LMB = "Craft iron rods",
+			SCREENTIP_CONTEXT_RMB = "Craft floor tiles",
+		),
+	)
+	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+
 /obj/item/stack/sheet/iron/examine(mob/user)
 	. = ..()
 	. += span_notice("You can build a wall girder (unanchored) by right clicking on an empty floor.")
@@ -172,6 +182,39 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 /obj/item/stack/sheet/iron/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins whacking [user.p_them()]self over the head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
+
+/obj/item/stack/sheet/iron/attackby(obj/item/attackby_item, mob/user, params)
+	if(attackby_item.tool_behaviour == TOOL_WELDER)
+		if(attackby_item.use_tool(src, user, 0, volume=40))
+			var/obj/item/stack/rods/two/new_item = new(usr.loc)
+			user.visible_message(span_notice("[user.name] shaped [src] into iron sheets with [attackby_item]."), \
+				span_notice("You shape [src] into iron sheets with [attackby_item]."), \
+				span_hear("You hear welding."))
+			var/obj/item/stack/rods/welded_sheet = src
+			src = null
+			var/replace = (user.get_inactive_held_item()==welded_sheet)
+			welded_sheet.use(1)
+			if (!welded_sheet && replace)
+				user.put_in_hands(new_item)
+	else
+		return ..()
+
+/obj/item/stack/sheet/iron/attackby_secondary(obj/item/attackby_item, mob/user, params)
+	if(attackby_item.tool_behaviour == TOOL_WELDER)
+		if(attackby_item.use_tool(src, user, 0, volume=40))
+			var/obj/item/stack/tile/iron/four/new_item = new(user.loc)
+			user.visible_message(span_notice("[user] shaped [src] into [new_item] with [attackby_item]."), \
+				span_notice("You shaped [src] into [new_item] with [attackby_item]."), \
+				span_hear("You hear welding."))
+			var/obj/item/stack/sheet/iron/welded_sheet = src
+			src = null
+			var/replace = (user.get_inactive_held_item()==welded_sheet)
+			welded_sheet.use(1)
+			if(!welded_sheet && replace)
+				user.put_in_hands(new_item)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/item/stack/sheet/iron/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
 	if(istype(target, /turf/open))

--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -99,48 +99,41 @@
 	)
 	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
 
-/obj/item/stack/tile/iron/attackby(obj/item/attackby_item, mob/user, params)
-	if(attackby_item.tool_behaviour == TOOL_WELDER)
-		if(get_amount() < 4)
-			balloon_alert(user, "not enough tiles!")
-			return
-		if(attackby_item.use_tool(src, user, 0, volume = 40))
-			var/obj/item/stack/sheet/iron/new_item = new(user.loc)
-			balloon_alert(user, "crafting sheets...")
-			user.visible_message(
-				span_notice("[user.name] shaped [src] into sheets with [attackby_item]."),
-				blind_message = span_hear("You hear welding."),
-				vision_distance = COMBAT_MESSAGE_RANGE,
-				ignored_mobs = user
-			)
-			var/obj/item/stack/tile/iron/welded_tile = src
-			src = null
-			welded_tile.use(4)
-			user.put_in_inactive_hand(new_item)
-	else
-		return ..()
+/obj/item/stack/tile/iron/welder_act(mob/living/user, obj/item/tool)
+	if(get_amount() < 4)
+		balloon_alert(user, "not enough tiles!")
+		return
+	if(tool.use_tool(src, user, delay = 0, volume = 40))
+		var/obj/item/stack/sheet/iron/new_item = new(user.loc)
+		balloon_alert(user, "crafting sheets...")
+		user.visible_message(
+			span_notice("[user.name] shaped [src] into sheets with [tool]."),
+			blind_message = span_hear("You hear welding."),
+			vision_distance = COMBAT_MESSAGE_RANGE,
+			ignored_mobs = user
+		)
+		var/obj/item/stack/tile/iron/welded_tile = src
+		welded_tile.use(4)
+		user.put_in_inactive_hand(new_item)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
-/obj/item/stack/tile/iron/attackby_secondary(obj/item/attackby_item, mob/user, params)
-	if(attackby_item.tool_behaviour == TOOL_WELDER)
-		if(get_amount() < 2)
-			balloon_alert(user, "not enough tiles!")
-			return
-		if(attackby_item.use_tool(src, user, 0, volume = 40))
-			var/obj/item/stack/rods/new_item = new(user.loc)
-			balloon_alert(user, "crafting rods...")
-			user.visible_message(
-				span_notice("[user.name] shaped [src] into rods with [attackby_item]."),
-				blind_message = span_hear("You hear welding."),
-				vision_distance = COMBAT_MESSAGE_RANGE,
-				ignored_mobs = user
-			)
-			var/obj/item/stack/tile/iron/welded_tile = src
-			src = null
-			welded_tile.use(2)
-			user.put_in_inactive_hand(new_item)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-	return SECONDARY_ATTACK_CONTINUE_CHAIN
+/obj/item/stack/tile/iron/welder_act_secondary(mob/living/user, obj/item/tool)
+	if(get_amount() < 2)
+		balloon_alert(user, "not enough tiles!")
+		return
+	if(tool.use_tool(src, user, delay = 0, volume = 40))
+		var/obj/item/stack/rods/new_item = new(user.loc)
+		balloon_alert(user, "crafting rods...")
+		user.visible_message(
+			span_notice("[user.name] shaped [src] into rods with [tool]."),
+			blind_message = span_hear("You hear welding."),
+			vision_distance = COMBAT_MESSAGE_RANGE,
+			ignored_mobs = user
+		)
+		var/obj/item/stack/tile/iron/welded_tile = src
+		welded_tile.use(2)
+		user.put_in_inactive_hand(new_item)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/tile/iron/base //this subtype should be used for most stuff
 	merge_type = /obj/item/stack/tile/iron/base

--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -83,22 +83,60 @@
 		/obj/item/stack/tile/iron/sepia,
 	)
 
-/obj/item/stack/tile/iron/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_WELDER)
+/obj/item/stack/tile/iron/two
+	amount = 2
+
+/obj/item/stack/tile/iron/four
+	amount = 4
+
+/obj/item/stack/tile/iron/Initialize(mapload)
+	. = ..()
+	var/static/list/tool_behaviors = list(
+		TOOL_WELDER = list(
+			SCREENTIP_CONTEXT_LMB = "Craft iron sheets",
+			SCREENTIP_CONTEXT_RMB = "Craft iron rods",
+		),
+	)
+	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+
+/obj/item/stack/tile/iron/attackby(obj/item/attackby_item, mob/user, params)
+	if(attackby_item.tool_behaviour == TOOL_WELDER)
 		if(get_amount() < 4)
 			to_chat(user, span_warning("You need at least four tiles to do this!"))
 			return
-		if(W.use_tool(src, user, 0, volume=40))
+		if(attackby_item.use_tool(src, user, 0, volume=40))
 			var/obj/item/stack/sheet/iron/new_item = new(user.loc)
-			user.visible_message(span_notice("[user] shaped [src] into [new_item] with [W]."), \
-				span_notice("You shaped [src] into [new_item] with [W]."), \
+			user.visible_message(span_notice("[user] shaped [src] into a sheet with [attackby_item]."), \
+				span_notice("You shaped [src] into a sheet with [attackby_item]."), \
 				span_hear("You hear welding."))
-			var/holding = user.is_holding(src)
-			use(4)
-			if(holding && QDELETED(src))
+			var/obj/item/stack/tile/iron/welded_tile = src
+			src = null
+			var/replace = (user.get_inactive_held_item()==welded_tile)
+			welded_tile.use(4)
+			if(!welded_tile && replace)
 				user.put_in_hands(new_item)
 	else
 		return ..()
+
+/obj/item/stack/tile/iron/attackby_secondary(obj/item/attackby_item, mob/user, params)
+	if(attackby_item.tool_behaviour == TOOL_WELDER)
+		if(get_amount() < 2)
+			to_chat(user, span_warning("You need at least two tiles to do this!"))
+			return
+		if(attackby_item.use_tool(src, user, 0, volume=40))
+			var/obj/item/stack/rods/new_item = new(user.loc)
+			user.visible_message(span_notice("[user] shaped [src] into [new_item] with [attackby_item]."), \
+				span_notice("You shaped [src] into [new_item] with [attackby_item]."), \
+				span_hear("You hear welding."))
+			var/obj/item/stack/tile/iron/welded_tile = src
+			src = null
+			var/replace = (user.get_inactive_held_item()==welded_tile)
+			welded_tile.use(2)
+			if(!welded_tile && replace)
+				user.put_in_hands(new_item)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/item/stack/tile/iron/base //this subtype should be used for most stuff
 	merge_type = /obj/item/stack/tile/iron/base

--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -102,38 +102,42 @@
 /obj/item/stack/tile/iron/attackby(obj/item/attackby_item, mob/user, params)
 	if(attackby_item.tool_behaviour == TOOL_WELDER)
 		if(get_amount() < 4)
-			to_chat(user, span_warning("You need at least four tiles to do this!"))
+			balloon_alert(user, "not enough tiles!")
 			return
-		if(attackby_item.use_tool(src, user, 0, volume=40))
+		if(attackby_item.use_tool(src, user, 0, volume = 40))
 			var/obj/item/stack/sheet/iron/new_item = new(user.loc)
-			user.visible_message(span_notice("[user] shaped [src] into a sheet with [attackby_item]."), \
-				span_notice("You shaped [src] into a sheet with [attackby_item]."), \
-				span_hear("You hear welding."))
+			balloon_alert(user, "crafting sheets...")
+			user.visible_message(
+				span_notice("[user.name] shaped [src] into sheets with [attackby_item]."),
+				blind_message = span_hear("You hear welding."),
+				vision_distance = COMBAT_MESSAGE_RANGE,
+				ignored_mobs = user
+			)
 			var/obj/item/stack/tile/iron/welded_tile = src
 			src = null
-			var/replace = (user.get_inactive_held_item()==welded_tile)
 			welded_tile.use(4)
-			if(!welded_tile && replace)
-				user.put_in_hands(new_item)
+			user.put_in_inactive_hand(new_item)
 	else
 		return ..()
 
 /obj/item/stack/tile/iron/attackby_secondary(obj/item/attackby_item, mob/user, params)
 	if(attackby_item.tool_behaviour == TOOL_WELDER)
 		if(get_amount() < 2)
-			to_chat(user, span_warning("You need at least two tiles to do this!"))
+			balloon_alert(user, "not enough tiles!")
 			return
-		if(attackby_item.use_tool(src, user, 0, volume=40))
+		if(attackby_item.use_tool(src, user, 0, volume = 40))
 			var/obj/item/stack/rods/new_item = new(user.loc)
-			user.visible_message(span_notice("[user] shaped [src] into [new_item] with [attackby_item]."), \
-				span_notice("You shaped [src] into [new_item] with [attackby_item]."), \
-				span_hear("You hear welding."))
+			balloon_alert(user, "crafting rods...")
+			user.visible_message(
+				span_notice("[user.name] shaped [src] into rods with [attackby_item]."),
+				blind_message = span_hear("You hear welding."),
+				vision_distance = COMBAT_MESSAGE_RANGE,
+				ignored_mobs = user
+			)
 			var/obj/item/stack/tile/iron/welded_tile = src
 			src = null
-			var/replace = (user.get_inactive_held_item()==welded_tile)
 			welded_tile.use(2)
-			if(!welded_tile && replace)
-				user.put_in_hands(new_item)
+			user.put_in_inactive_hand(new_item)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	return SECONDARY_ATTACK_CONTINUE_CHAIN

--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -115,7 +115,7 @@
 		var/obj/item/stack/tile/iron/welded_tile = src
 		welded_tile.use(4)
 		user.put_in_inactive_hand(new_item)
-	return TOOL_ACT_TOOLTYPE_SUCCESS
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/tile/iron/welder_act_secondary(mob/living/user, obj/item/tool)
 	if(get_amount() < 2)
@@ -133,7 +133,7 @@
 		var/obj/item/stack/tile/iron/welded_tile = src
 		welded_tile.use(2)
 		user.put_in_inactive_hand(new_item)
-	return TOOL_ACT_TOOLTYPE_SUCCESS
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/tile/iron/base //this subtype should be used for most stuff
 	merge_type = /obj/item/stack/tile/iron/base

--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -105,15 +105,13 @@
 		return
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
 		var/obj/item/stack/sheet/iron/new_item = new(user.loc)
-		balloon_alert(user, "crafting sheets...")
 		user.visible_message(
 			span_notice("[user.name] shaped [src] into sheets with [tool]."),
 			blind_message = span_hear("You hear welding."),
 			vision_distance = COMBAT_MESSAGE_RANGE,
 			ignored_mobs = user
 		)
-		var/obj/item/stack/tile/iron/welded_tile = src
-		welded_tile.use(4)
+		use(4)
 		user.put_in_inactive_hand(new_item)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
@@ -123,15 +121,13 @@
 		return
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
 		var/obj/item/stack/rods/new_item = new(user.loc)
-		balloon_alert(user, "crafting rods...")
 		user.visible_message(
 			span_notice("[user.name] shaped [src] into rods with [tool]."),
 			blind_message = span_hear("You hear welding."),
 			vision_distance = COMBAT_MESSAGE_RANGE,
 			ignored_mobs = user
 		)
-		var/obj/item/stack/tile/iron/welded_tile = src
-		welded_tile.use(2)
+		use(2)
 		user.put_in_inactive_hand(new_item)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds a new way to craft these 3 items without having to open the crafting menu by using a welder on them with left or right clicks.

Rods: Left click is the old behavior of crafting them back into sheets, right click turns them into floor tiles.
Floor tiles: Left click goes back to sheets, right click craft rods.
Iron sheets: Left click craft rods, right click craft floor tiles

They have contextual screen tips and balloon alerts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I keep seeing people complain about engineers not being able to fix breaches efficiently without RCDs and to a certain point they are right.
Fixing rooms without a RCD sucks, even for me and I hate RCDs.

We have 2 options:
Foam grenades to quickly patch the room, in theory, in practice it is a slow process because engineers only have access to the "smart" version of foam grenades that leave the room open. A noop trap considering that metal foam can't fix breaches under solid objects like consoles and lockers.
Manual construction with rods and metal tiles, it is not only slower but it hogs all your backpack as you need to carry rods, tiles and metal, then keep swapping between each of them and using the crafting menu if more are needed.

There is a third option that is the RAT and I did stop working on this when the Forklift PR was open, now that it was closed I decided to come back and possibly try other changes to improve our base construction system while we wait.

Now with this idea of "welder crafting" you can keep metal sheets (or rods/floor tiles) on your backpack and just click on it with a welder to smoothly make rods and floor tiles with left/right click as you need them without dealing with a huge TGUI crafting menu blocking a third of your screen.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
qol: You can now "welder craft" iron sheets/rods/floor tiles by Left or Right clicking one of these items with a welder. It will craft one of the other two options depending on the Left/Right click. There is a contextual screen tip too so just hover over them with a welder for details on the results.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
