### PR TITLE
Limb targeting fix

### DIFF
--- a/code/datums/components/irradiated.dm
+++ b/code/datums/components/irradiated.dm
@@ -129,7 +129,7 @@
 	if (should_halt_effects(parent))
 		return
 
-	var/obj/affected_limb = human_parent.get_bodypart(human_parent.get_random_valid_zone())
+	var/obj/item/bodypart/affected_limb = human_parent.get_bodypart(human_parent.get_random_valid_zone())
 	human_parent.visible_message(
 		span_boldwarning("[human_parent]'s [affected_limb.plaintext_zone] bubbles unnaturally, then bursts into blisters!"),
 		span_boldwarning("Your [affected_limb.plaintext_zone] bubbles unnaturally, then bursts into blisters!"),

--- a/code/datums/components/irradiated.dm
+++ b/code/datums/components/irradiated.dm
@@ -131,12 +131,12 @@
 
 	var/obj/affected_limb = human_parent.get_bodypart(human_parent.get_random_valid_zone())
 	human_parent.visible_message(
-		span_boldwarning("[human_parent]'s [affected_limb.name] bubbles unnaturally, then bursts into blisters!"),
-		span_boldwarning("Your [affected_limb.name] bubbles unnaturally, then bursts into blisters!"),
+		span_boldwarning("[human_parent]'s [affected_limb.plaintext_zone] bubbles unnaturally, then bursts into blisters!"),
+		span_boldwarning("Your [affected_limb.plaintext_zone] bubbles unnaturally, then bursts into blisters!"),
 	)
 
 	if (human_parent.is_blind())
-		to_chat(human_parent, span_boldwarning("Your [affected_limb.name] feels like it's bubbling, then burns like hell!"))
+		to_chat(human_parent, span_boldwarning("Your [affected_limb.plaintext_zone] feels like it's bubbling, then burns like hell!"))
 
 	human_parent.apply_damage(RADIATION_BURN_SPLOTCH_DAMAGE, BURN, affected_limb)
 	playsound(

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -110,7 +110,7 @@
 
 /datum/mood_event/table_limbsmash/add_effects(obj/item/bodypart/banged_limb)
 	if(banged_limb)
-		description = "My fucking [banged_limb.name], man that hurts..."
+		description = "My fucking [banged_limb.plaintext_zone], man that hurts..."
 
 /datum/mood_event/brain_damage
 	mood_change = -3

--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -44,9 +44,9 @@
 			if(WOUND_BURN)
 				occur_text = "is completely incinerated, falling to dust!"
 
-	var/msg = span_bolddanger("[victim]'s [dismembered_part.name] [occur_text]")
+	var/msg = span_bolddanger("[victim]'s [dismembered_part.plaintext_zone] [occur_text]")
 
-	victim.visible_message(msg, span_userdanger("Your [dismembered_part.name] [self_msg ? self_msg : occur_text]"))
+	victim.visible_message(msg, span_userdanger("Your [dismembered_part.plaintext_zone] [self_msg ? self_msg : occur_text]"))
 
 	set_limb(dismembered_part)
 	second_wind()

--- a/code/datums/wounds/scars/_scars.dm
+++ b/code/datums/wounds/scars/_scars.dm
@@ -136,7 +136,7 @@
 		if(WOUND_SEVERITY_CRITICAL)
 			msg = span_smallnoticeital("<b>[msg]</b>")
 		if(WOUND_SEVERITY_LOSS)
-			msg = "[victim.p_their(TRUE)] [limb.name] [description]." // different format
+			msg = "[victim.p_their(TRUE)] [limb.plaintext_zone] [description]." // different format
 			msg = span_notice("<i><b>[msg]</b></i>")
 	return "\t[msg]"
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -178,8 +178,8 @@
 	if(user.mind?.martial_art.smashes_tables && user.mind?.martial_art.can_use(user))
 		deconstruct(FALSE)
 	playsound(pushed_mob, 'sound/effects/bang.ogg', 90, TRUE)
-	pushed_mob.visible_message(span_danger("[user] smashes [pushed_mob]'s [banged_limb.name] against \the [src]!"),
-								span_userdanger("[user] smashes your [banged_limb.name] against \the [src]"))
+	pushed_mob.visible_message(span_danger("[user] smashes [pushed_mob]'s [banged_limb.plaintext_zone] against \the [src]!"),
+								span_userdanger("[user] smashes your [banged_limb.plaintext_zone] against \the [src]"))
 	log_combat(user, pushed_mob, "head slammed", null, "against [src]")
 	pushed_mob.add_mood_event("table", /datum/mood_event/table_limbsmash, banged_limb)
 

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -221,8 +221,8 @@
 		ADD_TRAIT(burn_limb, TRAIT_PLASMABURNT, name)
 		burn_human.update_body_parts()
 		burn_human.emote("scream")
-		burn_human.visible_message(span_warning("[burn_human]'s [burn_limb.name] melts down to the bone!"), \
-			span_userdanger("You scream out in pain as your [burn_limb.name] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
+		burn_human.visible_message(span_warning("[burn_human]'s [burn_limb.plaintext_zone] melts down to the bone!"), \
+			span_userdanger("You scream out in pain as your [burn_limb.plaintext_zone] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
 	if(!plasma_parts.len && !robo_parts.len) //a person with no potential organic limbs left AND no robotic limbs, time to turn them into a plasmaman
 		burn_human.ignite_mob()
 		burn_human.set_species(/datum/species/plasmaman)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -67,12 +67,12 @@
 		if(limb_zone in blacklisted_parts)
 			continue
 		if(even_weights)
-			limbs += limb_zone[1]
+			limbs[limb_zone] = 1
 			continue
 		if(limb_zone == BODY_ZONE_CHEST || limb_zone == BODY_ZONE_HEAD)
-			limbs += limb_zone[1]
+			limbs[limb_zone] = 1
 		else
-			limbs += limb_zone[4]
+			limbs[limb_zone] = 4
 
 	if(base_zone && !(check_zone(base_zone) in limbs))
 		base_zone = null //check if the passed zone is infact valid


### PR DESCRIPTION
Fixes half of  #69354
Fixes #69398

:cl: ShizCalev
fix: Targeting limbs now works again. Honk!
fix: Fixed a bunch of things that would say "your human arm" instead of just "your arm".
/:cl:
