### PR TITLE
Power tools are dangerous for the station's environment, and dangerous for users without proper equipment.

### DIFF
--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -34,3 +34,12 @@
 
 /// When [TOOL_ACT_TOOLTYPE_SUCCESS] or [TOOL_ACT_SIGNAL_BLOCKING] are set
 #define TOOL_ACT_MELEE_CHAIN_BLOCKING (TOOL_ACT_TOOLTYPE_SUCCESS | TOOL_ACT_SIGNAL_BLOCKING)
+
+/// Temperature of the gas released and glove temperature protection required for power tools.
+#define TOOL_POWER_HEAT_TEMPERATURE 1000
+
+/// Returns a 75% co2 25% h2o [TOOL_POWER_HEAT_TEMPERATURE] Kelvin gasmixture string. Higher duration increases the amount of gas released. Power tools use this.
+#define TOOL_POWER_CONTAMINATE(duration) "co2=[(duration) / 5];water_vapor=[(duration) / 15];TEMP=[TOOL_POWER_HEAT_TEMPERATURE]"
+
+/// The divisor for the damage dealt from using power tools without heat resistant gloves.
+#define TOOL_POWER_HEAT_DAMAGE_DIVISOR 5

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1107,7 +1107,7 @@
 				var/time_to_open = 50
 				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
 				prying_so_hard = TRUE
-				if(do_after(user, time_to_open, src))
+				if(I.use_tool(src, user, time_to_open))
 					if(check_electrified && shock(user,100))
 						prying_so_hard = FALSE
 						return

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -120,6 +120,28 @@
 	playsound(user ? user : src, 'sound/items/change_drill.ogg', 50, TRUE)
 	return COMPONENT_NO_DEFAULT_MESSAGE
 
+/obj/item/screwdriver/power/use_tool(atom/target, mob/living/user, delay, amount, volume, datum/callback/extra_checks)
+	var/active_hand_index = user.active_hand_index
+	. = ..()
+	if(!.)
+		return .
+	if(!isopenturf(user.loc))
+		return .
+	var/turf/open/open_turf = user.loc
+	open_turf.atmos_spawn_air(TOOL_POWER_CONTAMINATE(delay))
+	var/damage_amount = delay / TOOL_POWER_HEAT_DAMAGE_DIVISOR
+	var/mob/living/carbon/human/human = user
+	if(istype(human) && human.gloves)
+		var/obj/item/clothing/gloves/gloves = human.gloves
+		damage_amount *= max(TOOL_POWER_HEAT_TEMPERATURE - gloves.max_heat_protection_temperature, 0) / TOOL_POWER_HEAT_TEMPERATURE
+		damage_amount *= !(HAS_TRAIT(user, TRAIT_RESISTHEAT) || HAS_TRAIT(user, TRAIT_RESISTHEATHANDS))
+	if(damage_amount)
+		var/obj/item/bodypart/affecting = human.get_bodypart("[(active_hand_index % 2 == 0) ? "r" : "l"]_arm")
+		if(affecting?.receive_damage(burn = damage_amount))
+			human.update_damage_overlays()
+			user.show_message(span_userdanger("\The [src] burns your hand!"))
+	return .
+
 /obj/item/screwdriver/power/examine()
 	. = ..()
 	. += " It's fitted with a [tool_behaviour == TOOL_SCREWDRIVER ? "screw" : "bolt"] bit."

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -387,6 +387,28 @@
 	var/last_gen = 0
 	var/nextrefueltick = 0
 
+/obj/item/weldingtool/experimental/use_tool(atom/target, mob/living/user, delay, amount, volume, datum/callback/extra_checks)
+	var/active_hand_index = user.active_hand_index
+	. = ..()
+	if(!.)
+		return .
+	if(!isopenturf(user.loc))
+		return .
+	var/turf/open/open_turf = user.loc
+	open_turf.atmos_spawn_air(TOOL_POWER_CONTAMINATE(delay))
+	var/damage_amount = delay / TOOL_POWER_HEAT_DAMAGE_DIVISOR
+	var/mob/living/carbon/human/human = user
+	if(istype(human) && human.gloves)
+		var/obj/item/clothing/gloves/gloves = human.gloves
+		damage_amount *= max(TOOL_POWER_HEAT_TEMPERATURE - gloves.max_heat_protection_temperature, 0) / TOOL_POWER_HEAT_TEMPERATURE
+		damage_amount *= !(HAS_TRAIT(user, TRAIT_RESISTHEAT) || HAS_TRAIT(user, TRAIT_RESISTHEATHANDS))
+	if(damage_amount)
+		var/obj/item/bodypart/affecting = human.get_bodypart("[(active_hand_index % 2 == 0) ? "r" : "l"]_arm")
+		if(affecting?.receive_damage(burn = damage_amount))
+			human.update_damage_overlays()
+			user.show_message(span_userdanger("\The [src] burns your hand!"))
+	return .
+
 /obj/item/weldingtool/experimental/process()
 	..()
 	if(get_fuel() < max_fuel && nextrefueltick < world.time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the hand drill, jaws of life, and experimental welding tool have some downsides. The power tools will release a 75% co2 and 25% h2o gas mixture at 1,000 Kelvin when used. Longer tool usage times increases the gas released. Power tools will burn the user's hand if the user is not resistant to heat or do not have proper equipment (heat resistant gloves). The damage is based on how long the tool is used. The pressure from the released gas can be high enough to push the user, so magnetic boots will also be recommended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Turns power tools into a more specialist equipment, where engineers will need proper PPE to handle them. The environmental hazard will give the tools a downside over normal tools, giving the user a choice on whether they want faster tools with the cost of needing extra equipment to handle, or normal tools that they can safely use. The released gas can also give an environmental hazard for atmospheric technicians to solve if the power tools got distributed to everyone.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The hand drill, jaws of life, and experimental welding tool will release co2 and h2o when used.
balance: The hand drill, jaws of life, and experimental welding tool will burn the user's hand if they do not protect themselves via gloves or some other form of heat resistance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
