### PR TITLE
[NO GBP] Soulstone shades don't count against dynamic midroll chance

### DIFF
--- a/code/modules/antagonists/shade/shade_minion.dm
+++ b/code/modules/antagonists/shade/shade_minion.dm
@@ -10,6 +10,7 @@
 	show_in_roundend = FALSE
 	silent = TRUE
 	ui_name = "AntagInfoShade"
+	count_against_dynamic_roll_chance = FALSE
 	/// Name of this shade's master.
 	var/master_name = "nobody?"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I saw this comment made on a different PR adding an antag datum and realised it was also true for this recently merged one.
These aren't midround antags and aren't necessarily even antagonistic if their master is a crew-sided chaplain. Any evil shades are minions of other antagonists, there's no reason for them to count twice.

## Why It's Good For The Game

Fixes an oversight.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Creating shades with soulstones won't affect the chance of midround antagonist spawns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
