### PR TITLE
[NO GBP] [KS13] Fixes duped windows in KS13 north solar room

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -4736,11 +4736,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/service/cafe)
-"IH" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating,
-/area/ruin/space/ks13/engineering/sb_bow_solars_control)
 "II" = (
 /obj/item/shard,
 /obj/structure/grille/broken,
@@ -5660,7 +5655,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/ks13/security/court)
 "NA" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
@@ -15775,7 +15769,7 @@ aa
 xS
 pR
 pR
-IH
+xS
 VB
 gx
 DU
@@ -15888,7 +15882,7 @@ aa
 xS
 VB
 IK
-IH
+xS
 pR
 HC
 DU
@@ -16001,7 +15995,7 @@ Uk
 ud
 zC
 IK
-IH
+xS
 IK
 VB
 DU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes: #68996
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
An error I didn't catch somehow.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
fix: On KS13, the northern most solar room no longer has duped windows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
