### PR TITLE
Removes 1.4 seconds from game init on LOWMEMORYMODE

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -141,10 +141,6 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		for(var/turf/open/space/space_tile in RANGE_TURFS(1, src))
 			space_tile.update_starlight()
 
-	var/area/thisarea = get_area(W)
-	if(thisarea.lighting_effect)
-		W.add_overlay(thisarea.lighting_effect)
-
 	QUEUE_SMOOTH_NEIGHBORS(src)
 	QUEUE_SMOOTH(src)
 

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -47,8 +47,7 @@
 		add_base_lighting()
 
 /area/proc/remove_base_lighting()
-	for(var/turf/T in src)
-		T.cut_overlay(lighting_effect)
+	cut_overlay(lighting_effect)
 	QDEL_NULL(lighting_effect)
 	area_has_base_lighting = FALSE
 
@@ -60,7 +59,7 @@
 	lighting_effect.alpha = base_lighting_alpha
 	lighting_effect.color = base_lighting_color
 	lighting_effect.appearance_flags = RESET_TRANSFORM | RESET_ALPHA | RESET_COLOR
+	add_overlay(lighting_effect)
 	for(var/turf/T in src)
-		T.add_overlay(lighting_effect)
 		T.luminosity = 1
 	area_has_base_lighting = TRUE

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -99,11 +99,6 @@
 				lighting_build_overlay()
 			else
 				lighting_clear_overlay()
-	//Inherit overlay of new area
-	if(old_area.lighting_effect)
-		cut_overlay(old_area.lighting_effect)
-	if(new_area.lighting_effect)
-		add_overlay(new_area.lighting_effect)
 
 /turf/proc/generate_missing_corners()
 	if (!lighting_corner_NE)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We were spending 1.4 seconds on doing an add_overlay on EVERY turf in /area/space

There's no fukin reason to do this, you CAN JUST ADD OVERLAYS TO AREAS IT WAS POINTLESS. I HATE IT HERE
