### PR TITLE
Fixes belts only getting their appearance updated when removing an item from it

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -398,6 +398,9 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	to_insert.forceMove(resolve_location)
 	item_insertion_feedback(user, to_insert, override)
 
+	if(isobj(resolve_location))
+		resolve_location.update_appearance()
+
 	return TRUE
 
 /**


### PR DESCRIPTION
## About The Pull Request
Belts weren't being updated properly, visually, and that bugged me, so I fixed it.

Fixes https://github.com/tgstation/tgstation/issues/69052.

## Why It's Good For The Game
Because I should be able to see that I added a crowbar to my belt, when I add it to my belt, and not just when I remove a multitool from it.

## Changelog

:cl: GoldenAlpharex
fix: Belts will now change appearance when items are inserted into them as well, instead of only doing so when an item was removed from them.
/:cl: