### PR TITLE
Fixes monkey AI resist runtime

### DIFF
--- a/code/datums/ai/generic/generic_behaviors.dm
+++ b/code/datums/ai/generic/generic_behaviors.dm
@@ -2,7 +2,7 @@
 /datum/ai_behavior/resist/perform(delta_time, datum/ai_controller/controller)
 	. = ..()
 	var/mob/living/living_pawn = controller.pawn
-	living_pawn.resist()
+	living_pawn.execute_resist()
 	finish_action(controller, TRUE)
 
 /datum/ai_behavior/battle_screech


### PR DESCRIPTION
"_queue_verb() returned false because it wasnt called from player input!"

was calling resist() which queues it as a player input. 

:cl: ShizCalev
fix: Monkeys can now actually resist things!
/:cl:
