### PR TITLE
Fixes MMI controlled mecha not having access to doors.

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -32,7 +32,7 @@
 		if(check_access(animal.access_card))
 			return TRUE
 	else if(isbrain(accessor) && istype(accessor.loc, /obj/item/mmi))
-		return TRUE //So can MMI if they... you know, grow up and get metal forklift arms and a flamethrower or something. (mecha)
+		return TRUE //Like with AI, MMI can also do whatever if they... you know, grow up and get metal forklift arms and a flamethrower or something. (mecha)
 	return FALSE
 
 /obj/item/proc/GetAccess()

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -32,7 +32,10 @@
 		if(check_access(animal.access_card))
 			return TRUE
 	else if(isbrain(accessor) && istype(accessor.loc, /obj/item/mmi))
-		return TRUE //Like with AI, MMI can also do whatever if they... you know, grow up and get metal forklift arms and a flamethrower or something. (mecha)
+		var/obj/item/mmi/brain_mmi = accessor.loc
+		if(ismecha(brain_mmi.loc))
+			var/obj/vehicle/sealed/mecha/big_stompy_robot = brain_mmi.loc
+			return check_access_list(big_stompy_robot.operation_req_access)
 	return FALSE
 
 /obj/item/proc/GetAccess()

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -31,6 +31,8 @@
 		var/mob/living/simple_animal/animal = accessor
 		if(check_access(animal.access_card))
 			return TRUE
+	else if(isbrain(accessor) && istype(accessor.loc, /obj/item/mmi))
+		return TRUE //So can MMI if they... you know, grow up and get metal forklift arms and a flamethrower or something. (mecha)
 	return FALSE
 
 /obj/item/proc/GetAccess()

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -31,7 +31,9 @@
 	. = ..()
 	if(istype(A, /obj/machinery/door))
 		var/obj/machinery/door/conditionalwall = A
-		for(var/occupant in occupants)
+		for(var/mob/occupant as anything in return_drivers())
+			if(conditionalwall.try_safety_unlock(occupant))
+				return
 			conditionalwall.bumpopen(occupant)
 
 /obj/vehicle/sealed/after_add_occupant(mob/M)


### PR DESCRIPTION
Fixes #62153

:cl:
fix: MMI piloted mecha can now open doors using access granted through the ID card reader! 
fix: Mecha will now properly open doors when approaching from unrestricted sides.
/:cl:


