### PR TITLE
Headless humans can no longer recieve facial creampies.

### DIFF
--- a/code/game/objects/items/food/pie.dm
+++ b/code/game/objects/items/food/pie.dm
@@ -48,14 +48,18 @@
 	new/obj/effect/decal/cleanable/food/pie_smudge(hit_turf)
 	if(reagents?.total_volume)
 		reagents.expose(hit_atom, TOUCH)
+	var/is_creamable = TRUE
 	if(isliving(hit_atom))
 		var/mob/living/living_target_getting_hit = hit_atom
 		if(stunning)
 			living_target_getting_hit.Paralyze(2 SECONDS) //splat!
-		living_target_getting_hit.adjust_blurriness(1)
+		if(iscarbon(living_target_getting_hit))
+			is_creamable = !!(living_target_getting_hit.get_bodypart(BODY_ZONE_HEAD))
+		if(is_creamable)
+			living_target_getting_hit.adjust_blurriness(1)
 		living_target_getting_hit.visible_message(span_warning("[living_target_getting_hit] is creamed by [src]!"), span_userdanger("You've been creamed by [src]!"))
 		playsound(living_target_getting_hit, SFX_DESECRATION, 50, TRUE)
-	if(is_type_in_typecache(hit_atom, GLOB.creamable))
+	if(is_creamable && is_type_in_typecache(hit_atom, GLOB.creamable))
 		hit_atom.AddComponent(/datum/component/creamed, src)
 	qdel(src)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6209658/187312912-79d1e50b-cb46-4787-a7c6-9a35e86807bd.png)

:cl: ShizCalev
fix: Headless humans can no longer receive facial creampies.
/:cl:

fixes #69531