### PR TITLE
fixes staff-dsay (admin deadchat command)

### DIFF
--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -25,14 +25,9 @@
 		rank_name = pick(strings("admin_nicknames.json", "ranks", "config"))
 		admin_name = pick(strings("admin_nicknames.json", "names", "config"))
 	var/name_and_rank = "[span_tooltip(rank_name, "STAFF")] ([admin_name])"
-	var/rendered = "<span class='game deadsay'>[span_prefix("DEAD:")] [name_and_rank] says, <span class='message'>\"[emoji_parse(msg)]\"</span></span>"
+	var/rendered = "[span_prefix("DEAD:")] [name_and_rank] says, <span class='message'>\"[emoji_parse(msg)]\"</span>"
 
-	for (var/mob/M in GLOB.player_list)
-		var/admin_holder = M.client?.holder
-		if(isnewplayer(M) && !admin_holder) // We want to make sure admins can see this when in the lobby too!
-			continue
-		if (M.stat == DEAD || (admin_holder && (M.client?.prefs.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only given to Administrators and above
-			to_chat(M, rendered, confidential = TRUE)
+	deadchat_broadcast(rendered, null, null)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Dsay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
Fixes #69590

:cl: ShizCalev
admin: dsay now works again. 
/:cl:
