### PR TITLE
[Lua] You can now `await` expensive non-sleeping procs.

### DIFF
--- a/code/modules/admin/verbs/lua/helpers.dm
+++ b/code/modules/admin/verbs/lua/helpers.dm
@@ -7,6 +7,9 @@
  * a proc directly called from auxtools sleeps, the hook returns with whatever
  * the called proc had as its return value at the moment it slept. This may not
  * be desired behavior, so this datum exists to wrap these procs.
+ *
+ * Some procs that don't sleep could take longer than the execution limit would
+ * allow for. We can wrap these in a promise as well.
  */
 /datum/auxtools_promise
 	var/datum/callback/callback
@@ -20,6 +23,7 @@
 
 /datum/auxtools_promise/proc/perform()
 	set waitfor = 0
+	sleep() //In case we have to call a super-expensive non-sleeping proc (like getFlatIcon)
 	try
 		return_value = callback.Invoke()
 		status = PROMISE_RESOLVED


### PR DESCRIPTION
## About The Pull Request

When trying to run `getFlatIcon` using lua scripting, I discovered that it was so expensive that, for certain atoms like complex humans, there is no way it will complete within the lua execution limit. While Mothblocks would suggest just raising the execution limit, the idea leaves a bad taste in my mouth due to the possibility of a script causing extreme lag by consistently overrunning the BYOND tick.

I instead elected to make `/datum/auxtools_promise` sleep once before invoking its assigned proc, thus immediately returning execution to lua, even if the proc being awaited wouldn't sleep. This allows for awaiting extremely expensive non-sleeping procs (like the aforementioned `getFlatIcon`)

## Why It's Good For The Game

Allows lua scripts to properly run extremely expensive procs that would otherwise overrun the lua execution limit.

## Changelog

:cl:
admin: The lua function `SS13.await` can now await non-sleeping, but extremely expensive procs, such as `getFlatIcon`
/:cl:
