### PR TITLE
admin fax notifications

### DIFF
--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -56,7 +56,7 @@
 	GLOB.requests.fax_request(sender.client, msg)
 	var/turf/machine_location = get_turf(receiving_machine)
 	msg +=  " [ADMIN_JMP(machine_location)]"
-	msg = span_adminnotice("<b><font color=white>FAX:</font>[ADMIN_FULLMONTY(sender)] </b> [msg]")
+	msg = span_adminnotice("<b><font color=orange>FAX:</font>[ADMIN_FULLMONTY(sender)] </b> [msg]")
 	to_chat(GLOB.admins, msg, confidential = TRUE)
 
 /// Used by communications consoles to message CentCom

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -50,6 +50,15 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Prayer") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
+/// Used by fax machines if they are set to notify admins upon receiving a fax
+/proc/fax_request(obj/machinery/fax/sending_machine, obj/machinery/fax/receiving_machine, mob/sender)
+	var/msg = "sent a message from the [sanitize(sending_machine.fax_name)] fax machine to the [sanitize(receiving_machine.fax_name)] fax machine"
+	GLOB.requests.fax_request(sender.client, msg)
+	var/turf/machine_location = get_turf(receiving_machine)
+	msg +=  " [ADMIN_JMP(machine_location)]"
+	msg = span_adminnotice("<b><font color=white>FAX:</font>[ADMIN_FULLMONTY(sender)] </b> [msg]")
+	to_chat(GLOB.admins, msg, confidential = TRUE)
+
 /// Used by communications consoles to message CentCom
 /proc/message_centcom(text, mob/sender)
 	var/msg = copytext_char(sanitize(text), 1, MAX_MESSAGE_LEN)

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -144,11 +144,7 @@
 			flick("fax_send", src)
 			playsound(src, 'sound/machines/high_tech_confirm.ogg', 50, FALSE)
 			if (FAX.notify_admins_on_recieve)
-				var/turf/machine_location = get_turf(FAX)
-				var/msg = "sent a message from the [sanitize(fax_name)] fax machine to the [sanitize(FAX.fax_name)] fax machine [ADMIN_JMP(machine_location)]."
-				GLOB.requests.fax_request(usr.client, msg)
-				msg = span_adminnotice("<b><font color=orange>FAX:</font>[ADMIN_FULLMONTY(usr)] </b> [msg]")
-				to_chat(GLOB.admins, msg, confidential = TRUE)
+				fax_request(src, FAX, usr)
 			return TRUE
 	return FALSE
 

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -92,6 +92,7 @@
 		fax_data["has_paper"] = !!FAX.paper_contain
 		// Hacked doesn't mean on the syndicate network.
 		fax_data["syndicate_network"] = FAX.syndicate_network
+		fax_data["notify_admins"] = FAX.notify_admins_on_recieve
 		data["faxes"] += list(fax_data)
 
 	// Own data
@@ -99,6 +100,7 @@
 	data["fax_name"] = fax_name
 	// In this case, we don't care if the fax is hacked or in the syndicate's network. The main thing is to check the visibility of other faxes.
 	data["syndicate_network"] = (syndicate_network || (obj_flags & EMAGGED))
+	data["notify_admins"] = notify_admins_on_recieve
 	data["has_paper"] = !!paper_contain
 	data["fax_history"] = fax_history
 	return data

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -18,6 +18,8 @@
 	var/syndicate_network = FALSE
 	/// This is where the dispatch and reception history for each fax is stored.
 	var/list/fax_history = list()
+	/// Set to true to notify admins when this machine receives a fax
+	var/notify_admins_on_recieve = FALSE
 
 /obj/machinery/fax/Initialize(mapload)
 	. = ..()
@@ -141,6 +143,12 @@
 			history_add("Send", FAX.fax_name)
 			flick("fax_send", src)
 			playsound(src, 'sound/machines/high_tech_confirm.ogg', 50, FALSE)
+			if (FAX.notify_admins_on_recieve)
+				var/turf/machine_location = get_turf(FAX)
+				var/msg = "sent a message from the [sanitize(fax_name)] fax machine to the [sanitize(FAX.fax_name)] fax machine [ADMIN_JMP(machine_location)]."
+				GLOB.requests.fax_request(usr.client, msg)
+				msg = span_adminnotice("<b><font color=orange>FAX:</font>[ADMIN_FULLMONTY(usr)] </b> [msg]")
+				to_chat(GLOB.admins, msg, confidential = TRUE)
 			return TRUE
 	return FALSE
 

--- a/code/modules/requests/request.dm
+++ b/code/modules/requests/request.dm
@@ -6,6 +6,8 @@
 #define REQUEST_SYNDICATE "request_syndicate"
 /// Requests for the nuke code
 #define REQUEST_NUKE "request_nuke"
+/// Requests from faxes
+#define REQUEST_FAX "request_fax"
 
 /**
  * # Request

--- a/code/modules/requests/request_manager.dm
+++ b/code/modules/requests/request_manager.dm
@@ -3,7 +3,7 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 /**
  * # Request Manager
  *
- * Handles all player requests (prayers, centcom requests, syndicate requests)
+ * Handles all player requests (prayers, notified faxes, centcom requests, syndicate requests)
  * that occur in the duration of a round.
  */
 /datum/request_manager
@@ -56,7 +56,13 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 		if(is_chaplain && admin.prefs.chat_toggles & CHAT_PRAYER && admin.prefs.toggles & SOUND_PRAYERS)
 			SEND_SOUND(admin, sound('sound/effects/pray.ogg'))
 
-//TODO document
+/**
+ * Creates a fax request
+ *
+ * Arguments:
+ * * C - The client who sent the fax
+ * * message - The fax notification
+ */
 /datum/request_manager/proc/fax_request(client/C, message)
 	request_for_client(C, REQUEST_FAX, message)
 

--- a/code/modules/requests/request_manager.dm
+++ b/code/modules/requests/request_manager.dm
@@ -56,6 +56,10 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 		if(is_chaplain && admin.prefs.chat_toggles & CHAT_PRAYER && admin.prefs.toggles & SOUND_PRAYERS)
 			SEND_SOUND(admin, sound('sound/effects/pray.ogg'))
 
+//TODO document
+/datum/request_manager/proc/fax_request(client/C, message)
+	request_for_client(C, REQUEST_FAX, message)
+
 /**
  * Creates a request for a Centcom message
  *

--- a/tgui/packages/tgui/interfaces/Fax.tsx
+++ b/tgui/packages/tgui/interfaces/Fax.tsx
@@ -9,6 +9,7 @@ type FaxData = {
   fax_name: string;
   has_paper: string;
   syndicate_network: boolean;
+  notify_admins: boolean;
   fax_history: FaxHistory[];
 };
 
@@ -17,6 +18,7 @@ type FaxInfo = {
   fax_id: string;
   has_paper: boolean;
   syndicate_network: boolean;
+  notify_admins: boolean;
 };
 
 type FaxHistory = {
@@ -66,7 +68,7 @@ export const Fax = (props, context) => {
                 key={fax.fax_id}
                 title={fax.fax_name}
                 disabled={!data.has_paper}
-                color={fax.syndicate_network ? 'red' : 'blue'}
+                color={fax.syndicate_network ? 'red' : (fax.notify_admins) ? 'green' : 'blue'}
                 onClick={() =>
                   act('send', {
                     id: fax.fax_id,

--- a/tgui/packages/tgui/interfaces/RequestManager.js
+++ b/tgui/packages/tgui/interfaces/RequestManager.js
@@ -81,6 +81,7 @@ export const RequestManager = (props, context) => {
 
 const displayTypeMap = {
   'request_prayer': 'PRAYER',
+  'request_fax': 'FAX',
   'request_centcom': 'CENTCOM',
   'request_syndicate': 'SYNDICATE',
   'request_nuke': 'NUKE CODE',

--- a/tgui/packages/tgui/styles/interfaces/RequestManager.scss
+++ b/tgui/packages/tgui/styles/interfaces/RequestManager.scss
@@ -8,6 +8,7 @@
 @use '../functions.scss';
 
 $color-prayer: colors.bg(colors.$purple) !default;
+$color-fax: colors.bg(colors.$white) !default;
 $color-centcom: colors.bg(colors.$yellow) !default;
 $color-syndicate: colors.bg(colors.$red) !default;
 $color-nuke: colors.bg(colors.$yellow) !default;
@@ -19,12 +20,17 @@ $text-color: base.$color-fg !default;
 .RequestManager__request_centcom,
 .RequestManager__request_nuke,
 .RequestManager__request_prayer,
+.RequestManager__request_fax,
 .RequestManager__request_syndicate {
   margin-right: 0.5rem;
 }
 
 .RequestManager__request_prayer {
   color: $color-prayer;
+}
+
+.RequestManager__request_fax {
+  color: $color-fax;
 }
 
 .RequestManager__request_centcom {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The idea of fax notifications was brought up [on the forums](https://tgstation13.org/phpBB/viewtopic.php?p=650996#p650996). This PR lets admins VV edit a fax machine in order to receive notifications for it.

View the variables of a fax machine and set `notify_admins_on_recieve` to 1 to receive notifications for it.
![1](https://user-images.githubusercontent.com/94711066/187806266-7acba961-2943-479a-9d1e-08e500b6ecdf.PNG)

When this machine receives a fax a notification shows up in the info chat tab (same as prayers). You can also jump to the receiving machine so you can read the freshly faxed message.
![2](https://user-images.githubusercontent.com/94711066/187806268-a9e08df1-eab9-4678-ab47-3a7d0089d512.PNG)

Received faxes also show up in the request manager so you can keep track of who's been sending you faxes and when.
![4](https://user-images.githubusercontent.com/94711066/187806270-76eb1960-1273-41f1-8b95-cf70d714193a.PNG)
![3](https://user-images.githubusercontent.com/94711066/187806269-021b6b37-d54c-45a6-8d8f-78c5070ccda3.PNG)

Fax machines with `notify_admins_on_recieve` enabled will have a green send button. Syndicate network machines will still show up red even with `notify_admins_on_recieve` enabled.
![5](https://user-images.githubusercontent.com/94711066/187806272-9eceab0c-8a20-483a-898b-bf1e0941860a.PNG)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fax machines make for an interesting form of communication between the station and centcom. Getting notified of incoming messages makes it much easier for admins to engage with players using fax machines. This way they don't need to wait at the machine or risk missing a message.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: setting notify_admins_on_recieve to 1 on a fax machine allows you to receive notifications about incoming faxes in the info chat tab and the requests manager
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
