### PR TITLE
Examining shoes no longer calls parent twice

### DIFF
--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -57,7 +57,8 @@
 	. = ..()
 
 	if(!ishuman(loc))
-		return ..()
+		return
+
 	if(tied == SHOES_UNTIED)
 		. += "The shoelaces are untied."
 	else if(tied == SHOES_KNOTTED)


### PR DESCRIPTION
## About The Pull Request

`shoes/examine()` no longer calls parent twice

## Why It's Good For The Game

Saves processing

I thought about also allowing people to see if shoes are untied at distance / unworn but eh future qol pr

## Changelog

No change in behavior 
