### PR TITLE
Ambience no longer uses reverb

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(ambience)
 	var/turf/T = get_turf(M)
 
 	var/sound/new_sound = override_sound || pick(ambientsounds)
-	new_sound = sound(new_sound, repeat = 0, wait = 0, volume = volume ? volume : 25, channel = CHANNEL_AMBIENCE)
+	new_sound = sound(new_sound, repeat = 0, wait = 0, volume = volume, channel = CHANNEL_AMBIENCE)
 	SEND_SOUND(M, new_sound)
 
 	return rand(min_ambience_cooldown, max_ambience_cooldown)

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -51,15 +51,10 @@ SUBSYSTEM_DEF(ambience)
 ///Attempts to play an ambient sound to a mob, returning the cooldown in deciseconds
 /area/proc/play_ambience(mob/M, sound/override_sound, volume = 27)
 	var/turf/T = get_turf(M)
+
 	var/sound/new_sound = override_sound || pick(ambientsounds)
 	new_sound = sound(new_sound, channel = CHANNEL_AMBIENCE)
-	M.playsound_local(
-		T,
-		new_sound,
-		volume,
-		FALSE,
-		channel = CHANNEL_AMBIENCE
-	)
+	SEND_SOUND(M, new_sound)
 
 	return rand(min_ambience_cooldown, max_ambience_cooldown)
 

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -50,8 +50,6 @@ SUBSYSTEM_DEF(ambience)
 
 ///Attempts to play an ambient sound to a mob, returning the cooldown in deciseconds
 /area/proc/play_ambience(mob/M, sound/override_sound, volume = 27)
-	var/turf/T = get_turf(M)
-
 	var/sound/new_sound = override_sound || pick(ambientsounds)
 	new_sound = sound(new_sound, repeat = 0, wait = 0, volume = volume, channel = CHANNEL_AMBIENCE)
 	SEND_SOUND(M, new_sound)

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(ambience)
 	var/turf/T = get_turf(M)
 
 	var/sound/new_sound = override_sound || pick(ambientsounds)
-	new_sound = sound(new_sound, channel = CHANNEL_AMBIENCE)
+	new_sound = sound(new_sound, repeat = 0, wait = 0, volume = volume ? volume : 25, channel = CHANNEL_AMBIENCE)
 	SEND_SOUND(M, new_sound)
 
 	return rand(min_ambience_cooldown, max_ambience_cooldown)


### PR DESCRIPTION
## About The Pull Request

Removes the reverb that's applied on top of ambience, as most ambience has reverb in the sound itself. This made things like the chapel ambience sound bad. This reverb wasn't applied before, but at some point someone changed that and I don't think its been an improvement.

## Why It's Good For The Game

This PR will make ambience like the one found in the Chapel no longer sound like it was recorded in a quarrysite.

https://www.veed.io/view/489f97ff-29ee-47ce-be33-96287d78be07 

## Changelog

:cl:
soundadd: Ambience no longer uses reverb, as the sound files for ambience already has reverb as needed usually!
/:cl:

