### PR TITLE
Cleans up tgfont build command

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -89,6 +89,19 @@
 			],
 			"group": "build",
 			"label": "tgui: sonar"
+		},
+		{
+			"type": "shell",
+			"command": "bin/tgfont",
+			"windows": {
+				"command": ".\\bin\\tgfont.cmd"
+			},
+			"problemMatcher": [
+				"$tsc",
+				"$eslint-stylish"
+			],
+			"group": "build",
+			"label": "tgui: rebuild tgfont"
 		}
 	]
 }

--- a/bin/tgfont.cmd
+++ b/bin/tgfont.cmd
@@ -1,0 +1,2 @@
+@echo off
+call "%~dp0\..\tools\build\build.bat" --wait-on-error tg-font %*

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -168,9 +168,9 @@ export const TgFontTarget = new Juke.Target({
   ],
   executes: async () => {
     await yarn('tgfont:build');
-    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.css', 'tgui/packages/tgfont/static/tgfont.css')
-    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.eot', 'tgui/packages/tgfont/static/tgfont.eot')
-    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.woff2', 'tgui/packages/tgfont/static/tgfont.woff2')
+    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.css', 'tgui/packages/tgfont/static/tgfont.css');
+    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.eot', 'tgui/packages/tgfont/static/tgfont.eot');
+    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.woff2', 'tgui/packages/tgfont/static/tgfont.woff2');
   }
 });
 

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -166,7 +166,12 @@ export const TgFontTarget = new Juke.Target({
     'tgui/packages/tgfont/dist/tgfont.eot',
     'tgui/packages/tgfont/dist/tgfont.woff2',
   ],
-  executes: () => yarn('tgfont:build'),
+  executes: async () => {
+    await yarn('tgfont:build');
+    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.css','tgui/packages/tgfont/static/tgfont.css')
+    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.eot','tgui/packages/tgfont/static/tgfont.eot')
+    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.woff2','tgui/packages/tgfont/static/tgfont.woff2')
+  }
 });
 
 export const TguiTarget = new Juke.Target({

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -168,9 +168,9 @@ export const TgFontTarget = new Juke.Target({
   ],
   executes: async () => {
     await yarn('tgfont:build');
-    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.css','tgui/packages/tgfont/static/tgfont.css')
-    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.eot','tgui/packages/tgfont/static/tgfont.eot')
-    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.woff2','tgui/packages/tgfont/static/tgfont.woff2')
+    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.css', 'tgui/packages/tgfont/static/tgfont.css')
+    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.eot', 'tgui/packages/tgfont/static/tgfont.eot')
+    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.woff2', 'tgui/packages/tgfont/static/tgfont.woff2')
   }
 });
 


### PR DESCRIPTION
Makes tg-font build target copy the resulting css/font files to the static directory so you don't have to do this by hand.
Adds `tgui: rebuild tgfont` vscode task

Now you can just put your svg files in and run vscode task.