### PR TITLE
Mecha spark system runtime on destruction. Fixes mecha draining infinite powercells

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -286,14 +286,35 @@
 		diag_hud.remove_atom_from_hud(src) //YEET
 	return ..()
 
+/obj/vehicle/sealed/mecha/atom_break(damage_flag)
+	spark_system?.start()
+	return ..()
+
 /obj/vehicle/sealed/mecha/atom_destruction()
 	loc.assume_air(cabin_air)
+	var/mob/living/silicon/ai/unlucky_ais
 	for(var/mob/living/occupant as anything in occupants)
 		if(isAI(occupant))
+			unlucky_ais = occupant
 			occupant.gib() //No wreck, no AI to recover
 			continue
 		mob_exit(occupant, FALSE, TRUE)
 		occupant.SetSleeping(destruction_sleep_duration)
+	if(wreckage)
+		var/obj/structure/mecha_wreckage/WR = new wreckage(loc, unlucky_ais)
+		for(var/obj/item/mecha_parts/mecha_equipment/E in flat_equipment)
+			if(E.detachable && prob(30))
+				WR.crowbar_salvage += E
+				E.detach(WR) //detaches from src into WR
+				E.activated = TRUE
+			else
+				E.detach(loc)
+				qdel(E)
+		if(cell)
+			WR.crowbar_salvage += cell
+			cell.forceMove(WR)
+			cell.use(rand(0, cell.charge), TRUE)
+			cell = null
 	return ..()
 
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -286,12 +286,10 @@
 		diag_hud.remove_atom_from_hud(src) //YEET
 	return ..()
 
-/obj/vehicle/sealed/mecha/atom_break(damage_flag)
-	spark_system?.start()
-	return ..()
-
 /obj/vehicle/sealed/mecha/atom_destruction()
+	spark_system?.start()
 	loc.assume_air(cabin_air)
+
 	var/mob/living/silicon/ai/unlucky_ais
 	for(var/mob/living/occupant as anything in occupants)
 		if(isAI(occupant))
@@ -300,6 +298,7 @@
 			continue
 		mob_exit(occupant, FALSE, TRUE)
 		occupant.SetSleeping(destruction_sleep_duration)
+
 	if(wreckage)
 		var/obj/structure/mecha_wreckage/WR = new wreckage(loc, unlucky_ais)
 		for(var/obj/item/mecha_parts/mecha_equipment/E in flat_equipment)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -41,7 +41,7 @@
 	if(damage_taken <= 0 || atom_integrity < 0)
 		return damage_taken
 
-	spark_system.start()
+	spark_system?.start()
 	try_deal_internal_damage(damage_taken)
 	if(damage_taken >= 5 || prob(33))
 		to_chat(occupants, "[icon2html(src, occupants)][span_userdanger("Taking damage!")]")
@@ -371,31 +371,6 @@
 			visual_effect_icon = ATTACK_EFFECT_MECHTOXIN
 	..()
 
-/obj/vehicle/sealed/mecha/atom_destruction()
-	if(wreckage)
-		var/mob/living/silicon/ai/AI
-		for(var/crew in occupants)
-			if(isAI(crew))
-				if(AI)
-					var/mob/living/silicon/ai/unlucky_ais = crew
-					unlucky_ais.gib()
-					continue
-				AI = crew
-		var/obj/structure/mecha_wreckage/WR = new wreckage(loc, AI)
-		for(var/obj/item/mecha_parts/mecha_equipment/E in flat_equipment)
-			if(E.detachable && prob(30))
-				WR.crowbar_salvage += E
-				E.detach(WR) //detaches from src into WR
-				E.activated = TRUE
-			else
-				E.detach(loc)
-				qdel(E)
-		if(cell)
-			WR.crowbar_salvage += cell
-			cell.forceMove(WR)
-			cell.charge = rand(0, cell.charge)
-			cell = null
-	. = ..()
 
 /obj/vehicle/sealed/mecha/proc/ammo_resupply(obj/item/mecha_ammo/A, mob/user,fail_chat_override = FALSE)
 	if(!A.rounds)


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed mechas with infinite powercells draining the cells on destruction
/:cl:

take_damage()'s parent chain starts the atom's qdel, so spark_system was null by the time it was called. This stopped the final hit from being logged properly. 

Also cleaned up a duplicate definition for mecha/atom_destruction