### PR TITLE
Reduces CO2 heat penalty to 2, from 6, and halves the zap power boost.

### DIFF
--- a/code/__DEFINES/supermatter.dm
+++ b/code/__DEFINES/supermatter.dm
@@ -2,7 +2,7 @@
 #define OXYGEN_HEAT_PENALTY 1
 #define PLUOXIUM_HEAT_PENALTY -0.5 //Better then co2, worse then n2
 #define TRITIUM_HEAT_PENALTY 10
-#define CO2_HEAT_PENALTY 6
+#define CO2_HEAT_PENALTY 2
 #define NITROGEN_HEAT_PENALTY -1.5
 #define BZ_HEAT_PENALTY 5
 #define H2O_HEAT_PENALTY 12 //This'll get made slowly over time, I want my spice rock spicy god damnit
@@ -30,7 +30,6 @@
 #define HYPERNOBLIUM_TRANSMIT_MODIFIER 3
 #define H20_TRANSMIT_MODIFIER -2.5
 #define FREON_TRANSMIT_MODIFIER -30
-#define CO2_TRANSMIT_MODIFIER 10
 
 #define N2O_HEAT_RESISTANCE 6          //Higher == Gas makes the crystal more resistant against heat damage.
 #define HYDROGEN_HEAT_RESISTANCE 2 // just a bit of heat resistance to spice it up
@@ -125,11 +124,11 @@
 
 /// Means it's not forced, sm decides itself by checking the [/datum/sm_delam/proc/can_select]
 #define SM_DELAM_PRIO_NONE 0
-/// In-game factors like the destabilizing crystal [/obj/item/destabilizing_crystal]. 
+/// In-game factors like the destabilizing crystal [/obj/item/destabilizing_crystal].
 /// Purged when SM heals to 100
 #define SM_DELAM_PRIO_IN_GAME 1
 
-/// Purge the current forced delam and make it zero again (back to normal). 
+/// Purge the current forced delam and make it zero again (back to normal).
 /// Needs to be higher priority than current forced_delam though.
 #define SM_DELAM_STRATEGY_PURGE null
 
@@ -141,7 +140,7 @@
 #define SUPERMATTER_INACTIVE 0
 /// Normal operation
 #define SUPERMATTER_NORMAL 1
-/// Ambient temp 80% of the default temp for SM to take damage. 
+/// Ambient temp 80% of the default temp for SM to take damage.
 #define SUPERMATTER_NOTIFY 2
 /// Integrity below [/obj/machinery/power/supermatter_crystal/var/warning_point]. Start complaining on comms.
 #define SUPERMATTER_WARNING 3

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -40,10 +40,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	///The amount of damage we have currently
 	var/damage = 0
-	/// The damage we had before this cycle. 
+	/// The damage we had before this cycle.
 	/// Used to limit the damage we can take each cycle, and to check if we are currently taking damage or healing.
 	var/damage_archived = 0
-	
+
 	///The point at which we consider the supermatter to be [SUPERMATTER_STATUS_WARNING]
 	var/warning_point = 50
 	var/warning_channel = RADIO_CHANNEL_ENGINEERING
@@ -119,7 +119,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		/datum/gas/antinoblium = ANTINOBLIUM_TRANSMIT_MODIFIER,
 		/datum/gas/freon = FREON_TRANSMIT_MODIFIER,
 		/datum/gas/water_vapor = H20_TRANSMIT_MODIFIER,
-		/datum/gas/carbon_dioxide = CO2_TRANSMIT_MODIFIER,
 	)
 	///The list of gases mapped against their heat penaltys. We use it to determin molar and heat output
 	var/list/gas_heat = list(
@@ -269,7 +268,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	/// How we are delaminating.
 	var/datum/sm_delam/delamination_strategy
-	/// Whether the sm is forced in a specific delamination_strategy or not. All truthy values means it's forced. 
+	/// Whether the sm is forced in a specific delamination_strategy or not. All truthy values means it's forced.
 	/// Only values greater or equal to the current one can change the strat.
 	var/delam_priority = SM_DELAM_PRIO_NONE
 
@@ -442,9 +441,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		step_towards(movable_atom,center)
 
 /**
- * Count down, spout some messages, and then execute the delam itself. 
+ * Count down, spout some messages, and then execute the delam itself.
  * We guard for last second delam strat changes here, mostly because some have diff messages.
- * 
+ *
  * By last second changes, we mean that it's possible for say, a tesla delam to
  * just explode normally if at the absolute last second it loses power and switches to default one.
  * Even after countdown is already in progress.
@@ -455,7 +454,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	if(final_countdown) // We're already doing it go away
 		stack_trace("[src] told to delaminate again while it's already delaminating.")
 		return
-	
+
 	final_countdown = TRUE
 	update_appearance()
 
@@ -475,7 +474,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 		var/message
 		var/healed = FALSE
-		
+
 		if(damage < explosion_point) // Cutting it a bit close there engineers
 			message = count_down_messages[2]
 			healed = TRUE
@@ -488,7 +487,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			message = "[i*0.1]..."
 
 		radio.talk_into(src, message, emergency_channel)
-		
+
 		if(healed)
 			final_countdown = FALSE
 			update_appearance()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces CO2 heat penalty to 2, from 6, and removes the power transmission bonus. A heat penalty of 2 seems low, but the heat produced is also scales power, which CO2 increases, and is still 4 times higher than old CO2 (0.1, but gets clamped to the minimum value of 0.5).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Most engineers have a skill issue with CO2 before they can let its powerloss inhibitors to have a significant effect. Unless someone tries to intentionally sabotage with CO2, the skill issues will just make CO2 look like another high heat penalty gas, which is boring as it masks its gimmick of reducing powerloss. The high heat penalty made it produce more gas, which lowered CO2 composition, so it hard a harder time staying in the high power levels, and the high power levels were a unique danger for CO2 engines due to its more destructive zaps and anomalies.

I think the effect of having a skill issue when it reaches the dangerous power levels is a lot more interesting than having a skill issue at normal power levels, as high power delams are significantly more dangerous than low power delams.

Removing its power transmission (multiplier for power gained when teslas absorb the zaps, not the supermatter's power) will mean that CO2 will provide no benefit unless it is put at the composition to raise its power levels, which should bring CO2 usage back to its more interesting purpose of powerloss inhibition.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Reduces CO2 heat penalty to 2, from 6.
balance: Removes CO2 power transmission bonus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
