### PR TITLE
Touches up the tram whiteship

### DIFF
--- a/_maps/shuttles/whiteship_tram.dmm
+++ b/_maps/shuttles/whiteship_tram.dmm
@@ -23,7 +23,6 @@
 /area/shuttle/abandoned/engine)
 "ad" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "ae" = (
@@ -114,14 +113,13 @@
 /turf/open/floor/catwalk_floor,
 /area/shuttle/abandoned/engine)
 "aq" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/engine)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/crew)
 "ar" = (
 /obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	name = "Engineering"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
@@ -251,10 +249,10 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/abandoned/engine)
 "aM" = (
-/obj/structure/shuttle/engine/large{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/shuttle/engine/propulsion{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
@@ -440,12 +438,11 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
-/obj/item/shard/plasma,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
 "bu" = (
-/obj/item/shard,
+/obj/item/shard/titanium,
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
@@ -509,7 +506,7 @@
 	dir = 5
 	},
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "bE" = (
 /obj/machinery/stasis/survival_pod,
 /obj/effect/turf_decal/stripes/white/line{
@@ -523,12 +520,15 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/abandoned/bridge)
 "bG" = (
 /obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	name = "Command"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
@@ -550,7 +550,7 @@
 	pixel_x = -2
 	},
 /turf/open/floor/plastic,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "bJ" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/closet/syndicate,
@@ -609,7 +609,7 @@
 	},
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/plastic,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "bP" = (
 /obj/structure/closet/crate/radiation,
 /obj/effect/turf_decal/bot_white,
@@ -637,18 +637,18 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/iron/smooth_large,
 /area/shuttle/abandoned/engine)
 "bV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/stasis/survival_pod,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
 	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned/engine)
+/turf/open/floor/iron/dark/textured_large,
+/area/shuttle/abandoned/crew)
 "ca" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -672,8 +672,8 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/plasma/spawner,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned/engine)
 "cg" = (
 /obj/structure/sign/warning/fire,
@@ -684,7 +684,9 @@
 /area/shuttle/abandoned/engine)
 "cj" = (
 /obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	name = "Atmospherics"
+	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
@@ -694,7 +696,9 @@
 /area/shuttle/abandoned/engine)
 "ck" = (
 /obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	name = "Engine Room"
+	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -720,7 +724,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/abandoned/cargo)
 "cv" = (
-/obj/item/shard,
+/obj/item/shard/titanium,
 /turf/open/floor/mineral/titanium/airless,
 /area/shuttle/abandoned/cargo)
 "cx" = (
@@ -817,6 +821,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/lattice,
 /turf/template_noop,
 /area/shuttle/abandoned/cargo)
 "cO" = (
@@ -829,12 +834,14 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/lattice,
 /turf/template_noop,
 /area/shuttle/abandoned/cargo)
 "cS" = (
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/structure/lattice,
 /turf/template_noop,
 /area/shuttle/abandoned/cargo)
 "cU" = (
@@ -844,6 +851,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/structure/lattice,
 /turf/template_noop,
 /area/shuttle/abandoned/cargo)
 "cV" = (
@@ -853,6 +861,7 @@
 /area/shuttle/abandoned/cargo)
 "cY" = (
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/lattice,
 /turf/template_noop,
 /area/shuttle/abandoned/cargo)
 "da" = (
@@ -868,15 +877,14 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
 /area/shuttle/abandoned/bridge)
 "de" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/bridge)
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned/crew)
 "df" = (
 /obj/structure/rack,
 /obj/item/food/canned/beans{
@@ -896,7 +904,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plastic,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "dg" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -907,9 +915,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plastic,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "dh" = (
-/obj/machinery/door/window/brigdoor,
+/obj/machinery/door/window/brigdoor{
+	name = "Captain's Quarters"
+	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
@@ -918,6 +928,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -955,14 +966,14 @@
 "dl" = (
 /obj/structure/sign/warning/no_smoking/circle,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "dm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plastic,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "dn" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/knife/kitchen,
@@ -970,16 +981,20 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/shuttle/abandoned/bridge)
 "do" = (
 /obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	name = "Bridge"
+	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/abandoned/bridge)
 "dp" = (
@@ -987,11 +1002,14 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_half,
 /area/shuttle/abandoned/bridge)
 "dq" = (
 /obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	name = "Crew Quarters"
+	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -1002,7 +1020,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "ds" = (
 /obj/structure/sign/poster/official/do_not_question,
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -1033,7 +1051,7 @@
 	},
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/textured_large,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "dx" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
@@ -1050,7 +1068,7 @@
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plastic,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "dA" = (
 /obj/machinery/door/window/left/directional/east,
 /obj/effect/turf_decal/arrows/red{
@@ -1087,9 +1105,9 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "iH" = (
-/obj/item/shard,
+/obj/item/shard/titanium,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
@@ -1117,7 +1135,7 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "nV" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/microwave{
@@ -1127,10 +1145,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/shuttle/abandoned/bridge)
 "pm" = (
-/obj/effect/spawner/structure/window/reinforced/shuttle,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/bridge)
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned/crew)
 "rP" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/phone{
@@ -1219,7 +1236,7 @@
 /obj/structure/closet/syndicate,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/textured_large,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "yd" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/bot_white,
@@ -1232,7 +1249,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark/textured_large,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "zN" = (
 /obj/machinery/stasis/survival_pod,
 /obj/effect/turf_decal/stripes/white/line{
@@ -1240,7 +1257,7 @@
 	},
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/iron/dark/textured_large,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "AC" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/mob_spawn/corpse/human/assistant,
@@ -1258,7 +1275,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/smooth_half,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "DS" = (
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/stripes/white/line{
@@ -1268,10 +1285,11 @@
 /area/shuttle/abandoned/bridge)
 "Fp" = (
 /obj/structure/window/reinforced/spawner/west,
+/obj/structure/lattice,
 /turf/template_noop,
 /area/shuttle/abandoned/cargo)
 "FQ" = (
-/obj/item/shard,
+/obj/item/shard/titanium,
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/airless,
@@ -1291,12 +1309,13 @@
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "Ic" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
@@ -1324,7 +1343,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "Ki" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -1380,9 +1399,9 @@
 /obj/effect/turf_decal/bot_white,
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/iron/dark/textured_large,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "Qy" = (
-/obj/item/shard,
+/obj/item/shard/titanium,
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned/cargo)
@@ -1409,7 +1428,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "Tj" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/holosign/barrier,
@@ -1417,7 +1436,6 @@
 /area/shuttle/abandoned/cargo)
 "UC" = (
 /obj/effect/turf_decal/stripes/white/box,
-/obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/external/ruin{
 	name = "Escape Pod Loader"
 	},
@@ -1465,7 +1483,7 @@
 	dir = 6
 	},
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/bridge)
+/area/shuttle/abandoned/crew)
 "ZA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -1499,8 +1517,8 @@ dy
 dy
 dy
 dy
-pm
-pm
+dx
+dx
 mj
 "}
 (2,1,1) = {"
@@ -1530,12 +1548,12 @@ nV
 Wm
 DS
 rP
-pm
+dx
 "}
 (3,1,1) = {"
 cM
 cM
-bV
+aM
 ce
 ag
 bx
@@ -1559,7 +1577,7 @@ Ic
 Io
 Mp
 sE
-pm
+dx
 "}
 (4,1,1) = {"
 cM
@@ -1588,7 +1606,7 @@ dn
 yd
 OL
 sw
-pm
+dx
 "}
 (5,1,1) = {"
 aZ
@@ -1626,7 +1644,7 @@ ad
 ca
 ai
 bx
-aq
+ad
 cY
 cY
 cY
@@ -1640,7 +1658,7 @@ cD
 cY
 cY
 cY
-de
+dx
 dj
 dp
 dt
@@ -1684,7 +1702,7 @@ ad
 ae
 aj
 ap
-aq
+ad
 Fp
 Fp
 Fp
@@ -1698,7 +1716,7 @@ cF
 Fp
 Fp
 Fp
-de
+dx
 dk
 LM
 du
@@ -1726,14 +1744,14 @@ aY
 aG
 bz
 cS
-da
-dy
+de
+aq
 dl
 dq
-dv
-dy
-dy
-da
+pm
+aq
+aq
+de
 "}
 (10,1,1) = {"
 cM
@@ -1755,14 +1773,14 @@ cA
 bv
 cL
 cV
-dy
+aq
 df
 bO
 Rg
 dw
 zN
-bE
-dy
+bV
+aq
 "}
 (11,1,1) = {"
 cM
@@ -1784,19 +1802,19 @@ aS
 cG
 bA
 cU
-dy
+aq
 dg
 dm
 IC
 hr
 Hp
 nM
-dy
+aq
 "}
 (12,1,1) = {"
 cM
 cM
-bV
+aM
 ce
 ao
 bs
@@ -1813,14 +1831,14 @@ cA
 cH
 bB
 cV
-dy
+aq
 bI
 dz
 CS
 yA
 Qm
 wp
-dy
+aq
 "}
 (13,1,1) = {"
 cM
@@ -1843,11 +1861,11 @@ aG
 bz
 cP
 bD
-dy
-dy
-dy
-dy
-dy
-dy
+aq
+aq
+aq
+aq
+aq
+aq
 YI
 "}


### PR DESCRIPTION
i hate large engine rotation and you should too

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Splits bridge and crew quarters areas, the central room is under bridge area and there's an APC in the cap's quarters
It names all the doors appropriately, except for the front module one (I have no idea what to call that).
Adds lattices so the thindows don't vanish into thin fucking air, alongside the railings.
Replaces the large engines with 4 regular engines to avoid shuttle rotation fuckery, keep those things on the Starfury people
Removes the large firelocks from inter-module doors and all windows to prevent THIS from happening every round
![image](https://user-images.githubusercontent.com/80979251/187719802-91006fb0-310d-4429-be6f-551342417c5c.png)


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Stops unwanted firelock fuckery, stops shuttle engine rotation fuckery, keeps those thindows from falling off.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Tram whiteship now has named airlocks
add: Tram whiteship bridge and crew quarters areas are split, new APCs added
fix: no more shuttle engine rotation fuckery on tram whiteship
fix: no more firelock fuckery on tram whiteship
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
