### PR TITLE
Significantly increases the volume of tritium combustion radiation pulses. All gas reactions that release radiation pulses will now have a constant radiation threshold.

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -80,9 +80,9 @@
 /// The minimum released energy necessary for tritium to release radiation during combustion. (at a mix volume of [CELL_VOLUME]).
 #define TRITIUM_RADIATION_RELEASE_THRESHOLD (FIRE_TRITIUM_ENERGY_RELEASED)
 /// A scaling factor for the range of radiation pulses produced by tritium fires.
-#define TRITIUM_RADIATION_RANGE_DIVISOR 1.5
-/// A scaling factor for the irradiation threshold of radiation pulses produced by tritium fires.
-#define TRITIUM_RADIATION_THRESHOLD_BASE 15
+#define TRITIUM_RADIATION_RANGE_DIVISOR 0.5
+/// The threshold of the tritium combustion's radiation. Lower values means it will be able to penetrate through more structures.
+#define TRITIUM_RADIATION_THRESHOLD 0.3
 
 // - Freon:
 /// The maximum temperature freon can combust at.
@@ -235,9 +235,9 @@
 /// The minimum released energy necessary for proto-nitrate to release radiation when converting tritium. (With a reaction vessel volume of [CELL_VOLUME])
 #define PN_TRITIUM_CONVERSION_RAD_RELEASE_THRESHOLD 10000
 /// A scaling factor for the range of the radiation pulses generated when proto-nitrate converts tritium to hydrogen.
-#define PN_TRITIUM_RAD_RANGE_DIVISOR 1.5
-/// A scaling factor for the threshold of the radiation pulses generated when proto-nitrate converts tritium to hydrogen.
-#define PN_TRITIUM_RAD_THRESHOLD_BASE 15
+#define PN_TRITIUM_RAD_RANGE_DIVISOR 0.5
+/// The threshold of the radiation pulse released when proto-nitrate converts tritium into hydrogen. Lower values means it will be able to penetrate through more structures.
+#define PN_TRITIUM_RAD_THRESHOLD 0.3
 
 /// The minimum temperature proto-nitrate can break BZ down at.
 #define PN_BZASE_MIN_TEMP 260
@@ -249,8 +249,8 @@
 #define PN_BZASE_RAD_RELEASE_THRESHOLD 60000
 /// A scaling factor for the range of the radiation pulses generated when proto-nitrate breaks down BZ.
 #define PN_BZASE_RAD_RANGE_DIVISOR 1.5
-/// A scaling factor for the threshold of the radiation pulses generated when proto-nitrate breaks down BZ.
-#define PN_BZASE_RAD_THRESHOLD_BASE 15
+/// The threshold of the radiation pulse released when proto-nitrate breaks down BZ. Lower values means it will be able to penetrate through more structures.
+#define PN_BZASE_RAD_THRESHOLD 0.3
 /// A scaling factor for the nuclear particle production generated when proto-nitrate breaks down BZ.
 #define PN_BZASE_NUCLEAR_PARTICLE_DIVISOR 5
 /// The maximum amount of nuclear particles that can be produced from proto-nitrate breaking down BZ.

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -333,7 +333,7 @@
 
 	var/energy_released = FIRE_TRITIUM_ENERGY_RELEASED * burned_fuel
 	if(location && burned_fuel > TRITIUM_RADIATION_MINIMUM_MOLES && energy_released > TRITIUM_RADIATION_RELEASE_THRESHOLD * (air.volume / CELL_VOLUME) ** ATMOS_RADIATION_VOLUME_EXP && prob(10))
-		radiation_pulse(location, max_range = min(sqrt(burned_fuel) / TRITIUM_RADIATION_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = TRITIUM_RADIATION_THRESHOLD_BASE * INVERSE(TRITIUM_RADIATION_THRESHOLD_BASE + burned_fuel))
+		radiation_pulse(location, max_range = min(sqrt(burned_fuel) / TRITIUM_RADIATION_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = TRITIUM_RADIATION_THRESHOLD)
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()
@@ -1081,7 +1081,7 @@
 	else if(isatom(holder))
 		location = holder
 	if (location && energy_released > PN_TRITIUM_CONVERSION_RAD_RELEASE_THRESHOLD * (air.volume / CELL_VOLUME) ** ATMOS_RADIATION_VOLUME_EXP)
-		radiation_pulse(location, max_range = min(sqrt(produced_amount) / PN_TRITIUM_RAD_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = PN_TRITIUM_RAD_THRESHOLD_BASE * INVERSE(PN_TRITIUM_RAD_THRESHOLD_BASE + produced_amount))
+		radiation_pulse(location, max_range = min(sqrt(produced_amount) / PN_TRITIUM_RAD_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = PN_TRITIUM_RAD_THRESHOLD)
 
 	if(energy_released)
 		var/new_heat_capacity = air.heat_capacity()
@@ -1137,7 +1137,7 @@
 		var/nuclear_particle_amount = min(round(consumed_amount / PN_BZASE_NUCLEAR_PARTICLE_DIVISOR), PN_BZASE_NUCLEAR_PARTICLE_MAXIMUM)
 		for(var/i in 1 to nuclear_particle_amount)
 			location.fire_nuclear_particle()
-		radiation_pulse(location, max_range = min(sqrt(consumed_amount - nuclear_particle_amount * PN_BZASE_NUCLEAR_PARTICLE_RADIATION_ENERGY_CONVERSION) / PN_BZASE_RAD_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = PN_BZASE_RAD_THRESHOLD_BASE * INVERSE(PN_BZASE_RAD_THRESHOLD_BASE + consumed_amount - nuclear_particle_amount * PN_BZASE_NUCLEAR_PARTICLE_RADIATION_ENERGY_CONVERSION))
+		radiation_pulse(location, max_range = min(sqrt(consumed_amount - nuclear_particle_amount * PN_BZASE_NUCLEAR_PARTICLE_RADIATION_ENERGY_CONVERSION) / PN_BZASE_RAD_RANGE_DIVISOR, GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE), threshold = PN_BZASE_RAD_THRESHOLD)
 		for(var/mob/living/carbon/L in location)
 			L.hallucination += consumed_amount
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the range of radiation pulses from tritium combustion by 3 times, increasing the volume by almost 10 times. This will give tritium the same potential radiation volume as old tritium before the tritium combustion rework, as tritium gets consumed much faster now. The radiation pulse size from the incinerator should be somewhere around 9 to 10 if creating tritium via the wiki method. The radiation threshold property for all gas reactions that release radiation is now 0.3, instead of a value that converges to 0 depending on reaction rate. 4 walls, or 1 reinforced wall and 2 walls, will always be enough to stop any radiation from gas reactions.

The result of this change will make larger radiation pulses easier, but are shorter. Long burns such as tritium getting burned in the incinerator while getting created should be roughly the same as before the rework.

Proto-nitrate tritium response radiation pulse range have also been multiplied by 3 for consistency.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The tritium combustion rework has made tritium's consumption rate be 1/1 with the burn rate, instead of 0.1 times the burn rate. Since radiation pulses work based on the burn rate, this made radiation pulse volume decrease by 90%. This should make the radiation from tritium combustion be a threat again, making radiation suits more mandatory for people operating in a super saturated incinerator.

Setting the radiation threshold to a constant value will make mapping incinerators much easier, as mappers will know they will need 4 walls or 1 reinforced wall and 2 walls to stop a radiation pulse. The value should also prevent cases where a large amount of tritium getting burned all at once will cause areas such as botany or people completely unaware from getting irradiated from far away, limiting the radiation to be in and around the room instead.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Radiation range from tritium combustion and proto-nitrate tritium to hydrogen conversion increased by 3 times.
balance: Sets the radiation threshold for all gas reactions that release radiation to 0.3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
