### PR TITLE
Adds freeform and purge modules to Tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -36451,8 +36451,14 @@
 /area/station/ai_monitored/security/armory)
 "mzJ" = (
 /obj/structure/table,
-/obj/item/ai_module/reset,
+/obj/item/ai_module/reset{
+	pixel_x = 2
+	},
 /obj/machinery/airalarm/directional/north,
+/obj/item/ai_module/supplied/freeform{
+	pixel_y = 7;
+	pixel_x = -2
+	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "mzQ" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6263,6 +6263,9 @@
 	name = "High-Risk Modules";
 	req_access = list("captain")
 	},
+/obj/item/ai_module/reset/purge{
+	pixel_y = 11
+	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "ckH" = (


### PR DESCRIPTION
## About The Pull Request
Tramstation's AI upload was missing the freeform and purge modules, which doesn't seem right according to #67915. This re-adds these modules and enforces upload standards.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Freeform and purge modules are present in every other station's AI upload.
ai_module.dm states the following via a comment: `AI uploads have the ai_module/reset , ai_module/supplied/freeform , ai_module/reset/purge , and ai_module/core/full/asimov directly mapped in`
In other words, Tramstation _not_ having these modules appears erroneous.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Tramstation's AI Upload is now equipped with the proper modules.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
