### PR TITLE
Changes reagentscanner circuit component to use Table

### DIFF
--- a/code/modules/wiremod/components/atom/reagentscanner.dm
+++ b/code/modules/wiremod/components/atom/reagentscanner.dm
@@ -23,7 +23,6 @@
 	. += create_table_notices(list(
 		"reagent",
 		"volume",
-		"purity",
 		))
 
 /obj/item/circuit_component/reagentscanner/populate_ports()
@@ -41,6 +40,5 @@
 		var/list/entry = list()
 		entry["reagent"] = reagent.name
 		entry["volume"] = reagent.volume
-		entry["purity"] = reagent.purity
 		new_table += list(entry)
 	result.set_output(new_table)

--- a/code/modules/wiremod/components/atom/reagentscanner.dm
+++ b/code/modules/wiremod/components/atom/reagentscanner.dm
@@ -20,10 +20,15 @@
 /obj/item/circuit_component/reagentscanner/get_ui_notices()
 	. = ..()
 	. += create_ui_notice("Maximum Range: [max_range] tiles", "orange", "info")
+	. += create_table_notices(list(
+		"reagent",
+		"volume",
+		"purity",
+		))
 
 /obj/item/circuit_component/reagentscanner/populate_ports()
 	input_port = add_input_port("Entity", PORT_TYPE_ATOM)
-	result = add_output_port("Reagents", PORT_TYPE_ASSOC_LIST(PORT_TYPE_STRING, PORT_TYPE_NUMBER))
+	result = add_output_port("Reagents", PORT_TYPE_TABLE)
 
 /obj/item/circuit_component/reagentscanner/input_received(datum/port/input/port)
 	var/atom/entity = input_port.value
@@ -31,7 +36,11 @@
 	if(!istype(entity) || !IN_GIVEN_RANGE(location, entity, max_range))
 		result.set_output(null)
 		return
-	var/list/output_list = list()
+	var/list/new_table = list()
 	for(var/datum/reagent/reagent as anything in entity.reagents?.reagent_list)
-		output_list[reagent.name] += reagent.volume
-	result.set_output(output_list)
+		var/list/entry = list()
+		entry["reagent"] = reagent.name
+		entry["volume"] = reagent.volume
+		entry["purity"] = reagent.purity
+		new_table += list(entry)
+	result.set_output(new_table)


### PR DESCRIPTION
## About The Pull Request


Changes components\atom\reagentscanner to use table list from Assoc list.
Added purity output to components\atom\reagentscanner.

## Why It's Good For The Game




At time of making this its impossible to iterate through the output of reagentscanner via loops or numerical index and to determine the amount or the reagent scanned you needed to know its associated value which is less than idea.

Queried this issue on coderbus meeting 3 then asked Watermelon and he agreed that a change would be good.

~~Added a "purity" to the table outputs to make shells of this component "desirable" to chemistry who need to use Ph_meter to check exact purity. If this not allowed~~ I’m willing to make an \atom\reagentscanner\adv variant that will comparable to Ph_meter.

I intend to give the same treatment to materialscanner.


## Changelog


:cl:
qol: Reagent scanner circuit component now ouputs to a table list.
/:cl:

