### PR TITLE
Makes the game start faster by optimizing round-start manifest injections

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1050,7 +1050,8 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 		return J
 	return 0
 
-//For creating consistent icons for human looking simple animals
+/// # If you already have a human and need to get its flat icon, call `get_flat_existing_human_icon()` instead.
+/// For creating consistent icons for human looking simple animals.
 /proc/get_flat_human_icon(icon_id, datum/job/job, datum/preferences/prefs, dummy_key, showDirs = GLOB.cardinals, outfit_override = null)
 	var/static/list/humanoid_icon_cache = list()
 	if(icon_id && humanoid_icon_cache[icon_id])
@@ -1082,7 +1083,8 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
  * A simpler version of get_flat_human_icon() that uses an existing human as a base to create the icon.
  * Does not feature caching yet, since I could not think of a good way to cache them without having a possibility
  * of using the cached version when we don't want to, so only use this proc if you just need this flat icon
- * generated once.
+ * generated once and handle the caching yourself if you need to access that icon multiple times, or
+ * refactor this proc to feature caching of icons.
  *
  * Arguments:
  * * existing_human - The human we want to get a flat icon out of.

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -64,7 +64,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 
 	var/mutable_appearance/character_appearance = fields["character_appearance"]
 
-	var/atom/movable/screen/appearance_holder = new()
+	var/static/atom/movable/screen/appearance_holder = new()
 	appearance_holder.appearance = character_appearance
 	appearance_holder.setDir(orientation)
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -19,8 +19,6 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	var/list/fields = list()
 
 /datum/data/record/Destroy()
-	// We don't need to iterate over the records to see if they're in there,
-	// just let DM take the wheel.
 	GLOB.data_core.medical -= src
 	GLOB.data_core.security -= src
 	GLOB.data_core.general -= src

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -63,12 +63,9 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 		return new /icon()
 
 	var/mutable_appearance/character_appearance = fields["character_appearance"]
+	character_appearance.setDir(orientation)
 
-	var/static/atom/movable/screen/appearance_holder = new()
-	appearance_holder.appearance = character_appearance
-	appearance_holder.setDir(orientation)
-
-	var/icon/picture_image = getFlatIcon(appearance_holder)
+	var/icon/picture_image = getFlatIcon(character_appearance)
 
 	var/datum/picture/picture = new
 	picture.picture_name = "[fields["name"]]"

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -346,9 +346,6 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 		locked += L
 	return
 
-/datum/datacore/proc/get_id_photo(mob/living/carbon/human/human, show_directions = list(SOUTH))
-	return get_flat_existing_human_icon(human, show_directions)
-
 //Todo: Add citations to the prinout - you get them from sec record's "citation" field, same as "crim" (which is frankly a terrible fucking field name)
 ///Standardized printed records. SPRs. Like SATs but for bad guys who probably didn't actually finish school. Input the records and out comes a paper.
 /proc/print_security_record(datum/data/record/general_data, datum/data/record/security, atom/location)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -19,15 +19,65 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	var/list/fields = list()
 
 /datum/data/record/Destroy()
-	if(src in GLOB.data_core.medical)
-		GLOB.data_core.medical -= src
-	if(src in GLOB.data_core.security)
-		GLOB.data_core.security -= src
-	if(src in GLOB.data_core.general)
-		GLOB.data_core.general -= src
-	if(src in GLOB.data_core.locked)
-		GLOB.data_core.locked -= src
+	// We don't need to iterate over the records to see if they're in there,
+	// just let DM take the wheel.
+	GLOB.data_core.medical -= src
+	GLOB.data_core.security -= src
+	GLOB.data_core.general -= src
+	GLOB.data_core.locked -= src
 	. = ..()
+
+/// A helper proc to get the front photo of a character from the record.
+/// Handles calling `get_photo()`, read its documentation for more information.
+/datum/data/record/proc/get_front_photo()
+	return get_photo("photo_front", SOUTH)
+
+/// A helper proc to get the side photo of a character from the record.
+/// Handles calling `get_photo()`, read its documentation for more information.
+/datum/data/record/proc/get_side_photo()
+	return get_photo("photo_side", WEST)
+
+/**
+ * You shouldn't be calling this directly, use `get_front_photo()` or `get_side_photo()`
+ * instead.
+ *
+ * This is the proc that handles either fetching (if it was already generated before) or
+ * generating (if it wasn't) the specified photo from the specified record. This is only
+ * intended to be used by records that used to try to access `fields["photo_front"]` or
+ * `fields["photo_side"]`, and will return an empty icon if there isn't any of the necessary
+ * fields.
+ *
+ * Arguments:
+ * * field_name - The name of the key in the `fields` list, of the record itself.
+ * * orientation - The direction in which you want the character appearance to be rotated
+ * in the outputed photo.
+ *
+ * Returns an empty `/icon` if there was no `character_appearance` entry in the `fields` list,
+ * returns the generated/cached photo otherwise.
+ */
+/datum/data/record/proc/get_photo(field_name, orientation)
+	if(fields[field_name])
+		return fields[field_name]
+
+	if(!fields["character_appearance"])
+		return new /icon()
+
+	var/mutable_appearance/character_appearance = fields["character_appearance"]
+
+	var/atom/movable/screen/appearance_holder = new()
+	appearance_holder.appearance = character_appearance
+	appearance_holder.setDir(orientation)
+
+	var/icon/picture_image = getFlatIcon(appearance_holder)
+
+	var/datum/picture/picture = new
+	picture.picture_name = "[fields["name"]]"
+	picture.picture_desc = "This is [fields["name"]]."
+	picture.picture_image = picture_image
+
+	var/obj/item/photo/photo = new(null, picture)
+	fields[field_name] = photo
+	return photo
 
 /datum/data/crime
 	name = "crime"
@@ -223,17 +273,9 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 
 		var/static/record_id_num = 1001
 		var/id = num2hex(record_id_num++,6)
-		var/image = get_id_photo(H, show_directions)
-		var/datum/picture/pf = new
-		var/datum/picture/ps = new
-		pf.picture_name = "[H]"
-		ps.picture_name = "[H]"
-		pf.picture_desc = "This is [H]."
-		ps.picture_desc = "This is [H]."
-		pf.picture_image = icon(image, dir = SOUTH)
-		ps.picture_image = icon(image, dir = WEST)
-		var/obj/item/photo/photo_front = new(null, pf)
-		var/obj/item/photo/photo_side = new(null, ps)
+		// We need to compile the overlays now, otherwise we're basically copying an empty icon.
+		COMPILE_OVERLAYS(H)
+		var/mutable_appearance/character_appearance = new(H.appearance)
 
 		//These records should ~really~ be merged or something
 		//General Record
@@ -255,8 +297,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 			G.fields["gender"] = "Female"
 		else
 			G.fields["gender"] = "Other"
-		G.fields["photo_front"] = photo_front
-		G.fields["photo_side"] = photo_side
+		G.fields["character_appearance"] = character_appearance
 		general += G
 
 		//Medical Record
@@ -305,7 +346,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 		L.fields["identity"] = H.dna.unique_identity
 		L.fields["species"] = H.dna.species.type
 		L.fields["features"] = H.dna.features
-		L.fields["image"] = image
+		L.fields["character_appearance"] = character_appearance
 		L.fields["mindref"] = H.mind
 		locked += L
 	return

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -373,13 +373,13 @@
 					if("show_photo_front")
 						if(active1)
 							var/front_photo = active1.get_front_photo()
-							if(front_photo && istype(front_photo, /obj/item/photo))
+							if(istype(front_photo, /obj/item/photo))
 								var/obj/item/photo/photo = front_photo
 								photo.show(usr)
 					if("show_photo_side")
 						if(active1)
 							var/side_photo = active1.get_side_photo()
-							if(side_photo && istype(side_photo, /obj/item/photo))
+							if(istype(side_photo, /obj/item/photo))
 								var/obj/item/photo/photo = side_photo
 								photo.show(usr)
 					else

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -96,15 +96,17 @@
 
 					dat += "<table><tr><td><b><font size='4'>Medical Record</font></b></td></tr>"
 					if(active1 in GLOB.data_core.general)
-						if(istype(active1.fields["photo_front"], /obj/item/photo))
-							var/obj/item/photo/P1 = active1.fields["photo_front"]
-							user << browse_rsc(P1.picture.picture_image, "photo_front")
-						if(istype(active1.fields["photo_side"], /obj/item/photo))
-							var/obj/item/photo/P2 = active1.fields["photo_side"]
-							user << browse_rsc(P2.picture.picture_image, "photo_side")
+						var/front_photo = active1.get_front_photo()
+						if(istype(front_photo, /obj/item/photo))
+							var/obj/item/photo/photo_front = front_photo
+							user << browse_rsc(photo_front.picture.picture_image, "photo_front")
+						var/side_photo = active1.get_side_photo()
+						if(istype(side_photo, /obj/item/photo))
+							var/obj/item/photo/photo_side = side_photo
+							user << browse_rsc(photo_side.picture.picture_image, "photo_side")
 						dat += "<tr><td>Name:</td><td>[active1.fields["name"]]</td>"
-						dat += "<td><a href='?src=[REF(src)];field=show_photo_front'><img src=photo_front height=80 width=80 border=4></a></td>"
-						dat += "<td><a href='?src=[REF(src)];field=show_photo_side'><img src=photo_side height=80 width=80 border=4></a></td></tr>"
+						dat += "<td><a href='?src=[REF(src)];field=show_photo_front'><img src=photo_front height=96 width=96 border=4 style=\"-ms-interpolation-mode:nearest-neighbor\"></a></td>"
+						dat += "<td><a href='?src=[REF(src)];field=show_photo_side'><img src=photo_side height=96 width=96 border=4 style=\"-ms-interpolation-mode:nearest-neighbor\"></a></td></tr>"
 						dat += "<tr><td>ID:</td><td>[active1.fields["id"]]</td></tr>"
 						dat += "<tr><td>Gender:</td><td><A href='?src=[REF(src)];field=gender'>&nbsp;[active1.fields["gender"]]&nbsp;</A></td></tr>"
 						dat += "<tr><td>Age:</td><td><A href='?src=[REF(src)];field=age'>&nbsp;[active1.fields["age"]]&nbsp;</A></td></tr>"
@@ -370,16 +372,16 @@
 							active2.fields["b_dna"] = t1
 					if("show_photo_front")
 						if(active1)
-							if(active1.fields["photo_front"])
-								if(istype(active1.fields["photo_front"], /obj/item/photo))
-									var/obj/item/photo/P = active1.fields["photo_front"]
-									P.show(usr)
+							var/front_photo = active1.get_front_photo()
+							if(front_photo && istype(front_photo, /obj/item/photo))
+								var/obj/item/photo/photo = front_photo
+								photo.show(usr)
 					if("show_photo_side")
 						if(active1)
-							if(active1.fields["photo_side"])
-								if(istype(active1.fields["photo_side"], /obj/item/photo))
-									var/obj/item/photo/P = active1.fields["photo_side"]
-									P.show(usr)
+							var/side_photo = active1.get_side_photo()
+							if(side_photo && istype(side_photo, /obj/item/photo))
+								var/obj/item/photo/photo = side_photo
+								photo.show(usr)
 					else
 
 			else if(href_list["p_stat"])

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -336,12 +336,14 @@
 				if(3)
 					dat += "<font size='4'><b>Security Record</b></font><br>"
 					if(istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1))
-						if(istype(active1.fields["photo_front"], /obj/item/photo))
-							var/obj/item/photo/P1 = active1.fields["photo_front"]
-							user << browse_rsc(P1.picture.picture_image, "photo_front")
-						if(istype(active1.fields["photo_side"], /obj/item/photo))
-							var/obj/item/photo/P2 = active1.fields["photo_side"]
-							user << browse_rsc(P2.picture.picture_image, "photo_side")
+						var/front_photo = active1.get_front_photo()
+						if(istype(front_photo, /obj/item/photo))
+							var/obj/item/photo/photo_front = front_photo
+							user << browse_rsc(photo_front.picture.picture_image, "photo_front")
+						var/side_photo = active1.get_side_photo()
+						if(istype(side_photo, /obj/item/photo))
+							var/obj/item/photo/photo_side = side_photo
+							user << browse_rsc(photo_side.picture.picture_image, "photo_side")
 						dat += {"<table><tr><td><table>
 						<tr><td>Name:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=name'>&nbsp;[active1.fields["name"]]&nbsp;</A></td></tr>
 						<tr><td>ID:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=id'>&nbsp;[active1.fields["id"]]&nbsp;</A></td></tr>
@@ -354,10 +356,10 @@
 						<tr><td>Physical Status:</td><td>&nbsp;[active1.fields["p_stat"]]&nbsp;</td></tr>
 						<tr><td>Mental Status:</td><td>&nbsp;[active1.fields["m_stat"]]&nbsp;</td></tr>
 						</table></td>
-						<td><table><td align = center><a href='?src=[REF(src)];choice=Edit Field;field=show_photo_front'><img src=photo_front height=80 width=80 border=4></a><br>
+						<td><table><td align = center><a href='?src=[REF(src)];choice=Edit Field;field=show_photo_front'><img src=photo_front height=96 width=96 border=4 style="-ms-interpolation-mode:nearest-neighbor"></a><br>
 						<a href='?src=[REF(src)];choice=Edit Field;field=print_photo_front'>Print photo</a><br>
 						<a href='?src=[REF(src)];choice=Edit Field;field=upd_photo_front'>Update front photo</a></td>
-						<td align = center><a href='?src=[REF(src)];choice=Edit Field;field=show_photo_side'><img src=photo_side height=80 width=80 border=4></a><br>
+						<td align = center><a href='?src=[REF(src)];choice=Edit Field;field=show_photo_side'><img src=photo_side height=96 width=96 border=4 style="-ms-interpolation-mode:nearest-neighbor"></a><br>
 						<a href='?src=[REF(src)];choice=Edit Field;field=print_photo_side'>Print photo</a><br>
 						<a href='?src=[REF(src)];choice=Edit Field;field=upd_photo_side'>Update side photo</a></td></table>
 						</td></tr></table></td></tr></table>"}
@@ -574,7 +576,7 @@ What a mess.*/
 							printing = 1
 							sleep(30)
 							if((istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1)))//make sure the record still exists.
-								var/obj/item/photo/photo = active1.fields["photo_front"]
+								var/obj/item/photo/photo = active1.get_front_photo()
 								new /obj/item/poster/wanted(loc, photo.picture.picture_image, wanted_name, info, headerText)
 							printing = 0
 			if("Print Missing")
@@ -591,7 +593,7 @@ What a mess.*/
 							printing = 1
 							sleep(30)
 							if((istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1)))//make sure the record still exists.
-								var/obj/item/photo/photo = active1.fields["photo_front"]
+								var/obj/item/photo/photo = active1.get_front_photo()
 								new /obj/item/poster/wanted/missing(loc, photo.picture.picture_image, missing_name, info, headerText)
 							printing = 0
 
@@ -754,10 +756,11 @@ What a mess.*/
 								return
 							active1.fields["species"] = t1
 					if("show_photo_front")
-						if(active1.fields["photo_front"])
-							if(istype(active1.fields["photo_front"], /obj/item/photo))
-								var/obj/item/photo/P = active1.fields["photo_front"]
-								P.show(usr)
+						if(active1)
+							var/front_photo = active1.get_front_photo()
+							if(front_photo && istype(front_photo, /obj/item/photo))
+								var/obj/item/photo/photo = front_photo
+								photo.show(usr)
 					if("upd_photo_front")
 						var/obj/item/photo/photo = get_photo(usr)
 						if(photo)
@@ -771,15 +774,17 @@ What a mess.*/
 							I.Crop(dw/2, dh/2, w - dw/2, h - dh/2)
 							active1.fields["photo_front"] = photo
 					if("print_photo_front")
-						if(active1.fields["photo_front"])
-							if(istype(active1.fields["photo_front"], /obj/item/photo))
-								var/obj/item/photo/P = active1.fields["photo_front"]
-								print_photo(P.picture.picture_image, active1.fields["name"])
+						if(active1)
+							var/front_photo = active1.get_front_photo()
+							if(istype(front_photo, /obj/item/photo))
+								var/obj/item/photo/photo_front = front_photo
+								print_photo(photo_front.picture.picture_image, active1.fields["name"])
 					if("show_photo_side")
-						if(active1.fields["photo_side"])
-							if(istype(active1.fields["photo_side"], /obj/item/photo))
-								var/obj/item/photo/P = active1.fields["photo_side"]
-								P.show(usr)
+						if(active1)
+							var/side_photo = active1.get_side_photo()
+							if(side_photo && istype(side_photo, /obj/item/photo))
+								var/obj/item/photo/photo = side_photo
+								photo.show(usr)
 					if("upd_photo_side")
 						var/obj/item/photo/photo = get_photo(usr)
 						if(photo)
@@ -793,10 +798,11 @@ What a mess.*/
 							I.Crop(dw/2, dh/2, w - dw/2, h - dh/2)
 							active1.fields["photo_side"] = photo
 					if("print_photo_side")
-						if(active1.fields["photo_side"])
-							if(istype(active1.fields["photo_side"], /obj/item/photo))
-								var/obj/item/photo/P = active1.fields["photo_side"]
-								print_photo(P.picture.picture_image, active1.fields["name"])
+						if(active1)
+							var/side_photo = active1.get_side_photo()
+							if(istype(side_photo, /obj/item/photo))
+								var/obj/item/photo/photo_side = side_photo
+								print_photo(photo_side.picture.picture_image, active1.fields["name"])
 					if("crim_add")
 						if(istype(active1, /datum/data/record))
 							var/t1 = tgui_input_text(usr, "Input crime names", "Security Records")

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -758,7 +758,7 @@ What a mess.*/
 					if("show_photo_front")
 						if(active1)
 							var/front_photo = active1.get_front_photo()
-							if(front_photo && istype(front_photo, /obj/item/photo))
+							if(istype(front_photo, /obj/item/photo))
 								var/obj/item/photo/photo = front_photo
 								photo.show(usr)
 					if("upd_photo_front")
@@ -782,7 +782,7 @@ What a mess.*/
 					if("show_photo_side")
 						if(active1)
 							var/side_photo = active1.get_side_photo()
-							if(side_photo && istype(side_photo, /obj/item/photo))
+							if(istype(side_photo, /obj/item/photo))
 								var/obj/item/photo/photo = side_photo
 								photo.show(usr)
 					if("upd_photo_side")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -136,9 +136,9 @@
 				return
 			var/obj/item/photo/photo_from_record = null
 			if(href_list["photo_front"])
-				photo_from_record = target_record.fields["photo_front"]
+				photo_from_record = target_record.get_front_photo()
 			else if(href_list["photo_side"])
-				photo_from_record = target_record.fields["photo_side"]
+				photo_from_record = target_record.get_side_photo()
 			if(photo_from_record)
 				photo_from_record.show(human_user)
 			return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -660,7 +660,7 @@
 					var/list/personnel_list = list()
 
 					for(var/datum/data/record/record_datum in GLOB.data_core.locked)//Look in data core locked.
-						personnel_list["[record_datum.fields["name"]]: [record_datum.fields["rank"]]"] = record_datum.fields["image"]//Pull names, rank, and image.
+						personnel_list["[record_datum.fields["name"]]: [record_datum.fields["rank"]]"] = record_datum.fields["character_appearance"]//Pull names, rank, and image.
 
 					if(!length(personnel_list))
 						tgui_alert(usr,"No suitable records found. Aborting.")
@@ -670,10 +670,14 @@
 						return
 					if(isnull(personnel_list[input]))
 						return
-					var/icon/character_icon = personnel_list[input]
+					var/character_icon = personnel_list[input]
 					if(character_icon)
 						qdel(holo_icon)//Clear old icon so we're not storing it in memory.
-						holo_icon = getHologramIcon(icon(character_icon))
+						var/static/atom/movable/screen/appearance_holder = new()
+						appearance_holder.appearance = character_icon
+
+						var/icon/icon_for_holo = getFlatIcon(appearance_holder)
+						holo_icon = getHologramIcon(icon(icon_for_holo))
 
 				if("My Character")
 					switch(tgui_alert(usr,"WARNING: Your AI hologram will take the appearance of your currently selected character ([usr.client.prefs?.read_preference(/datum/preference/name/real_name)]). Are you sure you want to proceed?", "Customize", list("Yes","No")))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -670,13 +670,12 @@
 						return
 					if(isnull(personnel_list[input]))
 						return
-					var/character_icon = personnel_list[input]
+					var/mutable_appearance/character_icon = personnel_list[input]
 					if(character_icon)
 						qdel(holo_icon)//Clear old icon so we're not storing it in memory.
-						var/static/atom/movable/screen/appearance_holder = new()
-						appearance_holder.appearance = character_icon
+						character_icon.setDir(SOUTH)
 
-						var/icon/icon_for_holo = getFlatIcon(appearance_holder)
+						var/icon/icon_for_holo = getFlatIcon(character_icon)
 						holo_icon = getHologramIcon(icon(icon_for_holo))
 
 				if("My Character")


### PR DESCRIPTION
## About The Pull Request
So, I was trying to help @Jolly-66 port over something TGUI-related to his downstream, when I figured that, for that specific TGUI panel, the code was using a dummy to create a double of the character to display it on screen (hint: that's what the manifest code used to do), and I realized that I could make it a lot more performant by just copying the `appearance` of the mob directly, and sure enough, it was faster and more reliable.

But, when I did that, I asked questions about it on /tg/, and that's when @LemonInTheDark asked me if that was for the Manifest. Instantly, I knew what he meant, but I wanted to make my code work first, and promised I'd take a look today. So we started benching the time it takes to start the round (see: https://github.com/tgstation/tgstation/pull/69366), and funnily enough, there was like 12 seconds spent while starting the round on Sybil just generating the manifest entries.
![image](https://user-images.githubusercontent.com/58045821/186035821-4b35e513-94b7-428e-a830-ae4257699b79.png)

We had some back-and-forth about it, and eventually today came, and I was indeed able to deliver. The results are very promising, and should mean that this step of the start of the game should be, like, 50 times faster, roughly, but we'll see that once we get a test-merge on this.

While I was at it, I also quickly edited the resolution and scaling method of the pictures displayed in the security (and medical) records, to make them a lot more crisp and overall accurate, as you can see here:
![image](https://user-images.githubusercontent.com/58045821/186036280-03a6aaa2-85fe-4881-9436-f953cf97aefc.png)

## Why It's Good For The Game
The game will start *significantly* faster now. I'll be waiting on the results of the test-merge for a more accurate order of magnitude, but we're talking about cutting off several seconds.

Here's a comparison of the times before (obtained by @LemonInTheDark) and after my changes:
Before my changes:
![image](https://user-images.githubusercontent.com/58045821/186034811-ac318c84-ee4c-4f47-ada6-2adcf73c4fa4.png)

After my changes:
![image](https://user-images.githubusercontent.com/58045821/186034699-a007cd59-e7ad-4880-90a3-1d9cfbbf5823.png)

UPDATE:
Yeah so turns out it's faster than on my local somehow, on live. So it's like, what... 12159/5 = 2431 times faster. Good to know!
![image](https://user-images.githubusercontent.com/58045821/186043723-437579ae-d76d-4590-aba3-552948f9a2cf.png)


## Changelog

:cl: GoldenAlpharex
refactor: Refactored the manifest code to not rely on generating two photo of each character at roundstart. This means that the start of the game should be significantly faster.
fix: The images shown in the manifest no longer look crummy, and will instead look exactly like you'd expect them to!
/:cl: