### PR TITLE
Replaces the tram generic construction console with an aux construction console

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14290,10 +14290,10 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "eVQ" = (
-/obj/machinery/computer/camera_advanced/base_construction,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/computer/camera_advanced/base_construction/aux,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "eVY" = (


### PR DESCRIPTION

## About The Pull Request

This has regressed again.

## Why It's Good For The Game

Its nice to have that construction console to make a safe mining base, quickly.

## Changelog

:cl:
fix: The aux base construction console is once again present on Tramstation
/:cl:

