### PR TITLE
Adds contextual screentips to posters.

### DIFF
--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -14,7 +14,14 @@
 
 /obj/item/poster/Initialize(mapload, obj/structure/sign/poster/new_poster_structure)
 	. = ..()
-	register_context()
+
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/shard = list(
+			SCREENTIP_CONTEXT_LMB = "Booby trap poster",
+		),
+	)
+	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+
 	poster_structure = new_poster_structure
 	if(!new_poster_structure && poster_type)
 		poster_structure = new poster_type(src)
@@ -32,14 +39,6 @@
 		name = "[name] - [poster_structure.original_name]"
 		//If the poster structure is being deleted something has gone wrong, kill yourself off too
 		RegisterSignal(poster_structure, COMSIG_PARENT_QDELETING, .proc/react_to_deletion)
-
-/// Adds contextual screentips
-/obj/item/poster/add_context(atom/source, list/context, obj/item/held_item, mob/user)
-	. = ..()
-	if (!istype(held_item, /obj/item/shard))
-		return .
-	context[SCREENTIP_CONTEXT_LMB] = "Booby trap poster"
-	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/poster/attackby(obj/item/I, mob/user, params)
 	if(!istype(I, /obj/item/shard))

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -109,18 +109,19 @@
 /// Adds contextual screentips
 /obj/structure/sign/poster/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
-	if (held_item?.tool_behaviour == TOOL_WIRECUTTER)
+	if (!held_item)
+		if (ruined)
+			return .
+		context[SCREENTIP_CONTEXT_LMB] = "Rip up poster"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if (held_item.tool_behaviour == TOOL_WIRECUTTER)
 		if (ruined)
 			context[SCREENTIP_CONTEXT_LMB] = "Clean up remnants"
 			return CONTEXTUAL_SCREENTIP_SET
 		context[SCREENTIP_CONTEXT_LMB] = "Take down poster"
 		return CONTEXTUAL_SCREENTIP_SET
-
-	if (ruined)
-		return .
-
-	context[SCREENTIP_CONTEXT_LMB] = "Rip up poster"
-	return CONTEXTUAL_SCREENTIP_SET
+	return .
 
 /obj/structure/sign/poster/proc/randomise(base_type)
 	var/list/poster_types = subtypesof(base_type)

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -14,6 +14,7 @@
 
 /obj/item/poster/Initialize(mapload, obj/structure/sign/poster/new_poster_structure)
 	. = ..()
+	register_context()
 	poster_structure = new_poster_structure
 	if(!new_poster_structure && poster_type)
 		poster_structure = new poster_type(src)
@@ -31,6 +32,14 @@
 		name = "[name] - [poster_structure.original_name]"
 		//If the poster structure is being deleted something has gone wrong, kill yourself off too
 		RegisterSignal(poster_structure, COMSIG_PARENT_QDELETING, .proc/react_to_deletion)
+
+/// Adds contextual screentips
+/obj/item/poster/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if (!istype(held_item, /obj/item/shard))
+		return .
+	context[SCREENTIP_CONTEXT_LMB] = "Booby trap poster"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/poster/attackby(obj/item/I, mob/user, params)
 	if(!istype(I, /obj/item/shard))
@@ -87,6 +96,7 @@
 
 /obj/structure/sign/poster/Initialize(mapload)
 	. = ..()
+	register_context()
 	if(random_basetype)
 		randomise(random_basetype)
 	if(!ruined)
@@ -95,6 +105,22 @@
 		desc = "A large piece of space-resistant printed paper. [desc]"
 
 	AddElement(/datum/element/beauty, 300)
+
+/// Adds contextual screentips
+/obj/structure/sign/poster/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if (held_item?.tool_behaviour == TOOL_WIRECUTTER)
+		if (ruined)
+			context[SCREENTIP_CONTEXT_LMB] = "Clean up remnants"
+			return CONTEXTUAL_SCREENTIP_SET
+		context[SCREENTIP_CONTEXT_LMB] = "Take down poster"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if (ruined)
+		return .
+
+	context[SCREENTIP_CONTEXT_LMB] = "Rip up poster"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/structure/sign/poster/proc/randomise(base_type)
 	var/list/poster_types = subtypesof(base_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I figured out how these work recently and it seemed like this would be a useful place to apply them, as the difference in actions isn't necessarily obvious.

Tooltips are displayed:

- If you are holding a shard and hovering over a poster item (to place a trap).
- If you are hovering over a poster which is not ripped with nothing in hand (to rip it).
- If you are hovering over a poster with something which is like wirecutters (to remove it carefully or clean up the ripped parts).

## Why It's Good For The Game

More clarity is more good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Adds contextual screentips to explain whether you are going to destroy, remove, or place a trap into a poster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
