### PR TITLE
Heads are no longer tasked to kill their own pets

### DIFF
--- a/code/modules/antagonists/traitor/objectives/kill_pet.dm
+++ b/code/modules/antagonists/traitor/objectives/kill_pet.dm
@@ -64,6 +64,7 @@
 		possible_heads -= objective.target.title
 	if(limited_to_department_head)
 		possible_heads = possible_heads & role.department_head
+	possible_heads -= role.title
 
 	if(!length(possible_heads))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Someone on my server complained that they got assigned as CE to kill Poly, and I have taken a look, and printed the contents of the possible_heads list, and turns out, your own will never gets removed from it. This PR fixes that, by removing your own role from the off chance it is contained in the list of possible targets.

~~I consider this a fix, but if it is a balance issue, I will update the PR accordingly.~~ It is balance now.

## Why It's Good For The Game

Heads killing their own pets is an extremely low effort objective. Not to mention, they are their beloved companion...

## Changelog


:cl:
balance: Heads are no longer tasked to kill their own pets
/:cl:

