### PR TITLE
Fixes The human and monkey rudimentary transform commands in the player menu for admins. Makes the change_mob_type() proc more readable.

### DIFF
--- a/code/datums/ai/monkey/monkey_subtrees.dm
+++ b/code/datums/ai/monkey/monkey_subtrees.dm
@@ -30,10 +30,12 @@
 	var/list/enemies = controller.blackboard[BB_MONKEY_ENEMIES]
 
 	if((HAS_TRAIT(controller.pawn, TRAIT_PACIFISM)) || (!length(enemies) && !controller.blackboard[BB_MONKEY_AGGRESSIVE])) //Pacifist, or we have no enemies and we're not pissed
+		living_pawn.set_combat_mode(FALSE)
 		return
 
 	if(!controller.blackboard[BB_MONKEY_CURRENT_ATTACK_TARGET])
 		controller.queue_behavior(/datum/ai_behavior/monkey_set_combat_target, BB_MONKEY_CURRENT_ATTACK_TARGET, BB_MONKEY_ENEMIES)
+		living_pawn.set_combat_mode(FALSE)
 		return SUBTREE_RETURN_FINISH_PLANNING
 
 	var/datum/weakref/target_ref = controller.blackboard[BB_MONKEY_CURRENT_ATTACK_TARGET]
@@ -53,6 +55,7 @@
 		controller.queue_behavior(/datum/ai_behavior/monkey_attack_mob, BB_MONKEY_CURRENT_ATTACK_TARGET)
 		return SUBTREE_RETURN_FINISH_PLANNING
 
+	living_pawn.set_combat_mode(FALSE)
 	//by this point we have a target but they're down, let's try dumpstering this loser
 
 	if(!controller.blackboard[BB_MONKEY_TARGET_DISPOSAL])

--- a/code/datums/ai/monkey/monkey_subtrees.dm
+++ b/code/datums/ai/monkey/monkey_subtrees.dm
@@ -30,12 +30,10 @@
 	var/list/enemies = controller.blackboard[BB_MONKEY_ENEMIES]
 
 	if((HAS_TRAIT(controller.pawn, TRAIT_PACIFISM)) || (!length(enemies) && !controller.blackboard[BB_MONKEY_AGGRESSIVE])) //Pacifist, or we have no enemies and we're not pissed
-		living_pawn.set_combat_mode(FALSE)
 		return
 
 	if(!controller.blackboard[BB_MONKEY_CURRENT_ATTACK_TARGET])
 		controller.queue_behavior(/datum/ai_behavior/monkey_set_combat_target, BB_MONKEY_CURRENT_ATTACK_TARGET, BB_MONKEY_ENEMIES)
-		living_pawn.set_combat_mode(FALSE)
 		return SUBTREE_RETURN_FINISH_PLANNING
 
 	var/datum/weakref/target_ref = controller.blackboard[BB_MONKEY_CURRENT_ATTACK_TARGET]
@@ -55,7 +53,6 @@
 		controller.queue_behavior(/datum/ai_behavior/monkey_attack_mob, BB_MONKEY_CURRENT_ATTACK_TARGET)
 		return SUBTREE_RETURN_FINISH_PLANNING
 
-	living_pawn.set_combat_mode(FALSE)
 	//by this point we have a target but they're down, let's try dumpstering this loser
 
 	if(!controller.blackboard[BB_MONKEY_TARGET_DISPOSAL])

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -97,13 +97,12 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 
 	return ..()
 
-/datum/dna/proc/transfer_identity(mob/living/carbon/destination, transfer_SE = 0)
+/datum/dna/proc/transfer_identity(mob/living/carbon/destination, transfer_SE = FALSE, transfer_species = TRUE)
 	if(!istype(destination))
 		return
 	destination.dna.unique_enzymes = unique_enzymes
 	destination.dna.unique_identity = unique_identity
 	destination.dna.blood_type = blood_type
-	destination.set_species(species.type, icon_update=0)
 	destination.dna.unique_features = unique_features
 	destination.dna.features = features.Copy()
 	destination.dna.real_name = real_name
@@ -111,6 +110,8 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	if(transfer_SE)
 		destination.dna.mutation_index = mutation_index
 		destination.dna.default_mutation_genes = default_mutation_genes
+	if(transfer_species)
+		destination.set_species(species.type, icon_update=0)
 
 /datum/dna/proc/copy_dna(datum/dna/new_dna)
 	new_dna.unique_enzymes = unique_enzymes

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -22,39 +22,39 @@
 		to_chat(usr, span_danger("Cannot convert into a new_player mob type."))
 		return
 
-	var/mob/M
+	var/mob/desired_mob
 	if(isturf(location))
-		M = new new_type( location )
+		desired_mob = new new_type(location)
 	else
-		M = new new_type( src.loc )
+		desired_mob = new new_type(src.loc)
 
-	if(!M || !ismob(M))
+	if(!desired_mob || !ismob(desired_mob))
 		to_chat(usr, "Type path is not a mob (new_type = [new_type]) in change_mob_type(). Contact a coder.")
-		qdel(M)
+		qdel(desired_mob)
 		return
 
 	if( istext(new_name) )
-		M.name = new_name
-		M.real_name = new_name
+		desired_mob.name = new_name
+		desired_mob.real_name = new_name
 	else
-		M.name = src.name
-		M.real_name = src.real_name
+		desired_mob.name = src.name
+		desired_mob.real_name = src.real_name
 
-	if(has_dna() && M.has_dna())
-		var/mob/living/carbon/C = src
-		var/mob/living/carbon/D = M
-		C.dna.transfer_identity(D)
-		D.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
-	else if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		client?.prefs.safe_transfer_prefs_to(H)
-		H.dna.update_dna_identity()
+	if(has_dna() && desired_mob.has_dna())
+		var/mob/living/carbon/oldmob = src
+		var/mob/living/carbon/newmob = desired_mob
+		oldmob.dna.transfer_identity(newmob, transfer_species = FALSE)
+		newmob.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
+	else if(ishuman(desired_mob) && (!ismonkey(desried_mob)))
+		var/mob/living/carbon/human/new_human = desired_mob
+		client?.prefs.safe_transfer_prefs_to(new_human)
+		new_human.dna.update_dna_identity()
 
-	if(mind && isliving(M))
-		mind.transfer_to(M, 1) // second argument to force key move to new mob
+	if(mind && isliving(desired_mob))
+		mind.transfer_to(desired_mob, 1) // second argument to force key move to new mob
 	else
-		M.key = key
+		desired_mob.key = key
 
 	if(delete_old_mob)
 		QDEL_IN(src, 1)
-	return M
+	return desired_mob

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -45,7 +45,7 @@
 		var/mob/living/carbon/newmob = desired_mob
 		oldmob.dna.transfer_identity(newmob, transfer_species = FALSE)
 		newmob.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
-	else if(ishuman(desired_mob) && (!ismonkey(desried_mob)))
+	else if(ishuman(desired_mob) && (!ismonkey(desired_mob)))
 		var/mob/living/carbon/human/new_human = desired_mob
 		client?.prefs.safe_transfer_prefs_to(new_human)
 		new_human.dna.update_dna_identity()

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -46,10 +46,8 @@
 		old_mob.dna.transfer_identity(new_mob, transfer_species = FALSE)
 		new_mob.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
 	else if(ishuman(desired_mob) && (!ismonkey(desired_mob)))
-		var/mob/living/carbon/old_human
 		var/mob/living/carbon/human/new_human = desired_mob
-		client?.prefs.safe_transfer_prefs_to(old_human)
-		old_human.dna.transfer_identity(new_human, transfer_species = FALSE)
+		client?.prefs.safe_transfer_prefs_to(new_human)
 		new_human.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
 
 	if(mind && isliving(desired_mob))

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -41,14 +41,16 @@
 		desired_mob.real_name = src.real_name
 
 	if(has_dna() && desired_mob.has_dna())
-		var/mob/living/carbon/oldmob = src
-		var/mob/living/carbon/newmob = desired_mob
-		oldmob.dna.transfer_identity(newmob, transfer_species = FALSE)
-		newmob.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
+		var/mob/living/carbon/old_mob = src
+		var/mob/living/carbon/new_mob = desired_mob
+		old_mob.dna.transfer_identity(new_mob, transfer_species = FALSE)
+		new_mob.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
 	else if(ishuman(desired_mob) && (!ismonkey(desired_mob)))
+		var/mob/living/carbon/old_human
 		var/mob/living/carbon/human/new_human = desired_mob
-		client?.prefs.safe_transfer_prefs_to(new_human)
-		new_human.dna.update_dna_identity()
+		client?.prefs.safe_transfer_prefs_to(old_human)
+		old_human.dna.transfer_identity(new_human, transfer_species = FALSE)
+		new_human.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
 
 	if(mind && isliving(desired_mob))
 		mind.transfer_to(desired_mob, 1) // second argument to force key move to new mob


### PR DESCRIPTION
Fixes  #69142

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
change_mob_type is a vary archaic proc. I freshened it up, and made it stop transferring the species of the original mob to the desired mob, making monkeyfication impossible unless you were already a monkey. I also made it stop overriding your monkey species with the default dna string of human when transformed from a non-carbon.

The change_mob_proc while very old still has some utility that can't be found elsewhere, which I why I found it important to fix rather than simply make the admin command reroute to the monkeyize() proc and limit it to carbons or something like that,
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug. Part 3 of the crusade against monkeys.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: itseasytosee
fix: The monkey and human rudimentary transform commands now function as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
