### PR TITLE
Catches an edge case in ahelp replies

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -450,6 +450,20 @@
 
 	// Ok by this point the recipient has to be an admin, and this is either an admin on admin event, or a player replying to an admin
 
+	// You're replying to a ticket that is closed. Bad move. You must have started replying before the close, and then got input()'d
+	// Lets be nice and pass this off to a new ticket, as we recomend above
+	if(!ticket)
+		to_chat(src,
+			type = MESSAGE_TYPE_ADMINPM,
+			html = span_danger("Error: Admin-PM-Send: Attempted to send a reply to a closed ticket."),
+			confidential = TRUE)
+		to_chat(src,
+			type = MESSAGE_TYPE_ADMINPM,
+			html = span_notice("Relaying message to a new admin help."),
+			confidential = TRUE)
+		GLOB.admin_help_ui_handler.perform_adminhelp(src, raw_message, FALSE)
+		return FALSE
+
 	// Let's play some music for the admin, only if they want it tho
 	if(sound_prefs & SOUND_ADMINHELP)
 		SEND_SOUND(recipient, sound('sound/effects/adminhelp.ogg'))


### PR DESCRIPTION



<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It turns out if you hit reply to an ahelp before it was closed, and then
sent back the input() after close, you'd end up with a runtime leaking
your reply, and no feedback.

This catches that case, and instead forwards it to a new ahelp, so the
text isn't lost, and the closed ticket is respected

Behavior approved by sitting headcatmin Timberpose

Fixes #69039 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Attempting to send back a reply to an ahelp after it is closed now sends the reply to a new ticket, rather then just dropping it and leaving you for dead with a runtime
admin: see above
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
