### PR TITLE
Fixes #69020, stops export datums processing unneededly

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -79,26 +79,16 @@ Then the player gets the profit from selling his own wasted time.
 	var/list/exclude_types = list()
 
 	/// cost includes elasticity, this does not.
-	var/init_cost
 
 
 
 /datum/export/New()
 	..()
-	SSprocessing.processing += src
-	init_cost = cost
 	export_types = typecacheof(export_types, only_root_path = !include_subtypes, ignore_root_path = FALSE)
 	exclude_types = typecacheof(exclude_types)
 
 /datum/export/Destroy()
-	SSprocessing.processing -= src
 	return ..()
-
-/datum/export/process()
-	..()
-	cost *= NUM_E**(k_elasticity * (1/30))
-	if(cost > init_cost)
-		cost = init_cost
 
 // Checks the cost. 0 cost items are skipped in export.
 /datum/export/proc/get_cost(obj/O, apply_elastic = TRUE)

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -99,7 +99,7 @@ Then the player gets the profit from selling his own wasted time.
 		else
 			return round(cost * amount) //alternative form derived from L'Hopital to avoid division by 0
 	else
-		return round(init_cost * amount)
+		return round(cost * amount)
 
 // Checks the amount of exportable in object. Credits in the bill, sheets in the stack, etc.
 // Usually acts as a multiplier for a cost, so item that has 0 amount will be skipped in export.

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -78,17 +78,11 @@ Then the player gets the profit from selling his own wasted time.
 	/// Types excluded from export
 	var/list/exclude_types = list()
 
-	/// cost includes elasticity, this does not.
-
-
 
 /datum/export/New()
 	..()
 	export_types = typecacheof(export_types, only_root_path = !include_subtypes, ignore_root_path = FALSE)
 	exclude_types = typecacheof(exclude_types)
-
-/datum/export/Destroy()
-	return ..()
 
 // Checks the cost. 0 cost items are skipped in export.
 /datum/export/proc/get_cost(obj/O, apply_elastic = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was an interesting bug, it turned out to be caused by the processing code multiplying the price by roughly 1.0011 per second while clamping it at its original price, which meant that for most exports which have a original sale price that's positive, nothing changes. However, for exports with negative sale prices, this means that the price grows more negative in an exponential manner over time.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #69020
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Stops the export value for erroneous manifests from decreasing into the deep negatives exponentially over time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
