### PR TITLE
Micro-optimize RegisterSignal, saving 0.3s of init time

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -185,28 +185,26 @@
 	var/list/procs = signal_procs
 	if(!procs)
 		signal_procs = procs = list()
-	if(!procs[target])
-		procs[target] = list()
+	var/list/target_procs = procs[target] || (procs[target] = list())
 	var/list/lookup = target.comp_lookup
 	if(!lookup)
 		target.comp_lookup = lookup = list()
 
-	var/list/sig_types = islist(sig_type_or_types) ? sig_type_or_types : list(sig_type_or_types)
-	for(var/sig_type in sig_types)
-		if(!override && procs[target][sig_type])
+	for(var/sig_type in (islist(sig_type_or_types) ? sig_type_or_types : list(sig_type_or_types)))
+		if(!override && target_procs[sig_type])
 			stack_trace("[sig_type] overridden. Use override = TRUE to suppress this warning")
 
-		procs[target][sig_type] = proctype
+		target_procs[sig_type] = proctype
+		var/list/looked_up = lookup[sig_type]
 
-		if(!lookup[sig_type]) // Nothing has registered here yet
+		if(!looked_up) // Nothing has registered here yet
 			lookup[sig_type] = src
-		else if(lookup[sig_type] == src) // We already registered here
+		else if(looked_up == src) // We already registered here
 			continue
-		else if(!length(lookup[sig_type])) // One other thing registered here
-			lookup[sig_type] = list(lookup[sig_type]=TRUE)
-			lookup[sig_type][src] = TRUE
+		else if(!length(looked_up)) // One other thing registered here
+			lookup[sig_type] = list((looked_up) = TRUE, (src) = TRUE)
 		else // Many other things have registered here
-			lookup[sig_type][src] = TRUE
+			looked_up[src] = TRUE
 
 /**
  * Stop listening to a given signal from target


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Caches some vars, merges some statements by abusing `x = y` returning y. Goes from .53ms per call to .45ms per call, saving over .3s of init time due to its call count.