### PR TITLE
Removes converstion and deconversion from Cult. Cult is now a fixed 9 man team that needs to do 9 sacrifices to summon Nar'sie.

### DIFF
--- a/code/__DEFINES/cult.dm
+++ b/code/__DEFINES/cult.dm
@@ -13,9 +13,9 @@
 #define MAX_BLOODCHARGE 4
 #define RUNELESS_MAX_BLOODCHARGE 1
 /// percent before rise
-#define CULT_RISEN 0.2
+#define CULT_RISEN 0.5
 /// percent before ascend
-#define CULT_ASCENDENT 0.4
+#define CULT_ASCENDENT 1
 #define BLOOD_HALBERD_COST 150
 #define BLOOD_BARRAGE_COST 300
 #define BLOOD_BEAM_COST 500

--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -345,7 +345,10 @@
 	if(!check_if_in_ritual_site(cultist, cult_team))
 		return FALSE
 	if(sac_objective && !sac_objective.check_completion())
-		to_chat(cultist, span_warning("The sacrifice is not complete. The portal would lack the power to open if you tried!"))
+		to_chat(cultist, span_warning("The vital sacrifice is not complete. The portal would lack the power to open if you tried!"))
+		return FALSE
+	if(length(GLOB.sacrificed) < 9)
+		to_chat(cultist, span_warning("The required foundation of sacrifice is not complete. You need to sacrifice [9 - length(GLOB.sacrificed)] more souls!"))
 		return FALSE
 	if(summon_objective.check_completion())
 		to_chat(cultist, span_cultlarge("\"I am already here. There is no need to try to summon me now.\""))

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -323,7 +323,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 	)
-	required_candidates = 2
+	required_candidates = 9
 	weight = 3
 	cost = 20
 	requirements = list(100,90,80,60,40,30,10,10,10,10)
@@ -331,14 +331,9 @@
 	antag_cap = list("denominator" = 20, "offset" = 1)
 	var/datum/team/cult/main_cult
 
-/datum/dynamic_ruleset/roundstart/bloodcult/ready(population, forced = FALSE)
-	required_candidates = get_antag_cap(population)
-	return ..()
-
 /datum/dynamic_ruleset/roundstart/bloodcult/pre_execute(population)
 	. = ..()
-	var/cultists = get_antag_cap(population)
-	for(var/cultists_number = 1 to cultists)
+	for(var/cultists_number = 1 to required_candidates)
 		if(candidates.len <= 0)
 			break
 		var/mob/M = pick_n_take(candidates)

--- a/code/game/objects/items/stacks/sheets/runed_metal.dm
+++ b/code/game/objects/items/stacks/sheets/runed_metal.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_INIT(runed_metal_recipes, list( \
 		time = 4 SECONDS, \
 		one_per_turf = TRUE, \
 		on_floor = TRUE, \
-		desc = span_cultbold("Altar: Can make Eldritch Whetstones, Construct Shells, and Flasks of Unholy Water."), \
+		desc = span_cultbold("Altar: Can make Eldritch Whetstones and Flasks of Unholy Water."), \
 		required_noun = "runed metal sheet", \
 	), \
 	new /datum/stack_recipe/radial( \

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -179,7 +179,7 @@
 
 /datum/action/innate/cult/blood_spell/construction
 	name = "Twisted Construction"
-	desc = "Empowers your hand to corrupt certain metalic objects.<br><u>Converts:</u><br>Plasteel into runed metal<br>50 metal into a construct shell<br>Living cyborgs into constructs after a delay<br>Cyborg shells into construct shells<br>Purified soulstones (and any shades inside) into cultist soulstones<br>Airlocks into brittle runed airlocks after a delay (harm intent)"
+	desc = "Empowers your hand to corrupt certain metalic objects.<br><u>Converts:</u><br>Plasteel into runed metal<br>Living cyborgs into constructs after a delay<br>Airlocks into brittle runed airlocks after a delay (harm intent)"
 	button_icon_state = "transmute"
 	magic_path = "/obj/item/melee/blood_magic/construction"
 	health_cost = 12
@@ -524,7 +524,7 @@
 	. = ..()
 
 
-//Construction: Converts 50 iron to a construct shell, plasteel to runed metal, airlock to brittle runed airlock, a borg to a construct, or borg shell to a construct shell
+//Construction: Converts plasteel to runed metal, airlock to brittle runed airlock, or a borg to a construct
 /obj/item/melee/blood_magic/construction
 	name = "Twisting Aura"
 	desc = "Corrupts certain metalic objects on contact."
@@ -536,10 +536,7 @@
 	. = ..()
 	. += {"<u>A sinister spell used to convert:</u>\n
 	Plasteel into runed metal\n
-	[IRON_TO_CONSTRUCT_SHELL_CONVERSION] iron into a construct shell\n
 	Living cyborgs into constructs after a delay\n
-	Cyborg shells into construct shells\n
-	Purified soulstones (and any shades inside) into cultist soulstones\n
 	Airlocks into brittle runed airlocks after a delay (harm intent)"}
 
 /obj/item/melee/blood_magic/construction/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
@@ -548,17 +545,7 @@
 			to_chat(user, span_cultitalic("You are already invoking twisted construction!"))
 			return
 		var/turf/T = get_turf(target)
-		if(istype(target, /obj/item/stack/sheet/iron))
-			var/obj/item/stack/sheet/candidate = target
-			if(candidate.use(IRON_TO_CONSTRUCT_SHELL_CONVERSION))
-				uses--
-				to_chat(user, span_warning("A dark cloud emanates from your hand and swirls around the iron, twisting it into a construct shell!"))
-				new /obj/structure/constructshell(T)
-				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
-			else
-				to_chat(user, span_warning("You need [IRON_TO_CONSTRUCT_SHELL_CONVERSION] iron to produce a construct shell!"))
-				return
-		else if(istype(target, /obj/item/stack/sheet/plasteel))
+		if(istype(target, /obj/item/stack/sheet/plasteel))
 			var/obj/item/stack/sheet/plasteel/candidate = target
 			var/quantity = candidate.amount
 			if(candidate.use(quantity))
@@ -594,12 +581,6 @@
 					channeling = FALSE
 					candidate.color = prev_color
 					return
-			else
-				uses--
-				to_chat(user, span_warning("A dark cloud emanates from you hand and swirls around [candidate] - twisting it into a construct shell!"))
-				new /obj/structure/constructshell(T)
-				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
-				qdel(candidate)
 		else if(istype(target,/obj/machinery/door/airlock))
 			channeling = TRUE
 			playsound(T, 'sound/machines/airlockforced.ogg', 50, TRUE)
@@ -616,12 +597,6 @@
 			else
 				channeling = FALSE
 				return
-		else if(istype(target,/obj/item/soulstone))
-			var/obj/item/soulstone/candidate = target
-			if(candidate.corrupt())
-				uses--
-				to_chat(user, span_warning("You corrupt [candidate]!"))
-				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
 		else
 			to_chat(user, span_warning("The spell will not work on [target]!"))
 			return

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -275,24 +275,17 @@
 /datum/team/cult/proc/check_size()
 	if(cult_ascendent)
 		return
-	var/alive = 0
-	var/cultplayers = 0
-	for(var/I in GLOB.player_list)
-		var/mob/M = I
-		if(M.stat != DEAD)
-			if(IS_CULTIST(M))
-				++cultplayers
-			else
-				++alive
-	var/ratio = cultplayers/alive
+	var/needed_sacrifices = 9
+	var/current_sacrifices = length(GLOB.sacrificed)
+	var/ratio = current_sacrifices/needed_sacrifices
 	if(ratio > CULT_RISEN && !cult_risen)
 		for(var/datum/mind/mind as anything in members)
 			if(mind.current)
 				SEND_SOUND(mind.current, 'sound/hallucinations/i_see_you2.ogg')
-				to_chat(mind.current, span_cultlarge(span_warning("The veil weakens as your cult grows, your eyes begin to glow...")))
+				to_chat(mind.current, span_cultlarge(span_warning("The veil weakens as your sacrifice count grows, your eyes begin to glow...")))
 				mind.current.AddElement(/datum/element/cult_eyes)
 		cult_risen = TRUE
-		log_game("The blood cult has risen with [cultplayers] players.")
+		log_game("The blood cult has risen with [current_sacrifices] sacrifices.")
 
 	if(ratio > CULT_ASCENDENT && !cult_ascendent)
 		for(var/datum/mind/mind as anything in members)
@@ -301,7 +294,7 @@
 				to_chat(mind.current, span_cultlarge(span_warning("Your cult is ascendent and the red harvest approaches - you cannot hide your true nature for much longer!!")))
 				mind.current.AddElement(/datum/element/cult_halo)
 		cult_ascendent = TRUE
-		log_game("The blood cult has ascended with [cultplayers] players.")
+		log_game("The blood cult has ascended with [current_sacrifices] sacrifices.")
 
 /datum/team/cult/proc/make_image(datum/objective/sacrifice/sac_objective)
 	var/datum/job/job_of_sacrifice = sac_objective.target.assigned_role

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -169,13 +169,6 @@ Striking a noncultist, however, will tear their flesh."}
 	QDEL_NULL(linked_action)
 	return ..()
 
-/obj/item/cult_bastard/examine(mob/user)
-	. = ..()
-	if(length(contents))
-		. += "<b>There are [length(contents)] souls trapped within the sword's core.</b>"
-	else
-		. += "The sword appears to be quite lifeless."
-
 /obj/item/cult_bastard/can_be_pulled(user)
 	return FALSE
 
@@ -229,19 +222,6 @@ Striking a noncultist, however, will tear their flesh."}
 		return
 	if(!proximity)
 		return
-	if(ishuman(target))
-		var/mob/living/carbon/human/human_target = target
-		if(human_target.stat != CONSCIOUS)
-			var/obj/item/soulstone/stone = new /obj/item/soulstone(src)
-			stone.attack(human_target, user)
-			if(!LAZYLEN(stone.contents))
-				qdel(stone)
-	if(istype(target, /obj/structure/constructshell) && length(contents))
-		var/obj/item/soulstone/stone = contents[1]
-		if(!istype(stone))
-			stone.forceMove(drop_location())
-		else if(!stone.transfer_to_construct(target, user) && !(locate(/mob/living/simple_animal/shade) in stone))
-			qdel(stone)
 
 /datum/action/innate/dash/cult
 	name = "Rend the Veil"

--- a/code/modules/antagonists/cult/cult_structure_altar.dm
+++ b/code/modules/antagonists/cult/cult_structure_altar.dm
@@ -7,7 +7,7 @@
 /obj/structure/destructible/cult/item_dispenser/altar
 	name = "altar"
 	desc = "A bloodstained altar dedicated to Nar'Sie."
-	cult_examine_tip = "Can be used to create eldritch whetstones, construct shells, and flasks of unholy water."
+	cult_examine_tip = "Can be used to create eldritch whetstones and flasks of unholy water."
 	icon_state = "talismanaltar"
 	break_message = "<span class='warning'>The altar shatters, leaving only the wailing of the damned!</span>"
 
@@ -16,10 +16,6 @@
 		ELDRITCH_WHETSTONE = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/kitchen.dmi', icon_state = "cult_sharpener"),
 			OUTPUT_ITEMS = list(/obj/item/sharpener/cult),
-			),
-		CONSTRUCT_SHELL = list(
-			PREVIEW_IMAGE = image(icon = 'icons/obj/wizard.dmi', icon_state = "construct_cult"),
-			OUTPUT_ITEMS = list(/obj/structure/constructshell),
 			),
 		UNHOLY_WATER = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/drinks.dmi', icon_state = "holyflask"),

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -302,15 +302,12 @@
 	construct_spells = list(
 		/datum/action/cooldown/spell/conjure/cult_floor,
 		/datum/action/cooldown/spell/conjure/cult_wall,
-		/datum/action/cooldown/spell/conjure/soulstone,
-		/datum/action/cooldown/spell/conjure/construct/lesser,
 		/datum/action/cooldown/spell/aoe/magic_missile/lesser,
 		/datum/action/innate/cult/create_rune/revive,
 	)
 	playstyle_string = "<b>You are an Artificer. You are incredibly weak and fragile, \
 		but you are able to construct fortifications, use magic missile, and repair allied constructs, shades, \
-		and yourself (by clicking on them). Additionally, <i>and most important of all,</i> you can create new constructs \
-		by producing soulstones to capture souls, and shells to place those soulstones into.</b>"
+		and yourself (by clicking on them)."
 
 	can_repair = TRUE
 	can_repair_self = TRUE
@@ -368,8 +365,6 @@
 	theme = THEME_HOLY
 	loot = list(/obj/item/ectoplasm/angelic)
 	construct_spells = list(
-		/datum/action/cooldown/spell/conjure/soulstone/purified,
-		/datum/action/cooldown/spell/conjure/construct/lesser,
 		/datum/action/cooldown/spell/aoe/magic_missile/lesser,
 		/datum/action/innate/cult/create_rune/revive,
 	)
@@ -379,8 +374,6 @@
 	construct_spells = list(
 		/datum/action/cooldown/spell/conjure/cult_floor,
 		/datum/action/cooldown/spell/conjure/cult_wall,
-		/datum/action/cooldown/spell/conjure/soulstone/mystic,
-		/datum/action/cooldown/spell/conjure/construct/lesser,
 		/datum/action/cooldown/spell/aoe/magic_missile/lesser,
 		/datum/action/innate/cult/create_rune/revive,
 	)
@@ -389,8 +382,6 @@
 	construct_spells = list(
 		/datum/action/cooldown/spell/conjure/cult_floor,
 		/datum/action/cooldown/spell/conjure/cult_wall,
-		/datum/action/cooldown/spell/conjure/soulstone/noncult,
-		/datum/action/cooldown/spell/conjure/construct/lesser,
 		/datum/action/cooldown/spell/aoe/magic_missile/lesser,
 		/datum/action/innate/cult/create_rune/revive,
 	)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -274,9 +274,6 @@
 
 /datum/reagent/water/holywater/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
-	if(IS_CULTIST(exposed_mob))
-		to_chat(exposed_mob, span_userdanger("A vile holiness begins to spread its shining tendrils through your mind, purging the Geometer of Blood's influence!"))
-
 /datum/reagent/water/holywater/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	if(M.blood_volume)
 		M.blood_volume += 0.1 * REM * delta_time // water is good for you!
@@ -285,25 +282,10 @@
 
 	data["misc"] += delta_time SECONDS * REM
 	M.adjust_timed_status_effect(4 SECONDS * delta_time, /datum/status_effect/jitter, max_duration = 20 SECONDS)
-	if(IS_CULTIST(M))
-		for(var/datum/action/innate/cult/blood_magic/BM in M.actions)
-			to_chat(M, span_cultlarge("Your blood rites falter as holy water scours your body!"))
-			for(var/datum/action/innate/cult/blood_spell/BS in BM.spells)
-				qdel(BS)
 	if(data["misc"] >= (25 SECONDS)) // 10 units
 		M.adjust_timed_status_effect(4 SECONDS * delta_time, /datum/status_effect/speech/stutter, max_duration = 20 SECONDS)
 		M.set_timed_status_effect(10 SECONDS, /datum/status_effect/dizziness, only_if_higher = TRUE)
-		if(IS_CULTIST(M) && DT_PROB(10, delta_time))
-			M.say(pick("Av'te Nar'Sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","R'ge Na'sie","Diabo us Vo'iscum","Eld' Mon Nobis"), forced = "holy water")
-			if(prob(10))
-				M.visible_message(span_danger("[M] starts having a seizure!"), span_userdanger("You have a seizure!"))
-				M.Unconscious(12 SECONDS)
-				to_chat(M, "<span class='cultlarge'>[pick("Your blood is your bond - you are nothing without it", "Do not forget your place", \
-				"All that power, and you still fail?", "If you cannot scour this poison, I shall scour your meager life!")].</span>")
 	if(data["misc"] >= (1 MINUTES)) // 24 units
-		if(IS_CULTIST(M))
-			M.mind.remove_antag_datum(/datum/antagonist/cult)
-			M.Unconscious(100)
 		M.remove_status_effect(/datum/status_effect/jitter)
 		M.remove_status_effect(/datum/status_effect/speech/stutter)
 		holder.remove_reagent(type, volume) // maybe this is a little too perfect and a max() cap on the statuses would be better??


### PR DESCRIPTION
## About The Pull Request
Cults now spawn with 9 members, no more no less.
Cultists now cannot convert crewmembers or be deconverted.
Sacrifices do not provide soul shards nor can construct shells be built, summoned, or Artificer created.
Constructs are only obtainable via using Twisting Aura on a live cyborg.
Sacrifices must be living sentient humanoids, or for the body to be the Sacrifice Target.
Sacrifices and Nar'Sie summoning now require EITHER 3 live cultists, or however many cultists are still alive.
This means if you only have 1 or 2 cultists, you can sacrifice with 1 or 2 cultists present.
This also applies to Nar'Sie summoning and the 9 person requirement.
Summoning Nar'Sie now requires that you have 9 sacrifices total on top of the existing sacrifice target objective.
The Bloody Bastard Sword no longer harvests souls into soulstones.

## Why It's Good For The Game

## Conversion modes suck and we banned them officially
Cult as a conversion mode is an absolute mess to get into and 90% of cult converts just go murderboning when they get converted. It does not follow the rule we set out that a new player inducted into a conversion team must know immediately what they need to do, and thus it's been removed from being a conversion gamemode.

## Cult hasn't seen a big shakeup in half a decade
Cult is a stagnant gamemode that a lot of our players don't enjoy because it's stuck in a very unfun cycle of being both a conversion mode and a stagnant mode at the same time. Unshackling it from conversion allows us to explore more design space with the gamemode without fear of the conversion/deconversion aspect causing the design to snowball out of control.

These changes should freshen up the mode and make it significantly more fun to play as, against, and around.
## Changelog
:cl:
balance: Cults now spawn with 9 members, no more no less.
balance: Cultists now cannot convert crewmembers or be deconverted.
balance: Sacrifices do not provide soul shards nor can construct shells be built, summoned, or Artificer created.
balance: Constructs are only obtainable via using Twisting Aura on a live cyborg.
balance: Sacrifices must be living sentient humanoids, or for the body to be the Sacrifice Target.
balance: Sacrifices and Nar'Sie summoning now require EITHER 3 live cultists, or however many cultists are still alive.
balance: This means if you only have 1 or 2 cultists, you can sacrifice with 1 or 2 cultists present.
balance: This also applies to Nar'Sie summoning and the 9 person requirement.
balance: Summoning Nar'Sie now requires that you have 9 sacrifices total on top of the existing sacrifice target objective.
balance: The Bloody Bastard Sword no longer harvests souls into soulstones.
/:cl: