### PR TITLE
Makes `TRAIT_BOMBIMMUNE` a non-species trait (why was it a species trait no species used it whyyy)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -195,6 +195,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_RESISTCOLD "resist_cold"
 #define TRAIT_RESISTHIGHPRESSURE "resist_high_pressure"
 #define TRAIT_RESISTLOWPRESSURE "resist_low_pressure"
+/// This human is immune to the effects of being exploded. (ex_act)
 #define TRAIT_BOMBIMMUNE "bomb_immunity"
 #define TRAIT_RADIMMUNE "rad_immunity"
 #define TRAIT_GENELESS "geneless"

--- a/code/datums/martial/plasma_fist.dm
+++ b/code/datums/martial/plasma_fist.dm
@@ -93,7 +93,7 @@
 		var/mob/living/carbon/human/human_attacker = user
 		human_attacker.set_species(/datum/species/plasmaman)
 		ADD_TRAIT(human_attacker, TRAIT_FORCED_STANDING, type)
-		human_attacker.dna.species.species_traits += TRAIT_BOMBIMMUNE
+		ADD_TRAIT(human_attacker, TRAIT_BOMBIMMUNE, type)
 		human_attacker.unequip_everything()
 		human_attacker.underwear = "Nude"
 		human_attacker.undershirt = "Nude"
@@ -119,7 +119,7 @@
 	if(ishuman(dying))
 		var/mob/living/carbon/human/dying_human = dying
 		REMOVE_TRAIT(dying_human, TRAIT_FORCED_STANDING, type)
-		dying_human.dna.species.species_traits -= TRAIT_BOMBIMMUNE
+		REMOVE_TRAIT(dying_human, TRAIT_BOMBIMMUNE, type)
 	if(dying.stat == DEAD)
 		return
 	dying.death()

--- a/code/datums/martial/plasma_fist.dm
+++ b/code/datums/martial/plasma_fist.dm
@@ -116,10 +116,8 @@
 	plasma_power = 1 //just in case there is any clever way to cause it to happen again
 
 /datum/martial_art/plasma_fist/proc/Apotheosis_end(mob/living/dying)
-	if(ishuman(dying))
-		var/mob/living/carbon/human/dying_human = dying
-		REMOVE_TRAIT(dying_human, TRAIT_FORCED_STANDING, type)
-		REMOVE_TRAIT(dying_human, TRAIT_BOMBIMMUNE, type)
+	REMOVE_TRAIT(dying, TRAIT_FORCED_STANDING, type)
+	REMOVE_TRAIT(dying, TRAIT_BOMBIMMUNE, type)
 	if(dying.stat == DEAD)
 		return
 	dying.death()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -402,8 +402,8 @@
 
 
 /mob/living/carbon/human/ex_act(severity, target, origin)
-	if(TRAIT_BOMBIMMUNE in dna.species.species_traits)
-		return FALSE
+	if(HAS_TRAIT(src, TRAIT_BOMBIMMUNE))
+		return
 
 	. = ..()
 	if (!severity || QDELETED(src))


### PR DESCRIPTION
## About The Pull Request

`TRAIT_BOMBIMMUNE` is handled like a normal trait and not a species trait

Why was it a species trait? Can someone tell me? It doesn't make any sense, all it does is make it so if you apply it the normal way it doesn't work, it doesn't even follow the convention of species traits (it's called `TRAIT_`  guhh)

## Why It's Good For The Game

`TRAIT_BOMBIMMUNE` should do what people expect it to do if they add it as a trait

## Changelog

:cl: Melbert
fix: Some things that made you BOMBIMMUNE now actually make you BOMBIMMUNE, probably
/:cl:
