### PR TITLE
makes atmos_adjacent_turfs a non associative list

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_helpers.dm
+++ b/code/__DEFINES/atmospherics/atmos_helpers.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_INIT(atmos_adjacent_savings, list(0,0))
 #endif
 
 //If you're doing spreading things related to atmos, DO NOT USE CANATMOSPASS, IT IS NOT CHEAP. use this instead, the info is cached after all. it's tweaked just a bit to allow for circular checks
-#define TURFS_CAN_SHARE(T1, T2) (LAZYACCESS(T2.atmos_adjacent_turfs, T1) || LAZYLEN(T1.atmos_adjacent_turfs & T2.atmos_adjacent_turfs))
+#define TURFS_CAN_SHARE(T1, T2) ((T1 in T2.atmos_adjacent_turfs) || LAZYLEN(T1.atmos_adjacent_turfs & T2.atmos_adjacent_turfs))
 //Use this to see if a turf is fully blocked or not, think windows or firelocks. Fails with 1x1 non full tile windows, but it's not worth the cost.
 #define TURF_SHARES(T) (LAZYLEN(T.atmos_adjacent_turfs))
 
@@ -79,7 +79,7 @@ GLOBAL_LIST_INIT(atmos_adjacent_savings, list(0,0))
  *
  * To equalize two gas mixtures, we simply pool the energy and divide it by the pooled heat capacity.
  * T' = (W1+W2) / (C1+C2)
- * But if we want to moderate this conduction, maybe we can calculate the energy transferred 
+ * But if we want to moderate this conduction, maybe we can calculate the energy transferred
  * and multiply a coefficient to it instead.
  * This is the energy transferred:
  * W = T' * C1 - W1
@@ -91,20 +91,20 @@ GLOBAL_LIST_INIT(atmos_adjacent_savings, list(0,0))
  * W = (W2C1 - W1C2) / (C1+C2)
  * W = (T2*C2*C1 - T1*C1*C2) / (C1+C2)
  * W = (C1*C2) * (T2-T1) / (C1+C2)
- * 
+ *
  * W: Energy involved in the operation
  * T': Combined temperature
  * T1, C1, W1: Temp, heat cap, and thermal energy of the first gas mixture
  * T2, C2, W2: Temp, heat cap, and thermal energy of the second gas mixture
  *
  * Not immediately obvious, but saves us operation time.
- * 
- * We put a lot of parentheses here because the numbers get really really big. 
+ *
+ * We put a lot of parentheses here because the numbers get really really big.
  * By prioritizing the division we try to tone the number down so we dont get overflows.
- * 
+ *
  * Arguments:
  * * temperature_delta: T2 - T1. [/datum/gas_mixture/var/temperature]
- * If you have any moderating (less than 1) coefficients and are dealing with very big numbers 
+ * If you have any moderating (less than 1) coefficients and are dealing with very big numbers
  * multiply the temperature_delta by it first before passing so we get even more breathing room.
  * * heat_capacity_one:  gasmix one's [/datum/gas_mixture/proc/heat_capacity]
  * * heat_capacity_two: gasmix two's [/datum/gas_mixture/proc/heat_capacity]

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -1068,16 +1068,6 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 				return TRUE
 			return FALSE
 
-/atom/proc/count_adjacencies()
-	var/number_of_atmos_adjacent_turf_lists = 0
-	var/number_of_adjacent_turfs = 0
-	for(var/turf/turf_to_check)
-		if(turf_to_check.atmos_adjacent_turfs)
-			number_of_atmos_adjacent_turf_lists++
-			number_of_adjacent_turfs += length(turf_to_check.atmos_adjacent_turfs)
-
-	message_admins("there are [number_of_atmos_adjacent_turf_lists] atmos adjacent turf lists, and [number_of_adjacent_turfs] elements of all of those lists")
-
 /obj/item/construction/rld/mini
 	name = "mini-rapid-light-device (MRLD)"
 	desc = "A device used to rapidly provide lighting sources to an area. Reload with iron, plasteel, glass or compressed matter cartridges."

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -1068,6 +1068,16 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 				return TRUE
 			return FALSE
 
+/atom/proc/count_adjacencies()
+	var/number_of_atmos_adjacent_turf_lists = 0
+	var/number_of_adjacent_turfs = 0
+	for(var/turf/turf_to_check)
+		if(turf_to_check.atmos_adjacent_turfs)
+			number_of_atmos_adjacent_turf_lists++
+			number_of_adjacent_turfs += length(turf_to_check.atmos_adjacent_turfs)
+
+	message_admins("there are [number_of_atmos_adjacent_turf_lists] atmos adjacent turf lists, and [number_of_adjacent_turfs] elements of all of those lists")
+
 /obj/item/construction/rld/mini
 	name = "mini-rapid-light-device (MRLD)"
 	desc = "A device used to rapidly provide lighting sources to an area. Reload with iron, plasteel, glass or compressed matter cartridges."

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -327,8 +327,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	var/energy = 0
 	var/heat_cap = 0
 
-	for(var/t in turf_list)
-		var/turf/open/T = t
+	for(var/turf/open/T as anything in turf_list)
 		//Cache?
 		var/datum/gas_mixture/turf/mix = T.air
 		//"borrowing" this code from merge(), I need to play with the temp portion. Lets expand it out

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -168,8 +168,7 @@
 
 	current_cycle = times_fired
 	immediate_calculate_adjacent_turfs()
-	for(var/i in atmos_adjacent_turfs)
-		var/turf/open/enemy_tile = i
+	for(var/turf/open/enemy_tile as anything in atmos_adjacent_turfs)
 		var/datum/gas_mixture/enemy_air = enemy_tile.return_air()
 		if(!excited && air.compare(enemy_air))
 			//testing("Active turf found. Return value of compare(): [is_active]")

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -273,8 +273,7 @@
 			var/radiated_temperature = location.air.temperature*FIRE_SPREAD_RADIOSITY_SCALE
 			if(cold_fire)
 				radiated_temperature = location.air.temperature * COLD_FIRE_SPREAD_RADIOSITY_SCALE
-			for(var/t in location.atmos_adjacent_turfs)
-				var/turf/open/T = t
+			for(var/turf/open/T as anything in location.atmos_adjacent_turfs)
 				if(!T.active_hotspot)
 					T.hotspot_expose(radiated_temperature, CELL_VOLUME/4)
 

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -65,8 +65,8 @@
 		if(canpass && CANATMOSPASS(current_turf, src, (direction & (UP|DOWN))) && !(blocks_air || current_turf.blocks_air))
 			LAZYINITLIST(atmos_adjacent_turfs)
 			LAZYINITLIST(current_turf.atmos_adjacent_turfs)
-			atmos_adjacent_turfs[current_turf] = TRUE
-			current_turf.atmos_adjacent_turfs[src] = TRUE
+			atmos_adjacent_turfs += current_turf
+			current_turf.atmos_adjacent_turfs += src
 		else
 			if (atmos_adjacent_turfs)
 				atmos_adjacent_turfs -= current_turf
@@ -103,7 +103,7 @@
 
 		for (var/check_direction in GLOB.cardinals_multiz)
 			var/turf/secondary_turf = get_step(checked_turf, check_direction)
-			if(!checked_turf.atmos_adjacent_turfs || !checked_turf.atmos_adjacent_turfs[secondary_turf])
+			if(!checked_turf.atmos_adjacent_turfs || !(secondary_turf in checked_turf.atmos_adjacent_turfs))
 				continue
 
 			if (adjacent_turfs[secondary_turf])

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -65,8 +65,8 @@
 		if(canpass && CANATMOSPASS(current_turf, src, (direction & (UP|DOWN))) && !(blocks_air || current_turf.blocks_air))
 			LAZYINITLIST(atmos_adjacent_turfs)
 			LAZYINITLIST(current_turf.atmos_adjacent_turfs)
-			atmos_adjacent_turfs += current_turf
-			current_turf.atmos_adjacent_turfs += src
+			atmos_adjacent_turfs |= current_turf
+			current_turf.atmos_adjacent_turfs |= src
 		else
 			if (atmos_adjacent_turfs)
 				atmos_adjacent_turfs -= current_turf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
atmos_adjacent_turfs is instanced for every open turf that is atmos connected to another open turf, right now its an associative list which takes 32 bytes per element, but since it only stores orthogonal adjacencies it can only have 6 turfs per list at most. so theres no much downside to making it a non associative list since there arent many times where the associative property of hte list is used to quickly find if turf A is inside the adjacency list of turf B, and whenever it is used like this dm has to check a maximum of 6 turfs.  
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
now adding and removing from the list should be much faster since associative lists are secretly dictionaries and normal lists so they take up 4x the space, and it should save a few megabytes of memory

![Screenshot_2176](https://user-images.githubusercontent.com/15794172/188294465-5cb37bb1-eedf-4f8e-8074-3663e3eae439.png)
assoc space of elements = 32 * 515664 / 10^6 = 16 mb of memory
non assoc space of elements  = 8 * 515664 / 10^6 = 4.12 mb of memory

since adding assoc elements seems to be multiple times slower than adding non assoc elements i think this is worth it
![Screenshot_2177](https://user-images.githubusercontent.com/15794172/188294585-57b53014-2886-444d-a82d-00b08afbe88b.png)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
