### PR TITLE
Fixes heretic Cleave spell hitting the target twice

### DIFF
--- a/code/modules/antagonists/heretic/magic/blood_cleave.dm
+++ b/code/modules/antagonists/heretic/magic/blood_cleave.dm
@@ -22,7 +22,7 @@
 
 /datum/action/cooldown/spell/pointed/cleave/cast(mob/living/carbon/human/cast_on)
 	. = ..()
-	var/list/mob/living/carbon/human/nearby = list(cast_on)
+	var/list/mob/living/carbon/human/nearby = list()
 	for(var/mob/living/carbon/human/nearby_human in range(cleave_radius, cast_on))
 		nearby += nearby_human
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The Cleave spell was hitting the targeted mob twice as a result of the target being manually added to the list of nearby mobs and then being added to the same list a second time as a result of the following for loop.  This meant that the target would receive 40 burn damage and two critical slash wounds. This fixes that.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

This spell was hilariously deadly beforehand, as 40 burn damage and two critical slash wounds is entirely capable of killing a person from full health within less than a minute without immediate medical attention. This appeared to be unintentional behavior.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The heretic Cleave spell no longer hits targets twice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
