### PR TITLE
fixes nightmares not healing from darkness

### DIFF
--- a/code/modules/antagonists/nightmare/nightmare_organs.dm
+++ b/code/modules/antagonists/nightmare/nightmare_organs.dm
@@ -4,13 +4,13 @@
 #define HEART_SPECIAL_SHADOWIFY 2
 
 
-/obj/item/organ/internal/brain/nightmare
+/obj/item/organ/internal/brain/shadow/nightmare
 	name = "tumorous mass"
 	desc = "A fleshy growth that was dug out of the skull of a Nightmare."
 	icon_state = "brain-x-d"
 	var/datum/action/cooldown/spell/jaunt/shadow_walk/our_jaunt
 
-/obj/item/organ/internal/brain/nightmare/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = TRUE)
+/obj/item/organ/internal/brain/shadow/nightmare/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = TRUE)
 	. = ..()
 	if(M.dna.species.id != SPECIES_NIGHTMARE)
 		M.set_species(/datum/species/shadow/nightmare)
@@ -19,7 +19,7 @@
 	our_jaunt = new(M)
 	our_jaunt.Grant(M)
 
-/obj/item/organ/internal/brain/nightmare/Remove(mob/living/carbon/M, special = FALSE)
+/obj/item/organ/internal/brain/shadow/nightmare/Remove(mob/living/carbon/M, special = FALSE)
 	QDEL_NULL(our_jaunt)
 	return ..()
 

--- a/code/modules/antagonists/nightmare/nightmare_species.dm
+++ b/code/modules/antagonists/nightmare/nightmare_species.dm
@@ -24,7 +24,7 @@
 	)
 
 	mutantheart = /obj/item/organ/internal/heart/nightmare
-	mutantbrain = /obj/item/organ/internal/brain/nightmare
+	mutantbrain = /obj/item/organ/internal/brain/shadow/nightmare
 
 /datum/species/shadow/nightmare/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes #69666 

Caused by #69543, made shadowpeople brain a new subtype but then did not make nightmare brains the same subtype

## Why It's Good For The Game

Nightmares should abide by the main species mechanic

## Changelog

:cl: Melbert
fix: Nightmares heal in darkness again
/:cl:
