### PR TITLE
fixes qdeling atoms being thrown by explosions

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -731,6 +731,8 @@ SUBSYSTEM_DEF(explosions)
 			var/throw_dir = L[2]
 			var/max_range = L[3]
 			for(var/atom/movable/A in T)
+				if(QDELETED(A))
+					continue
 				if(!A.anchored && A.move_resist != INFINITY)
 					var/atom_throw_range = rand(throw_range, max_range)
 					var/turf/throw_at = get_ranged_target_turf(A, throw_dir, atom_throw_range)


### PR DESCRIPTION
fixes the `Qdeleted thing being thrown around.` runtimes spamming the shit out of the logs

```
[2022-08-31 18:10:39.118] runtime error: Qdeleted thing being thrown around.
 - proc name: throw at (/atom/movable/proc/throw_at)
 -   source file: atoms_movable.dm,1089
 -   usr: null
 -   src: the shard (/obj/item/shard)
 -   src.loc: the floor (110,99,2) (/turf/open/floor/iron)
 -   call stack:
 - the shard (/obj/item/shard): throw at(the floor (110,99,2) (/turf/open/floor/iron), 3, 4, null, 1, 0, /datum/callback (/datum/callback), 2000, 0, 0)
 - the shard (/obj/item/shard): throw at(the floor (110,99,2) (/turf/open/floor/iron), 3, 4, null, 1, 0, /datum/callback (/datum/callback), null, 0, 0)
 - Explosions (/datum/controller/subsystem/explosions): fire(0)
 - Explosions (/datum/controller/subsystem/explosions): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```