### PR TITLE
Fixes double define of multilayer cable examine

### DIFF
--- a/code/modules/power/multiz.dm
+++ b/code/modules/power/multiz.dm
@@ -12,9 +12,8 @@
 	. += locate(/obj/structure/cable/multilayer/multiz) in (SSmapping.get_turf_below(T))
 	. += locate(/obj/structure/cable/multilayer/multiz) in (SSmapping.get_turf_above(T))
 
-/obj/structure/cable/multilayer/examine(mob/user)
-	. += ..()
+/obj/structure/cable/multilayer/multiz/examine(mob/user)
+	. = ..()
 	var/turf/T = get_turf(src)
 	. += span_notice("[locate(/obj/structure/cable/multilayer/multiz) in (SSmapping.get_turf_below(T)) ? "Detected" : "Undetected"] hub UP.")
 	. += span_notice("[locate(/obj/structure/cable/multilayer/multiz) in (SSmapping.get_turf_above(T)) ? "Detected" : "Undetected"] hub DOWN.")
-


### PR DESCRIPTION
## About The Pull Request

One of the examines for multilayer cables were meant to be on the ``multiz`` subtype, since it's only for multiz stuff.

![image](https://user-images.githubusercontent.com/53777086/186652314-e12e0b0d-e5b5-48c4-b116-7e8c85b5cdcc.png)

## Why It's Good For The Game

Bug fix? A bug that doesn't appear in game. Either way, I thought I might as well put this up.

## Changelog

No player facing changes.