### PR TITLE
Long range Gas Analyzer now appears under "Tool Designs" as intended.

### DIFF
--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -41,7 +41,7 @@
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 100, /datum/material/glass = 20, /datum/material/gold = 300, /datum/material/bluespace=200)
 	build_path = /obj/item/analyzer/ranged
-	category = list("Tool Design")
+	category = list("Tool Designs")
 	departmental_flags= DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
 
 /datum/design/rpd


### PR DESCRIPTION
## About The Pull Request

Fix: #69125

## Why It's Good For The Game

Now shows under tools as intended...

## Changelog

:cl:
fix: Long range Gas Analyzer now appears under "Tool Designs" as intended.
/:cl:
