### PR TITLE
Moving a fax machine in the QM's office

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -28942,10 +28942,6 @@
 "koB" = (
 /obj/structure/table/wood,
 /obj/machinery/keycard_auth/directional/south,
-/obj/machinery/fax{
-	name = "Quartermaster's Fax Machine";
-	fax_name = "Quartermaster's Office"
-	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "koW" = (
@@ -35227,6 +35223,10 @@
 /area/station/command/bridge)
 "mCb" = (
 /obj/structure/table/wood,
+/obj/machinery/fax{
+	name = "Quartermaster's Fax Machine";
+	fax_name = "Quartermaster's Office"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "mCi" = (
@@ -85714,7 +85714,7 @@ jLb
 tTa
 kQP
 fSw
-lnG
+mCb
 kQP
 dHc
 dHc
@@ -85971,7 +85971,7 @@ mmR
 kQP
 kQP
 apZ
-mCb
+lnG
 aEd
 ikJ
 kKr


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix #69520

![изображение](https://user-images.githubusercontent.com/88540658/187147503-e09d8e19-16e4-400d-b945-575eaeff63e6.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fax no longer blocks access to the card reader on the MetaStation in the QM's office.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
