### PR TITLE
Fixes Social Anxiety capitalization mid-sentence words

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -541,7 +541,7 @@
 			if(prob(max(5,(nearby_people*12.5*moodmod)))) //Minimum 1/20 chance of stutter
 				// Add a short stutter, THEN treat our word
 				quirker.adjust_timed_status_effect(0.5 SECONDS, /datum/status_effect/speech/stutter)
-				new_message += quirker.treat_message(word)
+				new_message += quirker.treat_message(word, capitalize_message = FALSE)
 
 			else
 				new_message += word

--- a/code/modules/mob/living/brain/brain_say.dm
+++ b/code/modules/mob/living/brain/brain_say.dm
@@ -19,6 +19,7 @@
 	else
 		return ..()
 
-/mob/living/brain/treat_message(message)
-	message = capitalize(message)
+/mob/living/brain/treat_message(message, capitalize_message = TRUE)
+	if(capitalize_message)
+		message = capitalize(message)
 	return message

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -434,14 +434,20 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	return TRUE
 
 
-
-/mob/living/proc/treat_message(message)
+/**
+ * Treats the passed message with things that may modify speech (stuttering, slurring etc).
+ *
+ * message - The message to treat.
+ * capitalize_message - Whether we run capitalize() on the message after we're done.
+ */
+/mob/living/proc/treat_message(message, capitalize_message = TRUE)
 	if(HAS_TRAIT(src, TRAIT_UNINTELLIGIBLE_SPEECH))
 		message = unintelligize(message)
 
 	SEND_SIGNAL(src, COMSIG_LIVING_TREAT_MESSAGE, args)
 
-	message = capitalize(message)
+	if(capitalize_message)
+		message = capitalize(message)
 
 	return message
 


### PR DESCRIPTION
## About The Pull Request

A side effect of moving stutter to a status effect was that I used `treat_message` mid sentence but only for one word, this caused anxity-triggered words to capitalize when they shouldn't. 

I just added a parameter to treat message to make capitalization optional. It works. 

## Why It's Good For The Game

Looks a l-l-Little less w-w-Weird, no?

## Changelog

:cl: Melbert
fix: Fixes stuttered words with anxiety being capitalized 
/:cl:
