### PR TITLE
Fixes ghost role / admin events announcing after they failed to spawn the antagonist. Admin spawned blobs will no longer announce immediately.

### DIFF
--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -18,6 +18,7 @@
 
 /datum/round_event/ghost_role/blob
 	announce_chance = 0
+	announce_when = 15
 	role_name = "blob overmind"
 	fakeable = TRUE
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -18,11 +18,12 @@
 
 /datum/round_event/ghost_role/blob
 	announce_chance = 0
-	announce_when = 15
 	role_name = "blob overmind"
 	fakeable = TRUE
 
 /datum/round_event/ghost_role/blob/announce(fake)
+	if(!fake)
+		return //the mob itself handles this.
 	priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", ANNOUNCER_OUTBREAK5)
 
 /datum/round_event/ghost_role/blob/spawn_role()

--- a/code/modules/events/ghost_role.dm
+++ b/code/modules/events/ghost_role.dm
@@ -8,6 +8,7 @@
 	var/role_name = "debug rat with cancer" // Q U A L I T Y  M E M E S
 	var/list/spawned_mobs = list()
 	var/status
+	var/cached_announcement_chance
 	fakeable = FALSE
 
 /datum/round_event/ghost_role/start()
@@ -19,6 +20,9 @@
 	processing = FALSE
 
 	status = spawn_role()
+	if(isnull(cached_announcement_chance))
+		cached_announcement_chance = announce_chance //only announce once we've finished the spawning loop.
+	announce_chance = (status == SUCCESSFUL_SPAWN ? cached_announcement_chance : 0)
 	if((status == WAITING_FOR_SOMETHING))
 		if(retry >= MAX_SPAWN_ATTEMPT)
 			message_admins("[role_name] event has exceeded maximum spawn attempts. Aborting and refunding.")


### PR DESCRIPTION
Fixes #69670
:cl: ShizCalev
fix: Admin event spawned blobs will no longer immediately announce when the event is triggered.
fix: Admin events which poll candidates from ghosts will no longer announce the event if the event failed to spawn a mob. 
/:cl:
