### PR TITLE
Re-adds the accidentally-removed Dutch Jacket

### DIFF
--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -475,6 +475,15 @@
 	inhand_icon_state = "hawaiian_blue"
 	species_exception = list(/datum/species/golem)
 
+/obj/item/clothing/suit/costume/dutch
+	name = "dutch's jacket"
+	desc = "For those long nights on the beach in Tahiti."
+	icon_state = "DutchJacket"
+	inhand_icon_state = "DutchJacket"
+	body_parts_covered = ARMS
+	body_parts_covered = CHEST|GROIN|LEGS|ARMS
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+
 /obj/item/clothing/suit/costume/football_armor
 	name = "football protective gear"
 	desc = "Given to members of the football team!"
@@ -487,7 +496,7 @@
 
 /obj/item/clothing/suit/costume/joker
 	name = "comedian coat"
-	desc = "I mean, don’t you have to be funny to be a comedian?"
+	desc = "I mean, don't you have to be funny to be a comedian?"
 	icon_state = "joker_coat"
 
 /obj/item/clothing/suit/costume/deckers


### PR DESCRIPTION
## About The Pull Request
It was accidentally removed by Twaticus when they did the [Families GAGening](https://github.com/tgstation/tgstation/pull/68725/files#diff-4d72e46488b2a7c7c6eb5009053f23c9e01895ee295ec361997f3bdcbf4cecb6), because it was in-between two Families costume pieces (for whatever reason).

## Why It's Good For The Game
It looks cool, it'd be nice for it to still be there :)

## Changelog

:cl: GoldenAlpharex
fix: Nanotrasen fixed a critical supply mishap that previously restricted the usage of dutch jackets on stations.
/:cl: