### PR TITLE
Fix slimepeople soft landing showing message for stairs and self

### DIFF
--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -17,9 +17,17 @@
 	UnregisterSignal(target, COMSIG_ATOM_INTERCEPT_Z_FALL)
 
 ///signal called by the stat of the target changing
-/datum/element/soft_landing/proc/intercept_z_fall(obj/soft_object, falling_movables, levels)
+/datum/element/soft_landing/proc/intercept_z_fall(atom/soft_object, falling_movables, levels)
 	SIGNAL_HANDLER
 
-	for (var/mob/living/falling_victim in falling_movables)
-		to_chat(falling_victim, span_notice("[soft_object] provides a soft landing for you!"))
+	for(var/mob/living/falling_victim in falling_movables)
+		var/turf/falling_spot = get_turf(falling_victim)
+		
+		if(locate(/obj/structure/stairs/traveling_down) in falling_spot)
+			FALL_INTERCEPTED | FALL_NO_MESSAGE
+		
+		if(soft_object == falling_victim)
+			to_chat(falling_victim, span_notice("Your fall is cushioned by your body to provide a soft landing!"))
+		else
+			to_chat(falling_victim, span_notice("[soft_object] provides a soft landing for you!"))
 	return FALL_INTERCEPTED | FALL_NO_MESSAGE

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -20,12 +20,12 @@
 /datum/element/soft_landing/proc/intercept_z_fall(atom/soft_object, falling_movables, levels)
 	SIGNAL_HANDLER
 
+	var/turf/falling_spot = get_turf(soft_object)
+
+	if(locate(/obj/structure/stairs) in falling_spot)
+		return FALL_INTERCEPTED | FALL_NO_MESSAGE
+
 	for(var/mob/living/falling_victim in falling_movables)
-		var/turf/falling_spot = get_turf(falling_victim)
-		
-		if(locate(/obj/structure/stairs) in falling_spot)
-			return FALL_INTERCEPTED | FALL_NO_MESSAGE
-		
 		if(soft_object == falling_victim)
 			to_chat(falling_victim, span_notice("Your fall is cushioned by your body to provide a soft landing!"))
 		else

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -23,7 +23,7 @@
 	for(var/mob/living/falling_victim in falling_movables)
 		var/turf/falling_spot = get_turf(falling_victim)
 		
-		if(locate(/obj/structure/stairs/traveling_down) in falling_spot)
+		if(locate(/obj/structure/stairs) in falling_spot)
 			FALL_INTERCEPTED | FALL_NO_MESSAGE
 		
 		if(soft_object == falling_victim)

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -24,7 +24,7 @@
 		var/turf/falling_spot = get_turf(falling_victim)
 		
 		if(locate(/obj/structure/stairs) in falling_spot)
-			FALL_INTERCEPTED | FALL_NO_MESSAGE
+			return FALL_INTERCEPTED | FALL_NO_MESSAGE
 		
 		if(soft_object == falling_victim)
 			to_chat(falling_victim, span_notice("Your fall is cushioned by your body to provide a soft landing!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #68466

Fix slimepeople soft landing showing message for stairs and self.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Another bug off the tracker.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix slimepeople soft landing showing message for stairs and self
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
