### PR TITLE
Fixes the privacy bolts on two of the Tram station dorms rooms

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -39386,7 +39386,7 @@
 /area/station/hallway/primary/tram/right)
 "nwT" = (
 /obj/machinery/door/airlock{
-	id_tag = "private_c";
+	id_tag = "private_d";
 	name = "Private Quarters C"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47027,7 +47027,7 @@
 /area/station/maintenance/disposal/incinerator)
 "qhe" = (
 /obj/machinery/door/airlock{
-	id_tag = "private_R";
+	id_tag = "private_r";
 	name = "Private Quarters R"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -39387,7 +39387,7 @@
 "nwT" = (
 /obj/machinery/door/airlock{
 	id_tag = "private_d";
-	name = "Private Quarters C"
+	name = "Private Quarters D"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,


### PR DESCRIPTION

## About The Pull Request
Dorms Rooms D (mislabelled as C) and R's privacy bolt buttons didn't work due to mislabelling and a typo, now they do.

## Why It's Good For The Game
Sometimes you need to bolt your dorm room while you're doing things in dorms, like buying uplink stuff.

## Changelog

:cl:
fix: Dorms rooms D and R on tramstation now bolt properly.
/:cl:

