### PR TITLE
Fix tape recorder printing out transcripts phat enough to crash your game.

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -283,9 +283,8 @@
 	set name = "Print Transcript"
 	set category = "Object"
 
-	if(!mytape.storedinfo.len)
-		return
-	if(!can_use(usr))
+	var/list/transcribed_info = mytape.storedinfo
+	if(!length(transcribed_info))
 		return
 	if(!mytape)
 		return
@@ -294,22 +293,48 @@
 		return
 	if(recording || playing)
 		return
+	if(!can_use(usr))
+		return
 
-	say("Transcript printed.")
-	playsound(src, 'sound/items/taperecorder/taperecorder_print.ogg', 50, FALSE)
+	var/transcribed_text = "<b>Transcript:</b><br><br>"
+	var/page_count = 1
+
+	var/tape_name = mytape.name
+	var/initial_tape_name = initial(mytape.name)
+	var/paper_name = "paper- '[tape_name == initial_tape_name ? "Tape" : "[tape_name]"] Transcript'"
+
+	for(var/transcript_excerpt in transcribed_info)
+		var/excerpt_length = length(transcript_excerpt)
+
+		// Very unexpected. Better abort non-gracefully.
+		if(excerpt_length > MAX_PAPER_LENGTH)
+			say("Error: Data corruption detected. Cannot print.")
+			CRASH("Transcript entry has more than [MAX_PAPER_LENGTH] chars: [excerpt_length] chars")
+
+		// If we're going to overflow the paper's length, print the current transcribed text out first and reset to prevent us
+		// going over the paper char count.
+		if((length(transcribed_text) + excerpt_length) > MAX_PAPER_LENGTH)
+			var/obj/item/paper/transcript_paper = new /obj/item/paper(get_turf(src))
+			transcript_paper.add_raw_text(transcribed_text)
+			transcript_paper.name = "[paper_name] page [page_count]"
+			transcript_paper.update_appearance()
+			transcribed_text = ""
+			page_count++
+
+		transcribed_text += "[transcript_excerpt]<br>"
+
 	var/obj/item/paper/transcript_paper = new /obj/item/paper(get_turf(src))
-	var/t1 = "<B>Transcript:</B><BR><BR>"
-	for(var/i in 1 to mytape.storedinfo.len)
-		t1 += "[mytape.storedinfo[i]]<BR>"
-	transcript_paper.add_raw_text(t1)
-	var/tapename = mytape.name
-	var/prototapename = initial(mytape.name)
-	transcript_paper.name = "paper- '[tapename == prototapename ? "Tape" : "[tapename]"] Transcript'"
+	transcript_paper.add_raw_text(transcribed_text)
+	transcript_paper.name = "[paper_name] page [page_count]"
 	transcript_paper.update_appearance()
+
+	say("Transcript printed, [page_count] pages.")
+	playsound(src, 'sound/items/taperecorder/taperecorder_print.ogg', 50, FALSE)
+
+	// Can't put the entire stack into their hands if there's multple pages, but hey we can at least put one page in.
 	usr.put_in_hands(transcript_paper)
 	canprint = FALSE
 	addtimer(VARSET_CALLBACK(src, canprint, TRUE), 30 SECONDS)
-
 
 //empty tape recorders
 /obj/item/taperecorder/empty


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tape recorders can hold 10 minutes of say logs and then transcribe them.

People say a lot of things in 10 minutes.

These transcriptions can be quite large.

These transcriptions have a lot of spans, which get sanitised away to nothingness JS-side. This causes a lot of client-side JS processing on paper for transcripts that go ~~super saiyan~~ beyond the character limit.

This can hang peoples' games up when they're running SS13 on their Samsung SmartFridge.

This PR paginates printed transcripts.

I spent a lot of effort reproducing the average tgstation RP experience...
![0TLzOIH23G](https://user-images.githubusercontent.com/24975989/183944919-97682293-52c9-4398-930f-006cc2d027bb.gif)

Generated a lot of high quality RP logs...
![image](https://user-images.githubusercontent.com/24975989/183945118-037a746a-1f4f-4c94-baa7-1e4275b5fe21.png)

And hit print:
![image](https://user-images.githubusercontent.com/24975989/183945276-78637b51-6d70-4e7f-baf8-388c72439ff8.png)
![image](https://user-images.githubusercontent.com/24975989/183945300-d36b2f22-6364-4bc8-898d-5fa2c0a3c83e.png)

Boom. No more client crashing omegapaper...
![image](https://user-images.githubusercontent.com/24975989/183946079-66ce1a31-20a5-400a-a951-6169241a110e.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Papercode is fun.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix an issue where exceptionally large tape recorder printed transcripts could be generated. They now split across multiple pieces of paper. I sure hope you have a filing cabinet handy!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
