### PR TITLE
Changes a mining base prison intercom to a normal intercom

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -7704,7 +7704,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/item/radio/intercom/prison/directional/east,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},


### PR DESCRIPTION


## About The Pull Request

changes a prison intercom on the mining base to a normal one

## Why It's Good For The Game

miners arent prisoners (yet)

## Changelog



:cl:

fix: a mining intercom being the incorrect type

/:cl:


