### PR TITLE
Fixes hard-dels related to lua signal handlers

### DIFF
--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -76,6 +76,23 @@
 	var/datum/D = locate(reference)
 	return (!QDELETED(D) && D.weak_reference == src) ? D : null
 
+/**
+ * SERIOUSLY READ THE AUTODOC COMMENT FOR THIS PROC BEFORE EVEN THINKING ABOUT USING IT
+ *
+ * Like resolve, but doesn't care if the datum is being qdeleted but hasn't been deleted yet.
+ *
+ * The return value of this proc leaves hanging references if the datum is being qdeleted but hasn't been deleted yet.
+ *
+ * Do not do anything that would create a lasting reference to the return value, such as giving it a tag, putting it on the map,
+ * adding it to an atom's contents or vis_contents, giving it a key (if it's a mob), attaching it to an atom (if it's an image),
+ * or assigning it to a datum or list referenced somewhere other than a temporary value.
+ *
+ * Unless you're resolving a weakref to a datum in a COMSIG_PARENT_QDELETING signal handler registered on that very same datum,
+ * just use resolve instead.
+ */
+/datum/weakref/proc/hard_resolve()
+	var/datum/D = locate(reference)
+	return (D?.weak_reference == src) ? D : null
 
 /datum/weakref/vv_get_dropdown()
 	. = ..()

--- a/lua/SS13.lua
+++ b/lua/SS13.lua
@@ -65,10 +65,10 @@ function SS13.register_signal(datum, signal, func, make_easy_clear_function)
 	end
 	local callback = SS13.new("/datum/callback", SS13.state, "call_function_return_first")
 	callback:call_proc("RegisterSignal", datum, signal, "Invoke")
-	local path = { "SS13", "signal_handlers", datum, signal, callback, "func" }
+	local path = { "SS13", "signal_handlers", dm.global_proc("WEAKREF", datum), signal, dm.global_proc("WEAKREF", callback), "func" }
 	callback.vars.arguments = { path }
 	if not SS13.signal_handlers[datum]["_cleanup"] then
-		local cleanup_path = { "SS13", "signal_handlers", datum, "_cleanup", "func" }
+		local cleanup_path = { "SS13", "signal_handlers", dm.global_proc("WEAKREF", datum), "_cleanup", "func" }
 		local cleanup_callback = SS13.new("/datum/callback", SS13.state, "call_function_return_first", cleanup_path)
 		cleanup_callback:call_proc("RegisterSignal", datum, "parent_qdeleting", "Invoke")
 		SS13.signal_handlers[datum]["_cleanup"] = {
@@ -180,7 +180,7 @@ function SS13.set_timeout(time, func, timer)
 		dm.global_proc("qdel", callback)
 		func()
 	end
-	local path = { "SS13", "timeouts", callback }
+	local path = { "SS13", "timeouts", dm.global_proc("WEAKREF", callback) }
 	callback.vars.arguments = { path }
 end
 


### PR DESCRIPTION
## About The Pull Request

When I changed the syntax of `SS13.lua` to account for the ability to properly index tables with datums, it turns out that the callbacks created for signal handlers and timeouts had circular references, resulting in hard-deletes. 

My first solution was to make it so signal handler and timeout callbacks use weakrefs, which get resolved in `lua_state/call_function`, but it turns out that, when calling the signal cleanup function, a qdeleted-but-not-yet-garbage-collected datum's weakref resolves to `null` because `datum.gc_collected` is set to `GC_CURRENTLY_BEING_QDELETED` before `COMSIG_PARENT_QDELETING` gets sent.

To resolve this issue, Potato and Oranges both recommended that I make a snowflake variant of `resolve` which ignores whether the datum a weakref points to is qdeleted - only that it is null or it's weakref isn't the very weakref `resolve` was called on. This proc was given a lengthy autodoc comment describing when it should or shouldn't be used, to ensure it is only used in cases similar to the one I needed to create it for (needing to resolve a weakref to a datum in a `COMSIG_PARENT_QDELETING` handler registered on that very datum).

## Why It's Good For The Game

Hard-deletes bad.

## Changelog

:cl:
fix: Fixes a couple of hard-deletes related to lua signal handlers.
/:cl:
