### PR TITLE
Corporate sofa corners no longer swallow your sprite when oriented North

### DIFF
--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -58,6 +58,9 @@
 /obj/structure/chair/sofa/corp/corner
 	icon_state = "corp_sofacorner"
 
+/obj/structure/chair/sofa/corp/corner/handle_layer() //only the armrest/back of this chair should cover the mob.
+	return
+
 // Ported from Skyrat
 /obj/structure/chair/sofa/bench
 	name = "bench"


### PR DESCRIPTION
## About The Pull Request
That's about it. I still can't believe nobody else did this before, it took me like two minutes to fix it, and it's been bugging me for over a year.

## Why It's Good For The Game
You shouldn't go seemingly invisible when buckling to a sofa because its entire sprite is now layered above yours.

## Changelog

:cl: GoldenAlpharex
fix: Corporate sofa corners have been exorcised and will no longer engulf anyone that sits on them while they're in the L orientation.
/:cl: