### PR TITLE
Allows multiline text inputs to insert line breaks using Shift-Enter

### DIFF
--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -16,19 +16,11 @@ type TextInputData = {
 };
 
 export const SanitizeMultiline = (toSanitize: string) => {
-  const tooManySkiplinesFinder = RegExp('(\r\n\r\n\r\n|\n\n\n|\r\r\r)+');
-  while (toSanitize.search(tooManySkiplinesFinder) !== -1) {
-    toSanitize = toSanitize.replace(tooManySkiplinesFinder, '\n\n');
-  }
-  return toSanitize;
+  return toSanitize.replace(/(\n|\r\n){3,}/, '\n\n');
 };
 
 export const RemoveAllSkiplines = (toSanitize: string) => {
-  const skiplinesFinder = RegExp('(\n|\r)+');
-  while (toSanitize.search(skiplinesFinder) !== -1) {
-    toSanitize = toSanitize.replace(skiplinesFinder, '');
-  }
-  return toSanitize;
+  return toSanitize.replace(/[\r\n]+/, '');
 };
 
 export const TextInputModal = (props, context) => {

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -15,11 +15,11 @@ type TextInputData = {
   title: string;
 };
 
-export const SanitizeMultiline = (toSanitize: string) => {
+export const sanitizeMultiline = (toSanitize: string) => {
   return toSanitize.replace(/(\n|\r\n){3,}/, '\n\n');
 };
 
-export const RemoveAllSkiplines = (toSanitize: string) => {
+export const removeAllSkiplines = (toSanitize: string) => {
   return toSanitize.replace(/[\r\n]+/, '');
 };
 
@@ -44,8 +44,8 @@ export const TextInputModal = (props, context) => {
       return;
     }
     const sanitizedInput = multiline
-      ? SanitizeMultiline(value)
-      : RemoveAllSkiplines(value);
+      ? sanitizeMultiline(value)
+      : removeAllSkiplines(value);
     setInput(sanitizedInput);
   };
 

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -26,7 +26,7 @@ export const SanitizeMultiline = (toSanitize: string) => {
 export const RemoveAllSkiplines = (toSanitize: string) => {
   const skiplinesFinder = RegExp('(\n|\r)+');
   while (toSanitize.search(skiplinesFinder) !== -1) {
-    toSanitize = toSanitize.replace(skiplinesFinder, ' ');
+    toSanitize = toSanitize.replace(skiplinesFinder, '');
   }
   return toSanitize;
 };


### PR DESCRIPTION
## About The Pull Request
Makes it so the limit of line breaks is two consecutive ones on multiline text inputs, and visual-only multiline will not be allowed to enter line breaks at all (but it will also not send it right away).

## Why It's Good For The Game
Sometimes, separating certain long strings into paragraphs really helps with readability. The code ensures that people can't put more than two line breaks one after the other, and will work even on copy-pasted code (even if it might not update itself visually on the input for the user, the change will be applied before that input is then used by the code).

I made it so only the `tgui_text_input()` that set `multiline = TRUE` can benefit from this feature, because I didn't want to accidentally cause all tgui text inputs to suddenly allow you to have line breaks in your inputs, otherwise that would end up creating a _lot_ of unintended behavior.

## Changelog

:cl: GoldenAlpharex
fix: Multiline inputs can now finally support line breaks, accessible via shift-enter! A maximum of two consecutive line breaks is allowed, any more than that will be automatically stripped. This only applies to input boxes that start with the multiline view enabled, and will thus not work on input boxes that aren't meant to support it.
/:cl: