### PR TITLE
Disables overrides for rust-g url_encode()

### DIFF
--- a/code/__DEFINES/rust_g_overrides.dm
+++ b/code/__DEFINES/rust_g_overrides.dm
@@ -1,3 +1,3 @@
 // RUSTG_OVERRIDE_BUILTINS is not used since the file APIs don't work well over Linux.
-#define url_encode(text) rustg_url_encode("[text]")
+//#define url_encode(text) rustg_url_encode("[text]") // This is slower than the DM one
 #define url_decode(text) rustg_url_decode("[text]")


### PR DESCRIPTION
## About The Pull Request
Disables the rust-g override for `url_encode()`. The DM native one actually performs faster than the RUSTG supplied one. I found this out while optimising `to_chat` over at para, and attempted to use the rust-g `url_encode` to gain performance, however, I observed the following behaviour.

Test call with native DM `url_encode()`
```
1000 messages took 25.2217ms to dispatch server side.
1000 messages took 23.967ms to dispatch server side.
1000 messages took 23.8953ms to dispatch server side.
1000 messages took 23.6104ms to dispatch server side.
1000 messages took 23.928ms to dispatch server side.
1000 messages took 23.9253ms to dispatch server side.
1000 messages took 24.008ms to dispatch server side.
1000 messages took 26.0708ms to dispatch server side.
1000 messages took 23.885ms to dispatch server side.
1000 messages took 24.3118ms to dispatch server side.
```

Test call with rust-g `url_encode()`
```
1000 messages took 26.1583ms to dispatch server side.
1000 messages took 25.9507ms to dispatch server side.
1000 messages took 32.1889ms to dispatch server side.
1000 messages took 28.9285ms to dispatch server side.
1000 messages took 26.4968ms to dispatch server side.
1000 messages took 26.2923ms to dispatch server side.
1000 messages took 26.8448ms to dispatch server side.
1000 messages took 25.8535ms to dispatch server side.
1000 messages took 25.9808ms to dispatch server side.
1000 messages took 26.0295ms to dispatch server side.
```

## Why It's Good For The Game
Performance good

## Changelog

:cl: AffectedArc07
code: Removed rust override for url_encode, optimising performance
/:cl:

---

*cant wait to be flamed for making this PR*