### PR TITLE
Fixes security cameras showing up as static in consoles (For Real This Time Edition)

### DIFF
--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -235,7 +235,7 @@
 
 	C.network = tempnetwork
 	var/area/A = get_area(src)
-	C.c_tag = "[A.name] ([rand(1, 999)])"
+	C.c_tag = "[format_text(A.name)] ([rand(1, 999)])"
 	return TRUE
 
 /obj/structure/camera_assembly/wirecutter_act(mob/user, obj/item/I)

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -66,7 +66,7 @@
 			if(CA.type == A.type)
 				if(C.number)
 					number = max(number, C.number+1)
-		c_tag = "[A.name] #[number]"
+		c_tag = "[format_text(A.name)] #[number]"
 
 
 // UPGRADE PROCS

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -127,7 +127,7 @@
 		return
 
 	if(action == "switch_camera")
-		var/c_tag = format_text(params["name"])
+		var/c_tag = params["name"]
 		var/list/cameras = get_available_cameras()
 		var/obj/machinery/camera/selected_camera = cameras[c_tag]
 		active_camera = selected_camera
@@ -303,7 +303,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 
 	INVOKE_ASYNC(src, /atom.proc/interact, usr)
 
-///Sets the monitor's icon to the selected state, and says an announcement 
+///Sets the monitor's icon to the selected state, and says an announcement
 /obj/machinery/computer/security/telescreen/entertainment/proc/notify(on, announcement)
 	if(on && icon_state == icon_state_off)
 		icon_state = icon_state_on
@@ -354,7 +354,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 		"Spears! Camera! Action! LIVE NOW!")
 	/// List of phrases the entertainment console may say when the show ends
 	var/list/tv_enders = list("Thank you for tuning in to the slaughter!",
-		"What a show! And we guarantee next one will be bigger!", 
+		"What a show! And we guarantee next one will be bigger!",
 		"Celebrate the results with Thundermerch!",
 		"This show was brought to you by Nanotrasen.")
 


### PR DESCRIPTION
## About The Pull Request
Moves `format_text()` procs from wrapping c_tag values to wrapping area name in c_tag generation in both autoname cameras and newly built cameras.

## Why It's Good For The Game
`format_text()` proc as it was in #64429 wasn't picking up the usual `\improper` strings in the cameras' c_tag because apparently the values were showing up as either `?{16} area-name #x` or `mproper area-name #x`. However, the `\improper` strings seem to corrupt only after the c_tag generation is complete. Moving the `\improper` strings cleanup to during the c_tag generation process eliminates the issue.

<details>
<summary>Both roundstart cameras and newly-built cameras now show up properly</summary>

### Roundstart
![image](https://user-images.githubusercontent.com/75863639/187645178-c22d6f40-ff2b-433a-ac40-e5cd1b9b91f4.png)

### Newly-built
![image](https://user-images.githubusercontent.com/75863639/187645450-7bc1ac3f-0a62-48f6-b466-44943b1ee342.png)

</details>

_Once again (For Real This Time™ Edition):_
Closes #62528
Closes #64229

## Changelog

:cl:
fix: Fixed autonamed/newly-built security cameras in areas using \improper in their name showing up as static in security camera consoles. No, this is the first attempt to do so, why do you ask?
/:cl:
