### PR TITLE
[GBP NO UPDATE] Updates the auxlua dependency version in dependencies.sh

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -24,4 +24,4 @@ export PYTHON_VERSION=3.7.9
 export AUXLUA_REPO=tgstation/auxlua
 
 #auxlua git tag
-export AUXLUA_VERSION=1.1.1
+export AUXLUA_VERSION=1.2.1


### PR DESCRIPTION
## About The Pull Request

I forgot to update the auxlua dependency version number to 1.2.1 in #69271

## Why It's Good For The Game

Should be obvious that linux boxes should be running the same version as windows boxes.

## Changelog

no player-facing changes
