### PR TITLE
Makes APCs set lights to low power mode when < 30% (when equipment power turns off)

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -456,7 +456,7 @@
 			alarm_manager.send_alarm(ALARM_POWER)
 			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))
 				low_power_nightshift_lights = TRUE
-				addtimer(CALLBACK(src, .proc/set_nightshift, TRUE), 0)
+				INVOKE_ASYNC(src, .proc/set_nightshift, TRUE)
 		else if(cell.percent() < 15 && long_term_power < 0) // <15%, turn off lighting & equipment
 			equipment = autoset(equipment, AUTOSET_OFF)
 			lighting = autoset(lighting, AUTOSET_OFF)
@@ -464,7 +464,7 @@
 			alarm_manager.send_alarm(ALARM_POWER)
 			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))
 				low_power_nightshift_lights = TRUE
-				addtimer(CALLBACK(src, .proc/set_nightshift, TRUE), 0)
+				INVOKE_ASYNC(src, .proc/set_nightshift, TRUE)
 		else if(cell.percent() < 30 && long_term_power < 0) // <30%, turn off equipment
 			equipment = autoset(equipment, AUTOSET_OFF)
 			lighting = autoset(lighting, AUTOSET_ON)
@@ -472,7 +472,7 @@
 			alarm_manager.send_alarm(ALARM_POWER)
 			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))
 				low_power_nightshift_lights = TRUE
-				addtimer(CALLBACK(src, .proc/set_nightshift, TRUE), 0)
+				INVOKE_ASYNC(src, .proc/set_nightshift, TRUE)
 		else // otherwise all can be on
 			equipment = autoset(equipment, AUTOSET_ON)
 			lighting = autoset(lighting, AUTOSET_ON)
@@ -480,7 +480,7 @@
 			if(nightshift_lights && low_power_nightshift_lights)
 				low_power_nightshift_lights = FALSE
 				if(!SSnightshift.nightshift_active)
-					addtimer(CALLBACK(src, .proc/set_nightshift, FALSE), 0)
+					INVOKE_ASYNC(src, .proc/set_nightshift, FALSE)
 			if(cell.percent() > 75)
 				alarm_manager.clear_alarm(ALARM_POWER)
 

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -269,7 +269,7 @@
 		"malfStatus" = get_malf_status(user),
 		"emergencyLights" = !emergency_lights,
 		"nightshiftLights" = nightshift_lights,
-		"disable_nightshift_toggle" = (low_power_nightshift_lights || !cell || (cell_percentage < 30 && long_term_power < 0)),
+		"disable_nightshift_toggle" = low_power_nightshift_lights,
 
 		"powerChannels" = list(
 			list(

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -93,6 +93,8 @@
 	var/emergency_lights = FALSE
 	///Should the nighshift lights be on?
 	var/nightshift_lights = FALSE
+	///Tracks if lights channel was set to nightshift / reduced power usage mode automatically due to low power.
+	var/low_power_nightshift_lights = FALSE
 	///Time when the nightshift where turned on last, to prevent spamming
 	var/last_nightshift_switch = 0
 	///Stores the flags for the icon state
@@ -252,12 +254,13 @@
 		ui.open()
 
 /obj/machinery/power/apc/ui_data(mob/user)
+	var/cell_percentage = cell ? cell.percent() : null
 	var/list/data = list(
 		"locked" = locked,
 		"failTime" = failure_timer,
 		"isOperating" = operating,
 		"externalPower" = main_status,
-		"powerCellStatus" = cell ? cell.percent() : null,
+		"powerCellStatus" = cell_percentage,
 		"chargeMode" = chargemode,
 		"chargingStatus" = charging,
 		"totalLoad" = display_power(lastused_total),
@@ -266,6 +269,7 @@
 		"malfStatus" = get_malf_status(user),
 		"emergencyLights" = !emergency_lights,
 		"nightshiftLights" = nightshift_lights,
+		"disable_nightshift_toggle" = (low_power_nightshift_lights || !cell || (cell_percentage < 30 && long_term_power < 0)),
 
 		"powerChannels" = list(
 			list(
@@ -451,20 +455,33 @@
 			lighting = autoset(lighting, AUTOSET_FORCE_OFF)
 			environ = autoset(environ, AUTOSET_FORCE_OFF)
 			alarm_manager.send_alarm(ALARM_POWER)
+			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))
+				low_power_nightshift_lights = TRUE
+				addtimer(CALLBACK(src, .proc/set_nightshift, TRUE), 0)
 		else if(cell.percent() < 15 && long_term_power < 0) // <15%, turn off lighting & equipment
 			equipment = autoset(equipment, AUTOSET_OFF)
 			lighting = autoset(lighting, AUTOSET_OFF)
 			environ = autoset(environ, AUTOSET_ON)
 			alarm_manager.send_alarm(ALARM_POWER)
+			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))
+				low_power_nightshift_lights = TRUE
+				addtimer(CALLBACK(src, .proc/set_nightshift, TRUE), 0)
 		else if(cell.percent() < 30 && long_term_power < 0) // <30%, turn off equipment
 			equipment = autoset(equipment, AUTOSET_OFF)
 			lighting = autoset(lighting, AUTOSET_ON)
 			environ = autoset(environ, AUTOSET_ON)
 			alarm_manager.send_alarm(ALARM_POWER)
+			if(!nightshift_lights || (nightshift_lights && !low_power_nightshift_lights))
+				low_power_nightshift_lights = TRUE
+				addtimer(CALLBACK(src, .proc/set_nightshift, TRUE), 0)
 		else // otherwise all can be on
 			equipment = autoset(equipment, AUTOSET_ON)
 			lighting = autoset(lighting, AUTOSET_ON)
 			environ = autoset(environ, AUTOSET_ON)
+			if(nightshift_lights && low_power_nightshift_lights)
+				low_power_nightshift_lights = FALSE
+				if(!SSnightshift.nightshift_active)
+					addtimer(CALLBACK(src, .proc/set_nightshift, FALSE), 0)
 			if(cell.percent() > 75)
 				alarm_manager.clear_alarm(ALARM_POWER)
 

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -254,13 +254,12 @@
 		ui.open()
 
 /obj/machinery/power/apc/ui_data(mob/user)
-	var/cell_percentage = cell ? cell.percent() : null
 	var/list/data = list(
 		"locked" = locked,
 		"failTime" = failure_timer,
 		"isOperating" = operating,
 		"externalPower" = main_status,
-		"powerCellStatus" = cell_percentage,
+		"powerCellStatus" = cell ? cell.percent() : null,
 		"chargeMode" = chargemode,
 		"chargingStatus" = charging,
 		"totalLoad" = display_power(lastused_total),

--- a/code/modules/power/apc/apc_power_proc.dm
+++ b/code/modules/power/apc/apc_power_proc.dm
@@ -15,6 +15,9 @@
 	terminal.master = src
 
 /obj/machinery/power/apc/proc/toggle_nightshift_lights(mob/user)
+	if(low_power_nightshift_lights)
+		balloon_alert(user, "power is too low!")
+		return
 	if(last_nightshift_switch > world.time - 10 SECONDS) //~10 seconds between each toggle to prevent spamming
 		balloon_alert(user, "night breaker is cycling!")
 		return
@@ -126,6 +129,10 @@
 
 /obj/machinery/power/apc/proc/set_nightshift(on)
 	set waitfor = FALSE
+	if(low_power_nightshift_lights && !on)
+		return
+	if(nightshift_lights == on)
+		return //no change
 	nightshift_lights = on
 	for(var/obj/machinery/light/night_light in area)
 		if(night_light.nightshift_allowed)

--- a/tgui/packages/tgui/interfaces/Apc.js
+++ b/tgui/packages/tgui/interfaces/Apc.js
@@ -222,6 +222,7 @@ const ApcContent = (props, context) => {
                 tooltip="Dim lights to reduce power consumption."
                 icon="lightbulb-o"
                 content={data.nightshiftLights ? 'Enabled' : 'Disabled'}
+                disabled={data.disable_nightshift_toggle}
                 onClick={() => act('toggle_nightshift')}
               />
             }


### PR DESCRIPTION
:cl: ShizCalev
qol: APCs will now automatically set the lights in an area to low power mode when they are below 30% (same % as when equipment power turns off) to conserve additional power.
/:cl:

Results in a ~60% power reduction during 30% to 15% charge (when the lights channel automatically turns off.)