### PR TITLE
Water vapour electrolysis and hypernoblium electrolysis now respects heat capacity changes.

### DIFF
--- a/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer_reactions.dm
+++ b/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer_reactions.dm
@@ -50,11 +50,15 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
 
 /datum/electrolyzer_reaction/h2o_conversion/react(turf/location, datum/gas_mixture/air_mixture, working_power)
 
+	var/old_heat_capacity = air_mixture.heat_capacity()
 	air_mixture.assert_gases(/datum/gas/water_vapor, /datum/gas/oxygen, /datum/gas/hydrogen)
 	var/proportion = min(air_mixture.gases[/datum/gas/water_vapor][MOLES] * INVERSE(2), (2.5 * (working_power ** 2)))
 	air_mixture.gases[/datum/gas/water_vapor][MOLES] -= proportion * 2
 	air_mixture.gases[/datum/gas/oxygen][MOLES] += proportion
 	air_mixture.gases[/datum/gas/hydrogen][MOLES] += proportion * 2
+	var/new_heat_capacity = air_mixture.heat_capacity()
+	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
+		air_mixture.temperature = max(air_mixture.temperature * old_heat_capacity / new_heat_capacity, TCMB)
 
 /datum/electrolyzer_reaction/nob_conversion
 	name = "Hypernob conversion"
@@ -73,10 +77,14 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
 
 /datum/electrolyzer_reaction/nob_conversion/react(turf/location, datum/gas_mixture/air_mixture, working_power)
 
+	var/old_heat_capacity = air_mixture.heat_capacity()
 	air_mixture.assert_gases(/datum/gas/hypernoblium, /datum/gas/antinoblium)
 	var/proportion = min(air_mixture.gases[/datum/gas/hypernoblium][MOLES], (1.5 * (working_power ** 2)))
 	air_mixture.gases[/datum/gas/hypernoblium][MOLES] -= proportion
 	air_mixture.gases[/datum/gas/antinoblium][MOLES] += proportion * 0.5
+	var/new_heat_capacity = air_mixture.heat_capacity()
+	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
+		air_mixture.temperature = max(air_mixture.temperature * old_heat_capacity / new_heat_capacity, TCMB)
 
 /datum/electrolyzer_reaction/halon_generation
 	name = "Halon generation"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The electrolyzer now respects heat capacity changes for h2o electrolysis and hypernoblium electrolysis, adjusting the temperature based on the heat capacity changes. Water vapour electrolysis decreases heat capacity by 37.5%, so the temperature rises by 60%, causing it to rise to 468.04 Kelvin if it was room temperature, or needing at least 233.21875 Kelvin to reach combustion temperature. Hypernoblium electrolysis decreases heat capacity by 99.975%, so the temperature rises by a factor of 4,000, causing it to rise to 10,800 Kelvin from 2.7 Kelvin, or rise to 600,000 Kelvin from 150 Kelvin. It's probably recommended to use some heat reservoir for the noblium one.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's weird that those two reactions didn't respect heat capacity changes while the others did.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Water vapour electrolysis and hypernoblium electrolysis now respects heat capacity changes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
