### PR TITLE
Re-remove mention of shock resist from sec modsuits

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -604,7 +604,7 @@
 
 /datum/mod_theme/security
 	name = "security"
-	desc = "An Apadyne Technologies security suit, offering shock protection and quicker speed, at the cost of carrying capacity."
+	desc = "An Apadyne Technologies security suit, offering quicker speed at the cost of carrying capacity."
 	extended_desc = "An Apadyne Technologies classic, this model of MODsuit has been designed for quick response to \
 		hostile situations. These suits have been layered with plating worthy enough for fires or corrosive environments, \
 		and come with composite cushioning and an advanced honeycomb structure underneath the hull to ensure protection \


### PR DESCRIPTION
## About The Pull Request

Fixes: #69417

## Why It's Good
@Fikou already tried to do this once and it got overwritten or something.
https://github.com/tgstation/tgstation/blob/92c5fd9a88d875b330b6204baa9ae21984c583a2/html/changelogs/archive/2022-06.yml#L478-L481

## Changelog
:cl:
spellcheck: Removes the security MODsuit's description of being shockproof, as it's false advertising. 
/:cl:
