### PR TITLE
Xenomorph powers require hands and mobility up to use

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -12,7 +12,7 @@ Doesn't work on other aliens/AI.*/
 	background_icon_state = "bg_alien"
 	icon_icon = 'icons/mob/actions/actions_xeno.dmi'
 	button_icon_state = "spell_default"
-	check_flags = AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
 	melee_cooldown_time = 0 SECONDS
 
 	/// How much plasma this action uses.

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -12,7 +12,7 @@ Doesn't work on other aliens/AI.*/
 	background_icon_state = "bg_alien"
 	icon_icon = 'icons/mob/actions/actions_xeno.dmi'
 	button_icon_state = "spell_default"
-	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
 	melee_cooldown_time = 0 SECONDS
 
 	/// How much plasma this action uses.
@@ -244,7 +244,11 @@ Doesn't work on other aliens/AI.*/
 	plasma_cost = 50
 
 /datum/action/cooldown/alien/acid/neurotoxin/IsAvailable()
-	return ..() && isturf(owner.loc)
+	if(owner.is_muzzled())
+		return FALSE
+	if(!isturf(owner.loc))
+		return FALSE
+	return ..()
 
 /datum/action/cooldown/alien/acid/neurotoxin/set_click_ability(mob/on_who)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Xenomorph powers require not being immobile to use (on top of the currently existing conscious check), and neurotoxin spit now is blocked by muzzles.

## Why It's Good For The Game

Xenomorphs usually don't have blockable mouths/are immobile, so this mostly just affects Humans.
This aims to gut neurotoxin spit used as a way to bypass the stun system, because I find it unfair that anyone with Neurotoxin spit can use it on anyone trying to arrest them.
The abilities are already strong enough on their own, I find it is fair that if you get skill issue'd, you should just take the L, rather than permanently being able to, at any time, hardstun someone.

There's also an argument that people usually implant xeno organs in themselves to counter the rest of the xeno team, but Neurotoxin spit is hardcoded to not affect xenomorphs at all, even if spit by a Human, so there's really no use there.

## Changelog

:cl:
balance: Xenomorph abilities require being mobile to use.
balance: Neurotoxin spit can no longer be used if you're muzzled.
/:cl: