### PR TITLE
Removes number-only AI names (from ai_names).

### DIFF
--- a/strings/names/ai.txt
+++ b/strings/names/ai.txt
@@ -1,7 +1,5 @@
 1-Rover-1
-16-20
 7-Zark-7
-790
 Adaptive Manipulator
 Allied Mastercomputer
 Alpha 5
@@ -15,7 +13,7 @@ Aniel
 Asimov
 ASTAR
 Astor
-B O B 
+B O B
 B-4
 B-9
 B166ER
@@ -40,7 +38,7 @@ Dor-15
 Dorfl
 Dot Matrix
 Duey
-E D I 
+E D I
 E-Man
 ED-209
 Emma-2
@@ -57,9 +55,9 @@ G2
 George
 Gnut
 Gort
-H A R L I E 
-H E L P eR 
-H E R B I E 
+H A R L I E
+H E L P eR
+H E R B I E
 Hadaly
 HAL 9000
 Huey
@@ -86,7 +84,7 @@ Mechagodzilla
 Mechani-Kong
 Megatron
 Metalhead
-Mr R I N G 
+Mr R I N G
 Mugsy3000
 NCH
 Necron-99
@@ -103,10 +101,10 @@ Revelation
 Ro-Man
 Robbie
 Robot Devil
-S A M 
-S H O C K 
-S H R O U D 
-S O P H I E 
+S A M
+S H O C K
+S H R O U D
+S O P H I E
 SEN 5241
 Setaur
 SHODAN
@@ -130,7 +128,7 @@ TWA
 ULTRABOT
 Ulysses
 Uniblab
-V I N CENT 
+V I N CENT
 Voltes V
 W1k1
 Wikipedia


### PR DESCRIPTION
## About The Pull Request

Removes AI names that starts with/only has numbers in their name.
I personally support this over letting AIs use number-only names, because I find it important to be able to recognize AI names, and being just numbers messes with that idea.

It's also the system we have currently, and these being AI names means they will runtime if randomly selected, hence https://github.com/tgstation/tgstation/issues/68170

## Changelog

None needed.