### PR TITLE
Fixes clownborg not fixing their flash

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -142,6 +142,8 @@
 		cyborg.hud_used.update_robot_modules_display()
 
 /obj/item/robot_model/proc/respawn_consumable(mob/living/silicon/robot/cyborg, coeff = 1)
+	SHOULD_CALL_PARENT(TRUE)
+	
 	for(var/datum/robot_energy_storage/storage_datum in storages)
 		storage_datum.energy = min(storage_datum.max_energy, storage_datum.energy + coeff * storage_datum.recharge_rate)
 
@@ -301,6 +303,7 @@
 	hat_offset = -2
 
 /obj/item/robot_model/clown/respawn_consumable(mob/living/silicon/robot/cyborg, coeff = 1)
+	. = ..()
 	var/obj/item/soap/nanotrasen/cyborg/soap = locate(/obj/item/soap/nanotrasen/cyborg) in basic_modules
 	if(!soap)
 		return


### PR DESCRIPTION
## About The Pull Request

Clownborg now calls parent on respawn_consumable, so they will now actually repair their flash like all other cyborgs. I additionally added SHOULD_CALL_PARENT to respawn_consumable to prevent this from happening again in the future.


## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/69187
Prevents such a bug from happening again.

## Changelog

:cl:
fix: Clown cyborgs now repair their flash when recharging
/:cl:
