### PR TITLE
Fixes calomel's description to state toxic chems

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -422,7 +422,7 @@
 
 /datum/reagent/medicine/calomel
 	name = "Calomel"
-	description = "Quickly purges the body of all chemicals. Toxin damage is dealt if the patient is in good condition."
+	description = "Quickly purges the body of toxic chemicals. Toxin damage is dealt if the patient is in good condition."
 	reagent_state = LIQUID
 	color = "#19C832"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM


### PR DESCRIPTION
## About The Pull Request

Calomel was changed to only remove toxin reagents in https://github.com/tgstation/tgstation/pull/50583 yet their description wasn't updated to match this, this fixes that.

## Why It's Good For The Game

Small fix to better explain what the chemical does.

## Changelog

:cl:
spellcheck: Calomel now properly states that it only purges toxins, rather than all chemicals, like it already does.
/:cl: