### PR TITLE
Ambience buzzing no longer refreshes when you move into areas with the same buzzing sound

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -424,7 +424,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		return
 
 	if(ambient_buzz != old_area.ambient_buzz)
-		L.refresh_looping_ambience(old_area)
+		L.refresh_looping_ambience()
 
 ///Tries to play looping ambience to the mobs.
 /mob/proc/refresh_looping_ambience()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -423,9 +423,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if(!L.ckey)
 		return
 
-	if(old_area)
-		L.UnregisterSignal(old_area, COMSIG_AREA_POWER_CHANGE)
-
 	if(ambient_buzz != old_area.ambient_buzz)
 		L.refresh_looping_ambience(old_area)
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -425,8 +425,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 	if(old_area)
 		L.UnregisterSignal(old_area, COMSIG_AREA_POWER_CHANGE)
-	L.RegisterSignal(src, COMSIG_AREA_POWER_CHANGE, /mob/proc/refresh_looping_ambience)
-	L.refresh_looping_ambience()
+
+	if(ambient_buzz != old_area.ambient_buzz)
+		L.refresh_looping_ambience(old_area)
 
 ///Tries to play looping ambience to the mobs.
 /mob/proc/refresh_looping_ambience()


### PR DESCRIPTION
## About The Pull Request

Currently if you move between areas with the same buzzing ambience, the buzz will reset. The code now checks if it should do that beforehand.

I also removed a signal that isn't needed anymore because of the changes in #68375

fixes #68747

## Why It's Good For The Game

sounds less grating!

## Changelog
:cl: Capybara Holly
fix: ambience buzzing no longer resets if you move between areas that share a buzz (e.g. maintenance areas)
/:cl: