### PR TITLE
Adds unit test for reagent transfer and fixes infinite reagent transfer bug.

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -492,6 +492,7 @@
 	var/trans_data = null
 	var/transfer_log = list()
 	var/r_to_send = list()	// Validated list of reagents to be exposed
+	var/reagents_to_remove = list()
 	if(!round_robin)
 		var/part = amount / src.total_volume
 		for(var/datum/reagent/reagent as anything in cached_reagents)
@@ -507,12 +508,14 @@
 			if(methods)
 				r_to_send += reagent
 
+			reagents_to_remove += reagent
+
 		if(isorgan(target_atom))
 			R.expose_multiple(r_to_send, target, methods, part, show_message)
 		else
 			R.expose_multiple(r_to_send, target_atom, methods, part, show_message)
 
-		for(var/datum/reagent/reagent as anything in r_to_send)
+		for(var/datum/reagent/reagent as anything in reagents_to_remove)
 			var/transfer_amount = reagent.volume * part
 			remove_reagent(reagent.type, transfer_amount)
 			var/list/reagent_qualities = list(REAGENT_TRANSFER_AMOUNT = transfer_amount, REAGENT_PURITY = reagent.purity)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -135,6 +135,7 @@
 #include "reagent_mod_procs.dm"
 #include "reagent_names.dm"
 #include "reagent_recipe_collisions.dm"
+#include "reagent_transfer.dm"
 #include "resist.dm"
 #include "say.dm"
 #include "screenshot_antag_icons.dm"

--- a/code/modules/unit_tests/reagent_transfer.dm
+++ b/code/modules/unit_tests/reagent_transfer.dm
@@ -9,23 +9,23 @@
 	source_container.reagents.clear_reagents()
 	target_container.reagents.clear_reagents()
 
-	TEST_ASSERT_EQUAL(length(source_container.reagents), 0, "Source container has reagents when it should be empty.")
-	TEST_ASSERT_EQUAL(length(target_container.reagents), 0, "Target container has reagents when it should be empty.")
+	TEST_ASSERT_EQUAL(length(source_container.reagents.reagent_list), 0, "Source container has reagents when it should be empty.")
+	TEST_ASSERT_EQUAL(length(target_container.reagents.reagent_list), 0, "Target container has reagents when it should be empty.")
 
 	source_container.reagents.add_reagent(/datum/reagent/water, 10)
-	TEST_ASSERT_EQUAL(length(source_container.reagents), 1, "Source container has [length(source_container.reagents)] unique reagents when only 1 is expected.")
+	TEST_ASSERT_EQUAL(length(source_container.reagents.reagent_list), 1, "Source container has [length(source_container.reagents)] unique reagents when only 1 is expected.")
 
-	var/datum/reagent/water/water_reagent = source_container.reagents[1]
+	var/datum/reagent/water/water_reagent = source_container.reagents.reagent_list[1]
 	TEST_ASSERT(istype(water_reagent), "Incorrect reagent type detected in source container: [water_reagent.type] (should be /datum/reagent/water).")
-	TEST_ASSERT_EQUAL(water_reagent.total_volume, 10, "Source container has [water_reagent.total_volume] reagent volume when 10 is expected.")
+	TEST_ASSERT_EQUAL(water_reagent.volume, 10, "Source container has [water_reagent.volume] reagent volume when 10 is expected.")
 
 	source_container.reagents.trans_to(target_container, 10)
-	TEST_ASSERT_EQUAL(length(source_container.reagents), 0, "Source container has some reagents left over from transfer when none are expected.")
+	TEST_ASSERT_EQUAL(length(source_container.reagents.reagent_list), 0, "Source container has some reagents left over from transfer when none are expected.")
 
-	TEST_ASSERT_EQUAL(length(target_container.reagents), 1, "Target container has [length(source_container.reagents)] unique reagents when only 1 is expected.")
-	water_reagent = target_container.reagents[1]
+	TEST_ASSERT_EQUAL(length(target_container.reagents.reagent_list), 1, "Target container has [length(source_container.reagents)] unique reagents when only 1 is expected.")
+	water_reagent = target_container.reagents.reagent_list[1]
 	TEST_ASSERT(istype(water_reagent), "Incorrect reagent type detected in target container: [water_reagent.type] (should be /datum/reagent/water).")
-	TEST_ASSERT_EQUAL(water_reagent.total_volume, 10, "Target container has [water_reagent.total_volume] reagent volume when 10 is expected.")
+	TEST_ASSERT_EQUAL(water_reagent.volume, 10, "Target container has [water_reagent.volume] reagent volume when 10 is expected.")
 
 /datum/unit_test/reagent_mob_expose/Destroy()
 	SSmobs.ignite()

--- a/code/modules/unit_tests/reagent_transfer.dm
+++ b/code/modules/unit_tests/reagent_transfer.dm
@@ -1,28 +1,26 @@
-/// Tests transferring reagents between two reagent_containers, making sure all the regent transfers
-/// leaving nothing behind in the source container and making sure everything is in the target container.
+/// Tests transferring reagents between two reagents datums.
 /datum/unit_test/reagent_transfer
 
 /datum/unit_test/reagent_transfer/Run()
-	var/obj/item/reagent_containers/cup/glass/bottle/source_container = allocate(/obj/item/reagent_containers/cup/glass/bottle)
-	var/obj/item/reagent_containers/cup/glass/bottle/target_container = allocate(/obj/item/reagent_containers/cup/glass/bottle)
+	var/datum/reagents/source_reagents = allocate(/datum/reagents)
+	var/datum/reagents/target_reagents = allocate(/datum/reagents)
 
-	source_container.reagents.clear_reagents()
-	target_container.reagents.clear_reagents()
+	// Quick test to make sure reagents add properly.
+	source_reagents.add_reagent(/datum/reagent/water, 10)
+	TEST_ASSERT_EQUAL(length(source_reagents.reagent_list), 1, "Source reagents has [length(source_reagents.reagent_list)] unique reagents (expected 1).")
+	TEST_ASSERT_EQUAL(source_reagents.total_volume, 10, "Source reagents has incorrect total_volume [source_reagents.total_volume] (expected 10).")
 
-	TEST_ASSERT_EQUAL(length(source_container.reagents.reagent_list), 0, "Source container has reagents when it should be empty.")
-	TEST_ASSERT_EQUAL(length(target_container.reagents.reagent_list), 0, "Target container has reagents when it should be empty.")
+	// Test to make sure the water reagent was added correctly.
+	var/datum/reagent/water/water_reagent = source_reagents.reagent_list[1]
+	TEST_ASSERT(istype(water_reagent), "Incorrect reagent type detected source reagents: [water_reagent.type] (expected /datum/reagent/water).")
+	TEST_ASSERT_EQUAL(water_reagent.volume, 10, "Source reagents has [water_reagent.volume] reagent volume (expected 10).")
 
-	source_container.reagents.add_reagent(/datum/reagent/water, 10)
-	TEST_ASSERT_EQUAL(length(source_container.reagents.reagent_list), 1, "Source container has [length(source_container.reagents)] unique reagents when only 1 is expected.")
+	// Test to make sure reagents transfer properly.
+	source_reagents.trans_to(target_reagents, 10)
+	TEST_ASSERT_EQUAL(length(source_reagents.reagent_list), 0, "Source reagents has [length(source_reagents.reagent_list)] unique reagents after transfer (expected 0, possible duplication?)")
+	TEST_ASSERT_EQUAL(length(target_reagents.reagent_list), 1, "Target reagents has [length(target_reagents.reagent_list)] unique reagents after transfer (expected 1).")
+	TEST_ASSERT_EQUAL(target_reagents.total_volume, 10, "Target reagents has incorrect total_volume [source_reagents.total_volume] (expected 10).")
 
-	var/datum/reagent/water/water_reagent = source_container.reagents.reagent_list[1]
-	TEST_ASSERT(istype(water_reagent), "Incorrect reagent type detected in source container: [water_reagent.type] (should be /datum/reagent/water).")
-	TEST_ASSERT_EQUAL(water_reagent.volume, 10, "Source container has [water_reagent.volume] reagent volume when 10 is expected.")
-
-	source_container.reagents.trans_to(target_container, 10)
-	TEST_ASSERT_EQUAL(length(source_container.reagents.reagent_list), 0, "Source container has some reagents left over from transfer when none are expected.")
-
-	TEST_ASSERT_EQUAL(length(target_container.reagents.reagent_list), 1, "Target container has [length(source_container.reagents)] unique reagents when only 1 is expected.")
-	water_reagent = target_container.reagents.reagent_list[1]
-	TEST_ASSERT(istype(water_reagent), "Incorrect reagent type detected in target container: [water_reagent.type] (should be /datum/reagent/water).")
-	TEST_ASSERT_EQUAL(water_reagent.volume, 10, "Target container has [water_reagent.volume] reagent volume when 10 is expected.")
+	water_reagent = target_reagents.reagent_list[1]
+	TEST_ASSERT(istype(water_reagent), "Incorrect reagent type detected in target reagents after transfer: [water_reagent.type] (should be /datum/reagent/water).")
+	TEST_ASSERT_EQUAL(water_reagent.volume, 10, "Target reagents has [water_reagent.volume] reagent volume (expected 10)")

--- a/code/modules/unit_tests/reagent_transfer.dm
+++ b/code/modules/unit_tests/reagent_transfer.dm
@@ -1,0 +1,32 @@
+/// Tests transferring reagents between two reagent_containers, making sure all the regent transfers
+/// leaving nothing behind in the source container and making sure everything is in the target container.
+/datum/unit_test/reagent_transfer
+
+/datum/unit_test/reagent_transfer/Run()
+	var/obj/item/reagent_containers/cup/glass/bottle/source_container = allocate(/obj/item/reagent_containers/cup/glass/bottle)
+	var/obj/item/reagent_containers/cup/glass/bottle/target_container = allocate(/obj/item/reagent_containers/cup/glass/bottle)
+
+	source_container.reagents.clear_reagents()
+	target_container.reagents.clear_reagents()
+
+	TEST_ASSERT_EQUAL(length(source_container.reagents), 0, "Source container has reagents when it should be empty.")
+	TEST_ASSERT_EQUAL(length(target_container.reagents), 0, "Target container has reagents when it should be empty.")
+
+	source_container.reagents.add_reagent(/datum/reagent/water, 10)
+	TEST_ASSERT_EQUAL(length(source_container.reagents), 1, "Source container has [length(source_container.reagents)] unique reagents when only 1 is expected.")
+
+	var/datum/reagent/water/water_reagent = source_container.reagents[1]
+	TEST_ASSERT(istype(water_reagent), "Incorrect reagent type detected in source container: [water_reagent.type] (should be /datum/reagent/water).")
+	TEST_ASSERT_EQUAL(water_reagent.total_volume, 10, "Source container has [water_reagent.total_volume] reagent volume when 10 is expected.")
+
+	source_container.reagents.trans_to(target_container, 10)
+	TEST_ASSERT_EQUAL(length(source_container.reagents), 0, "Source container has some reagents left over from transfer when none are expected.")
+
+	TEST_ASSERT_EQUAL(length(target_container.reagents), 1, "Target container has [length(source_container.reagents)] unique reagents when only 1 is expected.")
+	water_reagent = target_container.reagents[1]
+	TEST_ASSERT(istype(water_reagent), "Incorrect reagent type detected in target container: [water_reagent.type] (should be /datum/reagent/water).")
+	TEST_ASSERT_EQUAL(water_reagent.total_volume, 10, "Target container has [water_reagent.total_volume] reagent volume when 10 is expected.")
+
+/datum/unit_test/reagent_mob_expose/Destroy()
+	SSmobs.ignite()
+	return ..()

--- a/code/modules/unit_tests/reagent_transfer.dm
+++ b/code/modules/unit_tests/reagent_transfer.dm
@@ -2,8 +2,8 @@
 /datum/unit_test/reagent_transfer
 
 /datum/unit_test/reagent_transfer/Run()
-	var/datum/reagents/source_reagents = allocate(/datum/reagents)
-	var/datum/reagents/target_reagents = allocate(/datum/reagents)
+	var/datum/reagents/source_reagents = allocate(/datum/reagents, 100)
+	var/datum/reagents/target_reagents = allocate(/datum/reagents, 100)
 
 	// Quick test to make sure reagents add properly.
 	source_reagents.add_reagent(/datum/reagent/water, 10)

--- a/code/modules/unit_tests/reagent_transfer.dm
+++ b/code/modules/unit_tests/reagent_transfer.dm
@@ -26,7 +26,3 @@
 	water_reagent = target_container.reagents.reagent_list[1]
 	TEST_ASSERT(istype(water_reagent), "Incorrect reagent type detected in target container: [water_reagent.type] (should be /datum/reagent/water).")
 	TEST_ASSERT_EQUAL(water_reagent.volume, 10, "Target container has [water_reagent.volume] reagent volume when 10 is expected.")
-
-/datum/unit_test/reagent_mob_expose/Destroy()
-	SSmobs.ignite()
-	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #69483

#69432 broke reagent transfer.

![image](https://user-images.githubusercontent.com/24975989/186919763-9d730323-c272-4b85-b14a-e957636db739.png)

As we can see above, we've gone from removing reagents 100% of the time, to removing reagents only when `methods` is truthy and thus they get added to `r_to_send`. `methods` is not always truthy. Infact, more often than not it's NULL.

As a result, common reagent transfer methods just broke, duplicating reagents.

Sometimes this has interesting consequences, like in reagent reactions: https://tgstation13.org/parsed-logs/terry/data/logs/2022/08/26/round-189263/game.txt

![image](https://user-images.githubusercontent.com/24975989/186919184-86fda706-eea2-41d9-9837-1105cb5b91b5.png)

This is what my search bar looked like highlighting the 1000+ explosions.
![image](https://user-images.githubusercontent.com/24975989/186919218-e7aff2bb-e95e-4b84-9ab9-9aa66cc15c68.png)

This adds a unit test to make sure reagent transfer actually works, then fixes the bug by caching reagents to be removed and removing them in a batch later on.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Infinitely looping explosions tend to be loud and obnoxious. This kills the player. This also kills the server.
Unit tests are cool because my test is an absolute unit and I'm in awe at the size of that lad.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes reagent transfer not properly emptying the source of reagents when transferring to a target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
