### PR TITLE
[MDB IGNORE] Fix ticket machines behaving unexpectedly and causing runtimes

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mailroom.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mailroom.dmm
@@ -146,7 +146,9 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "np" = (
-/obj/machinery/ticket_machine/directional/north,
+/obj/machinery/ticket_machine/directional/north{
+	id = "ticket_machine_icemailroom"
+	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/mailroom)
 "nM" = (

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -319,6 +319,10 @@
 		return
 	. += span_warning("You cannot read it!")
 
+/obj/item/paper/extinguish()
+	..()
+	update_appearance()
+
 /obj/item/paper/ui_status(mob/user,/datum/ui_state/state)
 	// Are we on fire?  Hard to read if so
 	if(resistance_flags & ON_FIRE)

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -17,7 +17,8 @@
 	var/ticket_number = 0
 	///What ticket number are we currently serving?
 	var/current_number = 0
-	var/max_number = 100 //At this point, you need to refill it.
+	///At this point, you need to refill it.
+	var/max_number = 100
 	var/cooldown = 5 SECONDS
 	var/ready = TRUE
 	var/id = "ticket_machine_default" //For buttons
@@ -66,6 +67,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/ticket_machine, 32)
 		tickets.Cut()
 	update_appearance()
 
+///Increments the counter by one, if there is a ticket after the current one we are serving.
+///If we have a current ticket, remove it from the top of our tickets list and replace it with the next one if applicable
 /obj/machinery/ticket_machine/proc/increment()
 	if(current_number > ticket_number)
 		return
@@ -239,9 +242,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/ticket_machine, 32)
 	var/owner_ref // A ref to our owner. Doesn't need to be weak because mobs have unique refs
 	var/obj/machinery/ticket_machine/source
 
-/obj/item/ticket_machine_ticket/New(loc, number)
+/obj/item/ticket_machine_ticket/New(loc, num)
 	. = ..()
-	src.number = number
+	number = num
 	name += " #[number]"
 	saved_maptext = MAPTEXT(number)
 	maptext = saved_maptext

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -70,15 +70,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/ticket_machine, 32)
 ///Increments the counter by one, if there is a ticket after the current one we are serving.
 ///If we have a current ticket, remove it from the top of our tickets list and replace it with the next one if applicable
 /obj/machinery/ticket_machine/proc/increment()
-	if(current_number > ticket_number)
-		return
 	if(!(obj_flags & EMAGGED) && current_ticket)
 		current_ticket.audible_message(span_notice("\the [current_ticket] disperses!"), hearing_distance = SAMETILE_MESSAGE_RANGE)
 		tickets.Cut(1,2)
 		QDEL_NULL(current_ticket)
-	if(!current_ticket && LAZYLEN(tickets))
+	if(LAZYLEN(tickets))
 		current_ticket = tickets[1]
-	if(current_ticket)
 		current_number++ //Increment the one we're serving.
 		playsound(src, 'sound/misc/announce_dig.ogg', 50, FALSE)
 		say("Now serving [current_ticket]!")

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -224,7 +224,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/ticket_machine, 32)
 	update_appearance()
 
 /obj/item/ticket_machine_ticket
-	name = "Ticket"
+	name = "\improper ticket"
 	desc = "A ticket which shows your place in the Head of Personnel's line. Made from Nanotrasen patented NanoPaper®. Though solid, its form seems to shimmer slightly. Feels (and burns) just like the real thing."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "ticket"

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -238,7 +238,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/ticket_machine, 32)
 	var/owner_ref // A ref to our owner. Doesn't need to be weak because mobs have unique refs
 	var/obj/machinery/ticket_machine/source
 
-/obj/item/ticket_machine_ticket/Initialize(loc, num)
+/obj/item/ticket_machine_ticket/Initialize(mapload, num)
 	. = ..()
 	number = num
 	if(!isnull(num))

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -111,7 +111,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/ticket_machine, 32)
 /obj/item/assembly/control/ticket_machine
 	name = "ticket machine controller"
 	desc = "A remote controller for the HoP's ticket machine."
-	var/datum/weakref/linked //To whom are we linked?
+	///To whom are we linked?
+	var/datum/weakref/linked
 
 /obj/item/assembly/control/ticket_machine/Initialize(mapload)
 	..()
@@ -120,7 +121,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/ticket_machine, 32)
 /obj/item/assembly/control/ticket_machine/LateInitialize()
 	find_machine()
 
-/obj/item/assembly/control/ticket_machine/proc/find_machine() //Locate the one to which we're linked
+/// Locate the ticket machine to which we're linked by our ID
+/obj/item/assembly/control/ticket_machine/proc/find_machine()
 	for(var/obj/machinery/ticket_machine/ticketsplease in GLOB.machines)
 		if(ticketsplease.id == id)
 			linked = WEAKREF(ticketsplease)

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -245,15 +245,17 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/ticket_machine, 32)
 /obj/item/ticket_machine_ticket/New(loc, num)
 	. = ..()
 	number = num
-	name += " #[number]"
-	saved_maptext = MAPTEXT(number)
-	maptext = saved_maptext
+	if(number != null) // dont make a zero ticket or ill cry
+		name += " #[number]"
+		saved_maptext = MAPTEXT(number)
+		maptext = saved_maptext
 
 /obj/item/ticket_machine_ticket/examine(mob/user)
 	. = ..()
-	. += span_notice("The ticket reads shimmering text that tells you that you are number [number] in queue.")
-	if(source)
-		. += span_notice("Below that, you can see that you are [number - source.current_number] spot\s away from being served.")
+	if(number != null)
+		. += span_notice("The ticket reads shimmering text that tells you that you are number [number] in queue.")
+		if(source)
+			. += span_notice("Below that, you can see that you are [number - source.current_number] spot\s away from being served.")
 
 /obj/item/ticket_machine_ticket/attack_hand(mob/user, list/modifiers)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The ticket machine used to desynchronize very easily due to out of bounds list accesses when trying to access the current ticket. The list that keeps track of tickets has been repurposed more into a queue, pushing all elements to the front with .Cut(1,2), compared to before where it would leave a space of nothingness where tickets used to be. 

Also, there was a ticket machine in a ruin in icebox which had the default id, causing an id collision.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

bgug fix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: HoPs all around the Spinward Sector scream in joy as their beloved ticket machine finally rises back from the dead.
qol: Add more examines to ticket machines and tickets, giving info about people's spot in queue and so on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
