### PR TITLE
Newly built turrets start unlocked

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret_construct.dm
+++ b/code/game/machinery/porta_turret/portable_turret_construct.dm
@@ -54,7 +54,7 @@
 			else if(I.tool_behaviour == TOOL_CROWBAR && !anchored)
 				I.play_tool_sound(src, 75)
 				to_chat(user, span_notice("You dismantle the turret construction."))
-				new /obj/item/stack/sheet/iron( loc, 5)
+				new /obj/item/stack/sheet/iron(loc, 5)
 				qdel(src)
 				return
 
@@ -85,12 +85,12 @@
 				return
 
 			else if(I.tool_behaviour == TOOL_WELDER)
-				if(!I.tool_start_check(user, amount=5)) //uses up 5 fuel
+				if(!I.tool_start_check(user, amount = 5)) //uses up 5 fuel
 					return
 
 				to_chat(user, span_notice("You start to remove the turret's interior metal armor..."))
 
-				if(I.use_tool(src, user, 20, volume=50, amount=5)) //uses up 5 fuel
+				if(I.use_tool(src, user, 20, volume = 50, amount = 5)) //uses up 5 fuel
 					build_step = PTURRET_BOLTED
 					to_chat(user, span_notice("You remove the turret's interior metal armor."))
 					new /obj/item/stack/sheet/iron(drop_location(), 2)
@@ -148,11 +148,11 @@
 
 		if(PTURRET_START_EXTERNAL_ARMOUR)
 			if(I.tool_behaviour == TOOL_WELDER)
-				if(!I.tool_start_check(user, amount=5))
+				if(!I.tool_start_check(user, amount = 5))
 					return
 
 				to_chat(user, span_notice("You begin to weld the turret's armor down..."))
-				if(I.use_tool(src, user, 30, volume=50, amount=5))
+				if(I.use_tool(src, user, 30, volume = 50, amount = 5))
 					build_step = PTURRET_EXTERNAL_ARMOUR_ON
 					to_chat(user, span_notice("You weld the turret's armor down."))
 
@@ -167,6 +167,7 @@
 					turret.name = finish_name
 					turret.installation = installed_gun.type
 					turret.setup(installed_gun)
+					turret.locked = FALSE
 					qdel(src)
 					return
 

--- a/code/game/machinery/porta_turret/portable_turret_construct.dm
+++ b/code/game/machinery/porta_turret/portable_turret_construct.dm
@@ -54,7 +54,7 @@
 			else if(I.tool_behaviour == TOOL_CROWBAR && !anchored)
 				I.play_tool_sound(src, 75)
 				to_chat(user, span_notice("You dismantle the turret construction."))
-				new /obj/item/stack/sheet/iron(loc, 5)
+				new /obj/item/stack/sheet/iron( loc, 5)
 				qdel(src)
 				return
 
@@ -85,12 +85,12 @@
 				return
 
 			else if(I.tool_behaviour == TOOL_WELDER)
-				if(!I.tool_start_check(user, amount = 5)) //uses up 5 fuel
+				if(!I.tool_start_check(user, amount=5)) //uses up 5 fuel
 					return
 
 				to_chat(user, span_notice("You start to remove the turret's interior metal armor..."))
 
-				if(I.use_tool(src, user, 20, volume = 50, amount = 5)) //uses up 5 fuel
+				if(I.use_tool(src, user, 20, volume=50, amount=5)) //uses up 5 fuel
 					build_step = PTURRET_BOLTED
 					to_chat(user, span_notice("You remove the turret's interior metal armor."))
 					new /obj/item/stack/sheet/iron(drop_location(), 2)
@@ -148,11 +148,11 @@
 
 		if(PTURRET_START_EXTERNAL_ARMOUR)
 			if(I.tool_behaviour == TOOL_WELDER)
-				if(!I.tool_start_check(user, amount = 5))
+				if(!I.tool_start_check(user, amount=5))
 					return
 
 				to_chat(user, span_notice("You begin to weld the turret's armor down..."))
-				if(I.use_tool(src, user, 30, volume = 50, amount = 5))
+				if(I.use_tool(src, user, 30, volume=50, amount=5))
 					build_step = PTURRET_EXTERNAL_ARMOUR_ON
 					to_chat(user, span_notice("You weld the turret's armor down."))
 
@@ -167,7 +167,6 @@
 					turret.name = finish_name
 					turret.installation = installed_gun.type
 					turret.setup(installed_gun)
-					turret.locked = FALSE
 					qdel(src)
 					return
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -300,7 +300,7 @@
 			to_chat(user, span_warning("You can't secure [src] here."))
 			return
 		set_anchored(!anchored)
-		user.visible_message(span_notice("[user] [anchored ? null : "un"]wrenches the solar assembly into place."), span_notice("You [anchored ? null : "un"]wrench the solar assembly into place."))
+		user.visible_message(span_notice("[user] [anchored ? null : "un"]wrenches the solar assembly [anchored ? "into place" : null]."), span_notice("You [anchored ? null : "un"]wrench the solar assembly [anchored ? "into place" : null]."))
 		W.play_tool_sound(src, 75)
 		return TRUE
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -300,7 +300,7 @@
 			to_chat(user, span_warning("You can't secure [src] here."))
 			return
 		set_anchored(!anchored)
-		user.visible_message(span_notice("[user] [anchored ? null : "un"]wrenches the solar assembly [anchored ? "into place" : null]."), span_notice("You [anchored ? null : "un"]wrench the solar assembly [anchored ? "into place" : null]."))
+		user.visible_message(span_notice("[user] [anchored ? null : "un"]wrenches the solar assembly into place."), span_notice("You [anchored ? null : "un"]wrench the solar assembly into place."))
 		W.play_tool_sound(src, 75)
 		return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #67787

Sets the completed turret's "locked" var to FALSE.

Cleans up some operator spacing style.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Built machines should start unlocked in agreement with APC and air alarm design.
Clean code.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Newly built turrets start unlocked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
