### PR TITLE
Displays a popup if you're converted into a shade who needs to follow instructions

### DIFF
--- a/code/modules/antagonists/shade/shade_minion.dm
+++ b/code/modules/antagonists/shade/shade_minion.dm
@@ -23,16 +23,23 @@
 /datum/antagonist/shade_minion/create_team(datum/team/shade_pact/team)
 	if (!istype(team))
 		return
-	for (var/datum/mind/member as anything in team.members)
-		if (member == owner)
-			continue
-		var/mob/master = member.current
-		if (!master)
-			CRASH("Master was not added to shade's team.")
-		master_name = master.real_name
+	master_name = team.master.current?.real_name
 
 /**
  * A team containing just the shade and master, so you can know who your master is.
  */
 /datum/team/shade_pact
 	show_roundend_report = FALSE
+	/// The master of the pact
+	var/datum/mind/master
+
+/**
+ * Create a new team consisting of a "pact master" and a subservient shade.
+ * The first player passed in should be the one everyone else needs to obey.
+ */
+/datum/team/shade_pact/New(starting_members)
+	. = ..()
+	if(islist(starting_members))
+		master = starting_members[0]
+		return
+	master = starting_members

--- a/code/modules/antagonists/shade/shade_minion.dm
+++ b/code/modules/antagonists/shade/shade_minion.dm
@@ -26,4 +26,8 @@
 	src.master_name = master_name
 	update_static_data(owner.current)
 	var/datum/action/antag_info/info_button = info_button_ref?.resolve()
-	info_button?.Trigger()
+	if (!info_button)
+		return
+	if (!istype(info_button))
+		return
+	info_button.Trigger()

--- a/code/modules/antagonists/shade/shade_minion.dm
+++ b/code/modules/antagonists/shade/shade_minion.dm
@@ -25,6 +25,4 @@
 
 	src.master_name = master_name
 	update_static_data(owner.current)
-	var/datum/action/antag_info/info_button = info_button_ref?.resolve()
-	if (info_button)
-		info_button.Trigger()
+	ui_interact(owner.current)

--- a/code/modules/antagonists/shade/shade_minion.dm
+++ b/code/modules/antagonists/shade/shade_minion.dm
@@ -26,4 +26,5 @@
 	src.master_name = master_name
 	update_static_data(owner.current)
 	var/datum/action/antag_info/info_button = info_button_ref?.resolve()
-	info_button?.Trigger()
+	if (info_button)
+		info_button.Trigger()

--- a/code/modules/antagonists/shade/shade_minion.dm
+++ b/code/modules/antagonists/shade/shade_minion.dm
@@ -5,7 +5,7 @@
  * Technically they're not 'antagonists' but they have antagonist-like properties.
  */
 /datum/antagonist/shade_minion
-	name = "\improper Shade"
+	name = "\improper Loyal Shade"
 	show_in_antagpanel = FALSE
 	show_in_roundend = FALSE
 	ui_name = "AntagInfoShade"

--- a/code/modules/antagonists/shade/shade_minion.dm
+++ b/code/modules/antagonists/shade/shade_minion.dm
@@ -8,6 +8,7 @@
 	name = "\improper Loyal Shade"
 	show_in_antagpanel = FALSE
 	show_in_roundend = FALSE
+	silent = TRUE
 	ui_name = "AntagInfoShade"
 	/// Name of this shade's master.
 	var/master_name = "nobody?"
@@ -17,29 +18,12 @@
 	data["master_name"] = master_name
 	return data
 
-/**
- * Gets your master's name, they should be the only other member of the team
- */
-/datum/antagonist/shade_minion/create_team(datum/team/shade_pact/team)
-	if (!istype(team))
+/// Apply a new master to the shade, will display the popup again also.
+/datum/antagonist/shade_minion/proc/update_master(master_name)
+	if (src.master_name == master_name)
 		return
-	master_name = team.master.current?.real_name
 
-/**
- * A team containing just the shade and master, so you can know who your master is.
- */
-/datum/team/shade_pact
-	show_roundend_report = FALSE
-	/// The master of the pact
-	var/datum/mind/master
-
-/**
- * Create a new team consisting of a "pact master" and a subservient shade.
- * The first player passed in should be the one everyone else needs to obey.
- */
-/datum/team/shade_pact/New(starting_members)
-	. = ..()
-	if(islist(starting_members))
-		master = starting_members[0]
-		return
-	master = starting_members
+	src.master_name = master_name
+	update_static_data(owner.current)
+	var/datum/action/antag_info/info_button = info_button_ref?.resolve()
+	info_button?.Trigger()

--- a/code/modules/antagonists/shade/shade_minion.dm
+++ b/code/modules/antagonists/shade/shade_minion.dm
@@ -1,0 +1,38 @@
+/**
+ * This datum is for use by shades who have a master but are not cultists.
+ * Cult shades don't get it because they get the cult datum instead.
+ * They are bound to follow the orders of their creator, probably a chaplain or miner.
+ * Technically they're not 'antagonists' but they have antagonist-like properties.
+ */
+/datum/antagonist/shade_minion
+	name = "\improper Shade"
+	show_in_antagpanel = FALSE
+	show_in_roundend = FALSE
+	ui_name = "AntagInfoShade"
+	/// Name of this shade's master.
+	var/master_name = "nobody?"
+
+/datum/antagonist/shade_minion/ui_static_data(mob/user)
+	var/list/data = list()
+	data["master_name"] = master_name
+	return data
+
+/**
+ * Gets your master's name, they should be the only other member of the team
+ */
+/datum/antagonist/shade_minion/create_team(datum/team/shade_pact/team)
+	if (!istype(team))
+		return
+	for (var/datum/mind/member as anything in team.members)
+		if (member == owner)
+			continue
+		var/mob/master = member.current
+		if (!master)
+			CRASH("Master was not added to shade's team.")
+		master_name = master.real_name
+
+/**
+ * A team containing just the shade and master, so you can know who your master is.
+ */
+/datum/team/shade_pact
+	show_roundend_report = FALSE

--- a/code/modules/antagonists/shade/shade_minion.dm
+++ b/code/modules/antagonists/shade/shade_minion.dm
@@ -25,9 +25,9 @@
 
 	src.master_name = master_name
 	update_static_data(owner.current)
+	INVOKE_ASYNC(src, .proc/display_panel)
+
+/// Shows the info panel, moved out into its own proc for signal handling reasons.
+/datum/antagonist/shade_minion/proc/display_panel()
 	var/datum/action/antag_info/info_button = info_button_ref?.resolve()
-	if (!info_button)
-		return
-	if (!istype(info_button))
-		return
-	info_button.Trigger()
+	info_button?.Trigger()

--- a/code/modules/antagonists/shade/shade_minion.dm
+++ b/code/modules/antagonists/shade/shade_minion.dm
@@ -25,4 +25,5 @@
 
 	src.master_name = master_name
 	update_static_data(owner.current)
-	ui_interact(owner.current)
+	var/datum/action/antag_info/info_button = info_button_ref?.resolve()
+	info_button?.Trigger()

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -392,58 +392,25 @@
 	soulstone_spirit.cancel_camera()
 	update_appearance()
 	if(user)
+		var/master
 		if(IS_CULTIST(user))
 			to_chat(soulstone_spirit, span_bold("Your soul has been captured! \
 				You are now bound to the cult's will. Help them succeed in their goals at all costs."))
+			master = "the cult"
 		else if(role_check(user))
 			to_chat(soulstone_spirit, span_bold("Your soul has been captured! You are now bound to [user.real_name]'s will. \
 				Help [user.p_them()] succeed in [user.p_their()] goals at all costs."))
+			master = user.real_name
 
-		var/datum/shade_popup/popup = new()
-		popup.ui_interact(soulstone_spirit)
+		if(master)
+			var/datum/shade_popup/popup = new(master)
+			popup.ui_interact(soulstone_spirit)
 
 		if(message_user)
 			to_chat(user, "[span_info("<b>Capture successful!</b>:")] [victim.real_name]'s soul has been ripped \
 				from [victim.p_their()] body and stored within [src].")
 
 	victim.dust(drop_items = TRUE)
-
-/obj/item/soulstone/proc/ui_test(mob/user)
-	var/datum/shade_popup/popup = new(src)
-	popup.ui_interact(user)
-
-/obj/item/soulstone/ui_interact(mob/user, datum/tgui/ui)
-	ui = SStgui.try_update_ui(user, src, ui)
-	if(!ui)
-		ui = new(user, src, "InfoShade")
-		ui.open()
-
-/obj/item/soulstone/ui_data(mob/user)
-	var/list/data = list()
-	data["master_name"] = "jonathonesque longname"
-	return data
-
-/obj/item/soulstone/ui_act(action, params)
-	if(..())
-		return
-
-/datum/shade_popup
-	var/master = "bob"
-
-/datum/shade_popup/ui_interact(mob/user, datum/tgui/ui)
-	ui = SStgui.try_update_ui(user, src, ui)
-	if(!ui)
-		ui = new(user, src, "InfoShade")
-		ui.open()
-
-/datum/shade_popup/ui_data(mob/user)
-	var/list/data = list()
-	data["master_name"] = master
-	return data
-
-/datum/shade_popup/ui_act(action, params)
-	if(..())
-		return
 
 /**
  * Gets a ghost from dead chat to replace a missing player when a shade is created.
@@ -571,3 +538,31 @@
 
 /obj/item/soulstone/anybody/mining
 	grab_sleeping = FALSE
+
+/**
+ * Holder for the popup to display to emphasise that you're someone's minion
+ */
+/datum/shade_popup
+	/// Name of the person whose goals you must pursue as your own.
+	var/master
+
+/datum/shade_popup/New(var/master_name)
+	src.master = master_name
+
+/datum/shade_popup/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "InfoShade")
+		ui.open()
+
+/datum/shade_popup/ui_state(mob/user)
+	return GLOB.always_state
+
+/datum/shade_popup/ui_data(mob/user)
+	var/list/data = list()
+	data["master_name"] = master
+	return data
+
+/datum/shade_popup/ui_act(action, params)
+	if(..())
+		return

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -412,10 +412,10 @@
  * Assigns the bearer as the new master of a shade.
  */
 /obj/item/soulstone/proc/assign_master(mob/shade, mob/user)
-	if (!user)
+	if (!shade || !user)
 		return
 	var/datum/team/shade_pact/pact = new(user.mind)
-	shade.mind?.add_antag_datum(/datum/antagonist/shade_minion, pact)
+	shade.mind.add_antag_datum(/datum/antagonist/shade_minion, pact)
 
 /**
  * Gets a ghost from dead chat to replace a missing player when a shade is created.

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -422,14 +422,9 @@
 		shade.mind.remove_antag_datum(/datum/antagonist/cult)
 
 	var/datum/antagonist/shade_minion/shade_datum = shade.mind.has_antag_datum(/datum/antagonist/shade_minion)
-	if (shade_datum)
-		// Don't bother to reassign if this person is already the master of this shade
-		if (shade_datum.master_name == user.real_name)
-			return
-		shade.mind.remove_antag_datum(/datum/antagonist/shade_minion)
-
-	var/datum/team/shade_pact/pact = new(user.mind)
-	shade.mind.add_antag_datum(/datum/antagonist/shade_minion, pact)
+	if (!shade_datum)
+		shade_datum = shade.mind.add_antag_datum(/datum/antagonist/shade_minion)
+	shade_datum.update_master(user.real_name)
 
 /**
  * Gets a ghost from dead chat to replace a missing player when a shade is created.

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -392,18 +392,13 @@
 	soulstone_spirit.cancel_camera()
 	update_appearance()
 	if(user)
-		var/master
 		if(IS_CULTIST(user))
 			to_chat(soulstone_spirit, span_bold("Your soul has been captured! \
 				You are now bound to the cult's will. Help them succeed in their goals at all costs."))
-			master = "the cult"
 		else if(role_check(user))
 			to_chat(soulstone_spirit, span_bold("Your soul has been captured! You are now bound to [user.real_name]'s will. \
 				Help [user.p_them()] succeed in [user.p_their()] goals at all costs."))
-			master = user.real_name
-
-		if(master)
-			var/datum/shade_popup/popup = new(master)
+			var/datum/shade_popup/popup = new(user.real_name)
 			popup.ui_interact(soulstone_spirit)
 
 		if(message_user)
@@ -546,7 +541,7 @@
 	/// Name of the person whose goals you must pursue as your own.
 	var/master
 
-/datum/shade_popup/New(var/master_name)
+/datum/shade_popup/New(master_name)
 	src.master = master_name
 
 /datum/shade_popup/ui_interact(mob/user, datum/tgui/ui)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -398,11 +398,52 @@
 		else if(role_check(user))
 			to_chat(soulstone_spirit, span_bold("Your soul has been captured! You are now bound to [user.real_name]'s will. \
 				Help [user.p_them()] succeed in [user.p_their()] goals at all costs."))
+
+		var/datum/shade_popup/popup = new()
+		popup.ui_interact(soulstone_spirit)
+
 		if(message_user)
 			to_chat(user, "[span_info("<b>Capture successful!</b>:")] [victim.real_name]'s soul has been ripped \
 				from [victim.p_their()] body and stored within [src].")
 
 	victim.dust(drop_items = TRUE)
+
+/obj/item/soulstone/proc/ui_test(mob/user)
+	var/datum/shade_popup/popup = new(src)
+	popup.ui_interact(user)
+
+/obj/item/soulstone/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "InfoShade")
+		ui.open()
+
+/obj/item/soulstone/ui_data(mob/user)
+	var/list/data = list()
+	data["master_name"] = "jonathonesque longname"
+	return data
+
+/obj/item/soulstone/ui_act(action, params)
+	if(..())
+		return
+
+/datum/shade_popup
+	var/master = "bob"
+
+/datum/shade_popup/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "InfoShade")
+		ui.open()
+
+/datum/shade_popup/ui_data(mob/user)
+	var/list/data = list()
+	data["master_name"] = master
+	return data
+
+/datum/shade_popup/ui_act(action, params)
+	if(..())
+		return
 
 /**
  * Gets a ghost from dead chat to replace a missing player when a shade is created.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2316,6 +2316,7 @@
 #include "code\modules\antagonists\separatist\nation_creation.dm"
 #include "code\modules\antagonists\separatist\objectives.dm"
 #include "code\modules\antagonists\separatist\separatist.dm"
+#include "code\modules\antagonists\shade\shade_minion.dm"
 #include "code\modules\antagonists\slaughter\imp_antag.dm"
 #include "code\modules\antagonists\slaughter\slaughter.dm"
 #include "code\modules\antagonists\slaughter\slaughter_antag.dm"

--- a/tgui/packages/tgui/interfaces/AntagInfoShade.js
+++ b/tgui/packages/tgui/interfaces/AntagInfoShade.js
@@ -2,9 +2,8 @@ import { useBackend } from '../backend';
 import { Icon, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
-export const InfoShade = (props, context) => {
+export const AntagInfoShade = (props, context) => {
   const { act, data } = useBackend(context);
-  // Extract `health` and `color` variables from the `data` object.
   const { master_name } = data;
   return (
     <Window width={400} height={400} theme="abductor">

--- a/tgui/packages/tgui/interfaces/InfoShade.js
+++ b/tgui/packages/tgui/interfaces/InfoShade.js
@@ -1,0 +1,36 @@
+import { useBackend } from '../backend';
+import { Icon, Section, Stack } from '../components';
+import { Window } from '../layouts';
+
+export const InfoShade = (props, context) => {
+  const { act, data } = useBackend(context);
+  // Extract `health` and `color` variables from the `data` object.
+  const { master_name } = data;
+  return (
+    <Window width={400} height={400} theme="abductor">
+      <Window.Content backgroundColor="#9d0032">
+        <Icon
+          size={20}
+          name="ghost"
+          color="#660020"
+          position="absolute"
+          top="20%"
+          left="28%"
+        />
+        <Section fill>
+          <Stack vertical fill textAlign="center">
+            <Stack.Item fontSize="20px">
+              Your soul has been captured!
+            </Stack.Item>
+            <Stack.Item fontSize="30px">
+              You are bound to the will of {master_name}!
+            </Stack.Item>
+            <Stack.Item fontSize="20px">
+              Help them succeed in their goals at all costs.
+            </Stack.Item>
+          </Stack>
+        </Section>
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/68918
A week or so ago I soulstoned someone and they just spent the whole time yelling at people to try and get me killed until I got tired of it and chucked them into some lava. After that they actually noticed the text telling them they were supposed to have been my new spectral pal.
Then I looked at the issue list and noticed someone else had this problem.

Text is easy to miss, so I made it display a big popup instead.
It looks like this.
![image](https://user-images.githubusercontent.com/7483112/185677291-76443c87-452c-4153-ba42-a69edc6b7878.png)
<details>
  <summary>Example with a longer name</summary>

![image](https://user-images.githubusercontent.com/7483112/185677634-bd099652-a511-4f1a-9892-65f9c8aded3e.png)
</details>
It also gives you the usual antag button to re-display it, in case you want to check who your master is.

This window will display if:

- You are placed into a soulstone for the first time by someone who is not in the cult.
- You are placed into a soulstone by someone who wasn't the original person who soulstoned you (they become your new master).
- You were previoulsy a cult shade but your soulstone is exorcised by a chaplain.
- You are still a cult shade but are soulstoned by a miner with a soulstone, which makes you loyal both to the cult and the miner. I am not sure how conflicts are resolved here but this isn't a mechanical change and is how the "text printed into chat" method already worked so that's up to general antagonist priority policy.

## Why It's Good For The Game

If you've suddenly gained a restriction similar to an AI law, it should be as obvious as possible, especially if it's potentially to be the friend of someone who just killed you.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Newly created Shades will be told much more clearly that they're supposed to be bound to their master, if they have one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
