### PR TITLE
Fixes cultist check_size div0

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -284,7 +284,9 @@
 				++cultplayers
 			else
 				++alive
-	var/ratio = cultplayers/alive
+
+	ASSERT(cultplayers) //we shouldn't be here.
+	var/ratio = alive ? cultplayers/alive : 1
 	if(ratio > CULT_RISEN && !cult_risen)
 		for(var/datum/mind/mind as anything in members)
 			if(mind.current)


### PR DESCRIPTION
Fixes #69718

:cl: ShizCalev
fix: Fixed a runtime when all alive players are converted to cultists that prevented them from getting their cool halo/eye effects.
/:cl:
