### PR TITLE
Fix plasma cutter or guns that burn not being able to ignite plasma 

### DIFF
--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -78,11 +78,11 @@
 		flood(user, thing.get_temperature())
 
 /// Shot by something
-/datum/component/combustible_flooder/proc/projectile_react(datum/source, obj/projectile/projectile)
+/datum/component/combustible_flooder/proc/projectile_react(datum/source, obj/projectile/shot)
 	SIGNAL_HANDLER
 
-	if(projectile.damage_type == BURN && !projectile.nodamage)
-		flood(projectile.firer, 2500)
+	if((shot.damage_type == BURN || istype(shot, /obj/projectile/plasma)) && !shot.nodamage)
+		flood(shot.firer, 2500)
 
 /// Welder check. Here because tool_act is higher priority than attackby.
 /datum/component/combustible_flooder/proc/welder_react(datum/source, mob/user, obj/item/tool)

--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -81,7 +81,7 @@
 /datum/component/combustible_flooder/proc/projectile_react(datum/source, obj/projectile/shot)
 	SIGNAL_HANDLER
 
-	if((shot.damage_type == BURN || istype(shot, /obj/projectile/plasma)) && !shot.nodamage)
+	if(shot.damage_type == BURN && !shot.nodamage)
 		flood(shot.firer, 2500)
 
 /// Welder check. Here because tool_act is higher priority than attackby.

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -26,6 +26,7 @@
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/explodable_attack)
 	RegisterSignal(parent, COMSIG_ATOM_EX_ACT, .proc/detonate)
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), .proc/welder_react)
+	RegisterSignal(parent, COMSIG_ATOM_BULLET_ACT, .proc/projectile_react)
 	if(ismovable(parent))
 		RegisterSignal(parent, COMSIG_MOVABLE_IMPACT, .proc/explodable_impact)
 		RegisterSignal(parent, COMSIG_MOVABLE_BUMP, .proc/explodable_bump)
@@ -82,6 +83,13 @@
 
 	if(check_if_detonate(tool))
 		return COMPONENT_BLOCK_TOOL_ATTACK
+
+/// Shot by something
+/datum/component/explodable/proc/projectile_react(datum/source, obj/projectile/projectile)
+	SIGNAL_HANDLER
+
+	if(projectile.damage_type == BURN && !projectile.nodamage)
+		detonate()
 
 ///Called when you attack a specific body part of the thing this is equipped on. Useful for exploding pants.
 /datum/component/explodable/proc/explodable_attack_zone(datum/source, damage, damagetype, def_zone)

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -58,7 +58,6 @@
 	SIGNAL_HANDLER
 	if(!(I.item_flags & IN_STORAGE))
 		return
-
 	check_if_detonate(I)
 
 /datum/component/explodable/proc/explodable_impact(datum/source, atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -87,7 +87,7 @@
 /datum/component/explodable/proc/projectile_react(datum/source, obj/projectile/shot)
 	SIGNAL_HANDLER
 
-	if((shot.damage_type == BURN || istype(shot, /obj/projectile/plasma)) && !shot.nodamage)
+	if(shot.damage_type == BURN && !shot.nodamage)
 		detonate()
 
 ///Called when you attack a specific body part of the thing this is equipped on. Useful for exploding pants.

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -58,7 +58,7 @@
 	SIGNAL_HANDLER
 	if(!(I.item_flags & IN_STORAGE))
 		return
-	
+
 	check_if_detonate(I)
 
 /datum/component/explodable/proc/explodable_impact(datum/source, atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -85,10 +85,10 @@
 		return COMPONENT_BLOCK_TOOL_ATTACK
 
 /// Shot by something
-/datum/component/explodable/proc/projectile_react(datum/source, obj/projectile/projectile)
+/datum/component/explodable/proc/projectile_react(datum/source, obj/projectile/shot)
 	SIGNAL_HANDLER
 
-	if(projectile.damage_type == BURN && !projectile.nodamage)
+	if((shot.damage_type == BURN || istype(shot, /obj/projectile/plasma)) && !shot.nodamage)
 		detonate()
 
 ///Called when you attack a specific body part of the thing this is equipped on. Useful for exploding pants.

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -45,7 +45,7 @@
 /mob/living/simple_animal/hostile/asteroid/bullet_act(obj/projectile/shot)//Reduces damage from most projectiles to curb off-screen kills
 	if(!stat)
 		Aggro()
-	if(shot.damage < 30 && shot.damage_type != BRUTE || !shot.penetrate_mining_mobs)
+	if(shot.damage < 30 && shot.damage_type != BRUTE)
 		shot.damage = (shot.damage / 3)
 		visible_message(span_danger("[shot] has a reduced effect on [src]!"))
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -42,12 +42,12 @@
 		return
 	icon_state = icon_living
 
-/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
+/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/projectile/shot)//Reduces damage from most projectiles to curb off-screen kills
 	if(!stat)
 		Aggro()
-	if(P.damage < 30 && P.damage_type != BRUTE)
-		P.damage = (P.damage / 3)
-		visible_message(span_danger("[P] has a reduced effect on [src]!"))
+	if(shot.damage < 30 && shot.damage_type != BRUTE || !shot.penetrate_mining_mobs)
+		shot.damage = (shot.damage / 3)
+		visible_message(span_danger("[shot] has a reduced effect on [src]!"))
 	..()
 
 /mob/living/simple_animal/hostile/asteroid/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum) //No floor tiling them to death, wiseguy

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -157,6 +157,8 @@
 	var/decayedRange //stores original range
 	var/reflect_range_decrease = 5 //amount of original range that falls off when reflecting, so it doesn't go forever
 	var/reflectable = NONE // Can it be reflected or not?
+	var/penetrate_mining_mobs = FALSE //Will this ignore the damage reduction applied to mining mobs (penetration also happens if BURN or +30 damage)
+	
 	// Status effects applied on hit
 	var/stun = 0
 	var/knockdown = 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -157,8 +157,7 @@
 	var/decayedRange //stores original range
 	var/reflect_range_decrease = 5 //amount of original range that falls off when reflecting, so it doesn't go forever
 	var/reflectable = NONE // Can it be reflected or not?
-	var/penetrate_mining_mobs = FALSE //Will this ignore the damage reduction applied to mining mobs (penetration also happens if BURN or +30 damage)
-	
+
 	// Status effects applied on hit
 	var/stun = 0
 	var/knockdown = 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -157,7 +157,6 @@
 	var/decayedRange //stores original range
 	var/reflect_range_decrease = 5 //amount of original range that falls off when reflecting, so it doesn't go forever
 	var/reflectable = NONE // Can it be reflected or not?
-
 	// Status effects applied on hit
 	var/stun = 0
 	var/knockdown = 0

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -1,7 +1,7 @@
 /obj/projectile/plasma
 	name = "plasma blast"
 	icon_state = "plasmacutter"
-	damage_type = BRUTE
+	damage_type = BURN
 	damage = 5
 	range = 4
 	dismemberment = 20

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -1,11 +1,10 @@
 /obj/projectile/plasma
 	name = "plasma blast"
 	icon_state = "plasmacutter"
-	damage_type = BURN
+	damage_type = BRUTE
 	damage = 5
 	range = 4
 	dismemberment = 20
-	penetrate_mining_mobs = TRUE
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	var/mine_range = 3 //mines this many additional tiles of rock
 	tracer_type = /obj/effect/projectile/tracer/plasma_cutter

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -1,10 +1,11 @@
 /obj/projectile/plasma
 	name = "plasma blast"
 	icon_state = "plasmacutter"
-	damage_type = BRUTE
+	damage_type = BURN
 	damage = 5
 	range = 4
 	dismemberment = 20
+	penetrate_mining_mobs = TRUE
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	var/mine_range = 3 //mines this many additional tiles of rock
 	tracer_type = /obj/effect/projectile/tracer/plasma_cutter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #40409

Plasma cutter had it's damage type set to BRUTE as a hack to allow it to damage mining mobs without suffering a damage reduction.  I switched it to BURN instead, as a result this will cause reduced damage to mining mobs.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

One less bug off the tracker.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix plasma cutter or guns that burn not being able to ignite plasma
balance: Change plasma cutters damage type to BURN and this will cause reduced damage to mining mobs 
balance: Explodable stuff now detonates when hit by a BURN projectile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
