### PR TITLE
Change abysmal mask to be a negative mood event instead of direct sanity drain

### DIFF
--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -464,10 +464,6 @@
 		qdel(moodlet)
 	update_mood()
 
-/// Helper to forcefully drain sanity
-/datum/mood/proc/direct_sanity_drain(amount)
-	set_sanity(sanity + amount, override = TRUE)
-
 /**
  * Returns true if you already have a mood from a provided category.
  * You may think to yourself, why am I trying to get a boolean from a component? Well, this system probably should not be a component.

--- a/code/datums/mood_events/_mood_event.dm
+++ b/code/datums/mood_events/_mood_event.dm
@@ -3,7 +3,7 @@
 	var/description
 	/// An integer value that affects overall sanity over time
 	var/mood_change = 0
-	/// How long this mood event should last
+	/// How long this mood event should last (if 0, the mood event has an infinite duration and needs to be cleared manually)
 	var/timeout = 0
 	/// Is this mood event hidden on examine
 	var/hidden = FALSE

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -389,3 +389,14 @@
 	description = "I just got squeezed way too hard."
 	mood_change = -1
 	timeout = 2 MINUTES
+
+/datum/mood_event/abyssal_mask
+	description = "I wonder... The face under the mask... Is that... your true face?"
+	mood_change = -10
+	timeout = 5 MINUTES
+
+/datum/mood_event/abyssal_mask/add_effects(is_wearing_mask)
+	if(is_wearing_mask)
+		description = "I wonder...what makes you happy...does it make...others happy, too?"
+		mood_change = -25
+		timeout = 0 // infinite duration until mask is taken off

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -391,12 +391,12 @@
 	timeout = 2 MINUTES
 
 /datum/mood_event/abyssal_mask
-	description = "I wonder... The face under the mask... Is that... your true face?"
+	description = "I wonder... The face under the mask... Is that... my true face?" // -Moon Child
 	mood_change = -15
 	timeout = 1 MINUTES
 
 /datum/mood_event/abyssal_mask/add_effects(is_wearing_mask)
 	if(is_wearing_mask)
-		description = "I wonder...what makes you happy...does it make...others happy, too?"
+		description = "I wonder...what makes me happy...does it make...others happy, too?" // -Moon Child
 		mood_change = -25
 		timeout = 0 // infinite duration until mask is taken off

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -392,8 +392,8 @@
 
 /datum/mood_event/abyssal_mask
 	description = "I wonder... The face under the mask... Is that... your true face?"
-	mood_change = -10
-	timeout = 5 MINUTES
+	mood_change = -15
+	timeout = 1 MINUTES
 
 /datum/mood_event/abyssal_mask/add_effects(is_wearing_mask)
 	if(is_wearing_mask)

--- a/code/modules/antagonists/heretic/items/madness_mask.dm
+++ b/code/modules/antagonists/heretic/items/madness_mask.dm
@@ -66,7 +66,9 @@
 		if(human_in_range.is_blind())
 			continue
 
-		human_in_range.add_mood_event("abyssal_mask", /datum/mood_event/abyssal_mask)
+		var/obj/item/clothing/mask/madness_mask/abyssal_mask = human_in_range.get_item_by_slot(ITEM_SLOT_MASK)
+		var/is_wearing_mask = istype(abyssal_mask)
+		human_in_range.add_mood_event("abyssal_mask", /datum/mood_event/abyssal_mask, is_wearing_mask)
 
 		if(DT_PROB(60, delta_time))
 			human_in_range.hallucination = min(human_in_range.hallucination + 5, 120)

--- a/code/modules/antagonists/heretic/items/madness_mask.dm
+++ b/code/modules/antagonists/heretic/items/madness_mask.dm
@@ -1,3 +1,5 @@
+#define INFINITE_DURATION TRUE
+
 // The spooky "void" / "abyssal" / "madness" mask for heretics.
 /obj/item/clothing/mask/madness_mask
 	name = "Abyssal Mask"
@@ -23,7 +25,7 @@
 	else
 		. += span_danger("The eyes fill you with dread... You best avoid it.")
 
-/obj/item/clothing/mask/madness_mask/equipped(mob/user, slot)
+/obj/item/clothing/mask/madness_mask/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(slot != ITEM_SLOT_MASK)
 		return
@@ -36,13 +38,20 @@
 	if(IS_HERETIC_OR_MONSTER(user))
 		return
 
+	user.add_mood_event("abyssal_mask", /datum/mood_event/abyssal_mask, INFINITE_DURATION)
+
 	ADD_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
 	to_chat(user, span_userdanger("[src] clamps tightly to your face as you feel your soul draining away!"))
 
-/obj/item/clothing/mask/madness_mask/dropped(mob/M)
+/obj/item/clothing/mask/madness_mask/dropped(mob/living/carbon/human/user)
 	local_user = null
 	STOP_PROCESSING(SSobj, src)
 	REMOVE_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
+	
+	if(!ishuman(user))
+		return
+		
+	user.clear_mood_event("abyssal_mask")
 	return ..()
 
 /obj/item/clothing/mask/madness_mask/process(delta_time)
@@ -58,7 +67,7 @@
 		if(human_in_range.is_blind())
 			continue
 
-		human_in_range.mob_mood.direct_sanity_drain(rand(-2, -20) * delta_time)
+		human_in_range.add_mood_event("abyssal_mask", /datum/mood_event/abyssal_mask)
 
 		if(DT_PROB(60, delta_time))
 			human_in_range.hallucination = min(human_in_range.hallucination + 5, 120)
@@ -72,3 +81,5 @@
 
 		if(DT_PROB(25, delta_time))
 			human_in_range.set_timed_status_effect(10 SECONDS, /datum/status_effect/dizziness, only_if_higher = TRUE)
+
+#undef INFINITE_DURATION

--- a/code/modules/antagonists/heretic/items/madness_mask.dm
+++ b/code/modules/antagonists/heretic/items/madness_mask.dm
@@ -66,8 +66,7 @@
 		if(human_in_range.is_blind())
 			continue
 
-		var/obj/item/clothing/mask/madness_mask/abyssal_mask = human_in_range.get_item_by_slot(ITEM_SLOT_MASK)
-		var/is_wearing_mask = istype(abyssal_mask)
+		var/is_wearing_mask = istype(human_in_range.get_item_by_slot(ITEM_SLOT_MASK), /obj/item/clothing/mask/madness_mask)
 		human_in_range.add_mood_event("abyssal_mask", /datum/mood_event/abyssal_mask, is_wearing_mask)
 
 		if(DT_PROB(60, delta_time))

--- a/code/modules/antagonists/heretic/items/madness_mask.dm
+++ b/code/modules/antagonists/heretic/items/madness_mask.dm
@@ -48,10 +48,9 @@
 	STOP_PROCESSING(SSobj, src)
 	REMOVE_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
 	
-	if(!ishuman(user))
-		return
-		
-	user.clear_mood_event("abyssal_mask")
+	if(ishuman(user))
+		user.clear_mood_event("abyssal_mask")
+
 	return ..()
 
 /obj/item/clothing/mask/madness_mask/process(delta_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #69082

The abysmal mask was using a custom proc to drain sanity which would go into the negative.  I made it into a mood event instead and removed the deprecated code.

The mask has been set to the highest negative mood effect.  I based it on the other antag mood events that cause similar heavy sanity drain.  (shadowrealm, mansus grasp, etc.)  The mood event also uses a duration which the original code did not do.  The current highest level sanity drain value is `-0.3`, regardless of how negative a person's mood reaches.

https://github.com/tgstation/tgstation/blob/3a7c3871a0a5db869afd508ed4c114fa4509883b/code/datums/mood.dm#L75-L94

After digging, the sanity drain from the original mask code was `prob(-2, -20)`, so on average it does `-10`.  Sanity is a integer from 150 to 0, with neutral being 100.  

Assuming someone is at (100) neutral sanity:
- Old mask code reaches zero sanity in ~10 seconds.
- New mask code reaches zero sanity in ~5.5 minutes.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Less bugs are good.  Sanity doesn't go into the negative and take hours to restore.  

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix abysmal mask draining sanity to negative
balance: Change abysmal mask to be a negative mood event instead of direct sanity drain
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
