### PR TITLE
Being in combat mode hits your target with the surgical tool during an ongoing surgery.

### DIFF
--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -110,6 +110,10 @@ have ways of interacting with a specific mob and control it.
 	for(var/obj/item/item in oview(2, living_pawn))
 		nearby_items += item
 
+	for(var/obj/item/item in living_pawn.held_items) // If we've got some garbage in out hands thats going to stop us from effectivly attacking, we should get rid of it.
+		if(item.force < 2)
+			living_pawn.dropItemToGround(item)
+
 	weapon = GetBestWeapon(src, nearby_items, living_pawn.held_items)
 
 	var/pickpocket = FALSE
@@ -119,6 +123,9 @@ have ways of interacting with a specific mob and control it.
 			continue
 		pickpocket = TRUE
 		weapon = held_weapon
+
+	if(weapon.force < 2) // or bite does 2 damage on avarage, no point in settling for anything less
+		return FALSE
 
 	if(!weapon || (weapon in living_pawn.held_items))
 		return FALSE

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -110,10 +110,6 @@ have ways of interacting with a specific mob and control it.
 	for(var/obj/item/item in oview(2, living_pawn))
 		nearby_items += item
 
-	for(var/obj/item/item in living_pawn.held_items) // If we've got some garbage in out hands thats going to stop us from effectivly attacking, we should get rid of it.
-		if(item.force < 2)
-			living_pawn.dropItemToGround(item)
-
 	weapon = GetBestWeapon(src, nearby_items, living_pawn.held_items)
 
 	var/pickpocket = FALSE
@@ -123,9 +119,6 @@ have ways of interacting with a specific mob and control it.
 			continue
 		pickpocket = TRUE
 		weapon = held_weapon
-
-	if(weapon.force < 2) // or bite does 2 damage on avarage, no point in settling for anything less
-		return FALSE
 
 	if(!weapon || (weapon in living_pawn.held_items))
 		return FALSE

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -93,6 +93,8 @@
 /datum/surgery/proc/next_step(mob/living/user, modifiers)
 	if(location != user.zone_selected)
 		return FALSE
+	if(user.combat_mode == TRUE)
+		return FALSE
 	if(step_in_progress)
 		return TRUE
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -93,7 +93,7 @@
 /datum/surgery/proc/next_step(mob/living/user, modifiers)
 	if(location != user.zone_selected)
 		return FALSE
-	if(user.combat_mode == TRUE)
+	if(user.combat_mode)
 		return FALSE
 	if(step_in_progress)
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is how it worked at some point, I couldn't find what messed it up.
This makes sense, and kills the very odd strategy of starting any surgery on yourself in order to make yourself completely immune from people trying to attack you with scalpels, **energy swords**, knifes, glass shards, and in fact, any sharp item.
Also, this kills ai monkeys being able to preform surgery on people out of raw monkey spite. Surgery should also probably require IS_ADVANCED_TOOL_USER, but that's a PR for a different day.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Oversight/bug.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: itseasytosee
fix: Preforming surgery steps now requires the surgeon not to be in combat mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
