### PR TITLE
Fixes a spurious runtime off the drift component

### DIFF
--- a/code/datums/components/drift.dm
+++ b/code/datums/components/drift.dm
@@ -32,8 +32,8 @@
 	RegisterSignal(drifting_loop, COMSIG_MOVELOOP_STOP, .proc/drifting_stop)
 	RegisterSignal(drifting_loop, COMSIG_MOVELOOP_PREPROCESS_CHECK, .proc/before_move)
 	RegisterSignal(drifting_loop, COMSIG_MOVELOOP_POSTPROCESS, .proc/after_move)
-	RegisterSignal(movable_parent, COMSIG_MOVABLE_NEWTONIAN_MOVE, .proc/newtonian_impulse)
 	RegisterSignal(drifting_loop, COMSIG_PARENT_QDELETING, .proc/loop_death)
+	RegisterSignal(movable_parent, COMSIG_MOVABLE_NEWTONIAN_MOVE, .proc/newtonian_impulse)
 	if(drifting_loop.running)
 		drifting_start(drifting_loop) // There's a good chance it'll autostart, gotta catch that
 


### PR DESCRIPTION
If a loop is made non active, then we end up allowing for double
applications of the component, which throws errors because the old
component (and it's loop) still exist by that point.

This resolves that