### PR TITLE
Fixes runtime when broadcasting to a frequency with no radios on it

### DIFF
--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -151,7 +151,8 @@
 		if (TRANSMISSION_SUBSPACE)
 			// Reaches any radios on the levels
 			var/list/all_radios_of_our_frequency = GLOB.all_radios["[frequency]"]
-			radios = all_radios_of_our_frequency.Copy()
+			if(LAZYLEN(all_radios_of_our_frequency))
+				radios = all_radios_of_our_frequency.Copy()
 
 			for(var/obj/item/radio/subspace_radio in radios)
 				if(!subspace_radio.can_receive(frequency, signal_reaches_every_z_level))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6209658/187774535-80a383b1-9a52-4b7b-bc6f-4a4cef9bbbe5.png)

```
[16:20:57] Runtime in broadcasting.dm, line 154: Cannot execute null.Copy().
proc name: broadcast (/datum/signal/subspace/vocal/broadcast)
src: /datum/signal/subspace/vocal (/datum/signal/subspace/vocal)
call stack:
/datum/signal/subspace/vocal (/datum/signal/subspace/vocal): broadcast()
the subspace broadcaster (/obj/machinery/telecomms/broadcaster/preset_left): receive information(/datum/signal/subspace/vocal (/datum/signal/subspace/vocal), the telecommunication hub (/obj/machinery/telecomms/hub/preset))
the telecommunication hub (/obj/machinery/telecomms/hub/preset): relay information(/datum/signal/subspace/vocal (/datum/signal/subspace/vocal), /obj/machinery/telecomms/broad... (/obj/machinery/telecomms/broadcaster), null, 20)
the telecommunication hub (/obj/machinery/telecomms/hub/preset): receive information(/datum/signal/subspace/vocal (/datum/signal/subspace/vocal), Common Server (/obj/machinery/telecomms/server/presets/common))
Common Server (/obj/machinery/telecomms/server/presets/common): relay information(/datum/signal/subspace/vocal (/datum/signal/subspace/vocal), /obj/machinery/telecomms/hub (/obj/machinery/telecomms/hub), null, 20)
Common Server (/obj/machinery/telecomms/server/presets/common): receive information(/datum/signal/subspace/vocal (/datum/signal/subspace/vocal), the bus mainframe (/obj/machinery/telecomms/bus/preset_four))
the bus mainframe (/obj/machinery/telecomms/bus/preset_four): relay information(/datum/signal/subspace/vocal (/datum/signal/subspace/vocal), /obj/machinery/telecomms/serve... (/obj/machinery/telecomms/server), null, 20)
the bus mainframe (/obj/machinery/telecomms/bus/preset_four): receive information(/datum/signal/subspace/vocal (/datum/signal/subspace/vocal), the processor unit (/obj/machinery/telecomms/processor/preset_four))
the processor unit (/obj/machinery/telecomms/processor/preset_four): relay direct information(/datum/signal/subspace/vocal (/datum/signal/subspace/vocal), the bus mainframe (/obj/machinery/telecomms/bus/preset_four))
the processor unit (/obj/machinery/telecomms/processor/preset_four): receive information(/datum/signal/subspace/vocal (/datum/signal/subspace/vocal), the bus mainframe (/obj/machinery/telecomms/bus/preset_four))
...
/datum/signal/subspace/vocal (/datum/signal/subspace/vocal): send to receivers()
Interrogation Intercom (/obj/item/radio/intercom/directional/south): talk into impl(the parrot (/mob/living/simple_animal/parrot), "BAWWWWK george mellons griffin...", null, /list (/list), /datum/language/common (/datum/language/common), /list (/list))
world: ImmediateInvokeAsync(Interrogation Intercom (/obj/item/radio/intercom/directional/south), /obj/item/radio/proc/talk_into... (/obj/item/radio/proc/talk_into_impl), the parrot (/mob/living/simple_animal/parrot), "BAWWWWK george mellons griffin...", null, /list (/list), /datum/language/common (/datum/language/common), /list (/list))
Interrogation Intercom (/obj/item/radio/intercom/directional/south): talk into(the parrot (/mob/living/simple_animal/parrot), "BAWWWWK george mellons griffin...", null, /list (/list), /datum/language/common (/datum/language/common), /list (/list))
Interrogation Intercom (/obj/item/radio/intercom/directional/south): Hear("<span class=\'game say\'><span...", the parrot (/mob/living/simple_animal/parrot), /datum/language/common (/datum/language/common), "BAWWWWK george mellons griffin...", null, /list (/list), /list (/list))
the parrot (/mob/living/simple_animal/parrot): say("BAWWWWK george mellons griffin...", null, /list (/list), 1, /datum/language/common (/datum/language/common), 0, "poly", null)
the parrot (/mob/living/simple_animal/parrot): handle automated speech()
NPC Pool (/datum/controller/subsystem/npcpool): ignite(0)
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```