### PR TITLE
Butcher's meathook is no longer restricted by TRAIT_NOGUNS

### DIFF
--- a/code/modules/projectiles/guns/special/meat_hook.dm
+++ b/code/modules/projectiles/guns/special/meat_hook.dm
@@ -18,6 +18,9 @@
 /obj/item/gun/magic/hook/shoot_with_empty_chamber(mob/living/user)
 	to_chat(user, span_warning("[src] isn't ready to fire yet!"))
 
+/obj/item/gun/magic/hook/can_trigger_gun(mob/living/user) // This isn't really a gun, so it shouldn't be checking for TRAIT_NOGUNS, a firing pin (pinless), or a trigger guard (guardless)
+	return TRUE
+
 /obj/item/ammo_casing/magic/hook
 	name = "hook"
 	desc = "A hook."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Well, it's not a gun, so I don't think it makes sense to push it under the NOGUNS umbrella

## Why It's Good For The Game
I tried to use the hook while unable to fire guns, and realized I couldn't, which seemed if not a bug, at least an oversight
Unsure if balance or fix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Butcher's meat hook no longer fails when the user has TRAIT_NOGUNS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
