### PR TITLE
Fix gas canister supply packs causing stray cargo pod runtime

### DIFF
--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -52,7 +52,11 @@
 		pack_type = pick(possible_pack_types)
 	else
 		pack_type = pick(stray_spawnable_supply_packs)
-	var/datum/supply_pack/SP = new pack_type
+	var/datum/supply_pack/SP
+	if(ispath(pack_type, /datum/supply_pack))
+		SP = new pack_type
+	else  // treat this as a supply pack id and resolving it with SSshuttle
+		SP = SSshuttle.supply_packs[pack_type] 
 	var/obj/structure/closet/crate/crate = SP.generate(null)
 	if(crate) //empty supply packs are a thing! get memed on.
 		crate.locked = FALSE //Unlock secure crates


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
(Highly likely) fixes #69075
Note on testing: Since I couldn't force the event to generate canister supply packs, I just ran the event 200 times and see if a runtime occurred (well one did occur but it was about the SM shard crate and not canister supply packs, so that's another bug)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Stray cargo event pods now don't runtime if a canister supply pack is chosen, meaning that you should actually see them in the pods now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
