### PR TITLE
Geiger counters can now reveal how much an object can insulate radiation, and reveals the distance and how much insulation you need to stop a radiation pulse.

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -26,13 +26,13 @@ Ask Mothblocks if they're around
 /// Amount of knockdown when it occurs
 #define RAD_MOB_KNOCKDOWN_AMOUNT 3
 
-#define RAD_NO_INSULATION 1.0 // For things that shouldn't become irradiated for whatever reason
-#define RAD_VERY_LIGHT_INSULATION 0.9 // What girders have
-#define RAD_LIGHT_INSULATION 0.8
-#define RAD_MEDIUM_INSULATION  0.7 // What common walls have
-#define RAD_HEAVY_INSULATION 0.6 // What reinforced walls have
-#define RAD_EXTREME_INSULATION 0.5 // What rad collectors have
-#define RAD_FULL_INSULATION 0 // Completely stops radiation from coming through
+#define RAD_NO_INSULATION 0 // For things that shouldn't become irradiated for whatever reason
+#define RAD_VERY_LIGHT_INSULATION 0.5 // What girders have
+#define RAD_LIGHT_INSULATION 1
+#define RAD_MEDIUM_INSULATION 2 // What common walls have
+#define RAD_HEAVY_INSULATION 4 // What reinforced walls have
+#define RAD_EXTREME_INSULATION 8 // What rad collectors have
+#define RAD_FULL_INSULATION INFINITY // Completely stops radiation from coming through
 
 /// The default chance something can be irradiated
 #define DEFAULT_RADIATION_CHANCE 10

--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -89,8 +89,8 @@
 #define TRITIUM_RADIATION_RELEASE_THRESHOLD (FIRE_TRITIUM_ENERGY_RELEASED * TRITIUM_OXYBURN_MULTIPLIER)
 /// A scaling factor for the range of radiation pulses produced by tritium fires.
 #define TRITIUM_RADIATION_RANGE_DIVISOR 1.5
-/// A scaling factor for the irradiation threshold of radiation pulses produced by tritium fires.
-#define TRITIUM_RADIATION_THRESHOLD_BASE 15
+/// The threshold of radiation pulses produced by tritium fires.
+#define TRITIUM_RADIATION_THRESHOLD 10
 
 // - Freon:
 /// The maximum temperature freon can combust at.
@@ -244,8 +244,8 @@
 #define PN_TRITIUM_CONVERSION_RAD_RELEASE_THRESHOLD 10000
 /// A scaling factor for the range of the radiation pulses generated when proto-nitrate converts tritium to hydrogen.
 #define PN_TRITIUM_RAD_RANGE_DIVISOR 1.5
-/// A scaling factor for the threshold of the radiation pulses generated when proto-nitrate converts tritium to hydrogen.
-#define PN_TRITIUM_RAD_THRESHOLD_BASE 15
+/// The threshold of the radiation pulses generated when proto-nitrate converts tritium to hydrogen.
+#define PN_TRITIUM_RAD_THRESHOLD 10
 
 /// The minimum temperature proto-nitrate can break BZ down at.
 #define PN_BZASE_MIN_TEMP 260
@@ -257,8 +257,8 @@
 #define PN_BZASE_RAD_RELEASE_THRESHOLD 60000
 /// A scaling factor for the range of the radiation pulses generated when proto-nitrate breaks down BZ.
 #define PN_BZASE_RAD_RANGE_DIVISOR 1.5
-/// A scaling factor for the threshold of the radiation pulses generated when proto-nitrate breaks down BZ.
-#define PN_BZASE_RAD_THRESHOLD_BASE 15
+/// The threshold of the radiation pulses generated when proto-nitrate breaks down BZ.
+#define PN_BZASE_RAD_THRESHOLD 20
 /// A scaling factor for the nuclear particle production generated when proto-nitrate breaks down BZ.
 #define PN_BZASE_NUCLEAR_PARTICLE_DIVISOR 5
 /// The maximum amount of nuclear particles that can be produced from proto-nitrate breaking down BZ.

--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -3,10 +3,10 @@
 
 /// Sends out a pulse of radiation, eminating from the source.
 /// Radiation is performed by collecting all radiatables within the max range (0 means source only, 1 means adjacent, etc),
-/// then makes their way towards them. A number, starting at 1, is multiplied
-/// by the insulation amounts of whatever is in the way (for example, walls lowering it down).
-/// If this number hits equal or below the threshold, then the target can no longer be irradiated.
-/// If the number is above the threshold, then the chance is the chance that the target will be irradiated.
+/// then makes their way towards them. A number, starting at 0, measured in decibels, is added
+/// by the insulation amounts in decibels of whatever is in the way (for example, walls increasing it).
+/// If this number hits equal or above the threshold, then the target can no longer be irradiated.
+/// If the number is below the threshold, then the chance is the chance for a target at half the max range to get irradiated without attenuation.
 /// As a consumer, this means that max_range going up usually means you want to lower the threshold too,
 /// as well as the other way around.
 /// If max_range is high, but threshold is too high, then it usually won't reach the source at the max range in time.
@@ -55,7 +55,7 @@
 /// Gets the perceived "danger" of radiation pulse, given the threshold to the target.
 /// Returns a RADIATION_DANGER_* define, see [code/__DEFINES/radiation.dm]
 /proc/get_perceived_radiation_danger(datum/radiation_pulse_information/pulse_information, insulation_to_target)
-	if (insulation_to_target > pulse_information.threshold)
+	if (insulation_to_target < pulse_information.threshold)
 		// We could get irradiated! The only thing stopping us now is chance, so scale based on that.
 		if (pulse_information.chance >= EXTREME_RADIATION_CHANCE)
 			return PERCEIVED_RADIATION_DANGER_EXTREME
@@ -67,6 +67,10 @@
 			return PERCEIVED_RADIATION_DANGER_MEDIUM
 		else
 			return PERCEIVED_RADIATION_DANGER_LOW
+
+/proc/get_perceived_radiation_pulse_information(datum/radiation_pulse_information/pulse_information, insulation_to_target, distance)
+	return list("perceived_threshold" = pulse_information.threshold - insulation_to_target, "perceived_distance" = distance)
+
 
 /// A common proc used to send COMSIG_ATOM_PROPAGATE_RAD_PULSE to adjacent atoms
 /// Only used for uranium (false/tram)walls to spread their radiation pulses

--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -49,7 +49,7 @@
 	var/minimum_exposure_time
 	var/list/turfs_to_process
 
-#define MEDIUM_RADIATION_THRESHOLD_RANGE 0.5
+#define MEDIUM_RADIATION_THRESHOLD_RANGE 2
 #define EXTREME_RADIATION_CHANCE 30
 
 /// Gets the perceived "danger" of radiation pulse, given the threshold to the target.
@@ -63,7 +63,7 @@
 			return PERCEIVED_RADIATION_DANGER_HIGH
 	else
 		// We're out of the threshold from being irradiated, but by how much?
-		if (insulation_to_target / pulse_information.threshold <= MEDIUM_RADIATION_THRESHOLD_RANGE)
+		if (pulse_information.threshold && insulation_to_target / pulse_information.threshold <= MEDIUM_RADIATION_THRESHOLD_RANGE)
 			return PERCEIVED_RADIATION_DANGER_MEDIUM
 		else
 			return PERCEIVED_RADIATION_DANGER_LOW

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -158,14 +158,14 @@
 			user.visible_message(span_danger("A hideous sound echoes as [item] is ashed out on contact with \the [atom_source]. That didn't seem like a good idea..."))
 			playsound(atom_source, 'sound/effects/supermatter.ogg', 150, TRUE)
 			consume(atom_source, item)
-			radiation_pulse(atom_source, max_range = 3, threshold = 0.1, chance = 50)
+			radiation_pulse(atom_source, max_range = 3, threshold = 10, chance = 50)
 			return
 		else
 			cig.light()
 			user.visible_message(span_danger("As [user] lights \their [item] on \the [atom_source], silence fills the room..."),\
 				span_danger("Time seems to slow to a crawl as you touch \the [atom_source] with \the [item].</span>\n<span class='notice'>\The [item] flashes alight with an eerie energy as you nonchalantly lift your hand away from \the [atom_source]. Damn."))
 			playsound(atom_source, 'sound/effects/supermatter.ogg', 50, TRUE)
-			radiation_pulse(atom_source, max_range = 1, threshold = 0, chance = 100)
+			radiation_pulse(atom_source, max_range = 1, threshold = RAD_FULL_INSULATION, chance = 100)
 			return
 
 	if(user.dropItemToGround(item))
@@ -176,7 +176,7 @@
 		consume(atom_source, item)
 		playsound(get_turf(atom_source), 'sound/effects/supermatter.ogg', 50, TRUE)
 
-		radiation_pulse(atom_source, max_range = 3, threshold = 0.1, chance = 50)
+		radiation_pulse(atom_source, max_range = 3, threshold = 10, chance = 50)
 		return
 
 	if(atom_source.Adjacent(user)) //if the item is stuck to the person, kill the person too instead of eating just the item.
@@ -261,7 +261,7 @@
 		matter_increase += 70 * object_size
 
 	//Some poor sod got eaten, go ahead and irradiate people nearby.
-	radiation_pulse(atom_source, max_range = 6, threshold = 1.2 / max(object_size, 1), chance = 10 * object_size)
+	radiation_pulse(atom_source, max_range = 6, threshold = 1.6 * max(object_size, 1) - 1.6, chance = 10 * object_size)
 	for(var/mob/living/near_mob in range(10))
 		atom_source.investigate_log("has irradiated [key_name(near_mob)] after consuming [consumed_object].", INVESTIGATE_ENGINE)
 		if (HAS_TRAIT(near_mob, TRAIT_RADIMMUNE) || issilicon(near_mob))

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -82,7 +82,7 @@
 
 	if (!CAN_IRRADIATE(target))
 		if (target.rad_insulation)
-			to_chat(user, span_info("\the [target] can attenuate [target.rad_insulation]dB of radiation."))
+			to_chat(user, span_info("\The [target] can block [target.rad_insulation]dB of radiation."))
 		return
 
 	user.visible_message(span_notice("[user] scans [target] with [src]."), span_notice("You scan [target]'s radiation levels with [src]..."))

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -232,6 +232,7 @@
 	sheetType = /obj/item/stack/sheet/mineral/uranium
 	max_integrity = 300
 	light_range = 2
+	rad_insulation = RAD_NO_INSULATION
 
 /obj/structure/mineral_door/uranium/ComponentInitialize()
 	return
@@ -254,13 +255,14 @@
 	name = "plasma door"
 	icon_state = "plasma"
 	sheetType = /obj/item/stack/sheet/mineral/plasma
+	rad_insulation = RAD_EXTREME_INSULATION
 
 /obj/structure/mineral_door/transparent/diamond
 	name = "diamond door"
 	icon_state = "diamond"
 	sheetType = /obj/item/stack/sheet/mineral/diamond
 	max_integrity = 1000
-	rad_insulation = RAD_EXTREME_INSULATION
+	rad_insulation = RAD_HEAVY_INSULATION
 
 /obj/structure/mineral_door/wood
 	name = "wood door"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -406,7 +406,7 @@
 	damage_deflection = 11
 	state = RWINDOW_SECURE
 	glass_type = /obj/item/stack/sheet/rglass
-	rad_insulation = RAD_HEAVY_INSULATION
+	rad_insulation = RAD_MEDIUM_INSULATION
 	receive_ricochet_chance_mod = 1.1
 
 //this is shitcode but all of construction is shitcode and needs a refactor, it works for now
@@ -516,7 +516,7 @@
 	max_integrity = 200
 	explosion_block = 1
 	glass_type = /obj/item/stack/sheet/plasmaglass
-	rad_insulation = RAD_NO_INSULATION
+	rad_insulation = RAD_MEDIUM_INSULATION
 
 /obj/structure/window/plasma/Initialize(mapload, direct)
 	. = ..()
@@ -554,6 +554,7 @@
 	damage_deflection = 21
 	explosion_block = 2
 	glass_type = /obj/item/stack/sheet/plasmarglass
+	rad_insulation = RAD_HEAVY_INSULATION
 
 /obj/structure/window/reinforced/plasma/block_superconductivity()
 	return TRUE
@@ -724,7 +725,7 @@
 	damage_deflection = 21 //The same as reinforced plasma windows.3
 	glass_type = /obj/item/stack/sheet/plastitaniumglass
 	glass_amount = 2
-	rad_insulation = RAD_HEAVY_INSULATION
+	rad_insulation = RAD_EXTREME_INSULATION
 
 /obj/structure/window/reinforced/plasma/plastitanium/spawnDebris(location)
 	. = list()

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -6,6 +6,7 @@
 	canSmoothWith = null
 	rcd_memory = null
 	material_flags = MATERIAL_EFFECTS
+	rad_insulation = RAD_MEDIUM_INSULATION
 
 /turf/closed/wall/mineral/gold
 	name = "gold wall"
@@ -19,6 +20,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_GOLD_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_GOLD_WALLS)
 	custom_materials = list(/datum/material/gold = 4000)
+	rad_insulation = RAD_HEAVY_INSULATION
 
 /turf/closed/wall/mineral/silver
 	name = "silver wall"
@@ -32,6 +34,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SILVER_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_SILVER_WALLS)
 	custom_materials = list(/datum/material/silver = 4000)
+	rad_insulation = RAD_HEAVY_INSULATION
 
 /turf/closed/wall/mineral/diamond
 	name = "diamond wall"
@@ -47,6 +50,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_DIAMOND_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_DIAMOND_WALLS)
 	custom_materials = list(/datum/material/diamond = 4000)
+	rad_insulation = RAD_HEAVY_INSULATION
 
 /turf/closed/wall/mineral/diamond/hulk_recoil(obj/item/bodypart/arm, mob/living/carbon/human/hulkman, damage = 41)
 	return ..()
@@ -63,6 +67,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_BANANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_BANANIUM_WALLS)
 	custom_materials = list(/datum/material/bananium = 4000)
+	rad_insulation = RAD_NO_INSULATION
 
 /turf/closed/wall/mineral/sandstone
 	name = "sandstone wall"
@@ -91,6 +96,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_URANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_URANIUM_WALLS)
 	custom_materials = list(/datum/material/uranium = 4000)
+	rad_insulation = RAD_NO_INSULATION
 
 	/// Mutex to prevent infinite recursion when propagating radiation pulses
 	var/active = null
@@ -148,6 +154,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_PLASMA_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_PLASMA_WALLS)
 	custom_materials = list(/datum/material/plasma = 4000)
+	rad_insulation = RAD_EXTREME_INSULATION
 
 /turf/closed/wall/mineral/wood
 	name = "wooden wall"
@@ -163,6 +170,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WOOD_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_WOOD_WALLS)
 	custom_materials = list(/datum/material/wood = 4000)
+	rad_insulation = RAD_LIGHT_INSULATION
 
 /turf/closed/wall/mineral/wood/attackby(obj/item/W, mob/user)
 	if(W.get_sharpness() && W.force)
@@ -181,6 +189,7 @@
 	desc = "A solidly wooden wall. It's a bit weaker than a wall made with metal."
 	girder_type = /obj/structure/barricade/wooden
 	hardness = 67 //a bit weaker than iron (60)
+	rad_insulation = RAD_VERY_LIGHT_INSULATION
 
 /turf/closed/wall/mineral/bamboo
 	name = "bamboo wall"
@@ -192,6 +201,7 @@
 	canSmoothWith = list(SMOOTH_GROUP_BAMBOO_WALLS)
 	sheet_type = /obj/item/stack/sheet/mineral/bamboo
 	hardness = 80 //it's not a mineral...
+	rad_insulation = RAD_VERY_LIGHT_INSULATION
 
 /turf/closed/wall/mineral/iron
 	name = "rough iron wall"
@@ -241,6 +251,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_ABDUCTOR_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_ABDUCTOR_WALLS)
 	custom_materials = list(/datum/material/alloy/alien = 4000)
+	rad_insulation = RAD_EXTREME_INSULATION
 
 /////////////////////Titanium walls/////////////////////
 
@@ -321,6 +332,7 @@
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_PLASTITANIUM_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_PLASTITANIUM_WALLS, SMOOTH_GROUP_SYNDICATE_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
 	custom_materials = list(/datum/material/alloy/plastitanium = 4000)
+	rad_insulation = RAD_EXTREME_INSULATION
 
 /turf/closed/wall/mineral/plastitanium/rust_heretic_act()
 	return // plastitanium does not rust

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -251,6 +251,7 @@
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SYNDICATE_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_SYNDICATE_WALLS, SMOOTH_GROUP_PLASTITANIUM_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
+	rad_insulation = RAD_EXTREME_INSULATION
 
 /turf/closed/wall/r_wall/syndicate/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	return FALSE

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -352,7 +352,7 @@
 
 	var/energy_released = FIRE_TRITIUM_ENERGY_RELEASED * burned_fuel * effect_scale
 	if(location && burned_fuel > TRITIUM_RADIATION_MINIMUM_MOLES && energy_released > TRITIUM_RADIATION_RELEASE_THRESHOLD * (air.volume / CELL_VOLUME) ** ATMOS_RADIATION_VOLUME_EXP && prob(10))
-		radiation_pulse(location, max_range = min(sqrt(burned_fuel * effect_scale / TRITIUM_OXYBURN_MULTIPLIER) / TRITIUM_RADIATION_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = TRITIUM_RADIATION_THRESHOLD_BASE * INVERSE(TRITIUM_RADIATION_THRESHOLD_BASE + (burned_fuel * effect_scale / TRITIUM_OXYBURN_MULTIPLIER)))
+		radiation_pulse(location, max_range = min(sqrt(burned_fuel * effect_scale / TRITIUM_OXYBURN_MULTIPLIER) / TRITIUM_RADIATION_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = TRITIUM_RADIATION_THRESHOLD)
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()
@@ -1100,7 +1100,7 @@
 	else if(isatom(holder))
 		location = holder
 	if (location && energy_released > PN_TRITIUM_CONVERSION_RAD_RELEASE_THRESHOLD * (air.volume / CELL_VOLUME) ** ATMOS_RADIATION_VOLUME_EXP)
-		radiation_pulse(location, max_range = min(sqrt(produced_amount) / PN_TRITIUM_RAD_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = PN_TRITIUM_RAD_THRESHOLD_BASE * INVERSE(PN_TRITIUM_RAD_THRESHOLD_BASE + produced_amount))
+		radiation_pulse(location, max_range = min(sqrt(produced_amount) / PN_TRITIUM_RAD_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = PN_TRITIUM_RAD_THRESHOLD)
 
 	if(energy_released)
 		var/new_heat_capacity = air.heat_capacity()
@@ -1156,7 +1156,7 @@
 		var/nuclear_particle_amount = min(round(consumed_amount / PN_BZASE_NUCLEAR_PARTICLE_DIVISOR), PN_BZASE_NUCLEAR_PARTICLE_MAXIMUM)
 		for(var/i in 1 to nuclear_particle_amount)
 			location.fire_nuclear_particle()
-		radiation_pulse(location, max_range = min(sqrt(consumed_amount - nuclear_particle_amount * PN_BZASE_NUCLEAR_PARTICLE_RADIATION_ENERGY_CONVERSION) / PN_BZASE_RAD_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = PN_BZASE_RAD_THRESHOLD_BASE * INVERSE(PN_BZASE_RAD_THRESHOLD_BASE + consumed_amount - nuclear_particle_amount * PN_BZASE_NUCLEAR_PARTICLE_RADIATION_ENERGY_CONVERSION))
+		radiation_pulse(location, max_range = min(sqrt(consumed_amount - nuclear_particle_amount * PN_BZASE_NUCLEAR_PARTICLE_RADIATION_ENERGY_CONVERSION) / PN_BZASE_RAD_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = PN_BZASE_RAD_THRESHOLD)
 		for(var/mob/living/carbon/L in location)
 			L.hallucination += consumed_amount
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -543,7 +543,7 @@
 		radiation_pulse(
 			source = loc,
 			max_range = rad_pulse_size,
-			threshold = 0.05,
+			threshold = 20,
 		)
 
 	if(em_pulse)
@@ -576,7 +576,7 @@
 	radiation_pulse(
 		src,
 		max_range = 6,
-		threshold = 0.3,
+		threshold = RAD_EXTREME_INSULATION,
 	)
 
 /*

--- a/code/modules/power/supermatter/supermatter_radiation.dm
+++ b/code/modules/power/supermatter/supermatter_radiation.dm
@@ -1,8 +1,5 @@
-// Any power past this number will be clamped down
-#define MAX_ACCEPTED_POWER_OUTPUT 5000
-
-// At the highest power output, assuming no integrity changes, the threshold will be 0.
-#define THRESHOLD_EQUATION_SLOPE (-1 / MAX_ACCEPTED_POWER_OUTPUT)
+// The divisor for the power_factor when calculating the threshold.
+#define THRESHOLD_POWER_DIVISOR 750
 
 // The higher this number, the faster low integrity will drop threshold
 // I would've named this "power", but y'know. :P
@@ -20,7 +17,7 @@
 /obj/machinery/power/supermatter_crystal/proc/emit_radiation()
 	// As power goes up, rads go up.
 	// A standard N2 SM seems to produce a value of around 1,500.
-	var/power_factor = min(power, MAX_ACCEPTED_POWER_OUTPUT)
+	var/power_factor = power
 
 	var/integrity = 1 - CLAMP01(damage / explosion_point)
 
@@ -32,17 +29,17 @@
 
 	power_factor = max(power_factor, integrity_power_nudge)
 
-	// At the "normal" N2 power output (with max integrity), this is 0.7, which is enough to be stopped
+	// At the "normal" N2 power output (with max integrity), this is 2dB, which is enough to be stopped
 	// by the walls or the radation shutters.
 	// As integrity does down, rads go up.
 	var/threshold
 	switch(integrity)
 		if(0)
-			threshold = power_factor ? 0 : 1
+			threshold = power_factor ? RAD_FULL_INSULATION : RAD_NO_INSULATION
 		if(1)
-			threshold = (THRESHOLD_EQUATION_SLOPE * power_factor + 1)
+			threshold = power_factor / THRESHOLD_POWER_DIVISOR
 		else
-			threshold = (THRESHOLD_EQUATION_SLOPE * power_factor + 1) ** ((1 / integrity) ** INTEGRITY_EXPONENTIAL_DEGREE)
+			threshold = power_factor / (THRESHOLD_POWER_DIVISOR * integrity ** INTEGRITY_EXPONENTIAL_DEGREE)
 
 	// Calculating chance is done entirely on integrity, so that actively delaminating SMs feel more dangerous
 	var/chance = (CHANCE_EQUATION_SLOPE * (1 - integrity)) + RADIATION_CHANCE_AT_FULL_INTEGRITY
@@ -58,7 +55,5 @@
 #undef INTEGRITY_EXPONENTIAL_DEGREE
 #undef INTEGRITY_MAX_POWER_NUDGE
 #undef INTEGRITY_MIN_NUDGABLE_AMOUNT
-#undef MAX_ACCEPTED_POWER_OUTPUT
 #undef RADIATION_CHANCE_AT_FULL_INTEGRITY
 #undef RADIATION_CHANCE_AT_ZERO_INTEGRITY
-#undef THRESHOLD_EQUATION_SLOPE

--- a/code/modules/power/supermatter/supermatter_radiation.dm
+++ b/code/modules/power/supermatter/supermatter_radiation.dm
@@ -1,5 +1,5 @@
 // The divisor for the power_factor when calculating the threshold.
-#define THRESHOLD_POWER_DIVISOR 750
+#define THRESHOLD_POWER_DIVISOR 300
 
 // The higher this number, the faster low integrity will drop threshold
 // I would've named this "power", but y'know. :P
@@ -29,8 +29,8 @@
 
 	power_factor = max(power_factor, integrity_power_nudge)
 
-	// At the "normal" N2 power output (with max integrity), this is 2dB, which is enough to be stopped
-	// by the walls or the radation shutters.
+	// At the "normal" N2 power output (with max integrity), this is 5dB, which is enough to be stopped
+	// by the walls or the radiation shutters.
 	// As integrity does down, rads go up.
 	var/threshold
 	switch(integrity)

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -281,7 +281,7 @@
 			ejectItem()
 		else if(prob(EFFECT_PROB_VERYLOW-malfunction_probability_coeff))
 			visible_message(span_danger("[src] malfunctions, melting [exp_on] and leaking radiation!"))
-			radiation_pulse(src, max_range = 6, threshold = 0.3)
+			radiation_pulse(src, max_range = 6, threshold = RAD_EXTREME_INSULATION)
 			ejectItem(TRUE)
 		else if(prob(EFFECT_PROB_LOW-malfunction_probability_coeff))
 			visible_message(span_warning("[src] malfunctions, spewing toxic waste!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When you examine a geiger counter, it will reveal the required insulation needed in order to fully stop the radiation. It will also show the distance. Using a geiger counter on something such as a wall will reveal how much radiation it blocks.

The threshold insulation stuff scale got converted into a decibel scale, so the math to know how many walls you need to stop a radiation ray is now fully linear.

Changes the radiation threshold defines. The numbers in the parenthesis would be the 1:1 conversion rounded if they were simply getting converted to the decibel scale. RAD_VERY_LIGHT_INSULATION to 0.5 (0.46), from 0.9, RAD_LIGHT_INSULATION to 1 (0.97), from 0.8, RAD_MEDIUM_INSULATION to 2 (1.55), from 0.7, RAD_HEAVY_INSULATION to 4 (2.22), from 0.6, RAD_EXTREME_INSULATION to 8 (3.01), from 0.5. The lighter rad insulating objects didn't differ much, but the heavier ones (and rad sources that use these defines) will block or require a lot more to be blocked than before.

Supermatter radiation threshold scales linearly with its power. At 100% integrity and normal conditions, it will now require a little more insulation to stop it, making operating inside some parts of the engine, and between the chamber airlocks a little more dangerous.

Gas reaction radiation thresholds are now constant, which should make balance around them a lot more meaningful and easy.

Reinforced windows now have reduced radiation insulation, but reinforced plasma windows will be as good as reinforced walls, and plastitanium windows will be better. Syndicate plastitanium walls, and plasma walls have the best radiation insulation. Diamond mineral doors no longer have extreme radiation insulation. Probably some other changes with mineral doors, but I forgot.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It allows people to have an IC way of finding this information about radiation, as currently the only way to find out is through trial and error, or just code diving, which sucks. The information will give people an insight on radiation, as well as how to make sure the radiation is contained.

Changing the scale turns the mental math from exponentiation to addition, which will make it easier to balance radiation, as well as for people to interpret the insulation.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can find how much radiation an object attenuates by using a geiger counter on it.
balance: You can find out how much radiation would need to get dissipated to completely stop it by examining a geiger counter.
balance: Gas reaction radiation thresholds are now constant.
balance: Reinforce windows aren't as good at blocking radiation as reinforced walls are, but reinforced plasma windows are.
balance: Things that block a lot of radiation now block more radiation, but things that emit stronger radiation will now emit even stronger radiation.
balance: The supermatter's radiation is now harder to block at normal power and integrity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
