### PR TITLE
Add silicon human spremacy override config, fixes #68957

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -289,6 +289,8 @@
 	min_val = 0
 	max_val = 4
 
+/datum/config_entry/flag/silicon_human_supremacy_override
+
 /datum/config_entry/number/silicon_max_law_amount
 	default = 12
 	min_val = 0

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -289,7 +289,7 @@
 	min_val = 0
 	max_val = 4
 
-/datum/config_entry/flag/silicon_human_supremacy_override
+/datum/config_entry/flag/silicon_asimov_superiority_override // Controls if Asimov Superiority appears as a perk for humans even if standard Asimov isn't the default AI lawset
 
 /datum/config_entry/number/silicon_max_law_amount
 	default = 12

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -289,7 +289,8 @@
 	min_val = 0
 	max_val = 4
 
-/datum/config_entry/flag/silicon_asimov_superiority_override // Controls if Asimov Superiority appears as a perk for humans even if standard Asimov isn't the default AI lawset
+/// Controls if Asimov Superiority appears as a perk for humans even if standard Asimov isn't the default AI lawset
+/datum/config_entry/flag/silicon_asimov_superiority_override
 
 /datum/config_entry/number/silicon_max_law_amount
 	default = 12

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -72,7 +72,7 @@
 /datum/species/human/create_pref_unique_perks()
 	var/list/to_add = list()
 
-	if(CONFIG_GET(number/default_laws) == 0) // Default lawset is set to Asimov
+	if(CONFIG_GET(number/default_laws) == 0 || CONFIG_GET(flag/silicon_human_supremacy_override)) // Default lawset is set to Asimov
 		to_add += list(list(
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 			SPECIES_PERK_ICON = "robot",

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -72,7 +72,7 @@
 /datum/species/human/create_pref_unique_perks()
 	var/list/to_add = list()
 
-	if(CONFIG_GET(number/default_laws) == 0 || CONFIG_GET(flag/silicon_human_supremacy_override)) // Default lawset is set to Asimov
+	if(CONFIG_GET(number/default_laws) == 0 || CONFIG_GET(flag/silicon_asimov_superiority_override)) // Default lawset is set to Asimov
 		to_add += list(list(
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 			SPECIES_PERK_ICON = "robot",

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -230,8 +230,8 @@ DEFAULT_LAWS 0
 
 ## SILICON HUMAN SUPREMACY OVERRIDE ###
 ## This makes "Asimov supremacy" show up as a perk for humans in the character creation menu even if asimov is not the default lawset, such as when used with asimov++
-## Comment this out to make "Asimov Supremacy" show up as a perk for humans
-SILICON_HUMAN_SUPREMACY_OVERRIDE
+## Uncomment this out to make "Asimov Supremacy" show up as a perk for humans
+# SILICON_HUMAN_SUPREMACY_OVERRIDE
 
 ## SPECIFIED LAWS ##
 ## ------------------------------------------------------------------------------------------

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -228,6 +228,11 @@ NEAR_DEATH_EXPERIENCE
 
 DEFAULT_LAWS 0
 
+## SILICON HUMAN SUPREMACY OVERRIDE ###
+## This makes "Asimov supremacy" show up as a perk for humans in the character creation menu even if asimov is not the default lawset, such as when used with asimov++
+## Comment this out to make "Asimov Supremacy" show up as a perk for humans
+SILICON_HUMAN_SUPREMACY_OVERRIDE
+
 ## SPECIFIED LAWS ##
 ## ------------------------------------------------------------------------------------------
 ## These control what lawset the AI will use, edit the specified law to an *existing* lawset to make it the default.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -228,10 +228,10 @@ NEAR_DEATH_EXPERIENCE
 
 DEFAULT_LAWS 0
 
-## SILICON HUMAN SUPREMACY OVERRIDE ###
-## This makes "Asimov supremacy" show up as a perk for humans in the character creation menu even if asimov is not the default lawset, such as when used with asimov++
-## Uncomment this out to make "Asimov Supremacy" show up as a perk for humans
-# SILICON_HUMAN_SUPREMACY_OVERRIDE
+## SILICON ASIMOV SUPERIORITY OVERRIDE ###
+## This makes "Asimov Superiority" show up as a perk for humans in the character creation menu even if asimov is not the default lawset, such as when used with asimov++
+## Uncomment this out to make "Asimov Superiority" show up as a perk for humans
+# SILICON_ASIMOV_SUPERIORITY_OVERRIDE
 
 ## SPECIFIED LAWS ##
 ## ------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #68957 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Asimov supremacy shows up as a human perk for default servers
config: Added a config option to make Asimov supremacy show up as a perk for humans even if the default lawset is not Asimov (intended for use with Asimov variants, notably Asimov++)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
