### PR TITLE
Metastation security camera cleanup

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -177,7 +177,7 @@
 /area/station/engineering/atmos/pumproom)
 "aek" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Medbay Main Hallway- South";
+	c_tag = "Medbay Main Hallway - South";
 	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1248,8 +1248,8 @@
 	dir = 6
 	},
 /obj/machinery/fax{
-	name = "Psychology Office Fax Machine";
-	fax_name = "Psychology Office"
+	fax_name = "Psychology Office";
+	name = "Psychology Office Fax Machine"
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
@@ -1341,7 +1341,7 @@
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
 /obj/machinery/camera/directional/east{
-	c_tag = "Science - Server Room";
+	c_tag = "Science Server Room";
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -5067,8 +5067,8 @@
 	},
 /obj/structure/table,
 /obj/machinery/fax{
-	name = "Service Fax Machine";
-	fax_name = "Service Hallway"
+	fax_name = "Service Hallway";
+	name = "Service Fax Machine"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
@@ -5282,7 +5282,7 @@
 /area/station/medical/abandoned)
 "bTq" = (
 /obj/machinery/camera/motion/directional/south{
-	c_tag = "ai_upload Chamber - Port";
+	c_tag = "AI Upload Chamber - Port";
 	network = list("aiupload")
 	},
 /obj/structure/cable,
@@ -6715,7 +6715,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "cxi" = (
-/obj/machinery/camera/directional/north,
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
@@ -6736,6 +6735,9 @@
 /obj/structure/closet/crate/engineering/electrical,
 /obj/item/stack/cable_coil,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/camera/directional/north{
+	c_tag = "Solar Maintenance - Aft Port"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "cxj" = (
@@ -7727,7 +7729,6 @@
 /obj/machinery/camera/motion/directional/south{
 	active_power_usage = 0;
 	c_tag = "Armory - External";
-	network = list("security");
 	use_power = 0
 	},
 /turf/open/space/basic,
@@ -10098,7 +10099,9 @@
 /obj/structure/table,
 /obj/item/analyzer,
 /obj/item/healthanalyzer,
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Technical Storage"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "dMu" = (
@@ -10534,7 +10537,6 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/east,
-/obj/machinery/camera/autoname/directional/east,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10667,7 +10669,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera/directional/north{
-	c_tag = "ai_upload Chamber - Fore";
+	c_tag = "AI Upload Chamber - Fore";
 	network = list("aiupload")
 	},
 /obj/structure/table/wood/fancy/green,
@@ -10917,8 +10919,8 @@
 	req_access = list("brig_entrance")
 	},
 /obj/item/folder/red{
-	pixel_y = 2;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 2
 	},
 /obj/item/paper,
 /turf/open/floor/plating,
@@ -13495,7 +13497,7 @@
 /area/station/hallway/primary/starboard)
 "eXO" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "Crew Quarters Entrance"
+	c_tag = "Locker Room Entrance"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20476,7 +20478,7 @@
 /area/station/maintenance/department/science/xenobiology)
 "hAW" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "RD Observation Cage";
+	c_tag = "Research Director's Office - Observation Cage";
 	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
@@ -20630,7 +20632,7 @@
 	dir = 5
 	},
 /obj/machinery/camera/directional/west{
-	c_tag = "Science Admin";
+	c_tag = "Research Director's Office";
 	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom/directional/west,
@@ -22284,8 +22286,8 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/table/wood,
 /obj/machinery/fax{
-	name = "Head of Personnel's Fax Machine";
-	fax_name = "Head of Personnel's Office"
+	fax_name = "Head of Personnel's Office";
+	name = "Head of Personnel's Fax Machine"
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
@@ -22381,8 +22383,8 @@
 /obj/item/radio/intercom/directional/east,
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
-	pixel_y = 14;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 14
 	},
 /obj/item/folder/white{
 	pixel_x = 6;
@@ -22749,7 +22751,7 @@
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera/directional/east{
-	c_tag = "Labor Shuttle Dock"
+	c_tag = "Brig - Labor Shuttle Dock"
 	},
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 24
@@ -22896,8 +22898,8 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/machinery/fax{
-	name = "Cargo Office Fax Machine";
-	fax_name = "Cargo Office"
+	fax_name = "Cargo Office";
+	name = "Cargo Office Fax Machine"
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -23273,6 +23275,7 @@
 "ixw" = (
 /obj/machinery/holopad,
 /obj/machinery/camera/directional/south{
+	c_tag = "MiniSat Exterior - Aft";
 	network = list("minisat")
 	},
 /obj/machinery/light/small/directional/south,
@@ -26253,7 +26256,7 @@
 /area/station/science/lab)
 "jtL" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Cargo - Mailroom"
+	c_tag = "Cargo Bay - Mailroom"
 	},
 /obj/effect/turf_decal/trimline/brown/filled/shrink_ccw,
 /obj/effect/turf_decal/trimline/white/filled/warning,
@@ -26287,7 +26290,6 @@
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
 /obj/effect/turf_decal/trimline/brown/warning,
-/obj/machinery/camera/directional/north,
 /obj/item/reagent_containers/cup/rag,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -28089,7 +28091,7 @@
 /area/station/maintenance/port/fore)
 "jZZ" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "Council Chamber"
+	c_tag = "Bridge - Council Chamber"
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/ai/directional/north,
@@ -31822,7 +31824,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/landmark/blobstart,
 /obj/machinery/camera/directional/north{
-	c_tag = "Evidence Storage"
+	c_tag = "Security - Evidence Storage"
 	},
 /obj/item/storage/secure/safe/directional/north{
 	name = "evidence safe"
@@ -31971,7 +31973,9 @@
 /area/station/security/lockers)
 "ltg" = (
 /obj/structure/chair/stool/directional/north,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Solar Maintenance - Fore Starboard"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "ltm" = (
@@ -32221,7 +32225,9 @@
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Technical Storage - Secure"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "lxw" = (
@@ -35694,7 +35700,7 @@
 /area/station/science/research)
 "mLu" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Science Hallway - Admin";
+	c_tag = "Science Hallway - RD Office";
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/siding/purple{
@@ -38346,7 +38352,10 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "nFL" = (
-/obj/machinery/camera/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat Exterior - Fore";
+	network = list("minisat")
+	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
@@ -38922,7 +38931,7 @@
 /area/station/maintenance/starboard/lesser)
 "nQC" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Firing Range"
+	c_tag = "Security - Firing Range"
 	},
 /obj/machinery/light_switch/directional/west{
 	pixel_y = -12
@@ -41255,7 +41264,7 @@
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera/directional/north{
-	c_tag = "ai_upload Foyer";
+	c_tag = "AI Upload Foyer";
 	network = list("aiupload")
 	},
 /obj/machinery/airalarm/directional/north,
@@ -42533,7 +42542,9 @@
 /area/station/commons/dorms)
 "pgJ" = (
 /obj/structure/chair/stool/directional/north,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Solar Maintenance - Fore Port"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "pgM" = (
@@ -43694,8 +43705,8 @@
 /obj/machinery/newscaster/directional/west,
 /obj/structure/table,
 /obj/machinery/fax{
-	name = "Security Office Fax Machine";
-	fax_name = "Security Office"
+	fax_name = "Security Office";
+	name = "Security Office Fax Machine"
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -43896,7 +43907,7 @@
 /area/station/commons/dorms)
 "pFg" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Medbay Surgery C";
+	c_tag = "Medbay Surgery Aft";
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -45678,7 +45689,7 @@
 	name = "Private Channel"
 	},
 /obj/machinery/camera/motion/directional/south{
-	c_tag = "ai_upload Chamber - Starboard";
+	c_tag = "AI Upload Chamber - Starboard";
 	network = list("aiupload")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45689,8 +45700,8 @@
 /obj/structure/table/wood,
 /obj/structure/cable,
 /obj/machinery/fax{
-	name = "Head of Security's Fax Machine";
-	fax_name = "Head of Security's Office"
+	fax_name = "Head of Security's Office";
+	name = "Head of Security's Fax Machine"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
@@ -48481,7 +48492,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/east{
-	c_tag = "Chapel- Starboard"
+	c_tag = "Chapel - Starboard"
 	},
 /turf/open/floor/iron/chapel{
 	dir = 4
@@ -49690,8 +49701,8 @@
 	},
 /obj/item/folder/white,
 /obj/item/pen{
-	pixel_y = 8;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 8
 	},
 /obj/item/computer_hardware/hard_drive/portable/chemistry,
 /obj/item/computer_hardware/hard_drive/portable/medical,
@@ -50059,7 +50070,7 @@
 /area/station/hallway/secondary/command)
 "rLN" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Supermatter Chamber";
+	c_tag = "Engineering Supermatter Chamber";
 	network = list("engine")
 	},
 /turf/open/floor/engine,
@@ -50663,14 +50674,14 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "rUT" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Aft Starboard Solar Maintenance"
-	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/south,
+/obj/machinery/camera/directional/west{
+	c_tag = "Solar Maintenance - Aft Starboard"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "rUU" = (
@@ -50901,7 +50912,7 @@
 /obj/item/radio/intercom/directional/west,
 /obj/structure/table/glass,
 /obj/machinery/camera/directional/west{
-	c_tag = "Pharmacy";
+	c_tag = "Medbay Pharmacy";
 	network = list("ss13","medbay")
 	},
 /obj/machinery/light/directional/west,
@@ -51255,7 +51266,7 @@
 "sdL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/camera/directional/east{
-	c_tag = "Medbay Main Hallway- CMO";
+	c_tag = "Medbay Main Hallway - CMO";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -53489,8 +53500,8 @@
 	network = list("ss13","medical")
 	},
 /obj/machinery/fax{
-	name = "Medical Fax Machine";
-	fax_name = "Medical"
+	fax_name = "Medical";
+	name = "Medical Fax Machine"
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
@@ -53506,8 +53517,8 @@
 /obj/machinery/light_switch/directional/west,
 /obj/structure/table/wood,
 /obj/machinery/fax{
-	name = "Detective's Fax Machine";
-	fax_name = "Detective's Office"
+	fax_name = "Detective's Office";
+	name = "Detective's Fax Machine"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
@@ -55483,8 +55494,8 @@
 /obj/structure/table/wood,
 /obj/structure/window/reinforced,
 /obj/machinery/fax{
-	name = "Captain's Fax Machine";
-	fax_name = "Captain's Office"
+	fax_name = "Captain's Office";
+	name = "Captain's Fax Machine"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
@@ -56019,8 +56030,8 @@
 "tKR" = (
 /obj/structure/table/glass,
 /obj/machinery/fax{
-	name = "Research Division Fax Machine";
 	fax_name = "Research Division";
+	name = "Research Division Fax Machine";
 	pixel_x = 1
 	},
 /turf/open/floor/iron/white,
@@ -56998,7 +57009,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/camera/directional/west{
-	c_tag = "Medbay Surgical Wing";
+	c_tag = "Medbay Virology Wing";
 	network = list("ss13","medbay")
 	},
 /obj/structure/bed/roller,
@@ -60130,8 +60141,8 @@
 	dir = 1
 	},
 /obj/machinery/fax{
-	name = "Chief Medical Officer's Fax Machine";
-	fax_name = "Chief Medical Officer's Office"
+	fax_name = "Chief Medical Officer's Office";
+	name = "Chief Medical Officer's Fax Machine"
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -60289,8 +60300,8 @@
 "vjw" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
-	name = "Quartermaster's Fax Machine";
-	fax_name = "Quartermaster's Office"
+	fax_name = "Quartermaster's Office";
+	name = "Quartermaster's Fax Machine"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
@@ -62233,7 +62244,7 @@
 "vRz" = (
 /obj/structure/sign/departments/chemistry/directional/east,
 /obj/machinery/camera/directional/east{
-	c_tag = "Medbay Main Hallway- Surgical Junction";
+	c_tag = "Medbay Main Hallway - Virology Junction";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -62926,7 +62937,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/east{
 	c_tag = "Outer Vault";
-	name = "storage wing camera"
+	name = "storage wing camera";
+	network = list("ss13", "vault")
 	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
@@ -63326,12 +63338,14 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/structure/window{
 	dir = 1
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Kitchen - Cold Room"
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
@@ -67700,7 +67714,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Kitchen"
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "xPm" = (
@@ -67714,8 +67730,8 @@
 /obj/structure/cable,
 /obj/structure/table,
 /obj/machinery/fax{
-	name = "Research Director's Fax Machine";
-	fax_name = "Research Director's Office"
+	fax_name = "Research Director's Office";
+	name = "Research Director's Fax Machine"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
@@ -68023,8 +68039,8 @@
 	req_access = list("lawyer")
 	},
 /obj/machinery/fax{
-	name = "Law Office Fax Machine";
-	fax_name = "Law Office"
+	fax_name = "Law Office";
+	name = "Law Office Fax Machine"
 	},
 /turf/open/floor/wood,
 /area/station/service/lawoffice)


### PR DESCRIPTION
## About The Pull Request
An overview of the Metastation's security camera network has led me to going around and fixing several issues with camera tags and networks, removing a few excess cameras as well as changing some c_tags for more consistent grouping of certain cameras.
<details>
  <summary>Full list of changes</summary>

- restore two cameras on AI Sat Exterior to the _minisat_ network (Fore and Aft a.k.a. north and south cameras were not connected)
- remove a non-existant camera network from _Armory Exterior_ camera, allowing users to actually use the cam through consoles
- remove excess cameras that were giving basically the same view as other cameras in the vicinity (_Service Hallway_ on the lathe and _Hydroponics_ near the backroom airlock)
- all _Solar Maintenance_ cameras are now grouped up instead of being spread over the entire list (i.e. _Solar Maintenance Aft/Fore Port/Starboard_)
- add _Vault - Exterior_ to _vault_ network, allowing use via the Vault Monitor in QM's office
- replace several autoname cameras with hand-tagged ones (_Tech Storage_, _Kitchen_ & _Cold Room_)
- c_tag change AI Upload cameras (_ai_upload_ -> _AI Upload_)
- c_tag change _RD Admin_, _RD Observation Cage_ & _Science Hallway - Admin_ to use _Research Director's (RD) Office_
- c_tag change _Surgical Wing_ and _Surgical Junction_ to use _Virology_ (the current version of the map only houses one auxillary Surgery room in this wing, so I'm marking the next important point of interest in that area a.k.a. Virology)
- c_tag change _Surgery C_ to _Surgery Aft_ (see above)
- c_tag change _Labor Shuttle Dock_ to _Brig_ group 
- c_tag change _Evidence Storage_ and _Firing Range_ to _Security_ group
- c_tag change _Supermatter Chamber_ to _Engineering_ Group
- c_tag change _Crew Quarters Entrance_ -> _Locker Room Entrance_ (the camera outside of Law Office) to group it up w/ the _Locker Room_
- minor edits to several c_tags i.e. spacings or `-` use

Edits to fax machines were automatic sanitization.

</details>

## Why It's Good For The Game
Easier & more fluid listing of available cameras on camera consoles, as well as actually adding some cameras to the network for use on their respective consoles/monitors.

## Changelog
:cl:
del: Metastation: removed two excess cameras in Service Hallway and Hydroponics
qol: Solar Maintenance cameras are now grouped up in one place on the console's list, several other cameras grouped up with their respective department group
qol: tweaks to some cameras' c_tags for easier use (i.e. Tech Storage cameras are now clearly signed as Secure and non-secure)
fix: Armory - Exterior camera fixed to actually appear on console lists
fix: two AI Minisat Exterior cameras fixed to be on the minisat network to actually appear on console lists
spellcheck: AI Upload cameras edited to not be lowercase (ai_upload -> AI Upload)
/:cl:

