### PR TITLE
Automatic R&D sync

### DIFF
--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -15,7 +15,7 @@
 /// Maximum ping timeout allowed to detect zombie windows
 #define TGUI_PING_TIMEOUT 4 SECONDS
 /// Used for rate-limiting to prevent DoS by excessively refreshing a TGUI window
-#define TGUI_REFRESH_FULL_UPDATE_COOLDOWN 5 SECONDS
+#define TGUI_REFRESH_FULL_UPDATE_COOLDOWN 0.5 SECONDS
 
 /// Window does not exist
 #define TGUI_WINDOW_CLOSED 0

--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -15,7 +15,7 @@
 /// Maximum ping timeout allowed to detect zombie windows
 #define TGUI_PING_TIMEOUT 4 SECONDS
 /// Used for rate-limiting to prevent DoS by excessively refreshing a TGUI window
-#define TGUI_REFRESH_FULL_UPDATE_COOLDOWN 0.5 SECONDS
+#define TGUI_REFRESH_FULL_UPDATE_COOLDOWN 1 SECONDS
 
 /// Window does not exist
 #define TGUI_WINDOW_CLOSED 0

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -43,8 +43,11 @@
 	RefreshParts()
 	update_icon(UPDATE_OVERLAYS)
 
-	RegisterSignal(stored_research, COMSIG_TECHWEB_ADD_DESIGN, .proc/update_designs)
-	RegisterSignal(stored_research, COMSIG_TECHWEB_REMOVE_DESIGN, .proc/update_designs)
+	RegisterSignal(
+		stored_research,
+		list(COMSIG_TECHWEB_ADD_DESIGN, COMSIG_TECHWEB_REMOVE_DESIGN),
+		.proc/update_designs
+	)
 
 /obj/machinery/rnd/production/Destroy()
 	materials = null
@@ -53,6 +56,8 @@
 
 /// Updates the list of designs this fabricator can print.
 /obj/machinery/rnd/production/proc/update_designs()
+	SIGNAL_HANDLER
+
 	cached_designs.Cut()
 
 	for(var/design_id in stored_research.researched_designs)
@@ -61,13 +66,13 @@
 		if((isnull(allowed_department_flags) || (design.departmental_flags & allowed_department_flags)) && (design.build_type & allowed_buildtypes))
 			cached_designs |= design
 
-	update_static_data(usr)
+	update_static_data_for_all_viewers()
 
 /obj/machinery/rnd/production/RefreshParts()
 	. = ..()
 
 	calculate_efficiency()
-	update_static_data(usr)
+	update_static_data_for_all_viewers()
 
 /obj/machinery/rnd/production/ui_assets(mob/user)
 	return list(

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -46,7 +46,7 @@
 	RegisterSignal(
 		stored_research,
 		list(COMSIG_TECHWEB_ADD_DESIGN, COMSIG_TECHWEB_REMOVE_DESIGN),
-		.proc/update_designs
+		.proc/on_techweb_update
 	)
 
 /obj/machinery/rnd/production/Destroy()
@@ -54,10 +54,15 @@
 	cached_designs = null
 	return ..()
 
-/// Updates the list of designs this fabricator can print.
-/obj/machinery/rnd/production/proc/update_designs()
+/obj/machinery/rnd/production/proc/on_techweb_update()
 	SIGNAL_HANDLER
 
+	// We're probably going to get more than one update (design) at a time, so batch
+	// them together.
+	addtimer(CALLBACK(src, .proc/update_designs), 0.25 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+
+/// Updates the list of designs this fabricator can print.
+/obj/machinery/rnd/production/proc/update_designs()
 	cached_designs.Cut()
 
 	for(var/design_id in stored_research.researched_designs)

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -43,6 +43,9 @@
 	RefreshParts()
 	update_icon(UPDATE_OVERLAYS)
 
+	RegisterSignal(stored_research, COMSIG_TECHWEB_ADD_DESIGN, .proc/update_designs)
+	RegisterSignal(stored_research, COMSIG_TECHWEB_REMOVE_DESIGN, .proc/update_designs)
+
 /obj/machinery/rnd/production/Destroy()
 	materials = null
 	cached_designs = null
@@ -59,8 +62,6 @@
 			cached_designs |= design
 
 	update_static_data(usr)
-
-	say("Successfully synchronized with R&D server.")
 
 /obj/machinery/rnd/production/RefreshParts()
 	. = ..()
@@ -133,9 +134,6 @@
 				return
 
 			eject_sheets(material, params["amount"])
-
-		if("sync_rnd")
-			update_designs()
 
 		if("build")
 			user_try_print_id(params["ref"], params["amount"])

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -203,8 +203,9 @@
 		return
 	if(!COOLDOWN_FINISHED(src, refresh_cooldown))
 		refreshing = TRUE
-		addtimer(CALLBACK(src, .proc/send_full_update), COOLDOWN_TIMELEFT(src, refresh_cooldown), TIMER_UNIQUE)
+		addtimer(CALLBACK(src, .proc/send_full_update, custom_data, force), COOLDOWN_TIMELEFT(src, refresh_cooldown), TIMER_UNIQUE)
 		return
+	refreshing = FALSE
 	var/should_update_data = force || status >= UI_UPDATE
 	window.send_message("update", get_payload(
 		custom_data,

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -203,9 +203,8 @@
 		return
 	if(!COOLDOWN_FINISHED(src, refresh_cooldown))
 		refreshing = TRUE
-		addtimer(CALLBACK(src, .proc/send_full_update), TGUI_REFRESH_FULL_UPDATE_COOLDOWN, TIMER_UNIQUE)
+		addtimer(CALLBACK(src, .proc/send_full_update), COOLDOWN_TIMELEFT(src, refresh_cooldown), TIMER_UNIQUE)
 		return
-	refreshing = FALSE
 	var/should_update_data = force || status >= UI_UPDATE
 	window.send_message("update", get_payload(
 		custom_data,

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -73,6 +73,8 @@
 	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload && link_on_init, mat_container_flags=BREAKDOWN_FLAGS_LATHE)
 	RefreshParts() //Recalculating local material sizes if the fab isn't linked
 	update_menu_tech()
+	RegisterSignal(stored_research, COMSIG_TECHWEB_ADD_DESIGN, .proc/update_menu_tech)
+	RegisterSignal(stored_research, COMSIG_TECHWEB_REMOVE_DESIGN, .proc/update_menu_tech)
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
@@ -231,6 +233,8 @@
 					continue
 
 				buildable_parts[cat] += list(part)
+
+	update_static_data(usr)
 
 /**
  * Intended to be called when an item starts printing.
@@ -518,12 +522,6 @@
 	usr.set_machine(src)
 
 	switch(action)
-		if("sync_rnd")
-			// Syncronises designs on interface with R&D techweb.
-			update_menu_tech()
-			update_static_data(usr)
-			say("Successfully synchronized with R&D server.")
-			return
 		if("add_queue_set")
 			// Add all parts of a set to queue
 			var/part_list = params["part_list"]

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -76,9 +76,16 @@
 	RegisterSignal(
 		stored_research,
 		list(COMSIG_TECHWEB_ADD_DESIGN, COMSIG_TECHWEB_REMOVE_DESIGN),
-		.proc/update_menu_tech
+		.proc/on_techweb_update
 	)
 	return ..()
+
+/obj/machinery/mecha_part_fabricator/proc/on_techweb_update()
+	SIGNAL_HANDLER
+
+	// We're probably going to get more than one update (design) at a time, so batch
+	// them together.
+	addtimer(CALLBACK(src, .proc/update_menu_tech), 0.25 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
 	. = ..()
@@ -213,8 +220,6 @@
  * Updates the `final_sets` and `buildable_parts` for the current mecha fabricator.
  */
 /obj/machinery/mecha_part_fabricator/proc/update_menu_tech()
-	SIGNAL_HANDLER
-
 	final_sets = list()
 	buildable_parts = list()
 	final_sets += part_sets

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -73,8 +73,11 @@
 	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload && link_on_init, mat_container_flags=BREAKDOWN_FLAGS_LATHE)
 	RefreshParts() //Recalculating local material sizes if the fab isn't linked
 	update_menu_tech()
-	RegisterSignal(stored_research, COMSIG_TECHWEB_ADD_DESIGN, .proc/update_menu_tech)
-	RegisterSignal(stored_research, COMSIG_TECHWEB_REMOVE_DESIGN, .proc/update_menu_tech)
+	RegisterSignal(
+		stored_research,
+		list(COMSIG_TECHWEB_ADD_DESIGN, COMSIG_TECHWEB_REMOVE_DESIGN),
+		.proc/update_menu_tech
+	)
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
@@ -106,7 +109,7 @@
 		var/new_build_time = (new_const_time / last_const_time) * const_time_left
 		build_finish = world.time + new_build_time
 
-	update_static_data(usr)
+	update_static_data_for_all_viewers()
 
 /obj/machinery/mecha_part_fabricator/examine(mob/user)
 	. = ..()
@@ -210,6 +213,8 @@
  * Updates the `final_sets` and `buildable_parts` for the current mecha fabricator.
  */
 /obj/machinery/mecha_part_fabricator/proc/update_menu_tech()
+	SIGNAL_HANDLER
+
 	final_sets = list()
 	buildable_parts = list()
 	final_sets += part_sets
@@ -234,7 +239,7 @@
 
 				buildable_parts[cat] += list(part)
 
-	update_static_data(usr)
+	update_static_data_for_all_viewers()
 
 /**
  * Intended to be called when an item starts printing.

--- a/tgui/packages/tgui/interfaces/ExosuitFabricator.js
+++ b/tgui/packages/tgui/interfaces/ExosuitFabricator.js
@@ -153,15 +153,7 @@ export const ExosuitFabricator = (props, context) => {
           <Stack.Item grow>
             <Stack fill>
               <Stack.Item>
-                <Section
-                  fill
-                  title="Categories"
-                  buttons={
-                    <Button
-                      content="R&D Sync"
-                      onClick={() => act('sync_rnd')}
-                    />
-                  }>
+                <Section fill title="Categories">
                   <PartSets />
                 </Section>
               </Stack.Item>

--- a/tgui/packages/tgui/interfaces/Fabricator.tsx
+++ b/tgui/packages/tgui/interfaces/Fabricator.tsx
@@ -63,14 +63,7 @@ export const Fabricator = (props, context) => {
                       ? 'All Designs'
                       : selectedCategory
                   }
-                  fill
-                  buttons={
-                    <Button
-                      color={'transparent'}
-                      onClick={() => act('sync_rnd')}>
-                      <Icon name="refresh" /> Sync Research
-                    </Button>
-                  }>
+                  fill>
                   <Stack vertical fill>
                     <Stack.Item>
                       <Section>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds hooks to techfabs and exofabs to automatically synchronize research when the linked techweb updates, and deletes the old R&D sync buttons. It also lowers `TGUI_REFRESH_FULL_UPDATE_COOLDOWN` to one second (one fifth of its original value), and now actually uses that value to compute when to send a full refresh.

Prior to this, windows would hang on "please wait" for 5-10 seconds, which felt _really_ broken (is this even doing anything?).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People will stop asking me to add this functionality, and people will no longer close out of tgui windows because they think they're broken when really they have to wait eight seconds for a refresh

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: techfabs, protolathes, circuit imprinters, and exosuit fabricators now automatically r&d sync
qol: the full window refresh time is now one second instead of five seconds
fix: refreshing windows ("please wait...") no longer hang for up to twice as long as they should
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
