### PR TITLE
restores an old SM delam bug making you not get the mood debuff if you're inside a locker when it explodes

### DIFF
--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -25,10 +25,11 @@
 			human.hallucination += max(50, min(300, DETONATION_HALLUCINATION * sqrt(1 / (get_dist(victim, sm) + 1)) ) )
 
 	for(var/mob/victim as anything in GLOB.player_list)
-		if(!is_valid_z_level(get_turf(victim), sm_turf))
+		var/turf/victim_turf = get_turf(victim)
+		if(!is_valid_z_level(victim_turf, sm_turf))
 			continue
-		SEND_SOUND(victim, 'sound/magic/charge.ogg')
-		if(!is_valid_z_level(get_turf(victim), sm_turf))
+		victim.playsound_local(victim_turf, 'sound/magic/charge.ogg')
+		if(victim.z == 0) //victim is inside an object, this is to maintain an old bug turned feature with lockers n shit i guess. tg issue #69687
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as hard as you can, as reality distorts around you. You feel safe."))
 			continue
 		to_chat(victim, span_boldannounce("You feel reality distort for a moment..."))

--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -10,6 +10,8 @@
 	for (var/mob/living/victim in range(20, sm))
 		if(!is_valid_z_level(get_turf(victim), sm_turf))
 			continue
+		if(victim.z == 0)
+			continue
 		SSradiation.irradiate(victim)
 	return TRUE
 
@@ -18,6 +20,8 @@
 	var/turf/sm_turf = get_turf(sm)
 	for(var/mob/living/victim as anything in GLOB.alive_mob_list)
 		if(!istype(victim) || !is_valid_z_level(get_turf(victim), sm_turf))
+			continue
+		if(victim.z == 0)
 			continue
 		if(ishuman(victim))
 			//Hilariously enough, running into a closet should make you get hit the hardest.


### PR DESCRIPTION
Closes #69687
:cl: ShizCalev
fix: Hiding inside lockers/objects when the SM delams will protect you from it's effects again.
/:cl:


for the record, i feel this is snowflake af and hate it. 