### PR TITLE
Fixes ethereal undersuit being adjustable, causing an error

### DIFF
--- a/code/modules/clothing/under/ethereal.dm
+++ b/code/modules/clothing/under/ethereal.dm
@@ -8,6 +8,7 @@
 	greyscale_config = /datum/greyscale_config/eth_tunic
 	greyscale_config_worn = /datum/greyscale_config/eth_tunic_worn
 	flags_1 = IS_PLAYER_COLORABLE_1
+	can_adjust = FALSE
 
 /obj/item/clothing/under/ethereal_tunic/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Sets can_adjust to false since it apparently defaults to true!

## Why It's Good For The Game
I just don't like bugs that's just me

## Changelog

:cl:
fix: You can no longer adjust ethereal tunics, causing a missing icon error
/:cl:
