### PR TITLE
Fixes 118(give or take) cases of mapload not being passed to initilaize

### DIFF
--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -82,7 +82,7 @@
 	appearance_flags = PLANE_MASTER //should use client color
 	blend_mode = BLEND_OVERLAY
 
-/atom/movable/screen/plane_master/game_world_fov_hidden/Initialize()
+/atom/movable/screen/plane_master/game_world_fov_hidden/Initialize(mapload)
 	. = ..()
 	add_filter("vision_cone", 1, alpha_mask_filter(render_source = FIELD_OF_VISION_BLOCKER_RENDER_TARGET, flags = MASK_INVERSE))
 

--- a/code/game/machinery/computer/atmos_computers/meters.dm
+++ b/code/game/machinery/computer/atmos_computers/meters.dm
@@ -5,7 +5,7 @@
 	var/frequency = FREQ_ATMOS_STORAGE
 	var/datum/radio_frequency/radio_connection
 
-/obj/machinery/meter/monitored/Initialize()
+/obj/machinery/meter/monitored/Initialize(mapload)
 	id_tag = chamber_id + "_sensor"
 	radio_connection = SSradio.add_object(src, frequency, RADIO_ATMOSIA)
 	return ..()
@@ -31,7 +31,7 @@
 	. = ..()
 	if(!radio_connection)
 		return
-	
+
 	var/datum/signal/signal = new(list(
 		"tag" = id_tag,
 		"device" = "AM",

--- a/code/game/objects/items/devices/portable_chem_mixer.dm
+++ b/code/game/objects/items/devices/portable_chem_mixer.dm
@@ -18,7 +18,7 @@
 	///If the UI has the pH meter shown
 	var/show_ph = TRUE
 
-/obj/item/storage/portable_chem_mixer/Initialize()
+/obj/item/storage/portable_chem_mixer/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 200
 	atom_storage.max_slots = 50

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -546,6 +546,6 @@
 /obj/item/radio/off // Station bounced radios, their only difference is spawning with the speakers off, this was made to help the lag.
 	dog_fashion = /datum/dog_fashion/back
 
-/obj/item/radio/off/Initialize()
+/obj/item/radio/off/Initialize(mapload)
 	. = ..()
 	set_listening(FALSE)

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -268,7 +268,7 @@
 	worn_icon_state = "mailbag"
 	resistance_flags = FLAMMABLE
 
-/obj/item/storage/bag/mail/Initialize()
+/obj/item/storage/bag/mail/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 42

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -189,7 +189,7 @@
 	/// Banned combinations of the list in decimal
 	var/static/list/banned_combinations = list(-1, 47, 95, 203, 311, 325, 422, 473, 488, 500, 511)
 
-/obj/structure/light_puzzle/Initialize()
+/obj/structure/light_puzzle/Initialize(mapload)
 	. = ..()
 	var/generated_board = -1
 	while(generated_board in banned_combinations)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -31,7 +31,7 @@
 	/// How much damage to do wielded
 	var/force_wielded = 18
 
-/obj/item/spear/Initialize()
+/obj/item/spear/Initialize(mapload)
 	. = ..()
 	force = force_unwielded
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -21,7 +21,7 @@
 	resistance_flags = NONE
 	max_integrity = 300
 
-/obj/item/storage/backpack/Initialize()
+/obj/item/storage/backpack/Initialize(mapload)
 	. = ..()
 	create_storage(max_slots = 21, max_total_storage = 21)
 
@@ -29,7 +29,7 @@
  * Backpack Types
  */
 
-/obj/item/storage/backpack/old/Initialize()
+/obj/item/storage/backpack/old/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 12
 
@@ -54,7 +54,7 @@
 	item_flags = NO_MAT_REDEMPTION
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 60, ACID = 50)
 
-/obj/item/storage/backpack/holding/Initialize()
+/obj/item/storage/backpack/holding/Initialize(mapload)
 	. = ..()
 
 	create_storage(max_specific_storage = WEIGHT_CLASS_GIGANTIC, max_total_storage = 35, max_slots = 30, type = /datum/storage/bag_of_holding)
@@ -79,7 +79,7 @@
 	. = ..()
 	regenerate_presents()
 
-/obj/item/storage/backpack/santabag/Initialize()
+/obj/item/storage/backpack/santabag/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 60
@@ -331,7 +331,7 @@
 	inhand_icon_state = "duffel"
 	slowdown = 1
 
-/obj/item/storage/backpack/duffelbag/Initialize()
+/obj/item/storage/backpack/duffelbag/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 30
 
@@ -483,7 +483,7 @@
 	slowdown = 0
 	resistance_flags = FIRE_PROOF
 
-/obj/item/storage/backpack/duffelbag/syndie/Initialize()
+/obj/item/storage/backpack/duffelbag/syndie/Initialize(mapload)
 	. = ..()
 	atom_storage.silent = TRUE
 
@@ -639,7 +639,7 @@
 	new /obj/item/grenade/syndieminibomb(src)
 
 // For ClownOps.
-/obj/item/storage/backpack/duffelbag/clown/syndie/Initialize()
+/obj/item/storage/backpack/duffelbag/clown/syndie/Initialize(mapload)
 	. = ..()
 	slowdown = 0
 	atom_storage.silent = TRUE

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -20,7 +20,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_BULKY
 
-/obj/item/storage/bag/Initialize()
+/obj/item/storage/bag/Initialize(mapload)
 	. = ..()
 	atom_storage.allow_quick_gather = TRUE
 	atom_storage.allow_quick_empty = TRUE
@@ -41,7 +41,7 @@
 	///If true, can be inserted into the janitor cart
 	var/insertable = TRUE
 
-/obj/item/storage/bag/trash/Initialize()
+/obj/item/storage/bag/trash/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_total_storage = 30
@@ -84,7 +84,7 @@
 	inhand_icon_state = "bluetrashbag"
 	item_flags = NO_MAT_REDEMPTION
 
-/obj/item/storage/bag/trash/bluespace/Initialize()
+/obj/item/storage/bag/trash/bluespace/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 60
 	atom_storage.max_slots = 60
@@ -111,7 +111,7 @@
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_HUGE
 	atom_storage.max_total_storage = 50
-	atom_storage.numerical_stacking = TRUE 
+	atom_storage.numerical_stacking = TRUE
 	atom_storage.allow_quick_empty = TRUE
 	atom_storage.allow_quick_gather = TRUE
 	atom_storage.set_holdable(list(/obj/item/stack/ore))
@@ -178,7 +178,7 @@
 	desc = "A revolution in convenience, this satchel allows for huge amounts of ore storage. It's been outfitted with anti-malfunction safety measures."
 	icon_state = "satchel_bspace"
 
-/obj/item/storage/bag/ore/holding/Initialize()
+/obj/item/storage/bag/ore/holding/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = INFINITY
 	atom_storage.max_specific_storage = INFINITY
@@ -195,7 +195,7 @@
 	worn_icon_state = "plantbag"
 	resistance_flags = FLAMMABLE
 
-/obj/item/storage/bag/plants/Initialize()
+/obj/item/storage/bag/plants/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 100
@@ -253,7 +253,7 @@
 
 	var/capacity = 300; //the number of sheets it can carry.
 
-/obj/item/storage/bag/sheetsnatcher/Initialize()
+/obj/item/storage/bag/sheetsnatcher/Initialize(mapload)
 	. = ..()
 	atom_storage.allow_quick_empty = TRUE
 	atom_storage.allow_quick_gather = TRUE
@@ -288,7 +288,7 @@
 	worn_icon_state = "bookbag"
 	resistance_flags = FLAMMABLE
 
-/obj/item/storage/bag/books/Initialize()
+/obj/item/storage/bag/books/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 21
@@ -317,7 +317,7 @@
 	custom_materials = list(/datum/material/iron=3000)
 	custom_price = PAYCHECK_CREW * 0.6
 
-/obj/item/storage/bag/tray/Initialize()
+/obj/item/storage/bag/tray/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_BULKY //Plates are required bulky to keep them out of backpacks
 	atom_storage.set_holdable(list(
@@ -404,7 +404,7 @@
 	desc = "A bag for storing pills, patches, and bottles."
 	resistance_flags = FLAMMABLE
 
-/obj/item/storage/bag/chemistry/Initialize()
+/obj/item/storage/bag/chemistry/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 200
 	atom_storage.max_slots = 50
@@ -431,7 +431,7 @@
 	desc = "A bag for the safe transportation and disposal of biowaste and other virulent materials."
 	resistance_flags = FLAMMABLE
 
-/obj/item/storage/bag/bio/Initialize()
+/obj/item/storage/bag/bio/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 200
 	atom_storage.max_slots = 25
@@ -460,7 +460,7 @@
 	desc = "A bag for the storage and transport of anomalous materials."
 	resistance_flags = FLAMMABLE
 
-/obj/item/storage/bag/xeno/Initialize()
+/obj/item/storage/bag/xeno/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 200
 	atom_storage.max_slots = 25
@@ -491,7 +491,7 @@
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
 	resistance_flags = FLAMMABLE
 
-/obj/item/storage/bag/construction/Initialize()
+/obj/item/storage/bag/construction/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 100
 	atom_storage.max_slots = 50
@@ -514,7 +514,7 @@
 	inhand_icon_state = "quiver"
 	worn_icon_state = "harpoon_quiver"
 
-/obj/item/storage/bag/harpoon_quiver/Initialize()
+/obj/item/storage/bag/harpoon_quiver/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_TINY
 	atom_storage.max_slots = 40

--- a/code/game/objects/items/storage/basket.dm
+++ b/code/game/objects/items/storage/basket.dm
@@ -5,7 +5,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = FLAMMABLE
 
-/obj/item/storage/basket/Initialize()
+/obj/item/storage/basket/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 21

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -41,7 +41,7 @@
 	drop_sound = 'sound/items/handling/toolbelt_drop.ogg'
 	pickup_sound = 'sound/items/handling/toolbelt_pickup.ogg'
 
-/obj/item/storage/belt/utility/Initialize()
+/obj/item/storage/belt/utility/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 21
@@ -205,7 +205,7 @@
 	inhand_icon_state = "medical"
 	worn_icon_state = "medical"
 
-/obj/item/storage/belt/medical/Initialize()
+/obj/item/storage/belt/medical/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 21
@@ -318,7 +318,7 @@
 	worn_icon_state = "security"
 	content_overlays = TRUE
 
-/obj/item/storage/belt/security/Initialize()
+/obj/item/storage/belt/security/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 5
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
@@ -357,7 +357,7 @@
 	content_overlays = FALSE
 	custom_premium_price = PAYCHECK_COMMAND * 3
 
-/obj/item/storage/belt/security/webbing/Initialize()
+/obj/item/storage/belt/security/webbing/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 6
 
@@ -369,7 +369,7 @@
 	worn_icon_state = "explorer1"
 	w_class = WEIGHT_CLASS_BULKY
 
-/obj/item/storage/belt/mining/Initialize()
+/obj/item/storage/belt/mining/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 6
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
@@ -430,7 +430,7 @@
 	inhand_icon_state = "ebelt"
 	worn_icon_state = "ebelt"
 
-/obj/item/storage/belt/mining/primitive/Initialize()
+/obj/item/storage/belt/mining/primitive/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 5
 
@@ -441,7 +441,7 @@
 	inhand_icon_state = "soulstonebelt"
 	worn_icon_state = "soulstonebelt"
 
-/obj/item/storage/belt/soulstone/Initialize()
+/obj/item/storage/belt/soulstone/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 6
 	atom_storage.set_holdable(list(
@@ -464,7 +464,7 @@
 	worn_icon_state = "championbelt"
 	custom_materials = list(/datum/material/gold=400)
 
-/obj/item/storage/belt/champion/Initialize()
+/obj/item/storage/belt/champion/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 1
 	atom_storage.set_holdable(list(
@@ -486,7 +486,7 @@
 	worn_icon_state = "militarywebbing"
 	resistance_flags = FIRE_PROOF
 
-/obj/item/storage/belt/military/Initialize()
+/obj/item/storage/belt/military/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 
@@ -498,7 +498,7 @@
 	var/sponsor = pick("Donk Co.", "Waffle Co.", "Roffle Co.", "Gorlax Marauders", "Tiger Cooperative")
 	desc = "A set of snack-tical webbing worn by athletes of the [sponsor] VR sports division."
 
-/obj/item/storage/belt/military/snack/Initialize()
+/obj/item/storage/belt/military/snack/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 6
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
@@ -568,7 +568,7 @@
 	inhand_icon_state = "security"
 	worn_icon_state = "assault"
 
-/obj/item/storage/belt/military/assault/Initialize()
+/obj/item/storage/belt/military/assault/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 6
 
@@ -585,7 +585,7 @@
 	inhand_icon_state = "security"
 	worn_icon_state = "grenadebeltnew"
 
-/obj/item/storage/belt/grenade/Initialize()
+/obj/item/storage/belt/grenade/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 30
 	atom_storage.numerical_stacking = TRUE
@@ -624,7 +624,7 @@
 	inhand_icon_state = "soulstonebelt"
 	worn_icon_state = "soulstonebelt"
 
-/obj/item/storage/belt/wands/Initialize()
+/obj/item/storage/belt/wands/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 6
 	atom_storage.set_holdable(list(
@@ -650,7 +650,7 @@
 	inhand_icon_state = "janibelt"
 	worn_icon_state = "janibelt"
 
-/obj/item/storage/belt/janitor/Initialize()
+/obj/item/storage/belt/janitor/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 6
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL // Set to this so the  light replacer can fit.
@@ -685,7 +685,7 @@
 	inhand_icon_state = "bandolier"
 	worn_icon_state = "bandolier"
 
-/obj/item/storage/belt/bandolier/Initialize()
+/obj/item/storage/belt/bandolier/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 18
 	atom_storage.max_total_storage = 18
@@ -704,7 +704,7 @@
 	dying_key = DYE_REGISTRY_FANNYPACK
 	custom_price = PAYCHECK_CREW * 2
 
-/obj/item/storage/belt/fannypack/Initialize()
+/obj/item/storage/belt/fannypack/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 3
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
@@ -777,7 +777,7 @@
 	worn_icon_state = "sheath"
 	w_class = WEIGHT_CLASS_BULKY
 
-/obj/item/storage/belt/sabre/Initialize()
+/obj/item/storage/belt/sabre/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
@@ -826,7 +826,7 @@
 	worn_icon_state = "plantbelt"
 	content_overlays = TRUE
 
-/obj/item/storage/belt/plant/Initialize()
+/obj/item/storage/belt/plant/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 6
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -10,7 +10,7 @@
 	resistance_flags = FLAMMABLE
 	var/title = "book"
 
-/obj/item/storage/book/Initialize()
+/obj/item/storage/book/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 1
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -470,7 +470,7 @@
 	for(var/i in 1 to 6)
 		new donktype(src)
 
-/obj/item/storage/box/donkpockets/Initialize()
+/obj/item/storage/box/donkpockets/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(list(/obj/item/food/donkpocket))
 
@@ -511,7 +511,7 @@
 	illustration = null
 	var/cube_type = /obj/item/food/monkeycube
 
-/obj/item/storage/box/monkeycubes/Initialize()
+/obj/item/storage/box/monkeycubes/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 7
 	atom_storage.set_holdable(list(/obj/item/food/monkeycube))
@@ -530,7 +530,7 @@
 	icon_state = "monkeycubebox"
 	illustration = null
 
-/obj/item/storage/box/gorillacubes/Initialize()
+/obj/item/storage/box/gorillacubes/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 3
 	atom_storage.set_holdable(list(/obj/item/food/monkeycube))
@@ -687,7 +687,7 @@
 	icon_state = "spbox"
 	illustration = ""
 
-/obj/item/storage/box/snappops/Initialize()
+/obj/item/storage/box/snappops/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(list(/obj/item/toy/snappop))
 	atom_storage.max_slots = 8
@@ -711,7 +711,7 @@
 	base_icon_state = "matchbox"
 	illustration = null
 
-/obj/item/storage/box/matches/Initialize()
+/obj/item/storage/box/matches/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 10
 	atom_storage.set_holdable(list(/obj/item/match))
@@ -746,7 +746,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	foldable = /obj/item/stack/sheet/cardboard //BubbleWrap
 
-/obj/item/storage/box/lights/Initialize()
+/obj/item/storage/box/lights/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 21
 	atom_storage.set_holdable(list(/obj/item/light/tube, /obj/item/light/bulb))
@@ -1243,7 +1243,7 @@
 	foldable = null
 	custom_price = PAYCHECK_CREW
 
-/obj/item/storage/box/gum/Initialize()
+/obj/item/storage/box/gum/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(list(/obj/item/food/bubblegum))
 	atom_storage.max_slots = 4

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -16,7 +16,7 @@
 	max_integrity = 150
 	var/folder_path = /obj/item/folder //this is the path of the folder that gets spawned in New()
 
-/obj/item/storage/briefcase/Initialize()
+/obj/item/storage/briefcase/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 21
@@ -70,4 +70,3 @@
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
 	new /obj/item/suppressor/specialoffer(src)
-

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -29,7 +29,7 @@
 	/// What this container folds up into when it's empty.
 	var/obj/fold_result = /obj/item/stack/sheet/cardboard
 
-/obj/item/storage/fancy/Initialize()
+/obj/item/storage/fancy/Initialize(mapload)
 	. = ..()
 
 	atom_storage.max_slots = spawn_count
@@ -93,7 +93,7 @@
 	custom_premium_price = PAYCHECK_COMMAND * 1.75
 	contents_tag = "donut"
 
-/obj/item/storage/fancy/donut_box/Initialize()
+/obj/item/storage/fancy/donut_box/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(list(/obj/item/food/donut))
 
@@ -140,7 +140,7 @@
 	spawn_count = 12
 	contents_tag = "egg"
 
-/obj/item/storage/fancy/egg_box/Initialize()
+/obj/item/storage/fancy/egg_box/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(list(/obj/item/food/egg))
 
@@ -213,7 +213,7 @@
 	atom_storage.max_slots = 0
 	return
 
-/obj/item/storage/fancy/cigarettes/Initialize()
+/obj/item/storage/fancy/cigarettes/Initialize(mapload)
 	. = ..()
 	atom_storage.quickdraw = TRUE
 	atom_storage.set_holdable(list(/obj/item/clothing/mask/cigarette, /obj/item/lighter))
@@ -359,7 +359,7 @@
 	spawn_count = 10
 	custom_price = PAYCHECK_LOWER
 
-/obj/item/storage/fancy/rollingpapers/Initialize()
+/obj/item/storage/fancy/rollingpapers/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(list(/obj/item/rollingpaper))
 
@@ -390,7 +390,7 @@
 	spawn_coupon = FALSE
 	display_cigs = FALSE
 
-/obj/item/storage/fancy/cigarettes/cigars/Initialize()
+/obj/item/storage/fancy/cigarettes/cigars/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(list(/obj/item/clothing/mask/cigarette/cigar))
 
@@ -439,7 +439,7 @@
 	spawn_type = /obj/item/food/tinychocolate
 	spawn_count = 8
 
-/obj/item/storage/fancy/heart_box/Initialize()
+/obj/item/storage/fancy/heart_box/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(list(/obj/item/food/tinychocolate))
 
@@ -454,6 +454,6 @@
 	spawn_type = /obj/item/food/nugget
 	spawn_count = 6
 
-/obj/item/storage/fancy/nugget_box/Initialize()
+/obj/item/storage/fancy/nugget_box/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(list(/obj/item/food/nugget))

--- a/code/game/objects/items/storage/garment.dm
+++ b/code/game/objects/items/storage/garment.dm
@@ -30,7 +30,7 @@
 	name = "chief engineer's garment bag"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the chief engineer."
 
-/obj/item/storage/bag/garment/Initialize()
+/obj/item/storage/bag/garment/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.numerical_stacking = FALSE
@@ -120,4 +120,3 @@
 	new /obj/item/clothing/neck/cloak/ce(src)
 	new /obj/item/clothing/shoes/sneakers/brown(src)
 	new /obj/item/clothing/suit/hooded/wintercoat/engineering/ce(src)
-

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	REMOVE_TRAIT(user, TRAIT_GUNFLIP, CLOTHING_TRAIT)
 
-/obj/item/storage/belt/holster/Initialize()
+/obj/item/storage/belt/holster/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 1
 	atom_storage.max_total_storage = 16
@@ -35,7 +35,7 @@
 	name = "thermal shoulder holsters"
 	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. Meant to hold a twinned pair of thermal pistols, but can fit several kinds of energy handguns as well."
 
-/obj/item/storage/belt/holster/thermal/Initialize()
+/obj/item/storage/belt/holster/thermal/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 2
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
@@ -58,7 +58,7 @@
 	desc = "A holster able to carry handguns and some ammo. WARNING: Badasses only."
 	w_class = WEIGHT_CLASS_BULKY
 
-/obj/item/storage/belt/holster/detective/Initialize()
+/obj/item/storage/belt/holster/detective/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 3
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
@@ -117,7 +117,7 @@
 	chameleon_action.initialize_disguises()
 	add_item_action(chameleon_action)
 
-/obj/item/storage/belt/holster/chameleon/Initialize()
+/obj/item/storage/belt/holster/chameleon/Initialize(mapload)
 	. = ..()
 	atom_storage.silent = TRUE
 
@@ -131,7 +131,7 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/storage/belt/holster/chameleon/Initialize()
+/obj/item/storage/belt/holster/chameleon/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 2
 	atom_storage.max_total_storage = WEIGHT_CLASS_NORMAL
@@ -161,7 +161,7 @@
 	worn_icon_state = "syndicate_holster"
 	w_class = WEIGHT_CLASS_BULKY
 
-/obj/item/storage/belt/holster/nukie/Initialize()
+/obj/item/storage/belt/holster/nukie/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 2
 	atom_storage.max_specific_storage = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -13,7 +13,7 @@
 	var/icon_closed = "lockbox"
 	var/icon_broken = "lockbox+b"
 
-/obj/item/storage/lockbox/Initialize()
+/obj/item/storage/lockbox/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 14
@@ -96,7 +96,7 @@
 	icon_closed = "medalbox"
 	icon_broken = "medalbox+b"
 
-/obj/item/storage/lockbox/medal/Initialize()
+/obj/item/storage/lockbox/medal/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_slots = 10
@@ -169,12 +169,12 @@
 	name = "security medal box"
 	desc = "A locked box used to store medals to be given to members of the security department."
 	req_access = list(ACCESS_HOS)
-	
+
 /obj/item/storage/lockbox/medal/med
 	name = "medical medal box"
 	desc = "A locked box used to store medals to be given to members of the medical department."
 	req_access = list(ACCESS_CMO)
-	
+
 /obj/item/storage/lockbox/medal/med/PopulateContents()
 	new /obj/item/clothing/accessory/medal/med_medal(src)
 	new /obj/item/clothing/accessory/medal/med_medal2(src)
@@ -240,4 +240,3 @@
 	privacy_lock = atom_storage.locked
 	user.visible_message(span_notice("[user] [privacy_lock ? "" : "un"]locks [src]'s privacy lock."),
 					span_notice("You [privacy_lock ? "" : "un"]lock [src]'s privacy lock."))
-

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -60,7 +60,7 @@
 	inhand_icon_state = "medkit"
 	desc = "A high capacity aid kit for doctors, full of medical supplies and basic surgical equipment"
 
-/obj/item/storage/medkit/surgery/Initialize()
+/obj/item/storage/medkit/surgery/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL //holds the same equipment as a medibelt
 	atom_storage.max_slots = 12
@@ -258,7 +258,7 @@
 	icon_state = "medkit_tactical"
 	damagetype_healed = "all"
 
-/obj/item/storage/medkit/tactical/Initialize()
+/obj/item/storage/medkit/tactical/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 
@@ -316,7 +316,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/storage/pill_bottle/Initialize()
+/obj/item/storage/pill_bottle/Initialize(mapload)
 	. = ..()
 	atom_storage.allow_quick_gather = TRUE
 	atom_storage.set_holdable(list(/obj/item/reagent_containers/pill))

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -33,7 +33,7 @@
 	var/can_hack_open = TRUE
 
 
-/obj/item/storage/secure/Initialize()
+/obj/item/storage/secure/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_total_storage = 14
@@ -143,7 +143,7 @@
 	new /obj/item/paper(src)
 	new /obj/item/pen(src)
 
-/obj/item/storage/secure/briefcase/Initialize()
+/obj/item/storage/secure/briefcase/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 21
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
@@ -172,7 +172,7 @@
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/secure/safe, 32)
 
-/obj/item/storage/secure/safe/Initialize()
+/obj/item/storage/secure/safe/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(cant_hold_list = list(/obj/item/storage/secure/briefcase))
 	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC

--- a/code/game/objects/items/storage/sixpack.dm
+++ b/code/game/objects/items/storage/sixpack.dm
@@ -21,7 +21,7 @@
 	. = ..()
 	update_appearance()
 
-/obj/item/storage/cans/Initialize()
+/obj/item/storage/cans/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_total_storage = 12

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -38,7 +38,7 @@
 	if(has_latches)
 		. += latches
 
-/obj/item/storage/toolbox/Initialize()
+/obj/item/storage/toolbox/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 
@@ -101,7 +101,7 @@
 	force = 5
 	w_class = WEIGHT_CLASS_NORMAL
 
-/obj/item/storage/toolbox/mechanical/old/heirloom/Initialize()
+/obj/item/storage/toolbox/mechanical/old/heirloom/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 
@@ -168,7 +168,7 @@
 	throwforce = 18
 	material_flags = NONE
 
-/obj/item/storage/toolbox/syndicate/Initialize()
+/obj/item/storage/toolbox/syndicate/Initialize(mapload)
 	. = ..()
 	atom_storage.silent = TRUE
 
@@ -205,7 +205,7 @@
 	w_class = WEIGHT_CLASS_GIGANTIC //Holds more than a regular toolbox!
 	material_flags = NONE
 
-/obj/item/storage/toolbox/artistic/Initialize()
+/obj/item/storage/toolbox/artistic/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 20
 	atom_storage.max_slots = 10
@@ -271,7 +271,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	has_latches = FALSE
 
-/obj/item/storage/toolbox/infiltrator/Initialize()
+/obj/item/storage/toolbox/infiltrator/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 10
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
@@ -338,6 +338,3 @@
 /obj/item/storage/toolbox/haunted
 	name = "old toolbox"
 	custom_materials = list(/datum/material/hauntium = 500)
-
-
-

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -385,7 +385,7 @@
 /obj/item/storage/box/syndie_kit/space
 	name = "boxed space suit and helmet"
 
-/obj/item/storage/box/syndie_kit/space/Initialize()
+/obj/item/storage/box/syndie_kit/space/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.set_holdable(list(/obj/item/clothing/suit/space/syndicate, /obj/item/clothing/head/helmet/space/syndicate))
@@ -410,7 +410,7 @@
 /obj/item/storage/box/syndie_kit/chemical
 	name = "chemical kit"
 
-/obj/item/storage/box/syndie_kit/chemical/Initialize()
+/obj/item/storage/box/syndie_kit/chemical/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 14
 

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -10,7 +10,7 @@
 	var/list/combined_access
 	var/cached_flat_icon
 
-/obj/item/storage/wallet/Initialize()
+/obj/item/storage/wallet/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 4
 	atom_storage.set_holdable(list(

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -73,7 +73,7 @@
 	throwforce = 10
 	throw_speed = 2
 
-/obj/item/crowbar/large/old/Initialize()
+/obj/item/crowbar/large/old/Initialize(mapload)
 	. = ..()
 	if(prob(50))
 		icon_state = "crowbar_powergame"

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -479,7 +479,7 @@ LINEN BINS
 	icon_state = "random_bedsheet"
 	bedsheet_type = BEDSHEET_ABSTRACT
 
-/obj/item/bedsheet/dorms_double/Initialize()
+/obj/item/bedsheet/dorms_double/Initialize(mapload)
 	..()
 	var/type = pick_weight(list("Colors" = 80, "Special" = 20))
 	switch(type)

--- a/code/game/objects/structures/toiletbong.dm
+++ b/code/game/objects/structures/toiletbong.dm
@@ -9,7 +9,7 @@
 	var/smokeradius = 1
 	var/mutable_appearance/weed_overlay
 
-/obj/structure/toiletbong/Initialize()
+/obj/structure/toiletbong/Initialize(mapload)
 	. = ..()
 	create_storage()
 	atom_storage.attack_hand_interact = FALSE

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_map.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_map.dm
@@ -18,7 +18,7 @@ GLOBAL_LIST_EMPTY(heretic_sacrifice_landmarks)
 	/// What path this landmark is intended for.
 	var/for_heretic_path = PATH_START
 
-/obj/effect/landmark/heretic/Initialize()
+/obj/effect/landmark/heretic/Initialize(mapload)
 	. = ..()
 	GLOB.heretic_sacrifice_landmarks[for_heretic_path] = src
 
@@ -60,7 +60,7 @@ GLOBAL_LIST_EMPTY(heretic_sacrifice_landmarks)
 	/// Light power of the signpost.
 	var/power = 0.8
 
-/obj/structure/no_effect_signpost/void/Initialize()
+/obj/structure/no_effect_signpost/void/Initialize(mapload)
 	. = ..()
 	set_light(range, power)
 

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -401,7 +401,7 @@
 
 	custom_premium_price = PAYCHECK_CREW * 1.25
 
-/obj/item/canvas/thirtysix_twentyfour/Initialize()
+/obj/item/canvas/thirtysix_twentyfour/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/item_scaling, 1, 0.8)
 	icon = 'icons/obj/artstuff_64x64.dmi'
@@ -424,7 +424,7 @@
 
 	custom_premium_price = PAYCHECK_CREW * 1.75
 
-/obj/item/canvas/fortyfive_twentyseven/Initialize()
+/obj/item/canvas/fortyfive_twentyseven/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/item_scaling, 1, 0.7)
 	icon = 'icons/obj/artstuff_64x64.dmi'
@@ -762,7 +762,7 @@
 	///Chosen paint color
 	var/current_color = "#000000"
 
-/obj/item/paint_palette/Initialize()
+/obj/item/paint_palette/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/palette, AVAILABLE_PALETTE_SPACE, current_color)
 

--- a/code/modules/awaymissions/mission_code/Cabin.dm
+++ b/code/modules/awaymissions/mission_code/Cabin.dm
@@ -110,7 +110,7 @@
 	icon_state = "1"
 	color = rgb(0,0,255)
 
-/obj/structure/ladder/unbreakable/rune/Initialize()
+/obj/structure/ladder/unbreakable/rune/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/update_icon_blocker)
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -788,7 +788,7 @@
 	/// The badmin mode. Makes your projectiles act like the real deal.
 	var/real_hits = FALSE
 
-/obj/item/gun/energy/laser/chameleon/Initialize()
+/obj/item/gun/energy/laser/chameleon/Initialize(mapload)
 	. = ..()
 	chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/gun

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -70,7 +70,7 @@
 	inhand_icon_state = "artistic_toolbox"
 	material_flags = NONE
 
-/obj/item/storage/toolbox/Initialize()
+/obj/item/storage/toolbox/Initialize(mapload)
 	. = ..()
 	// Can hold fishing rod despite the size
 	var/static/list/exception_cache = typecacheof(/obj/item/fishing_rod)

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -381,7 +381,7 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 
-/obj/machinery/microwave/hell/Initialize()
+/obj/machinery/microwave/hell/Initialize(mapload)
 	. = ..()
 	//We want there to be some chance of them getting a working microwave (eventually).
 	if(prob(95))

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -106,7 +106,7 @@
 	///Maximum icon state number
 	var/maximum_book_state = 8
 
-/obj/item/book/Initialize()
+/obj/item/book/Initialize(mapload)
 	. = ..()
 	book_data = new(starting_title, starting_author, starting_content)
 

--- a/code/modules/mining/equipment/kheiral_cuffs.dm
+++ b/code/modules/mining/equipment/kheiral_cuffs.dm
@@ -22,7 +22,7 @@
 	/// If we're off the station's Z-level
 	var/far_from_home = FALSE
 
-/obj/item/kheiral_cuffs/Initialize()
+/obj/item/kheiral_cuffs/Initialize(mapload)
 	. = ..()
 	update_icon(UPDATE_OVERLAYS)
 	RegisterSignal(src, COMSIG_MOVABLE_Z_CHANGED, .proc/check_z)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drone_tools.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drone_tools.dm
@@ -6,7 +6,7 @@
 	item_flags = ABSTRACT
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
-/obj/item/storage/drone_tools/Initialize()
+/obj/item/storage/drone_tools/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 
@@ -86,4 +86,3 @@
 	inhand_icon_state = "cutters"
 	item_flags = NO_MAT_REDEMPTION
 	random_color = FALSE
-

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -84,7 +84,7 @@ Difficulty: Hard
 	/// Blood warp ability
 	var/datum/action/cooldown/mob_cooldown/blood_warp/blood_warp
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/Initialize()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NO_FLOATING_ANIM, INNATE_TRAIT)
 	triple_charge = new /datum/action/cooldown/mob_cooldown/charge/triple_charge()
@@ -331,7 +331,7 @@ Difficulty: Hard
 	true_spawn = FALSE
 	var/move_through_mob
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/Initialize()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/Initialize(mapload)
 	. = ..()
 	toggle_ai(AI_OFF)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -83,7 +83,7 @@
 	/// Lava swoop ability
 	var/datum/action/cooldown/mob_cooldown/lava_swoop/lava_swoop
 
-/mob/living/simple_animal/hostile/megafauna/dragon/Initialize()
+/mob/living/simple_animal/hostile/megafauna/dragon/Initialize(mapload)
 	. = ..()
 	fire_cone = new /datum/action/cooldown/mob_cooldown/fire_breath/cone()
 	meteors = new /datum/action/cooldown/mob_cooldown/meteors()
@@ -359,7 +359,7 @@
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)
 	attack_action_types = list()
 
-/mob/living/simple_animal/hostile/megafauna/dragon/lesser/Initialize()
+/mob/living/simple_animal/hostile/megafauna/dragon/lesser/Initialize(mapload)
 	. = ..()
 	fire_cone.Remove(src)
 	meteors.Remove(src)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
@@ -166,7 +166,7 @@
 	light_power = 3
 	light_range = 2
 
-/obj/effect/brimbeam/Initialize()
+/obj/effect/brimbeam/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSfastprocess, src)
 

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -481,7 +481,7 @@
 	/// Whitelist of attachable hats, read note in Initialize() below this line
 	var/static/list/attachable_hats_list
 
-/obj/item/mod/module/hat_stabilizer/Initialize()
+/obj/item/mod/module/hat_stabilizer/Initialize(mapload)
 	. = ..()
 	attachable_hats_list = typecacheof(
 	//List of attachable hats. Make sure these and their subtypes are all tested, so they dont appear janky.
@@ -507,7 +507,7 @@
 			/obj/item/clothing/head/papersack,
 			/obj/item/clothing/head/caphat/beret,
 			))
-			
+
 /obj/item/mod/module/hat_stabilizer/on_suit_activation()
 	RegisterSignal(mod.helmet, COMSIG_PARENT_EXAMINE, .proc/add_examine)
 	RegisterSignal(mod.helmet, COMSIG_PARENT_ATTACKBY, .proc/place_hat)

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -41,7 +41,7 @@
 	var/can_customise = TRUE
 	var/default_picture_name
 
-/obj/item/camera/Initialize()
+/obj/item/camera/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/shell, list(new /obj/item/circuit_component/camera), SHELL_CAPACITY_SMALL)
 

--- a/code/modules/photography/photos/frame.dm
+++ b/code/modules/photography/photos/frame.dm
@@ -197,7 +197,7 @@
 	var/portrait_state
 	var/portrait_desc
 
-/obj/structure/sign/picture_frame/portrait/Initialize()
+/obj/structure/sign/picture_frame/portrait/Initialize(mapload)
 	. = ..()
 	switch(rand(1,4))
 		if(1) // Deempisi
@@ -265,7 +265,7 @@
 	del_id_on_destroy = TRUE
 
 ///Generates a persistence id unique to the current map. Every bar should feel a little bit different after all.
-/obj/structure/sign/picture_frame/portrait/bar/Initialize()
+/obj/structure/sign/picture_frame/portrait/bar/Initialize(mapload)
 	if(SSmapping.config.map_path != CUSTOM_MAP_PATH) //skip adminloaded custom maps.
 		persistence_id = "frame_bar_[SSmapping.config.map_name]"
 	return ..()

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -317,7 +317,7 @@
 	icon_broken = "medalbox+b"
 	base_icon_state = "medalbox"
 
-/obj/item/storage/lockbox/dueling/Initialize()
+/obj/item/storage/lockbox/dueling/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_slots = 2

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -14,7 +14,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	var/pshoom_or_beepboopblorpzingshadashwoosh = 'sound/items/rped.ogg'
 	var/alt_sound = null
 
-/obj/item/storage/part_replacer/Initialize()
+/obj/item/storage/part_replacer/Initialize(mapload)
 	. = ..()
 	create_storage(type = /datum/storage/rped)
 


### PR DESCRIPTION
## About The Pull Request

See #61623, #61759

All `/atom` `Initialize()`s should be passed `mapload` as first arg

Regex used: `(\/(obj|mob|turf|area|atom|atom\/movable)\/.+\/Initialize)\(\)`

(this doesn't cover cases of init having args but missing mapload)

## Why It's Good For The Game

it's important, sort of
