### PR TITLE
Add more checks to view sensor code

### DIFF
--- a/code/modules/wiremod/components/sensors/view_sensor.dm
+++ b/code/modules/wiremod/components/sensors/view_sensor.dm
@@ -53,9 +53,12 @@
 	var/object_list = list()
 
 	for(var/atom/movable/target in view(5, get_turf(parent.shell)))
+		if(target.mouse_opacity == MOUSE_OPACITY_TRANSPARENT)
+			continue
 		if(target.invisibility > see_invisible)
 			continue
-
+		if(target.IsObscured())
+			continue
 		object_list += target
 
 	result.set_output(object_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title, these checks are based on those used by `set_turf_examine_tab` for the statpanel.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #68596 (in the specific case of the plasma image holder in the bug, it has MOUSE_OPACITY_TRANSPARENT)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Circuit view sensors should no longer display undertile objects or abstract objects or other people's hallucinations etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
