### PR TITLE
Fix heretic sacrifice minigame to drop legcuffs

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
@@ -30,8 +30,14 @@
 	REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, type)
 
 /datum/status_effect/unholy_determination/tick()
+	// If a person is legcuffed they get a healing bonus since it's harder to dodge
+	var/healing_legcuff_bonus = 0
+	if(ishuman(owner))
+		var/mob/living/carbon/human/human_owner = owner
+		healing_legcuff_bonus = human_owner.legcuffed ? 2 : 0
+
 	// The amount we heal of each damage type per tick. If we're missing legs we heal better because we can't dodge.
-	var/healing_amount = 1 + (2 - owner.usable_legs)
+	var/healing_amount = 1 + (2 - owner.usable_legs) + healing_legcuff_bonus
 
 	// In softcrit you're, strong enough to stay up.
 	if(owner.health <= owner.crit_threshold && owner.health >= owner.hardcrit_threshold)

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
@@ -30,14 +30,8 @@
 	REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, type)
 
 /datum/status_effect/unholy_determination/tick()
-	// If a person is legcuffed they get a healing bonus since it's harder to dodge
-	var/healing_legcuff_bonus = 0
-	if(ishuman(owner))
-		var/mob/living/carbon/human/human_owner = owner
-		healing_legcuff_bonus = human_owner.legcuffed ? 2 : 0
-
 	// The amount we heal of each damage type per tick. If we're missing legs we heal better because we can't dodge.
-	var/healing_amount = 1 + (2 - owner.usable_legs) + healing_legcuff_bonus
+	var/healing_amount = 1 + (2 - owner.usable_legs)
 
 	// In softcrit you're, strong enough to stay up.
 	if(owner.health <= owner.crit_threshold && owner.health >= owner.hardcrit_threshold)

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -225,6 +225,13 @@
 	sac_target.visible_message(span_danger("[sac_target] begins to shudder violenty as dark tendrils begin to drag them into thin air!"))
 	sac_target.set_handcuffed(new /obj/item/restraints/handcuffs/energy/cult(sac_target))
 	sac_target.update_handcuffed()
+	
+	if(sac_target.legcuffed)
+		sac_target.legcuffed.forceMove(sac_target.drop_location())
+		sac_target.legcuffed.dropped(sac_target)
+		sac_target.legcuffed = null
+		sac_target.update_worn_legcuffs()
+	
 	sac_target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 85, 150)
 	sac_target.do_jitter_animation()
 	log_combat(heretic_mind.current, sac_target, "sacrificed")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #69435

Legcuffed people would die during the heretic minigames.  They now have their legcuffs removed before the minigame is started.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Herectic minigame won't be instadeath if you are legcuffed.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: heretic sacrifices will drop their legcuffs before entering the minigame (bolas, bear traps)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
