### PR TITLE
fixes runtime when clicking an airlock with TK

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -6,7 +6,7 @@
 	//check if it doesn't require any access at all
 	if(check_access(null))
 		return TRUE
-	if(!accessor) //likely a TK user.
+	if(!istype(accessor)) //likely a TK user.
 		return FALSE
 	if(issilicon(accessor))
 		if(ispAI(accessor))

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -6,6 +6,8 @@
 	//check if it doesn't require any access at all
 	if(check_access(null))
 		return TRUE
+	if(!accessor) //likely a TK user.
+		return FALSE
 	if(issilicon(accessor))
 		if(ispAI(accessor))
 			return FALSE


### PR DESCRIPTION
resulted in hiddenprints not being logged. 

```
[00:01:46] Runtime in access.dm, line 17: Cannot read null.comp_lookup
 proc name: allowed (/obj/proc/allowed)
usr: SinfulBliss/(Axle Brady)
usr.loc: (Research Division (121,100,2))
src: Security Office (/obj/machinery/door/airlock/security/glass)
src.loc: the floor (123,99,2) (/turf/open/floor/iron)
call stack:
Security Office (/obj/machinery/door/airlock/security/glass): allowed(null)
Security Office (/obj/machinery/door/airlock/security/glass): allowed(null)
Security Office (/obj/machinery/door/airlock/security/glass): attack tk(Axle Brady (/mob/living/carbon/human))
Telekinesis (/datum/mutation/human/telekinesis): on ranged attack(Axle Brady (/mob/living/carbon/human), Security Office (/obj/machinery/door/airlock/security/glass), /list (/list))
Axle Brady (/mob/living/carbon/human): SendSignal("mob_attack_ranged", /list (/list))
Axle Brady (/mob/living/carbon/human): RangedAttack(Security Office (/obj/machinery/door/airlock/security/glass), /list (/list))
Axle Brady (/mob/living/carbon/human): RangedAttack(Security Office (/obj/machinery/door/airlock/security/glass), /list (/list))
Axle Brady (/mob/living/carbon/human): ClickOn(Security Office (/obj/machinery/door/airlock/security/glass), "icon-x=9;icon-y=22;left=1;scre...")
Security Office (/obj/machinery/door/airlock/security/glass): Click(the floor (123,99,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=9;icon-y=22;left=1;scre...")
SinfulBliss (/client): Click(Security Office (/obj/machinery/door/airlock/security/glass), the floor (123,99,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=9;icon-y=22;left=1;scre...")
```