### PR TITLE
Wooden siding decals can be placed using wooden tiles

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -307,30 +307,6 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	. = ..()
 	. += GLOB.wood_recipes
 
-/obj/item/stack/sheet/mineral/wood/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
-	if(istype(target, /turf/open))
-		var/turf/open/build_on = target
-		if(!user.Adjacent(build_on))
-			balloon_alert(user, "get closer!")
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		if(!isfloorturf(build_on))
-			user.balloon_alert(user, "can't place siding here!")
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		if(!do_after(user, 4 SECONDS, build_on))
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-			balloon_alert(user, "Placing siding...")
-		if(!use(1))
-			user.balloon_alert(user, "not enough material!")
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		build_on.AddElement(/datum/element/decal, 'icons/turf/decals.dmi', "siding_wood_line", user.dir, null, null, alpha, "#916741", null, FALSE, null)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-	return SECONDARY_ATTACK_CONTINUE_CHAIN
-
-
-/obj/item/stack/sheet/mineral/wood/examine(mob/user)
-	. = ..()
-	. += span_notice("You can place wooden sidings by right clicking on floors.")
-
 /obj/item/stack/sheet/mineral/wood/fifty
 	amount = 50
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -307,6 +307,30 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	. = ..()
 	. += GLOB.wood_recipes
 
+/obj/item/stack/sheet/mineral/wood/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
+	if(istype(target, /turf/open))
+		var/turf/open/build_on = target
+		if(!user.Adjacent(build_on))
+			balloon_alert(user, "get closer!")
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		if(!isfloorturf(build_on))
+			user.balloon_alert(user, "can't place siding here!")
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		if(!do_after(user, 4 SECONDS, build_on))
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+			balloon_alert(user, "Placing siding...")
+		if(!use(1))
+			user.balloon_alert(user, "not enough material!")
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		build_on.AddElement(/datum/element/decal, 'icons/turf/decals.dmi', "siding_wood_line", user.dir, null, null, alpha, "#916741", null, FALSE, null)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
+
+
+/obj/item/stack/sheet/mineral/wood/examine(mob/user)
+	. = ..()
+	. += span_notice("You can place wooden sidings by right clicking on floors.")
+
 /obj/item/stack/sheet/mineral/wood/fifty
 	amount = 50
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -151,8 +151,8 @@
 			user.balloon_alert(user, "can't place siding here!")
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 		if(!do_after(user, 4 SECONDS, build_on))
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 			balloon_alert(user, "Placing siding...")
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 		if(!use(1))
 			user.balloon_alert(user, "not enough material!")
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -141,6 +141,29 @@
 		/obj/item/stack/tile/wood/parquet,
 	)
 
+/obj/item/stack/tile/wood/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
+	if(istype(target, /turf/open))
+		var/turf/open/build_on = target
+		if(!user.Adjacent(build_on))
+			balloon_alert(user, "get closer!")
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		if(!isfloorturf(build_on))
+			user.balloon_alert(user, "can't place siding here!")
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		if(!do_after(user, 4 SECONDS, build_on))
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+			balloon_alert(user, "Placing siding...")
+		if(!use(1))
+			user.balloon_alert(user, "not enough material!")
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		build_on.AddElement(/datum/element/decal, 'icons/turf/decals.dmi', "siding_wood_line", user.dir, null, null, alpha, "#916741", null, FALSE, null)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
+
+/obj/item/stack/tile/wood/examine(mob/user)
+	. = ..()
+	. += span_notice("You can place wooden sidings by right clicking on floors.")
+
 /obj/item/stack/tile/wood/parquet
 	name = "parquet wood floor tile"
 	singular_name = "parquet wood floor tile"


### PR DESCRIPTION
## About The Pull Request

Right click on a floor with tiles to add wooden siding to it. 1 tile per siding to prevent spam and they can be destroyed by removing the floor, same as any other decal.

## Why It's Good For The Game

Wooden siding decals have been around for a while and are a great way to cover up the rough transition from wood floors to other turfs. These aren't currently able to be placed in game so repairs to destroyed carpentry look less polished than what is present round start.

## Changelog

:cl:
add: You can now place wooden sidings on the floor using wooden tiles
/:cl:
