### PR TITLE
Spends 6 hours teaching Papercode how to conform to better standards and practices, and also fixes a trivial 5 minute bug with command reports.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -75,9 +75,12 @@
 	if(!GLOB.station_goals.len)
 		return
 	. = "<hr><b>Special Orders for [station_name()]:</b><BR>"
+	var/list/goal_reports = list()
 	for(var/datum/station_goal/station_goal as anything in GLOB.station_goals)
 		station_goal.on_report()
-		. += station_goal.get_report()
+		goal_reports += station_goal.get_report()
+
+	. += goal_reports.Join("<hr>")
 	return
 
 /*

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -10,11 +10,13 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	name = "Bluespace Artillery"
 
 /datum/station_goal/bluespace_cannon/get_report()
-	return {"Our military presence is inadequate in your sector.
-		We need you to construct BSA-[rand(1,99)] Artillery position aboard your station.
-
-		Base parts are available for shipping via cargo.
-		-Nanotrasen Naval Command"}
+	return list(
+		"Our military presence is inadequate in your sector.",
+		"We need you to construct BSA-[rand(1,99)] Artillery position aboard your station.",
+		"",
+		"Base parts are available for shipping via cargo.",
+		"-Nanotrasen Naval Command",
+	).Join("\n")
 
 /datum/station_goal/bluespace_cannon/on_report()
 	//Unlock BSA parts

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -11,11 +11,11 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 
 /datum/station_goal/bluespace_cannon/get_report()
 	return list(
-		"Our military presence is inadequate in your sector.",
+		"<blockquote>Our military presence is inadequate in your sector.",
 		"We need you to construct BSA-[rand(1,99)] Artillery position aboard your station.",
 		"",
 		"Base parts are available for shipping via cargo.",
-		"-Nanotrasen Naval Command",
+		"-Nanotrasen Naval Command</blockquote>",
 	).Join("\n")
 
 /datum/station_goal/bluespace_cannon/on_report()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -32,15 +32,17 @@
 			.++
 
 /datum/station_goal/dna_vault/get_report()
-	return {"Our long term prediction systems indicate a 99% chance of system-wide cataclysm in the near future.
-		We need you to construct a DNA Vault aboard your station.
-
-		The DNA Vault needs to contain samples of:
-		[animal_count] unique animal data
-		[plant_count] unique non-standard plant data
-		[human_count] unique sapient humanoid DNA data
-
-		Base vault parts are available for shipping via cargo."}
+	return list(
+		"Our long term prediction systems indicate a 99% chance of system-wide cataclysm in the near future.",
+		"We need you to construct a DNA Vault aboard your station.",
+		"",
+		"The DNA Vault needs to contain samples of:",
+		"* [animal_count] unique animal data",
+		"* [plant_count] unique non-standard plant data",
+		"* [human_count] unique sapient humanoid DNA data",
+		"",
+		"Base vault parts are available for shipping via cargo.",
+	).Join("\n")
 
 
 /datum/station_goal/dna_vault/on_report()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -33,7 +33,7 @@
 
 /datum/station_goal/dna_vault/get_report()
 	return list(
-		"Our long term prediction systems indicate a 99% chance of system-wide cataclysm in the near future.",
+		"<blockquote>Our long term prediction systems indicate a 99% chance of system-wide cataclysm in the near future.",
 		"We need you to construct a DNA Vault aboard your station.",
 		"",
 		"The DNA Vault needs to contain samples of:",
@@ -41,7 +41,7 @@
 		"* [plant_count] unique non-standard plant data",
 		"* [human_count] unique sapient humanoid DNA data",
 		"",
-		"Base vault parts are available for shipping via cargo.",
+		"Base vault parts are available for shipping via cargo.</blockquote>",
 	).Join("\n")
 
 

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -7,11 +7,12 @@
 	requires_space = TRUE
 
 /datum/station_goal/station_shield/get_report()
-	return {"The station is located in a zone full of space debris.
-		We have a prototype shielding system you must deploy to reduce collision-related accidents.
-
-		You can order the satellites and control systems at cargo.
-		"}
+	return list(
+		"The station is located in a zone full of space debris.",
+		"We have a prototype shielding system you must deploy to reduce collision-related accidents.",
+		"",
+		"You can order the satellites and control systems at cargo.",
+	).Join("\n")
 
 
 /datum/station_goal/station_shield/on_report()

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -8,10 +8,10 @@
 
 /datum/station_goal/station_shield/get_report()
 	return list(
-		"The station is located in a zone full of space debris.",
+		"<blockquote>The station is located in a zone full of space debris.",
 		"We have a prototype shielding system you must deploy to reduce collision-related accidents.",
 		"",
-		"You can order the satellites and control systems at cargo.",
+		"You can order the satellites and control systems at cargo.</blockquote>",
 	).Join("\n")
 
 

--- a/tgui/packages/tgui/sanitize.js
+++ b/tgui/packages/tgui/sanitize.js
@@ -7,6 +7,7 @@ import DOMPurify from 'dompurify';
 // Default values
 const defTag = [
   'b',
+  'blockquote',
   'br',
   'center',
   'code',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #69016

The station goal command reports use DM's document string syntax for formatting.

They also use tabs for padding. To make them look prettier in DM. The document string syntax parses those tabs into the final string.

https://www.markdownguide.org/basic-syntax/
> Code Blocks
> Code blocks are normally indented four spaces or one tab. When they’re in a list, indent them eight spaces or two tabs.

Markdown then converts these errant tabs to \<code\> blocks on papercode.

By using list(...).Join() to create nicely formatted DM-side strings that parse out appropriately into the game instead of using document string syntax, we completely bypass this problem and the shiftstart command reports now look gucci.

I've also made it properly support multiple goals displaying properly.

![image](https://user-images.githubusercontent.com/24975989/183316782-2be1c6c2-0f7a-45f8-815a-a54c2d293b12.png)
![image](https://user-images.githubusercontent.com/24975989/183317014-7762469b-54b9-4b45-8a75-64f119e64550.png)

## BUT WAIT A SECOND, WHAT ARE ALL THE OTHER CHANGES?

Well, you see... I wanted to use the nice block quote markdown in order to make the reports stand out a bit from the rest of the command report and sort of group them under that one heading a bit nicer, right?

But sanitising the raw text mangles `>` into `&gt;`, totally killing the ability for markdown to do block quotes. And HTML blockquotes weren't allowed through the sanitiser. Sssad.

And herein lies the eternal triangle:
Sanitize has to be run before input fields, because adding input fields is only allowed with the specified syntax.
Input fields have to be run before markdown, because markdown mangles input fields as it parses their underscores as emphasis.
Markdown has to be run before sanitise, as sanitise will mangle certain markdown inputs such as `>`.

So I spent some time reading up on it, a bit of trial and error, and some big slamming my head against the wall at times. And I came up with the following solution:

Following https://marked.js.org/using_pro#extensions I created a custom extension that jumps in, tokenizes `[_____]` input fields before the emStrong can mangle them, and replaces them with... Exactly the same thing.

This means markedjs no longer mangles input fields, breaking the circular deadlock. We can now markedjs parse as the first step.

We can then sanitise markedjs output, which is what they recommend we should have been doing in the first place.
https://marked.js.org/#usage
![image](https://user-images.githubusercontent.com/24975989/183315618-a06df53b-7517-4a0f-ab0c-ed35c1c25092.png)

Then we insert the input fields. This step has to come last in the chain because we strip any player attempts at making input fields themselves and only allow inserting our own trusted ones.

I've added block quotes to the allowed set of tags for sanitising to allow them both manually via html and via markdown.

I believe all other markdown HTML tags (that we want to keep) are there too.

This means we gain security and gain functionality with no losses elsewhere.

![eozb6EODP7](https://user-images.githubusercontent.com/24975989/183317213-b6e53cf7-a136-43af-9646-5d78050370d2.gif)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Papercode is more security compliant, sanitising at a later step in the process than before.

Fixes bugs in markdown (block quotes not working).

Also fixes the command report. That's a good thing.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes broken command report formatting for station goals.
fix: Fixes markdown paragraphing not working in paper code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
