### PR TITLE
Reverts #49103 Krav Maga: Stompies Edition (mostly)

### DIFF
--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -86,13 +86,11 @@
 /datum/martial_art/krav_maga/proc/leg_sweep(mob/living/attacker, mob/living/defender)
 	if(defender.stat || defender.IsParalyzed())
 		return FALSE
-	var/obj/item/bodypart/affecting = defender.get_bodypart(BODY_ZONE_CHEST)
-	var/armor_block = defender.run_armor_check(affecting, MELEE)
 	defender.visible_message(span_warning("[attacker] leg sweeps [defender]!"), \
 					span_userdanger("Your legs are sweeped by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
 	to_chat(attacker, span_danger("You leg sweep [defender]!"))
 	playsound(get_turf(attacker), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
-	defender.apply_damage(rand(20, 30), STAMINA, affecting, armor_block)
+	defender.apply_damage(5, BRUTE, BODY_ZONE_CHEST)
 	defender.Knockdown(60)
 	log_combat(attacker, defender, "leg sweeped")
 	return TRUE
@@ -113,8 +111,8 @@
 					span_userdanger("Your neck is karate chopped by [attacker], rendering you unable to speak!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
 	to_chat(attacker, span_danger("You karate chop [defender]'s neck, rendering [defender.p_them()] unable to speak!"))
 	playsound(get_turf(attacker), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-	defender.apply_damage(5, attacker.get_attack_type())
-	if (iscarbon(defender))
+	defender.apply_damage(10, attacker.get_attack_type(), BODY_ZONE_HEAD)
+	if(iscarbon(defender))
 		var/mob/living/carbon/carbon_defender = defender
 		if(carbon_defender.silent <= 10)
 			carbon_defender.silent = clamp(carbon_defender.silent + 10, 0, 10)
@@ -132,13 +130,12 @@
 		return TRUE
 	log_combat(attacker, defender, "punched")
 	var/obj/item/bodypart/affecting = defender.get_bodypart(ran_zone(attacker.zone_selected))
-	var/armor_block = defender.run_armor_check(affecting, MELEE)
 	var/picked_hit_type = pick("punch", "kick")
 	var/bonus_damage = 0
 	if(defender.body_position == LYING_DOWN)
 		bonus_damage += 5
 		picked_hit_type = "stomp"
-	defender.apply_damage(rand(5, 10) + bonus_damage, attacker.get_attack_type(), affecting, armor_block)
+	defender.apply_damage(10 + bonus_damage, attacker.get_attack_type(), affecting)
 	if(picked_hit_type == "kick" || picked_hit_type == "stomp")
 		attacker.do_attack_animation(defender, ATTACK_EFFECT_KICK)
 		playsound(get_turf(defender), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
@@ -154,28 +151,17 @@
 /datum/martial_art/krav_maga/disarm_act(mob/living/attacker, mob/living/defender)
 	if(check_streak(attacker, defender))
 		return TRUE
-	var/obj/item/bodypart/affecting = defender.get_bodypart(ran_zone(attacker.zone_selected))
-	var/armor_block = defender.run_armor_check(affecting, MELEE)
-	if(defender.body_position == STANDING_UP)
-		defender.visible_message(span_danger("[attacker] reprimands [defender]!"), \
-					span_userdanger("You're slapped by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
-		to_chat(attacker, span_danger("You jab [defender]!"))
-		attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
-		playsound(defender, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-		defender.apply_damage(rand(5, 10), STAMINA, affecting, armor_block)
-		log_combat(attacker, defender, "punched nonlethally")
-	if(defender.body_position == LYING_DOWN)
-		defender.visible_message(span_danger("[attacker] reprimands [defender]!"), \
-					span_userdanger("You're manhandled by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
-		to_chat(attacker, span_danger("You stomp [defender]!"))
-		attacker.do_attack_animation(defender, ATTACK_EFFECT_KICK)
-		playsound(defender, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-		defender.apply_damage(rand(10, 15), STAMINA, affecting, armor_block)
-		log_combat(attacker, defender, "stomped nonlethally")
-	if(prob(defender.getStaminaLoss()) && defender.stat < UNCONSCIOUS)
-		defender.visible_message(span_warning("[defender] sputters and recoils in pain!"), span_userdanger("You recoil in pain as you are jabbed in a nerve!"))
-		defender.drop_all_held_items()
-	return TRUE
+	var/obj/item/stuff_in_hand = null
+	stuff_in_hand = defender.get_active_held_item()
+	if(prob(60) && stuff_in_hand)
+		if(defender.temporarilyRemoveItemFromInventory(stuff_in_hand))
+			attacker.put_in_hands(stuff_in_hand)
+			defender.visible_message("<span class='danger'>[attacker] disarms [defender]!</span>", \
+				"<span class='userdanger'>You're disarmed by [attacker]!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, attacker)
+			to_chat(attacker, "<span class='danger'>You disarm [defender]!</span>")
+			playsound(defender, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
+	log_combat(attacker, defender, "shoved (Krav Maga)", "[stuff_in_hand ? " removing \the [stuff_in_hand]" : ""]")
+	return FALSE
 
 //Krav Maga Gloves
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts Krav Maga to a state prior to #49103 with only some minor retention. That is, leg sweep is still a knockdown.

Technically ports https://github.com/AetherStation/AetherStation13/pull/53, which reminded me of this fuckup.

## Why It's Good For The Game

I tried my best, but I think I actually fucked up with this change. It was kind of with the focus of trying to tackle the stun it had at the time, but also trying to fit it in with the rest of the warden's equipment. That is, baton and disabler. I overloaded it with stamina damage and thought 'yeah this will be worth it'.

Well, frankly, it didn't turn out so hot, and many people didn't use the gloves. **I** eventually stopped using the gloves. If I knew they weren't very strong, I probably shouldn't keep this change around, yeah? It was one of the first PR's I ever made, and as time does to ones perspective, it sure didn't age well.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Reverts https://github.com/tgstation/tgstation/pull/49103. Krav Maga is back to a much older state. Mostly.
balance: Krav maga right click shoves again, and can have a chance of stealing held items.
balance: Most attacks with krav maga no longer check armor, and do a flat amount of damage.
balance: Legsweep deals 5 brute instead of stamina damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
