### PR TITLE
Fixes chat log saving breaking because of unsupported CSS rules

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -495,7 +495,9 @@ class ChatRenderer {
       const cssRules = styleSheets[i].cssRules;
       for (let i = 0; i < cssRules.length; i++) {
         const rule = cssRules[i];
-        cssText += rule.cssText + '\n';
+        if (rule && typeof rule.cssText === 'string') {
+          cssText += rule.cssText + '\n';
+        }
       }
     }
     cssText += 'body, html { background-color: #141414 }\n';


### PR DESCRIPTION
## About The Pull Request
Title explains it. The chat saving wasn't working because what we can only assume to be an invalid CSS rule. I managed to figure out that it was the 38th of a certain stylesheet, and I'm assuming that it's from the FontAwesome one, but I can't be sure and I also couldn't really figure out a sane way to find out which one caused it exactly, as that file is an utter mess.

Stylemistake and AnturK both said it was a good fix, mostly to prevent stuff like this happening in the future.

Huge props to @Valtosin for actually being the one suggesting the fix, and saving me probably a few hours of digging around.

Fixes #69097.

## Why It's Good For The Game
Saving chat logs is an important feature for many people, and it being functional is also quite important.

## Changelog

:cl: GoldenAlpharex, but really Valtosin for suggesting the fix
fix: Chat saving will no longer break if the CSS stylesheets contain unsupported CSS rules.
/:cl: