### PR TITLE
Allows the icebox aux base to land on ice moon

### DIFF
--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -224,7 +224,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/auxiliary_base, 32)
 			var/turf/place = colony_turfs[i]
 			if(!place)
 				return BAD_COORDS
-			if(!(istype(place.loc, /area/lavaland/surface) || istype(place.loc, /area/icemoon)))
+			if(!istype(place.loc, /area/lavaland/surface) && !istype(place.loc, /area/icemoon))
 				return BAD_AREA
 			if(disallowed_turf_types[place.type])
 				return BAD_TURF

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -224,7 +224,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/auxiliary_base, 32)
 			var/turf/place = colony_turfs[i]
 			if(!place)
 				return BAD_COORDS
-			if(!istype(place.loc, /area/lavaland/surface))
+			if(!(istype(place.loc, /area/lavaland/surface) || istype(place.loc, /area/icemoon)))
 				return BAD_AREA
 			if(disallowed_turf_types[place.type])
 				return BAD_TURF

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -5,6 +5,7 @@
 #define BAD_AREA 2
 #define BAD_COORDS 3
 #define BAD_TURF 4
+#define BAD_LAYER 5
 
 /area/shuttle/auxiliary_base
 	name = "Auxiliary Base"
@@ -224,7 +225,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/auxiliary_base, 32)
 			var/turf/place = colony_turfs[i]
 			if(!place)
 				return BAD_COORDS
-			if(!istype(place.loc, /area/lavaland/surface) && !istype(place.loc, /area/icemoon))
+			if(istype(place.loc, /area/icemoon/surface))
+				return BAD_LAYER
+			if(!istype(place.loc, /area/lavaland/surface) && !istype(place.loc, /area/icemoon/underground))
 				return BAD_AREA
 			if(disallowed_turf_types[place.type])
 				return BAD_TURF
@@ -295,6 +298,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/auxiliary_base, 32)
 			to_chat(user, span_warning("Location is too close to the edge of the station's scanning range. Move several paces away and try again."))
 		if(BAD_TURF)
 			to_chat(user, span_warning("The landing zone contains turfs unsuitable for a base. Make sure you've removed all walls and dangerous terrain from the landing zone."))
+		if(BAD_LAYER)
+			to_chat(user, span_warning("This area is not hazardous enough to justify an auxiliary base. Try again on a deeper layer."))
 
 /obj/item/assault_pod/mining/unrestricted
 	name = "omni-locational landing field designator"
@@ -444,3 +449,4 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/auxiliary_base, 32)
 #undef BAD_AREA
 #undef BAD_COORDS
 #undef BAD_TURF
+#undef BAD_LAYER


### PR DESCRIPTION
## About The Pull Request

When you were setting up the aux base's landing location, it checked the area of the turf: only lavaland/surface was allowed (though lavaland/underground is actually unused). This meant, icemoon had no places available for it to land. I have enabled every icemoon area, including undergrounds. Clearly it uses bluespace to squeeze into the caves.

I have tested what happens if you fall off during transit, you appear on a random icemoon tile, so clearly it is indeed bluespace.

The public mining shuttle landing beacon is still there, useless, but maybe it becomes buildable in the future.

I don't think this is a fix, so I am going to eat some feature points.

## Why It's Good For The Game

The aux base was unusable on Icebox, this is no longer the case.

Fixes #69787

## Changelog

:cl:
add: Icebox's mining aux base can now teleport to your chosen underground location on the icemoon.
/:cl:
