### PR TITLE
Fix combustible flooder temperature param not being parsed.

### DIFF
--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -37,7 +37,7 @@
 		flooded_turf = parent_turf.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
 		delete_parent = FALSE
 
-	flooded_turf.atmos_spawn_air("[gas_id]=[gas_amount]; TEMP=[temp_amount || trigger_temperature]")
+	flooded_turf.atmos_spawn_air("[gas_id]=[gas_amount];TEMP=[temp_amount || trigger_temperature]")
 
 	// Logging-related
 	var/admin_message = "[flooded_turf] ignited in [ADMIN_VERBOSEJMP(flooded_turf)]"


### PR DESCRIPTION
## About The Pull Request
" TEMP" != "TEMP"
Fixes #69579

## Why It's Good For The Game
Less bugs

## Changelog
:cl:
fix: fixed plasma mat ignition spitting room temperature plasma.
/:cl: