### PR TITLE
[s] Fixes bluespace bodybags allowing you to delete them when you're inside of them

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -137,6 +137,11 @@
 	if(contents.len >= mob_storage_capacity / 2)
 		to_chat(the_folder, span_warning("There are too many things inside of [src] to fold it up!"))
 		return
+
+	if(the_folder.in_contents_of(src))
+		to_chat(the_folder, span_warning("You can't fold [src] while you're inside of it!"))
+		return
+
 	for(var/obj/item/bodybag/bluespace/B in src)
 		to_chat(the_folder, span_warning("You can't recursively fold bluespace body bags!") )
 		return


### PR DESCRIPTION
## About The Pull Request
Turns out you could just use right-click when you're inside to basically fold the bag on itself and qdel everything that was inside of it, which obviously is quite bad.

## Why It's Good For The Game
Letting players be able to delete nearly anything with relative ease is not really good.

## Changelog

:cl: GoldenAlpharex
fix: Bluespace bodybags will no longer fold on themselves and delete everything inside of them when someone inside of them attempts to fold them.
/:cl: