### PR TITLE
Fixes tesla blast

### DIFF
--- a/code/modules/spells/spell_types/self/lightning.dm
+++ b/code/modules/spells/spell_types/self/lightning.dm
@@ -62,8 +62,6 @@
 		reset_tesla(cast_on)
 		return . | SPELL_CANCEL_CAST
 
-	return TRUE
-
 /datum/action/cooldown/spell/tesla/reset_spell_cooldown()
 	reset_tesla(owner)
 	return ..()
@@ -90,7 +88,6 @@
 	playsound(get_turf(cast_on), 'sound/magic/lightningbolt.ogg', 50, TRUE)
 	zap_target(cast_on, to_zap_first)
 	reset_tesla(cast_on)
-	return TRUE
 
 /// Zaps a target, the bolt originating from origin.
 /datum/action/cooldown/spell/tesla/proc/zap_target(atom/origin, mob/living/carbon/to_zap, bolt_energy = 30, bounces = 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, if you invoke tesla blast, it gets stuck on channeling forever. This is due to an oversight in the new spell/action system; returning TRUE (1) is the same as returning SPELL_CANCEL_CAST (1), resulting in the spell being erroneously cancelled without any cleanup.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Wizards can now, once again, electrocute people.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: tesla blast works again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
