### PR TITLE
Log subsystem initialize times in feedback, give more precise displays

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_subsystem.dm
+++ b/code/__DEFINES/dcs/signals/signals_subsystem.dm
@@ -3,7 +3,7 @@
 // All signals send the source datum of the signal as the first argument
 
 ///Subsystem signals
-///From base of datum/controller/subsystem/Initialize: (start_timeofday)
+///From base of datum/controller/subsystem/Initialize
 #define COMSIG_SUBSYSTEM_POST_INITIALIZE "subsystem_post_initialize"
 
 ///Called when the ticker enters the pre-game phase

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -310,3 +310,6 @@
 #define SSMACHINES_DT (SSmachines.wait/10)
 #define SSMOBS_DT (SSmobs.wait/10)
 #define SSOBJ_DT (SSobj.wait/10)
+
+/// The timer key used to know how long subsystem initialization takes
+#define SS_INIT_TIMER_KEY "ss_init"

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -241,7 +241,10 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 			if (subsystem.flags & SS_NO_INIT || subsystem.initialized) //Don't init SSs with the correspondig flag or if they already are initialzized
 				continue
 			current_initializing_subsystem = subsystem
-			subsystem.Initialize(REALTIMEOFDAY)
+
+			rustg_time_reset(SS_INIT_TIMER_KEY)
+			subsystem.Initialize()
+
 			CHECK_TICK
 		current_initializing_subsystem = null
 		init_stage_completed = current_init_stage

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -56,10 +56,10 @@
 
 	/// Running average of the amount of tick usage (in percents of a game tick) the subsystem has spent past its allocated time without pausing
 	var/tick_overrun = 0
-	
+
 	/// How much of a tick (in percents of a tick) were we allocated last fire.
 	var/tick_allocation_last = 0
-	
+
 	/// How much of a tick (in percents of a tick) do we get allocated by the mc on avg.
 	var/tick_allocation_avg = 0
 
@@ -113,10 +113,10 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 	set waitfor = FALSE
 	. = SS_IDLE
-	
+
 	tick_allocation_last = Master.current_ticklimit-(TICK_USAGE)
 	tick_allocation_avg = MC_AVERAGE(tick_allocation_avg, tick_allocation_last)
-	
+
 	. = SS_SLEEPING
 	fire(resumed)
 	. = state
@@ -255,14 +255,18 @@
 /datum/controller/subsystem/proc/OnConfigLoad()
 
 //used to initialize the subsystem AFTER the map has loaded
-/datum/controller/subsystem/Initialize(start_timeofday)
+/datum/controller/subsystem/Initialize()
 	initialized = TRUE
-	SEND_SIGNAL(src, COMSIG_SUBSYSTEM_POST_INITIALIZE, start_timeofday)
-	var/time = (REALTIMEOFDAY - start_timeofday) / 10
-	var/msg = "Initialized [name] subsystem within [time] second[time == 1 ? "" : "s"]!"
+	SEND_SIGNAL(src, COMSIG_SUBSYSTEM_POST_INITIALIZE)
+
+	var/time = rustg_time_milliseconds(SS_INIT_TIMER_KEY)
+	var/seconds = round(time / 1000, 0.01)
+
+	var/msg = "Initialized [name] subsystem within [seconds] second[seconds == 1 ? "" : "s"]!"
 	to_chat(world, span_boldannounce("[msg]"))
 	log_world(msg)
-	return time
+	SSblackbox.record_feedback("tally", "subsystem_initialize", time, name)
+	return seconds
 
 /datum/controller/subsystem/stat_entry(msg)
 	if(can_fire && !(SS_NO_FIRE & flags) && init_stage <= Master.init_stage_completed)

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -3,17 +3,17 @@
 ## administration, and the in game library.
 
 ## Should SQL be enabled? Uncomment to enable
-#SQL_ENABLED
+SQL_ENABLED
 
 ## Server the MySQL database can be found at.
 ## Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.
 ADDRESS localhost
 
 ## MySQL server port (default is 3306).
-PORT 3306
+PORT 3333
 
 ## Database for all SQL functions, not just feedback.
-FEEDBACK_DATABASE feedback
+FEEDBACK_DATABASE tgstation
 
 ## Prefix to be added to the name of every table, older databases will require this be set to erro_
 ## Note, this does not change the table names in the database, you will have to do that yourself.
@@ -21,13 +21,13 @@ FEEDBACK_DATABASE feedback
 ##	FEEDBACK_TABLEPREFIX
 ##	FEEDBACK_TABLEPREFIX SS13_
 ## Remove "SS13_" if you are using the standard schema file.
-FEEDBACK_TABLEPREFIX SS13_
+FEEDBACK_TABLEPREFIX
 
 ## Username/Login used to access the database.
-FEEDBACK_LOGIN username
+FEEDBACK_LOGIN root
 
 ## Password used to access the database.
-FEEDBACK_PASSWORD password
+FEEDBACK_PASSWORD
 
 ## Time in seconds for asynchronous queries to timeout
 ## Set to 0 for infinite

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -3,17 +3,17 @@
 ## administration, and the in game library.
 
 ## Should SQL be enabled? Uncomment to enable
-SQL_ENABLED
+#SQL_ENABLED
 
 ## Server the MySQL database can be found at.
 ## Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.
 ADDRESS localhost
 
 ## MySQL server port (default is 3306).
-PORT 3333
+PORT 3306
 
 ## Database for all SQL functions, not just feedback.
-FEEDBACK_DATABASE tgstation
+FEEDBACK_DATABASE feedback
 
 ## Prefix to be added to the name of every table, older databases will require this be set to erro_
 ## Note, this does not change the table names in the database, you will have to do that yourself.
@@ -21,13 +21,13 @@ FEEDBACK_DATABASE tgstation
 ##	FEEDBACK_TABLEPREFIX
 ##	FEEDBACK_TABLEPREFIX SS13_
 ## Remove "SS13_" if you are using the standard schema file.
-FEEDBACK_TABLEPREFIX
+FEEDBACK_TABLEPREFIX SS13_
 
 ## Username/Login used to access the database.
-FEEDBACK_LOGIN root
+FEEDBACK_LOGIN username
 
 ## Password used to access the database.
-FEEDBACK_PASSWORD
+FEEDBACK_PASSWORD password
 
 ## Time in seconds for asynchronous queries to timeout
 ## Set to 0 for infinite


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Logs subsystem initialize times in feedback in milliseconds.

Makes chat messages about SS inits precise to 2 decimal points.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Subsystem initialization times now show to 2 decimal points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
