### PR TITLE
Adds a unit test for species changes keeping clothings

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -124,6 +124,8 @@
 ///The species is forced to have digitigrade legs in generation.
 #define DIGITIGRADE_FORCED 2
 
+#define DIGITIGRADE_LEGS "Digitigrade Legs"
+
 //TODO: Remove entirely in favor of the BODYTYPE system
 ///Body type bitfields for allowed_animal_origin used to check compatible surgery body types (use NONE for no matching body type)
 #define HUMAN_BODY (1 << 0)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -124,6 +124,7 @@
 ///The species is forced to have digitigrade legs in generation.
 #define DIGITIGRADE_FORCED 2
 
+///Digitigrade's prefs, used in features for legs if you're meant to be a Digitigrade.
 #define DIGITIGRADE_LEGS "Digitigrade Legs"
 
 //TODO: Remove entirely in favor of the BODYTYPE system

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -708,7 +708,19 @@
 	switch(random)
 		if(1)
 			to_chat(user, span_danger("Your appearance morphs to that of a very small humanoid ash dragon! You get to look like a freak without the cool abilities."))
-			consumer.dna.features = list("mcolor" = "#A02720", "tail_lizard" = "Dark Tiger", "tail_human" = "None", "snout" = "Sharp", "horns" = "Curled", "ears" = "None", "wings" = "None", "frills" = "None", "spines" = "Long", "body_markings" = "Dark Tiger Body", "legs" = "Digitigrade Legs")
+			consumer.dna.features = list(
+				"mcolor" = "#A02720",
+				"tail_lizard" = "Dark Tiger",
+				"tail_human" = "None",
+				"snout" = "Sharp",
+				"horns" = "Curled",
+				"ears" = "None",
+				"wings" = "None",
+				"frills" = "None",
+				"spines" = "Long",
+				"body_markings" = "Dark Tiger Body",
+				"legs" = DIGITIGRADE_LEGS,
+			)
 			consumer.eye_color_left = "#FEE5A3"
 			consumer.eye_color_right = "#FEE5A3"
 			consumer.set_species(/datum/species/lizard)

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -2049,7 +2049,7 @@
 	name = "Normal Legs"
 
 /datum/sprite_accessory/legs/digitigrade_lizard
-	name = "Digitigrade Legs"
+	name = DIGITIGRADE_LEGS
 
 /datum/sprite_accessory/caps
 	icon = 'icons/mob/species/mutant_bodyparts.dmi'

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2217,7 +2217,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	new_species ||= target.dna.species //If no new species is provided, assume its src.
 	//Note for future: Potentionally add a new C.dna.species() to build a template species for more accurate limb replacement
 
-	if((new_species.digitigrade_customization == DIGITIGRADE_OPTIONAL && target.dna.features["legs"] == "Digitigrade Legs") || new_species.digitigrade_customization == DIGITIGRADE_FORCED)
+	if((new_species.digitigrade_customization == DIGITIGRADE_OPTIONAL && target.dna.features["legs"] == DIGITIGRADE_LEGS) || new_species.digitigrade_customization == DIGITIGRADE_FORCED)
 		new_species.bodypart_overrides[BODY_ZONE_R_LEG] = /obj/item/bodypart/r_leg/digitigrade
 		new_species.bodypart_overrides[BODY_ZONE_L_LEG] = /obj/item/bodypart/l_leg/digitigrade
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -150,6 +150,7 @@
 #include "slips.dm"
 #include "spawn_humans.dm"
 #include "spawn_mobs.dm"
+#include "species_change_clothing.dm"
 #include "species_config_sanity.dm"
 #include "species_unique_id.dm"
 #include "species_whitelists.dm"

--- a/code/modules/unit_tests/species_change_clothing.dm
+++ b/code/modules/unit_tests/species_change_clothing.dm
@@ -1,3 +1,4 @@
+///Gives a Human lizard-incompatible shoes, then changes their species over to see if they drop the now incompatible shoes.
 /datum/unit_test/species_change_clothing
 
 /datum/unit_test/species_change_clothing/Run()

--- a/code/modules/unit_tests/species_change_clothing.dm
+++ b/code/modules/unit_tests/species_change_clothing.dm
@@ -1,0 +1,16 @@
+/datum/unit_test/species_change_clothing
+
+/datum/unit_test/species_change_clothing/Run()
+	// Test lizards as their own thing so we can get more coverage on their features
+	var/mob/living/carbon/human/human_to_lizard = allocate(/mob/living/carbon/human/dummy/consistent)
+	human_to_lizard.equipOutfit(/datum/outfit/job/assistant/consistent)
+
+	var/obj/item/human_shoes = human_to_lizard.get_item_by_slot(ITEM_SLOT_FEET)
+
+	human_shoes.supports_variations_flags = NONE //do not fit lizards at all costs.
+
+	human_to_lizard.set_species(/datum/species/lizard/ashwalker)
+
+	var/obj/item/lizard_shoes = human_to_lizard.get_item_by_slot(ITEM_SLOT_FEET)
+
+	TEST_ASSERT_NOTEQUAL(human_shoes, lizard_shoes, "Lizard still has shoes after changing species.")

--- a/code/modules/unit_tests/species_change_clothing.dm
+++ b/code/modules/unit_tests/species_change_clothing.dm
@@ -4,13 +4,12 @@
 	// Test lizards as their own thing so we can get more coverage on their features
 	var/mob/living/carbon/human/human_to_lizard = allocate(/mob/living/carbon/human/dummy/consistent)
 	human_to_lizard.equipOutfit(/datum/outfit/job/assistant/consistent)
+	human_to_lizard.dna.features["legs"] = DIGITIGRADE_LEGS //you WILL have digitigrade legs
 
 	var/obj/item/human_shoes = human_to_lizard.get_item_by_slot(ITEM_SLOT_FEET)
-
 	human_shoes.supports_variations_flags = NONE //do not fit lizards at all costs.
 
-	human_to_lizard.set_species(/datum/species/lizard/ashwalker)
+	human_to_lizard.set_species(/datum/species/lizard)
 
 	var/obj/item/lizard_shoes = human_to_lizard.get_item_by_slot(ITEM_SLOT_FEET)
-
 	TEST_ASSERT_NOTEQUAL(human_shoes, lizard_shoes, "Lizard still has shoes after changing species.")


### PR DESCRIPTION
## About The Pull Request

Adds a unit test that checks if people who species change into a Lizard keeps their non-digitigrade shoes or not, which will also affect Monkeys.

It isn't a problem right now, because https://github.com/tgstation/tgstation/pull/68489 fixed it, but it is what it is.

## Why It's Good For The Game

This was a wanted Unit test, from https://github.com/tgstation/tgstation/issues/66465

I got motivation to work on unit tests so thought I might as well make one or two before I burn out,

## Changelog

Nothing player facing.