### PR TITLE
Nerfs the scrubber overflow event

### DIFF
--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -20,37 +20,37 @@
 		/datum/reagent/carbon,
 		/datum/reagent/consumable/flour,
 		/datum/reagent/space_cleaner,
+		/datum/reagent/carpet/royal/blue
+		/datum/reagent/carpet/orange
 		/datum/reagent/consumable/nutriment,
 		/datum/reagent/consumable/condensedcapsaicin,
 		/datum/reagent/drug/mushroomhallucinogen,
 		/datum/reagent/lube,
+		/datum/reagent/glitter/blue,
 		/datum/reagent/glitter/pink,
 		/datum/reagent/cryptobiolin,
-		/datum/reagent/toxin/plantbgone,
 		/datum/reagent/blood,
 		/datum/reagent/medicine/c2/multiver,
-		/datum/reagent/drug/space_drugs,
-		/datum/reagent/medicine/morphine,
 		/datum/reagent/water/holywater,
 		/datum/reagent/consumable/ethanol,
 		/datum/reagent/consumable/hot_coco,
-		/datum/reagent/toxin/acid,
-		/datum/reagent/toxin/mindbreaker,
-		/datum/reagent/toxin/rotatium,
+		/datum/reagent/consumable/yoghurt
+		/datum/reagent/consumable/tinlux
+		/datum/reagent/hydrogen_peroxide
 		/datum/reagent/bluespace,
 		/datum/reagent/pax,
 		/datum/reagent/consumable/laughter,
 		/datum/reagent/concentrated_barbers_aid,
 		/datum/reagent/baldium,
 		/datum/reagent/colorful_reagent,
-		/datum/reagent/peaceborg/confuse,
-		/datum/reagent/peaceborg/tire,
 		/datum/reagent/consumable/salt,
 		/datum/reagent/consumable/ethanol/beer,
 		/datum/reagent/hair_dye,
 		/datum/reagent/consumable/sugar,
 		/datum/reagent/glitter/white,
+		/datum/reagent/gravitum,
 		/datum/reagent/growthserum,
+		/datum/reagent/yuck,
 	)
 	//needs to be chemid unit checked at some point
 
@@ -61,7 +61,7 @@
 	end_when = rand(25, 100)
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/temp_vent in GLOB.machines)
 		var/turf/scrubber_turf = get_turf(temp_vent)
-		if(scrubber_turf && is_station_level(scrubber_turf.z) && !temp_vent.welded)
+		if(scrubber_turf && is_station_level(scrubber_turf.z) && !temp_vent.welded && prob(50))
 			scrubbers += temp_vent
 	if(!scrubbers.len)
 		return kill()

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -20,8 +20,8 @@
 		/datum/reagent/carbon,
 		/datum/reagent/consumable/flour,
 		/datum/reagent/space_cleaner,
-		/datum/reagent/carpet/royal/blue
-		/datum/reagent/carpet/orange
+		/datum/reagent/carpet/royal/blue,
+		/datum/reagent/carpet/orange,
 		/datum/reagent/consumable/nutriment,
 		/datum/reagent/consumable/condensedcapsaicin,
 		/datum/reagent/drug/mushroomhallucinogen,
@@ -34,9 +34,9 @@
 		/datum/reagent/water/holywater,
 		/datum/reagent/consumable/ethanol,
 		/datum/reagent/consumable/hot_coco,
-		/datum/reagent/consumable/yoghurt
-		/datum/reagent/consumable/tinlux
-		/datum/reagent/hydrogen_peroxide
+		/datum/reagent/consumable/yoghurt,
+		/datum/reagent/consumable/tinlux,
+		/datum/reagent/hydrogen_peroxide,
 		/datum/reagent/bluespace,
 		/datum/reagent/pax,
 		/datum/reagent/consumable/laughter,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the scrubber event trigger on half of scrubbers.

Removes peaceborg tire, peaceborg confuse, morphine, space drugs, acid, mindbreaker, rotatium and plant-b-gone from the scrubber "safer" reagents list. They're not so much "safe." 

Adds orange carpet, royal blue carpet, blue glitter, yoghurt, tinea luxor, hydrogen peroxide, gravitum, and yuck to the "safer" reagents list.

Related to #69689

## Why It's Good For The Game
_Hopefully_ will take off some strain on ssfoam, and even if it doesn't, won't make all of the station unusable. I did test this locally on Meta and it works pretty quickly. I'll look into a proper fix for foam being fussy, but I don't have the time or energy to power through this right now.

Also the "safer" chems should actually be safer.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: the scrubber overflow event now only triggers for half of scrubbers
balance: removed peaceborg tire, peaceborg confuse, morphine, space drugs, acid, mindbreaker, rotatium and plant-b-gone from the scrubber "safer" reagents list
balance: added orange carpet, royal blue carpet, blue glitter, yoghurt, tinea luxor, hydrogen peroxide, gravitum, and yuck to the "safer" reagents list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
