### PR TITLE
Necropolis Tendrils now need to be interacted with to drop their loot, and multiple people can receive multiple chests.

### DIFF
--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -114,7 +114,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 	return ..()
 
 /obj/effect/collapse/proc/has_collected(mob/collector)
-	for(var/datum/weakref/weakref in collected)
+	for(var/datum/weakref/weakref as anything in collected)
 		var/mob/living/resolved = weakref.resolve()
 		//it could have been collector, it could not have been, we don't care
 		if(!resolved)

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -41,9 +41,13 @@ GLOBAL_LIST_INIT(tendrils, list())
 
 /obj/structure/spawner/lavaland/deconstruct(disassembled)
 	new /obj/effect/collapse(loc)
-	new /obj/structure/closet/crate/necropolis/tendril(loc)
 	return ..()
 
+/obj/structure/spawner/lavaland/examine(mob/user)
+	var/list/examine_messages = ..()
+	examine_messages += span_notice("Once this thing gets hurts enough, it triggers a violent final retaliation.")
+	examine_messages += span_notice("You'll only have a few moments to run up, grab some loot with an open hand, and get out with it.")
+	return examine_messages
 
 /obj/structure/spawner/lavaland/Destroy()
 	var/last_tendril = TRUE
@@ -69,25 +73,55 @@ GLOBAL_LIST_INIT(tendrils, list())
 
 /obj/effect/collapse
 	name = "collapsing necropolis tendril"
-	desc = "Get clear!"
+	desc = "Get your loot and get clear!"
 	layer = TABLE_LAYER
 	icon = 'icons/mob/nest.dmi'
 	icon_state = "tendril"
 	anchored = TRUE
 	density = TRUE
+	/// weakref list of which mobs have gotten their loot from this effect.
+	var/list/collected = list()
+	/// a bit of light as to make less unfair deaths from the chasm
 	var/obj/effect/light_emitter/tendril/emitted_light
 
 /obj/effect/collapse/Initialize(mapload)
 	. = ..()
 	emitted_light = new(loc)
 	visible_message(span_boldannounce("The tendril writhes in fury as the earth around it begins to crack and break apart! Get back!"))
-	visible_message(span_warning("Something falls free of the tendril!"))
 	playsound(loc,'sound/effects/tendril_destroyed.ogg', 200, FALSE, 50, TRUE, TRUE)
 	addtimer(CALLBACK(src, .proc/collapse), 50)
 
+/obj/effect/collapse/examine(mob/user)
+	var/list/examine_messages = ..()
+	if(has_collected(user))
+		examine_messages += span_boldnotice("You've grabbed what you can, now get out!")
+	else
+		examine_messages += span_boldnotice("You might have some time to grab some goodies with an open hand before it collapses!")
+	return examine_messages
+
+/obj/effect/collapse/attack_hand(mob/living/collector, list/modifiers)
+	. = ..()
+	if(has_collected(collector))
+		to_chat(collector, span_danger("You've already gotten some loot, just get out of there with it!"))
+		return
+	visible_message(span_warning("Something falls free of the tendril!"))
+	new /obj/structure/closet/crate/necropolis/tendril(loc)
+	collected += WEAKREF(collector)
+
 /obj/effect/collapse/Destroy()
+	QDEL_NULL(collected)
 	QDEL_NULL(emitted_light)
 	return ..()
+
+/obj/effect/collapse/proc/has_collected(mob/collector)
+	for(var/datum/weakref/weakref in collected)
+		var/mob/living/resolved = weakref.resolve()
+		//it could have been collector, it could not have been, we don't care
+		if(!resolved)
+			continue
+		if(resolved == collector)
+			return TRUE
+	return FALSE
 
 /obj/effect/collapse/proc/collapse()
 	for(var/mob/M in range(7,src))

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -93,10 +93,11 @@ GLOBAL_LIST_INIT(tendrils, list())
 
 /obj/effect/collapse/examine(mob/user)
 	var/list/examine_messages = ..()
-	if(has_collected(user))
-		examine_messages += span_boldnotice("You've grabbed what you can, now get out!")
-	else
-		examine_messages += span_boldnotice("You might have some time to grab some goodies with an open hand before it collapses!")
+	if(isliving(user))
+		if(has_collected(user))
+			examine_messages += span_boldnotice("You've grabbed what you can, now get out!")
+		else
+			examine_messages += span_boldnotice("You might have some time to grab some goodies with an open hand before it collapses!")
 	return examine_messages
 
 /obj/effect/collapse/attack_hand(mob/living/collector, list/modifiers)
@@ -105,7 +106,8 @@ GLOBAL_LIST_INIT(tendrils, list())
 		to_chat(collector, span_danger("You've already gotten some loot, just get out of there with it!"))
 		return
 	visible_message(span_warning("Something falls free of the tendril!"))
-	new /obj/structure/closet/crate/necropolis/tendril(loc)
+	var/obj/structure/closet/crate/necropolis/tendril/loot = new /obj/structure/closet/crate/necropolis/tendril(loc)
+	collector.start_pulling(loot)
 	collected += WEAKREF(collector)
 
 /obj/effect/collapse/Destroy()

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -115,6 +115,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 	QDEL_NULL(emitted_light)
 	return ..()
 
+///Helper proc that resolves weakrefs to determine if collector is in collected list, returning a boolean.
 /obj/effect/collapse/proc/has_collected(mob/collector)
 	for(var/datum/weakref/weakref as anything in collected)
 		var/mob/living/resolved = weakref.resolve()

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -88,6 +88,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 	. = ..()
 	emitted_light = new(loc)
 	visible_message(span_boldannounce("The tendril writhes in fury as the earth around it begins to crack and break apart! Get back!"))
+	balloon_alert_to_viewers("interact to grab loot before collapse!", vision_distance = 7)
 	playsound(loc,'sound/effects/tendril_destroyed.ogg', 200, FALSE, 50, TRUE, TRUE)
 	addtimer(CALLBACK(src, .proc/collapse), 50)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tendrils no longer immediately drop their chests, they will drop it once you have used an empty hand on the collapsing tendril. You can only spawn a chest once, but every unique mob that interacts can spawn one chest.

## Why It's Good For The Game

This is a buff to coop mining. Mining with a friend and attacking a tendril now opens the possibility to get 2x the loot, or more. I find that coop mining historically hasn't been worth it and it's much more productive to split everyone up and clear the map that way. That's sad, I hate that! We should encourage working together because the social and cooperative aspect of ss13 is fun and unfortunately not viable as-is.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Tendrils now drop their loot when you interact with them during the collapse.
balance: But they can be interacted with by multiple people, so mining with a friend brings more loot!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
