### PR TITLE
Fix mindswap spell to only work on mobs with brains

### DIFF
--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -43,29 +43,25 @@
 		return FALSE
 	return TRUE
 
-/datum/action/cooldown/spell/pointed/mind_transfer/is_valid_target(atom/cast_on)
+/datum/action/cooldown/spell/pointed/mind_transfer/is_valid_target(mob/living/living_target)
 	. = ..()
 	if(!.)
 		return FALSE
 
-	if(!isliving(cast_on))
+	if(!isliving(living_target))
 		to_chat(owner, span_warning("You can only swap minds with living beings!"))
 		return FALSE
-	if(is_type_in_typecache(cast_on, blacklisted_mobs))
+	if(is_type_in_typecache(living_target, blacklisted_mobs))
 		to_chat(owner, span_warning("This creature is too [pick("powerful", "strange", "arcane", "obscene")] to control!"))
 		return FALSE
-	if(isguardian(cast_on))
-		var/mob/living/simple_animal/hostile/guardian/stand = cast_on
-		if(stand.summoner && stand.summoner == owner)
-			to_chat(owner, span_warning("Swapping minds with your own guardian would just put you back into your own head!"))
-			return FALSE
-
-	var/mob/living/living_target = cast_on
 	if(living_target.stat == DEAD)
 		to_chat(owner, span_warning("You don't particularly want to be dead!"))
 		return FALSE
 	if(!living_target.mind)
 		to_chat(owner, span_warning("[living_target.p_theyve(TRUE)] doesn't appear to have a mind to swap into!"))
+		return FALSE
+	if(!living_target.getorganslot(ORGAN_SLOT_BRAIN))
+		to_chat(owner, span_warning("[living_target.p_theyve(TRUE)] doesn't appear to have a brain to swap into!"))
 		return FALSE
 	if(!living_target.key && target_requires_key)
 		to_chat(owner, span_warning("[living_target.p_theyve(TRUE)] appear[living_target.p_s()] to be catatonic! \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #56861

I added a check to only allow mind swapping with mobs that have brains.  So no mindswapping weird mobs like ~~silicons, AIs,~~ pAIs, revenants, blobs, etc.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

This should prevent a lot of edge cases involving bugs with this spell.  Also this restriction makes sense since it should require a brain to swap minds, thus the name of the spell.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix mind transfer to only work on mobs with brains
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
