### PR TITLE
Fixes large crates (e.g. canisters) not abiding by delivery requirements

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -28,7 +28,8 @@
 	if(W.tool_behaviour == TOOL_CROWBAR)
 		if(manifest)
 			tear_manifest(user)
-
+		if(SEND_SIGNAL(src, COMSIG_CLOSET_PRE_OPEN, user, force) & BLOCK_OPEN)
+			return FALSE
 		user.visible_message(span_notice("[user] pries \the [src] open."), \
 			span_notice("You pry open \the [src]."), \
 			span_hear("You hear splitting wood."))
@@ -39,7 +40,7 @@
 			new material_drop(src)
 		for(var/atom/movable/AM in contents)
 			AM.forceMove(T)
-
+		SEND_SIGNAL(src, COMSIG_CLOSET_POST_OPEN, force)
 		qdel(src)
 
 	else

--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -28,7 +28,7 @@
 	if(W.tool_behaviour == TOOL_CROWBAR)
 		if(manifest)
 			tear_manifest(user)
-		if(SEND_SIGNAL(src, COMSIG_CLOSET_PRE_OPEN, user, force) & BLOCK_OPEN)
+		if(!open(user))
 			return FALSE
 		user.visible_message(span_notice("[user] pries \the [src] open."), \
 			span_notice("You pry open \the [src]."), \
@@ -40,7 +40,6 @@
 			new material_drop(src)
 		for(var/atom/movable/AM in contents)
 			AM.forceMove(T)
-		SEND_SIGNAL(src, COMSIG_CLOSET_POST_OPEN, force)
 		qdel(src)
 
 	else


### PR DESCRIPTION
## About The Pull Request
Closes #68982 by ~~adding signal sends for large crates' pre- and post-prying/opening checks, which interacts with the `deliver_first` element~~ literally just adding an `if(!open(user))` check. My previous use of signals has been widely regarded as a "skill issue".

unrelated fun fact did you know engineering supply consoles can be accessed by literally anyone with maint access by technicality (it's an engi access covered under its' REQ_ONE_ACCESS check)
## Why It's Good For The Game
Having canister crates not play by the same rules as every other departmental order kind of sucks, actually.
## Changelog
:cl:
fix: Departmentally ordered large crates (the big ones that need crowbars) now properly register that they need to be opened in their appropriate department, and provide proper payouts to the cargo budget upon delivery.
/:cl: