### PR TITLE
fixes listening post intercom not being entirely organic

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -243,7 +243,9 @@
 /area/ruin/space/has_grav/listeningstation)
 "lk" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/item/radio/intercom/directional/east,
+/obj/item/radio/intercom/directional/east{
+	freerange = 1
+	},
 /obj/machinery/computer/camera_advanced{
 	dir = 8
 	},


### PR DESCRIPTION
fixes #69328
:cl: ShizCalev
fix: The syndicate outpost intercom is now an actual functional syndicate intercom!
/:cl: