### PR TITLE
Fixes our rendering for 514.1587

### DIFF
--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -135,7 +135,6 @@
 	name = "darkness plane master"
 	plane = BLACKNESS_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	color = list(null, null, null, "#0000", "#000f")
 	blend_mode = BLEND_MULTIPLY
 	appearance_flags = PLANE_MASTER | NO_CLIENT_COLOR | PIXEL_SCALE
 	//byond internal end


### PR DESCRIPTION
## About The Pull Request

Ok so we have a blackness plane master right? it's setup to catch byond darkness but it doesn't rn cause we don't got the sight flags set.

So what it does is just sit there and do NOTHING.

BUT some genius put a color var on it, prob meant to just make it fully black.
But I think they just wrote it wrong, because byond just treats it as "make this plane have alpha 255 everywhere"

The problem is it's got zip on it, so if it actually worked this would black out everything below plane 0.
BUT it didn't work before, because setting anything on non overlay PMs broke them, and made them invis.

Then lummy fixed that, and now we get this.

I've fixed this bug by just removing the color set. It's not actually used for anything so outside this accidential working as intended behavior, it effects nothing, and doesn't actually impact darkness even if we used the sight flag. (I know this because I did this same thing in my multiz pr, which uses the sightflag)

Anyho I think they just wrote it wrong, because byond just treats it as "make this plane have alpha 255 everywhere"

We support 514.1587 now, so that's nice (NOT FOR RUNTIME THO CAUSE IT BROKE ?. LUMMOX ALSO KNOWS THIS)

Fixes #69774

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Hey, we support byond version 514.1587 now. You can upgrade if you'd like. I hope.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
