### PR TITLE
Fixes role banned players not being banned from roles that they are banned from (Option Two)

### DIFF
--- a/code/controllers/subsystem/ban_cache.dm
+++ b/code/controllers/subsystem/ban_cache.dm
@@ -19,17 +19,28 @@ SUBSYSTEM_DEF(ban_cache)
 		return
 	var/current_time = REALTIMEOFDAY
 	var/list/look_for = list()
+
+	var/list/query_args = list()
+	var/list/query_arg_keys = list()
+
+	var/num_keys = 0
 	for(var/ckey in GLOB.directory)
 		var/client/lad = GLOB.directory[ckey]
 		// If they've already got a ban cached, or a request goin, don't do it
 		if(lad.ban_cache || lad.ban_cache_start)
 			continue
+
 		look_for += ckey
 		lad.ban_cache_start = current_time
+
+		query_args += list("key[num_keys]" = ckey)
+		query_arg_keys += ":key[num_keys]"
+		num_keys++
+
 	// We're gonna try and make a query for clients
 	var/datum/db_query/query_batch_ban_cache = SSdbcore.NewQuery(
-		"SELECT ckey, role, applies_to_admins FROM [format_table_name("ban")] WHERE ckey IN (:ckeys) AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())",
-		list("ckeys" = look_for.Join(","))
+		"SELECT ckey, role, applies_to_admins FROM [format_table_name("ban")] WHERE ckey IN ([query_arg_keys.Join(",")]) AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())",
+		query_args
 	)
 
 	var/succeeded = query_batch_ban_cache.Execute()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #69702
Closes #69704

Fixes #69688

#69376 broke role bans.

How? Wasn't it tested?

Well, here's the catch. It doesn't break role bans as long as there's only 1 player connected to the server when the ban cache SS fires.

So if you test with 1 client, it works perfectly, 100% of the time. So yes, it was tested.

Test with 2 or more connected to your server and it breaks, though. Sadface goes here.

Let's look at an example from my DB logs with 1 client connected:
```SQL
SELECT ckey, role, applies_to_admins FROM ban WHERE ckey IN ('timberpoes') AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())
```

Good query. Works. Add in a second player, wwwtimberpoescom?

```SQL
SELECT ckey, role, applies_to_admins FROM ban WHERE ckey IN ('timberpoes,wwwtimberpoescom') AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())
```

And herein lies the problem! It doesn't parse out as a list of ckeys, but as a single very long ckey. As a result, the query is like "No ckeys in my database match this string" and the operation returns nothing.

Trying to force the formatting in some way will always fail, because we escape single and double quotes so we end up with malformed queries like

```SQL
SELECT ckey, role, applies_to_admins FROM ban WHERE ckey IN ('timberpoes\',\'wwwtimberpoescom') AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())
```

So there are ~~two~~ three options.

Option one is to bake the ckey list directly into the query string. This is a very easy and "intuitive" fix, but is probably not the correct one because it just bypasses the args system entirely, which is probably poor coding practice.

The second is to generate the query args dynamically instead.

The third is to use mystical arcane syntax from https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_find-in-set instead. MSO suggested this in an ivory tower.

This PR goes for option two. An alternative doing option one will also be opened, and they will fight to the death for supremacy.

What this PR ends up generating is a query string that looks like this DM-side:
![image](https://user-images.githubusercontent.com/24975989/188295628-fdc163b7-b56d-46d5-bf6e-a1f63a97635b.png)

And it resolves to this correct query in my database logs:
```SQL
SELECT ckey, role, applies_to_admins FROM ban WHERE ckey IN ('wwwtimberpoescom','timberpoes') AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())
```

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I feex.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes an SQL query so that role banned players are now correctly banned from their roles again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
