### PR TITLE
Ringer is no longer needed to get Ntmessengers recieved.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -351,7 +351,7 @@
 		if(signal.data["emojis"] == TRUE)//so will not parse emojis as such from pdas that don't send emojis
 			inbound_message = emoji_parse(inbound_message)
 
-		if(ringer_status && L.is_literate())
+		if(L.is_literate())
 			to_chat(L, "<span class='infoplain'>[icon2html(src)] <b>PDA message from [hrefstart][signal.data["name"]] ([signal.data["job"]])[hrefend], </b>[inbound_message] [reply]</span>")
 
 


### PR DESCRIPTION
## About The Pull Request

When getting a message, you will have it sent to your chat regardless of ringer status, like old PDAs did

## Why It's Good For The Game

Being able to actually see you got messages, to which you can reply, is actually cool. I'm assuming this was unintended because the var's comments doesn't mention hiding all alerts to being messaged, only the ringtone.

## Changelog

:cl:
fix: NT Messenger having their ringtone off will now get their messages displayed in chat again.
/:cl: