### PR TITLE
Restricted input can now work with negative numbers

### DIFF
--- a/tgui/packages/tgui/components/RestrictedInput.js
+++ b/tgui/packages/tgui/components/RestrictedInput.js
@@ -18,7 +18,7 @@ const getClampedNumber = (value, minValue, maxValue) => {
   if (!value || !value.length) {
     return String(minimum);
   }
-  let parsedValue = parseInt(value.replace(/[^(\-|\d)]]/, ''), 10);
+  let parsedValue = parseInt(value.replace(/[^\-\d]/g, ''), 10);
   if (isNaN(parsedValue)) {
     return String(minimum);
   } else {

--- a/tgui/packages/tgui/components/RestrictedInput.js
+++ b/tgui/packages/tgui/components/RestrictedInput.js
@@ -18,7 +18,7 @@ const getClampedNumber = (value, minValue, maxValue) => {
   if (!value || !value.length) {
     return String(minimum);
   }
-  let parsedValue = parseInt(value.replace(/\D/g, ''), 10);
+  let parsedValue = parseInt(value.replace(/[^(\-|\d)]]/, ''), 10);
   if (isNaN(parsedValue)) {
     return String(minimum);
   } else {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

changes a bit of regex in the restrictedinput component of tgui to allow it to accept negative numbers if so desired

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

allows for further expansion of tgui_input_number to things that require negative numbers to be inputted

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: restrictedinput can now accept negative numbers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
