### PR TITLE
Minor QuerySelect code improvements, QuerySelect documented.

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -336,7 +336,8 @@ SUBSYSTEM_DEF(dbcore)
 	for (var/datum/db_query/query as anything in queries)
 		if (!istype(query))
 			queries -= query
-			stack_trace("Invalid query passed to Query_Select: `[query]` [REF(query)]")
+			stack_trace("Invalid query passed to QuerySelect: `[query]` [REF(query)]")
+			continue
 		
 		if (warn)
 			INVOKE_ASYNC(query, /datum/db_query.proc/warn_execute)

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -318,21 +318,32 @@ SUBSYSTEM_DEF(dbcore)
 		return FALSE
 	return new /datum/db_query(connection, sql_query, arguments)
 
-/datum/controller/subsystem/dbcore/proc/QuerySelect(list/querys, warn = FALSE, qdel = FALSE)
-	if (!islist(querys))
-		if (!istype(querys, /datum/db_query))
-			CRASH("Invalid query passed to QuerySelect: [querys]")
-		querys = list(querys)
+/** QuerySelect
+	Run a list of query datums in parallel, blocking until they all complete.
+	* queries - List of queries or single query datum to run.
+	* warn - Controls rather warn_execute() or Execute() is called.
+	* qdel - If you don't care about the result or checking for errors, you can have the queries be deleted afterwards.
+		This can be combined with invoke_async as a way of running queries async without having to care about waiting for them to finish so they can be deleted.
+*/
+/datum/controller/subsystem/dbcore/proc/QuerySelect(list/queries, warn = FALSE, qdel = FALSE)
+	if (!islist(queries))
+		if (!istype(queries, /datum/db_query))
+			CRASH("Invalid query passed to QuerySelect: [queries]")
+		queries = list(queries)
+	else
+		queries = queries.Copy() //we don't want to hide bugs in the parent caller by removing invalid values from this list.
 
-	for (var/thing in querys)
-		var/datum/db_query/query = thing
+	for (var/datum/db_query/query as anything in queries)
+		if (!istype(query))
+			queries -= query
+			stack_trace("Invalid query passed to Query_Select: `[query]` [REF(query)]")
+		
 		if (warn)
 			INVOKE_ASYNC(query, /datum/db_query.proc/warn_execute)
 		else
 			INVOKE_ASYNC(query, /datum/db_query.proc/Execute)
 
-	for (var/thing in querys)
-		var/datum/db_query/query = thing
+	for (var/datum/db_query/query as anything in queries)
 		query.sync()
 		if (qdel)
 			qdel(query)


### PR DESCRIPTION
We don't handle bad values being given in the query list well enough. This normally won't matter, runtimes are runtimes, but if mixed with real queries, it can lead to inconsistent state where we have query datums that have been ran, and query datums that have not been ran.

pre-checking is also an option, so that it can just refuse to run any of them if one is bad by checking before, but my main goal was to prevent runtimes from bad inputs leading to undeleted queries spam while being more clear about where the bug is, not try to perfectly handle the side effects of bad code.

(To be clear, i started intending to just add codedoc but now it uses as anything and typechecks because that was just eating at me while typing up the codedoc.)