### PR TITLE
Fixes* the dir 3 objects from the nature and disco inferno emergency shuttles

### DIFF
--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -178,9 +178,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "I" = (
-/obj/machinery/computer/slot_machine{
-	dir = 3
-	},
+/obj/machinery/computer/slot_machine,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "J" = (

--- a/_maps/shuttles/emergency_nature.dmm
+++ b/_maps/shuttles/emergency_nature.dmm
@@ -59,12 +59,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"cL" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 3
-	},
-/turf/open/floor/iron/white,
-/area/shuttle/escape)
 "cR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -80,13 +74,11 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "dj" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 3
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "dP" = (
@@ -958,12 +950,10 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Kx" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 3
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "KT" = (
@@ -1030,10 +1020,8 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "OS" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 3
-	},
 /obj/machinery/vending/coffee,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "Ps" = (
@@ -1292,20 +1280,16 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "YW" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 3
-	},
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "Zd" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 3
-	},
 /obj/machinery/light/directional/south,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "Zg" = (
@@ -1676,7 +1660,7 @@ Bt
 ST
 wg
 PG
-cL
+Zt
 gj
 Um
 cm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The south green decals on the nature emergency shuttle and the bottom gambling machine on the disco inferno shuttle had dir 3. Now they're both dir 2.

(Sorry for the accidental removal tag.)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Dir 3 is the direction north + south, which doesn't really have a reason to be used anywhere, specially on these items. The decals should be, and now are, exclusively south and the gambling machine seemed to just be a mistype which this PR fixes.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: changed the directions of the bottom decals on the nature emergency shuttle and the bottom gambling machine on the disco inferno shuttle from 3 (north+south) to simply 2 (south), as they should be.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
