### PR TITLE
mecha logs are now accurate

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -325,9 +325,16 @@
 
 	if(ismob(firer))
 		log_combat(firer, L, "shot", src, reagent_note)
-	else
-		L.log_message("has been shot by [firer] with [src]", LOG_ATTACK, color="orange")
+		return BULLET_ACT_HIT
 
+	if(ismecha(firer))
+		var/obj/vehicle/sealed/mecha/chassis = firer
+		var/mob/occupant = chassis.occupants[1]
+
+		log_combat(occupant, L, "shot", src, "from [chassis] [chassis.occupants.len > 1 ? "with multiple occupants" : ""] [reagent_note]")
+		return BULLET_ACT_HIT
+
+	L.log_message("has been shot by [firer] with [src]", LOG_ATTACK, color="orange")
 	return BULLET_ACT_HIT
 
 /obj/projectile/proc/vol_by_damage()

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -77,7 +77,8 @@
 
 		if(kickback)
 			chassis.newtonian_move(newtonian_target)
-	chassis.log_message("Fired from [name], targeting [target].", LOG_ATTACK)
+
+	log_combat(source, target, "shot", src, "from [chassis]")
 
 //Base energy weapon type
 /obj/item/mecha_parts/mecha_equipment/weapon/energy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

mecha logs now accurately give information to the current occupant of the mecha in combat logs (and adds a disclaimer if there are multiple occupants in said mecha (and at that point its an admin issue))

fixes #69575

## Why It's Good For The Game

logging good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: mecha combat now has accurate logging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
