### PR TITLE
Lowers the in-repo threat cost of heretics + also their requirements

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -196,8 +196,8 @@
 	)
 	required_candidates = 1
 	weight = 4
-	cost = 7
-	requirements = list(101,101,101,10,10,10,10,10,10,10)
+	cost = 6
+	requirements = list(101,101,50,10,10,10,10,10,10,10)
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/latejoin/heretic_smuggler/execute()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -221,9 +221,9 @@
 	)
 	required_candidates = 1
 	weight = 3
-	cost = 15
+	cost = 10
 	scaling_cost = 9
-	requirements = list(101,101,101,40,35,20,20,15,10,10)
+	requirements = list(101,101,60,30,30,25,20,15,10,10)
 	antag_cap = list("denominator" = 24)
 
 


### PR DESCRIPTION
## About The Pull Request

- Roundstart heretics
   - Lowers the cost of from 15 to 10
   - Adjusts the requirements for heretics
     - in the 12-17 pop range, heretics can now trigger if threat > 60 (previously: never)
     - in the 18-29, > 30
     - 30-35, > 25

- Latejoin heretics
   - Lowers the cost of from 7 to 6
   - Adjusts the requirements for heretics
     - in the 12-17 pop range, heretics can now trigger if threat > 50 (previously: never)

## Why It's Good For The Game

Heretics had their threat and pop requirements bumped up in the past because they were deplorable murderhoboes who gibbed a ton of people 

Now they've changed a lot, and in a few aspects, they're actually less egregious than traitors
(Heretics no longer gib / round remove, traitors have a final objective a la ascension)

So I feel like their threat values need to be adjusted to accommodate. 

(Note: This only touches in-repo values, what is reflected on the servers may be different)

## Changelog

:cl: Melbert
balance: Default heretic threat costs have been bumped down, and they can appear at slightly lower pop if the round is high threat. (Server configuration may differ from this)
/:cl:
