### PR TITLE
mood runtime fix

### DIFF
--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -189,6 +189,8 @@
 /// Updates the mobs mood.
 /// Called after mood events have been added/removed.
 /datum/mood/proc/update_mood()
+	if(QDELETED(mob_parent)) //don't bother updating their mood if they're about to be salty anyway. (in other words, we're about to be destroyed too anyway.)
+		return
 	mood = 0
 	shown_mood = 0
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2306,13 +2306,13 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 /// Adds a mood event to the mob
 /mob/living/proc/add_mood_event(category, type, ...)
-	if (!mob_mood)
+	if(QDELETED(mob_mood))
 		return
 	mob_mood.add_mood_event(arglist(args))
 
 /// Clears a mood event from the mob
 /mob/living/proc/clear_mood_event(category)
-	if (!mob_mood)
+	if(QDELETED(mob_mood))
 		return
 	mob_mood.clear_mood_event(category)
 


### PR DESCRIPTION
```
/*[00:13:54] Runtime in mood.dm, line 195: Cannot read null.comp_lookup
 proc name: update mood (/datum/mood/proc/update_mood)
src: /datum/mood (/datum/mood)
call stack:
/datum/mood (/datum/mood): update mood()
/datum/mood (/datum/mood): clear mood event("family_heirloom")
Noris Glookin (/mob/living/carbon/human): clear mood event("family_heirloom")
Family Heirloom (/datum/quirk/item_quirk/family_heirloom): remove()
Family Heirloom (/datum/quirk/item_quirk/family_heirloom): remove from current holder(0)
Family Heirloom (/datum/quirk/item_quirk/family_heirloom): Destroy(0)
qdel(Family Heirloom (/datum/quirk/item_quirk/family_heirloom), 0)
Family Heirloom (/datum/quirk/item_quirk/family_heirloom): on holder qdeleting(Noris Glookin (/mob/living/carbon/human), 0)
Noris Glookin (/mob/living/carbon/human): SendSignal("parent_qdeleting", /list (/list))
qdel(Noris Glookin (/mob/living/carbon/human), 0)
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)*/
```

Sanity check. Sending signals to the parent during the parent's Destroy()