### PR TITLE
fixes verbs not actually queuing. 

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -20,7 +20,7 @@
 ///creates a running average of "things elapsed" per time period when you need to count via a smaller time period.
 ///eg you want an average number of things happening per second but you measure the event every tick (50 milliseconds).
 ///make sure both time intervals are in the same units. doesnt work if current_duration > total_duration or if total_duration == 0
-#define MC_AVG_OVER_TIME(average, current, total_duration, current_duration) (((total_duration - current_duration) / (total_duration)) * (average) + (current))
+#define MC_AVG_OVER_TIME(average, current, total_duration, current_duration) ((((total_duration) - (current_duration)) / (total_duration)) * (average) + (current))
 
 #define MC_AVG_MINUTES(average, current, current_duration) (MC_AVG_OVER_TIME(average, current, 1 MINUTES, current_duration))
 

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -65,9 +65,16 @@ VERB_MANAGER_SUBSYSTEM_DEF(input)
 	if(usr)
 		Click(location, control, params)
 
-
 /datum/controller/subsystem/verb_manager/input/fire()
+	..()
+
 	var/moves_this_run = 0
+	for(var/mob/user in GLOB.keyloop_list)
+		moves_this_run += user.focus?.keyLoop(user.client)//only increments if a player moves due to their own input
+
+	movements_per_second = MC_AVG_SECONDS(movements_per_second, moves_this_run, wait TICKS)
+
+/datum/controller/subsystem/verb_manager/input/run_verb_queue()
 	var/deferred_clicks_this_run = 0 //acts like current_clicks but doesnt count clicks that dont get processed by SSinput
 
 	for(var/datum/callback/verb_callback/queued_click as anything in verb_queue)
@@ -83,16 +90,11 @@ VERB_MANAGER_SUBSYSTEM_DEF(input)
 
 	verb_queue.Cut() //is ran all the way through every run, no exceptions
 
-	for(var/mob/user in GLOB.keyloop_list)
-		moves_this_run += user.focus?.keyLoop(user.client)//only increments if a player changes their movement input from the last tick
-
-	clicks_per_second = MC_AVG_SECONDS(clicks_per_second, current_clicks, wait TICKS)
-	delayed_clicks_per_second = MC_AVG_SECONDS(delayed_clicks_per_second, deferred_clicks_this_run, wait TICKS)
-	movements_per_second = MC_AVG_SECONDS(movements_per_second, moves_this_run, wait TICKS)
-
+	clicks_per_second = MC_AVG_SECONDS(clicks_per_second, current_clicks, wait SECONDS)
+	delayed_clicks_per_second = MC_AVG_SECONDS(delayed_clicks_per_second, deferred_clicks_this_run, wait SECONDS)
 	current_clicks = 0
 
 /datum/controller/subsystem/verb_manager/input/stat_entry(msg)
 	. = ..()
-	. += "M/S:[round(movements_per_second,0.01)] | C/S:[round(clicks_per_second,0.01)]([round(delayed_clicks_per_second,0.01)] | CD: [round(average_click_delay,0.01)])"
+	. += "M/S:[round(movements_per_second,0.01)] | C/S:[round(clicks_per_second,0.01)] ([round(delayed_clicks_per_second,0.01)] | CD: [round(average_click_delay,0.01)])"
 

--- a/code/controllers/subsystem/verb_manager.dm
+++ b/code/controllers/subsystem/verb_manager.dm
@@ -91,6 +91,7 @@ SUBSYSTEM_DEF(verb_manager)
 		return TRUE
 
 	if(usr.client?.holder && !can_queue_admin_verbs \
+	|| (!initialized && !(flags & SS_NO_INIT)) \
 	|| FOR_ADMINS_IF_VERBS_FUCKED_immediately_execute_all_verbs \
 	|| !(runlevels & Master.current_runlevel))
 		return FALSE

--- a/code/controllers/subsystem/verb_manager.dm
+++ b/code/controllers/subsystem/verb_manager.dm
@@ -30,13 +30,6 @@ SUBSYSTEM_DEF(verb_manager)
 	///this list is ran through every tick, and the subsystem does not yield until this queue is finished.
 	var/list/datum/callback/verb_callback/verb_queue = list()
 
-	///what REALTIMEOFDAY we last cleared the verb queue. used for stat info
-	var/last_verb_run_realtime = 0
-	///what world.time we last cleared the verb queue. used for stat info
-	var/last_verb_run_worldtime = 0
-	///what world.tick_usage we last cleared the verb queue. used for stat info
-	var/last_verb_run_starting_tick_usage = 0
-
 	///running average of how many verb callbacks are executed every second. used for the stat entry
 	var/verbs_executed_per_second = 0
 
@@ -136,11 +129,6 @@ SUBSYSTEM_DEF(verb_manager)
 /// runs through all of this subsystems queue of verb callbacks.
 /// goes through the entire verb queue without yielding.
 /// used so you can flush the queue outside of fire() without interfering with anything else subtype subsystems might do in fire().
-///
-/// ---DO NOT CALL OUTSIDE OF execute_verbs()!---
-/// - otherwise timing data will not be set!
-///
-/// delta_seconds - amount of time since this was last called in seconds. this is real time and not based on wait.
 /datum/controller/subsystem/verb_manager/proc/run_verb_queue()
 	var/executed_verbs = 0
 

--- a/code/modules/unit_tests/resist.dm
+++ b/code/modules/unit_tests/resist.dm
@@ -12,6 +12,11 @@
 	// Stop, drop, and roll has a sleep call. This would delay the test, and is not necessary.
 	call_async(human, /mob/living/verb/resist)
 
+	//since resist() is a verb that possibly queues its actual execution for the next tick, we need to make the subsystem that handles the delayed execution process
+	//the callback. either that or sleep ourselves and see if it ran.
+	if(human.fire_stacks > 5)
+		SSverb_manager.fire()
+
 	TEST_ASSERT(human.fire_stacks < 5, "Human did not lower fire stacks after resisting")
 
 /// Test that you can resist out of a container
@@ -26,4 +31,10 @@
 	TEST_ASSERT(human in closet.contents, "Human was not in the contents of the closed closet")
 
 	human.resist()
+
+	//since resist() is a verb that possibly queues itself for the next tick, we need to make the subsystem that handles the delayed execution process
+	//the callback. either that or sleep ourselves and see if it ran.
+	if(human in closet.contents)
+		SSverb_manager.fire()
+
 	TEST_ASSERT(!(human in closet.contents), "Human resisted out of a standard closet, but was still in it")

--- a/code/modules/unit_tests/resist.dm
+++ b/code/modules/unit_tests/resist.dm
@@ -14,7 +14,7 @@
 
 	//since resist() is a verb that possibly queues its actual execution for the next tick, we need to make the subsystem that handles the delayed execution process
 	//the callback. either that or sleep ourselves and see if it ran.
-	SSverb_manager.fire()
+	SSverb_manager.run_verb_queue()
 
 	TEST_ASSERT(human.fire_stacks < 5, "Human did not lower fire stacks after resisting")
 
@@ -33,6 +33,6 @@
 
 	//since resist() is a verb that possibly queues itself for the next tick, we need to make the subsystem that handles the delayed execution process
 	//the callback. either that or sleep ourselves and see if it ran.
-	SSverb_manager.fire()
+	SSverb_manager.run_verb_queue()
 
 	TEST_ASSERT(!(human in closet.contents), "Human resisted out of a standard closet, but was still in it")

--- a/code/modules/unit_tests/resist.dm
+++ b/code/modules/unit_tests/resist.dm
@@ -14,8 +14,7 @@
 
 	//since resist() is a verb that possibly queues its actual execution for the next tick, we need to make the subsystem that handles the delayed execution process
 	//the callback. either that or sleep ourselves and see if it ran.
-	if(human.fire_stacks > 5)
-		SSverb_manager.fire()
+	SSverb_manager.fire()
 
 	TEST_ASSERT(human.fire_stacks < 5, "Human did not lower fire stacks after resisting")
 
@@ -34,7 +33,6 @@
 
 	//since resist() is a verb that possibly queues itself for the next tick, we need to make the subsystem that handles the delayed execution process
 	//the callback. either that or sleep ourselves and see if it ran.
-	if(human in closet.contents)
-		SSverb_manager.fire()
+	SSverb_manager.fire()
 
 	TEST_ASSERT(!(human in closet.contents), "Human resisted out of a standard closet, but was still in it")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
thanks to Vallat for pointing this out 

whoops turns out most verbs havent been queued since may 11th because I made /datum/controller/subsystem/verb_manager have the SS_NO_INIT flag, without also removing a check in verb_manager/proc/can_queue_verb() that stops the verb callback from being queued if the subsystem isnt initialized yet. since subsystems with SS_NO_INIT obviously never have initialized set to TRUE, this always failed for every verb manager subsystem except for SSinput (because it doesnt have SS_NO_INIT). 

also adds a debug var to force a subsystem to always queue incoming verbs if possible.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
now the default verb management subsystem, and speech_controller will successfully queue verbs again. SSinput always queued verbs so that shouldnt change.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: makes verb queuing work again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
