### PR TITLE
Asking critters to identify themselves with vog works

### DIFF
--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -262,7 +262,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 ///just states the target's name, but also includes the renaming funny.
 /datum/voice_of_god_command/who_are_you/proc/state_name(mob/living/target)
 	if(QDELETED(target))
-	   return
+		return
 	if(isanimal_or_basicmob(target) && target.name == initial(target.name) && target:gold_core_spawnable == FRIENDLY_SPAWN)
 		var/canonical_deep_lore_name
 		switch(target.gender)

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -261,7 +261,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 
 ///just states the target's name, but also includes the renaming funny.
 /datum/voice_of_god_command/who_are_you/proc/state_name(mob/living/target)
-	if(isanimal_or_basicmob(target) && target.name == initial(target.name) && target:gold_core_spawnable = FRIENDLY_SPAWN)
+	if(isanimal_or_basicmob(target) && target.name == initial(target.name) && target:gold_core_spawnable == FRIENDLY_SPAWN)
 		var/canonical_deep_lore_name
 		switch(target.gender)
 			if(MALE)

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -261,6 +261,8 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 
 ///just states the target's name, but also includes the renaming funny.
 /datum/voice_of_god_command/who_are_you/proc/state_name(mob/living/target)
+	if(QDELETED(target))
+	   return
 	if(isanimal_or_basicmob(target) && target.name == initial(target.name) && target:gold_core_spawnable == FRIENDLY_SPAWN)
 		var/canonical_deep_lore_name
 		switch(target.gender)

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -267,7 +267,7 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 	if(isbasicmob(target))
 		var/mob/living/basic/basic_bandy = target
 		gold_core_spawnable = basic_bandy.gold_core_spawnable
-	if(isanimal(target))
+	else if(isanimal(target))
 		var/mob/living/simple_animal/simple_sandy = target
 		gold_core_spawnable = simple_sandy.gold_core_spawnable
 	if(target.name == initial(target.name) && gold_core_spawnable == FRIENDLY_SPAWN)

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -21,10 +21,6 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 		separator = "|" // Shouldn't be at the start or end of the regex, or it won't work.
 	GLOB.all_voice_of_god_triggers = regex(all_triggers, "i")
 
-//////////////////////////////////////
-///////////VOICE OF GOD///////////////
-//////////////////////////////////////
-
 /*
  * The main proc for the voice of god power. it makes the user shout a message in an ominous way,
  * The first matching command (from a list of static datums) the listeners must obey,
@@ -253,14 +249,21 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 		target.throw_at(get_step_towards(user, target), 3 * power_multiplier, 1 * power_multiplier)
 
 /// This command forces the listeners to say their true name (so masks and hoods won't help).
+/// Basic and simple mobs who are forced to state their name and don't have one already will... reveal their actual one!
 /datum/voice_of_god_command/who_are_you
 	trigger = "who\\s*are\\s*you|say\\s*your\\s*name|state\\s*your\\s*name|identify"
 
 /datum/voice_of_god_command/who_are_you/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	var/iteration = 1
 	for(var/mob/living/target as anything in listeners)
-		addtimer(CALLBACK(target, /atom/movable/proc/say, target.real_name), 0.5 SECONDS * iteration)
+		addtimer(CALLBACK(src, .proc/state_name, target), 0.5 SECONDS * iteration)
 		iteration++
+
+///just states the target's name, but also includes the renaming funny.
+/datum/voice_of_god_command/who_are_you/proc/state_name(mob/living/target)
+	if(isanimal_or_basicmob(target) && target.name == initial(target.name))
+		target.fully_replace_character_name(target.real_name, pick(GLOB.first_names))
+	target.say(target.real_name)
 
 /// This command forces the listeners to say the user's name
 /datum/voice_of_god_command/say_my_name

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -263,7 +263,14 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 /datum/voice_of_god_command/who_are_you/proc/state_name(mob/living/target)
 	if(QDELETED(target))
 		return
-	if(isanimal_or_basicmob(target) && target.name == initial(target.name) && target:gold_core_spawnable == FRIENDLY_SPAWN)
+	var/gold_core_spawnable = NO_SPAWN
+	if(isbasicmob(target))
+		var/mob/living/basic/basic_bandy = target
+		gold_core_spawnable = basic_bandy.gold_core_spawnable
+	if(isanimal(target))
+		var/mob/living/simple_animal/simple_sandy = target
+		gold_core_spawnable = simple_sandy.gold_core_spawnable
+	if(target.name == initial(target.name) && gold_core_spawnable == FRIENDLY_SPAWN)
 		var/canonical_deep_lore_name
 		switch(target.gender)
 			if(MALE)

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -261,8 +261,16 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 
 ///just states the target's name, but also includes the renaming funny.
 /datum/voice_of_god_command/who_are_you/proc/state_name(mob/living/target)
-	if(isanimal_or_basicmob(target) && target.name == initial(target.name))
-		target.fully_replace_character_name(target.real_name, pick(GLOB.first_names))
+	if(isanimal_or_basicmob(target) && target.name == initial(target.name) && target:gold_core_spawnable = FRIENDLY_SPAWN)
+		var/canonical_deep_lore_name
+		switch(target.gender)
+			if(MALE)
+				canonical_deep_lore_name = pick(GLOB.first_names_male)
+			if(FEMALE)
+				canonical_deep_lore_name = pick(GLOB.first_names_female)
+			else
+				canonical_deep_lore_name = pick(GLOB.first_names)
+		target.fully_replace_character_name(target.real_name, canonical_deep_lore_name)
 	target.say(target.real_name)
 
 /// This command forces the listeners to say the user's name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Asking basic or simple mobs to identify themselves will now actually get them to say their REAL name

![image](https://user-images.githubusercontent.com/40974010/185847204-22cb8237-4f09-456b-ade0-3e9cf3fd1fe1.png)

## Why It's Good For The Game

~IDENTIFY
the kid named cockroach:~

I like this as a small easter egg functionality, being able to defacto name critters stuff.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now ask critters their name with voice of god. Their ACTUAL name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
