### PR TITLE
Fix lockers giving no feedback when trying to close them with another locker inside 

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -460,7 +460,7 @@
 		var/item_is_id = W.GetID()
 		if(!item_is_id)
 			return FALSE
-		if(item_is_id || !toggle(user))
+		if((item_is_id || !toggle(user)) && !opened)
 			togglelock(user)
 	else
 		return FALSE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -221,7 +221,7 @@
 	for(var/obj/structure/closet/closet in T)
 		if(closet != src && !closet.wall_mounted)
 			if(user)
-				to_chat(user, span_danger("There's something too large in [src], preventing it from closing."))
+				balloon_alert(user, "another closet is in the way!")
 			return FALSE
 	for(var/mob/living/L in T)
 		if(L.anchored || horizontal && L.mob_size > MOB_SIZE_TINY && L.density)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -220,6 +220,8 @@
 	var/turf/T = get_turf(src)
 	for(var/obj/structure/closet/closet in T)
 		if(closet != src && !closet.wall_mounted)
+			if(user)
+				to_chat(user, span_danger("There's something too large in [src], preventing it from closing."))
 			return FALSE
 	for(var/mob/living/L in T)
 		if(L.anchored || horizontal && L.mob_size > MOB_SIZE_TINY && L.density)
@@ -538,9 +540,11 @@
 	if(user.body_position == LYING_DOWN && get_dist(src, user) > 0)
 		return
 
-	if(!toggle(user))
-		togglelock(user)
+	if(toggle(user))
+		return
 
+	if(!opened)
+		togglelock(user)
 
 /obj/structure/closet/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)


### PR DESCRIPTION
## About The Pull Request

Fix lockers giving no feedback when trying to close them with another locker inside 

You also no longer try to toggle the lock status when you fail to close an open locker. I think this was a bit weird behaviour because changing the lock status of an open locker doesn't really make sense and only resulted in confusing messages. 

## Why It's Good For The Game

Fix #67811

## Changelog

:cl:

fix: Lockers now give proper feedback when you are unable to close them and no longer try to toggle lock status when you fail to close them. 

/:cl:
