### PR TITLE
Fixes some cases of adjusting wound blood flow to use the hlper

### DIFF
--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -222,7 +222,7 @@
 	if(!lasgun.process_fire(victim, victim, TRUE, null, limb.body_zone))
 		return
 	victim.emote("scream")
-	blood_flow -= damage / (5 * self_penalty_mult) // 20 / 5 = 4 bloodflow removed, p good
+	adjust_blood_flow(-1 * (damage / (5 * self_penalty_mult))) // 20 / 5 = 4 bloodflow removed, p good
 	victim.visible_message(span_warning("The cuts on [victim]'s [limb.plaintext_zone] scar over!"))
 
 /// If someone is using either a cautery tool or something with heat to cauterize this cut

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -219,7 +219,7 @@
 	route = PATH_BLADE
 
 /// The amount of blood flow reduced per level of severity of gained bleeding wounds for Stance of the Torn Champion.
-#define BLOOD_FLOW_PER_SEVEIRTY 1
+#define BLOOD_FLOW_PER_SEVEIRTY -1
 
 /datum/heretic_knowledge/duel_stance
 	name = "Stance of the Torn Champion"
@@ -268,7 +268,7 @@
 	if(gained_wound.blood_flow <= 0)
 		return
 
-	gained_wound.blood_flow -= (gained_wound.severity * BLOOD_FLOW_PER_SEVEIRTY)
+	gained_wound.adjust_blood_flow(gained_wound.severity * BLOOD_FLOW_PER_SEVEIRTY)
 
 /datum/heretic_knowledge/duel_stance/proc/on_health_update(mob/living/source)
 	SIGNAL_HANDLER

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
@@ -102,5 +102,7 @@
 		if(iter_wound.blood_flow && (iter_wound.blood_flow > bloodiest_wound?.blood_flow))
 			bloodiest_wound = iter_wound
 
-	if(bloodiest_wound)
-		bloodiest_wound.set_blood_flow(max(0, bloodiest_wound.blood_flow - 0.5))
+	if(!bloodiest_wound)
+		return
+
+	bloodiest_wound.adjust_blood_flow(-0.5)


### PR DESCRIPTION
## About The Pull Request

Modifying a wound's blood flow should use this helper instead of hard adjusting the var, otherwise nothing gets done. 

I also changed a `set`- to an `adjust`- because it didn't make sense to be set.

## Why It's Good For The Game

Things which help blood flow, help blood flow

## Changelog

:cl: Melbert
fix: Blade heretics and cauterizing slashes should actually help blood loss
/:cl:
