### PR TITLE
Fixes the capitalization of the long-range gas analyzer

### DIFF
--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -194,7 +194,7 @@
 
 /obj/item/analyzer/ranged
 	desc = "A hand-held long-range environmental scanner which reports current gas levels."
-	name = "Long-range gas analyzer"
+	name = "long-range gas analyzer"
 	icon_state = "analyzerranged"
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron = 100, /datum/material/glass = 20, /datum/material/gold = 300, /datum/material/bluespace=200)


### PR DESCRIPTION
## About The Pull Request
It had a capital "L" and that bugged me.

## Why It's Good For The Game
Consistency.

## Changelog

:cl: GoldenAlpharex
spellcheck: The long-range gas analyzer's name is no longer capitalized, as it's not a proper name.
/:cl: