### PR TITLE
Kilostation Whiteship gripe repair dust cleanup

### DIFF
--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -23,7 +23,7 @@
 /obj/structure/closet/crate/trashcart/filled,
 /obj/item/bodypart/r_arm/robot/surplus{
 	name = "rusty robotic arm";
-	desc = "A rusted and decayed robotic arm. Probably still works... Probably."
+	desc = "It's rusted but still functional, at least for robots."
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/cargo)
@@ -53,6 +53,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "ei" = (
@@ -80,7 +81,7 @@
 "eT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/cup/bucket,
+/obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
 /obj/item/storage/bag/trash{
 	pixel_x = 6
@@ -756,7 +757,7 @@
 	name = "fridge"
 	},
 /obj/item/food/sausage,
-/obj/item/reagent_containers/cup/glass/bottle/beer,
+/obj/item/reagent_containers/food/drinks/bottle/beer,
 /obj/item/food/sandwich,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -821,6 +822,7 @@
 	},
 /obj/effect/spawner/random/maintenance/three,
 /obj/item/wirebrush,
+/obj/item/stack/sheet/mineral/plasma/five,
 /obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
@@ -889,13 +891,14 @@
 "OS" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/reagent_containers/cup/glass/drinkingglass/filled/cola{
+/obj/item/reagent_containers/food/drinks/drinkingglass/filled/cola{
 	pixel_y = 5;
 	pixel_x = 8
 	},
 /obj/item/plate/small{
 	pixel_x = -5
 	},
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/bamboo,
 /area/shuttle/abandoned/bar)
 "OZ" = (


### PR DESCRIPTION
hehehehe

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Repairs the gripes with the debris of the last gripes. Specifically:
Engine APC has cable now
Ten plasma instead of five, power rebalance was shit and I want to subtly counter it
b a n g i n '   d o n k

WARNING: MADE BEFORE THAT DRINK CHANGE PR, MAY HAVE UNINTENDED CONSEQUENCES. TREAD LIGHTLY.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
do ya wanna put a bangin donk on it, also rewires APC

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Kilo whiteship has bangin donk, is now a bug liability, and has a rewired engine APC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
