### PR TITLE
Fixes monkeys trying to shove non-carbon mobs instead of biting them

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -288,7 +288,7 @@
 		return martial_result
 
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		if (user != src)
+		if (user != src && iscarbon(src))
 			user.disarm(src)
 			return TRUE
 	if (!user.combat_mode)


### PR DESCRIPTION
```
[00:34:14] Runtime in carbon_defense.dm, line 283: undefined proc or verb /mob/living/simple_animal/bot/secbot/beepsky/officer/is shove knockdown blocked(). 
proc name: disarm (/mob/living/carbon/proc/disarm)
usr: Mr Hat.PNG/(monkey (334))
usr.loc: (Library (84,127,2))
src: the monkey (334) (/mob/living/carbon/human)
src.loc: the carpet (84,127,2) (/turf/open/floor/carpet)
call stack:
the monkey (334) (/mob/living/carbon/human): disarm(Officer Beepsky (/mob/living/simple_animal/bot/secbot/beepsky/officer))
Officer Beepsky (/mob/living/simple_animal/bot/secbot/beepsky/officer): attack paw(the monkey (334) (/mob/living/carbon/human), /list (/list))
Officer Beepsky (/mob/living/simple_animal/bot/secbot/beepsky/officer): attack paw(the monkey (334) (/mob/living/carbon/human), /list (/list))
Monkey (/datum/species/monkey): spec unarmedattack(the monkey (334) (/mob/living/carbon/human), Officer Beepsky (/mob/living/simple_animal/bot/secbot/beepsky/officer), /list (/list))
the monkey (334) (/mob/living/carbon/human): UnarmedAttack(Officer Beepsky (/mob/living/simple_animal/bot/secbot/beepsky/officer), 1, /list (/list))
the monkey (334) (/mob/living/carbon/human): ClickOn(Officer Beepsky (/mob/living/simple_animal/bot/secbot/beepsky/officer), "icon-x=18;icon-y=7;right=1;scr...")
Officer Beepsky (/mob/living/simple_animal/bot/secbot/beepsky/officer): Click(the carpet (84,126,2) (/turf/open/floor/carpet), "mapwindow.map", "icon-x=18;icon-y=7;right=1;scr...")
Officer Beepsky (/mob/living/simple_animal/bot/secbot/beepsky/officer): Click(the carpet (84,126,2) (/turf/open/floor/carpet), "mapwindow.map", "icon-x=18;icon-y=7;right=1;scr...")
/datum/callback/verb_callback (/datum/callback/verb_callback): Invoke()
world: push usr(the monkey (334) (/mob/living/carbon/human), /datum/callback/verb_callback (/datum/callback/verb_callback))
/datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
Input (/datum/controller/subsystem/verb_manager/input): run verb queue()
Input (/datum/controller/subsystem/verb_manager/input): fire(0)
Input (/datum/controller/subsystem/verb_manager/input): fire(0)
Input (/datum/controller/subsystem/verb_manager/input): fire(0)
Input (/datum/controller/subsystem/verb_manager/input): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```

:cl: ShizCalev
fix: Right-clicking a non-carbon based mob (humans, xeno, ect) will now bite them instead of doing nothing.
/:cl: