### PR TITLE
Paper bins now create paper dynamically, rather than creating thousands of pieces of paper on init every round

### DIFF
--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -53,25 +53,33 @@
 		return TRUE
 	if(istype(I, /obj/item/paper_bin))
 		var/obj/item/paper_bin/bin = I
-		if(LAZYLEN(bin.papers))
+		if(bin.total_paper > 0)
 			if(stored_paper >= max_paper)
 				balloon_alert(user, "it's full!")
 				return FALSE
 			/// Number of sheets we're adding
 			var/num_to_add = 0
-			for(var/obj/item/paper/the_paper as anything in bin.papers) // Search for the first blank sheet of paper, then toss it in
-				if(the_paper.get_total_length()) // Uh oh, paper has words!
+
+			for(var/obj/item/paper/paper_in_stack as anything in bin.paper_stack) // Search for the first blank sheet of paper, then toss it in
+				if(paper_in_stack.get_total_length()) // Uh oh, paper has words!
 					continue
-				if(istype(the_paper, /obj/item/paper/carbon)) // Add both the carbon, and the copy
-					var/obj/item/paper/carbon/carbon_paper = the_paper
+				if(istype(paper_in_stack, /obj/item/paper/carbon)) // Add both the carbon, and the copy
+					var/obj/item/paper/carbon/carbon_paper = paper_in_stack
 					if(!carbon_paper.copied && ((max_paper - stored_paper) >= 2)) // See if there's room for both
 						num_to_add = 2
 				else
 					num_to_add = 1
-				LAZYREMOVE(bin.papers, the_paper)
-				qdel(the_paper)
+				bin.paper_stack -= paper_in_stack
+				bin.total_paper -= 1
+				qdel(paper_in_stack)
 				stored_paper += num_to_add
 				break // All full!
+
+			if (num_to_add == 0 && bin.total_paper > 0)
+				bin.total_paper -= 1
+				num_to_add = 1
+				stored_paper += 1
+
 			bin.update_appearance()
 			if(!num_to_add)
 				balloon_alert(user, "everything is written on!")

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -35,6 +35,10 @@
 			bin_pen = pen
 	update_appearance()
 
+/obj/item/paper_bin/Destroy()
+	QDEL_LIST(paper_stack)
+	return ..()
+
 /// Returns a fresh piece of paper
 /obj/item/paper_bin/proc/generate_paper()
 	var/obj/item/paper/paper = new papertype
@@ -141,7 +145,9 @@
 /obj/item/paper_bin/update_overlays()
 	. = ..()
 
-	var/static/reference_paper = new /obj/item/paper
+	var/static/reference_paper
+	if (isnull(reference_paper))
+		reference_paper = new /obj/item/paper
 
 	if(bin_pen)
 		pen_overlay = mutable_appearance(bin_pen.icon, bin_pen.icon_state)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -15,7 +15,7 @@
 	pressure_resistance = 8
 	var/papertype = /obj/item/paper
 	var/total_paper = 30
-	var/list/papers = list()
+	var/list/paper_stack = list()
 	var/obj/item/pen/bin_pen
 	///Overlay of the pen on top of the bin.
 	var/mutable_appearance/pen_overlay
@@ -33,22 +33,17 @@
 		if(pen && !bin_pen)
 			pen.forceMove(src)
 			bin_pen = pen
-	for(var/i in 1 to total_paper)
-		papers.Add(generate_paper())
 	update_appearance()
 
+/// Returns a fresh piece of paper
 /obj/item/paper_bin/proc/generate_paper()
-	var/obj/item/paper/paper = new papertype(src)
+	var/obj/item/paper/paper = new papertype
 	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
 		if(prob(30))
 			paper.add_raw_text("<font face=\"[CRAYON_FONT]\" color=\"red\"><b>HONK HONK HONK HONK HONK HONK HONK<br>HOOOOOOOOOOOOOOOOOOOOOONK<br>APRIL FOOLS</b></font>")
 			paper.AddElement(/datum/element/honkspam)
 			paper.update_appearance()
 	return paper
-
-/obj/item/paper_bin/Destroy()
-	QDEL_LIST(papers)
-	. = ..()
 
 /obj/item/paper_bin/dump_contents(atom/droppoint, collapse = FALSE)
 	if(!droppoint)
@@ -61,13 +56,13 @@
 			movable_atom.pixel_y = rand(-3,3)
 		if(!movable_atom.pixel_x)
 			movable_atom.pixel_x = rand(-3,3)
-	LAZYNULL(papers)
 	update_appearance()
 
 /obj/item/paper_bin/fire_act(exposed_temperature, exposed_volume)
-	if(LAZYLEN(papers))
-		LAZYNULL(papers)
+	if(total_paper > 0)
+		total_paper = 0
 		update_appearance()
+
 	..()
 
 /obj/item/paper_bin/attack_paw(mob/user, list/modifiers)
@@ -91,9 +86,9 @@
 		to_chat(user, span_notice("You take [pen] out of [src]."))
 		bin_pen = null
 		update_appearance()
-	else if(LAZYLEN(papers))
-		var/obj/item/paper/top_paper = papers[papers.len]
-		LAZYREMOVE(papers, top_paper)
+	else if(total_paper > 0)
+		var/obj/item/paper/top_paper = pop(paper_stack) || generate_paper()
+		total_paper -= 1
 		top_paper.add_fingerprint(user)
 		top_paper.forceMove(user.loc)
 		user.put_in_hands(top_paper)
@@ -113,7 +108,8 @@
 		if(!user.transferItemToLoc(paper, src))
 			return
 		to_chat(user, span_notice("You put [paper] in [src]."))
-		LAZYADD(papers, paper)
+		paper_stack += paper
+		total_paper += 1
 		update_appearance()
 	else if(istype(I, /obj/item/pen) && !bin_pen)
 		var/obj/item/pen/pen = I
@@ -145,7 +141,7 @@
 /obj/item/paper_bin/update_overlays()
 	. = ..()
 
-	total_paper = LAZYLEN(papers)
+	var/static/reference_paper = new /obj/item/paper
 
 	if(bin_pen)
 		pen_overlay = mutable_appearance(bin_pen.icon, bin_pen.icon_state)
@@ -153,16 +149,20 @@
 	if(!bin_overlay)
 		bin_overlay = mutable_appearance(icon, bin_overlay_string)
 
-	if(LAZYLEN(papers))
-		for(var/paper_number in 1 to papers.len)
-			if(paper_number != papers.len && paper_number % PAPERS_PER_OVERLAY != 0) //only top paper and every nth paper get overlays
+	if(total_paper > 0)
+		for(var/paper_number in 1 to total_paper)
+			if(paper_number != total_paper && paper_number % PAPERS_PER_OVERLAY != 0) //only top paper and every nth paper get overlays
 				continue
-			var/obj/item/paper/current_paper = papers[paper_number]
+
+			var/obj/item/paper/current_paper = paper_number > (total_paper - paper_stack.len) \
+				? paper_stack[paper_stack.len - (total_paper - paper_number + 1) + 1] \
+				: reference_paper
+
 			var/mutable_appearance/paper_overlay = mutable_appearance(current_paper.icon, current_paper.icon_state)
 			paper_overlay.color = current_paper.color
 			paper_overlay.pixel_y = paper_number/PAPERS_PER_OVERLAY - PAPER_OVERLAY_PIXEL_SHIFT //gives the illusion of stacking
 			. += paper_overlay
-			if(paper_number == papers.len) //this is our top paper
+			if(paper_number == total_paper) //this is our top paper
 				. += current_paper.overlays //add overlays only for top paper
 				if(istype(src, /obj/item/paper_bin/bundlenatural))
 					bin_overlay.pixel_y = paper_overlay.pixel_y //keeps binding centred on stack
@@ -206,7 +206,7 @@
 
 /obj/item/paper_bin/bundlenatural/attack_hand(mob/user, list/modifiers)
 	. = ..()
-	if(!LAZYLEN(papers))
+	if(total_paper == 0)
 		deconstruct(FALSE)
 
 /obj/item/paper_bin/bundlenatural/deconstruct(disassembled)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -65,6 +65,7 @@
 /obj/item/paper_bin/fire_act(exposed_temperature, exposed_volume)
 	if(total_paper > 0)
 		total_paper = 0
+		QDEL_LIST(paper_stack)
 		update_appearance()
 
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Every paper bin creates 30 pieces of paper. DeltaStation has 87, CentCom has 36, Meta has 66. A round of Delta has 3,690 sheets of paper created.

This fixes that by making it so paper bins lazily create pieces of paper when needed. 

This reduces paper bin initialization time (regularly in the top 5) from ~300ms to about 17.