### PR TITLE
Cameras in the Dormitories can no longer be upgraded with X-Ray capabilities, making dorm rooms significantly more useful for antagonists trying to be sneaky.

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -309,6 +309,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 			assembly_ref = null
 		if(attacking_item.tool_behaviour == TOOL_ANALYZER)
 			if(!isXRay(TRUE)) //don't reveal it was already upgraded if was done via MALF AI Upgrade Camera Network ability
+				var/area/dorms_check = get_area(src)
+				if(is_type_in_list(dorms_check, GLOB.no_xray_in_dorms))
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 20, TRUE)
+					balloon_alert_to_viewers("no xray in dorms!")
+					return
 				if(!user.temporarilyRemoveItemFromInventory(attacking_item))
 					return
 				upgradeXRay(FALSE, TRUE)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -78,7 +78,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 		var/area/dorms_check = get_area(src)
 		if(assembly.xray_module || assembly.malf_xray_firmware_present)
 			if(is_type_in_list(dorms_check, GLOB.no_xray_in_dorms))
-				if(!assembly_malf_xray_firmware_present) // dont alert them there's a malf AI doing xrays
+				if(!assembly.malf_xray_firmware_present) // dont alert them there's a malf AI doing xrays
 					playsound(src, 'sound/machines/buzz-sigh.ogg', 20, TRUE)
 					balloon_alert_to_viewers("no xray in dorms!")
 			else

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -1,3 +1,5 @@
+GLOBAL_LIST_INIT(no_xray_in_dorms, list(/area/station/commons/dorms, /area/station/maintenance/department/crew_quarters/dorms))
+
 #define CAMERA_UPGRADE_XRAY (1<<0)
 #define CAMERA_UPGRADE_EMP_PROOF (1<<1)
 #define CAMERA_UPGRADE_MOTION (1<<2)
@@ -73,10 +75,17 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 	if(old_assembly) //check to see if the camera assembly was upgraded at all.
 		assembly = old_assembly
 		assembly_ref = WEAKREF(assembly) //important to do this now since upgrades call back to the assembly_ref
-		if(assembly.xray_module)
-			upgradeXRay()
-		else if(assembly.malf_xray_firmware_present) //if it was secretly upgraded via the MALF AI Upgrade Camera Network ability
-			upgradeXRay(TRUE)
+		var/area/dorms_check = get_area(src)
+		if(assembly.xray_module || assembly.malf_xray_firmware_present)
+			if(is_type_in_list(dorms_check, GLOB.no_xray_in_dorms))
+				if(!assembly_malf_xray_firmware_present) // dont alert them there's a malf AI doing xrays
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 20, TRUE)
+					balloon_alert_to_viewers("no xray in dorms!")
+			else
+				if(assembly.malf_xray_firmware_present) //if it was secretly upgraded via the MALF AI Upgrade Camera Network ability
+					upgradeXRay(TRUE)
+				else
+					upgradeXRay()
 
 		if(assembly.emp_module)
 			upgradeEmpProof()


### PR DESCRIPTION
## About The Pull Request

Cameras in the Dormitories can no longer be upgraded with X-Ray capabilities, making dorm rooms significantly more useful for antagonists trying to be sneaky.

Malf AI xray upgrades will fail silently, to avoid tipping off any nearby viewers that there's a malf AI, but normal xray upgraded cameras will throw an error and report that they're not x-ray compatible due to being in the dorms.

## Why It's Good For The Game

The dorms are supposed to be a useful stealthy area for our antagonists to use to switch gear, buy items, do upgrades, etc. without getting caught. Being able to just nullify the dorms entirely as a gameplay element by simply stuffing a gas analyzer into a camera, something available basically anywhere for free, is ridiculous and makes the dorms just a noob trap.
If you want to see into a dorm room, build a camera inside the dorm room or open the door. This adds danger and risk to checking the inside of a room.

## Changelog

:cl:
balance: Cameras in the Dormitories can no longer be upgraded with X-Ray capabilities, making dorm rooms significantly more useful for antagonists trying to be sneaky.
/:cl:
