### PR TITLE
Fixes improper locker type on Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -71503,7 +71503,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "wbf" = (
-/obj/structure/closet/decay,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "wbk" = (


### PR DESCRIPTION
## About The Pull Request
![feex](https://user-images.githubusercontent.com/105393050/183239817-77f8ac22-5b10-448b-b5aa-0b19a5c48556.png)
/obj/structure/closet/decay is from some wizard magic, and has an auto_destroy variable so it just deletes itself immediately upon roundstart. Thats not good! I replaced this pointless, self-destructing locker with a loot-spawning maintenance locker.

## Why It's Good For The Game
Call it bluespace all you want, maintenance lockers aren't supposed to just disappear like that.
Fixes #69027

## Changelog
:cl:
fix: A locker in Icebox Maintenance will no longer disappear immediately upon roundstart.
/:cl:
