### PR TITLE
Revert "Fixes Fucked Job Requirement Displays" and "Converts Job Hour Requirements System To HOURS Define"

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -5,7 +5,7 @@
 #define ID_ICON_BORDERS 1, 9, 32, 24
 
 /// Fallback time if none of the config entries are set for USE_LOW_LIVING_HOUR_INTERN
-#define INTERN_THRESHOLD_FALLBACK_TIME (15 HOURS)
+#define INTERN_THRESHOLD_FALLBACK_HOURS 15
 
 /// Max time interval between projecting holopays
 #define HOLOPAY_PROJECTION_INTERVAL 7 SECONDS
@@ -935,11 +935,10 @@
 	if(!SSdbcore.Connect())
 		return
 
-	var/intern_threshold = (CONFIG_GET(number/use_low_living_hour_intern_hours) * (1 HOURS)) || (CONFIG_GET(number/use_exp_restrictions_heads_hours) * (1 HOURS)) || INTERN_THRESHOLD_FALLBACK_TIME
-	var/playtime = user.client.get_exp_living(pure_numeric = TRUE) //Pure numeric, so any values returned by this proc will be in minutes (via the DB).
+	var/intern_threshold = (CONFIG_GET(number/use_low_living_hour_intern_hours) * 60) || (CONFIG_GET(number/use_exp_restrictions_heads_hours) * 60) || INTERN_THRESHOLD_FALLBACK_HOURS * 60
+	var/playtime = user.client.get_exp_living(pure_numeric = TRUE)
 
-	// The evaluation done here is done on the deciseconds level using the time defines.
-	if((intern_threshold >= (playtime MINUTES)) && (user.mind?.assigned_role.job_flags & JOB_CAN_BE_INTERN))
+	if((intern_threshold >= playtime) && (user.mind?.assigned_role.job_flags & JOB_CAN_BE_INTERN))
 		is_intern = TRUE
 		update_label()
 		return
@@ -1644,5 +1643,5 @@
 	desc = "A card used to identify members of the green team for CTF"
 	icon_state = "ctf_green"
 
-#undef INTERN_THRESHOLD_FALLBACK_TIME
+#undef INTERN_THRESHOLD_FALLBACK_HOURS
 #undef ID_ICON_BORDERS

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -18,13 +18,12 @@ GLOBAL_PROTECT(exp_to_update)
 	var/isexempt = C.prefs.db_flags & DB_FLAG_EXEMPT
 	if(isexempt)
 		return 0
-	var/my_exp = (C.calc_exp_type(get_exp_req_type()) SECONDS) // this value is returned in minutes via the DB, we set it to seconds.
-	var/job_requirement = (get_exp_req_amount() / 10) // this value is returned in deciseconds, we set it to seconds.
-	if(my_exp >= job_requirement) // The evaluation done here is done on the seconds level using the time defines.
+	var/my_exp = C.calc_exp_type(get_exp_req_type()) // this value is returned in minutes via the DB.
+	var/job_requirement = get_exp_req_amount() // this value is returned in deciseconds.
+	if((my_exp * (1 MINUTES)) >= job_requirement) // The evaluation done here is done on the deciseconds level using the time defines.
 		return 0
 	else
-		return (job_requirement - my_exp) / 60 // this turns it into minutes, Jobs will turn it into hours.
-
+		return (job_requirement - (my_exp * (1 MINUTES)))
 #undef IS_XP_LOCKED
 
 

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -2,7 +2,6 @@ GLOBAL_LIST_EMPTY(exp_to_update)
 GLOBAL_PROTECT(exp_to_update)
 
 #define IS_XP_LOCKED(job) (exp_requirements && ((exp_required_type_department && CONFIG_GET(flag/use_exp_restrictions_heads)) || (exp_required_type && CONFIG_GET(flag/use_exp_restrictions_other))))
-
 // Procs
 /datum/job/proc/required_playtime_remaining(client/C)
 	if(!C)
@@ -18,20 +17,20 @@ GLOBAL_PROTECT(exp_to_update)
 	var/isexempt = C.prefs.db_flags & DB_FLAG_EXEMPT
 	if(isexempt)
 		return 0
-	var/my_exp = C.calc_exp_type(get_exp_req_type()) // this value is returned in minutes via the DB.
-	var/job_requirement = get_exp_req_amount() // this value is returned in deciseconds.
-	if((my_exp * (1 MINUTES)) >= job_requirement) // The evaluation done here is done on the deciseconds level using the time defines.
+	var/my_exp = C.calc_exp_type(get_exp_req_type())
+	var/job_requirement = get_exp_req_amount()
+	if(my_exp >= job_requirement)
 		return 0
 	else
-		return (job_requirement - (my_exp * (1 MINUTES)))
+		return (job_requirement - my_exp)
 #undef IS_XP_LOCKED
 
 
 /datum/job/proc/get_exp_req_amount()
 	if(exp_required_type_department)
-		var/config_minimum_time = CONFIG_GET(number/use_exp_restrictions_heads_hours)
-		if(config_minimum_time)
-			return config_minimum_time * (1 HOURS)
+		var/uerhh = CONFIG_GET(number/use_exp_restrictions_heads_hours)
+		if(uerhh)
+			return uerhh * 60
 	return exp_requirements
 
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -52,8 +52,8 @@
 	/// The job's outfit that will be assigned for plasmamen.
 	var/plasmaman_outfit = null
 
-	/// Hours of experience-time required to play in this job. There are codebase defined constants for this, but this can be overwritten via config using `USE_EXP_RESTRICTIONS_HEADS_HOURS`.
-	var/exp_requirements = 0 HOURS
+	/// Minutes of experience-time required to play in this job. The type is determined by [exp_required_type] and [exp_required_type_department] depending on configs.
+	var/exp_requirements = 0
 	/// Experience required to play this job, if the config is enabled, and `exp_required_type_department` is not enabled with the proper config.
 	var/exp_required_type = ""
 	/// Department experience required to play this job, if the config is enabled.

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -10,7 +10,7 @@
 	spawn_type = /mob/living/silicon/ai
 	req_admin_notify = TRUE
 	minimal_player_age = 30
-	exp_requirements = 3 HOURS
+	exp_requirements = 180
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_SILICON
 	exp_granted_type = EXP_TYPE_CREW

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 2
 	supervisors = SUPERVISOR_CE
 	selection_color = "#fff5cc"
-	exp_requirements = 1 HOURS
+	exp_requirements = 60
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -12,7 +12,7 @@
 	selection_color = "#ccccff"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 3 HOURS
+	exp_requirements = 180
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_COMMAND
 	exp_granted_type = EXP_TYPE_CREW

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 2
 	supervisors = SUPERVISOR_CMO
 	selection_color = "#ffeef0"
-	exp_requirements = 1 HOURS
+	exp_requirements = 60
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -12,7 +12,7 @@
 	selection_color = "#ffeeaa"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 3 HOURS
+	exp_requirements = 180
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_ENGINEERING
 	exp_granted_type = EXP_TYPE_CREW

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -12,7 +12,7 @@
 	selection_color = "#ffddf0"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 3 HOURS
+	exp_requirements = 180
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_MEDICAL
 	exp_granted_type = EXP_TYPE_CREW

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -9,7 +9,7 @@
 	selection_color = "#ddffdd"
 	spawn_type = /mob/living/silicon/robot
 	minimal_player_age = 21
-	exp_requirements = 3 HOURS
+	exp_requirements = 120
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -10,7 +10,7 @@
 	supervisors = SUPERVISOR_HOS
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 5 HOURS
+	exp_requirements = 300
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 2
 	supervisors = SUPERVISOR_RD
 	selection_color = "#ffeeff"
-	exp_requirements = 1 HOURS
+	exp_requirements = 60
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -12,7 +12,7 @@
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	minimal_player_age = 10
-	exp_requirements = 3 HOURS
+	exp_requirements = 180
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_SERVICE
 	exp_granted_type = EXP_TYPE_CREW

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -12,7 +12,7 @@
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 5 HOURS
+	exp_requirements = 300
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_SECURITY
 	exp_granted_type = EXP_TYPE_CREW

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -14,7 +14,7 @@
 	req_admin_notify = 1
 	minimal_player_age = 7
 	exp_required_type_department = EXP_TYPE_SCIENCE
-	exp_requirements = 3 HOURS
+	exp_requirements = 180
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 2
 	supervisors = SUPERVISOR_RD
 	selection_color = "#ffeeff"
-	exp_requirements = 1 HOURS
+	exp_requirements = 60
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 	bounty_types = CIV_JOB_ROBO

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 3
 	supervisors = SUPERVISOR_RD
 	selection_color = "#ffeeff"
-	exp_requirements = 1 HOURS
+	exp_requirements = 60
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -10,7 +10,7 @@
 	supervisors = "the Head of Security, and the head of your assigned department (if applicable)"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 5 HOURS
+	exp_requirements = 300
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 5
 	supervisors = SUPERVISOR_CE
 	selection_color = "#fff5cc"
-	exp_requirements = 1 HOURS
+	exp_requirements = 60
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 1
 	supervisors = SUPERVISOR_CMO
 	selection_color = "#ffeef0"
-	exp_requirements = 1 HOURS
+	exp_requirements = 60
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -11,7 +11,7 @@
 	supervisors = SUPERVISOR_HOS
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 5 HOURS
+	exp_requirements = 300
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_CREW
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -66,7 +66,7 @@ ENABLE_LOCALHOST_RANK
 ## Unhash this to enable playtime requirements for head jobs.
 #USE_EXP_RESTRICTIONS_HEADS
 ## Unhash this to override head jobs' playtime requirements with this number of hours.
-## Leave this commented out to use the values defined in the job datums.
+## Leave this commented out to use the values defined in the job datums. Values in the datums are stored as minutes.
 #USE_EXP_RESTRICTIONS_HEADS_HOURS 3
 ## Unhash this to change head jobs' playtime requirements so that they're based on department playtime, rather than crew playtime.
 #USE_EXP_RESTRICTIONS_HEADS_DEPARTMENT


### PR DESCRIPTION
Fixes #69422

Reverts tgstation/tgstation#69368 (6f2354e694f3412a76b383f684a0bfc85a448d8e)

Also reverting https://github.com/tgstation/tgstation/pull/68856 (5b77361d399ba0dd992e61a16b9bbe38e8aa5a60).

I played with systems beyond my comphrension, as well as anyone else's. Doing these types/calibre of changes appears to break job requirement restrictions in ways that I am presently unable to unravel. 