### PR TITLE
Fixes Abyssal Gaze always being valid to cast

### DIFF
--- a/code/modules/spells/spell_types/pointed/abyssal_gaze.dm
+++ b/code/modules/spells/spell_types/pointed/abyssal_gaze.dm
@@ -22,7 +22,7 @@
 	var/amount_to_cool = 200
 
 /datum/action/cooldown/spell/pointed/abyssal_gaze/is_valid_target(atom/cast_on)
-	return iscarbon(target)
+	return iscarbon(cast_on)
 
 /datum/action/cooldown/spell/pointed/abyssal_gaze/cast(mob/living/carbon/cast_on)
 	. = ..()


### PR DESCRIPTION
`/datum/action/var/target` is the holder, which is always a human. 

:cl: ShizCalev
admin: Fixed Abyssal Gaze being logged when it wasn't actually being used
/:cl:
