### PR TITLE
Fixes conveyor belts not updating their sprites immediately when modified with a screwdriver

### DIFF
--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -210,6 +210,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		set_operating(FALSE)
 		return FALSE
 
+	update_appearance()
 	// If we're on, start conveying so moveloops on our tile can be refreshed if they stopped for some reason
 	if(operating != CONVEYOR_OFF)
 		for(var/atom/movable/movable in get_turf(src))


### PR DESCRIPTION
## About The Pull Request
They didn't update visually, until you'd do something else that had them updating visually, like activating/deactivating them.

That's what led to [this issue](https://github.com/tgstation/tgstation/issues/64274) being filed, when it wasn't actually broken.

Either way, fixes https://github.com/tgstation/tgstation/issues/64274.

## Why It's Good For The Game
Now it's going to be more obvious when you flip the belt around. Yay for prettier corner belts!

## Changelog

:cl: GoldenAlpharex
fix: Conveyor belts now properly update their sprites when flipped or inverted using a screwdriver, without the need to being turned on and off to take effect.
/:cl: