### PR TITLE
adds a waste pipe to Icebox atmos

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4506,6 +4506,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "bti" = (


### PR DESCRIPTION
## About The Pull Request

Icebox's atmos was missing a waste pipe under the maint door connecting a scrubber.

Under this airlock
![image](https://user-images.githubusercontent.com/53777086/183010031-a970feec-d781-409f-b32b-94fdc71daec1.png)

## Why It's Good For The Game

The scrubber in atmos will be connected to the waste pipe now.

## Changelog

:cl:
fix: The air scrubber in atmos near the northern maintenance airlock is now connected to waste.
/:cl: