### PR TITLE
Clean up subsystem Initialize(), require an explicit result returned, give a formal way to fail (for SSlua)

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -104,6 +104,25 @@
 	}\
 }
 
+//! ### SS initialization hints
+/**
+ * Negative values incidate a failure or warning of some kind, positive are good.
+ * 0 and 1 are unused so that TRUE and FALSE are guarenteed to be invalid values.
+ */
+
+/// Subsystem failed to initialize entirely. Print a warning, log, and disable firing.
+#define SS_INIT_FAILURE -2
+
+/// The default return value which must be overriden. Will succeed with a warning.
+#define SS_INIT_NONE -1
+
+/// Subsystem initialized sucessfully.
+#define SS_INIT_SUCCESS 2
+
+/// Successful, but don't print anything. Useful if subsystem was disabled.
+#define SS_INIT_NO_NEED 3
+
+//! ### SS initialization load orders
 // Subsystem init_order, from highest priority to lowest priority
 // Subsystems shutdown in the reverse of the order they initialize in
 // The numbers just define the ordering, they are meaningless otherwise.

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -288,7 +288,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		SS_INIT_NO_NEED,
 	)
 
-	if (subsystem.flags & SS_NO_INIT || subsystem.initialized) //Don't init SSs with the correspondig flag or if they already are initialzized
+	if (subsystem.flags & SS_NO_INIT || subsystem.initialized) //Don't init SSs with the corresponding flag or if they already are initialized
 		return
 
 	current_initializing_subsystem = subsystem

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -238,12 +238,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 		// Initialize subsystems.
 		for (var/datum/controller/subsystem/subsystem in stage_sorted_subsystems[current_init_stage])
-			if (subsystem.flags & SS_NO_INIT || subsystem.initialized) //Don't init SSs with the corresponding flag or if they already are initialized
-				continue
-			current_initializing_subsystem = subsystem
-
-			rustg_time_reset(SS_INIT_TIMER_KEY)
-			subsystem.Initialize()
+			init_subsystem(subsystem)
 
 			CHECK_TICK
 		current_initializing_subsystem = null
@@ -279,6 +274,78 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		world.sleep_offline = FALSE
 	initializations_finished_with_no_players_logged_in = initialized_tod < REALTIMEOFDAY - 10
 
+/**
+ * Initialize a given subsystem and handle the results.
+ *
+ * Arguments:
+ * * subsystem - the subsystem to initialize.
+ */
+/datum/controller/master/proc/init_subsystem(datum/controller/subsystem/subsystem)
+	var/static/list/valid_results = list(
+		SS_INIT_FAILURE,
+		SS_INIT_NONE,
+		SS_INIT_SUCCESS,
+		SS_INIT_NO_NEED,
+	)
+
+	if (subsystem.flags & SS_NO_INIT || subsystem.initialized) //Don't init SSs with the correspondig flag or if they already are initialzized
+		return
+
+	current_initializing_subsystem = subsystem
+	rustg_time_reset(SS_INIT_TIMER_KEY)
+
+	var/result = subsystem.Initialize()
+
+	// Capture end time
+	var/time = rustg_time_milliseconds(SS_INIT_TIMER_KEY)
+	var/seconds = round(time / 1000, 0.01)
+
+	// Always update the blackbox tally regardless.
+	SSblackbox.record_feedback("tally", "subsystem_initialize", time, subsystem.name)
+
+	// Gave invalid return value.
+	if(result && !(result in valid_results))
+		warning("[subsystem.name] subsystem initialized, returning invalid result [result]. This is a bug.")
+
+	// just returned ..() or didn't implement Initialize() at all
+	if(result == SS_INIT_NONE)
+		warning("[subsystem.name] subsystem does not implement Initialize() or it returns ..(). If the former is true, the SS_NO_INIT flag should be set for this subsystem.")
+
+	if(result != SS_INIT_FAILURE)
+		// Some form of success, implicit failure, or the SS in unused.
+		subsystem.initialized = TRUE
+
+		SEND_SIGNAL(subsystem, COMSIG_SUBSYSTEM_POST_INITIALIZE)
+	else
+		// The subsystem officially reports that it failed to init and wishes to be treated as such.
+		subsystem.initialized = FALSE
+		subsystem.can_fire = FALSE
+
+	// The rest of this proc is printing the world log and chat message.
+	var/message_prefix
+
+	// If true, print the chat message with boldwarning text.
+	var/chat_warning = FALSE
+
+	switch(result)
+		if(SS_INIT_FAILURE)
+			message_prefix = "Failed to initialize [subsystem.name] subsystem after"
+			chat_warning = TRUE
+		if(SS_INIT_SUCCESS)
+			message_prefix = "Initialized [subsystem.name] subsystem within"
+		if(SS_INIT_NO_NEED)
+			// This SS is disabled or is otherwise shy.
+			return
+		else
+			// SS_INIT_NONE or an invalid value.
+			message_prefix = "Initialized [subsystem.name] subsystem with errors within"
+			chat_warning = TRUE
+
+	var/message = "[message_prefix] [seconds] second[seconds == 1 ? "" : "s"]!"
+	var/chat_message = chat_warning ? span_boldwarning(message) : span_boldannounce(message)
+
+	to_chat(world, chat_message)
+	log_world(message)
 
 /datum/controller/master/proc/SetRunLevel(new_runlevel)
 	var/old_runlevel = current_runlevel

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -254,17 +254,28 @@
 /// Called after the config has been loaded or reloaded.
 /datum/controller/subsystem/proc/OnConfigLoad()
 
-//used to initialize the subsystem AFTER the map has loaded
-/datum/controller/subsystem/Initialize()
+/**
+ * Used to initialize the subsystem.
+ * failed - Optional: If true, tell everyone that the subsystem failed to init and cancel firing.
+ */
+/datum/controller/subsystem/Initialize(failed = FALSE)
 	initialized = TRUE
-	SEND_SIGNAL(src, COMSIG_SUBSYSTEM_POST_INITIALIZE)
+
+	if(!failed)
+		SEND_SIGNAL(src, COMSIG_SUBSYSTEM_POST_INITIALIZE)
+	else
+		can_fire = FALSE
 
 	var/time = rustg_time_milliseconds(SS_INIT_TIMER_KEY)
 	var/seconds = round(time / 1000, 0.01)
 
-	var/msg = "Initialized [name] subsystem within [seconds] second[seconds == 1 ? "" : "s"]!"
-	to_chat(world, span_boldannounce("[msg]"))
-	log_world(msg)
+	var/message_prefix = !failed ? "Initialized [name] subsystem within" : "Failed to initialize [name] subsystem after"
+	var/message = "[message_prefix] [seconds] second[seconds == 1 ? "" : "s"]!"
+	var/chat_message = !failed ? span_boldannounce(message) : span_boldwarning(message)
+
+	to_chat(world, chat_message)
+	log_world(message)
+
 	SSblackbox.record_feedback("tally", "subsystem_initialize", time, name)
 	return seconds
 

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -255,29 +255,10 @@
 /datum/controller/subsystem/proc/OnConfigLoad()
 
 /**
- * Used to initialize the subsystem.
- * failed - Optional: If true, tell everyone that the subsystem failed to init and cancel firing.
+ * Used to initialize the subsystem. This is expected to be overriden by subtypes.
  */
-/datum/controller/subsystem/Initialize(failed = FALSE)
-	initialized = TRUE
-
-	if(!failed)
-		SEND_SIGNAL(src, COMSIG_SUBSYSTEM_POST_INITIALIZE)
-	else
-		can_fire = FALSE
-
-	var/time = rustg_time_milliseconds(SS_INIT_TIMER_KEY)
-	var/seconds = round(time / 1000, 0.01)
-
-	var/message_prefix = !failed ? "Initialized [name] subsystem within" : "Failed to initialize [name] subsystem after"
-	var/message = "[message_prefix] [seconds] second[seconds == 1 ? "" : "s"]!"
-	var/chat_message = !failed ? span_boldannounce(message) : span_boldwarning(message)
-
-	to_chat(world, chat_message)
-	log_world(message)
-
-	SSblackbox.record_feedback("tally", "subsystem_initialize", time, name)
-	return seconds
+/datum/controller/subsystem/Initialize()
+	return SS_INIT_NONE
 
 /datum/controller/subsystem/stat_entry(msg)
 	if(can_fire && !(SS_NO_FIRE & flags) && init_stage <= Master.init_stage_completed)

--- a/code/controllers/subsystem/achievements.dm
+++ b/code/controllers/subsystem/achievements.dm
@@ -11,9 +11,9 @@ SUBSYSTEM_DEF(achievements)
 	///List of all awards
 	var/list/datum/award/awards = list()
 
-/datum/controller/subsystem/achievements/Initialize(timeofday)
+/datum/controller/subsystem/achievements/Initialize()
 	if(!SSdbcore.Connect())
-		return ..()
+		return SS_INIT_NO_NEED
 	achievements_enabled = TRUE
 
 	for(var/T in subtypesof(/datum/award/achievement))
@@ -33,7 +33,7 @@ SUBSYSTEM_DEF(achievements)
 		if(!C.player_details.achievements.initialized)
 			C.player_details.achievements.InitializeData()
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/achievements/Shutdown()
 	save_achievements_to_db()

--- a/code/controllers/subsystem/addiction.dm
+++ b/code/controllers/subsystem/addiction.dm
@@ -8,9 +8,9 @@ SUBSYSTEM_DEF(addiction)
 	///Dictionary of addiction.type || addiction ref
 	var/list/all_addictions = list()
 
-/datum/controller/subsystem/addiction/Initialize(timeofday)
+/datum/controller/subsystem/addiction/Initialize()
 	InitializeAddictions()
-	return ..()
+	return SS_INIT_SUCCESS
 
 ///Ran on initialize, populates the addiction dictionary
 /datum/controller/subsystem/addiction/proc/InitializeAddictions()

--- a/code/controllers/subsystem/ai_controllers.dm
+++ b/code/controllers/subsystem/ai_controllers.dm
@@ -12,9 +12,9 @@ SUBSYSTEM_DEF(ai_controllers)
 	///List of all ai controllers currently running
 	var/list/active_ai_controllers = list()
 
-/datum/controller/subsystem/ai_controllers/Initialize(timeofday)
+/datum/controller/subsystem/ai_controllers/Initialize()
 	setup_subtrees()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/ai_controllers/proc/setup_subtrees()
 	ai_subtrees = list()

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -87,7 +87,7 @@ SUBSYSTEM_DEF(air)
 	return ..()
 
 
-/datum/controller/subsystem/air/Initialize(timeofday)
+/datum/controller/subsystem/air/Initialize()
 	map_loading = FALSE
 	gas_reactions = init_gas_reactions()
 	hotspot_reactions = init_hotspot_reactions()
@@ -98,7 +98,7 @@ SUBSYSTEM_DEF(air)
 	setup_turf_visuals()
 	process_adjacent_rebuild()
 	atmos_handbooks_init()
-	return ..()
+	return SS_INIT_SUCCESS
 
 
 /datum/controller/subsystem/air/fire(resumed = FALSE)

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(assets)
 
 
 
-/datum/controller/subsystem/assets/Initialize(timeofday)
+/datum/controller/subsystem/assets/Initialize()
 	for(var/type in typesof(/datum/asset))
 		var/datum/asset/A = type
 		if (type != initial(A._abstract))
@@ -30,7 +30,7 @@ SUBSYSTEM_DEF(assets)
 
 	transport.Initialize(cache)
 
-	..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/assets/Recover()
 	cache = SSassets.cache

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -28,7 +28,7 @@ SUBSYSTEM_DEF(atoms)
 
 	initialized = INITIALIZATION_INSSATOMS
 
-/datum/controller/subsystem/atoms/Initialize(timeofday)
+/datum/controller/subsystem/atoms/Initialize()
 	GLOB.fire_overlay.appearance_flags = RESET_COLOR
 	setupGenetics() //to set the mutations' sequence
 
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(atoms)
 	InitializeAtoms()
 	initialized = INITIALIZATION_INNEW_REGULAR
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 #ifdef PROFILE_MAPLOAD_INIT_ATOM
 #define PROFILE_INIT_ATOM_BEGIN(...) var/__profile_stat_time = TICK_USAGE

--- a/code/controllers/subsystem/ban_cache.dm
+++ b/code/controllers/subsystem/ban_cache.dm
@@ -8,7 +8,7 @@ SUBSYSTEM_DEF(ban_cache)
 	flags = SS_NO_FIRE
 	var/query_started = FALSE
 
-/datum/controller/subsystem/ban_cache/Initialize(start_timeofday)
+/datum/controller/subsystem/ban_cache/Initialize()
 	generate_queries()
 	return ..()
 

--- a/code/controllers/subsystem/ban_cache.dm
+++ b/code/controllers/subsystem/ban_cache.dm
@@ -10,7 +10,7 @@ SUBSYSTEM_DEF(ban_cache)
 
 /datum/controller/subsystem/ban_cache/Initialize()
 	generate_queries()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /// Generates ban caches for any logged in clients. This ensures the amount of in-series ban checking we have to do that actually involves sleeps is VERY low
 /datum/controller/subsystem/ban_cache/proc/generate_queries()

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(blackbox)
 	record_feedback("amount", "dm_build", DM_BUILD)
 	record_feedback("amount", "byond_version", world.byond_version)
 	record_feedback("amount", "byond_build", world.byond_build)
-	. = ..()
+	return SS_INIT_SUCCESS
 
 //poll population
 /datum/controller/subsystem/blackbox/fire()

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(blackmarket)
 	/// Currently queued purchases.
 	var/list/queued_purchases = list()
 
-/datum/controller/subsystem/blackmarket/Initialize(timeofday)
+/datum/controller/subsystem/blackmarket/Initialize()
 	for(var/market in subtypesof(/datum/market))
 		markets[market] += new market
 
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(blackmarket)
 				continue
 			markets[M].add_item(item)
 		qdel(I)
-	. = ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/blackmarket/fire(resumed)
 	while(length(queued_purchases))

--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -12,6 +12,11 @@ SUBSYSTEM_DEF(chat)
 
 	var/list/payload_by_client = list()
 
+/datum/controller/subsystem/chat/Initialize()
+	// Just used by chat system to know that initialization is nearly finished.
+	// The to_chat checks could probably check the runlevel instead, but would require testing.
+	return SS_INIT_SUCCESS
+
 /datum/controller/subsystem/chat/fire()
 	for(var/key in payload_by_client)
 		var/client/client = key

--- a/code/controllers/subsystem/circuit_component.dm
+++ b/code/controllers/subsystem/circuit_component.dm
@@ -2,6 +2,7 @@ SUBSYSTEM_DEF(circuit_component)
 	name = "Circuit Components"
 	wait = 0.1 SECONDS
 	priority = FIRE_PRIORITY_DEFAULT
+	flags = SS_NO_INIT
 
 	var/list/callbacks_to_invoke = list()
 	var/list/currentrun = list()

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -49,7 +49,7 @@ SUBSYSTEM_DEF(dbcore)
 		if(2)
 			message_admins("Could not get schema version from database")
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/dbcore/stat_entry(msg)
 	msg = "P:[length(all_queries)]|Active:[length(queries_active)]|Standby:[length(queries_standby)]"
@@ -338,7 +338,7 @@ SUBSYSTEM_DEF(dbcore)
 			queries -= query
 			stack_trace("Invalid query passed to QuerySelect: `[query]` [REF(query)]")
 			continue
-		
+
 		if (warn)
 			INVOKE_ASYNC(query, /datum/db_query.proc/warn_execute)
 		else

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -60,7 +60,7 @@ SUBSYSTEM_DEF(discord)
 		enabled = TRUE // Allows other procs to use this (Account linking, etc)
 	else
 		can_fire = FALSE // We dont want excess firing
-		return ..() // Cancel
+		return SS_INIT_NO_NEED
 
 	try
 		people_to_notify = json_decode(file2text(notify_file))
@@ -71,7 +71,7 @@ SUBSYSTEM_DEF(discord)
 		notifymsg += ", a new round is starting!"
 		send2chat(trim(notifymsg), CONFIG_GET(string/chat_new_game_notifications)) // Sends the message to the discord, using same config option as the roundstart notification
 	fdel(notify_file) // Deletes the file
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/discord/fire()
 	if(!enabled)

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -52,7 +52,7 @@ SUBSYSTEM_DEF(discord)
 	/// Is TGS enabled (If not we won't fire because otherwise this is useless)
 	var/enabled = FALSE
 
-/datum/controller/subsystem/discord/Initialize(start_timeofday)
+/datum/controller/subsystem/discord/Initialize()
 	common_words = world.file2list("strings/1000_most_common.txt")
 	reverify_cache = list()
 	// Check for if we are using TGS, otherwise return and disables firing

--- a/code/controllers/subsystem/disease.dm
+++ b/code/controllers/subsystem/disease.dm
@@ -12,12 +12,12 @@ SUBSYSTEM_DEF(disease)
 	if(!diseases)
 		diseases = subtypesof(/datum/disease)
 
-/datum/controller/subsystem/disease/Initialize(timeofday)
+/datum/controller/subsystem/disease/Initialize()
 	var/list/all_common_diseases = diseases - typesof(/datum/disease/advance)
 	for(var/common_disease_type in all_common_diseases)
 		var/datum/disease/prototype = new common_disease_type()
 		archive_diseases[prototype.GetDiseaseID()] = prototype
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/disease/stat_entry(msg)
 	msg = "P:[length(active_diseases)]"

--- a/code/controllers/subsystem/early_assets.dm
+++ b/code/controllers/subsystem/early_assets.dm
@@ -21,4 +21,4 @@ SUBSYSTEM_DEF(early_assets)
 
 		CHECK_TICK
 
-	return ..()
+	return SS_INIT_SUCCESS

--- a/code/controllers/subsystem/early_assets.dm
+++ b/code/controllers/subsystem/early_assets.dm
@@ -8,7 +8,7 @@ SUBSYSTEM_DEF(early_assets)
 	init_order = INIT_ORDER_EARLY_ASSETS
 	flags = SS_NO_FIRE
 
-/datum/controller/subsystem/early_assets/Initialize(start_timeofday)
+/datum/controller/subsystem/early_assets/Initialize()
 	for (var/datum/asset/asset_type as anything in subtypesof(/datum/asset))
 		if (initial(asset_type._abstract) == asset_type)
 			continue

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -69,7 +69,7 @@ SUBSYSTEM_DEF(economy)
 	/// We need this on the subsystem because of yielding and such
 	var/temporary_total = 0
 
-/datum/controller/subsystem/economy/Initialize(timeofday)
+/datum/controller/subsystem/economy/Initialize()
 	//removes cargo from the split
 	var/budget_to_hand_out = round(budget_pool / department_accounts.len -1)
 	if(time2text(world.timeofday, "DDD") == SUNDAY)
@@ -79,7 +79,7 @@ SUBSYSTEM_DEF(economy)
 			new /datum/bank_account/department(dep_id, 0, player_account = FALSE)
 			continue
 		new /datum/bank_account/department(dep_id, budget_to_hand_out, player_account = FALSE)
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/economy/Recover()
 	generated_accounts = SSeconomy.generated_accounts

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -14,7 +14,7 @@ SUBSYSTEM_DEF(events)
 	var/list/holidays //List of all holidays occuring today or null if no holidays
 	var/wizardmode = FALSE
 
-/datum/controller/subsystem/events/Initialize(time, zlevel)
+/datum/controller/subsystem/events/Initialize()
 	for(var/type in typesof(/datum/round_event_control))
 		var/datum/round_event_control/E = new type()
 		if(!E.typepath)
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(events)
 		control += E //add it to the list of all events (controls)
 	reschedule()
 	getHoliday()
-	return ..()
+	return SS_INIT_SUCCESS
 
 
 /datum/controller/subsystem/events/fire(resumed = FALSE)

--- a/code/controllers/subsystem/fluids.dm
+++ b/code/controllers/subsystem/fluids.dm
@@ -51,7 +51,7 @@ SUBSYSTEM_DEF(fluids)
 	/// Whether the subsystem has resumed processing fluid effects.
 	var/resumed_effect_processing
 
-/datum/controller/subsystem/fluids/Initialize(start_timeofday)
+/datum/controller/subsystem/fluids/Initialize()
 	initialize_waits()
 	initialize_spread_carousel()
 	initialize_effect_carousel()

--- a/code/controllers/subsystem/fluids.dm
+++ b/code/controllers/subsystem/fluids.dm
@@ -55,7 +55,7 @@ SUBSYSTEM_DEF(fluids)
 	initialize_waits()
 	initialize_spread_carousel()
 	initialize_effect_carousel()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /**
  * Initializes the subsystem waits.

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -55,7 +55,7 @@ SUBSYSTEM_DEF(icon_smooth)
 		var/turf/item_loc = movable_item.loc
 		item_loc.add_blueprints(movable_item)
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 
 /datum/controller/subsystem/icon_smooth/proc/add_to_queue(atom/thing)

--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(id_access)
 	/// The roundstart generated code for the spare ID safe. This is given to the Captain on shift start. If there's no Captain, it's given to the HoP. If there's no HoP
 	var/spare_id_safe_code = ""
 
-/datum/controller/subsystem/id_access/Initialize(timeofday)
+/datum/controller/subsystem/id_access/Initialize()
 	// We use this because creating the trim singletons requires the config to be loaded.
 	setup_access_flags()
 	setup_region_lists()
@@ -47,7 +47,7 @@ SUBSYSTEM_DEF(id_access)
 
 	spare_id_safe_code = "[rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)]"
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /**
  * Called by [/datum/controller/subsystem/ticker/proc/setup]

--- a/code/controllers/subsystem/init_profiler.dm
+++ b/code/controllers/subsystem/init_profiler.dm
@@ -11,7 +11,7 @@ SUBSYSTEM_DEF(init_profiler)
 /datum/controller/subsystem/init_profiler/Initialize()
 	if(CONFIG_GET(flag/auto_profile))
 		write_init_profile()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/init_profiler/proc/write_init_profile()
 	var/current_profile_data = world.Profile(PROFILE_REFRESH, format = "json")

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -29,7 +29,7 @@ VERB_MANAGER_SUBSYSTEM_DEF(input)
 
 	refresh_client_macro_sets()
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 // This is for when macro sets are eventualy datumized
 /datum/controller/subsystem/verb_manager/input/proc/setup_default_macro_sets()

--- a/code/controllers/subsystem/ipintel.dm
+++ b/code/controllers/subsystem/ipintel.dm
@@ -8,7 +8,6 @@ SUBSYSTEM_DEF(ipintel)
 
 	var/list/cache = list()
 
-/datum/controller/subsystem/ipintel/Initialize(timeofday, zlevel)
+/datum/controller/subsystem/ipintel/Initialize()
 	enabled = TRUE
-	. = ..()
-
+	return SS_INIT_SUCCESS

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -62,14 +62,14 @@ SUBSYSTEM_DEF(job)
 	/// Dictionary that maps job priorities to low/medium/high. Keys have to be number-strings as assoc lists cannot be indexed by integers. Set in setup_job_lists.
 	var/list/job_priorities_to_strings
 
-/datum/controller/subsystem/job/Initialize(timeofday)
+/datum/controller/subsystem/job/Initialize()
 	setup_job_lists()
 	if(!length(all_occupations))
 		SetupOccupations()
 	if(CONFIG_GET(flag/load_jobs_from_txt))
 		LoadJobs()
 	set_overflow_role(CONFIG_GET(string/overflow_job))
-	return ..()
+	return SS_INIT_SUCCESS
 
 
 /datum/controller/subsystem/job/proc/set_overflow_role(new_overflow_role)

--- a/code/controllers/subsystem/lag_switch.dm
+++ b/code/controllers/subsystem/lag_switch.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(lag_switch)
 	/// Cooldown between say verb uses when slowmode is enabled
 	var/slowmode_cooldown = 3 SECONDS
 
-/datum/controller/subsystem/lag_switch/Initialize(start_timeofday)
+/datum/controller/subsystem/lag_switch/Initialize()
 	for(var/i in 1 to measures.len)
 		measures[i] = FALSE
 	var/auto_switch_pop = CONFIG_GET(number/auto_lag_switch_pop)

--- a/code/controllers/subsystem/lag_switch.dm
+++ b/code/controllers/subsystem/lag_switch.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(lag_switch)
 		auto_switch = TRUE
 		trigger_pop = auto_switch_pop
 		RegisterSignal(SSdcs, COMSIG_GLOB_CLIENT_CONNECT, .proc/client_connected)
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/lag_switch/proc/client_connected(datum/source, client/connected)
 	SIGNAL_HANDLER

--- a/code/controllers/subsystem/language.dm
+++ b/code/controllers/subsystem/language.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(language)
 	init_order = INIT_ORDER_LANGUAGE
 	flags = SS_NO_FIRE
 
-/datum/controller/subsystem/language/Initialize(timeofday)
+/datum/controller/subsystem/language/Initialize()
 	for(var/L in subtypesof(/datum/language))
 		var/datum/language/language = L
 		if(!initial(language.key))
@@ -15,4 +15,4 @@ SUBSYSTEM_DEF(language)
 
 		GLOB.language_datum_instances[language] = instance
 
-	return ..()
+	return SS_INIT_SUCCESS

--- a/code/controllers/subsystem/library.dm
+++ b/code/controllers/subsystem/library.dm
@@ -19,10 +19,10 @@ SUBSYSTEM_DEF(library)
 	var/list/library_areas = list()
 
 /datum/controller/subsystem/library/Initialize()
-	. = ..()
 	prepare_official_posters()
 	prepare_library_areas()
 	load_shelves()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/library/proc/load_shelves()
 	for(var/obj/structure/bookcase/case_to_load as anything in shelves_to_load)

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -16,14 +16,14 @@ SUBSYSTEM_DEF(lighting)
 	return ..()
 
 
-/datum/controller/subsystem/lighting/Initialize(timeofday)
+/datum/controller/subsystem/lighting/Initialize()
 	if(!initialized)
 		create_all_lighting_objects()
 		initialized = TRUE
 
 	fire(FALSE, TRUE)
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/lighting/fire(resumed, init_tick_checks)
 	MC_SPLIT_TICK_INIT(3)

--- a/code/controllers/subsystem/lua.dm
+++ b/code/controllers/subsystem/lua.dm
@@ -23,7 +23,6 @@ SUBSYSTEM_DEF(lua)
 
 /datum/controller/subsystem/lua/Initialize(start_timeofday)
 	try
-
 		// Initialize the auxtools library
 		AUXTOOLS_CHECK(AUXLUA)
 
@@ -35,13 +34,10 @@ SUBSYSTEM_DEF(lua)
 		return ..()
 	catch(var/exception/e)
 		// Something went wrong, best not allow the subsystem to run
-		initialized = SSLUA_INIT_FAILED
-		can_fire = FALSE
-		var/time = (REALTIMEOFDAY - start_timeofday) / 10
-		var/msg = "Failed to initialize [name] subsystem after [time] seconds!"
-		to_chat(world, span_boldwarning("[msg]"))
+		. = ..(failed = TRUE)
+
 		warning(e.name)
-		return time
+		initialized = SSLUA_INIT_FAILED
 
 /datum/controller/subsystem/lua/OnConfigLoad()
 	// Read the paths from the config file

--- a/code/controllers/subsystem/lua.dm
+++ b/code/controllers/subsystem/lua.dm
@@ -1,5 +1,3 @@
-#define SSLUA_INIT_FAILED 2
-
 SUBSYSTEM_DEF(lua)
 	name = "Lua Scripting"
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
@@ -21,7 +19,7 @@ SUBSYSTEM_DEF(lua)
 	/// Protects return values from getting GCed before getting converted to lua values
 	var/gc_guard
 
-/datum/controller/subsystem/lua/Initialize(start_timeofday)
+/datum/controller/subsystem/lua/Initialize()
 	try
 		// Initialize the auxtools library
 		AUXTOOLS_CHECK(AUXLUA)
@@ -31,13 +29,11 @@ SUBSYSTEM_DEF(lua)
 		__lua_set_datum_proc_call_wrapper("/proc/wrap_lua_datum_proc_call")
 		__lua_set_global_proc_call_wrapper("/proc/wrap_lua_global_proc_call")
 		__lua_set_print_wrapper("/proc/wrap_lua_print")
-		return ..()
+		return SS_INIT_SUCCESS
 	catch(var/exception/e)
 		// Something went wrong, best not allow the subsystem to run
-		. = ..(failed = TRUE)
-
-		warning(e.name)
-		initialized = SSLUA_INIT_FAILED
+		warning("Error initializing SSlua: [e.name]")
+		return SS_INIT_FAILURE
 
 /datum/controller/subsystem/lua/OnConfigLoad()
 	// Read the paths from the config file
@@ -51,7 +47,7 @@ SUBSYSTEM_DEF(lua)
 	AUXTOOLS_SHUTDOWN(AUXLUA)
 
 /datum/controller/subsystem/lua/proc/queue_resume(datum/lua_state/state, index, arguments)
-	if(initialized != TRUE)
+	if(!initialized)
 		return
 	if(!istype(state))
 		return
@@ -136,5 +132,3 @@ SUBSYSTEM_DEF(lua)
 	// Update every lua editor TGUI open for each state that had a task awakened or resumed
 	for(var/datum/lua_state/state in affected_states)
 		INVOKE_ASYNC(state, /datum/lua_state.proc/update_editors)
-
-#undef SSLUA_INIT_FAILED

--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -10,7 +10,7 @@ SUBSYSTEM_DEF(machines)
 /datum/controller/subsystem/machines/Initialize()
 	makepowernets()
 	fire()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/machines/proc/makepowernets()
 	for(var/datum/powernet/power_network as anything in powernets)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -63,7 +63,7 @@ SUBSYSTEM_DEF(mapping)
 	/// list of traits and their associated z leves
 	var/list/z_trait_levels = list()
 
-/datum/controller/subsystem/mapping/New()
+/datum/controller/subsystem/mapping/PreInit()
 	..()
 #ifdef FORCE_MAP
 	config = load_map_config(FORCE_MAP, FORCE_MAP_DIRECTORY)
@@ -71,9 +71,9 @@ SUBSYSTEM_DEF(mapping)
 	config = load_map_config(error_if_missing = FALSE)
 #endif
 
-/datum/controller/subsystem/mapping/Initialize(timeofday)
+/datum/controller/subsystem/mapping/Initialize()
 	if(initialized)
-		return
+		return SS_INIT_SUCCESS
 	if(config.defaulted)
 		var/old_config = config
 		config = global.config.defaultmap
@@ -118,7 +118,7 @@ SUBSYSTEM_DEF(mapping)
 	generate_z_level_linkages()
 	calculate_default_z_level_gravities()
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/mapping/proc/calculate_default_z_level_gravities()
 	for(var/z_level in 1 to length(z_list))

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -5,10 +5,10 @@ SUBSYSTEM_DEF(minor_mapping)
 	init_order = INIT_ORDER_MINOR_MAPPING
 	flags = SS_NO_FIRE
 
-/datum/controller/subsystem/minor_mapping/Initialize(timeofday)
+/datum/controller/subsystem/minor_mapping/Initialize()
 	trigger_migration(CONFIG_GET(number/mice_roundstart))
 	place_satchels()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10)
 	var/list/exposed_wires = find_exposed_wires()

--- a/code/controllers/subsystem/movement/ai_movement.dm
+++ b/code/controllers/subsystem/movement/ai_movement.dm
@@ -9,9 +9,9 @@ MOVEMENT_SUBSYSTEM_DEF(ai_movement)
 	///an assoc list of all ai_movement types. Assoc type to instance
 	var/list/movement_types
 
-/datum/controller/subsystem/movement/ai_movement/Initialize(timeofday)
+/datum/controller/subsystem/movement/ai_movement/Initialize()
 	SetupAIMovementInstances()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/movement/ai_movement/proc/SetupAIMovementInstances()
 	movement_types = list()

--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -13,7 +13,7 @@ SUBSYSTEM_DEF(nightshift)
 /datum/controller/subsystem/nightshift/Initialize()
 	if(!CONFIG_GET(flag/enable_night_shifts))
 		can_fire = FALSE
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/nightshift/fire(resumed = FALSE)
 	if(resumed)

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -15,7 +15,7 @@ SUBSYSTEM_DEF(overlays)
 /datum/controller/subsystem/overlays/Initialize()
 	initialized = TRUE
 	fire(mc_check = FALSE)
-	return ..()
+	return SS_INIT_SUCCESS
 
 
 /datum/controller/subsystem/overlays/stat_entry(msg)

--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(parallax)
 	name = "Parallax"
 	wait = 2
-	flags = SS_POST_FIRE_TIMING | SS_BACKGROUND
+	flags = SS_POST_FIRE_TIMING | SS_BACKGROUND | SS_NO_INIT
 	priority = FIRE_PRIORITY_PARALLAX
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	var/list/currentrun

--- a/code/controllers/subsystem/pathfinder.dm
+++ b/code/controllers/subsystem/pathfinder.dm
@@ -8,7 +8,7 @@ SUBSYSTEM_DEF(pathfinder)
 /datum/controller/subsystem/pathfinder/Initialize()
 	space_type_cache = typecacheof(/turf/open/space)
 	mobs = new(10)
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/flowcache
 	var/lcount

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -34,7 +34,7 @@ SUBSYSTEM_DEF(persistence)
 	load_custom_outfits()
 
 	load_adventures()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/persistence/proc/collect_data()
 	save_wall_engravings()

--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -130,7 +130,7 @@ SUBSYSTEM_DEF(persistent_paintings)
 		"supermatter" = PATRONAGE_LEGENDARY_FRAME
 			)
 
-/datum/controller/subsystem/persistent_paintings/Initialize(start_timeofday)
+/datum/controller/subsystem/persistent_paintings/Initialize()
 	var/json_file = file("data/paintings.json")
 	if(fexists(json_file))
 		var/list/raw_data = update_format(json_decode(file2text(json_file)))

--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -142,7 +142,7 @@ SUBSYSTEM_DEF(persistent_paintings)
 	for(var/obj/structure/sign/painting/painting_frame as anything in painting_frames)
 		painting_frame.load_persistent()
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /**
  * Generates painting data ready to be consumed by ui.

--- a/code/controllers/subsystem/processing/ai_behaviors.dm
+++ b/code/controllers/subsystem/processing/ai_behaviors.dm
@@ -9,9 +9,9 @@ PROCESSING_SUBSYSTEM_DEF(ai_behaviors)
 	///List of all ai_behavior singletons, key is the typepath while assigned value is a newly created instance of the typepath. See SetupAIBehaviors()
 	var/list/ai_behaviors
 
-/datum/controller/subsystem/processing/ai_behaviors/Initialize(timeofday)
+/datum/controller/subsystem/processing/ai_behaviors/Initialize()
 	SetupAIBehaviors()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/processing/ai_behaviors/proc/SetupAIBehaviors()
 	ai_behaviors = list()

--- a/code/controllers/subsystem/processing/greyscale.dm
+++ b/code/controllers/subsystem/processing/greyscale.dm
@@ -7,7 +7,7 @@ PROCESSING_SUBSYSTEM_DEF(greyscale)
 	var/list/datum/greyscale_config/configurations = list()
 	var/list/datum/greyscale_layer/layer_types = list()
 
-/datum/controller/subsystem/processing/greyscale/Initialize(start_timeofday)
+/datum/controller/subsystem/processing/greyscale/Initialize()
 	for(var/datum/greyscale_layer/fake_type as anything in subtypesof(/datum/greyscale_layer))
 		layer_types[initial(fake_type.layer_type)] = fake_type
 

--- a/code/controllers/subsystem/processing/greyscale.dm
+++ b/code/controllers/subsystem/processing/greyscale.dm
@@ -27,7 +27,7 @@ PROCESSING_SUBSYSTEM_DEF(greyscale)
 		var/datum/greyscale_config/config = configurations[greyscale_type]
 		config.CrossVerify()
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/processing/greyscale/proc/RefreshConfigsFromFile()
 	for(var/i in configurations)

--- a/code/controllers/subsystem/processing/instruments.dm
+++ b/code/controllers/subsystem/processing/instruments.dm
@@ -25,7 +25,7 @@ PROCESSING_SUBSYSTEM_DEF(instruments)
 /datum/controller/subsystem/processing/instruments/Initialize()
 	initialize_instrument_data()
 	synthesizer_instrument_ids = get_allowed_instrument_ids()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/processing/instruments/proc/on_song_new(datum/song/S)
 	songs += S

--- a/code/controllers/subsystem/processing/networks.dm
+++ b/code/controllers/subsystem/processing/networks.dm
@@ -72,7 +72,7 @@ SUBSYSTEM_DEF(networks)
 	// At round start, fix the network_id's so the station root is on them
 	initialized = TRUE
 	// Now when the objects Initialize they will join the right network
-	return ..()
+	return SS_INIT_SUCCESS
 
 /*
  * Process incoming queued packet and return NAK/ACK signals

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -28,9 +28,9 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Extrovert", "Introvert"),
 	)
 
-/datum/controller/subsystem/processing/quirks/Initialize(timeofday)
+/datum/controller/subsystem/processing/quirks/Initialize()
 	get_quirks()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /// Returns the list of possible quirks
 /datum/controller/subsystem/processing/quirks/proc/get_quirks()

--- a/code/controllers/subsystem/processing/reagents.dm
+++ b/code/controllers/subsystem/processing/reagents.dm
@@ -11,14 +11,13 @@ PROCESSING_SUBSYSTEM_DEF(reagents)
 	var/previous_world_time = 0
 
 /datum/controller/subsystem/processing/reagents/Initialize()
-	. = ..()
 	//So our first step isn't insane
 	previous_world_time = world.time
 	///Blacklists these reagents from being added to the master list. the exact type only. Children are not blacklisted.
 	GLOB.fake_reagent_blacklist = list(/datum/reagent/medicine/c2, /datum/reagent/medicine, /datum/reagent/reaction_agent)
 	//Build GLOB lists - see holder.dm
 	build_chemical_reactions_lists()
-	return
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/processing/reagents/fire(resumed = FALSE)
 	if (!resumed)

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -12,7 +12,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	///Currently active announcer. Starts as a type but gets initialized after traits are selected
 	var/datum/centcom_announcer/announcer = /datum/centcom_announcer/default
 
-/datum/controller/subsystem/processing/station/Initialize(timeofday)
+/datum/controller/subsystem/processing/station/Initialize()
 
 	//If doing unit tests we don't do none of that trait shit ya know?
 	// Autowiki also wants consistent outputs, for example making sure the vending machine page always reports the normal products
@@ -22,7 +22,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 	announcer = new announcer() //Initialize the station's announcer datum
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 ///Rolls for the amount of traits and adds them to the traits list
 /datum/controller/subsystem/processing/station/proc/SetupTraits()

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -21,7 +21,7 @@ SUBSYSTEM_DEF(profiler)
 		StartProfiling()
 	else
 		StopProfiling() //Stop the early start profiler
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/profiler/fire()
 	if(CONFIG_GET(flag/auto_profile))

--- a/code/controllers/subsystem/radio.dm
+++ b/code/controllers/subsystem/radio.dm
@@ -5,7 +5,7 @@ SUBSYSTEM_DEF(radio)
 	var/list/datum/radio_frequency/frequencies = list()
 	var/list/saymodes = list()
 
-/datum/controller/subsystem/radio/PreInit(timeofday)
+/datum/controller/subsystem/radio/PreInit()
 	for(var/_SM in subtypesof(/datum/saymode))
 		var/datum/saymode/SM = new _SM()
 		saymodes[SM.key] = SM

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -81,7 +81,7 @@ SUBSYSTEM_DEF(research)
 	autosort_categories()
 	error_design = new
 	error_node = new
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/research/fire()
 	var/list/bitcoins = list()

--- a/code/controllers/subsystem/restaurant.dm
+++ b/code/controllers/subsystem/restaurant.dm
@@ -14,9 +14,9 @@ SUBSYSTEM_DEF(restaurant)
 	///Caches appearances of food, assoc list where key is the type of food, and value is the appearance. Used so we don't have to keep creating new food. Gets filled whenever a new food that hasn't been ordered gets ordered for the first time.
 	var/list/food_appearance_cache = list()
 
-/datum/controller/subsystem/restaurant/Initialize(timeofday)
-	. = ..()
+/datum/controller/subsystem/restaurant/Initialize()
 	for(var/key in subtypesof(/datum/venue))
 		all_venues[key] = new key()
 	for(var/key in subtypesof(/datum/customer_data))
 		all_customers[key] = new key()
+	return SS_INIT_SUCCESS

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -8,11 +8,11 @@ SUBSYSTEM_DEF(security_level)
 	var/list/available_levels = list()
 
 /datum/controller/subsystem/security_level/Initialize()
-	. = ..()
 	for(var/iterating_security_level_type in subtypesof(/datum/security_level))
 		var/datum/security_level/new_security_level = new iterating_security_level_type
 		available_levels[new_security_level.name] = new_security_level
 	current_security_level = available_levels[number_level_to_text(SEC_LEVEL_GREEN)]
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/security_level/fire(resumed)
 	if(!current_security_level.looping_sound) // No sound? No play.

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(security_level)
 	/// A list of initialised security level datums.
 	var/list/available_levels = list()
 
-/datum/controller/subsystem/security_level/Initialize(start_timeofday)
+/datum/controller/subsystem/security_level/Initialize()
 	. = ..()
 	for(var/iterating_security_level_type in subtypesof(/datum/security_level))
 		var/datum/security_level/new_security_level = new iterating_security_level_type

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -18,7 +18,7 @@ SUBSYSTEM_DEF(server_maint)
 /datum/controller/subsystem/server_maint/PreInit()
 	world.hub_password = "" //quickly! before the hubbies see us.
 
-/datum/controller/subsystem/server_maint/Initialize(timeofday)
+/datum/controller/subsystem/server_maint/Initialize()
 	if (CONFIG_GET(flag/hub))
 		world.update_hub_visibility(TRUE)
 	//Keep in mind, because of how delay works adding a list here makes each list take wait * delay more time to clear
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(server_maint)
 		"dead_mob_list" = GLOB.dead_mob_list,
 		"keyloop_list" = GLOB.keyloop_list, //A null here will cause new clients to be unable to move. totally unacceptable
 	)
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/server_maint/fire(resumed = FALSE)
 	if(!resumed)

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -135,7 +135,7 @@ SUBSYSTEM_DEF(shuttle)
 	/// Did the supermatter start a cascade event?
 	var/supermatter_cascade = FALSE
 
-/datum/controller/subsystem/shuttle/Initialize(timeofday)
+/datum/controller/subsystem/shuttle/Initialize()
 	order_number = rand(1, 9000)
 
 	var/list/pack_processing = subtypesof(/datum/supply_pack)
@@ -166,7 +166,7 @@ SUBSYSTEM_DEF(shuttle)
 		log_mapping("No /obj/docking_port/mobile/emergency/backup placed on the map!")
 	if(!supply)
 		log_mapping("No /obj/docking_port/mobile/supply placed on the map!")
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/shuttle/proc/setup_shuttles(list/stationary)
 	for(var/obj/docking_port/stationary/port as anything in stationary)

--- a/code/controllers/subsystem/skills.dm
+++ b/code/controllers/subsystem/skills.dm
@@ -1,4 +1,4 @@
-/*! 
+/*!
 This subsystem mostly exists to populate and manage the skill singletons.
 */
 
@@ -7,16 +7,16 @@ SUBSYSTEM_DEF(skills)
 	flags = SS_NO_FIRE
 	init_order = INIT_ORDER_SKILLS
 	///Dictionary of skill.type || skill ref
-	var/list/all_skills = list() 
+	var/list/all_skills = list()
 	///List of level names with index corresponding to skill level
 	var/list/level_names = list("None", "Novice", "Apprentice", "Journeyman", "Expert", "Master", "Legendary") //List of skill level names. Note that indexes can be accessed like so: level_names[SKILL_LEVEL_NOVICE]
 
-/datum/controller/subsystem/skills/Initialize(timeofday)
+/datum/controller/subsystem/skills/Initialize()
 	InitializeSkills()
-	return ..()
+	return SS_INIT_SUCCESS
 
 ///Ran on initialize, populates the skills dictionary
-/datum/controller/subsystem/skills/proc/InitializeSkills(timeofday)
+/datum/controller/subsystem/skills/proc/InitializeSkills()
 	for(var/type in GLOB.skill_types)
 		var/datum/skill/ref = new type
 		all_skills[type] = ref

--- a/code/controllers/subsystem/sounds.dm
+++ b/code/controllers/subsystem/sounds.dm
@@ -25,7 +25,7 @@ SUBSYSTEM_DEF(sounds)
 
 /datum/controller/subsystem/sounds/Initialize()
 	setup_available_channels()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/sounds/proc/setup_available_channels()
 	channel_list = list()

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -102,7 +102,7 @@ SUBSYSTEM_DEF(spatial_grid)
 	///how many pregenerated /mob/oranges_ear instances currently exist. this should hopefully never exceed its starting value
 	var/number_of_oranges_ears = NUMBER_OF_PREGENERATED_ORANGES_EARS
 
-/datum/controller/subsystem/spatial_grid/Initialize(start_timeofday)
+/datum/controller/subsystem/spatial_grid/Initialize()
 	. = ..()
 
 	cells_on_x_axis = SPATIAL_GRID_CELLS_PER_SIDE(world.maxx)

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -103,10 +103,11 @@ SUBSYSTEM_DEF(spatial_grid)
 	var/number_of_oranges_ears = NUMBER_OF_PREGENERATED_ORANGES_EARS
 
 /datum/controller/subsystem/spatial_grid/Initialize()
-	. = ..()
-
 	cells_on_x_axis = SPATIAL_GRID_CELLS_PER_SIDE(world.maxx)
 	cells_on_y_axis = SPATIAL_GRID_CELLS_PER_SIDE(world.maxy)
+
+	// enter_cell only runs if 'initialized'
+	initialized = TRUE
 
 	for(var/datum/space_level/z_level as anything in SSmapping.z_list)
 		propogate_spatial_grid_to_new_z(null, z_level)
@@ -126,6 +127,7 @@ SUBSYSTEM_DEF(spatial_grid)
 
 	RegisterSignal(SSdcs, COMSIG_GLOB_NEW_Z, .proc/propogate_spatial_grid_to_new_z)
 	RegisterSignal(SSdcs, COMSIG_GLOB_EXPANDED_WORLD_BOUNDS, .proc/after_world_bounds_expanded)
+	return SS_INIT_SUCCESS
 
 ///add a movable to the pre init queue for whichever type is specified so that when the subsystem initializes they get added to the grid
 /datum/controller/subsystem/spatial_grid/proc/enter_pre_init_queue(atom/movable/waiting_movable, type)

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -5,6 +5,7 @@ SUBSYSTEM_DEF(statpanels)
 	init_stage = INITSTAGE_EARLY
 	priority = FIRE_PRIORITY_STATPANEL
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
+	flags = SS_NO_INIT
 	var/list/currentrun = list()
 	var/list/global_data
 	var/list/mc_data

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -9,7 +9,7 @@ SUBSYSTEM_DEF(stickyban)
 	var/dbcacheexpire = 0
 
 
-/datum/controller/subsystem/stickyban/Initialize(timeofday)
+/datum/controller/subsystem/stickyban/Initialize()
 	if (length(GLOB.stickybanadminexemptions))
 		restore_stickybans()
 	var/list/bannedkeys = sticky_banned_ckeys()
@@ -61,7 +61,7 @@ SUBSYSTEM_DEF(stickyban)
 		cache[ckey] = ban
 		world.SetConfig("ban", ckey, list2stickyban(ban))
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/stickyban/proc/Populatedbcache()
 	var/newdbcache = list() //so if we runtime or the db connection dies we don't kill the existing cache

--- a/code/controllers/subsystem/sun.dm
+++ b/code/controllers/subsystem/sun.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(sun)
 	var/azimuth_mod = 1 ///multiplier against base_rotation
 	var/base_rotation = 6 ///base rotation in degrees per fire
 
-/datum/controller/subsystem/sun/Initialize(start_timeofday)
+/datum/controller/subsystem/sun/Initialize()
 	azimuth = rand(0, 359)
 	azimuth_mod = round(rand(50, 200)/100, 0.01) // 50% - 200% of standard rotation
 	if(prob(50))

--- a/code/controllers/subsystem/sun.dm
+++ b/code/controllers/subsystem/sun.dm
@@ -11,7 +11,7 @@ SUBSYSTEM_DEF(sun)
 	azimuth_mod = round(rand(50, 200)/100, 0.01) // 50% - 200% of standard rotation
 	if(prob(50))
 		azimuth_mod *= -1
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/sun/fire(resumed = FALSE)
 	azimuth += azimuth_mod * base_rotation

--- a/code/controllers/subsystem/tcgsetup.dm
+++ b/code/controllers/subsystem/tcgsetup.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(trading_card_game)
 //Let's load the cards before the map fires, so we can load cards on the map safely
 /datum/controller/subsystem/trading_card_game/Initialize()
 	reloadAllCardFiles()
-	return ..()
+	return SS_INIT_SUCCESS
 
 ///Loads all the card files
 /datum/controller/subsystem/trading_card_game/proc/loadAllCardFiles()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -62,7 +62,7 @@ SUBSYSTEM_DEF(ticker)
 	/// Why an emergency shuttle was called
 	var/emergency_reason
 
-/datum/controller/subsystem/ticker/Initialize(timeofday)
+/datum/controller/subsystem/ticker/Initialize()
 	var/list/byond_sound_formats = list(
 		"mid" = TRUE,
 		"midi" = TRUE,
@@ -140,7 +140,7 @@ SUBSYSTEM_DEF(ticker)
 		gametime_offset = rand(0, 23) HOURS
 	else if(CONFIG_GET(flag/shift_time_realtime))
 		gametime_offset = world.timeofday
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/ticker/fire()
 	switch(current_state)

--- a/code/controllers/subsystem/time_track.dm
+++ b/code/controllers/subsystem/time_track.dm
@@ -42,7 +42,6 @@ SUBSYSTEM_DEF(time_track)
 	)
 
 /datum/controller/subsystem/time_track/Initialize()
-	. = ..()
 	GLOB.perf_log = "[GLOB.log_directory]/perf-[GLOB.round_id ? GLOB.round_id : "NULL"]-[SSmapping.config?.map_name].csv"
 	world.Profile(PROFILE_RESTART, type = "sendmaps")
 	//Need to do the sendmaps stuff in its own file, since it works different then everything else
@@ -78,7 +77,7 @@ SUBSYSTEM_DEF(time_track)
 			"queries_standby"
 		) + sendmaps_headers
 	)
-
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/time_track/fire()
 

--- a/code/controllers/subsystem/time_track.dm
+++ b/code/controllers/subsystem/time_track.dm
@@ -41,7 +41,7 @@ SUBSYSTEM_DEF(time_track)
 		"SendMaps: Per client: Map data: Look for movable changes: Movables examined" = "movables_examined",
 	)
 
-/datum/controller/subsystem/time_track/Initialize(start_timeofday)
+/datum/controller/subsystem/time_track/Initialize()
 	. = ..()
 	GLOB.perf_log = "[GLOB.log_directory]/perf-[GLOB.round_id ? GLOB.round_id : "NULL"]-[SSmapping.config?.map_name].csv"
 	world.Profile(PROFILE_RESTART, type = "sendmaps")

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -11,7 +11,7 @@ SUBSYSTEM_DEF(title)
 
 /datum/controller/subsystem/title/Initialize()
 	if(file_path && icon)
-		return
+		return SS_INIT_SUCCESS
 
 	if(fexists("data/previous_title.dat"))
 		var/previous_path = file2text("data/previous_title.dat")
@@ -42,7 +42,7 @@ SUBSYSTEM_DEF(title)
 		splash_turf.icon = icon
 		splash_turf.handle_generic_titlescreen_sizes()
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/title/vv_edit_var(var_name, var_value)
 	. = ..()

--- a/code/controllers/subsystem/traitor.dm
+++ b/code/controllers/subsystem/traitor.dm
@@ -41,7 +41,6 @@ SUBSYSTEM_DEF(traitor)
 	var/list/all_objectives_by_type = list()
 
 /datum/controller/subsystem/traitor/Initialize()
-	. = ..()
 	category_handler = new()
 	traitor_debug_panel = new(category_handler)
 
@@ -52,6 +51,7 @@ SUBSYSTEM_DEF(traitor)
 			if(!actual_typepath)
 				log_world("[configuration_path] has an invalid type ([typepath]) that doesn't exist in the codebase! Please correct or remove [typepath]")
 			configuration_data[actual_typepath] = data[typepath]
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/traitor/fire(resumed)
 	var/player_count = length(GLOB.alive_player_list)

--- a/code/controllers/subsystem/traitor.dm
+++ b/code/controllers/subsystem/traitor.dm
@@ -40,7 +40,7 @@ SUBSYSTEM_DEF(traitor)
 	/// A list of all existing objectives by type
 	var/list/all_objectives_by_type = list()
 
-/datum/controller/subsystem/traitor/Initialize(start_timeofday)
+/datum/controller/subsystem/traitor/Initialize()
 	. = ..()
 	category_handler = new()
 	traitor_debug_panel = new(category_handler)

--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -9,7 +9,7 @@ SUBSYSTEM_DEF(vis_overlays)
 
 /datum/controller/subsystem/vis_overlays/Initialize()
 	vis_overlay_cache = list()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/vis_overlays/fire(resumed = FALSE)
 	if(!resumed)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(vote)
 
 		possible_votes[vote.name] = vote
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 
 // Called by master_controller

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -18,7 +18,7 @@ SUBSYSTEM_DEF(vote)
 	/// A list of all ckeys currently voting for the current vote.
 	var/list/voting = list()
 
-/datum/controller/subsystem/vote/Initialize(start_timeofday)
+/datum/controller/subsystem/vote/Initialize()
 	for(var/vote_type in subtypesof(/datum/vote))
 		var/datum/vote/vote = new vote_type()
 		if(!vote.is_accessible_vote())

--- a/code/controllers/subsystem/wardrobe.dm
+++ b/code/controllers/subsystem/wardrobe.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(wardrobe)
 	/// How many items would we make just by loading the master list once?
 	var/one_go_master = 0
 
-/datum/controller/subsystem/wardrobe/Initialize(start_timeofday)
+/datum/controller/subsystem/wardrobe/Initialize()
 	. = ..()
 	setup_callbacks()
 	load_outfits()

--- a/code/controllers/subsystem/wardrobe.dm
+++ b/code/controllers/subsystem/wardrobe.dm
@@ -39,7 +39,6 @@ SUBSYSTEM_DEF(wardrobe)
 	var/one_go_master = 0
 
 /datum/controller/subsystem/wardrobe/Initialize()
-	. = ..()
 	setup_callbacks()
 	load_outfits()
 	load_species()
@@ -47,6 +46,7 @@ SUBSYSTEM_DEF(wardrobe)
 	hard_refresh_queue()
 	stock_hit = 0
 	stock_miss = 0
+	return SS_INIT_SUCCESS
 
 /// Resets the load queue to the master template, accounting for the existing stock
 /datum/controller/subsystem/wardrobe/proc/hard_refresh_queue()

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(weather)
 		var/randTime = rand(3000, 6000)
 		next_hit_by_zlevel["[z]"] = addtimer(CALLBACK(src, .proc/make_eligible, z, possible_weather), randTime + initial(our_event.weather_duration_upper), TIMER_UNIQUE|TIMER_STOPPABLE) //Around 5-10 minutes between weathers
 
-/datum/controller/subsystem/weather/Initialize(start_timeofday)
+/datum/controller/subsystem/weather/Initialize()
 	for(var/V in subtypesof(/datum/weather))
 		var/datum/weather/W = V
 		var/probability = initial(W.probability)

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -43,7 +43,7 @@ SUBSYSTEM_DEF(weather)
 			for(var/z in SSmapping.levels_by_trait(target_trait))
 				LAZYINITLIST(eligible_zlevels["[z]"])
 				eligible_zlevels["[z]"][W] = probability
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/weather/proc/update_z_level(datum/space_level/level)
 	var/z = level.z_value

--- a/code/controllers/subsystem/wiremod_composite.dm
+++ b/code/controllers/subsystem/wiremod_composite.dm
@@ -11,7 +11,7 @@ SUBSYSTEM_DEF(wiremod_composite)
 	/// The templates created and stored
 	var/list/templates = list()
 
-/datum/controller/subsystem/wiremod_composite/New()
+/datum/controller/subsystem/wiremod_composite/PreInit()
 	. = ..()
 	// This needs to execute before global variables have initialized.
 	for(var/datum/circuit_composite_template/type as anything in subtypesof(/datum/circuit_composite_template))
@@ -20,10 +20,10 @@ SUBSYSTEM_DEF(wiremod_composite)
 		templates[initial(type.datatype)] = new type()
 
 /datum/controller/subsystem/wiremod_composite/Initialize()
-	. = ..()
 	for(var/type in templates)
 		var/datum/circuit_composite_template/template = templates[type]
 		template.Initialize()
+	return SS_INIT_SUCCESS
 
 /**
  * Used to produce a composite datatype using another datatype, or

--- a/code/controllers/subsystem/wiremod_composite.dm
+++ b/code/controllers/subsystem/wiremod_composite.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(wiremod_composite)
 			continue
 		templates[initial(type.datatype)] = new type()
 
-/datum/controller/subsystem/wiremod_composite/Initialize(start_timeofday)
+/datum/controller/subsystem/wiremod_composite/Initialize()
 	. = ..()
 	for(var/type in templates)
 		var/datum/circuit_composite_template/template = templates[type]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After #69533, the custom error message that SSlua used (eg. if auxtools.dll is missing) was completely broken (just simply showing the number of seconds since midnight) as `start_timeofday` is no longer passed to `subsystem/Initialize()`.

I then realized that literally nothing uses that `start_timeofday` argument except for SSlua failing, period, so I completely cut it out from all of the implementations of SS/Initialize().

I also didn't like that SSlua was just doing its own thing for error handling in the first place, so now there's an explicit result returned for `...subsystem/Initialize()`, similar to `atom/Initialize()`. You no longer need to call the base ..() in subsystem/Initialize() unless you've created an intermediate type that has init code.

Further, if you don't implement Initialize() anymore, you must set the `SS_NO_INIT` flag or your subsystem will throw a warning on init.

The logic is as follows and is derived from MSO's request in the comments below:

Return:
- `SS_INIT_SUCCESS`: Subsystem initialization completes as before.
- `SS_INIT_NO_NEED`: Initialization completes successfully, but nothing is printed to world chat, nor the log.
  - Used if your subsystem detects that it's been disabled or not sufficiently configured to be considered enabled/active to the users, such as with the discord subsystem if not configured.
- `SS_INIT_FAILURE`: The subsystem has canonically failed to initialize and should be suppressed.
   - Subsystem as having not initialized, and firing is disabled. Failure is reflected in the log and world chat.
- `SS_INIT_NONE`: Never intentionally return this, used to detect that Initialize() wasn't actually implemented.
- Any other value: Treated as a bug, or that an unhandled runtime error occurred.
   - For compatibility, the subsystem is treated as fully initialized, but a warning is printed to the console, and the world chat indicates that it initialized with errors.

As a result of implementing this, nearly all subsystems were touched.
- Some were found to previously call ..() at the beginning of their init rather than their end, meaning they were lying about their time metrics (locked to 0 seconds).
   - I only found one instance of this effecting behavior, (spatial grid) so initialized is manually set to TRUE before the rest of the code is written.
- 1 or 2 subsystems didn't previously call ..() at all, evading metrics and logging.
- Achievement and Discord had an early return for lock of configuration, so `SS_INIT_NO_NEED` is appropriately returned.
- Stat Panel and Circuit Components didn't implement Initialize() and don't seem to rely on the value of `initialized` so they are now flagged to `SS_NO_INIT`. They appear to work fine.
   - Conversely, chat code *does* rely on SSchat's `initialized` being set, even though I think it could use the runlevel instead. Testing chat code locally is a nightmare since the relevent code is for handling startup lag, so I'm retaining the old behavior, by adding an initialized that just returns `SS_INIT_SUCCESSS`.
- Mapping and Wiremod Composite previously overrode `New()` instead of the correct `PreInit()`, so that's been corrected.

Because of the sheer number of changes, I'd recommend test merging it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Gets rid of dead argument in a major proc, SSlua is slightly less rogue.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Error message is technically user/admin-facing, but only if the deployment is broken, so eh.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
