### PR TITLE
admin deadsay now uses deadchat_broadcasts as it ought to.

### DIFF
--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -25,14 +25,8 @@
 		rank_name = pick(strings("admin_nicknames.json", "ranks", "config"))
 		admin_name = pick(strings("admin_nicknames.json", "names", "config"))
 	var/name_and_rank = "[span_tooltip(rank_name, "STAFF")] ([admin_name])"
-	var/rendered = "<span class='game deadsay'>[span_prefix("DEAD:")] [name_and_rank] says, <span class='message'>\"[emoji_parse(msg)]\"</span></span>"
 
-	for (var/mob/M in GLOB.player_list)
-		var/admin_holder = M.client?.holder
-		if(isnewplayer(M) && !admin_holder) // We want to make sure admins can see this when in the lobby too!
-			continue
-		if (M.stat == DEAD || (admin_holder && (M.client?.prefs.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only given to Administrators and above
-			to_chat(M, rendered, confidential = TRUE)
+	deadchat_broadcast("[span_prefix("DEAD:")] [name_and_rank] says, <span class='message'>\"[emoji_parse(msg)]\"</span>")
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Dsay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
## About The Pull Request
The admin deadsay command is old and still based on the assumption that ghosts and admins are the only ones that can hear deadchat messages, while using a snowflake loop that's pretty much superseded by the deadchat_broadcast proc.

## Why It's Good For The Game

This will fix  #69590

## Changelog

:cl:
fix: Brought a portion of the admin deadsay command up to date. Revenants and EOR players will now see admin deadchat messages in their chat tab.
/:cl:
