### PR TITLE
Monkeys won't stay in combat mode forever after getting pissed off anymore.

### DIFF
--- a/code/datums/ai/monkey/monkey_subtrees.dm
+++ b/code/datums/ai/monkey/monkey_subtrees.dm
@@ -30,10 +30,12 @@
 	var/list/enemies = controller.blackboard[BB_MONKEY_ENEMIES]
 
 	if((HAS_TRAIT(controller.pawn, TRAIT_PACIFISM)) || (!length(enemies) && !controller.blackboard[BB_MONKEY_AGGRESSIVE])) //Pacifist, or we have no enemies and we're not pissed
+		living_pawn.set_combat_mode(FALSE)
 		return
 
 	if(!controller.blackboard[BB_MONKEY_CURRENT_ATTACK_TARGET])
 		controller.queue_behavior(/datum/ai_behavior/monkey_set_combat_target, BB_MONKEY_CURRENT_ATTACK_TARGET, BB_MONKEY_ENEMIES)
+		living_pawn.set_combat_mode(FALSE)
 		return SUBTREE_RETURN_FINISH_PLANNING
 
 	var/datum/weakref/target_ref = controller.blackboard[BB_MONKEY_CURRENT_ATTACK_TARGET]
@@ -54,6 +56,8 @@
 		return SUBTREE_RETURN_FINISH_PLANNING
 
 	//by this point we have a target but they're down, let's try dumpstering this loser
+
+	living_pawn.set_combat_mode(FALSE)
 
 	if(!controller.blackboard[BB_MONKEY_TARGET_DISPOSAL])
 		controller.queue_behavior(/datum/ai_behavior/find_and_set, BB_MONKEY_TARGET_DISPOSAL, /obj/machinery/disposal, MONKEY_ENEMY_VISION)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Monkeys will now drop out of combat mode in the following situations
>They have no enemies
>They have enemies but the monkey can not target them because they are far away
>They have enemies but they are dead/disabled

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its an oversight. Part 4 of the monkey crusade.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: itseasytosee
fix: Monkeys won't stay on combat mode forever after getting pissed off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
