### PR TITLE
Makes alerts for blind people being fed/stripped larger

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -380,14 +380,14 @@ Behavior that's still missing from this component that original food items had t
 				span_userdanger("[feeder] attempts to [eater.get_bodypart(BODY_ZONE_HEAD) ? "feed you [parent]." : "stuff [parent] down your throat hole! Gross."]")
 			)
 			if(eater.is_blind())
-				to_chat(eater, span_danger("You feel someone trying to feed you something!"))
+				to_chat(eater, span_userdanger("You feel someone trying to feed you something!"))
 		else
 			eater.visible_message(
 				span_danger("[feeder] cannot force any more of [parent] down [eater]'s [eater.get_bodypart(BODY_ZONE_HEAD) ? "throat!" : "throat hole! Eugh."]"),
 				span_userdanger("[feeder] cannot force any more of [parent] down your [eater.get_bodypart(BODY_ZONE_HEAD) ? "throat!" : "throat hole! Eugh."]")
 			)
 			if(eater.is_blind())
-				to_chat(eater, span_danger("You're too full to eat what's being fed to you!"))
+				to_chat(eater, span_userdanger("You're too full to eat what's being fed to you!"))
 			return
 		if(!do_mob(feeder, eater, time = time_to_eat)) //Wait 3-ish seconds before you can feed
 			return
@@ -399,7 +399,7 @@ Behavior that's still missing from this component that original food items had t
 			span_userdanger("[feeder] forces you to eat [parent]!")
 		)
 		if(eater.is_blind())
-			to_chat(eater, span_danger("You're forced to eat something!"))
+			to_chat(eater, span_userdanger("You're forced to eat something!"))
 
 	TakeBite(eater, feeder)
 

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -111,7 +111,7 @@
 					LAZYADD(victim_human.afk_thefts, new_entry)
 
 			else if(victim_human.is_blind())
-				to_chat(source, span_danger("You feel someone trying to put something on you."))
+				to_chat(source, span_userdanger("You feel someone trying to put something on you."))
 
 	to_chat(user, span_notice("You try to put [equipping] on [source]..."))
 
@@ -174,7 +174,7 @@
 				LAZYADD(victim_human.afk_thefts, new_entry)
 
 		else if(victim_human.is_blind())
-			to_chat(source, span_danger("You feel someone fumble with your belongings."))
+			to_chat(source, span_userdanger("You feel someone fumble with your belongings."))
 
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reverts tgstation/tgstation#69114

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I didn't check closely enough to see that the other feeding messages were big for seeing users, so there's no reason for blind users to be less aware of what's being fed to them than seeing users. The alert is still comically big but that's a different issue. 

## Changelog
:cl:
qol: blind forcefeeding and stripping is lorge again
/:cl:
