### PR TITLE
adds location atom to deletion message

### DIFF
--- a/code/modules/admin/view_variables/admin_delete.dm
+++ b/code/modules/admin/view_variables/admin_delete.dm
@@ -5,8 +5,10 @@
 	if(istype(A))
 		var/turf/T = get_turf(A)
 		if(T)
-			coords = "at [COORD(T)]"
-			jmp_coords = "at [ADMIN_COORDJMP(T)]"
+			var/atom/a_loc = A.loc
+			var/is_turf = isturf(a_loc)
+			coords = "[is_turf ? "at" : "from [a_loc] at"] [AREACOORD(T)]"
+			jmp_coords = "[is_turf ? "at" : "from [a_loc] at"] [ADMIN_VERBOSEJMP(T)]"
 		else
 			jmp_coords = coords = "in nullspace"
 


### PR DESCRIPTION
:cl:
admin: Admin deletion messages are now a little more verbose.
/:cl:

Helps with debugging to know that `a flash was deleted from engi borg #424 at robotics` than just `a flash was deleted at X,Y,Z`.