### PR TITLE
Fixes runtime when throwing held simplemob

### DIFF
--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -6,7 +6,6 @@
 	icon = null
 	icon_state = ""
 	slot_flags = NONE
-	throwforce = 5
 	var/mob/living/held_mob
 	var/destroying = FALSE
 

--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -6,6 +6,7 @@
 	icon = null
 	icon_state = ""
 	slot_flags = NONE
+	throwforce = 5
 	var/mob/living/held_mob
 	var/destroying = FALSE
 
@@ -43,6 +44,18 @@
 
 /obj/item/clothing/head/mob_holder/proc/update_visuals(mob/living/L)
 	appearance = L.appearance
+
+/obj/item/clothing/head/mob_holder/on_thrown(mob/living/carbon/user, atom/target)
+	if((item_flags & ABSTRACT) || HAS_TRAIT(src, TRAIT_NODROP))
+		return
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, span_notice("You set [src] down gently on the ground."))
+		release()
+		return
+
+	var/mob/living/throw_mob = held_mob
+	release()
+	return throw_mob
 
 /obj/item/clothing/head/mob_holder/dropped()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #53218

The first step (after validation) of throwing an object is to place it on the ground.
Placing a "mob holder" object on the ground causes it to release the held mob and delete itself.
A runtime would then occur as you tried to throw something which just deleted itself.

I overrode `on_thrown` on `/obj/item/clothing/head/mob_holder` so that it calls `release` instead of `dropItemToGround` and returns the held mob instead of the item. 
The result is that you can now walk around with a backpack full of mice and throw them at people, just like in real life.

## Why It's Good For The Game

It's bad when the code runtimes on throw.
It is good when you can throw Runtime.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Any mob you can hold in your hand can now also be thrown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
