### PR TITLE
Medipen Description Reagent Display

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -245,12 +245,18 @@ Primarily used in reagents/reaction_agents
 		creation_purity = src.creation_purity
 	return creation_purity / normalise_num_to
 
-/proc/pretty_string_from_reagent_list(list/reagent_list)
+/proc/pretty_string_from_reagent_list(list/reagent_list, names_only, join_text = " | ", final_and, capitalize_names)
 	//Convert reagent list to a printable string for logging etc
 	var/list/rs = list()
+	var/reagents_left = reagent_list.len
+	var/intial_list_length = reagents_left
 	for (var/datum/reagent/R in reagent_list)
-		rs += "[R.name], [R.volume]"
+		reagents_left--
+		if(final_and && intial_list_length > 1 && reagents_left == 0)
+			rs += "and [capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
+		else
+			rs += "[capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
 
-	return rs.Join(" | ")
+	return rs.Join(join_text)
 
 

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -248,7 +248,7 @@ Primarily used in reagents/reaction_agents
 /**
  * Input a reagent_list, outputs pretty readable text!
  * Default output will be formatted as
- * * water, 5 | silicon, 6 | soup, 4 | space lube, 8 		(zoop :DDD)
+ * * water, 5 | silicon, 6 | soup, 4 | space lube, 8
  *
  * * names_only will remove the amount displays, showing
  * * water | silicon | soup | space lube
@@ -267,15 +267,15 @@ Primarily used in reagents/reaction_agents
  * * * Water, Silicon, Soup, and Space Lube
  */
 /proc/pretty_string_from_reagent_list(list/reagent_list, names_only, join_text = " | ", final_and, capitalize_names)
-    //Convert reagent list to a printable string for logging etc
-    var/list/rs = list()
-    var/reagents_left = reagent_list.len
-    var/intial_list_length = reagents_left
-    for (var/datum/reagent/R in reagent_list)
-        reagents_left--
-        if(final_and && intial_list_length > 1 && reagents_left == 0)
-        	rs += "and [capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
-        else
-        	rs += "[capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
+	//Convert reagent list to a printable string for logging etc
+	var/list/rs = list()
+	var/reagents_left = reagent_list.len
+	var/intial_list_length = reagents_left
+	for (var/datum/reagent/R in reagent_list)
+		reagents_left--
+		if(final_and && intial_list_length > 1 && reagents_left == 0)
+			rs += "and [capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
+		else
+			rs += "[capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
 
-    return rs.Join(join_text)
+	return rs.Join(join_text)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -248,7 +248,7 @@ Primarily used in reagents/reaction_agents
 /**
  * Input a reagent_list, outputs pretty readable text!
  * Default output will be formatted as
- * * water, 5 | silicon, 6 | soup, 4 | space lube, 8
+ * * water, 5 | silicon, 6 | soup, 4 | space lube, 8 		(who the fuck has soup in a medipen???)
  *
  * * names_only will remove the amount displays, showing
  * * water | silicon | soup | space lube

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -274,10 +274,8 @@ Primarily used in reagents/reaction_agents
     for (var/datum/reagent/R in reagent_list)
         reagents_left--
         if(final_and && intial_list_length > 1 && reagents_left == 0)
-            rs += "and [capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
+        	rs += "and [capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
         else
-            rs += "[capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
+        	rs += "[capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
 
     return rs.Join(join_text)
-
-

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -248,7 +248,7 @@ Primarily used in reagents/reaction_agents
 /**
  * Input a reagent_list, outputs pretty readable text!
  * Default output will be formatted as
- * * water, 5 | silicon, 6 | soup, 4 | space lube, 8 		(who the fuck has soup in a medipen???)
+ * * water, 5 | silicon, 6 | soup, 4 | space lube, 8 		(zoop :DDD)
  *
  * * names_only will remove the amount displays, showing
  * * water | silicon | soup | space lube

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -245,18 +245,39 @@ Primarily used in reagents/reaction_agents
 		creation_purity = src.creation_purity
 	return creation_purity / normalise_num_to
 
+/**
+ * Input a reagent_list, outputs pretty readable text!
+ * Default output will be formatted as
+ * * water, 5 | silicon, 6 | soup, 4 | space lube, 8
+ *
+ * * names_only will remove the amount displays, showing
+ * * water | silicon | soup | space lube
+ *
+ * * join_text will alter the text between reagents
+ * * setting to ", " will result in
+ * * water, 5, silicon, 6, soup, 4, space lube, 8
+ *
+ * * final_and should be combined with the above. will format as
+ * * water, 5, silicon, 6, soup, 4, and space lube, 8
+ *
+ * * capitalize_names will result in
+ * * Water, 5 | Silicon, 6 | Soup, 4 | Space lube, 8
+ *
+ * * * use (reagent_list, TRUE, ", ", TRUE, TRUE) for the formatting
+ * * * Water, Silicon, Soup, and Space Lube
+ */
 /proc/pretty_string_from_reagent_list(list/reagent_list, names_only, join_text = " | ", final_and, capitalize_names)
-	//Convert reagent list to a printable string for logging etc
-	var/list/rs = list()
-	var/reagents_left = reagent_list.len
-	var/intial_list_length = reagents_left
-	for (var/datum/reagent/R in reagent_list)
-		reagents_left--
-		if(final_and && intial_list_length > 1 && reagents_left == 0)
-			rs += "and [capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
-		else
-			rs += "[capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
+    //Convert reagent list to a printable string for logging etc
+    var/list/rs = list()
+    var/reagents_left = reagent_list.len
+    var/intial_list_length = reagents_left
+    for (var/datum/reagent/R in reagent_list)
+        reagents_left--
+        if(final_and && intial_list_length > 1 && reagents_left == 0)
+            rs += "and [capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
+        else
+            rs += "[capitalize_names ? capitalize(R.name) : R.name][names_only ? null : ", [R.volume]"]"
 
-	return rs.Join(join_text)
+    return rs.Join(join_text)
 
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -139,25 +139,7 @@
 /obj/item/reagent_containers/hypospray/medipen/examine()
 	. = ..()
 	if(length(reagents?.reagent_list))
-		var/reagent_text = ""
-
-		if(length(reagents.reagent_list) == 1)
-			var/datum/reagent/first = reagents.reagent_list[1]
-			reagent_text = first.name
-
-		else
-			var/len = length(reagents.reagent_list)
-			var/list/reagent_names_list = list()
-			for(var/i in 1 to (len - 2))
-				var/datum/reagent/reagent_object = reagents.reagent_list[i]
-				reagent_names_list += "[reagent_object.name], "
-			var/datum/reagent/last_reagent = reagents.reagent_list[len]
-			var/datum/reagent/second_to_last_reagent = reagents.reagent_list[len - 1]
-			reagent_names_list += "[second_to_last_reagent.name], and [last_reagent.name]"
-			reagent_text = reagent_names_list.Join("")
-
-		. += span_notice("There\'s a small LCD screen on the side of the medipen which reads, 'WARNING: This medipen contains [reagent_text]. Do not use if allergic to any listed chemicals.' in small text.") //cheapskates at nanotrasen couldnt ball out for LED
-
+		. += span_notice("There\'s a small LCD screen on the side of the medipen which reads, 'WARNING: This medipen contains [pretty_string_from_reagent_list(reagents.reagent_list, TRUE, ", ", TRUE, TRUE)]. Do not use if allergic to any listed chemicals.' in small text.") //cheapskates at nanotrasen couldnt ball out for LED
 	else
 		. += span_notice("There\'s a blank LCD screen on the side of the medipen.")
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -146,20 +146,20 @@
 			reagent_text = first.name
 
 		else
-			var/len = reagents.reagent_list.len
+			var/len = length(reagents.reagent_list)
 			var/list/reagent_names_list = list()
 			for(var/i in 1 to (len - 2))
 				var/datum/reagent/reagent_object = reagents.reagent_list[i]
 				reagent_names_list += "[reagent_object.name], "
 			var/datum/reagent/last_reagent = reagents.reagent_list[len]
 			var/datum/reagent/second_to_last_reagent = reagents.reagent_list[len - 1]
-			reagent_names_list += "[second_to_last_reagent.name] and [last_reagent.name]"
+			reagent_names_list += "[second_to_last_reagent.name], and [last_reagent.name]"
 			reagent_text = reagent_names_list.Join("")
 
-		. += span_notice("Theres a small LCD screen on the side of the medipen which reads, 'WARNING: This medipen contains [reagent_text]. Do not use if allergic to any listed chemicals.' in small text.") //cheapskates at nanotrasen couldnt ball out for LED
+		. += span_notice("There\'s a small LCD screen on the side of the medipen which reads, 'WARNING: This medipen contains [reagent_text]. Do not use if allergic to any listed chemicals.' in small text.") //cheapskates at nanotrasen couldnt ball out for LED
 
 	else
-		. += span_notice("Theres a blank LCD screen on the side of the medipen.")
+		. += span_notice("There\'s a blank LCD screen on the side of the medipen.")
 
 /obj/item/reagent_containers/hypospray/medipen/stimpack //goliath kiting
 	name = "stimpack medipen"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -156,7 +156,7 @@
 			reagent_names_list += "[second_to_last_reagent.name] and [last_reagent.name]"
 			reagent_text = reagent_names_list.Join("")
 
-		. += span_notice("Theres a small LCD screen on a side of the medipen which reads, 'WARNING: This medipen contains [reagent_text]. Do not use if allergic to any listed chemicals.' in small text.") //cheapskates at nanotrasen couldnt ball out for LED
+		. += span_notice("Theres a small LCD screen on the side of the medipen which reads, 'WARNING: This medipen contains [reagent_text]. Do not use if allergic to any listed chemicals.' in small text.") //cheapskates at nanotrasen couldnt ball out for LED
 
 /obj/item/reagent_containers/hypospray/medipen/stimpack //goliath kiting
 	name = "stimpack medipen"
@@ -266,7 +266,7 @@
 	return ..()
 
 
-/obj/item/reagent_containers/hypospray/medipen/survival/luxury // hmmm today I will combine this with the survival pen, surely I will recieve a boosted healing effect
+/obj/item/reagent_containers/hypospray/medipen/survival/luxury // clueless
 	name = "luxury medipen"
 	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 60u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of very hard enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE."
 	icon_state = "luxpen"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -138,10 +138,25 @@
 
 /obj/item/reagent_containers/hypospray/medipen/examine()
 	. = ..()
-	if(reagents?.reagent_list.len)
-		. += span_notice("It is currently loaded.")
-	else
-		. += span_notice("It is spent.")
+	if(length(reagents?.reagent_list))
+		var/reagent_text = ""
+
+		if(length(reagents.reagent_list) == 1)
+			var/datum/reagent/first = reagents.reagent_list[1]
+			reagent_text = first.name
+
+		else
+			var/len = reagents.reagent_list.len
+			var/list/reagent_names_list = list()
+			for(var/i in 1 to (len - 2))
+				var/datum/reagent/reagent_object = reagents.reagent_list[i]
+				reagent_names_list += "[reagent_object.name], "
+			var/datum/reagent/last_reagent = reagents.reagent_list[len]
+			var/datum/reagent/second_to_last_reagent = reagents.reagent_list[len - 1]
+			reagent_names_list += "[second_to_last_reagent.name] and [last_reagent.name]"
+			reagent_text = reagent_names_list.Join("")
+
+		. += span_notice("Theres a small LCD screen on a side of the medipen which reads, 'WARNING: This medipen contains [reagent_text]. Do not use if allergic to any listed chemicals.' in small text.") //cheapskates at nanotrasen couldnt ball out for LED
 
 /obj/item/reagent_containers/hypospray/medipen/stimpack //goliath kiting
 	name = "stimpack medipen"
@@ -251,7 +266,7 @@
 	return ..()
 
 
-/obj/item/reagent_containers/hypospray/medipen/survival/luxury
+/obj/item/reagent_containers/hypospray/medipen/survival/luxury // hmmm today I will combine this with the survival pen, surely I will recieve a boosted healing effect
 	name = "luxury medipen"
 	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 60u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of very hard enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE."
 	icon_state = "luxpen"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -270,7 +270,7 @@
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury
 	name = "luxury medipen"
-	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 60u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of very hard enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE."
+	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 60u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of very hard enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE." //anybody else fucking die
 	icon_state = "luxpen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "luxpen"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -158,6 +158,9 @@
 
 		. += span_notice("Theres a small LCD screen on the side of the medipen which reads, 'WARNING: This medipen contains [reagent_text]. Do not use if allergic to any listed chemicals.' in small text.") //cheapskates at nanotrasen couldnt ball out for LED
 
+	else
+		. += span_notice("Theres a blank LCD screen on the side of the medipen.")
+
 /obj/item/reagent_containers/hypospray/medipen/stimpack //goliath kiting
 	name = "stimpack medipen"
 	desc = "A rapid way to stimulate your body's adrenaline, allowing for freer movement in restrictive armor."
@@ -265,8 +268,7 @@
 	amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5
 	return ..()
 
-
-/obj/item/reagent_containers/hypospray/medipen/survival/luxury // clueless
+/obj/item/reagent_containers/hypospray/medipen/survival/luxury
 	name = "luxury medipen"
 	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 60u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of very hard enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE."
 	icon_state = "luxpen"
@@ -292,6 +294,14 @@
 	base_icon_state = "snail"
 	list_reagents = list(/datum/reagent/snail = 10)
 
+/obj/item/reagent_containers/hypospray/medipen/snail/examine()		// no LCD screen for the snails :(
+	. = ..()
+	if(length(reagents?.reagent_list))
+		. += span_notice("It is currently loaded.")
+
+	else
+		. += span_notice("It is spent")
+
 /obj/item/reagent_containers/hypospray/medipen/magillitis
 	name = "experimental autoinjector"
 	desc = "A custom-frame needle injector with a small single-use reservoir, containing an experimental serum. Unlike the more common medipen frame, it cannot pierce through protective armor or space suits, nor can the chemical inside be extracted."
@@ -311,6 +321,11 @@
 	list_reagents = list(/datum/reagent/drug/pumpup = 15)
 	icon_state = "maintenance"
 	base_icon_state = "maintenance"
+
+/obj/item/reagent_containers/hypospray/medipen/pumpup/examine()
+	. = ..()
+	if(length(reagents?.reagent_list))
+		. += span_notice("Theres a small LCD screen on the side of the medipen which reads, 'ERROR: Unidentified chemical contained inside medipen, use with caution!' in small text.")
 
 /obj/item/reagent_containers/hypospray/medipen/ekit
 	name = "emergency first-aid autoinjector"


### PR DESCRIPTION
## About The Pull Request

Nanotrasen is rolling out their new and improved Medipen Casing 2.0! This all new casing comes with a fancy new LCD screen on the side of the pen which displays the chemicals inside (legally required after the court ruling of Nanotrasen V Hennington) in an attempt to reduce allergic attacks onboard their station due to not properly advertising the contents of their issued medipens.

Thanks to Rohesie#4152 for teaching me a bunch of stuff about DM, couldn't have done this without him.

## Why It's Good For The Game

As stated above everybody hates when they think they're gonna get a free few points from taking a medical allergy, then being on the verge of crit and popping their epi-pen, only to have a vicious allergic reaction do to the 3u of formaldehyde contained inside, who would've known that the epinephrine pen contained something that wasn't epinephrine? Shocking, I know. This update changes that, now before popping your medipen, the advanced scanners inside the pen (recycled pregnancy test parts) will scan the chemicals contained inside the pen and display them on the side of the pen. The hypo spray chassis has not received the same remodel

![image](https://user-images.githubusercontent.com/91508746/184509345-b3bc7e2f-ec40-46e5-bd3a-efed7976d159.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Changed how medipens descriptions work
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
