### PR TITLE
Fixes login() runtime when players connect before SSsecurity_level finishes initializing

### DIFF
--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -76,13 +76,13 @@ SUBSYSTEM_DEF(security_level)
  * Returns the current security level as a number
  */
 /datum/controller/subsystem/security_level/proc/get_current_level_as_number()
-	return current_security_level ? current_security_level.number_level : SEC_LEVEL_GREEN //Send a response in case the subsystem hasn't finished setting up yet
+	return ((!initialized || !current_security_level) ? SEC_LEVEL_GREEN : current_security_level.number_level) //Send the default security level in case the subsystem hasn't finished initializing yet
 
 /**
  * Returns the current security level as text
  */
 /datum/controller/subsystem/security_level/proc/get_current_level_as_text()
-	return current_security_level ? current_security_level.name : "green"
+	return ((!initialized || !current_security_level) ? "green" : current_security_level.name)
 
 /**
  * Converts a text security level to a number


### PR DESCRIPTION
Tried to fix this before with #68500, partially did! This finishes the job.

```
[2022-07-14 01:36:03.458] Running /tg/ revision: 
 - origin/master: d9f62bdcffd733db8c94b5bfaf929e54d0dddd2d
 - Test merge active of PR #68396 commit bcf26096733ff8c6997d49762d86f48d277e3758
 - Test merge active of PR #68401 commit b175bb84b63836406c2a7bb5656088bb405ad6e7
 - Test merge active of PR #68241 commit 01f26ab2fd1967f8d42a0c4dee8761f21257885b
 - Test merge active of PR #68389 commit 68551ab621600f9279252a3f7a9b9111714c58a0
 - HEAD: 9c06b5f9fb073736a9cfa25cf59b34f2f09f1fb8
[2022-07-14 01:36:08.055] runtime error: Cannot read null.name
 - proc name: get current level as text (/datum/controller/subsystem/security_level/proc/get_current_level_as_text)
 -   source file: security_level.dm,87
 -   usr: null
 -   src: Security Level (/datum/controller/subsystem/security_level)
 -   call stack:
 - Security Level (/datum/controller/subsystem/security_level): get current level as text()
 - /datum/world_topic/status (/datum/world_topic/status): Run(/list (/list))
 - /datum/world_topic/status (/datum/world_topic/status): TryRun(/list (/list))
 - world: Topic("status&format=json", "-censored-", null, null)
 - 
[2022-07-14 01:36:08.135] Initialized Title Screen subsystem within 0 seconds!
[2022-07-14 01:36:08.135] Initialized Server Tasks subsystem within 0 seconds!
[2022-07-14 01:36:08.135] Initialized Input subsystem within 0 seconds!
[2022-07-14 01:36:08.136] Initialized Stat Panels subsystem within 0 seconds!
[2022-07-14 01:36:08.139] Initialized Profiler subsystem within 0 seconds!
[2022-07-14 01:36:08.139] Initialized Database subsystem within 0 seconds!
[2022-07-14 01:36:08.139] Initialized Blackbox subsystem within 0 seconds!
[2022-07-14 01:36:08.139] Initialized Sounds subsystem within 0 seconds!
[2022-07-14 01:36:08.156] Initialized Instruments subsystem within 0 seconds!
[2022-07-14 01:36:08.256] runtime error: Cannot read null.name
 - proc name: get current level as text (/datum/controller/subsystem/security_level/proc/get_current_level_as_text)
 -   source file: security_level.dm,87
 -   usr: 19dollarfortnitecard (/mob/dead/new_player)
 -   src: Security Level (/datum/controller/subsystem/security_level)
 -   usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
 -   call stack:
 - Security Level (/datum/controller/subsystem/security_level): get current level as text()
 - world: update status()
 - 19dollarfortnitecard (/mob/dead/new_player): Login()
 - 19dollarfortnitecard (/mob/dead/new_player): Login()
 - 19dollarfortnitecard (/mob/dead/new_player): Login()
 - 
[2022-07-14 01:36:08.260] runtime error: Cannot read null.name
 - proc name: get current level as text (/datum/controller/subsystem/security_level/proc/get_current_level_as_text)
 -   source file: security_level.dm,87
 -   usr: Prototypemeat (/mob/dead/new_player)
 -   src: Security Level (/datum/controller/subsystem/security_level)
 -   usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
 -   call stack:
 - Security Level (/datum/controller/subsystem/security_level): get current level as text()
 - world: update status()
 - Prototypemeat (/mob/dead/new_player): Login()
 - Prototypemeat (/mob/dead/new_player): Login()
 - Prototypemeat (/mob/dead/new_player): Login()
 - 
[2022-07-14 01:36:08.262] runtime error: Cannot read null.name
 - proc name: get current level as text (/datum/controller/subsystem/security_level/proc/get_current_level_as_text)
 -   source file: security_level.dm,87
 -   usr: Private Tristan (/mob/dead/new_player)
 -   src: Security Level (/datum/controller/subsystem/security_level)
 -   usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
 -   call stack:
 - Security Level (/datum/controller/subsystem/security_level): get current level as text()
 - world: update status()
 - Private Tristan (/mob/dead/new_player): Login()
 - Private Tristan (/mob/dead/new_player): Login()
 - Private Tristan (/mob/dead/new_player): Login()
 - 
[2022-07-14 01:36:08.264] runtime error: Cannot read null.name
 - proc name: get current level as text (/datum/controller/subsystem/security_level/proc/get_current_level_as_text)
 -   source file: security_level.dm,87
 -   usr: Ahri The Nine-Tailed Fox (/mob/dead/new_player)
 -   src: Security Level (/datum/controller/subsystem/security_level)
 -   usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
 -   call stack:
 - Security Level (/datum/controller/subsystem/security_level): get current level as text()
 - world: update status()
 - Ahri The Nine-Tailed Fox (/mob/dead/new_player): Login()
 - Ahri The Nine-Tailed Fox (/mob/dead/new_player): Login()
 - Ahri The Nine-Tailed Fox (/mob/dead/new_player): Login()
 - 
[2022-07-14 01:36:08.265] runtime error: Cannot read null.name
 - proc name: get current level as text (/datum/controller/subsystem/security_level/proc/get_current_level_as_text)
 -   source file: security_level.dm,87
 -   usr: Cheshify (/mob/dead/new_player)
 -   src: Security Level (/datum/controller/subsystem/security_level)
 -   usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
 -   call stack:
 - Security Level (/datum/controller/subsystem/security_level): get current level as text()
 - world: update status()
 - Cheshify (/mob/dead/new_player): Login()
 - Cheshify (/mob/dead/new_player): Login()
 - Cheshify (/mob/dead/new_player): Login()
 - 
[2022-07-14 01:36:08.267] runtime error: Cannot read null.name
 - proc name: get current level as text (/datum/controller/subsystem/security_level/proc/get_current_level_as_text)
 -   source file: security_level.dm,87
 -   usr: Userisinvalid (/mob/dead/new_player)
 -   src: Security Level (/datum/controller/subsystem/security_level)
 -   usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
 -   call stack:
 - Security Level (/datum/controller/subsystem/security_level): get current level as text()
 - world: update status()
 - Userisinvalid (/mob/dead/new_player): Login()
 - Userisinvalid (/mob/dead/new_player): Login()
 - Userisinvalid (/mob/dead/new_player): Login()
 - 
[2022-07-14 01:36:08.269] runtime error: Cannot read null.name
 - proc name: get current level as text (/datum/controller/subsystem/security_level/proc/get_current_level_as_text)
 -   source file: security_level.dm,87
 -   usr: Sebaselciclon (/mob/dead/new_player)
 -   src: Security Level (/datum/controller/subsystem/security_level)
 -   usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
 -   call stack:
 - Security Level (/datum/controller/subsystem/security_level): get current level as text()
 - world: update status()
 - Sebaselciclon (/mob/dead/new_player): Login()
 - Sebaselciclon (/mob/dead/new_player): Login()
 - Sebaselciclon (/mob/dead/new_player): Login()
 - 
[2022-07-14 01:36:08.271] runtime error: Cannot read null.name
 - proc name: get current level as text (/datum/controller/subsystem/security_level/proc/get_current_level_as_text)
 -   source file: security_level.dm,87
 -   usr: Zzzarck (/mob/dead/new_player)
 -   src: Security Level (/datum/controller/subsystem/security_level)
 -   usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
 -   call stack:
 - Security Level (/datum/controller/subsystem/security_level): get current level as text()
 - world: update status()
 - Zzzarck (/mob/dead/new_player): Login()
 - Zzzarck (/mob/dead/new_player): Login()
 - Zzzarck (/mob/dead/new_player): Login()
 - 
[2022-07-14 01:36:09.412] Initialized Greyscale subsystem within 1.3 seconds!
[2022-07-14 01:36:09.412] Initialized Vis contents overlays subsystem within 0 seconds!
[2022-07-14 01:36:09.413] Initialized Security Level subsystem within 0 seconds!
```