### PR TITLE
Mining mobs now take attrition damage on station z-levels when inside station areas.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -62,5 +62,5 @@
 	
 /mob/living/simple_animal/hostile/asteroid/Life(delta_time = SSMOBS_DT, times_fired)
 	..()
-	if(is_station_level(z) && istype(get_area(src), /area/station)
+	if(is_station_level(z) && istype(get_area(src), /area/station))
 		adjustHealth(-2)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -59,3 +59,8 @@
 			visible_message(span_notice("The [T.name] [throw_message] [src.name]!"))
 			return
 	..()
+	
+/mob/living/simple_animal/hostile/asteroid/Life(delta_time = SSMOBS_DT, times_fired)
+	..()
+	if(is_station_level(z) && istype(get_area(src), /area/station)
+		adjustHealth(-2)


### PR DESCRIPTION
## About The Pull Request
Mining mobs now take attrition damage on station z-levels when inside station areas.

## Why It's Good For The Game

Megafauna, mining mobs, and really any mining simple_animal has massive, massive health pools, easy ways to regen that health, and armor against 85% of station weapons.

They aren't really supposed to be on the station, but antagonists bring them up anyways knowing that they're basically unkillable deadly roadblocks for the crew.

This sucks to play against because the only people on the station who can kill them(shaft miners) either died to them coming on station, helped them get on station in the first place, or are off playing the roguelite that is modern mining and won't be back for another 30 minutes.

God help you if the fauna is controlled by a player.

This PR resolves the issue by making fauna take attrition damage when they're on the station's z-level and areas. This means the crew can whittle them down or simply wait out the problem by boxing it in to an area, if the actual solution(miners) is unavailable.

## Changelog
:cl:
balance: Mining mobs now take attrition damage on station z-levels when inside station areas.
/:cl: