### PR TITLE
CTF qol update for admins, map selection and admins can't render CTF unplayable by accident anymore.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -175,6 +175,7 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/map_template_load,
 	/client/proc/map_template_upload,
 	/client/proc/jump_to_ruin,
+	/client/proc/unload_ctf,
 	/client/proc/clear_dynamic_transit,
 	/client/proc/run_empty_query,
 	/client/proc/toggle_medal_disable,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -717,6 +717,13 @@
 	else
 		to_chat(src, span_warning("Failed to place [template.name]."), confidential = TRUE)
 
+/client/proc/unload_ctf()
+	set category = "Debug"
+	set name = "Unload CTF"
+	set desc = "Despawns the majority of CTF"
+
+	toggle_id_ctf(usr, unload=TRUE)
+
 /client/proc/run_empty_query(val as num)
 	set category = "Debug"
 	set name = "Run empty query"

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -178,8 +178,21 @@
 #define CTF_LOADING_LOADING 1
 #define CTF_LOADING_LOADED 2
 
-/proc/toggle_id_ctf(user, activated_id, automated = FALSE)
+/proc/toggle_id_ctf(user, activated_id, automated = FALSE, unload = FALSE)
 	var/static/loading = CTF_LOADING_UNLOADED
+	if(unload == TRUE)
+		log_admin("[key_name_admin(user)] is attempting to unload CTF.")
+		message_admins("[key_name_admin(user)] is attempting to unload CTF.")
+		if(loading == CTF_LOADING_UNLOADED)
+			to_chat(user, span_warning("CTF cannot be unloaded if it was not loaded in the first place"))
+			return
+		to_chat(user, span_warning("CTF is being unloaded"))
+		for(var/obj/machinery/capture_the_flag/CTF in GLOB.machines)
+			CTF.unload()
+		log_admin("[key_name_admin(user)] has unloaded CTF.")
+		message_admins("[key_name_admin(user)] has unloaded CTF.")
+		loading = CTF_LOADING_UNLOADED
+		return
 	switch (loading)
 		if (CTF_LOADING_UNLOADED)
 			if (isnull(GLOB.ctf_spawner))
@@ -490,6 +503,7 @@
 		return
 
 	if(ctf_landmark == GLOB.ctf_spawner)
+		stop_ctf()
 		new /obj/effect/landmark/ctf(get_turf(GLOB.ctf_spawner))
 
 

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -473,7 +473,7 @@
 
 	notify_ghosts("[name] has been activated!", source = src, action=NOTIFY_ORBIT, header = "CTF has been activated")
 
-/obj/machinery/capture_the_flag/proc/machine_reset(var/obj/machinery/capture_the_flag/CTF)
+/obj/machinery/capture_the_flag/proc/machine_reset(obj/machinery/capture_the_flag/CTF)
 	CTF.points = 0
 	CTF.control_points = 0
 	CTF.ctf_enabled = FALSE

--- a/code/modules/capture_the_flag/ctf_map_loading.dm
+++ b/code/modules/capture_the_flag/ctf_map_loading.dm
@@ -42,7 +42,7 @@ GLOBAL_DATUM(ctf_spawner, /obj/effect/landmark/ctf)
 		for(var/datum/map_template/ctf/map as anything in map_options)
 			var/mapname = initial(map.name)
 			map_choices[mapname] = map
-		chosen_map = tgui_input_list(user, "Select a map", "Choose Map",list("Random")|sort_list(map_choices))
+		chosen_map = tgui_input_list(user, "Select a map", "Choose CTF Map",list("Random")|sort_list(map_choices))
 		if (isnull(chosen_map))
 			return FALSE;
 		else

--- a/code/modules/capture_the_flag/ctf_map_loading.dm
+++ b/code/modules/capture_the_flag/ctf_map_loading.dm
@@ -28,15 +28,29 @@ GLOBAL_DATUM(ctf_spawner, /obj/effect/landmark/ctf)
 	GLOB.ctf_spawner = null
 	return ..()
 
-/obj/effect/landmark/ctf/proc/load_map()
+/obj/effect/landmark/ctf/proc/load_map(user)
 	if (map_bounds)
 		return
 
 	var/list/map_options = subtypesof(/datum/map_template/ctf)
 	var/turf/spawn_area = get_turf(src)
 	var/datum/map_template/ctf/current_map
+	var/chosen_map
 
-	current_map = pick(map_options)
+	if(user)
+		var/list/map_choices = list()
+		for(var/datum/map_template/ctf/map as anything in map_options)
+			var/mapname = initial(map.name)
+			map_choices[mapname] = map
+		chosen_map = tgui_input_list(user, "Select a map", "Choose Map",list("Random")|sort_list(map_choices))
+		if (isnull(chosen_map))
+			return FALSE;
+		else
+			current_map = map_choices[chosen_map]
+
+	if(!user || chosen_map=="Random")
+		current_map = pick(map_options)
+
 	current_map = new current_map()
 
 	if(!spawn_area)
@@ -46,6 +60,7 @@ GLOBAL_DATUM(ctf_spawner, /obj/effect/landmark/ctf)
 	map_bounds = current_map.load(spawn_area, TRUE)
 	if(!map_bounds)
 		CRASH("Loading CTF map failed!")
+	return TRUE
 
 /datum/map_template/ctf
 	var/description = ""

--- a/code/modules/capture_the_flag/ctf_map_loading.dm
+++ b/code/modules/capture_the_flag/ctf_map_loading.dm
@@ -87,5 +87,5 @@ GLOBAL_DATUM(ctf_spawner, /obj/effect/landmark/ctf)
 
 /datum/map_template/ctf/cruiser
 	name = "Crusier"
-	description = "A CTF map that takes place across multiple space ships, one carring a powerful device that can accelerate those who obtain it"
+	description = "A CTF map that takes place across multiple space ships, one carrying a powerful device that can accelerate those who obtain it"
 	mappath = "_maps/map_files/CTF/cruiser.dmm"

--- a/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
+++ b/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
@@ -19,7 +19,7 @@
 	toggle_id_ctf(null, game_id, automated = TRUE)//only one machine runs the victory proc, start_ctf proc would break the other machine
 
 // We don't clean up for the medisim.
-/obj/machinery/capture_the_flag/medisim/reset_the_arena()
+/obj/machinery/capture_the_flag/medisim/unload()
 	return
 
 /obj/machinery/capture_the_flag/medisim/spawn_team_member(client/new_team_member)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When CTF map unloading was originally created in had an unforeseen consequence of not entirely removing parts of the ongoing CTF round, namely the flags, as a result of this, this system that was originally made as a precursor to map rotation was not really usable. Since this was added various PRs have made this more and less buggy but the recent CTF voting PR has caused unloading CTF rounds to be a one way process without far more involved admin intervention to reverse. As such, I've made the disable CTF buttons admins have access to only disable CTF and not unload the map entirely. I've left the function to unload the map in incase a situation arises where an admin or maintainer really needs to get rid of the CTF map.

Removing this functionality also removes a really clunky but theoretical function of it, being that you could repeatedly unload and reload the CTF map to get one of your choice, since this is not an option anymore this PR also allows admins to pick a CTF map when they start CTF themself.

EDIT: I fixed the bug introduced by the CTF voting PR, CTF maps can now be reloaded after being unloaded, the flag issue is still around so it shouldn't be used without admin supervision however. Also unloading is a debug verb now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Map unloading was super buggy so it shouldn't be easily accessible.
Since admins cannot repeatedly unload and reload CTF maps anymore to get the one they want they can now just pick the one they want from a list which is significantly less dumb.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: When admins start CTF they can now choose which map is played or choose random as its always been
admin: Admins can no-longer permanently break CTF by unloading the map accidentally
spellcheck: Fixed a typo in the Map Description for CTF Cruiser
fix: CTF can now be reloaded after being unloaded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
