### PR TITLE
fixes some free firedoor lag

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -437,6 +437,8 @@
 	return FALSE //No bumping to open, not even in mechs
 
 /obj/machinery/door/firedoor/proc/on_power_loss()
+	SIGNAL_HANDLER 
+	
 	soundloop.stop()
 
 /obj/machinery/door/firedoor/proc/on_power_restore()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -77,6 +77,8 @@
 		base_icon_state = "sus"
 		desc += " This one looks a bit sus..."
 
+	RegisterSignal(src, COMSIG_MACHINERY_POWER_RESTORED, .proc/on_power_restore)
+	RegisterSignal(src, COMSIG_MACHINERY_POWER_LOST, .proc/on_power_loss)
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/door/firedoor/LateInitialize()
@@ -340,7 +342,7 @@
 	active = TRUE
 	alarm_type = code
 	add_as_source()
-	update_icon() //Sets the door lights even if the door doesn't move.
+	update_appearance(UPDATE_ICON) //Sets the door lights even if the door doesn't move.
 	correct_state()
 
 /// Adds this fire door as a source of trouble to all of its areas
@@ -367,7 +369,7 @@
 	remove_as_source()
 	soundloop.stop()
 	is_playing_alarm = FALSE
-	update_icon() //Sets the door lights even if the door doesn't move.
+	update_appearance(UPDATE_ICON) //Sets the door lights even if the door doesn't move.
 	correct_state()
 
 /**
@@ -385,7 +387,7 @@
 	soundloop.stop()
 	is_playing_alarm = FALSE
 	remove_as_source()
-	update_icon() //Sets the door lights even if the door doesn't move.
+	update_appearance(UPDATE_ICON) //Sets the door lights even if the door doesn't move.
 	correct_state()
 
 	/// Please be called 3 seconds after the LAST open, rather then 3 seconds after the first
@@ -434,14 +436,10 @@
 /obj/machinery/door/firedoor/bumpopen(mob/living/user)
 	return FALSE //No bumping to open, not even in mechs
 
-/obj/machinery/door/firedoor/power_change()
-	. = ..()
-	update_icon()
+/obj/machinery/door/firedoor/proc/on_power_loss()
+	soundloop.stop()
 
-	if(machine_stat & NOPOWER)
-		soundloop.stop()
-		return
-
+/obj/machinery/door/firedoor/proc/on_power_restore()
 	correct_state()
 
 	if(is_playing_alarm)
@@ -689,7 +687,7 @@
 			light_xoffset = 2
 		if(WEST)
 			light_xoffset = -2
-	update_icon()
+	update_appearance(UPDATE_ICON)
 
 /obj/machinery/door/firedoor/border_only/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -440,6 +440,8 @@
 	soundloop.stop()
 
 /obj/machinery/door/firedoor/proc/on_power_restore()
+	SIGNAL_HANDLER 
+	
 	correct_state()
 
 	if(is_playing_alarm)


### PR DESCRIPTION
`power_change()` wasn't checking if `.` was `TRUE` (meaning something actually changed), resulting in firedoors calling `update_appearance` in `.`, a redundant `update_icon` immediately after that (wrong thing to call to start with), `correct_state` (which calls BOTH `open` & `close` procs to make sure shit's synced), and trying to start a soundloop repeatedly 4noraisin. this was happening about 5 times a second.

now using the proper signals.