### PR TITLE
replace the directional firelocks on metastation with windoors

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -26730,7 +26730,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "jzC" = (
-/obj/machinery/door/firedoor/border_only/closed{
+/obj/machinery/door/window/right/directional/north{
 	dir = 8;
 	name = "Animal Pen A"
 	},
@@ -66712,7 +66712,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "xyI" = (
-/obj/machinery/door/firedoor/border_only/closed{
+/obj/machinery/door/window/left/directional/south{
 	dir = 8;
 	name = "Animal Pen B"
 	},


### PR DESCRIPTION
## About The Pull Request

<details><summary>-Replaces the two directional firelocks that start closed with windoors</summary>
<img src="https://user-images.githubusercontent.com/85910816/186397984-9677a127-6aee-4270-92a6-71df0d5afe8f.png"></details>

<details><summary>it got the ok</summary>
<img src="https://user-images.githubusercontent.com/85910816/186397133-9289a557-c758-43b8-915e-d389acac56fa.png"></details>

Fixes: #69403

## Why It's Good For The Game

No more firealarm trigger roundstart

## Changelog
:cl:
fix: Replaced the directional firelocks on Metastation garden with windoors, so the fire alarm isn't triggered shift start.
/:cl:

