### PR TITLE
Load circuit components from USB ports on demand, saving 0.5s of init time (0.7s on prod)

### DIFF
--- a/code/datums/components/usb_port.dm
+++ b/code/datums/components/usb_port.dm
@@ -24,7 +24,7 @@
 
 	circuit_components = list()
 
-	set_circuit_components(circuit_component_types)
+	src.circuit_component_types = circuit_component_types
 
 /datum/component/usb_port/proc/set_circuit_components(list/components)
 	var/should_register = FALSE
@@ -136,6 +136,9 @@
 /datum/component/usb_port/proc/on_atom_usb_cable_try_attach(datum/source, obj/item/usb_cable/connecting_cable, mob/user)
 	SIGNAL_HANDLER
 
+	if (!length(circuit_components))
+		set_circuit_components(circuit_component_types)
+
 	var/atom/atom_parent = parent
 
 	if (!isnull(attached_circuit))
@@ -156,7 +159,7 @@
 	if (connecting_cable.attached_circuit.locked)
 		connecting_cable.balloon_alert(user, "shell is locked!")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK
-	
+
 	usb_cable_ref = WEAKREF(connecting_cable)
 	attached_circuit = connecting_cable.attached_circuit
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We create 2,383 circuit components (on whatever map I was looking at on Sybil at the time, don't know) from USB ports every round, quite pricey. This makes them initialize once when a USB is first plugged in.