### PR TITLE
[Space Ruins] Fixes the stairs used in the Sulaco Ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
@@ -179,9 +179,10 @@
 /turf/open/floor/pod/light,
 /area/ruin/unpowered)
 "mi" = (
-/obj/structure/stairs/west,
 /obj/machinery/door/window/brigdoor/left/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/iron/stairs{
+	dir = 8
+	},
 /area/ruin/unpowered)
 "mu" = (
 /obj/structure/frame/computer{
@@ -226,9 +227,10 @@
 /turf/open/floor/iron/airless,
 /area/ruin/unpowered)
 "pj" = (
-/obj/structure/stairs/west,
 /obj/machinery/door/window/brigdoor/right/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/iron/stairs{
+	dir = 8
+	},
 /area/ruin/unpowered)
 "pv" = (
 /obj/machinery/door/airlock/command/glass{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The stairs used here were the multi-z stairs, not the turf stairs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
fix: Somewhere in space, stairs were fixed. I don't know where, but they were fixed. You're welcome.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
