### PR TITLE
Cult shades can now use Cult communion channel.

### DIFF
--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -8,6 +8,8 @@
 	ranged_mousepointer = 'icons/effects/mouse_pointers/cult_target.dmi'
 
 /datum/action/innate/cult/IsAvailable()
+	if(isshade(owner))
+		return TRUE
 	if(!IS_CULTIST(owner))
 		return FALSE
 	return ..()
@@ -66,19 +68,19 @@
 /datum/action/innate/cult/comm/spirit/IsAvailable()
 	if(IS_CULTIST(owner.mind.current))
 		return TRUE
+	return ..()
 
 /datum/action/innate/cult/comm/spirit/cultist_commune(mob/living/user, message)
 	var/my_message
 	if(!message)
 		return
 	my_message = span_cultboldtalic("The [user.name]: [message]")
-	for(var/i in GLOB.player_list)
-		var/mob/M = i
-		if(IS_CULTIST(M))
-			to_chat(M, my_message)
-		else if(M in GLOB.dead_mob_list)
-			var/link = FOLLOW_LINK(M, user)
-			to_chat(M, "[link] [my_message]")
+	for(var/mob/player_list as anything in GLOB.player_list)
+		if(IS_CULTIST(player_list))
+			to_chat(player_list, my_message)
+		else if(player_list in GLOB.dead_mob_list)
+			var/link = FOLLOW_LINK(player_list, user)
+			to_chat(player_list, "[link] [my_message]")
 
 /datum/action/innate/cult/mastervote
 	name = "Assert Leadership"

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -8,8 +8,6 @@
 	ranged_mousepointer = 'icons/effects/mouse_pointers/cult_target.dmi'
 
 /datum/action/innate/cult/IsAvailable()
-	if(isshade(owner))
-		return TRUE
 	if(!IS_CULTIST(owner))
 		return FALSE
 	return ..()
@@ -18,6 +16,11 @@
 	name = "Communion"
 	desc = "Whispered words that all cultists can hear.<br><b>Warning:</b>Nearby non-cultists can still hear you."
 	button_icon_state = "cult_comms"
+
+/datum/action/innate/cult/comm/IsAvailable()
+	if(isshade(owner) && IS_CULTIST(owner))
+		return TRUE
+	return ..()
 
 /datum/action/innate/cult/comm/Activate()
 	var/input = tgui_input_text(usr, "Message to tell to the other acolytes", "Voice of Blood")


### PR DESCRIPTION
## About The Pull Request

Cult shades have their hands blocked while in a shard, which makes them completely useless when put in someone's bag as they are unable to use their cult comms ability. Sorta like a pAI, they should be able to contact for help when the person who has them is in trouble.

I thought it would be best to avoid removing the hands blocked check, because I like that it blocks handcuffed cultists from talking over it (and want to avoid balance label).

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/68933 - It was being complained about in the discord so I thought I would look into it.

This lets shades be useful while being in someone's bag, pAI-style.

## Changelog

:cl:
fix: Cultist shades can now use their Communion ability while in their shade.
/:cl: