### PR TITLE
Tweaks the description for material tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -40,7 +40,6 @@
 	. = ..()
 	if(_buildstack)
 		buildstack = _buildstack
-		desc = "A square table, fashioned out of [buildstack]. What will they think of next?"
 	AddElement(/datum/element/climbable)
 
 	var/static/list/loc_connections = list(
@@ -326,6 +325,7 @@
 	return COMSIG_CARBON_SHOVE_HANDLED
 
 /obj/structure/table/greyscale
+	desc = "A four legged table, fashioned out of suboptimal table construction material."
 	icon = 'icons/obj/smooth_structures/table_greyscale.dmi'
 	icon_state = "table_greyscale-0"
 	base_icon_state = "table_greyscale"

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -40,6 +40,7 @@
 	. = ..()
 	if(_buildstack)
 		buildstack = _buildstack
+		desc = "A square table, fashioned out of [buildstack]. What will they think of next?"
 	AddElement(/datum/element/climbable)
 
 	var/static/list/loc_connections = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the description for material tables sharing the description of standard, iron tables. I got stuck for an hour trying to implement a way to update the description with the material contents, only to realize that it lists the materials on the next line of the examine message either way. Whoops.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Closes #69750.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: fixes the description for material tables to not say they're made of iron.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
