### PR TITLE
I shaved 2 seconds off atom init times and it's boring

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -108,7 +108,7 @@ SUBSYSTEM_DEF(atoms)
 		count = 0
 		#endif
 
-		for(var/atom/A as anything in world)
+		for(var/atom/A in world)
 			if(!(A.flags_1 & INITIALIZED_1))
 				PROFILE_INIT_ATOM_BEGIN()
 				InitAtom(A, FALSE, mapload_arg)

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -85,12 +85,18 @@ SUBSYSTEM_DEF(atoms)
 	if (atoms_to_return)
 		LAZYINITLIST(created_atoms)
 
+	#ifdef TESTING
 	var/count
+	#endif
+
 	var/list/mapload_arg = list(TRUE)
 
 	if(atoms)
+		#ifdef TESTING
 		count = atoms.len
-		for(var/I in 1 to count)
+		#endif
+
+		for(var/I in 1 to atoms.len)
 			var/atom/A = atoms[I]
 			if(!(A.flags_1 & INITIALIZED_1))
 				CHECK_TICK
@@ -98,17 +104,21 @@ SUBSYSTEM_DEF(atoms)
 				InitAtom(A, TRUE, mapload_arg)
 				PROFILE_INIT_ATOM_END(A)
 	else
+		#ifdef TESTING
 		count = 0
-		for(var/atom/A in world)
+		#endif
+
+		for(var/atom/A as anything in world)
 			if(!(A.flags_1 & INITIALIZED_1))
 				PROFILE_INIT_ATOM_BEGIN()
 				InitAtom(A, FALSE, mapload_arg)
 				PROFILE_INIT_ATOM_END(A)
+				#ifdef TESTING
 				++count
+				#endif
 				CHECK_TICK
 
 	testing("Initialized [count] atoms")
-	pass(count)
 
 /// Init this specific atom
 /datum/controller/subsystem/atoms/proc/InitAtom(atom/A, from_template = FALSE, list/arguments)
@@ -117,27 +127,33 @@ SUBSYSTEM_DEF(atoms)
 		BadInitializeCalls[the_type] |= BAD_INIT_QDEL_BEFORE
 		return TRUE
 
+	// This is handled and battle tested by dreamchecker. Limit to UNIT_TESTS just in case that ever fails.
+	#ifdef UNIT_TESTS
 	var/start_tick = world.time
+	#endif
 
 	var/result = A.Initialize(arglist(arguments))
 
+	#ifdef UNIT_TESTS
 	if(start_tick != world.time)
 		BadInitializeCalls[the_type] |= BAD_INIT_SLEPT
+	#endif
 
 	var/qdeleted = FALSE
 
-	if(result != INITIALIZE_HINT_NORMAL)
-		switch(result)
-			if(INITIALIZE_HINT_LATELOAD)
-				if(arguments[1]) //mapload
-					late_loaders += A
-				else
-					A.LateInitialize()
-			if(INITIALIZE_HINT_QDEL)
-				qdel(A)
-				qdeleted = TRUE
+	switch(result)
+		if (INITIALIZE_HINT_NORMAL)
+			// pass
+		if(INITIALIZE_HINT_LATELOAD)
+			if(arguments[1]) //mapload
+				late_loaders += A
 			else
-				BadInitializeCalls[the_type] |= BAD_INIT_NO_HINT
+				A.LateInitialize()
+		if(INITIALIZE_HINT_QDEL)
+			qdel(A)
+			qdeleted = TRUE
+		else
+			BadInitializeCalls[the_type] |= BAD_INIT_NO_HINT
 
 	if(!A) //possible harddel
 		qdeleted = TRUE

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -108,7 +108,7 @@ SUBSYSTEM_DEF(atoms)
 		count = 0
 		#endif
 
-		for(var/atom/A in world)
+		for(var/atom/A as anything in world)
 			if(!(A.flags_1 & INITIALIZED_1))
 				PROFILE_INIT_ATOM_BEGIN()
 				InitAtom(A, FALSE, mapload_arg)


### PR DESCRIPTION
Turns out tweaking something called 887,808 times has some nice boosts.

1. Moves sleep tests to UNIT_TESTS. Every single atom is initialized during tests, and dreamchecker has so far done an excellent job of catching these.
2. Moves some count code behind TESTING, the only environment it worked anyway.
3. Changes `atom/A in world` to `atom/A as anything in world`, which feels like it should be weird but it's a lot faster.
4. Changes an `if(x != y)` to a switch statement with `if (y)` as the first case, which, yes is decently faster.

Couldn't think of anything else.