### PR TITLE
Improves glove finger cutting.

### DIFF
--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -42,14 +42,15 @@
 		M.update_worn_gloves()
 
 /obj/item/clothing/gloves/attackby(obj/item/I, mob/user, params)
-	if(do_after(user, 3 SECONDS, target=src))
-		if(I.tool_behaviour == TOOL_WIRECUTTER || I.get_sharpness())
-			if(!cut_type)
-				return
-			if(icon_state != initial(icon_state))
-				return // We don't want to cut dyed gloves.
-			balloon_alert(user, "cut fingertips off")
-			qdel(src)
-			user.put_in_hands(new cut_type)
-		else
+	if(I.tool_behaviour == TOOL_WIRECUTTER || I.get_sharpness())
+		if(!cut_type)
 			return
+		if(icon_state != initial(icon_state))
+			return // We don't want to cut dyed gloves.
+		if(!do_after(user, 3 SECONDS, target=src))
+			return
+		balloon_alert(user, "cut fingertips off")
+		qdel(src)
+		user.put_in_hands(new cut_type)
+	else
+		return

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -41,12 +41,14 @@
 		var/mob/M = loc
 		M.update_worn_gloves()
 
-/obj/item/clothing/gloves/wirecutter_act(mob/living/user, obj/item/I)
-	. = ..()
-	if(!cut_type)
+/obj/item/clothing/gloves/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_WIRECUTTER || I.get_sharpness())
+		if(!cut_type)
+			return
+		if(icon_state != initial(icon_state))
+			return // We don't want to cut dyed gloves.
+		to_chat(user, "<span class='notice'>You cut the fingers off of [src].</span>")
+		qdel(src)
+		user.put_in_hands(new cut_type)
+	else
 		return
-	if(icon_state != initial(icon_state))
-		return // We don't want to cut dyed gloves.
-	new cut_type(drop_location())
-	qdel(src)
-	return TRUE

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -55,7 +55,7 @@
 		return
 	balloon_alert(user, "cutting off fingertips...")
 	
-	if(!do_after(user, 3 SECONDS, target=src, extra_checks = CALLBACK(src, .proc/can_cut_with, tool, user)))
+	if(!do_after(user, 3 SECONDS, target=src, extra_checks = CALLBACK(src, .proc/can_cut_with, tool)))
 		return
 	balloon_alert(user, "cut fingertips off")
 	qdel(src)

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -42,13 +42,14 @@
 		M.update_worn_gloves()
 
 /obj/item/clothing/gloves/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_WIRECUTTER || I.get_sharpness())
-		if(!cut_type)
+	if(do_after(user, 3 SECONDS, target=src))
+		if(I.tool_behaviour == TOOL_WIRECUTTER || I.get_sharpness())
+			if(!cut_type)
+				return
+			if(icon_state != initial(icon_state))
+				return // We don't want to cut dyed gloves.
+			balloon_alert(user, "cut fingertips off")
+			qdel(src)
+			user.put_in_hands(new cut_type)
+		else
 			return
-		if(icon_state != initial(icon_state))
-			return // We don't want to cut dyed gloves.
-		to_chat(user, span_notice("You cut the fingertips off of [src]."))
-		qdel(src)
-		user.put_in_hands(new cut_type)
-	else
-		return

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -41,19 +41,22 @@
 		var/mob/M = loc
 		M.update_worn_gloves()
 		
-/obj/item/clothing/gloves/proc/can_cut_with(obj/item/I, mob/user)
+/obj/item/clothing/gloves/proc/can_cut_with(obj/item/tool)
 	if(!cut_type)
 		return FALSE
 	if(icon_state != initial(icon_state))
 		return FALSE // We don't want to cut dyed gloves.
-	else
-		return TRUE
+	return TRUE
 
-/obj/item/clothing/gloves/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_WIRECUTTER || I.get_sharpness())	
-		if(do_after(user, 3 SECONDS, target=src, extra_checks = CALLBACK(src, .proc/can_cut_with, I, user)))
-			balloon_alert(user, "cut fingertips off")
-			qdel(src)
-			user.put_in_hands(new cut_type)
-		else
-			return
+/obj/item/clothing/gloves/attackby(obj/item/tool, mob/user, params)
+	if(tool.tool_behaviour != TOOL_WIRECUTTER && !tool.get_sharpness())
+		return
+	if (!can_cut_with(tool))
+		return
+	balloon_alert(user, "cutting off fingertips...")
+	
+	if(!do_after(user, 3 SECONDS, target=src, extra_checks = CALLBACK(src, .proc/can_cut_with, tool, user)))
+		return
+	balloon_alert(user, "cut fingertips off")
+	qdel(src)
+	user.put_in_hands(new cut_type)

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -40,17 +40,20 @@
 	if(ismob(loc))
 		var/mob/M = loc
 		M.update_worn_gloves()
+		
+/obj/item/clothing/gloves/proc/can_cut_with(obj/item/I, mob/user)
+	if(!cut_type)
+		return FALSE
+	if(icon_state != initial(icon_state))
+		return FALSE // We don't want to cut dyed gloves.
+	else
+		return TRUE
 
 /obj/item/clothing/gloves/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_WIRECUTTER || I.get_sharpness())
-		if(!cut_type)
+	if(I.tool_behaviour == TOOL_WIRECUTTER || I.get_sharpness())	
+		if(do_after(user, 3 SECONDS, target=src, extra_checks = CALLBACK(src, .proc/can_cut_with, I, user)))
+			balloon_alert(user, "cut fingertips off")
+			qdel(src)
+			user.put_in_hands(new cut_type)
+		else
 			return
-		if(icon_state != initial(icon_state))
-			return // We don't want to cut dyed gloves.
-		if(!do_after(user, 3 SECONDS, target=src))
-			return
-		balloon_alert(user, "cut fingertips off")
-		qdel(src)
-		user.put_in_hands(new cut_type)
-	else
-		return

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -47,7 +47,7 @@
 			return
 		if(icon_state != initial(icon_state))
 			return // We don't want to cut dyed gloves.
-		to_chat(user, "<span class='notice'>You cut the fingers off of [src].</span>")
+		to_chat(user, span_notice("You cut the fingertips off of [src]."))
 		qdel(src)
 		user.put_in_hands(new cut_type)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request changes glove finger cutting to be more like other actions of its sort, like bedsheet cutting.

Namely:
1. You can cut fingers off of gloves with anything sharp, instead of just wirecutters.
2. You get a notice in the chat when you do it, instead of it being silent.
3. The fingerless glove shows up in your hand, instead of dropping on the floor.

There used to be a notice when you did it before #54446, but i guess it was lost inadvertently.

## Why It's Good For The Game

By bringing glove cutting up to par with other, similar cutting actions (like bedsheet cutting and hedge trimming), i think it makes the game more consistent.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now cut the fingers off of black or insulated gloves with any sharp object, instead of just wirecutters.
qol: You now get a notice in chat when you cut the fingers off of gloves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
