### PR TITLE
Makes custom built table descriptions more accurate

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -336,7 +336,7 @@
 	var/list/materials_list = list()
 	for(var/datum/material/current_material as anything in materials)
 		materials_list += "[current_material.name]"
-	desc = "A square [(materials_list.len > 1) ? "amagamation" : "peice"] of [english_list(materials_list)] on four legs. It can not move."
+	desc = "A square [(materials_list.len > 1) ? "amalgamation" : "piece"] of [english_list(materials_list)] on four legs. It can not move."
 
 ///Table on wheels
 /obj/structure/table/rolling

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -62,12 +62,6 @@
 		AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
 		register_context()
 
-	if(custom_materials && ispath(type, /obj/structure/table) && (custom_materials != initial(custom_materials)))
-		var/list/materials_list = list()
-		for(var/datum/material/current_material as anything in custom_materials)
-			materials_list += "[current_material.name]"
-		desc = "A square [(materials_list.len > 1) ? "amagamation" : "peice"] of [english_list(materials_list)] on four legs. It can not move."
-
 /obj/structure/table/examine(mob/user)
 	. = ..()
 	. += deconstruction_hints(user)
@@ -336,6 +330,13 @@
 	base_icon_state = "table_greyscale"
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	buildstack = null //No buildstack, so generate from mat datums
+
+/obj/structure/table/greyscale/set_custom_materials(list/materials, multiplier)
+	. = ..()
+	var/list/materials_list = list()
+	for(var/datum/material/current_material as anything in materials)
+		materials_list += "[current_material.name]"
+	desc = "A square [(materials_list.len > 1) ? "amagamation" : "peice"] of [english_list(materials_list)] on four legs. It can not move."
 
 ///Table on wheels
 /obj/structure/table/rolling

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -62,6 +62,12 @@
 		AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
 		register_context()
 
+	if(custom_materials && ispath(type, /obj/structure/table) && (custom_materials != initial(custom_materials)))
+		var/list/materials_list = list()
+		for(var/datum/material/current_material as anything in custom_materials)
+			materials_list += "[current_material.name]"
+		desc = "A square [(materials_list.len > 1) ? "amagamation" : "peice"] of [english_list(materials_list)] on four legs. It can not move."
+
 /obj/structure/table/examine(mob/user)
 	. = ..()
 	. += deconstruction_hints(user)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -334,7 +334,7 @@
 /obj/structure/table/greyscale/set_custom_materials(list/materials, multiplier)
 	. = ..()
 	var/list/materials_list = list()
-	for(var/datum/material/current_material as anything in materials)
+	for(var/datum/material/current_material as anything in custom_materials)
 		materials_list += "[current_material.name]"
 	desc = "A square [(materials_list.len > 1) ? "amalgamation" : "piece"] of [english_list(materials_list)] on four legs. It can not move."
 


### PR DESCRIPTION
Fixes #69750

:cl: ShizCalev
fix: Tables built out of custom materials (ie meat) will no longer say that they are built from iron in their description.
/:cl:
