### PR TITLE
Removes the "proximity crew pinpointer" (the ones parameds spawn with), paramedic PDAs start with the lifeline app instead

### DIFF
--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -162,28 +162,6 @@
 	if(!target) //target can be set to null from above code, or elsewhere
 		active = FALSE
 
-/obj/item/pinpointer/crew/prox //Weaker version of crew monitor primarily for EMT
-	name = "proximity crew pinpointer"
-	desc = "A handheld tracking device that displays its proximity to crew suit sensors."
-	icon_state = "pinpointer_crewprox"
-	worn_icon_state = "pinpointer_prox"
-	custom_price = PAYCHECK_CREW * 3
-
-/obj/item/pinpointer/crew/prox/get_direction_icon(here, there)
-	var/size = ""
-	if(here == there)
-		size = "small"
-	else
-		switch(get_dist(here, there))
-			if(1 to 4)
-				size = "xtrlarge"
-			if(5 to 16)
-				size = "large"
-			//17 through 28 use the normal pinion, "pinondirect"
-			if(29 to INFINITY)
-				size = "small"
-	return "pinondirect[size]"
-
 /obj/item/pinpointer/pair
 	name = "pair pinpointer"
 	desc = "A handheld tracking device that locks onto its other half of the matching pair."

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -270,8 +270,8 @@
 	SSwardrobe.provide_type(/obj/item/stack/medical/gauze/twelve, src)
 	SSwardrobe.provide_type(/obj/item/stack/medical/bone_gel, src)
 	SSwardrobe.provide_type(/obj/item/stack/sticky_tape/surgical, src)
-	SSwardrobe.provide_type(/obj/item/bonesetter, src)
 	SSwardrobe.provide_type(/obj/item/reagent_containers/syringe, src)
+	SSwardrobe.provide_type(/obj/item/reagent_containers/glass/bottle/calomel, src)
 	SSwardrobe.provide_type(/obj/item/reagent_containers/glass/bottle/formaldehyde, src)
 	update_appearance()
 
@@ -281,8 +281,8 @@
 	to_preload += /obj/item/stack/medical/gauze/twelve
 	to_preload += /obj/item/stack/medical/bone_gel
 	to_preload += /obj/item/stack/sticky_tape/surgical
-	to_preload += /obj/item/bonesetter
 	to_preload += /obj/item/reagent_containers/syringe
+	to_preload += /obj/item/reagent_containers/glass/bottle/calomel
 	to_preload += /obj/item/reagent_containers/glass/bottle/formaldehyde
 	return to_preload
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -268,9 +268,10 @@
 /obj/item/storage/belt/medical/paramedic/PopulateContents()
 	SSwardrobe.provide_type(/obj/item/sensor_device, src)
 	SSwardrobe.provide_type(/obj/item/stack/medical/gauze/twelve, src)
-	SSwardrobe.provide_type(/obj/item/reagent_containers/syringe, src)
 	SSwardrobe.provide_type(/obj/item/stack/medical/bone_gel, src)
 	SSwardrobe.provide_type(/obj/item/stack/sticky_tape/surgical, src)
+	SSwardrobe.provide_type(/obj/item/bonesetter, src)
+	SSwardrobe.provide_type(/obj/item/reagent_containers/syringe, src)
 	SSwardrobe.provide_type(/obj/item/reagent_containers/glass/bottle/formaldehyde, src)
 	update_appearance()
 
@@ -278,9 +279,10 @@
 	var/list/to_preload = list() //Yes this is a pain. Yes this is the point
 	to_preload += /obj/item/sensor_device
 	to_preload += /obj/item/stack/medical/gauze/twelve
-	to_preload += /obj/item/reagent_containers/syringe
 	to_preload += /obj/item/stack/medical/bone_gel
 	to_preload += /obj/item/stack/sticky_tape/surgical
+	to_preload += /obj/item/bonesetter
+	to_preload += /obj/item/reagent_containers/syringe
 	to_preload += /obj/item/reagent_containers/glass/bottle/formaldehyde
 	return to_preload
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -267,7 +267,6 @@
 
 /obj/item/storage/belt/medical/paramedic/PopulateContents()
 	SSwardrobe.provide_type(/obj/item/sensor_device, src)
-	SSwardrobe.provide_type(/obj/item/pinpointer/crew/prox, src)
 	SSwardrobe.provide_type(/obj/item/stack/medical/gauze/twelve, src)
 	SSwardrobe.provide_type(/obj/item/reagent_containers/syringe, src)
 	SSwardrobe.provide_type(/obj/item/stack/medical/bone_gel, src)
@@ -278,7 +277,6 @@
 /obj/item/storage/belt/medical/paramedic/get_types_to_preload()
 	var/list/to_preload = list() //Yes this is a pain. Yes this is the point
 	to_preload += /obj/item/sensor_device
-	to_preload += /obj/item/pinpointer/crew/prox
 	to_preload += /obj/item/stack/medical/gauze/twelve
 	to_preload += /obj/item/reagent_containers/syringe
 	to_preload += /obj/item/stack/medical/bone_gel

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -55,7 +55,7 @@
 	head = /obj/item/clothing/head/soft/paramedic
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile
 	shoes = /obj/item/clothing/shoes/sneakers/blue
-	l_pocket = /obj/item/modular_computer/tablet/pda/medical
+	l_pocket = /obj/item/modular_computer/tablet/pda/medical/paramedic
 
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -224,6 +224,14 @@
 		/datum/computer_file/program/robocontrol,
 	)
 
+/obj/item/modular_computer/tablet/pda/medical/paramedic
+	name = "paramedic PDA"
+	default_applications = list(
+		/datum/computer_file/program/phys_scanner/medical,
+		/datum/computer_file/program/records/medical,
+		/datum/computer_file/program/radar/lifeline,
+	)
+
 /obj/item/modular_computer/tablet/pda/viro
 	name = "virology PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_split
@@ -383,4 +391,3 @@
 	icon_state = "pda-clear"
 	greyscale_config = null
 	greyscale_colors = null
-

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -140,16 +140,6 @@
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/crewpinpointerprox
-	name = "Proximity Crew Pinpointer"
-	desc = "Displays your approximate proximity to someone if their suit sensors are turned to tracking beacon."
-	id = "crewpinpointerprox"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 1200, /datum/material/glass = 300, /datum/material/gold = 200)
-	build_path = /obj/item/pinpointer/crew/prox
-	category = list("Medical Designs")
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
-
 /datum/design/defibrillator
 	name = "Defibrillator"
 	desc = "A portable defibrillator, used for resuscitating recently deceased crew."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -322,7 +322,6 @@
 		"chem_mass_spec",
 		"chem_master",
 		"chem_pack",
-		"crewpinpointerprox",
 		"defibmount",
 		"defibrillator",
 		"genescanner",


### PR DESCRIPTION
## About The Pull Request

- Removes the proximity crew pinpointer. 
- Paramedic PDAs now start with the lifeline app instead
- Replaced the empty spot in their belt with a bottle of Calomel

## Why It's Good For The Game

- Removes the proximity crew pinpointer. 
  - This pinpointer was fairly useless and also unintuitive. Did you know that the circle grew SMALLER the FURTHER you were from your target, and LARGER the CLOSER? I sure didn't until reading the code. It also goes back to being the smallest circle if you are on the same turf as the target. 
  - When's the last time you've seen a paramedic not throw away the pinpointer roundstart?
  - There are still valid arguments to be said about keeping the proximity pinpointer as "backup pinpointers", and fixing their untuitiveness, for situations in which you somehow lose your PDA and also can't print a real pinpointer. I'm still undecided on the full removal vs just removal from the paramedic kit. I'll see based on response to this PR
- Paramedic PDAs now start with the Lifeline app instead
  - Prior to the PDA rework, there was still a good argument to keep the prox pinpointer, as the only way to get a Lifeline app was to buy a modular tablet. But now, since everyone starts with one as their PDA, there is 0 reason not to just install the pinpointer app and use it instead of the prox pinpointer.
- Replaced the empty spot in their belt with ~~a bonesetter~~ a bottle of Calomel
   - I figured it'd be awkward to leave a spot empty, so I replaced it with ~~a bonesetter~~ a bottle of Calomel. 

## Changelog

:cl: Melbert
add: Paramedic PDAs now start with the Lifeline pinpointer app
add: Replaced the "proximity crew pinpointer" in the paramedic's belt with a bottle of Calomel
del: Removed the "proximity crew pinpointer"
/:cl:
