### PR TITLE
Refactors z level trait checking to be less shit

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -55,6 +55,9 @@ SUBSYSTEM_DEF(mapping)
 	///associative list of the form: list("[z level num]" = max generator gravity in that z level OR the gravity level trait)
 	var/list/gravity_by_z_level = list()
 
+	/// list of traits and their associated z leves
+	var/list/z_trait_levels = list()
+
 /datum/controller/subsystem/mapping/New()
 	..()
 #ifdef FORCE_MAP

--- a/code/modules/mapping/space_management/space_level.dm
+++ b/code/modules/mapping/space_management/space_level.dm
@@ -14,10 +14,8 @@
 
 	if (islist(new_traits))
 		for (var/trait in new_traits)
-			SSmapping.z_trait_levels |= trait
 			SSmapping.z_trait_levels[trait] += list(new_z)
 	else // in case a single trait is passed in
-		SSmapping.z_trait_levels |= new_traits
 		SSmapping.z_trait_levels[new_traits] += list(new_z)
 
 	set_linkage(new_traits[ZTRAIT_LINKAGE])

--- a/code/modules/mapping/space_management/space_level.dm
+++ b/code/modules/mapping/space_management/space_level.dm
@@ -11,4 +11,13 @@
 	z_value = new_z
 	name = new_name
 	traits = new_traits
+
+	if (islist(new_traits))
+		for (var/trait in new_traits)
+			SSmapping.z_trait_levels |= trait
+			SSmapping.z_trait_levels[trait] += list(new_z)
+	else // in case a single trait is passed in
+		SSmapping.z_trait_levels |= new_traits
+		SSmapping.z_trait_levels[new_traits] += list(new_z)
+
 	set_linkage(new_traits[ZTRAIT_LINKAGE])

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -6,7 +6,7 @@
 		if (z > z_list.len)
 			stack_trace("Unmanaged z-level [z]! maxz = [world.maxz], z_list.len = [z_list.len]")
 			return list()
-		var/datum/space_level/S = get_level(z)
+		var/datum/space_level/S = z_list[z]
 		return S.traits[trait]
 	else
 		var/list/default = DEFAULT_MAP_TRAITS
@@ -17,34 +17,30 @@
 
 /// Check if levels[z] has any of the specified traits
 /datum/controller/subsystem/mapping/proc/level_has_any_trait(z, list/traits)
-	for (var/I in traits)
-		if (level_trait(z, I))
+	for (var/trait in traits)
+		if (z in z_trait_levels[trait])
 			return TRUE
 	return FALSE
 
 /// Check if levels[z] has all of the specified traits
 /datum/controller/subsystem/mapping/proc/level_has_all_traits(z, list/traits)
-	for (var/I in traits)
-		if (!level_trait(z, I))
+	for (var/trait in traits)
+		if (!z_trait_levels[trait])
+			return FALSE
+		if (!(z in z_trait_levels[trait]))
 			return FALSE
 	return TRUE
 
 /// Get a list of all z which have the specified trait
 /datum/controller/subsystem/mapping/proc/levels_by_trait(trait)
-	var/list/final_return = list()
-	for(var/datum/space_level/level as anything in z_list)
-		if (level.traits[trait])
-			final_return += level.z_value
-	return final_return
+	return z_trait_levels[trait] ? z_trait_levels[trait] : list()
 
 /// Get a list of all z which have any of the specified traits
 /datum/controller/subsystem/mapping/proc/levels_by_any_trait(list/traits)
 	var/list/final_return = list()
-	for(var/datum/space_level/level as anything in z_list)
-		for (var/trait in traits)
-			if (level.traits[trait])
-				final_return += level.z_value
-				break
+	for (var/trait in traits)
+		if (z_trait_levels[trait])
+			final_return |= z_trait_levels[trait]
 	return final_return
 
 /// Get a list of all z which have all of the specified traits

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -17,23 +17,21 @@
 
 /// Check if levels[z] has any of the specified traits
 /datum/controller/subsystem/mapping/proc/level_has_any_trait(z, list/traits)
-	for (var/trait in traits)
-		if (z in z_trait_levels[trait])
+	var/datum/space_level/level_to_check = z_list[z]
+	if (length(level_to_check.traits & traits))
 			return TRUE
 	return FALSE
 
 /// Check if levels[z] has all of the specified traits
 /datum/controller/subsystem/mapping/proc/level_has_all_traits(z, list/traits)
-	for (var/trait in traits)
-		if (!z_trait_levels[trait])
-			return FALSE
-		if (!(z in z_trait_levels[trait]))
-			return FALSE
-	return TRUE
+	var/datum/space_level/level_to_check = z_list[z]
+	if (length(level_to_check.traits & traits) == length(traits))
+		return TRUE
+	return FALSE
 
 /// Get a list of all z which have the specified trait
 /datum/controller/subsystem/mapping/proc/levels_by_trait(trait)
-	return z_trait_levels[trait] ? z_trait_levels[trait] : list()
+	return z_trait_levels[trait] || list()
 
 /// Get a list of all z which have any of the specified traits
 /datum/controller/subsystem/mapping/proc/levels_by_any_trait(list/traits)

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -19,7 +19,7 @@
 /datum/controller/subsystem/mapping/proc/level_has_any_trait(z, list/traits)
 	var/datum/space_level/level_to_check = z_list[z]
 	if (length(level_to_check.traits & traits))
-			return TRUE
+		return TRUE
 	return FALSE
 
 /// Check if levels[z] has all of the specified traits


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts level traits and their associated zs into a list and then uses it to make the z level trait procs less shit.
They no longer need to loop through every z level to do what they aim to do.

Also removes `get_level` from `level_trait` because it just does the same checks as already done above in the proc.
According to Kyler this makes `level_trait` 30% faster idk what the actual stats are

Thanks to @LemonInTheDark for the help