### PR TITLE
Simple flying element typecast thing

### DIFF
--- a/code/datums/elements/simple_flying.dm
+++ b/code/datums/elements/simple_flying.dm
@@ -20,7 +20,7 @@
 	UnregisterSignal(target, COMSIG_MOB_STATCHANGE)
 
 ///signal called by the stat of the target changing
-/datum/element/simple_flying/proc/on_stat_change(mob/living/simple_animal/target, new_stat)
+/datum/element/simple_flying/proc/on_stat_change(mob/living/target, new_stat)
 	SIGNAL_HANDLER
 
 	if(new_stat == CONSCIOUS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This variable on simple_flying was typecasted as a simplemob, but it should be perfectly safe to use by anything living.

## Why It's Good For The Game

Just a little correction

## Changelog

not player facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
