### PR TITLE
Fixes a copy+paste error with ladder screentips

### DIFF
--- a/code/modules/awaymissions/mission_code/Cabin.dm
+++ b/code/modules/awaymissions/mission_code/Cabin.dm
@@ -114,7 +114,7 @@
 	. = ..()
 	AddElement(/datum/element/update_icon_blocker)
 
-/obj/structure/ladder/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+/obj/structure/ladder/unbreakable/rune/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	if(up)
 		context[SCREENTIP_CONTEXT_LMB] = "Warp up"
 	if(down)


### PR DESCRIPTION
## About The Pull Request

`/obj/structure/ladder/unbreakable/rune` had a copy+past error, so either all ladders were showing as "warp up / down" or all ladder runes were showing as "climb up / down", I'm not sure which as I don't use screentips, I just saw the dupe definition lint while doing the mapload PR

![image](https://user-images.githubusercontent.com/51863163/183816745-9c560c23-5147-4abf-b48d-c7acab75d9d5.png)

## Why It's Good For The Game

Maybe fixes some screentips

## Changelog

:cl: Melbert
fix: Either ladders will no longer show screentips relating to "warping", or fake teleportation runes will no longer show screentips related to "climbing". Honestly not sure but one of them was wrong
/:cl:
