### PR TITLE
updates the HFR fuel input component description

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -95,7 +95,7 @@
 
 /obj/machinery/atmospherics/components/unary/hypertorus/fuel_input
 	name = "HFR fuel input port"
-	desc = "Input port for the Hypertorus Fusion Reactor, designed to take in only Hydrogen and Tritium in gas forms."
+	desc = "Input port for the Hypertorus Fusion Reactor, designed to take in fuels with the optimal fuel mix being a 50/50 split."
 	icon_state = "fuel_input_off"
 	icon_state_open = "fuel_input_open"
 	icon_state_off = "fuel_input_off"


### PR DESCRIPTION

## About The Pull Request
Changes the HFR fuel input part description to reflect that it no longer only accepts tritium and hydrogen

## Why It's Good For The Game

Less confusion for players

## Changelog



:cl:
fix: fixed the HFR fuel input part saying that it can only take tritium and hydrogen
/:cl:


