### PR TITLE
Adds an examine hint to explorer gas masks

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -147,7 +147,7 @@
 
 // Mining survival box
 /obj/item/storage/box/survival/mining
-	mask_type = /obj/item/clothing/mask/gas/explorer
+	mask_type = /obj/item/clothing/mask/gas/explorer/folded
 
 /obj/item/storage/box/survival/mining/PopulateContents()
 	..()

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -63,8 +63,17 @@
 	adjustmask(user)
 
 /obj/item/clothing/mask/gas/explorer/adjustmask(user)
-	..()
-	w_class = mask_adjusted ? WEIGHT_CLASS_NORMAL : WEIGHT_CLASS_SMALL
+	. = ..()
+	// adjusted = out of the way = smaller = can fit in boxes
+	w_class = mask_adjusted ? WEIGHT_CLASS_SMALL : WEIGHT_CLASS_NORMAL
+
+/obj/item/clothing/mask/gas/explorer/examine(mob/user)
+	. = ..()
+	if(mask_adjusted || w_class == WEIGHT_CLASS_SMALL)
+		return
+	. += span_notice("You could fit this into a box if you adjusted it.")
+
+/obj/item/clothing/mask/gas/explorer/folded
 
 /obj/item/clothing/mask/gas/explorer/folded/Initialize(mapload)
 	. = ..()

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -74,6 +74,7 @@
 	. += span_notice("You could fit this into a box if you adjusted it.")
 
 /obj/item/clothing/mask/gas/explorer/folded
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/clothing/mask/gas/explorer/folded/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Closes #69644 

- Explorer gas mask in shaft miner kit spawns folded
- Gas mask adjusted w_class follows initial setup (adjusted = small, unadjusted = normal)
- Adds examine tip to explorer gas masks

## Why It's Good For The Game

You always could fit these in the box, they just had to be adjusted a certain way
So, an examine hit and a bit of a consistency pass should help 

## Changelog

:cl: Melbert
qol: Add an examine tip explaining how to fit an explorer gas mask into a box
/:cl:

