### PR TITLE
Upgrade mortar, so it gives user an option to either grind or juice.

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -385,7 +385,7 @@
 	icon_state = "pestle"
 	force = 7
 
-/obj/item/reagent_containers/glass/mortar
+/obj/item/reagent_containers/cup/mortar
 	name = "mortar"
 	desc = "A specially formed bowl of ancient design. It is possible to crush or juice items placed in it using a pestle; however the process, unlike modern methods, is slow and physically exhausting. <b>Alt click to eject the item.</b>"
 	icon_state = "mortar"
@@ -397,13 +397,13 @@
 	spillable = TRUE
 	var/obj/item/grinded
 
-/obj/item/reagent_containers/glass/mortar/AltClick(mob/user)
+/obj/item/reagent_containers/cup/mortar/AltClick(mob/user)
 	if(grinded)
 		grinded.forceMove(drop_location())
 		grinded = null
 		to_chat(user, span_notice("You eject the item inside."))
 
-/obj/item/reagent_containers/glass/mortar/attackby(obj/item/I, mob/living/carbon/human/user)
+/obj/item/reagent_containers/cup/mortar/attackby(obj/item/I, mob/living/carbon/human/user)
 	..()
 	if(istype(I,/obj/item/pestle))
 		if(grinded)

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -385,9 +385,9 @@
 	icon_state = "pestle"
 	force = 7
 
-/obj/item/reagent_containers/cup/mortar
+/obj/item/reagent_containers/glass/mortar
 	name = "mortar"
-	desc = "A specially formed bowl of ancient design. It is possible to crush or juice items placed in it using a pestle; however the process, unlike modern methods, is slow and physically exhausting. Alt click to eject the item."
+	desc = "A specially formed bowl of ancient design. It is possible to crush or juice items placed in it using a pestle; however the process, unlike modern methods, is slow and physically exhausting. <b>Alt click to eject the item.</b>"
 	icon_state = "mortar"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50, 100)
@@ -397,35 +397,60 @@
 	spillable = TRUE
 	var/obj/item/grinded
 
-/obj/item/reagent_containers/cup/mortar/AltClick(mob/user)
+/obj/item/reagent_containers/glass/mortar/AltClick(mob/user)
 	if(grinded)
 		grinded.forceMove(drop_location())
 		grinded = null
 		to_chat(user, span_notice("You eject the item inside."))
 
-/obj/item/reagent_containers/cup/mortar/attackby(obj/item/I, mob/living/carbon/human/user)
+/obj/item/reagent_containers/glass/mortar/attackby(obj/item/I, mob/living/carbon/human/user)
 	..()
 	if(istype(I,/obj/item/pestle))
 		if(grinded)
 			if(user.getStaminaLoss() > 50)
 				to_chat(user, span_warning("You are too tired to work!"))
 				return
-			to_chat(user, span_notice("You start grinding..."))
-			if((do_after(user, 25, target = src)) && grinded)
-				user.adjustStaminaLoss(40)
-				if(grinded.juice_results) //prioritize juicing
-					grinded.on_juice()
-					reagents.add_reagent_list(grinded.juice_results)
-					to_chat(user, span_notice("You juice [grinded] into a fine liquid."))
-					QDEL_NULL(grinded)
-					return
-				grinded.on_grind()
-				reagents.add_reagent_list(grinded.grind_results)
-				if(grinded.reagents) //food and pills
-					grinded.reagents.trans_to(src, grinded.reagents.total_volume, transfered_by = user)
-				to_chat(user, span_notice("You break [grinded] into powder."))
-				QDEL_NULL(grinded)
-				return
+			var/list/choose_options = list(
+				"Grind" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_grind"),
+				"Juice" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_juice")
+			)
+			var/picked_option = show_radial_menu(user, src, choose_options, radius = 38, require_near = TRUE)
+			if(grinded && in_range(src, user) && user.is_holding(I) && picked_option)
+				to_chat(user, span_notice("You start grinding..."))
+				if(do_after(user, 25, target = src))
+					user.adjustStaminaLoss(40)
+					switch(picked_option)
+						if("Juice") //prioritize juicing
+							if(grinded.juice_results)
+								grinded.on_juice()
+								reagents.add_reagent_list(grinded.juice_results)
+								to_chat(user, span_notice("You juice [grinded] into a fine liquid."))
+								QDEL_NULL(grinded)
+								return
+							else
+								grinded.on_grind()
+								reagents.add_reagent_list(grinded.grind_results)
+								grinded.reagents.trans_to(src, grinded.reagents.total_volume, transfered_by = user)
+								to_chat(user, span_notice("You try to juice [grinded] but there is no liquids in it. Instead you get nice powder."))
+								QDEL_NULL(grinded)
+								return
+						if("Grind")
+							if(grinded.grind_results)
+								grinded.on_grind()
+								reagents.add_reagent_list(grinded.grind_results)
+								grinded.reagents.trans_to(src, grinded.reagents.total_volume, transfered_by = user)
+								to_chat(user, span_notice("You break [grinded] into powder."))
+								QDEL_NULL(grinded)
+								return
+							else
+								grinded.on_juice()
+								reagents.add_reagent_list(grinded.juice_results)
+								to_chat(user, span_notice("You try to grind [grinded] but it almost instantly turns into a fine liquid."))
+								QDEL_NULL(grinded)
+								return
+						else
+							to_chat(user, span_notice("You try to grind the mortar itself instead of [grinded]. You failed."))
+							return
 			return
 		else
 			to_chat(user, span_warning("There is nothing to grind!"))


### PR DESCRIPTION

## About The Pull Request

So this idea came to me, when I tried to grind Korta nut into Korta Flour in mortar. I failed and my dissapointment was immeasurable. Someone thought this was very smart to JUICE first, and if it's not juiceable, only then grind it.

The solution is presented on the images below. Now you can choose to either grind or juice with the Stylish radial menu.
![image](https://user-images.githubusercontent.com/59139863/184502136-bb168e37-d2ff-4372-9aa1-663f560ff8af.png)
![image](https://user-images.githubusercontent.com/59139863/184502137-f68d7f86-357f-4fb3-9638-a5325f041821.png)
![image](https://user-images.githubusercontent.com/59139863/184502139-0ef236bb-0e2e-40ce-884c-2bd9f0c90d6e.png)

It's a second try of #68917 , because there was an update.

## Why It's Good For The Game

Uh oh.... Tribal roleplay?
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SuperDrish
add: Mortar now gives you an option. Do you want to grind or juice your thing?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
