### PR TITLE
Supermatter cascade subsystems fire when it needs to

### DIFF
--- a/code/controllers/subsystem/processing/supermatter_cascade.dm
+++ b/code/controllers/subsystem/processing/supermatter_cascade.dm
@@ -2,6 +2,7 @@ PROCESSING_SUBSYSTEM_DEF(supermatter_cascade)
 	name = "Supermatter Cascade"
 	wait = 0.5 SECONDS
 	stat_tag = "SC"
+	can_fire = FALSE
 
 	///Is a cascade happening right now?
 	var/cascade_initiated = FALSE

--- a/code/modules/power/supermatter/supermatter_delamination/cascade_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/cascade_delam.dm
@@ -11,14 +11,14 @@
 		if(!percent || percent < 0.4)
 			return FALSE
 	return TRUE
-	
-/datum/sm_delam/cascade/delam_progress(obj/machinery/power/supermatter_crystal/sm)	
+
+/datum/sm_delam/cascade/delam_progress(obj/machinery/power/supermatter_crystal/sm)
 	. = ..()
 	if(!.)
 		return FALSE
 	sm.radio.talk_into(
 		sm,
-		"DANGER: HYPERSTRUCTURE OSCILLATION FREQUENCY OUT OF BOUNDS.", 
+		"DANGER: HYPERSTRUCTURE OSCILLATION FREQUENCY OUT OF BOUNDS.",
 		sm.damage >= sm.emergency_point ? sm.emergency_channel : sm.warning_channel
 	)
 	var/list/messages = list(
@@ -64,6 +64,7 @@
 	var/obj/cascade_portal/rift = effect_evac_rift_start()
 	RegisterSignal(rift, COMSIG_PARENT_QDELETING, .proc/end_round_holder)
 	effect_crystal_mass(sm, rift)
+	SSsupermatter_cascade.can_fire = TRUE
 	SSsupermatter_cascade.cascade_initiated = TRUE
 	qdel(sm)
 


### PR DESCRIPTION
## About The Pull Request

Supermatter cascade by default is offline, and will fire when a supermatter cascade occurs.

## Why It's Good For The Game

This fires every 0.5 seconds for what??? help
This barely changes anything since the subsystem does nothing, but it bugged me when I found out this is a thing.

## Changelog

No player facing changes.