### PR TITLE
Refactors team antagonists and roundend report handling

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -604,7 +604,7 @@
 
 		//remove the team's individual antag reports, if the team actually shows up in the report.
 		for(var/datum/mind/team_minds as anything in active_teams.members)
-			if(!isnull(team_minds.mind.antag_datums)) // is_special_character passes if they have a special role instead of an antag
+			if(!isnull(team_minds.antag_datums)) // is_special_character passes if they have a special role instead of an antag
 				all_antagonists -= team_minds.antag_datums
 
 		result += active_teams.roundend_report()

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -589,19 +589,25 @@
 	var/list/all_teams = list()
 	var/list/all_antagonists = list()
 
-	for(var/datum/team/A in GLOB.antagonist_teams)
-		all_teams |= A
+	for(var/datum/team/teams as anything in GLOB.antagonist_teams)
+		all_teams |= teams
 
-	for(var/datum/antagonist/A in GLOB.antagonists)
-		if(!A.owner)
+	for(var/datum/antagonist/antagonists as anything in GLOB.antagonists)
+		if(!antagonists.owner)
 			continue
-		all_antagonists |= A
+		all_antagonists |= antagonists
 
-	for(var/datum/team/T in all_teams)
-		result += T.roundend_report()
-		for(var/datum/antagonist/X in all_antagonists)
-			if(X.get_team() == T)
-				all_antagonists -= X
+	for(var/datum/team/active_teams as anything in all_teams)
+		//check if we should show the team
+		if(!active_teams.show_roundend_report)
+			continue
+
+		//remove the team's individual antag reports, if the team actually shows up in the report.
+		for(var/datum/mind/team_minds as anything in active_teams.members)
+			if(!isnull(team_minds.mind.antag_datums)) // is_special_character passes if they have a special role instead of an antag
+				all_antagonists -= team_minds.antag_datums
+
+		result += active_teams.roundend_report()
 		result += " "//newline between teams
 		CHECK_TICK
 
@@ -610,18 +616,18 @@
 
 	sortTim(all_antagonists, /proc/cmp_antag_category)
 
-	for(var/datum/antagonist/A in all_antagonists)
-		if(!A.show_in_roundend)
+	for(var/datum/antagonist/antagonists in all_antagonists)
+		if(!antagonists.show_in_roundend)
 			continue
-		if(A.roundend_category != currrent_category)
+		if(antagonists.roundend_category != currrent_category)
 			if(previous_category)
 				result += previous_category.roundend_report_footer()
 				result += "</div>"
 			result += "<div class='panel redborder'>"
-			result += A.roundend_report_header()
-			currrent_category = A.roundend_category
-			previous_category = A
-		result += A.roundend_report()
+			result += antagonists.roundend_report_header()
+			currrent_category = antagonists.roundend_category
+			previous_category = antagonists
+		result += antagonists.roundend_report()
 		result += "<br><br>"
 		CHECK_TICK
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -589,8 +589,8 @@
 	var/list/all_teams = list()
 	var/list/all_antagonists = list()
 
-	for(var/datum/team/teams as anything in GLOB.antagonist_teams)
-		all_teams |= teams
+	for(var/datum/team/team as anything in GLOB.antagonist_teams)
+		all_teams |= team
 
 	for(var/datum/antagonist/antagonists as anything in GLOB.antagonists)
 		if(!antagonists.owner)

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -48,35 +48,6 @@
 	parts += antag_listing_commands()
 	return "<tr><td>[parts.Join("</td><td>")]</td></tr>"
 
-
-/datum/team/proc/get_team_antags(antag_type,specific = FALSE)
-	. = list()
-	for(var/datum/antagonist/A in GLOB.antagonists)
-		if(A.get_team() == src && (!antag_type || !specific && istype(A,antag_type) || specific && A.type == antag_type))
-			. += A
-
-//Builds section for the team
-/datum/team/proc/antag_listing_entry()
-	//NukeOps:
-	// Jim (Status) FLW PM TP
-	// Joe (Status) FLW PM TP
-	//Disk:
-	// Deep Space FLW
-	var/list/parts = list()
-	parts += "<b>[antag_listing_name()]</b><br>"
-	parts += "<table cellspacing=5>"
-	for(var/datum/antagonist/A in get_team_antags())
-		parts += A.antag_listing_entry()
-	parts += "</table>"
-	parts += antag_listing_footer()
-	return parts.Join()
-
-/datum/team/proc/antag_listing_name()
-	return name
-
-/datum/team/proc/antag_listing_footer()
-	return
-
 /datum/admins/proc/build_antag_listing()
 	var/list/sections = list()
 	var/list/priority_sections = list()

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -93,8 +93,8 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	var/list/parts = list()
 	parts += "<b>[antag_listing_name()]</b><br>"
 	parts += "<table cellspacing=5>"
-	for(var/datum/antagonist/A in get_team_antags())
-		parts += A.antag_listing_entry()
+	for(var/datum/antagonist/antag_entry as anything in get_team_antags())
+		parts += antag_entry.antag_listing_entry()
 	parts += "</table>"
 	return parts.Join()
 

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 //A barebones antagonist team.
 /datum/team
 	///Name of the entire Team
-	var/name = "team"
+	var/name = "\improper Team"
 	///What members are considered in the roundend report (ex: 'cultists')
 	var/member_name = "member"
 	///Whether the team shows up in the roundend report.

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 
 	return list
 
-//Builds section for the team
+/// Builds section for the team
 /datum/team/proc/antag_listing_entry()
 	//NukeOps:
 	// Jim (Status) FLW PM TP

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -71,17 +71,17 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	return "<div class='panel redborder'>[report.Join("<br>")]</div>"
 
 /datum/team/proc/get_team_antags(antag_datum, include_subtypes = TRUE)
-	var/datum/list = list()
+	var/list/antag_list = list()
 	for(var/datum/antagonist/antagonists as anything in GLOB.antagonists)
 		if(!(antagonists.owner in members))
 			continue
 
 		if(include_subtypes && istype(antagonists, antag_datum))
-			list += antagonists
+			antag_list += antagonists
 		else if(antagonists.type == antag_datum)
-			list += antagonists
+			antag_list += antagonists
 
-	return list
+	return antag_list
 
 /// Builds section for the team
 /datum/team/proc/antag_listing_entry()

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -2,11 +2,17 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 
 //A barebones antagonist team.
 /datum/team
-	var/list/datum/mind/members = list()
+	///Name of the entire Team
 	var/name = "team"
+	///What members are considered in the roundend report (ex: 'cultists')
 	var/member_name = "member"
-	var/list/objectives = list() //common objectives, these won't be added or removed automatically, subtypes handle this, this is here for bookkeeping purposes.
+	///Whether the team shows up in the roundend report.
 	var/show_roundend_report = TRUE
+
+	///List of all members in the team
+	var/list/datum/mind/members = list()
+	///Common objectives, these won't be added or removed automatically, subtypes handle this, this is here for bookkeeping purposes.
+	var/list/datum/objective/objectives = list()
 
 /datum/team/New(starting_members)
 	. = ..()
@@ -20,10 +26,9 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 
 /datum/team/Destroy(force, ...)
 	GLOB.antagonist_teams -= src
-	. = ..()
-
-/datum/team/proc/is_solo()
-	return members.len == 1
+	members = null
+	objectives = null
+	return ..()
 
 /datum/team/proc/add_member(datum/mind/new_member)
 	members |= new_member
@@ -31,14 +36,18 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 /datum/team/proc/remove_member(datum/mind/member)
 	members -= member
 
+/datum/team/proc/add_objective(datum/objective/new_objective, needs_target = FALSE)
+	new_objective.team = src
+	if(needs_target)
+		new_objective.find_target(dupe_search_range = list(src))
+	new_objective.update_explanation_text()
+	objectives += new_objective
+
 //Display members/victory/failure/objectives for the team
 /datum/team/proc/roundend_report()
-	if(!show_roundend_report)
-		return
-
 	var/list/report = list()
 
-	report += "<span class='header'>[name]:</span>"
+	report += "<span class='header'>\The [name]:</span>"
 	report += "The [member_name]s were:"
 	report += printplayerlist(members)
 
@@ -46,7 +55,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 		report += "<span class='header'>Team had following objectives:</span>"
 		var/win = TRUE
 		var/objective_count = 1
-		for(var/datum/objective/objective in objectives)
+		for(var/datum/objective/objective as anything in objectives)
 			if(objective.check_completion())
 				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] [span_greentext("Success!")]"
 			else
@@ -60,3 +69,36 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 
 
 	return "<div class='panel redborder'>[report.Join("<br>")]</div>"
+
+/datum/team/proc/get_team_antags(antag_datum, include_subtypes = TRUE)
+	var/datum/list = list()
+	for(var/datum/antagonist/antagonists as anything in GLOB.antagonists)
+		if(!(antagonists.owner in members))
+			continue
+
+		if(include_subtypes && istype(antagonists, antag_datum))
+			list += antagonists
+		else if(antagonists.type == antag_datum)
+			list += antagonists
+
+	return list
+
+//Builds section for the team
+/datum/team/proc/antag_listing_entry()
+	//NukeOps:
+	// Jim (Status) FLW PM TP
+	// Joe (Status) FLW PM TP
+	//Disk:
+	// Deep Space FLW
+	var/list/parts = list()
+	parts += "<b>[antag_listing_name()]</b><br>"
+	parts += "<table cellspacing=5>"
+	for(var/datum/antagonist/A in get_team_antags())
+		parts += A.antag_listing_entry()
+	parts += "</table>"
+	return parts.Join()
+
+///Custom names for individuals in a team
+/datum/team/proc/antag_listing_name()
+	return name
+

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -148,7 +148,7 @@ GLOBAL_LIST_INIT(possible_abductor_names, list("Alpha","Beta","Gamma","Delta","E
 			H.equipOutfit(/datum/outfit/abductor/scientist)
 
 /datum/team/abductor_team
-	member_name = "abductor"
+	member_name = "\improper Abductor"
 	var/team_number
 	var/static/team_count = 1
 	///List of all brainwashed victims' minds

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -150,22 +150,15 @@ GLOBAL_LIST_INIT(possible_abductor_names, list("Alpha","Beta","Gamma","Delta","E
 /datum/team/abductor_team
 	member_name = "abductor"
 	var/team_number
-	var/list/datum/mind/abductees = list()
 	var/static/team_count = 1
+	///List of all brainwashed victims' minds
+	var/list/datum/mind/abductees = list()
 
 /datum/team/abductor_team/New()
 	..()
 	team_number = team_count++
 	name = "Mothership [pick(GLOB.possible_abductor_names)]" //TODO Ensure unique and actual alieny names
-	add_objective(new/datum/objective/experiment)
-
-/datum/team/abductor_team/is_solo()
-	return FALSE
-
-/datum/team/abductor_team/proc/add_objective(datum/objective/O)
-	O.team = src
-	O.update_explanation_text()
-	objectives += O
+	add_objective(new /datum/objective/experiment)
 
 /datum/team/abductor_team/roundend_report()
 	var/list/result = list()

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -109,7 +109,6 @@
 	T.forge_brother_objectives()
 	new_owner.add_antag_datum(/datum/antagonist/brother,T)
 	bro.add_antag_datum(/datum/antagonist/brother, T)
-	T.update_name()
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] and [key_name_admin(bro)] into blood brothers.")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] and [key_name(bro)] into blood brothers.")
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -88,6 +88,7 @@
 
 /datum/antagonist/brother/proc/finalize_brother()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/tatoralert.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
+	team.update_name()
 
 /datum/antagonist/brother/admin_add(datum/mind/new_owner,mob/admin)
 	//show list of possible brothers
@@ -120,13 +121,22 @@
 	return data
 
 /datum/team/brother_team
-	name = "brotherhood"
+	name = "\improper Blood Brothers"
 	member_name = "blood brother"
+	///Selected meeting area given to the team members
 	var/meeting_area
-	var/static/meeting_areas = list("The Bar", "Dorms", "Escape Dock", "Arrivals", "Holodeck", "Primary Tool Storage", "Recreation Area", "Chapel", "Library")
-
-/datum/team/brother_team/is_solo()
-	return FALSE
+	///List of meeting areas that are randomly selected.
+	var/static/meeting_areas = list(
+		"The Bar",
+		"Dorms",
+		"Escape Dock",
+		"Arrivals",
+		"Holodeck",
+		"Primary Tool Storage",
+		"Recreation Area",
+		"Chapel",
+		"Library",
+	)
 
 /datum/team/brother_team/proc/pick_meeting_area()
 	meeting_area = pick(meeting_areas)
@@ -134,40 +144,11 @@
 
 /datum/team/brother_team/proc/update_name()
 	var/list/last_names = list()
-	for(var/datum/mind/M in members)
-		var/list/split_name = splittext(M.name," ")
+	for(var/datum/mind/team_minds as anything in members)
+		var/list/split_name = splittext(team_minds.name," ")
 		last_names += split_name[split_name.len]
 
-	name = last_names.Join(" & ")
-
-/datum/team/brother_team/roundend_report()
-	var/list/parts = list()
-
-	parts += "<span class='header'>The blood brothers of [name] were:</span>"
-	for(var/datum/mind/M in members)
-		parts += printplayer(M)
-	var/win = TRUE
-	var/objective_count = 1
-	for(var/datum/objective/objective in objectives)
-		if(objective.check_completion())
-			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] [span_greentext("Success!")]"
-		else
-			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] [span_redtext("Fail.")]"
-			win = FALSE
-		objective_count++
-	if(win)
-		parts += span_greentext("The blood brothers were successful!")
-	else
-		parts += span_redtext("The blood brothers have failed!")
-
-	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"
-
-/datum/team/brother_team/proc/add_objective(datum/objective/O, needs_target = FALSE)
-	O.team = src
-	if(needs_target)
-		O.find_target(dupe_search_range = list(src))
-	O.update_explanation_text()
-	objectives += O
+	name = "[initial(name)] of " + last_names.Join(" & ")
 
 /datum/team/brother_team/proc/forge_brother_objectives()
 	objectives = list()
@@ -176,20 +157,17 @@
 		forge_single_objective()
 	if(is_hijacker)
 		if(!locate(/datum/objective/hijack) in objectives)
-			add_objective(new/datum/objective/hijack)
+			add_objective(new /datum/objective/hijack)
 	else if(!locate(/datum/objective/escape) in objectives)
-		add_objective(new/datum/objective/escape)
+		add_objective(new /datum/objective/escape)
 
 /datum/team/brother_team/proc/forge_single_objective()
 	if(prob(50))
 		if(LAZYLEN(active_ais()) && prob(100/GLOB.joined_player_list.len))
-			add_objective(new/datum/objective/destroy, TRUE)
+			add_objective(new /datum/objective/destroy, needs_target = TRUE)
 		else if(prob(30))
-			add_objective(new/datum/objective/maroon, TRUE)
+			add_objective(new /datum/objective/maroon, needs_target = TRUE)
 		else
-			add_objective(new/datum/objective/assassinate, TRUE)
+			add_objective(new /datum/objective/assassinate, needs_target = TRUE)
 	else
-		add_objective(new/datum/objective/steal, TRUE)
-
-/datum/team/brother_team/antag_listing_name()
-	return "[name] blood brothers"
+		add_objective(new /datum/objective/steal, needs_target = TRUE)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -249,7 +249,7 @@
 	current.remove_status_effect(/datum/status_effect/cult_master)
 
 /datum/team/cult
-	name = "Cult"
+	name = "\improper Cult"
 
 	///The blood mark target
 	var/atom/blood_target

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -51,7 +51,7 @@
 	return ..()
 
 /datum/team/pirate
-	name = "Pirate crew"
+	name = "\improper Pirate crew"
 
 /datum/team/pirate/proc/forge_objectives()
 	var/datum/objective/loot/getbooty = new()

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -330,7 +330,7 @@
 		to_chat(C, "Your eyes have been implanted with a cybernetic security HUD which will help you keep track of who is mindshield-implanted, and therefore unable to be recruited.")
 
 /datum/team/revolution
-	name = "Revolution"
+	name = "\improper Revolution"
 	var/max_headrevs = 3
 	var/list/ex_headrevs = list() // Dynamic removes revs on loss, used to keep a list for the roundend report.
 	var/list/ex_revs = list()

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -615,13 +615,12 @@
 	parts += "<b>[antag_listing_name()]</b><br>"
 	parts += "<table cellspacing=5>"
 
-	var/list/heads = get_team_antags(/datum/antagonist/rev/head,TRUE)
+	var/list/heads = get_team_antags(/datum/antagonist/rev/head, FALSE)
 
 	for(var/datum/antagonist/A in heads | get_team_antags())
 		parts += A.antag_listing_entry()
 
 	parts += "</table>"
-	parts += antag_listing_footer()
 	common_part = parts.Join()
 
 	var/heads_report = "<b>Heads of Staff</b><br>"

--- a/code/modules/antagonists/separatist/separatist.dm
+++ b/code/modules/antagonists/separatist/separatist.dm
@@ -1,5 +1,5 @@
 /datum/team/nation
-	name = "Nation"
+	name = "\improper Nation"
 	member_name = "separatist"
 	///a list of ranks that can join this nation.
 	var/list/potential_recruits

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	return wiz_team
 
 /datum/team/wizard
-	name = "wizard team"
+	name = "\improper Wizard team"
 	var/datum/antagonist/wizard/master_wizard
 
 /datum/antagonist/wizard/proc/create_wiz_team()

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -1,5 +1,5 @@
 /datum/team/xeno
-	name = "Aliens"
+	name = "\improper Aliens"
 
 //Simply lists them.
 /datum/team/xeno/roundend_report()

--- a/code/modules/mob_spawn/ghost_roles/space_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/space_roles.dm
@@ -125,7 +125,7 @@
 	mob_mind.add_antag_datum(antag_datum_to_give, antag_team)
 
 /datum/team/battlecruiser
-	name = "Battlecruiser Crew"
+	name = "\improper Battlecruiser Crew"
 	member_name = "crewmember"
 	/// The central objective of this battlecruiser
 	var/core_objective = /datum/objective/nuclear


### PR DESCRIPTION
## About The Pull Request

Refactors teams and subtypes
* Makes use of ``as anything`` and ``\improper`` (like I already did for Antagonists in https://github.com/tgstation/tgstation/pull/63469)
* Removes many single letter variables
* Moves team code to the team file
* Makes team objectives only allow objectives for SpacemanDMM
* Makes members and objectives clear when a team is deleted
* Generalizes team's add_objective
* Checks for show_roundend_report in roundend
* Replaces ``get_team == src`` with a simple ``if(mind in members)``
* Makes Bloodbrothers fit using parent's endround report.
* Removes the unused procs ``is_solo`` and ``antag_listing_footer``
* Makes replaces ``get_team_antag`` ``specific`` with ``include_subtypes`` to be consistent with Antag helpers (and because I thought it looked better that way)

![image](https://user-images.githubusercontent.com/53777086/187680533-4184694c-a6bf-4bf0-bd2f-c202dcb25094.png)
![image](https://user-images.githubusercontent.com/53777086/187680673-a68fd806-410d-4030-ba49-8341e4771260.png)

This is what it looks like in-game currently (2 bloodbrother teams, 1 solo abductor, 2 traitors- 1 traitor was also a bloodbrother):
![image](https://user-images.githubusercontent.com/53777086/187680825-287bd55f-80f0-4c43-b4bd-581c22475e4b.png)


## Why It's Good For The Game

I looked at the code for this and it make me legitimately sad, a lot of it was meant to be placeholders, so hopefully this will be better long-term

## Changelog

:cl:
refactor: Teams used by Antagonists have been refactored, please report any bugs you might find.
spellcheck: Team antagonists are now improper.
spellcheck: Bloodbrothers now show their team antagonist name in admin panels.
/:cl: