### PR TITLE
ghouls now have Fakedeath

### DIFF
--- a/code/modules/antagonists/heretic/status_effects/ghoul.dm
+++ b/code/modules/antagonists/heretic/status_effects/ghoul.dm
@@ -55,6 +55,7 @@
 		human_target.health = new_max_health
 
 	on_made_callback?.Invoke(human_target)
+	ADD_TRAIT(human_target, TRAIT_FAKEDEATH, REF(src))
 	human_target.become_husk(MAGIC_TRAIT)
 	human_target.faction |= FACTION_HERETIC
 
@@ -80,6 +81,7 @@
 		human_target.setMaxHealth(initial(human_target.maxHealth))
 
 	on_lost_callback?.Invoke(human_target)
+	REMOVE_TRAIT(human_target, TRAIT_FAKEDEATH, REF(src))
 	human_target.cure_husk(MAGIC_TRAIT)
 	human_target.faction -= FACTION_HERETIC
 	human_target.mind?.remove_antag_datum(/datum/antagonist/heretic_monster)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ghouls now appear dead on most scanners, and other things that check life.

## Why It's Good For The Game

Ghouls are definitely supposed to be undead. One subtype of them is literally called "voiceless dead", and as such they are definitely also not human. But when they LOOK human (not visually, but rather lack of nodeath trait) it becomes an administrative mess to deal with.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Ghouls now appear dead to health scanners and other detections of life.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
