### PR TITLE
Replaces non-departmental required experisci experiments with extremely expensive discount experiments

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -334,8 +334,8 @@
 		"pandemic",
 		"soda_dispenser",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	required_experiments = list(/datum/experiment/dissection/human)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500)
+	discount_experiments = list(/datum/experiment/dissection/human = 10000) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
 
 /datum/techweb_node/adv_biotech
 	id = "adv_biotech"
@@ -356,9 +356,11 @@
 		"plasmarefiller",
 		"smoke_machine",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	required_experiments = list(/datum/experiment/dissection/nonhuman)
-	discount_experiments = list(/datum/experiment/scanning/random/material/meat = 4000) //Big discount to reinforce doing it.
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000)
+	discount_experiments = list(
+		/datum/experiment/scanning/random/material/meat = 4000,
+		/datum/experiment/dissection/nonhuman = 10000,
+		) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
 
 /datum/techweb_node/xenoorgan_biotech
 	id = "xenoorgan_bio"
@@ -549,9 +551,11 @@
 		"sheetifier",
 		"weldingmask",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	required_experiments = list(/datum/experiment/ordnance/gaseous/bz)
-	discount_experiments = list(/datum/experiment/scanning/random/material/medium/one = 4000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000)
+	discount_experiments = list(
+		/datum/experiment/scanning/random/material/medium/one = 4000,
+		/datum/experiment/ordnance/gaseous/bz = 10000,
+	) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
 
 /datum/techweb_node/anomaly
 	id = "anomaly_research"
@@ -985,9 +989,11 @@
 	design_ids = list(
 		"quadultra_micro_laser",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000)
-	required_experiments = list(/datum/experiment/ordnance/gaseous/noblium)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000)
+	discount_experiments = list(
+		/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000,
+		/datum/experiment/ordnance/gaseous/noblium = 10000,
+	) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
 
 /////////////////////////Clown tech/////////////////////////
 /datum/techweb_node/clown
@@ -1331,9 +1337,11 @@
 		"seed_extractor",
 		"adv_watering_can",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
-	required_experiments = list(/datum/experiment/scanning/random/plants/wild)
-	discount_experiments = list(/datum/experiment/scanning/random/plants/traits = 3000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 14000)
+	discount_experiments = list(
+		/datum/experiment/scanning/random/plants/traits = 3000,
+		/datum/experiment/scanning/random/plants/wild = 10000,
+	) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
 
 /datum/techweb_node/exp_tools
 	id = "exp_tools"
@@ -1404,8 +1412,8 @@
 		"pin_testing",
 		"tele_shield",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	required_experiments = list(/datum/experiment/ordnance/explosive/pressurebomb)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 20000)
+	discount_experiments = list(/datum/experiment/ordnance/explosive/pressurebomb = 10000) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
 
 /datum/techweb_node/adv_weaponry
 	id = "adv_weaponry"
@@ -1770,9 +1778,11 @@
 		"mech_ccw_armor",
 		"mech_proj_armor",
 	)
-	required_experiments = list(/datum/experiment/scanning/random/mecha_damage_scan)
-	discount_experiments = list(/datum/experiment/scanning/random/mecha_destroyed_scan = 5000)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	discount_experiments = list(
+		/datum/experiment/scanning/random/mecha_destroyed_scan = 5000,
+		/datum/experiment/scanning/random/mecha_damage_scan = 10000,
+		) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 20000)
 
 /datum/techweb_node/mech_scattershot
 	id = "mecha_tools"
@@ -1988,8 +1998,8 @@
 		/obj/item/wrench/abductor,
 	)
 
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	required_experiments = list(/datum/experiment/scanning/points/slime/hard)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500)
+	discount_experiments = list(/datum/experiment/scanning/points/slime/hard = 10000) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
 	hidden = TRUE
 
 /datum/techweb_node/alien_engi

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -335,7 +335,7 @@
 		"soda_dispenser",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500)
-	discount_experiments = list(/datum/experiment/dissection/human = 10000) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
+	discount_experiments = list(/datum/experiment/dissection/human = 10000)
 
 /datum/techweb_node/adv_biotech
 	id = "adv_biotech"
@@ -360,7 +360,7 @@
 	discount_experiments = list(
 		/datum/experiment/scanning/random/material/meat = 4000,
 		/datum/experiment/dissection/nonhuman = 10000,
-		) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
+		)
 
 /datum/techweb_node/xenoorgan_biotech
 	id = "xenoorgan_bio"
@@ -555,7 +555,7 @@
 	discount_experiments = list(
 		/datum/experiment/scanning/random/material/medium/one = 4000,
 		/datum/experiment/ordnance/gaseous/bz = 10000,
-	) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
+	)
 
 /datum/techweb_node/anomaly
 	id = "anomaly_research"
@@ -993,7 +993,7 @@
 	discount_experiments = list(
 		/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000,
 		/datum/experiment/ordnance/gaseous/noblium = 10000,
-	) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
+	)
 
 /////////////////////////Clown tech/////////////////////////
 /datum/techweb_node/clown
@@ -1341,7 +1341,7 @@
 	discount_experiments = list(
 		/datum/experiment/scanning/random/plants/traits = 3000,
 		/datum/experiment/scanning/random/plants/wild = 10000,
-	) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
+	)
 
 /datum/techweb_node/exp_tools
 	id = "exp_tools"
@@ -1413,7 +1413,7 @@
 		"tele_shield",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 20000)
-	discount_experiments = list(/datum/experiment/ordnance/explosive/pressurebomb = 10000) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
+	discount_experiments = list(/datum/experiment/ordnance/explosive/pressurebomb = 10000)
 
 /datum/techweb_node/adv_weaponry
 	id = "adv_weaponry"
@@ -1781,7 +1781,7 @@
 	discount_experiments = list(
 		/datum/experiment/scanning/random/mecha_destroyed_scan = 5000,
 		/datum/experiment/scanning/random/mecha_damage_scan = 10000,
-		) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
+		)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 20000)
 
 /datum/techweb_node/mech_scattershot
@@ -1999,7 +1999,7 @@
 	)
 
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500)
-	discount_experiments = list(/datum/experiment/scanning/points/slime/hard = 10000) //ex-required experiments have large costs as a temp measure to see how often they get done when not a hard requirement.
+	discount_experiments = list(/datum/experiment/scanning/points/slime/hard = 10000)
 	hidden = TRUE
 
 /datum/techweb_node/alien_engi

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -334,8 +334,8 @@
 		"pandemic",
 		"soda_dispenser",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500)
-	discount_experiments = list(/datum/experiment/dissection/human = 10000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	required_experiments = list(/datum/experiment/dissection/human)
 
 /datum/techweb_node/adv_biotech
 	id = "adv_biotech"
@@ -356,11 +356,9 @@
 		"plasmarefiller",
 		"smoke_machine",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000)
-	discount_experiments = list(
-		/datum/experiment/scanning/random/material/meat = 4000,
-		/datum/experiment/dissection/nonhuman = 10000,
-		)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	required_experiments = list(/datum/experiment/dissection/nonhuman)
+	discount_experiments = list(/datum/experiment/scanning/random/material/meat = 4000)
 
 /datum/techweb_node/xenoorgan_biotech
 	id = "xenoorgan_bio"
@@ -1338,10 +1336,8 @@
 		"adv_watering_can",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 14000)
-	discount_experiments = list(
-		/datum/experiment/scanning/random/plants/traits = 3000,
-		/datum/experiment/scanning/random/plants/wild = 10000,
-	)
+	required_experiments = list(/datum/experiment/scanning/random/plants/wild)
+	discount_experiments = list(/datum/experiment/scanning/random/plants/traits = 3000)
 
 /datum/techweb_node/exp_tools
 	id = "exp_tools"
@@ -1778,10 +1774,8 @@
 		"mech_ccw_armor",
 		"mech_proj_armor",
 	)
-	discount_experiments = list(
-		/datum/experiment/scanning/random/mecha_destroyed_scan = 5000,
-		/datum/experiment/scanning/random/mecha_damage_scan = 10000,
-		)
+	required_experiments = list(/datum/experiment/scanning/random/mecha_damage_scan)
+	discount_experiments = list(/datum/experiment/scanning/random/mecha_destroyed_scan = 5000)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 20000)
 
 /datum/techweb_node/mech_scattershot

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1335,7 +1335,7 @@
 		"seed_extractor",
 		"adv_watering_can",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 14000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
 	required_experiments = list(/datum/experiment/scanning/random/plants/wild)
 	discount_experiments = list(/datum/experiment/scanning/random/plants/traits = 3000)
 
@@ -1776,7 +1776,7 @@
 	)
 	required_experiments = list(/datum/experiment/scanning/random/mecha_damage_scan)
 	discount_experiments = list(/datum/experiment/scanning/random/mecha_destroyed_scan = 5000)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 20000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 
 /datum/techweb_node/mech_scattershot
 	id = "mecha_tools"


### PR DESCRIPTION
## About The Pull Request
All of the current set of required_experiments have been swapped out for discount_experiments with a value of 10000, and all of the technodes that previously had required experiments have had their base costs increased by 10000 to compensate.

## Why It's Good For The Game
Required experiments vary between busywork and being incredibly annoying, repetition of the exact same actions every single round doesn't promote deep and interesting gameplay, it just gets frustrating and annoying both for the people who have to tick the boxes and for the people who who have to play a lesser game when people inevitably get bored and stop doing the same things every round.

I've been told, and I don't disagree with the idea that in the average 90 minute round, the entire techweb shouldn't all be easily researched, promoting some degree of round by round variation in what is available depending on the science team and their efforts. Frankly, required experiments fail to accomplish this goal in any interesting way - the fact that required experiments are static both in which tech nodes they apply to and in the ways in which they are unlocked means that by and large we tend to see very similar patterns of tech acquisition, as techs with simple requirements are always simple, whereas techs with more complex experimental requirements are always complex in very repetitive ways.

Discount experiments, in my experience, do not have nearly the same problems with mandatory repetition. While repeatedly performing the same discounts every time for the same technologies itself can easily get repetitive, the nature of discounted experiments in drawing from a shared pool of tech points means that players can effectively positively contribute to the acquisition of technology in general as they desire. Players can perform whichever experiments they feel like engaging with in any particular round - or not perform whichever experiments - paying for or being rewarded for their choices dynamically.

Switching over required experiments to discount experiments (and raising base prices to compensate) thus reduces the repetitiveness of science - different experiments can be substituted in and out for experiments players aren't confident with, don't feel like or have repeated too often. This also increases the potential dynamic nature of techweb limitations over an average 90 minute round, as players can make decisions to obtain priority techs (such as weapon technologies) at the cost of less points to spend in other places.

I've left the discount (and subsequent basecost increase) for every previously required experiment at 10000 points - I don't want to discourage doing experiments or make them irrelevant, so in most cases the station should still want to do as many experiments as possible, but I'd like to see a more dynamic experimental system where players can substitute in and out the experiments they want to do as they will, rather than a "but thou must" system where players *must* do the same exact set of tasks every round. I'm happily open to changing this number either across the board or individually if maintainers disagree on the number point (either too high or too low or both across different technodes)

I've tested this PR on local just in case I broke everything and nothing seems to be broken, so hopefully no spook coding moments in here.
## Changelog

:cl:
balance: All required techweb experiments have been substituted for expensive discount experiments.
/:cl:

