### PR TITLE
Excited groups will care about gas reactions before dismantling. Turfs will not sleep when there are gas reactions. Fixes water vapour not consuming water vapour when freezing turfs.

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -386,8 +386,9 @@ SUBSYSTEM_DEF(air)
 		EG.dismantle_cooldown++
 		if(EG.breakdown_cooldown >= EXCITED_GROUP_BREAKDOWN_CYCLES)
 			EG.self_breakdown(poke_turfs = TRUE)
-		else if(EG.dismantle_cooldown >= EXCITED_GROUP_DISMANTLE_CYCLES)
+		else if(EG.dismantle_cooldown >= EXCITED_GROUP_DISMANTLE_CYCLES && !(EG.has_reactions & (REACTING | STOP_REACTIONS)))
 			EG.dismantle()
+		EG.has_reactions = NONE
 		if (MC_TICK_CHECK)
 			return
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -386,9 +386,9 @@ SUBSYSTEM_DEF(air)
 		EG.dismantle_cooldown++
 		if(EG.breakdown_cooldown >= EXCITED_GROUP_BREAKDOWN_CYCLES)
 			EG.self_breakdown(poke_turfs = TRUE)
-		else if(EG.dismantle_cooldown >= EXCITED_GROUP_DISMANTLE_CYCLES && !(EG.has_reactions & (REACTING | STOP_REACTIONS)))
+		else if(EG.dismantle_cooldown >= EXCITED_GROUP_DISMANTLE_CYCLES && !(EG.turf_reactions & (REACTING | STOP_REACTIONS)))
 			EG.dismantle()
-		EG.has_reactions = NONE
+		EG.turf_reactions = NONE
 		if (MC_TICK_CHECK)
 			return
 

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -347,7 +347,7 @@
 
 	var/reacting = our_air.react(src)
 	if(our_excited_group)
-		our_excited_group.turf_reactions |= reacting
+		our_excited_group.turf_reactions |= reacting //Adds the flag to turf_reactions so excited groups can check for them before dismantling.
 
 	update_visuals()
 	if(!consider_superconductivity(starting = TRUE) && !active_hotspot && !(reacting & (REACTING | STOP_REACTIONS)))

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -41,8 +41,6 @@
 
 	///If there is an active hotspot on us store a reference to it here
 	var/obj/effect/hotspot/active_hotspot
-	///If there is a reaction, store the result.
-	var/reacting
 	/// air will slowly revert to initial_gas_mix
 	var/planetary_atmos = FALSE
 	/// once our paired turfs are finished with all other shares, do one 100% share
@@ -347,12 +345,12 @@
 		else
 			enemy_tile.consider_pressure_difference(src, difference)
 
-	reacting = our_air.react(src)
+	var/reacting = our_air.react(src)
 	if(our_excited_group)
-		our_excited_group.has_reactions |= reacting
+		our_excited_group.turf_reactions |= reacting
 
 	update_visuals()
-	if(!consider_superconductivity(starting = TRUE) && !active_hotspot && !reacting) //Might need to include the return of react() here
+	if(!consider_superconductivity(starting = TRUE) && !active_hotspot && !(reacting & (REACTING | STOP_REACTIONS)))
 		if(!our_excited_group) //If nothing of interest is happening, kill the active turf
 			SSair.remove_from_active(src) //This will kill any connected excited group, be careful (This broke atmos for 4 years)
 		if(cached_ticker > EXCITED_GROUP_DISMANTLE_CYCLES) //If you're stalling out, take a rest
@@ -411,8 +409,8 @@
 	var/display_id = 0
 	///Wrapping loop of the index colors
 	var/static/wrapping_id = 0
-	///If there are turfs in the group with gasmixtures with reactions occuring.
-	var/has_reactions = NONE
+	///All turf reaction flags we have received.
+	var/turf_reactions = NONE
 
 /datum/excited_group/New()
 	SSair.excited_groups += src

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -41,6 +41,8 @@
 
 	///If there is an active hotspot on us store a reference to it here
 	var/obj/effect/hotspot/active_hotspot
+	///If there is a reaction, store the result.
+	var/reacting
 	/// air will slowly revert to initial_gas_mix
 	var/planetary_atmos = FALSE
 	/// once our paired turfs are finished with all other shares, do one 100% share
@@ -345,10 +347,12 @@
 		else
 			enemy_tile.consider_pressure_difference(src, difference)
 
-	our_air.react(src)
+	reacting = our_air.react(src)
+	if(our_excited_group)
+		our_excited_group.has_reactions |= reacting
 
 	update_visuals()
-	if(!consider_superconductivity(starting = TRUE) && !active_hotspot) //Might need to include the return of react() here
+	if(!consider_superconductivity(starting = TRUE) && !active_hotspot && !reacting) //Might need to include the return of react() here
 		if(!our_excited_group) //If nothing of interest is happening, kill the active turf
 			SSair.remove_from_active(src) //This will kill any connected excited group, be careful (This broke atmos for 4 years)
 		if(cached_ticker > EXCITED_GROUP_DISMANTLE_CYCLES) //If you're stalling out, take a rest
@@ -407,6 +411,8 @@
 	var/display_id = 0
 	///Wrapping loop of the index colors
 	var/static/wrapping_id = 0
+	///If there are turfs in the group with gasmixtures with reactions occuring.
+	var/has_reactions = NONE
 
 /datum/excited_group/New()
 	SSair.excited_groups += src

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -106,17 +106,19 @@
 		return
 
 	var/turf/open/location = holder
+	var/consumed = 0
 	switch(air.temperature)
 		if(-INFINITY to WATER_VAPOR_DEPOSITION_POINT)
 			if(location?.freeze_turf())
-				air.gases[/datum/gas/water_vapor][MOLES] -= MOLES_GAS_VISIBLE
-				SET_REACTION_RESULTS(MOLES_GAS_VISIBLE)
-				. = REACTING
+				consumed = MOLES_GAS_VISIBLE
 		if(WATER_VAPOR_DEPOSITION_POINT to WATER_VAPOR_CONDENSATION_POINT)
 			location.water_vapor_gas_act()
-			air.gases[/datum/gas/water_vapor][MOLES] -= MOLES_GAS_VISIBLE
-			SET_REACTION_RESULTS(MOLES_GAS_VISIBLE)
-			. = REACTING
+			consumed = MOLES_GAS_VISIBLE
+
+	if(consumed)
+		air.gases[/datum/gas/water_vapor] -= consumed
+		SET_REACTION_RESULTS(consumed)
+		. = REACTING
 
 
 /**

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -109,8 +109,9 @@
 	switch(air.temperature)
 		if(-INFINITY to WATER_VAPOR_DEPOSITION_POINT)
 			if(location?.freeze_turf())
-				SET_REACTION_RESULTS(0)
-			. = REACTING
+				air.gases[/datum/gas/water_vapor][MOLES] -= MOLES_GAS_VISIBLE
+				SET_REACTION_RESULTS(MOLES_GAS_VISIBLE)
+				. = REACTING
 		if(WATER_VAPOR_DEPOSITION_POINT to WATER_VAPOR_CONDENSATION_POINT)
 			location.water_vapor_gas_act()
 			air.gases[/datum/gas/water_vapor][MOLES] -= MOLES_GAS_VISIBLE

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -116,7 +116,7 @@
 			consumed = MOLES_GAS_VISIBLE
 
 	if(consumed)
-		air.gases[/datum/gas/water_vapor] -= consumed
+		air.gases[/datum/gas/water_vapor][MOLES] -= consumed
 		SET_REACTION_RESULTS(consumed)
 		. = REACTING
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Excited groups will no longer dismantle when there is a gas reaction occurring, and turfs no longer sleep when there's a gas reaction. Fixes water vapour not consuming water vapour when freezing turfs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
To prevent odd phenomena where turfs with water vapour sleep, then stop applying the slippery effect despite being in conditions to react.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes water vapour not consuming water vapour when freezing turfs.
code: Turfs will not sleep during an ongoing gas reaction, and excited groups won't dismantle if one of their turfs are reacting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
