### PR TITLE
Fixes cowboy boot runtime

### DIFF
--- a/code/modules/clothing/shoes/cowboy.dm
+++ b/code/modules/clothing/shoes/cowboy.dm
@@ -48,7 +48,7 @@
 
 /obj/item/clothing/shoes/cowboy/MouseDrop_T(mob/living/target, mob/living/user)
 	. = ..()
-	if(!(user.mobility_flags & MOBILITY_USE) || user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user) || !user.Adjacent(target) || target.stat == DEAD)
+	if(!(user.mobility_flags & MOBILITY_USE) || user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user) || !isliving(target) || !user.Adjacent(target) || target.stat == DEAD)
 		return
 	if(contents.len >= max_occupants)
 		to_chat(user, span_warning("[src] are full!"))


### PR DESCRIPTION
Sanity check

```
[23:38:00] Runtime in cowboy.dm, line 51: undefined variable /turf/open/floor/iron/var/stat
 proc name: MouseDrop T (/obj/item/clothing/shoes/cowboy/MouseDrop_T)
usr: Enderman Kitten/(Riki-Rikiki)
usr.loc: (Hydroponics (135,114,2))
src: the cowboy boots (/obj/item/clothing/shoes/cowboy)
src.loc: the floor (135,115,2) (/turf/open/floor/iron)
call stack:
the cowboy boots (/obj/item/clothing/shoes/cowboy): MouseDrop T(the floor (135,114,2) (/turf/open/floor/iron), Riki-Rikiki (/mob/living/carbon/human), "icon-x=14;icon-y=15;right=1;bu...")
the floor (135,114,2) (/turf/open/floor/iron): MouseDrop(the cowboy boots (/obj/item/clothing/shoes/cowboy), the floor (135,114,2) (/turf/open/floor/iron), the floor (135,115,2) (/turf/open/floor/iron), "mapwindow.map", "mapwindow.map", "icon-x=14;icon-y=15;right=1;bu...")
Enderman Kitten (/client): MouseDrop(the floor (135,114,2) (/turf/open/floor/iron), the cowboy boots (/obj/item/clothing/shoes/cowboy), the floor (135,114,2) (/turf/open/floor/iron), the floor (135,115,2) (/turf/open/floor/iron), "mapwindow.map", "mapwindow.map", "icon-x=14;icon-y=15;right=1;bu...")
```