### PR TITLE
Fixes update_icon_updates_onmob not working.

### DIFF
--- a/code/datums/elements/update_icon_updates_onmob.dm
+++ b/code/datums/elements/update_icon_updates_onmob.dm
@@ -13,6 +13,8 @@
 	if(!istype(target, /obj/item))
 		return ELEMENT_INCOMPATIBLE
 	RegisterSignal(target, COMSIG_ATOM_UPDATED_ICON, .proc/update_onmob)
+	update_flags = flags
+	update_body = body
 
 /datum/element/update_icon_updates_onmob/proc/update_onmob(obj/item/target)
 	SIGNAL_HANDLER


### PR DESCRIPTION
Fixes #69303

:cl: ShizCalev
fix: Icons will now actually update on mobs lol
/:cl:

#69179 added args but didn't actually utilize them. 10/10 completely tested pr lol