### PR TITLE
Various assembly fixes.

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -191,11 +191,7 @@
 	var/obj/item/assembly/S = get_attached(color)
 	if(S && istype(S))
 		assemblies -= color
-		S.connected = null
-		if(S.holder == holder)	// This should be the case
-			S.on_detach()		// Notify the assembly.  This should remove the reference to our holder
-			if(S.holder == holder) // If it didn't remove the reference, force it.  So sue me, I'm paranoid.
-				S.holder = null
+		S.on_detach()		// Notify the assembly.  This should remove the reference to our holder
 		S.forceMove(holder.drop_location())
 		return S
 

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -184,7 +184,7 @@
 		assemblies[color] = S
 		S.forceMove(holder)
 		S.connected = src
-		S.on_attach()
+		S.on_attach() // Notify assembly that it is attached
 		return S
 
 /datum/wires/proc/detach_assembly(color)
@@ -192,9 +192,9 @@
 	if(S && istype(S))
 		assemblies -= color
 		S.connected = null
-		if(S.holder == holder)
-			S.on_detach()
-			if(S.holder == holder)
+		if(S.holder == holder)	// This should be the case
+			S.on_detach()		// Notify the assembly.  This should remove the reference to our holder
+			if(S.holder == holder) // If it didn't remove the reference, force it.  So sue me, I'm paranoid.
 				S.holder = null
 		S.forceMove(holder.drop_location())
 		return S

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -184,6 +184,7 @@
 		assemblies[color] = S
 		S.forceMove(holder)
 		S.connected = src
+		S.on_attach()
 		return S
 
 /datum/wires/proc/detach_assembly(color)
@@ -191,6 +192,10 @@
 	if(S && istype(S))
 		assemblies -= color
 		S.connected = null
+		if(S.holder == holder)
+			S.on_detach()
+			if(S.holder == holder)
+				S.holder = null
 		S.forceMove(holder.drop_location())
 		return S
 

--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -161,6 +161,9 @@ GLOBAL_LIST_INIT(reverseradiochannels, list(
 	//Send the data
 	for(var/current_filter in filter_list)
 		for(var/datum/weakref/device_ref as anything in devices[current_filter])
+			if(isnull(device_ref))
+				devices[current_filter] -= null
+				continue
 			var/obj/device = device_ref.resolve()
 			if(!device)
 				devices[current_filter] -= device_ref
@@ -185,7 +188,6 @@ GLOBAL_LIST_INIT(reverseradiochannels, list(
 		devices[filter] = devices_line = list()
 	devices_line += WEAKREF(device)
 
-
 /datum/radio_frequency/proc/remove_listener(obj/device)
 	for(var/devices_filter in devices)
 		var/list/devices_line = devices[devices_filter]
@@ -194,7 +196,6 @@ GLOBAL_LIST_INIT(reverseradiochannels, list(
 		devices_line -= WEAKREF(device)
 		if(!devices_line.len)
 			devices -= devices_filter
-
 
 /obj/proc/receive_signal(datum/signal/signal)
 	return

--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -161,9 +161,6 @@ GLOBAL_LIST_INIT(reverseradiochannels, list(
 	//Send the data
 	for(var/current_filter in filter_list)
 		for(var/datum/weakref/device_ref as anything in devices[current_filter])
-			if(isnull(device_ref))
-				devices[current_filter] -= null
-				continue
 			var/obj/device = device_ref.resolve()
 			if(!device)
 				devices[current_filter] -= device_ref
@@ -183,10 +180,13 @@ GLOBAL_LIST_INIT(reverseradiochannels, list(
 	if (!filter)
 		filter = "_default"
 
+	var/datum/weakref/new_listener = WEAKREF(device)
+	if(isnull(new_listener))
+		return stack_trace("null, non-datum, or qdeleted device")
 	var/list/devices_line = devices[filter]
 	if(!devices_line)
 		devices[filter] = devices_line = list()
-	devices_line += WEAKREF(device)
+	devices_line += new_listener
 
 /datum/radio_frequency/proc/remove_listener(obj/device)
 	for(var/devices_filter in devices)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -65,8 +65,8 @@
 			return
 		attached_device = A
 		to_chat(user, span_notice("You attach the [item] to the valve controls and secure it."))
-		A.on_attach()
 		A.holder = src
+		A.on_attach()
 		A.toggle_secure() //this calls update_icon(), which calls update_icon() on the holder (i.e. the bomb).
 		log_bomber(user, "attached a [item.name] to a ttv -", src, null, FALSE)
 		attacher = user

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -137,9 +137,12 @@
 	return ui_interact(user)
 
 /obj/item/assembly/ui_host(mob/user)
-	if(connected)
-		return connected.holder
-	return holder?.master || holder || src
+	// In order, return:
+	// - The conencted wiring datum's owner, or
+	// - The thing your assembly holder is attached to, or
+	// - the assembly holder itself, or
+	// - us
+	return connected?.holder || holder?.master || holder || src
 
 /obj/item/assembly/ui_state(mob/user)
 	return GLOB.hands_state

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -45,6 +45,8 @@
 
 //Call this when detaching it from a device. handles any special functions that need to be updated ex post facto
 /obj/item/assembly/proc/on_detach()
+	if(connected)
+		connected = null
 	if(!holder)
 		return FALSE
 	forceMove(holder.drop_location())
@@ -95,6 +97,15 @@
 	secured = !secured
 	update_appearance()
 	return secured
+
+// This is overwritten so that clumsy people can set off mousetraps even when in a holder.
+// We are not going deeper than that however (won't set off if in a tank bomb or anything with wires)
+// That would need to be added to all parent objects, or a signal created, whatever.
+// Anyway this return check prevents you from picking up every assembly inside the holder at once.
+/obj/item/assembly/attack_hand(mob/living/user, list/modifiers)
+	if(holder || connected)
+		return
+	. = ..()
 
 /obj/item/assembly/attackby(obj/item/W, mob/user, params)
 	if(isassembly(W))

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -40,6 +40,8 @@
 	return 1
 
 /obj/item/assembly/proc/on_attach()
+	if(!holder && connected)
+		holder = connected.holder
 
 //Call this when detaching it from a device. handles any special functions that need to be updated ex post facto
 /obj/item/assembly/proc/on_detach()
@@ -135,9 +137,9 @@
 	return ui_interact(user)
 
 /obj/item/assembly/ui_host(mob/user)
-	if(holder)
-		return holder
-	return src
+	if(connected)
+		return connected.holder
+	return holder?.master || holder || src
 
 /obj/item/assembly/ui_state(mob/user)
 	return GLOB.hands_state

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -39,11 +39,18 @@
 /obj/item/assembly/get_part_rating()
 	return 1
 
+/**
+ * on_attach: Called when attached to a holder, wiring datum, or other special assembly
+ *
+ * Will also be called if the assembly holder is attached to a plasma (internals) tank or welding fuel (dispenser) tank.
+ */
 /obj/item/assembly/proc/on_attach()
 	if(!holder && connected)
 		holder = connected.holder
 
-//Call this when detaching it from a device. handles any special functions that need to be updated ex post facto
+/**
+ * on_detach: Called when removed from an assembly holder or wiring datum
+ */
 /obj/item/assembly/proc/on_detach()
 	if(connected)
 		connected = null
@@ -53,7 +60,9 @@
 	holder = null
 	return TRUE
 
-//Called when the holder is moved
+/**
+ * holder_movement: Called when the assembly's holder detects movement
+ */
 /obj/item/assembly/proc/holder_movement()
 	if(!holder)
 		return FALSE

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -136,6 +136,7 @@
 
 	bomb.bombassembly = assembly //Tell the bomb about its assembly part
 	assembly.master = bomb //Tell the assembly about its new owner
+	assembly.on_attach()
 
 	bomb.bombtank = src //Same for tank
 	master = bomb

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -28,7 +28,6 @@
 /obj/item/assembly_holder/IsAssemblyHolder()
 	return TRUE
 
-
 /obj/item/assembly_holder/proc/assemble(obj/item/assembly/A, obj/item/assembly/A2, mob/user)
 	attach(A,user)
 	attach(A2,user)
@@ -36,6 +35,10 @@
 	update_appearance()
 	SSblackbox.record_feedback("tally", "assembly_made", 1, "[initial(A.name)]-[initial(A2.name)]")
 
+/**
+ * on_attach: Pass on_attach message to child assemblies
+ *
+ */
 /obj/item/assembly_holder/proc/on_attach()
 	var/obj/item/newloc = loc
 	if(!newloc.IsSpecialAssembly() && !newloc.IsAssemblyHolder())
@@ -156,7 +159,7 @@
 /obj/item/assembly_holder/proc/process_activation(obj/device, normal = TRUE, special = TRUE)
 	if(!device)
 		return FALSE
-	if(normal && assemblies.len >= 2)
+	if(normal && LAZYLEN(assemblies.len))
 		for(var/obj/item/assembly/assembly as anything in assemblies)
 			if(assembly != device)
 				assembly.pulsed(FALSE)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -159,7 +159,7 @@
 /obj/item/assembly_holder/proc/process_activation(obj/device, normal = TRUE, special = TRUE)
 	if(!device)
 		return FALSE
-	if(normal && LAZYLEN(assemblies))
+	if(normal && LAZYLEN(assemblies) >= 2)
 		for(var/obj/item/assembly/assembly as anything in assemblies)
 			if(assembly != device)
 				assembly.pulsed(FALSE)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -114,7 +114,7 @@
 	if(.)
 		return
 	for(var/obj/item/assembly/assembly as anything in assemblies)
-		assembly.attack_hand()
+		assembly.attack_hand(user, modifiers) // Note override in assembly.dm to prevent side effects here
 
 /obj/item/assembly_holder/attackby(obj/item/weapon, mob/user, params)
 	if(isassembly(weapon))
@@ -159,7 +159,7 @@
 /obj/item/assembly_holder/proc/process_activation(obj/device, normal = TRUE, special = TRUE)
 	if(!device)
 		return FALSE
-	if(normal && LAZYLEN(assemblies.len))
+	if(normal && LAZYLEN(assemblies))
 		for(var/obj/item/assembly/assembly as anything in assemblies)
 			if(assembly != device)
 				assembly.pulsed(FALSE)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -36,6 +36,13 @@
 	update_appearance()
 	SSblackbox.record_feedback("tally", "assembly_made", 1, "[initial(A.name)]-[initial(A2.name)]")
 
+/obj/item/assembly_holder/proc/on_attach()
+	var/obj/item/newloc = loc
+	if(!newloc.IsSpecialAssembly() && !newloc.IsAssemblyHolder())
+		return
+	for(var/obj/item/assembly/assembly in assemblies)
+		assembly.on_attach()
+
 /**
  * Adds an assembly to the assembly holder
  *
@@ -149,9 +156,9 @@
 /obj/item/assembly_holder/proc/process_activation(obj/device, normal = TRUE, special = TRUE)
 	if(!device)
 		return FALSE
-	if(normal && LAZYLEN(assemblies) >= 2)
+	if(normal && assemblies.len >= 2)
 		for(var/obj/item/assembly/assembly as anything in assemblies)
-			if(LAZYACCESS(assemblies, assembly) != device)
+			if(assembly != device)
 				assembly.pulsed(FALSE)
 	if(master)
 		master.receive_signal()

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -11,7 +11,7 @@
 	var/obj/item/host = null
 	var/turf/host_turf = null
 
-/obj/item/assembly/mousetrap/proc/update_host(var/force = FALSE)
+/obj/item/assembly/mousetrap/proc/update_host(force = FALSE)
 	var/obj/item/newhost
 	if(connected)
 		newhost = connected.holder // this won't actually do anything unless someone makes opening a wiring panel call on_found (which would be boss)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -145,7 +145,7 @@
 	playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 	pulse(FALSE)
 
-/*
+/**
  * clumsy_check: Sets off the mousetrap if handled by a clown (with some probability)
  *
  * Arguments:

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -202,6 +202,15 @@
 	triggered(null)
 
 
+/obj/item/assembly/mousetrap/Destroy()
+	if(host)
+		UnregisterSignal(host,COMSIG_MOVABLE_MOVED)
+		host = null
+	if(isturf(host_turf))
+		UnregisterSignal(host_turf,COMSIG_ATOM_ENTERED)
+		host_turf = null
+	return ..()
+
 /obj/item/assembly/mousetrap/armed
 	icon_state = "mousetraparmed"
 	armed = TRUE

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -145,18 +145,30 @@
 	playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 	pulse(FALSE)
 
+/*
+ * clumsy_check: Sets off the mousetrap if handled by a clown (with some probability)
+ *
+ * Arguments:
+ * * user: The mob handling the trap
+ */
+/obj/item/assembly/mousetrap/proc/clumsy_check(mob/living/carbon/human/user)
+	if(!armed)
+		return FALSE
+	if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(50))
+		var/which_hand = BODY_ZONE_PRECISE_L_HAND
+		if(!(user.active_hand_index % 2))
+			which_hand = BODY_ZONE_PRECISE_R_HAND
+		triggered(user, which_hand)
+		user.visible_message(span_warning("[user] accidentally sets off [src], breaking their fingers."), \
+			span_warning("You accidentally trigger [src]!"))
+		return TRUE
+	return FALSE
 
 /obj/item/assembly/mousetrap/attack_self(mob/living/carbon/human/user)
 	if(!armed)
 		to_chat(user, span_notice("You arm [src]."))
 	else
-		if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(50))
-			var/which_hand = BODY_ZONE_PRECISE_L_HAND
-			if(!(user.active_hand_index % 2))
-				which_hand = BODY_ZONE_PRECISE_R_HAND
-			triggered(user, which_hand)
-			user.visible_message(span_warning("[user] accidentally sets off [src], breaking their fingers."), \
-				span_warning("You accidentally trigger [src]!"))
+		if(clumsy_check(user))
 			return
 		to_chat(user, span_notice("You disarm [src]."))
 	armed = !armed
@@ -164,17 +176,10 @@
 	playsound(src, 'sound/weapons/handcuffs.ogg', 30, TRUE, -3)
 
 
-//ATTACK HAND IGNORING PARENT RETURN VALUE
+// Clumsy check only
 /obj/item/assembly/mousetrap/attack_hand(mob/living/carbon/human/user, list/modifiers)
-	if(armed)
-		if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(50))
-			var/which_hand = BODY_ZONE_PRECISE_L_HAND
-			if(!(user.active_hand_index % 2))
-				which_hand = BODY_ZONE_PRECISE_R_HAND
-			triggered(user, which_hand)
-			user.visible_message(span_warning("[user] accidentally sets off [src], breaking their fingers."), \
-					span_warning("You accidentally trigger [src]!"))
-			return
+	if(clumsy_check(user))
+		return
 	return ..()
 
 

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -36,13 +36,28 @@
 		scanning = FALSE
 	update_appearance()
 	return TRUE
+/obj/item/assembly/prox_sensor/dropped()
+	. = ..()
+	if(connected)
+		proximity_monitor.set_host(connected.holder,src)
+	else
+		proximity_monitor.set_host(holder?.master || holder || src, src)
+/obj/item/assembly/prox_sensor/on_attach()
+	. = ..()
+	if(connected)
+		proximity_monitor.set_host(connected.holder,src)
+	else
+		proximity_monitor.set_host(holder?.master || holder || src, src)
 
 /obj/item/assembly/prox_sensor/on_detach()
 	. = ..()
 	if(!.)
 		return
 	else
-		proximity_monitor.set_host(src, src)
+		if(connected)
+			proximity_monitor.set_host(connected.holder,src)
+		else
+			proximity_monitor.set_host(holder?.master || holder || src, src)
 
 /obj/item/assembly/prox_sensor/toggle_secure()
 	secured = !secured

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -36,28 +36,36 @@
 		scanning = FALSE
 	update_appearance()
 	return TRUE
+
 /obj/item/assembly/prox_sensor/dropped()
 	. = ..()
-	if(connected)
-		proximity_monitor.set_host(connected.holder,src)
-	else
-		proximity_monitor.set_host(holder?.master || holder || src, src)
+	// Pick the first valid object in this list:
+	// Wiring datum's owner
+	// assembly holder's attached object
+	// assembly holder itself
+	// us
+	proximity_monitor.set_host(connected?.holder || holder?.master || holder || src, src)
+
 /obj/item/assembly/prox_sensor/on_attach()
 	. = ..()
-	if(connected)
-		proximity_monitor.set_host(connected.holder,src)
-	else
-		proximity_monitor.set_host(holder?.master || holder || src, src)
+	// Pick the first valid object in this list:
+	// Wiring datum's owner
+	// assembly holder's attached object
+	// assembly holder itself
+	// us
+	proximity_monitor.set_host(connected?.holder || holder?.master || holder || src, src)
 
 /obj/item/assembly/prox_sensor/on_detach()
 	. = ..()
 	if(!.)
 		return
 	else
-		if(connected)
-			proximity_monitor.set_host(connected.holder,src)
-		else
-			proximity_monitor.set_host(holder?.master || holder || src, src)
+		// Pick the first valid object in this list:
+		// Wiring datum's owner
+		// assembly holder's attached object
+		// assembly holder itself
+		// us
+		proximity_monitor.set_host(connected?.holder || holder?.master || holder || src, src)
 
 /obj/item/assembly/prox_sensor/toggle_secure()
 	secured = !secured

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -54,12 +54,11 @@
 	return secured
 
 /obj/item/assembly/timer/proc/timer_end()
-	if(!secured || next_activate > world.time)
-		return FALSE
-	pulse(FALSE)
-	audible_message("<span class='infoplain'>[icon2html(src, hearers(src))] *beep* *beep* *beep*</span>", null, hearing_range)
-	for(var/mob/hearing_mob in get_hearers_in_view(hearing_range, src))
-		hearing_mob.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
+	if(secured && next_activate <= world.time)
+		pulse(FALSE)
+		audible_message("<span class='infoplain'>[icon2html(src, hearers(src))] *beep* *beep* *beep*</span>", null, hearing_range)
+		for(var/mob/hearing_mob in get_hearers_in_view(hearing_range, src))
+			hearing_mob.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
 	if(loop)
 		timing = TRUE
 	update_appearance()

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -56,7 +56,7 @@
 /obj/item/assembly/timer/proc/timer_end()
 	if(secured && next_activate <= world.time)
 		pulse(FALSE)
-		audible_message("<span class='infoplain'>[icon2html(src, hearers(src))] *beep* *beep* *beep*</span>", null, hearing_range)
+		audible_message(span_infoplain("[icon2html(src, hearers(src))] *beep* *beep* *beep*"), null, hearing_range)
 		for(var/mob/hearing_mob in get_hearers_in_view(hearing_range, src))
 			hearing_mob.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
 	if(loop)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -7,29 +7,30 @@
 	anchored = FALSE
 	pressure_resistance = 2*ONE_ATMOSPHERE
 	max_integrity = 300
-	///In units, how much the dispenser can hold
+	/// In units, how much the dispenser can hold
 	var/tank_volume = 1000
-	///The ID of the reagent that the dispenser uses
+	/// The ID of the reagent that the dispenser uses
 	var/reagent_id = /datum/reagent/water
-	///Can you turn this into a plumbing tank?
+	/// Can you turn this into a plumbing tank?
 	var/can_be_tanked = TRUE
-	///Is this source self-replenishing?
+	/// Is this source self-replenishing?
 	var/refilling = FALSE
-	///Can this dispenser be opened using a wrench?
+	/// Can this dispenser be opened using a wrench?
 	var/openable = FALSE
-	///Is this dispenser slowly leaking its reagent?
+	/// Is this dispenser slowly leaking its reagent?
 	var/leaking = FALSE
-	///How much reagent to leak
+	/// How much reagent to leak
 	var/amount_to_leak = 10
-	//an assembly attached to the tank - for flammable tanks
+	/// An assembly attached to the tank - if this dispenser accepts_rig
 	var/obj/item/assembly_holder/rig = null
-	//whether it accepts assemblies or not
+	/// Whether this dispenser can be rigged with an assembly (and blown up with an igniter)
 	var/accepts_rig = FALSE
 	//overlay of attached assemblies
 	var/mutable_appearance/assembliesoverlay
-	/// The last person to rig this fuel tank - Stored with the object. Only the last person matters for investigation
+	/// The person who attached an assembly to this dispenser, for bomb logging purposes
 	var/last_rigger = ""
 
+// This check is necessary for assemblies to automatically detect that we are compatible
 /obj/structure/reagent_dispensers/IsSpecialAssembly()
 	return accepts_rig
 
@@ -38,7 +39,7 @@
 	return ..()
 
 /**
- * rig_boom: Wrapper to log a reagent_dispenser set off by an assembly
+ * rig_boom: Wrapper to log when a reagent_dispenser is set off by an assembly
  *
  */
 /obj/structure/reagent_dispensers/proc/rig_boom()
@@ -147,6 +148,12 @@
 		reagents.add_reagent(reagent_id, tank_volume)
 	. = ..()
 
+/**
+ * boom: Detonate a reagent dispenser.
+ *
+ * This is most dangerous for fuel tanks, which will explosion().
+ * Other dispensers will scatter their contents within range.
+ */
 /obj/structure/reagent_dispensers/proc/boom()
 	var/datum/reagent/fuel/volatiles = reagents.has_reagent(/datum/reagent/fuel)
 	var/fuel_amt = 0

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -36,6 +36,11 @@
 /obj/structure/reagent_dispensers/Destroy()
 	QDEL_NULL(rig)
 	return ..()
+
+/**
+ * rig_boom: Wrapper to log a reagent_dispenser set off by an assembly
+ *
+ */
 /obj/structure/reagent_dispensers/proc/rig_boom()
 	log_bomber(last_rigger, "rigged [src] exploded", src)
 	boom()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #69043 assemblies not providing a UI when part of a one-tank bomb.  (This doesn't count voice analyzers, which don't have UI)
Fixes #68139 assemblies triggering themselves (and often turning themselves off).
Fixes timers ceasing to loop if the timer is set to less than the 3-second anti-spam threshold.
<s>#69335, #68733 signalers occasionally runtiming due to qdel'd weak reference datums.</s> Already addressed by another PR
Proximity sensors and mousetraps work on more wire datums, but proximity sensors are still buggy.
Igniter-sensor pairs can detonate fuel tanks properly, including plumbed fuel tanks.  Fuel tank explosions scale with how much fuel is in them; this is slightly nerfed from existing values.

The fuel tank detonation code has been made generic, but other reagent dispensers have rigging turned off.  If turned on with a varedit, you can rig and detonate water and other reagent tanks.  Reagent tanks can theoretically both explode and spread reagents if it should happen to contain both welding fuel and other stuff.  I have not actually tested this part of it, but I have detonated both water tanks and fuel tanks and each works correctly.

In making mousetraps work on wire datums, I had the opportunity to make it so that you could place a mousetrap in a door's wire and it would activate when someone passed through the door (useful to bolt a door open when someone authorized goes through, for example).  This is a fun mechanic but does not make sense for a simple mousetrap to be so powerful, so it is disabled.  Ideally, you could put the laser tripwire in a door's wires to do the same thing, but that would be a massive rework.  Mousetraps still work in on-found mode for all wire datums, and will work on items with wiring datums (like C4 and chem bombs) when stepped on.

The signaler runtimes were a result of weak_ref datums being deleted, and the communications system not handling that.  It's probably not ideal to run null checks in the post_signal loop, but I am not going to worry about it.

Many of the assemblies were not properly registering when the assembly holder was attached to an item.  This was most important for proximity sensors, but that also has other problems that I haven't been able to track down.

The problem with UI not appearing was a result of the transition to TGUI however long ago that was; the proc that assures TGUI that you have the right item needed to be aware of one-tank bombs and similar, or else when you pass along an interact request it says "but you can't see it" and ignores you.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfixen.

The thing with the reagent dispensers only got this complicated when I realized that the plumbed fuel tank variant wasn't a subtype and therefore couldn't be rigged.  And then... I basically just scaled it because the flat scale no matter the contents of the tank offended me.  You could wrench open tanks, drain them entirely of fuel, rig them, and they would still go off like a pile of dynamite.

I used to have code in my branch that turned chem bombs into variants depending on the trigger, with mousetraps being mines for example.  That's honestly the main reason I went out of my way to make mousetraps work better as assemblies.  I could wish it were better supported, but mousetraps on grenade wiring will have to do for now.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Welding fuel tank explosions have been scaled slightly down and require the fuel tanks to actually be full of welding fuel
fix: You can detonate welding fuel tanks with an igniter-sensor assembly
fix: You can reach your one-tank bomb's assembly controls by activating the item in your hand.
fix: Certain assemblies should no longer turn themselves off.
fix: Clumsy fools handling a mousetrap-based multi-part assembly may set it off by accident
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
