### PR TITLE
Adds team objectives to the cult antag panel

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -202,6 +202,17 @@
 		if(istype(o, /obj/item/melee/cultblade/dagger) || istype(o, /obj/item/stack/sheet/runed_metal))
 			qdel(o)
 
+/datum/antagonist/cult/antag_panel_objectives()
+	. = ..()
+
+	. += "<br>"
+	. += "<i><b>Team Objectives:</b></i><br>"
+	var/obj_count = 1
+	for (var/datum/objective/objective as anything in cult_team.objectives)
+		. += "<B>[obj_count]</B>: [objective.explanation_text] <br>"
+		obj_count++
+
+
 /datum/antagonist/cult/master
 	ignore_implant = TRUE
 	show_in_antagpanel = FALSE //Feel free to add this later

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -209,7 +209,7 @@
 	. += "<i><b>Team Objectives:</b></i><br>"
 	var/obj_count = 1
 	for (var/datum/objective/objective as anything in cult_team.objectives)
-		. += "<B>[obj_count]</B>: [objective.explanation_text] <br>"
+		. += "<B>[obj_count]</B>: [objective.explanation_text]<br>"
 		obj_count++
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cult wasn't showing the objectives for new joins, this displays the team's objectives so that admins can see what objectives the cultist might actually have, instead of digging through VV to find them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Admins deserve SOME things i guess

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: The antag panel will display the cult's team objectives
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
