### PR TITLE
Fixes runtime from bookshelves being maploaded in after SSlibrary is done instantiating

### DIFF
--- a/code/modules/library/bookcase.dm
+++ b/code/modules/library/bookcase.dm
@@ -25,6 +25,7 @@
 	. = ..()
 	if(!mapload || QDELETED(src))
 		return
+	// Only mapload from here on
 	set_anchored(TRUE)
 	state = BOOKCASE_FINISHED
 	for(var/obj/item/I in loc)
@@ -32,7 +33,11 @@
 			continue
 		I.forceMove(src)
 	update_appearance()
-	SSlibrary.shelves_to_load += src
+
+	if(SSlibrary.initialized)
+		load_shelf()
+	else
+		SSlibrary.shelves_to_load += src
 
 ///Loads the shelf, both by allowing it to generate random items, and by adding its contents to a list used by library machines
 /obj/structure/bookcase/proc/load_shelf()

--- a/code/modules/library/bookcase.dm
+++ b/code/modules/library/bookcase.dm
@@ -35,7 +35,7 @@
 	update_appearance()
 
 	if(SSlibrary.initialized)
-		load_shelf()
+		INVOKE_ASYNC(src, .proc/load_shelf)
 	else
 		SSlibrary.shelves_to_load += src
 


### PR DESCRIPTION

## About The Pull Request

![image](https://user-images.githubusercontent.com/51863163/186324800-b6696dd0-cef7-42e7-9c6a-2d68c1ffe2fa.png)

- If a bookshelf is maploaded after the library subsystem is done initializing, it runtimes due to `shelves_to_load` being null (it attempts to += to a `null` instead of a list).
- So, I changed it so that if a bookcase is maploaded after SSlibrary is done initializing, just load the shelf directly in init instead of delegating to the subsystem.

## Why It's Good For The Game

- Stops a lot of runtimes from loading map templates, even if no books end up being loaded ultimately. 

## Changelog

:cl: Melbert
fix: Fixes some runtimes from loading maptemplates with random populated bookselves, who knows they might even spawn with books now. 
/:cl:
