### PR TITLE
Fixes engraved component runtime on destroy()

### DIFF
--- a/code/datums/components/engraved.dm
+++ b/code/datums/components/engraved.dm
@@ -51,13 +51,15 @@
 	engraved_wall.update_appearance()
 
 /datum/component/engraved/Destroy(force, silent)
-	. = ..()
+	if(!parent)
+		return ..()
 	parent.RemoveElement(/datum/element/art)
 	//must be here to allow overlays to be updated
 	UnregisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS)
-	if(parent && !QDELING(parent))
+	if(!QDELING(parent))
 		var/atom/parent_atom = parent
 		parent_atom.update_appearance()
+	return ..() //call this after since we null out the parent
 
 /datum/component/engraved/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)


### PR DESCRIPTION
..() nulls the parent