### PR TITLE
Pun Pun will not save the name "Unknown" to legacy data

### DIFF
--- a/code/modules/mob/living/carbon/human/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey/monkey.dm
@@ -128,7 +128,7 @@ GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/pu
 		file_data["relic_hat"] = null
 		file_data["relic_mask"] = null
 	else
-		file_data["ancestor_name"] = ancestor_name ? ancestor_name : name
+		file_data["ancestor_name"] = ancestor_name ? ancestor_name : real_name
 		file_data["ancestor_chain"] = dead ? ancestor_chain + 1 : ancestor_chain
 		file_data["relic_hat"] = head ? head.type : null
 		file_data["relic_mask"] = wear_mask ? wear_mask.type : null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #69266
If Pun Pun were gibbed in a previous round and ended the next round either wearing a mask or husked, it would save their display name "unknown" to the ancestor data file rather than their real name.

## Why It's Good For The Game

It's sad for Pun Pun to inherit the non-name Unknown instead of a name.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Pun Pun shouldn't save the name "Unknown" between rounds unless that is actually their real name for some reason.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
