### PR TITLE
Bureaucracy logging

### DIFF
--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -679,6 +679,7 @@
 			fill.set_content(content, trusted = TRUE)
 			printed_book.gen_random_icon_state()
 			visible_message(span_notice("[src]'s printer hums as it produces a completely bound book. How did it do that?"))
+			log_paper("[key_name(usr)] has printed \"[title]\" by [author] from a book management console.")
 		break
 	qdel(query_library_print)
 

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -679,7 +679,7 @@
 			fill.set_content(content, trusted = TRUE)
 			printed_book.gen_random_icon_state()
 			visible_message(span_notice("[src]'s printer hums as it produces a completely bound book. How did it do that?"))
-			log_paper("[key_name(usr)] has printed \"[title]\" by [author] from a book management console.")
+			log_paper("[key_name(usr)] has printed \"[title]\" (id: [id]) by [author] from a book management console.")
 		break
 	qdel(query_library_print)
 

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -60,6 +60,7 @@
 			if (syndicate_network != TRUE && obj_flags != EMAGGED)
 				to_chat(user, span_warning("There is already a fax machine with this name on the network."))
 				return TOOL_ACT_TOOLTYPE_SUCCESS
+		user.log_message("renamed [fax_name] (fax machine) to [new_fax_name].", LOG_GAME)
 		fax_name = new_fax_name
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
@@ -117,6 +118,7 @@
 			return TRUE
 		if("send")
 			if(send(paper_contain, params["id"]))
+				log_paper("[usr] has sent a fax with the message \"[paper_contain.get_raw_text()]\" to [params["id"]].")
 				paper_contain = null
 				update_appearance()
 				return TRUE

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -652,7 +652,7 @@
 /// Get a single string representing the text on a page
 /obj/item/paper/proc/get_raw_text()
 	var/paper_contents = ""
-	for(var/datum/paper_input/line in raw_text_inputs)
+	for(var/datum/paper_input/line as anything in raw_text_inputs)
 		paper_contents += line.raw_text + "/"
 	return paper_contents
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -649,6 +649,13 @@
 
 	return total_length
 
+/// Get a single string representing the text on a page
+/obj/item/paper/proc/get_raw_text()
+	var/paper_contents = ""
+	for(var/datum/paper_input/line in raw_text_inputs)
+		paper_contents += line.raw_text + "/"
+	return paper_contents
+
 /// A single instance of a saved raw input onto paper.
 /datum/paper_input
 	/// Raw, unsanitised, unparsed text for an input.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sent fax messages' contents and printing out books is now logged to paper.log.
Renaming fax machines is logged to game.log (and to individual players' logs).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mostly because I was annoyed earlier looking for who printed out books. And then faxes seemed like a logical continuation.
Plus it seems like an interesting way to see how often certain books are printed out! 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: fax messages and book printings are now logged in paper.log
admin: renaming fax machines is logged in game log
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
