### PR TITLE
remove unnecessary list copy

### DIFF
--- a/code/modules/admin/verbs/admin.dm
+++ b/code/modules/admin/verbs/admin.dm
@@ -64,8 +64,7 @@
 
 	var/list/msg = list()
 	msg += "<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Playtime Report</title></head><body>Playtime:<BR><UL>"
-	var/list/clients_list_copy = GLOB.clients.Copy()
-	for(var/client/client in sort_list(clients_list_copy, /proc/cmp_playtime_asc))
+	for(var/client/client in sort_list(GLOB.clients, /proc/cmp_playtime_asc))
 		msg += "<LI> [ADMIN_PP(client.mob)] [key_name_admin(client)]: <A href='?_src_=holder;[HrefToken()];getplaytimewindow=[REF(client.mob)]'>" + client.get_exp_living() + "</a></LI>"
 	msg += "</UL></BODY></HTML>"
 	src << browse(msg.Join(), "window=Player_playtime_check")


### PR DESCRIPTION
## About The Pull Request

Removes an unnecessary list copy. `copy_list()` already copies the list internally (this is in contrast to the `timSort()` proc)

## Why It's Good For The Game

idk faster and less memory usage i guess, more of a cleanliness issue

## Changelog

lol no
