### PR TITLE
Fixes drones being shy of mobs they can't see!

### DIFF
--- a/code/datums/components/shy.dm
+++ b/code/datums/components/shy.dm
@@ -89,6 +89,10 @@
 		for(var/mob/living/person in strangers)
 			if(person == owner)
 				continue
+			if(person.invisibility > owner.see_invisible)
+				continue
+			if(HAS_TRAIT(person, TRAIT_MAGICALLY_PHASED))
+				continue
 			if(is_type_in_typecache(person, mob_whitelist))
 				continue
 			if(!person.key && !keyless_shy)


### PR DESCRIPTION
Fixes #69370

:cl: ShizCalev
fix: Drones will no longer by shy when invisible mobs are around! (eg phased revenants, bloodcrawling slaughter demons, ect)
/:cl: