### PR TITLE
Fixes storage mass transfer being generally broken, adds mass transferring onto griddles 

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_storage.dm
+++ b/code/__DEFINES/dcs/signals/signals_storage.dm
@@ -1,0 +1,4 @@
+/// Sent when /datum/storage/dump_content_at(): (obj/item/storage_source, mob/user)
+#define COMSIG_STORAGE_DUMP_CONTENT "storage_dump_contents"
+	/// Return to stop the standard dump behavior.
+	#define STORAGE_DUMP_HANDLED (1<<0)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -393,11 +393,17 @@
 	if(!istype(storage_master))
 		return FALSE
 
-	var/obj/item/inserted = usr.get_active_held_item()
-	if(!inserted)
-		return FALSE
+	if(world.time <= usr.next_move)
+		return TRUE
+	if(usr.incapacitated())
+		return TRUE
+	if(ismecha(usr.loc)) // stops inventory actions in a mech
+		return TRUE
 
-	storage_master.attempt_insert(inserted, usr)
+	var/obj/item/inserted = usr.get_active_held_item()
+	if(inserted)
+		storage_master.attempt_insert(inserted, usr)
+
 	return TRUE
 
 /atom/movable/screen/throw_catch

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -389,16 +389,15 @@
 	master = new_master
 
 /atom/movable/screen/storage/Click(location, control, params)
-	if(world.time <= usr.next_move)
-		return TRUE
-	if(usr.incapacitated())
-		return TRUE
-	if(ismecha(usr.loc)) // stops inventory actions in a mech
-		return TRUE
-	if(master)
-		var/obj/item/I = usr.get_active_held_item()
-		if(I)
-			master.attackby(null, I, usr, params)
+	var/datum/storage/storage_master = master
+	if(!istype(storage_master))
+		return FALSE
+
+	var/obj/item/inserted = usr.get_active_held_item()
+	if(!inserted)
+		return FALSE
+
+	storage_master.attempt_insert(inserted, usr)
 	return TRUE
 
 /atom/movable/screen/throw_catch

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -120,8 +120,7 @@
 
 	RegisterSignal(resolve_parent, COMSIG_ITEM_ATTACK_SELF, .proc/mass_empty)
 
-	RegisterSignal(resolve_parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ATTACK_HAND_SECONDARY), .proc/open_storage_on_signal)
-	//RegisterSignal(resolve_parent, COMSIG_PARENT_ATTACKBY_SECONDARY, .proc/open_storage_attackby_secondary)
+	RegisterSignal(resolve_parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ATTACK_HAND_SECONDARY, COMSIG_PARENT_ATTACKBY_SECONDARY), .proc/open_storage_on_signal)
 
 	RegisterSignal(resolve_location, COMSIG_ATOM_ENTERED, .proc/handle_enter)
 	RegisterSignal(resolve_location, COMSIG_ATOM_EXITED, .proc/handle_exit)
@@ -744,12 +743,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	remove_all(dump_loc)
 
-	/*
-	atom_storage.orient_to_hud(user)
-	src_object.atom_storage?.orient_to_hud(user)
-	user.active_storage?.refresh_views()
-	*/
-
 /// Signal handler for whenever something gets mouse-dropped onto us.
 /datum/storage/proc/on_mousedropped_onto(datum/source, obj/item/dropping, mob/user)
 	SIGNAL_HANDLER
@@ -906,13 +899,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	closer.screen_loc = "[screen_start_x + cols]:[screen_pixel_x],[screen_start_y]:[screen_pixel_y]"
 
-/*
-/// Signal handler for when we get attacked with secondary click by an item.
-/datum/storage/proc/open_storage_attackby_secondary(datum/source, atom/weapon, mob/user)
-	SIGNAL_HANDLER
-
-	open_storage(user)
-*/
 
 /// Signal handler to open up the storage when we recieve a signal.
 /datum/storage/proc/open_storage_on_signal(datum/source, mob/to_show)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -109,20 +109,19 @@
 		qdel(src)
 		return
 
-	RegisterSignal(resolve_parent, list(COMSIG_ATOM_ATTACK_PAW, COMSIG_ATOM_ATTACK_HAND), .proc/handle_attack)
-	RegisterSignal(resolve_parent, COMSIG_MOUSEDROP_ONTO, .proc/mousedrop_onto)
-	RegisterSignal(resolve_parent, COMSIG_MOUSEDROPPED_ONTO, .proc/mousedropped_onto)
+	RegisterSignal(resolve_parent, list(COMSIG_ATOM_ATTACK_PAW, COMSIG_ATOM_ATTACK_HAND), .proc/on_attack)
+	RegisterSignal(resolve_parent, COMSIG_MOUSEDROP_ONTO, .proc/on_mousedrop_onto)
+	RegisterSignal(resolve_parent, COMSIG_MOUSEDROPPED_ONTO, .proc/on_mousedropped_onto)
 
-	RegisterSignal(resolve_parent, COMSIG_ATOM_EMP_ACT, .proc/emp_act)
-	RegisterSignal(resolve_parent, COMSIG_PARENT_ATTACKBY, .proc/attackby)
-	RegisterSignal(resolve_parent, COMSIG_ITEM_PRE_ATTACK, .proc/intercept_preattack)
-	RegisterSignal(resolve_parent, COMSIG_OBJ_DECONSTRUCT, .proc/deconstruct)
+	RegisterSignal(resolve_parent, COMSIG_ATOM_EMP_ACT, .proc/on_emp_act)
+	RegisterSignal(resolve_parent, COMSIG_PARENT_ATTACKBY, .proc/on_attackby)
+	RegisterSignal(resolve_parent, COMSIG_ITEM_PRE_ATTACK, .proc/on_preattack)
+	RegisterSignal(resolve_parent, COMSIG_OBJ_DECONSTRUCT, .proc/on_deconstruct)
 
 	RegisterSignal(resolve_parent, COMSIG_ITEM_ATTACK_SELF, .proc/mass_empty)
 
-	RegisterSignal(resolve_parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST), .proc/open_storage)
-	RegisterSignal(resolve_parent, COMSIG_ATOM_ATTACK_HAND_SECONDARY, .proc/open_storage_secondary)
-	RegisterSignal(resolve_parent, COMSIG_PARENT_ATTACKBY_SECONDARY, .proc/open_storage_attackby_secondary)
+	RegisterSignal(resolve_parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ATTACK_HAND_SECONDARY), .proc/open_storage_on_signal)
+	//RegisterSignal(resolve_parent, COMSIG_PARENT_ATTACKBY_SECONDARY, .proc/open_storage_attackby_secondary)
 
 	RegisterSignal(resolve_location, COMSIG_ATOM_ENTERED, .proc/handle_enter)
 	RegisterSignal(resolve_location, COMSIG_ATOM_EXITED, .proc/handle_exit)
@@ -150,7 +149,7 @@
 
 	return ..()
 
-/datum/storage/proc/deconstruct()
+/datum/storage/proc/on_deconstruct()
 	SIGNAL_HANDLER
 
 	remove_all()
@@ -208,7 +207,7 @@
 		return
 
 	if(should_drop)
-		remove_all(src, get_turf(resolve_parent))
+		remove_all(get_turf(resolve_parent))
 
 	resolve_location.flags_1 &= ~HAS_DISASSOCIATED_STORAGE_1
 	real.flags_1 |= HAS_DISASSOCIATED_STORAGE_1
@@ -229,7 +228,7 @@
 /datum/storage/proc/handle_show_valid_items(datum/source, user)
 	to_chat(user, span_notice("[source] can hold: [can_hold_description]"))
 
-/// Almost 100% of the time the lists passed into set_holdable are reused for each instance of the component
+/// Almost 100% of the time the lists passed into set_holdable are reused for each instance
 /// Just fucking cache it 4head
 /// Yes I could generalize this, but I don't want anyone else using it. in fact, DO NOT COPY THIS
 /// If you find yourself needing this pattern, you're likely better off using static typecaches
@@ -323,12 +322,12 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return FALSE
 
 	if(to_insert.w_class > max_specific_storage && !is_type_in_typecache(to_insert, exception_hold))
-		if(messages)
+		if(messages && user)
 			to_chat(user, span_warning("\The [to_insert] is too big for \the [resolve_parent]!"))
 		return FALSE
 
 	if(resolve_location.contents.len >= max_slots)
-		if(messages)
+		if(messages && user)
 			to_chat(user, span_warning("\The [to_insert] can't fit into \the [resolve_parent]! Make some space!"))
 		return FALSE
 
@@ -338,18 +337,18 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		total_weight += thing.w_class
 
 	if(total_weight > max_total_storage)
-		if(messages)
+		if(messages && user)
 			to_chat(user, span_warning("\The [to_insert] can't fit into \the [resolve_parent]! Make some space!"))
 		return FALSE
 
 	if(length(can_hold))
 		if(!is_type_in_typecache(to_insert, can_hold))
-			if(messages)
+			if(messages && user)
 				to_chat(user, span_warning("\The [resolve_parent] cannot hold \the [to_insert]!"))
 			return FALSE
 
 	if(is_type_in_typecache(to_insert, cant_hold) || HAS_TRAIT(to_insert, TRAIT_NO_STORAGE_INSERT) || (can_hold_trait && !HAS_TRAIT(to_insert, can_hold_trait)))
-		if(messages)
+		if(messages && user)
 			to_chat(user, span_warning("\The [resolve_parent] cannot hold \the [to_insert]!"))
 		return FALSE
 
@@ -361,14 +360,14 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	var/datum/storage/biggerfish = resolve_parent.loc.atom_storage // this is valid if the container our resolve_parent is being held in is a storage item
 
 	if(biggerfish && biggerfish.max_specific_storage < max_specific_storage)
-		if(messages)
+		if(messages && user)
 			to_chat(user, span_warning("[to_insert] can't fit in [resolve_parent] while [resolve_parent.loc] is in the way!"))
 		return FALSE
 
 	if(istype(resolve_parent))
 		var/datum/storage/item_storage = to_insert.atom_storage
 		if((to_insert.w_class >= resolve_parent.w_class) && item_storage && !allow_big_nesting)
-			if(messages)
+			if(messages && user)
 				to_chat(user, span_warning("[resolve_parent] cannot hold [to_insert] as it's a storage item of the same size!"))
 			return FALSE
 
@@ -383,24 +382,18 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
  * @param override see item_insertion_feedback()
  * @param force bypass locked storage
  */
-/datum/storage/proc/attempt_insert(datum/source, obj/item/to_insert, mob/user, override = FALSE, force = FALSE)
-	SIGNAL_HANDLER
-
+/datum/storage/proc/attempt_insert(obj/item/to_insert, mob/user, override = FALSE, force = FALSE)
 	var/obj/item/resolve_location = real_location?.resolve()
 	if(!resolve_location)
-		return
+		return FALSE
 
 	if(!can_insert(to_insert, user, force = force))
 		return FALSE
 
 	to_insert.item_flags |= IN_STORAGE
-
 	to_insert.forceMove(resolve_location)
 	item_insertion_feedback(user, to_insert, override)
-
-	if(isobj(resolve_location))
-		resolve_location.update_appearance()
-
+	resolve_location.update_appearance()
 	return TRUE
 
 /**
@@ -439,31 +432,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	progress.update(progress.goal - things.len)
 	return FALSE
-
-/**
- * Used to transfer all the items inside of us to another atom
- *
- * @param mob/user the user who is transferring the items
- * @param atom/going_to the atom we're transferring to
- * @param override enable override on attempt_insert
- */
-/datum/storage/proc/handle_mass_transfer(mob/user, atom/going_to, override = FALSE)
-	var/obj/item/resolve_location = real_location?.resolve()
-	if(!resolve_location)
-		return
-
-	var/obj/item/resolve_parent = parent?.resolve()
-	if(!resolve_parent)
-		return
-
-	if(!going_to.atom_storage)
-		return
-
-	if(rustle_sound)
-		playsound(resolve_parent, SFX_RUSTLE, 50, TRUE, -5)
-
-	for (var/atom/thing in resolve_location.contents)
-		going_to.atom_storage.attempt_insert(src, thing, user, override = override)
 
 /**
  * Provides visual feedback in chat for an item insertion
@@ -544,11 +512,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
  */
 /datum/storage/proc/remove_all(atom/target)
 	var/obj/item/resolve_parent = parent?.resolve()
-	if(!resolve_parent)
-		return
-
 	var/obj/item/resolve_location = real_location?.resolve()
-	if(!resolve_location)
+	if(!resolve_parent || !resolve_location)
 		return
 
 	if(!target)
@@ -557,7 +522,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	for(var/obj/item/thing in resolve_location)
 		if(thing.loc != resolve_location)
 			continue
-		attempt_remove(thing, target, silent = TRUE)
+		if(!attempt_remove(thing, target, silent = TRUE))
+			continue
+		thing.pixel_x = thing.base_pixel_x + rand(-8, 8)
+		thing.pixel_y = thing.base_pixel_y + rand(-8, 8)
+
 
 /**
  * Removes only a specific type of item from our storage
@@ -641,7 +610,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	refresh_views()
 
 /// Signal handler for the emp_act() of all contents
-/datum/storage/proc/emp_act(datum/source, severity)
+/datum/storage/proc/on_emp_act(datum/source, severity)
 	SIGNAL_HANDLER
 
 	var/obj/item/resolve_location = real_location?.resolve()
@@ -655,7 +624,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		thing.emp_act(severity)
 
 /// Signal handler for preattack from an object.
-/datum/storage/proc/intercept_preattack(datum/source, obj/item/thing, mob/user, params)
+/datum/storage/proc/on_preattack(datum/source, obj/item/thing, mob/user, params)
 	SIGNAL_HANDLER
 
 	if(!istype(thing) || !allow_quick_gather || thing.atom_storage)
@@ -702,41 +671,35 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	resolve_parent.balloon_alert(user, "picked up")
 
 /// Signal handler for whenever we drag the storage somewhere.
-/datum/storage/proc/mousedrop_onto(datum/source, atom/over_object, mob/user)
+/datum/storage/proc/on_mousedrop_onto(datum/source, atom/over_object, mob/user)
 	SIGNAL_HANDLER
 
 	var/obj/item/resolve_parent = parent?.resolve()
-	if(!resolve_parent)
+	var/obj/item/resolve_location = real_location?.resolve()
+	if(!resolve_parent || !resolve_location)
 		return
 
-	if(!istype(user))
-		return
-	if(!over_object)
-		return
-	if(ismecha(user.loc))
-		return
-	if(user.incapacitated() || !user.canUseStorage())
+	if(ismecha(user.loc) || user.incapacitated() || !user.canUseStorage())
 		return
 
 	resolve_parent.add_fingerprint(user)
 
-	if(over_object == user)
-		open_storage(resolve_parent, user)
-
-	if(!istype(over_object, /atom/movable/screen))
-		INVOKE_ASYNC(src, .proc/dump_content_at, over_object, user)
-		return
-
-	if(resolve_parent.loc != user)
-		return
-
-	if(rustle_sound)
-		playsound(resolve_parent, SFX_RUSTLE, 50, TRUE, -5)
-
 	if(istype(over_object, /atom/movable/screen/inventory/hand))
+
+		if(resolve_parent.loc != user)
+			return
+
 		var/atom/movable/screen/inventory/hand/hand = over_object
 		user.putItemFromInventoryInHandIfPossible(resolve_parent, hand.held_index)
-		return
+
+	else if(ismob(over_object))
+		if(over_object != user)
+			return
+
+		INVOKE_ASYNC(src, .proc/open_storage, user)
+
+	else if(!istype(over_object, /atom/movable/screen))
+		INVOKE_ASYNC(src, .proc/dump_content_at, over_object, user)
 
 /**
  * Dumps all of our contents at a specific location.
@@ -745,39 +708,73 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
  * @param mob/user the user who is dumping the contents
  */
 /datum/storage/proc/dump_content_at(atom/dest_object, mob/user)
-	var/obj/item/resolve_parent = parent?.resolve()
-	if(!resolve_parent)
+	var/obj/item/resolve_parent = parent.resolve()
+	var/obj/item/resolve_location = real_location.resolve()
+
+	if(locked)
+		return
+	if(!user.CanReach(resolve_parent) || !user.CanReach(dest_object))
 		return
 
-	var/obj/item/resolve_location = real_location?.resolve()
-	if(!resolve_location)
+	if(SEND_SIGNAL(dest_object, COMSIG_STORAGE_DUMP_CONTENT, resolve_location, user) & STORAGE_DUMP_HANDLED)
 		return
 
-	if(user.CanReach(resolve_parent) && dest_object && user.CanReach(dest_object))
-		if(locked)
-			return
-		if(dest_object.storage_contents_dump_act(resolve_parent, user))
-			return
+	// Storage to storage transfer is instant
+	if(dest_object.atom_storage)
+		to_chat(user, span_notice("You dump the contents of [resolve_parent] into [dest_object]."))
+
+		if(rustle_sound)
+			playsound(resolve_parent, SFX_RUSTLE, 50, TRUE, -5)
+
+		for(var/obj/item/to_dump in resolve_location)
+			if(to_dump.loc != resolve_location)
+				continue
+			dest_object.atom_storage.attempt_insert(to_dump, user)
+
+		return
+
+	var/atom/dump_loc = dest_object.get_dumping_location()
+	if(isnull(dump_loc))
+		return
+
+	// Storage to loc transfer requires a do_after
+	to_chat(user, span_notice("You start dumping out the contents of [resolve_parent] onto [dest_object]..."))
+	if(!do_after(user, 2 SECONDS, target = dest_object))
+		return
+
+	remove_all(dump_loc)
+
+	/*
+	atom_storage.orient_to_hud(user)
+	src_object.atom_storage?.orient_to_hud(user)
+	user.active_storage?.refresh_views()
+	*/
 
 /// Signal handler for whenever something gets mouse-dropped onto us.
-/datum/storage/proc/mousedropped_onto(datum/source, obj/item/dropping, mob/user)
+/datum/storage/proc/on_mousedropped_onto(datum/source, obj/item/dropping, mob/user)
 	SIGNAL_HANDLER
 
 	var/obj/item/resolve_parent = parent?.resolve()
-
 	if(!resolve_parent)
 		return
+
 	if(!istype(dropping))
 		return
+	if(dropping != user.get_active_held_item())
+		return
+	if(dropping.atom_storage) // If it has storage it should be trying to dump, not insert.
+		return
 
-	if(iscarbon(user) || isdrone(user))
-		var/mob/living/user_living = user
-		if(!user_living.incapacitated() && dropping == user_living.get_active_held_item())
-			if(!dropping.atom_storage && can_insert(dropping, user)) //If it has storage it should be trying to dump, not insert.
-				attempt_insert(src, dropping, user)
+	if(!iscarbon(user) && !isdrone(user))
+		return
+	var/mob/living/user_living = user
+	if(user_living.incapacitated())
+		return
+
+	attempt_insert(dropping, user)
 
 /// Signal handler for whenever we're attacked by an object.
-/datum/storage/proc/attackby(datum/source, obj/item/thing, mob/user, params)
+/datum/storage/proc/on_attackby(datum/source, obj/item/thing, mob/user, params)
 	SIGNAL_HANDLER
 
 	var/obj/item/resolve_parent = parent?.resolve()
@@ -790,11 +787,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(iscyborg(user))
 		return TRUE
 
-	attempt_insert(resolve_parent, thing, user)
+	attempt_insert(thing, user)
 	return TRUE
 
 /// Signal handler for whenever we're attacked by a mob.
-/datum/storage/proc/handle_attack(datum/source, mob/user)
+/datum/storage/proc/on_attack(datum/source, mob/user)
 	SIGNAL_HANDLER
 
 	var/obj/item/resolve_parent = parent?.resolve()
@@ -818,7 +815,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 			return
 
 	if(resolve_parent.loc == user)
-		open_storage(resolve_parent, user)
+		INVOKE_ASYNC(src, .proc/open_storage, user)
 		return TRUE
 
 /// Generates the numbers on an item in storage to show stacking.
@@ -909,80 +906,49 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	closer.screen_loc = "[screen_start_x + cols]:[screen_pixel_x],[screen_start_y]:[screen_pixel_y]"
 
+/*
 /// Signal handler for when we get attacked with secondary click by an item.
-/datum/storage/proc/open_storage_attackby_secondary(datum/source, atom/weapon, mob/toshow)
+/datum/storage/proc/open_storage_attackby_secondary(datum/source, atom/weapon, mob/user)
 	SIGNAL_HANDLER
 
-	return open_storage_secondary(source, toshow)
+	open_storage(user)
+*/
 
-/// Signal handler for when we get attacked with secondary click.
-/datum/storage/proc/open_storage_secondary(datum/source, mob/toshow)
+/// Signal handler to open up the storage when we recieve a signal.
+/datum/storage/proc/open_storage_on_signal(datum/source, mob/to_show)
 	SIGNAL_HANDLER
 
+	INVOKE_ASYNC(src, .proc/open_storage, to_show)
+	return COMPONENT_NO_AFTERATTACK
+
+/// Opens the storage to the mob, showing them the contents to their UI.
+/datum/storage/proc/open_storage(mob/to_show)
 	var/obj/item/resolve_parent = parent?.resolve()
 	if(!resolve_parent)
-		return
+		return FALSE
 
 	var/obj/item/resolve_location = real_location?.resolve()
 	if(!resolve_location)
-		return
-
-	if(isobserver(toshow))
-		show_contents(toshow)
-		return
-
-	if(!toshow.CanReach(resolve_parent))
-		resolve_parent.balloon_alert(toshow, "can't reach!")
 		return FALSE
 
-	if(!isliving(toshow) || toshow.incapacitated())
+	if(isobserver(to_show))
+		show_contents(to_show)
+		return FALSE
+
+	if(!to_show.CanReach(resolve_parent))
+		resolve_parent.balloon_alert(to_show, "can't reach!")
+		return FALSE
+
+	if(!isliving(to_show) || to_show.incapacitated())
 		return FALSE
 
 	if(locked)
 		if(!silent)
-			to_chat(toshow, span_warning("[pick("Ka-chunk!", "Ka-chink!", "Plunk!", "Glorf!")] \The [resolve_parent] appears to be locked!"))
+			resolve_parent.balloon_alert(to_show, "locked!")
 		return FALSE
 
-	show_contents(toshow)
-
-	if(animated)
-		animate_parent()
-
-	if(rustle_sound)
-		playsound(resolve_parent, SFX_RUSTLE, 50, TRUE, -5)
-
-	return TRUE
-
-/// Signal handler for when we're showing ourselves to a mob.
-/datum/storage/proc/open_storage(datum/source, mob/toshow)
-	SIGNAL_HANDLER
-
-	var/obj/item/resolve_parent = parent?.resolve()
-	if(!resolve_parent)
-		return
-
-	var/obj/item/resolve_location = real_location?.resolve()
-	if(!resolve_location)
-		return
-
-	if(isobserver(toshow))
-		show_contents(toshow)
-		return
-
-	if(!toshow.CanReach(resolve_parent))
-		resolve_parent.balloon_alert(toshow, "can't reach!")
-		return FALSE
-
-	if(!isliving(toshow) || toshow.incapacitated())
-		return FALSE
-
-	if(locked)
-		if(!silent)
-			resolve_parent.balloon_alert(toshow, "locked!")
-		return FALSE
-
-	if(!quickdraw || toshow.get_active_held_item())
-		show_contents(toshow)
+	if(!quickdraw || to_show.get_active_held_item())
+		show_contents(to_show)
 
 		if(animated)
 			animate_parent()
@@ -999,10 +965,10 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	attempt_remove(to_remove)
 
-	INVOKE_ASYNC(src, .proc/put_in_hands_async, toshow, to_remove)
+	INVOKE_ASYNC(src, .proc/put_in_hands_async, to_show, to_remove)
 
 	if(!silent)
-		toshow.visible_message(span_warning("[toshow] draws [to_remove] from [resolve_parent]!"), span_notice("You draw [to_remove] from [resolve_parent]."))
+		to_show.visible_message(span_warning("[to_show] draws [to_remove] from [resolve_parent]!"), span_notice("You draw [to_remove] from [resolve_parent]."))
 
 	return TRUE
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -397,7 +397,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	return TRUE
 
 /**
- * Inserts every time in a given list, with a progress bar
+ * Inserts every item in a given list, with a progress bar
  *
  * @param mob/user the user who is inserting the items
  * @param list/things the list of items to insert
@@ -407,11 +407,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
  */
 /datum/storage/proc/handle_mass_pickup(mob/user, list/things, atom/thing_loc, list/rejections, datum/progressbar/progress)
 	var/obj/item/resolve_parent = parent?.resolve()
-	if(!resolve_parent)
-		return
-
 	var/obj/item/resolve_location = real_location?.resolve()
-	if(!resolve_location)
+	if(!resolve_parent || !resolve_location)
 		return
 
 	for(var/obj/item/thing in things)
@@ -420,7 +417,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 			continue
 		if(thing.type in rejections) // To limit bag spamming: any given type only complains once
 			continue
-		if(!attempt_insert(resolve_parent, thing, user, TRUE)) // Note can_be_inserted still makes noise when the answer is no
+		if(!attempt_insert(thing, user, TRUE)) // Note can_be_inserted still makes noise when the answer is no
 			if(resolve_location.contents.len >= max_slots)
 				break
 			rejections += thing.type // therefore full bags are still a little spammy
@@ -628,17 +625,17 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	SIGNAL_HANDLER
 
 	if(!istype(thing) || !allow_quick_gather || thing.atom_storage)
-		return FALSE
+		return
 
 	if(collection_mode == COLLECT_ONE)
-		attempt_insert(source, thing, user)
-		return TRUE
+		attempt_insert(thing, user)
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(!isturf(thing.loc))
-		return TRUE
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	INVOKE_ASYNC(src, .proc/collect_on_turf, thing, user)
-	return TRUE
+	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /**
  * Collects every item of a type on a turf.

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -120,7 +120,8 @@
 
 	RegisterSignal(resolve_parent, COMSIG_ITEM_ATTACK_SELF, .proc/mass_empty)
 
-	RegisterSignal(resolve_parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ATTACK_HAND_SECONDARY, COMSIG_PARENT_ATTACKBY_SECONDARY), .proc/open_storage_on_signal)
+	RegisterSignal(resolve_parent, list(COMSIG_CLICK_ALT, COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ATTACK_HAND_SECONDARY), .proc/open_storage_on_signal)
+	RegisterSignal(resolve_parent, COMSIG_PARENT_ATTACKBY_SECONDARY, .proc/open_storage_attackby_secondary)
 
 	RegisterSignal(resolve_location, COMSIG_ATOM_ENTERED, .proc/handle_enter)
 	RegisterSignal(resolve_location, COMSIG_ATOM_EXITED, .proc/handle_exit)
@@ -899,6 +900,12 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	closer.screen_loc = "[screen_start_x + cols]:[screen_pixel_x],[screen_start_y]:[screen_pixel_y]"
 
+
+/// Signal handler for when we get attacked with secondary click by an item.
+/datum/storage/proc/open_storage_attackby_secondary(datum/source, atom/weapon, mob/user)
+	SIGNAL_HANDLER
+
+	return open_storage_on_signal(source, user)
 
 /// Signal handler to open up the storage when we recieve a signal.
 /datum/storage/proc/open_storage_on_signal(datum/source, mob/to_show)

--- a/code/datums/storage/subtypes/bag_of_holding.dm
+++ b/code/datums/storage/subtypes/bag_of_holding.dm
@@ -1,4 +1,4 @@
-/datum/storage/bag_of_holding/attempt_insert(datum/source, obj/item/to_insert, mob/user, override, force)
+/datum/storage/bag_of_holding/attempt_insert(obj/item/to_insert, mob/user, override, force)
 	var/obj/item/resolve_parent = parent?.resolve()
 	if(!resolve_parent)
 		return

--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -4,18 +4,22 @@
 	max_total_storage = 50
 	rustle_sound = FALSE
 
-/datum/storage/pockets/attempt_insert(datum/source, obj/item/to_insert, mob/user, override, force)
+/datum/storage/pockets/attempt_insert(obj/item/to_insert, mob/user, override, force)
 	. = ..()
+	if(!.)
+		return
 
 	var/obj/item/resolve_parent = parent?.resolve()
 	if(!resolve_parent)
 		return
 
-	if(. && silent && !override)
-		if(quickdraw)
-			to_chat(user, span_notice("You discreetly slip [to_insert] into [resolve_parent]. Right-click [resolve_parent] to remove it."))
-		else
-			to_chat(user, span_notice("You discreetly slip [to_insert] into [resolve_parent]."))
+	if(!silent || override)
+		return
+
+	if(quickdraw)
+		to_chat(user, span_notice("You discreetly slip [to_insert] into [resolve_parent]. Right-click [resolve_parent] to remove it."))
+	else
+		to_chat(user, span_notice("You discreetly slip [to_insert] into [resolve_parent]."))
 
 /datum/storage/pockets/small
 	max_slots = 1

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1026,32 +1026,10 @@
 	return
 
 /**
- * Implement the behaviour for when a user click drags a storage object to your atom
+ * If someone's trying to dump items onto our atom, where should they be dumped to?
  *
- * This behaviour is usually to mass transfer, but this is no longer a used proc as it just
- * calls the underyling /datum/component/storage dump act if a component exists
- *
- * TODO these should be purely component items that intercept the atom clicks higher in the
- * call chain
+ * Return a loc to place objects, or null to stop dumping.
  */
-/atom/proc/storage_contents_dump_act(obj/item/src_object, mob/user)
-	if(src_object.atom_storage)
-		to_chat(user, span_notice("You start dumping out the contents of \the [src_object] into \the [src]."))
-
-		if(!do_after(user, 20, target = src))
-			return FALSE
-
-		src_object.atom_storage.handle_mass_transfer(user, src, /* override = */ TRUE)
-
-		atom_storage.orient_to_hud(user)
-		src_object.atom_storage?.orient_to_hud(user)
-		user.active_storage?.refresh_views()
-
-		return TRUE
-
-	return FALSE
-
-///Get the best place to dump the items contained in the source storage item?
 /atom/proc/get_dumping_location()
 	return null
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -927,7 +927,7 @@
 					if(replacer_tool.atom_storage.attempt_remove(secondary_part, src))
 						component_parts += secondary_part
 						secondary_part.forceMove(src)
-				replacer_tool.atom_storage.attempt_insert(replacer_tool, primary_part, user, TRUE)
+				replacer_tool.atom_storage.attempt_insert(primary_part, user, TRUE)
 				component_parts -= primary_part
 				to_chat(user, span_notice("[capitalize(primary_part.name)] replaced with [secondary_part.name]."))
 				shouldplaysound = 1 //Only play the sound when parts are actually replaced!

--- a/code/game/objects/items/implants/implant_storage.dm
+++ b/code/game/objects/items/implants/implant_storage.dm
@@ -7,7 +7,7 @@
 
 /obj/item/implant/storage/activate()
 	. = ..()
-	atom_storage?.open_storage(src, imp_in)
+	atom_storage?.open_storage(imp_in)
 
 /obj/item/implant/storage/removed(source, silent = FALSE, special = 0)
 	if(!special)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -97,7 +97,7 @@
 	if(user.mind && HAS_TRAIT(user.mind, TRAIT_CANNOT_OPEN_PRESENTS))
 		var/turf/floor = get_turf(src)
 		var/obj/item/thing = new /obj/item/a_gift/anything(floor)
-		if(!atom_storage.attempt_insert(src, thing, user, override = TRUE))
+		if(!atom_storage.attempt_insert(thing, user, override = TRUE))
 			qdel(thing)
 
 

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -111,7 +111,7 @@
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_HUGE
 	atom_storage.max_total_storage = 50
-	atom_storage.numerical_stacking = TRUE 
+	atom_storage.numerical_stacking = TRUE
 	atom_storage.allow_quick_empty = TRUE
 	atom_storage.allow_quick_gather = TRUE
 	atom_storage.set_holdable(list(/obj/item/stack/ore))
@@ -151,7 +151,7 @@
 			if(box)
 				user.transferItemToLoc(thing, box)
 				show_message = TRUE
-			else if(atom_storage.attempt_insert(src, thing, user))
+			else if(atom_storage.attempt_insert(thing, user))
 				show_message = TRUE
 			else
 				if(!spam_protection)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -400,25 +400,3 @@
 ///unfreezes this obj if its frozen
 /obj/proc/unfreeze()
 	SEND_SIGNAL(src, COMSIG_OBJ_UNFREEZE)
-
-/obj/storage_contents_dump_act(obj/item/src_object, mob/user)
-	. = ..()
-
-	if(.)
-		return
-
-	if(!src_object.atom_storage)
-		return
-
-	var/atom/resolve_location = src_object.atom_storage.real_location?.resolve()
-	if(!resolve_location)
-		return FALSE
-
-	if(length(resolve_location.contents))
-		to_chat(user, span_notice("You start dumping out the contents of [src_object]..."))
-		if(!do_after(user, 20, target=resolve_location))
-			return FALSE
-
-	src_object.atom_storage.remove_all(get_dumping_location())
-
-	return TRUE

--- a/code/game/objects/structures/crates_lockers/crates/bins.dm
+++ b/code/game/objects/structures/crates_lockers/crates/bins.dm
@@ -28,7 +28,7 @@
 		var/obj/item/storage/bag/trash/T = W
 		to_chat(user, span_notice("You fill the bag."))
 		for(var/obj/item/O in src)
-			T.atom_storage?.attempt_insert(T, O, user, TRUE)
+			T.atom_storage?.attempt_insert(O, user, TRUE)
 		T.update_appearance()
 		do_animate()
 		return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -454,24 +454,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/proc/Bless()
 	new /obj/effect/blessing(src)
 
-/turf/storage_contents_dump_act(atom/src_object, mob/user)
-	. = ..()
-	if(.)
-		return
-	if(!src_object.atom_storage)
-		return
-	var/atom/resolve_parent = src_object.atom_storage.real_location?.resolve()
-	if(!resolve_parent)
-		return FALSE
-	if(length(resolve_parent.contents))
-		to_chat(user, span_notice("You start dumping out the contents of [src_object]..."))
-		if(!do_after(user, 20, target=resolve_parent))
-			return FALSE
-
-	src_object.atom_storage.remove_all(src)
-
-	return TRUE
-
 //////////////////////////////
 //Distance procs
 //////////////////////////////

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -90,7 +90,7 @@ GLOBAL_DATUM(rpgloot_controller, /datum/rpgloot_controller)
 			var/datum/storage/storage_component = storage_item.atom_storage
 			if(prob(upgrade_scroll_chance) && storage_item.contents.len < storage_component.max_slots && !storage_item.invisibility)
 				var/obj/item/upgradescroll/scroll = new(get_turf(storage_item))
-				storage_item.atom_storage?.attempt_insert(storage_item, scroll, null, TRUE)
+				storage_item.atom_storage?.attempt_insert(scroll, override = TRUE)
 				upgrade_scroll_chance = max(0,upgrade_scroll_chance-100)
 				if(isturf(scroll.loc))
 					qdel(scroll)

--- a/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
@@ -140,6 +140,8 @@
 		if(!storage_source.atom_storage.attempt_remove(to_dump, src, silent = TRUE))
 			continue
 
+		to_dump.pixel_x = to_dump.base_pixel_x + rand(-5, 5)
+		to_dump.pixel_y = to_dump.base_pixel_y + rand(-5, 5)
 		AddToGrill(to_dump, user)
 
 	to_chat(user, span_notice("You dump out [storage_source] onto [src]."))

--- a/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
@@ -28,10 +28,11 @@
 	if(isnum(variant))
 		variant = rand(1,3)
 	RegisterSignal(src, COMSIG_ATOM_EXPOSE_REAGENT, .proc/on_expose_reagent)
+	RegisterSignal(src, COMSIG_STORAGE_DUMP_CONTENT, .proc/on_storage_dump)
 
 /obj/machinery/griddle/Destroy()
 	QDEL_NULL(grill_loop)
-	. = ..()
+	return ..()
 
 /obj/machinery/griddle/crowbar_act(mob/living/user, obj/item/I)
 	. = ..()
@@ -76,7 +77,6 @@
 		I.pixel_y = clamp(text2num(LAZYACCESS(modifiers, ICON_Y)) - 16, -(world.icon_size/2), world.icon_size/2)
 		to_chat(user, span_notice("You place [I] on [src]."))
 		AddToGrill(I, user)
-		update_appearance()
 	else
 		return ..()
 
@@ -99,6 +99,7 @@
 	RegisterSignal(item_to_grill, COMSIG_GRILL_COMPLETED, .proc/GrillCompleted)
 	RegisterSignal(item_to_grill, COMSIG_PARENT_QDELETING, .proc/ItemRemovedFromGrill)
 	update_grill_audio()
+	update_appearance()
 
 /obj/machinery/griddle/proc/ItemRemovedFromGrill(obj/item/I)
 	SIGNAL_HANDLER
@@ -127,9 +128,22 @@
 	default_unfasten_wrench(user, tool, time = 2 SECONDS)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
-///Override to prevent storage dumping onto the griddle until I figure out how to navigate the mess that is storage code to allow me to nicely move the dumped objects onto the griddle.
-/obj/machinery/griddle/get_dumping_location()
-	return
+/obj/machinery/griddle/proc/on_storage_dump(datum/source, obj/item/storage_source, mob/user)
+	SIGNAL_HANDLER
+
+	for(var/obj/item/to_dump in storage_source)
+		if(to_dump.loc != storage_source)
+			continue
+		if(griddled_objects.len >= max_items)
+			break
+
+		if(!storage_source.atom_storage.attempt_remove(to_dump, src, silent = TRUE))
+			continue
+
+		AddToGrill(to_dump, user)
+
+	to_chat(user, span_notice("You dump out [storage_source] onto [src]."))
+	return STORAGE_DUMP_HANDLED
 
 /obj/machinery/griddle/process(delta_time)
 	..()

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -156,7 +156,7 @@
 			return TRUE
 	else
 		if(O.loc.atom_storage)
-			return O.loc.atom_storage.attempt_remove(O, src)
+			return O.loc.atom_storage.attempt_remove(O, src, silent = TRUE)
 		else
 			O.forceMove(src)
 			return TRUE

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -961,7 +961,7 @@
 	else if(istype(O, /obj/item/storage/bag/plants))
 		attack_hand(user)
 		for(var/obj/item/food/grown/G in locate(user.x,user.y,user.z))
-			O.atom_storage?.attempt_insert(O, G, user, TRUE)
+			O.atom_storage?.attempt_insert(G, user, TRUE)
 		return
 
 	else if(istype(O, /obj/item/shovel/spade))

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 			to_chat(user, span_notice("You attach the pack to [A] and activate it."))
 			if(loc == user && istype(user.back, /obj/item/storage/backpack))
 				var/obj/item/storage/backpack/B = user.back
-				B.atom_storage?.attempt_insert(B, src, user)
+				B.atom_storage?.attempt_insert(src, user)
 			uses_left--
 			if(uses_left <= 0)
 				user.transferItemToLoc(src, A, TRUE)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -409,7 +409,7 @@
 		if(equip_delay_self)
 			return
 
-	if(M.active_storage?.attempt_insert(M.active_storage, src, M))
+	if(M.active_storage?.attempt_insert(src, M))
 		return TRUE
 
 	var/list/obj/item/possible = list(M.get_inactive_held_item(), M.get_item_by_slot(ITEM_SLOT_BELT), M.get_item_by_slot(ITEM_SLOT_DEX_STORAGE), M.get_item_by_slot(ITEM_SLOT_BACK))
@@ -417,7 +417,7 @@
 		if(!i)
 			continue
 		var/obj/item/I = i
-		if(I.atom_storage?.attempt_insert(I, src, M))
+		if(I.atom_storage?.attempt_insert(src, M))
 			return TRUE
 
 	to_chat(M, span_warning("You are unable to equip that!"))

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -351,7 +351,7 @@
 			to_chat(src, span_warning("You can't fit [thing] into your [equipped_item.name]!"))
 		return
 	if(thing) // put thing in storage item
-		if(!equipped_item.atom_storage?.attempt_insert(equipped_item, thing, src))
+		if(!equipped_item.atom_storage?.attempt_insert(thing, src))
 			to_chat(src, span_warning("You can't fit [thing] into your [equipped_item.name]!"))
 		return
 	var/atom/real_location = storage.real_location?.resolve()

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -116,7 +116,7 @@
 			put_in_hands(I)
 			update_inv_hands()
 		if(ITEM_SLOT_BACKPACK)
-			if(!back || !back.atom_storage?.attempt_insert(back, I, src, override = TRUE))
+			if(!back || !back.atom_storage?.attempt_insert(I, src, override = TRUE))
 				not_handled = TRUE
 		else
 			not_handled = TRUE

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -38,7 +38,7 @@
 	if(QDELETED(source) || !mod.wearer || newloc == mod.wearer || !mod.wearer.s_store)
 		return
 	to_chat(mod.wearer, span_notice("[src] tries to store [mod.wearer.s_store] inside itself."))
-	atom_storage?.attempt_insert(src, mod.wearer.s_store, mod.wearer, TRUE)
+	atom_storage?.attempt_insert(mod.wearer.s_store, mod.wearer, override = TRUE)
 
 /obj/item/mod/module/storage/large_capacity
 	name = "MOD expanded storage module"
@@ -507,7 +507,7 @@
 			/obj/item/clothing/head/papersack,
 			/obj/item/clothing/head/caphat/beret,
 			))
-			
+
 /obj/item/mod/module/hat_stabilizer/on_suit_activation()
 	RegisterSignal(mod.helmet, COMSIG_PARENT_EXAMINE, .proc/add_examine)
 	RegisterSignal(mod.helmet, COMSIG_PARENT_ATTACKBY, .proc/place_hat)

--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -52,7 +52,7 @@
 			continue
 		var/obj/item/photo/old/P = load_photo_from_disk(i)
 		if(istype(P))
-			if(!atom_storage?.attempt_insert(src, P, null, TRUE))
+			if(!atom_storage?.attempt_insert(P, override = TRUE))
 				qdel(P)
 
 /obj/item/storage/photo_album/hos

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -269,7 +269,10 @@
 			continue
 		if(user.active_storage != storage_source && to_dump.on_found(user))
 			return
-		storage_source.atom_storage.attempt_remove(to_dump, src, silent = TRUE)
+		if(!storage_source.atom_storage.attempt_remove(to_dump, src, silent = TRUE))
+			continue
+		to_dump.pixel_x = to_dump.base_pixel_x + rand(-5, 5)
+		to_dump.pixel_y = to_dump.base_pixel_y + rand(-5, 5)
 
 // Disposal bin
 // Holds items for disposal into pipe system

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -41,6 +41,7 @@
 	//gas.volume = 1.05 * CELLSTANDARD
 	update_appearance()
 	RegisterSignal(src, COMSIG_RAT_INTERACT, .proc/on_rat_rummage)
+	RegisterSignal(src, COMSIG_STORAGE_DUMP_CONTENT, .proc/on_storage_dump)
 	var/static/list/loc_connections = list(
 		COMSIG_CARBON_DISARM_COLLIDE = .proc/trash_carbon,
 	)
@@ -255,23 +256,20 @@
 		AM.forceMove(T)
 	..()
 
-/obj/machinery/disposal/get_dumping_location()
-	return src
-
 //How disposal handles getting a storage dump from a storage object
-/obj/machinery/disposal/storage_contents_dump_act(obj/item/src_object, mob/user)
-	. = ..()
-	if(.)
-		return
-	var/atom/resolve_parent = src_object.atom_storage?.real_location?.resolve()
-	if(!resolve_parent)
-		return FALSE
-	for(var/obj/item/I in resolve_parent)
-		if(user.active_storage != src_object)
-			if(I.on_found(user))
-				return
-		src_object.atom_storage?.attempt_remove(I, src)
-	return TRUE
+/obj/machinery/disposal/proc/on_storage_dump(datum/source, obj/item/storage_source, mob/user)
+	SIGNAL_HANDLER
+
+	. = STORAGE_DUMP_HANDLED
+
+	to_chat(user, span_notice("You dump out [storage_source] into [src]."))
+
+	for(var/obj/item/to_dump in storage_source)
+		if(to_dump.loc != storage_source)
+			continue
+		if(user.active_storage != storage_source && to_dump.on_found(user))
+			return
+		storage_source.atom_storage.attempt_remove(to_dump, src, silent = TRUE)
 
 // Disposal bin
 // Holds items for disposal into pipe system

--- a/code/modules/research/xenobiology/crossbreeding/reproductive.dm
+++ b/code/modules/research/xenobiology/crossbreeding/reproductive.dm
@@ -50,7 +50,7 @@ Reproductive extracts:
 		return
 
 	else if(istype(O, /obj/item/food/monkeycube))
-		if(atom_storage?.attempt_insert(src, O, user, override = TRUE, force = TRUE))
+		if(atom_storage?.attempt_insert(O, user, override = TRUE, force = TRUE))
 			to_chat(user, span_notice("You feed 1 Monkey Cube to [src], and it pulses gently."))
 			slime_storage?.processCubes(user)
 			playsound(src, 'sound/items/eatfood.ogg', 20, TRUE)

--- a/code/modules/unit_tests/hydroponics_extractor_storage.dm
+++ b/code/modules/unit_tests/hydroponics_extractor_storage.dm
@@ -15,7 +15,7 @@
 	for(var/i in 1 to num_seeds_to_make_of_each)
 		for(var/seed_type in seeds_to_put_in_the_bag)
 			var/obj/item/seeds/new_seed = new seed_type(dummy.loc)
-			storage.atom_storage.attempt_insert(to_insert = new_seed, user = dummy)
+			storage.atom_storage.attempt_insert(new_seed, dummy)
 
 	// Store the number of seeds we start with in the bag for later.
 	var/num_seeds_starting_with = length(storage.contents)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -252,6 +252,7 @@
 #include "code\__DEFINES\dcs\signals\signals_spatial_grid.dm"
 #include "code\__DEFINES\dcs\signals\signals_specie.dm"
 #include "code\__DEFINES\dcs\signals\signals_spell.dm"
+#include "code\__DEFINES\dcs\signals\signals_storage.dm"
 #include "code\__DEFINES\dcs\signals\signals_subsystem.dm"
 #include "code\__DEFINES\dcs\signals\signals_swab.dm"
 #include "code\__DEFINES\dcs\signals\signals_techweb.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes #68751
Fixes #68750 
Fixes #68752
Fixes #68824 
Closes #69267

- Fixes storage mass transferring being generally broken.
   - The logic for the mousedrop proc was pretty ... messy, which led to a lot of weird behavior. I just re-wrote it in its entirely
- Brings some vague sanity to storage procs
   - Storage procs that were simultaneously signal procs were also normal procs that returned `TRUE` and `FALSE`, this isn't good. I re-adjusted a good bit of it.
   - `attempt_insert` was purportedly a signal proc but didn't even register any signal to it. Why? 
- Allowed mass transfer onto a griddle
   - I found a comment implying this was originally a goal, so I real quick whipped it in

## Why It's Good For The Game

Mass transferring isn't horrible to use

## Changelog

:cl: Melbert
fix: Fixes storage to storage mass transfering not being instant
fix: Fixes two do_afters for storage mass transfer
fix: Dumping storage spreads its items around again
fix: Drag-opening a storage won't try to dump inside you
fix: Transferring a ton of things into a fridge won't deafen you anymore
add: You can now mass transfer onto griddles
/:cl:
