### PR TITLE
Fixes weakref resolving in View Variables not working

### DIFF
--- a/code/modules/admin/view_variables/debug_variables.dm
+++ b/code/modules/admin/view_variables/debug_variables.dm
@@ -63,7 +63,7 @@
 			item = "[name_part] = <a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>[DV.type] [REF(value)]</a>"
 		if(istype(value,/datum/weakref))
 			var/datum/weakref/weakref = value
-			item += " <a href='?_src_=vars;[HrefToken()];Vars=[REF(weakref.reference)]'>(Resolve)</a>"
+			item += " <a href='?_src_=vars;[HrefToken()];Vars=[weakref.reference]'>(Resolve)</a>"
 
 	else if (islist(value))
 		var/list/L = value


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The string to the underlying instance that a weakref was pointing to was ref'ed itself, like a ref double whammy. stuff

## Why It's Good For The Game

bgug fix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Resolving weakrefs in VV should open a menu now instead of doing nothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
