### PR TITLE
bodybags / crates will now be explicit about what is ontop of them if you can't close them due to other bodybags / crates being in the same tile.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -221,7 +221,7 @@
 	for(var/obj/structure/closet/closet in T)
 		if(closet != src && !closet.wall_mounted)
 			if(user)
-				balloon_alert(user, "another closet is in the way!")
+				balloon_alert(user, "[closet.name] is in the way!")
 			return FALSE
 	for(var/mob/living/L in T)
 		if(L.anchored || horizontal && L.mob_size > MOB_SIZE_TINY && L.density)


### PR DESCRIPTION
:cl: ShizCalev
fix: bodybags / crates will now be explicit about what is ontop of them if you can't close them due to other bodybags / crates being in the same tile.
/:cl:

this seemed silly.
![image](https://user-images.githubusercontent.com/6209658/187308238-2d825005-a156-4720-bf2b-4e66b298bff9.png)
