### PR TITLE
Moves some more dynamic logs to dynamic.log

### DIFF
--- a/code/__HELPERS/logging/dynamic.dm
+++ b/code/__HELPERS/logging/dynamic.dm
@@ -1,3 +1,8 @@
+/// Log to dynamic and message admins
+/datum/game_mode/dynamic/proc/log_dynamic_and_announce(text)
+	message_admins("DYNAMIC: [text]")
+	log_dynamic("[text]")
+
 /// Logging for dynamic procs
 /proc/log_dynamic(text)
 	WRITE_LOG(GLOB.dynamic_log, "DYNAMIC: [text]")

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -768,11 +768,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if (20 to INFINITY)
 			return rand(90, 100)
 
-/// Log to messages and to the game
-/datum/game_mode/dynamic/proc/dynamic_log(text)
-	message_admins("DYNAMIC: [text]")
-	log_dynamic("[text]")
-
 #undef FAKE_REPORT_CHANCE
 #undef FAKE_GREENSHIFT_FORM_CHANCE
 #undef REPORT_NEG_DIVERGENCE

--- a/code/game/gamemodes/dynamic/dynamic_hijacking.dm
+++ b/code/game/gamemodes/dynamic/dynamic_hijacking.dm
@@ -7,7 +7,7 @@
 		return
 
 	if (random_event_hijacked != HIJACKED_NOTHING)
-		dynamic_log("Random event [round_event_control.name] tried to roll, but Dynamic vetoed it (random event has already ran).")
+		log_dynamic_and_announce("Random event [round_event_control.name] tried to roll, but Dynamic vetoed it (random event has already ran).")
 		SSevents.spawnEvent()
 		SSevents.reschedule()
 		return CANCEL_PRE_RANDOM_EVENT
@@ -16,10 +16,10 @@
 
 	if (world.time - last_midround_injection_attempt < time_range)
 		random_event_hijacked = HIJACKED_TOO_RECENT
-		dynamic_log("Random event [round_event_control.name] tried to roll, but the last midround injection \
+		log_dynamic_and_announce("Random event [round_event_control.name] tried to roll, but the last midround injection \
 			was too recent. Heavy injection chance has been raised to [get_heavy_midround_injection_chance(dry_run = TRUE)]%.")
 		return CANCEL_PRE_RANDOM_EVENT
 
 	if (next_midround_injection() - world.time < time_range)
-		dynamic_log("Random event [round_event_control.name] tried to roll, but the next midround injection is too soon.")
+		log_dynamic_and_announce("Random event [round_event_control.name] tried to roll, but the next midround injection is too soon.")
 		return CANCEL_PRE_RANDOM_EVENT

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -32,7 +32,7 @@
 	next_midround_injection = null
 	forced_injection = FALSE
 
-	dynamic_log("A midround ruleset is rolling, and will be [spawn_heavy ? "HEAVY" : "LIGHT"].")
+	log_dynamic_and_announce("A midround ruleset is rolling, and will be [spawn_heavy ? "HEAVY" : "LIGHT"].")
 
 	random_event_hijacked = HIJACKED_NOTHING
 
@@ -41,29 +41,29 @@
 
 	for (var/datum/dynamic_ruleset/midround/ruleset in midround_rules)
 		if (ruleset.weight == 0)
-			log_game("DYNAMIC: FAIL: [ruleset] has a weight of 0")
+			log_dynamic("FAIL: [ruleset] has a weight of 0")
 			continue
 
 		if (!ruleset.acceptable(GLOB.alive_player_list.len, threat_level))
-			log_game("DYNAMIC: FAIL: [ruleset] is not acceptable with the current parameters. Alive players: [GLOB.alive_player_list.len], threat level: [threat_level]")
+			log_dynamic("FAIL: [ruleset] is not acceptable with the current parameters. Alive players: [GLOB.alive_player_list.len], threat level: [threat_level]")
 			continue
 
 		if (mid_round_budget < ruleset.cost)
-			log_game("DYNAMIC: FAIL: [ruleset] is too expensive, and cannot be bought. Midround budget: [mid_round_budget], ruleset cost: [ruleset.cost]")
+			log_dynamic("FAIL: [ruleset] is too expensive, and cannot be bought. Midround budget: [mid_round_budget], ruleset cost: [ruleset.cost]")
 			continue
 
 		if (ruleset.minimum_round_time > world.time - SSticker.round_start_time)
-			log_game("DYNAMIC: FAIL: [ruleset] is trying to run too early. Minimum round time: [ruleset.minimum_round_time], current round time: [world.time - SSticker.round_start_time]")
+			log_dynamic("FAIL: [ruleset] is trying to run too early. Minimum round time: [ruleset.minimum_round_time], current round time: [world.time - SSticker.round_start_time]")
 			continue
 
 		// If admins have disabled dynamic from picking from the ghost pool
 		if(istype(ruleset, /datum/dynamic_ruleset/midround/from_ghosts) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))
-			log_game("DYNAMIC: FAIL: [ruleset] is a from_ghosts ruleset, but ghost roles are disabled")
+			log_dynamic("FAIL: [ruleset] is a from_ghosts ruleset, but ghost roles are disabled")
 			continue
 
 		ruleset.trim_candidates()
 		if (!ruleset.ready())
-			log_game("DYNAMIC: FAIL: [ruleset] is not ready()")
+			log_dynamic("FAIL: [ruleset] is not ready()")
 			continue
 
 		var/ruleset_is_heavy = (ruleset.midround_ruleset_style == MIDROUND_RULESET_STYLE_HEAVY)
@@ -74,15 +74,15 @@
 
 	var/heavy_light_log_count = "[drafted_heavies.len] heavies / [drafted_lights.len] lights"
 
-	log_game("DYNAMIC: Rolling [spawn_heavy ? "HEAVY" : "LIGHT"]... [heavy_light_log_count]")
+	log_dynamic("Rolling [spawn_heavy ? "HEAVY" : "LIGHT"]... [heavy_light_log_count]")
 
 	if (spawn_heavy && drafted_heavies.len > 0 && pick_midround_rule(drafted_heavies, "heavy rulesets"))
 		return
 	else if (drafted_lights.len > 0 && pick_midround_rule(drafted_lights, "light rulesets"))
 		if (spawn_heavy)
-			dynamic_log("A heavy ruleset was intended to roll, but there weren't any available. [heavy_light_log_count]")
+			log_dynamic_and_announce("A heavy ruleset was intended to roll, but there weren't any available. [heavy_light_log_count]")
 	else
-		dynamic_log("No midround rulesets could be drafted. ([heavy_light_log_count])")
+		log_dynamic_and_announce("No midround rulesets could be drafted. ([heavy_light_log_count])")
 
 /// Gets the chance for a heavy ruleset midround injection, the dry_run argument is only used for forced injection.
 /datum/game_mode/dynamic/proc/get_heavy_midround_injection_chance(dry_run)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -104,15 +104,15 @@
 	indice_pop = min(requirements.len,round(population/pop_per_requirement)+1)
 
 	if(minimum_players > population)
-		log_game("DYNAMIC: FAIL: [src] failed acceptable: minimum_players ([minimum_players]) > population ([population])")
+		log_dynamic("FAIL: [src] failed acceptable: minimum_players ([minimum_players]) > population ([population])")
 		return FALSE
 
 	if(maximum_players > 0 && population > maximum_players)
-		log_game("DYNAMIC: FAIL: [src] failed acceptable: maximum_players ([maximum_players]) < population ([population])")
+		log_dynamic("FAIL: [src] failed acceptable: maximum_players ([maximum_players]) < population ([population])")
 		return FALSE
 
 	if (threat_level < requirements[indice_pop])
-		log_game("DYNAMIC: FAIL: [src] failed acceptable: threat_level ([threat_level]) < requirement ([requirements[indice_pop]])")
+		log_dynamic("FAIL: [src] failed acceptable: threat_level ([threat_level]) < requirement ([requirements[indice_pop]])")
 		return FALSE
 
 	return TRUE
@@ -189,7 +189,7 @@
 	if (required_candidates <= candidates.len)
 		return TRUE
 
-	log_game("DYNAMIC: FAIL: [src] does not have enough candidates ([required_candidates] needed, [candidates.len] found)")
+	log_dynamic("FAIL: [src] does not have enough candidates ([required_candidates] needed, [candidates.len] found)")
 	return FALSE
 
 /// Here you can remove candidates that do not meet your requirements.

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -116,9 +116,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/proc/send_applications(list/possible_volunteers = list())
 	if (possible_volunteers.len <= 0) // This shouldn't happen, as ready() should return FALSE if there is not a single valid candidate
 		message_admins("Possible volunteers was 0. This shouldn't appear, because of ready(), unless you forced it!")
-		return
-	message_admins("Polling [possible_volunteers.len] players to apply for the [name] ruleset.")
-	log_dynamic("Polling [possible_volunteers.len] players to apply for the [name] ruleset.")
+	mode.log_dynamic_and_announce("Polling [possible_volunteers.len] players to apply for the [name] ruleset.")
 
 	candidates = poll_ghost_candidates("The mode is looking for volunteers to become [antag_flag] for [name]", antag_flag_override, antag_flag || antag_flag_override, poll_time = 300)
 
@@ -128,7 +126,7 @@
 		attempt_replacement()
 		return
 
-	log_dynamic_and_announce("[candidates.len] players volunteered for [name].")
+	mode.log_dynamic_and_announce("[candidates.len] players volunteered for [name].")
 	review_applications()
 
 /// Here is where you can check if your ghost applicants are valid for the ruleset.

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -123,13 +123,12 @@
 	candidates = poll_ghost_candidates("The mode is looking for volunteers to become [antag_flag] for [name]", antag_flag_override, antag_flag || antag_flag_override, poll_time = 300)
 
 	if(!candidates || candidates.len <= 0)
-		mode.dynamic_log("The ruleset [name] received no applications.")
+		mode.log_dynamic_and_announce("The ruleset [name] received no applications.")
 		mode.executed_rules -= src
 		attempt_replacement()
 		return
 
-	message_admins("[candidates.len] players volunteered for the ruleset [name].")
-	log_dynamic("[candidates.len] players volunteered for [name].")
+	log_dynamic_and_announce("[candidates.len] players volunteered for [name].")
 	review_applications()
 
 /// Here is where you can check if your ghost applicants are valid for the ruleset.

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -47,11 +47,11 @@
 		var/datum/round_event_control/round_event_control_type = pick(unfavorable_random_events)
 		var/delay = rand(20 SECONDS, 1 MINUTES)
 
-		dynamic_log("An unfavorable situation was requested, but no heavy rulesets could be drafted. Spawning [initial(round_event_control_type.name)] in [DisplayTimeText(delay)] instead.")
+		log_dynamic_and_announce("An unfavorable situation was requested, but no heavy rulesets could be drafted. Spawning [initial(round_event_control_type.name)] in [DisplayTimeText(delay)] instead.")
 
 		var/datum/round_event_control/round_event_control = new round_event_control_type
 		addtimer(CALLBACK(round_event_control, /datum/round_event_control.proc/runEvent), delay)
 	else
 		var/datum/dynamic_ruleset/midround/heavy_ruleset = pick_weight(possible_heavies)
-		dynamic_log("An unfavorable situation was requested, spawning [initial(heavy_ruleset.name)]")
+		log_dynamic_and_announce("An unfavorable situation was requested, spawning [initial(heavy_ruleset.name)]")
 		picking_specific_rule(heavy_ruleset, forced = TRUE, ignore_cost = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When I made #68532 the intention was to put all dynamic logs into dynamic.log, but it appears I missed a few. 

Also moved dynamic_log() into the helper file for dynamic logs and gave it a more descriptive name, 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dynamic logs should all be in the same place.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Moved the rest of the dynamic logs to dynamic.log
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
