### PR TITLE
Converts Surgery Sounds To Defines

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -16,3 +16,15 @@
 
 /// When the surgery step fails :(
 #define SURGERY_STEP_FAIL -1
+
+// Surgery Sounds
+#define SURGERY_SOUND_CAUTERY_ONE 'sound/surgery/cautery1.ogg'
+#define SURGERY_SOUND_CAUTERY_TWO 'sound/surgery/cautery2.ogg'
+#define SURGERY_SOUND_HEMOSTAT 'sound/surgery/hemostat1.ogg'
+#define SURGERY_SOUND_ORGAN_ONE 'sound/surgery/organ1.ogg'
+#define SURGERY_SOUND_ORGAN_TWO 'sound/surgery/organ2.ogg'
+#define SURGERY_SOUND_RETRACTOR_ONE 'sound/surgery/retractor1.ogg'
+#define SURGERY_SOUND_RETRACTOR_TWO 'sound/surgery/retractor2.ogg'
+#define SURGERY_SOUND_SAW 'sound/surgery/saw.ogg'
+#define SURGERY_SOUND_SCALPEL_ONE 'sound/surgery/scalpel1.ogg'
+#define SURGERY_SOUND_SCALPEL_TWO 'sound/surgery/scalpel2.ogg'

--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -192,7 +192,7 @@
 
 	to_chat(user, span_notice("You successfully extract [victim]'s eyeballs using [src]."))
 	victim.emote("scream")
-	playsound(victim, 'sound/surgery/retractor2.ogg', 100, TRUE)
+	playsound(victim, SURGERY_SOUND_RETRACTOR_TWO, 100, TRUE)
 	playsound(victim, 'sound/effects/pop.ogg', 100, TRAIT_MUTE)
 	eyeballies.Remove(victim)
 	eyeballies.forceMove(get_turf(victim))

--- a/code/modules/mob/living/basic/farm_animals/sheep.dm
+++ b/code/modules/mob/living/basic/farm_animals/sheep.dm
@@ -41,7 +41,7 @@
 		item_generation_wait = 3 MINUTES, \
 		item_reduction_time = 30 SECONDS, \
 		item_harvest_time = 5 SECONDS, \
-		item_harvest_sound = 'sound/surgery/scalpel1.ogg', \
+		item_harvest_sound = SURGERY_SOUND_SCALPEL_ONE, \
 	)
 	RegisterSignal(src, COMSIG_LIVING_CULT_SACRIFICED, .proc/on_sacrificed)
 

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -33,9 +33,9 @@
 		/obj/item/stack/package_wrap = 35,
 		/obj/item/stack/cable_coil = 15)
 	time = 200
-	preop_sound = 'sound/surgery/hemostat1.ogg'
-	success_sound = 'sound/surgery/hemostat1.ogg'
-	failure_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_HEMOSTAT
+	success_sound = SURGERY_SOUND_HEMOSTAT
+	failure_sound = SURGERY_SOUND_ORGAN_TWO
 	var/objective
 
 /datum/surgery_step/brainwash/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -30,9 +30,9 @@
 		/obj/item/shard = 25,
 		/obj/item = 20)
 	time = 100
-	preop_sound = 'sound/surgery/scalpel1.ogg'
-	success_sound = 'sound/surgery/scalpel2.ogg'
-	failure_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_SCALPEL_ONE
+	success_sound = SURGERY_SOUND_SCALPEL_TWO
+	failure_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery_step/lobotomize/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.get_sharpness())

--- a/code/modules/surgery/advanced/pacification.dm
+++ b/code/modules/surgery/advanced/pacification.dm
@@ -26,9 +26,9 @@
 		TOOL_SCREWDRIVER = 35,
 		/obj/item/pen = 15)
 	time = 40
-	preop_sound = 'sound/surgery/hemostat1.ogg'
-	success_sound = 'sound/surgery/hemostat1.ogg'
-	failure_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_HEMOSTAT
+	success_sound = SURGERY_SOUND_HEMOSTAT
+	failure_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery_step/pacify/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to pacify [target]..."),

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -24,8 +24,8 @@
 		/obj/item/hatchet = 40,
 		/obj/item/knife/butcher = 25)
 	time = 64
-	preop_sound = 'sound/surgery/scalpel1.ogg'
-	success_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_SCALPEL_ONE
+	success_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery_step/sever_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to sever [target]'s [parse_zone(target_zone)]..."),

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -20,9 +20,9 @@
 		/obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100
 	repeatable = TRUE
 	time = 100 //long and complicated
-	preop_sound = 'sound/surgery/hemostat1.ogg'
-	success_sound = 'sound/surgery/hemostat1.ogg'
-	failure_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_HEMOSTAT
+	success_sound = SURGERY_SOUND_HEMOSTAT
+	failure_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery/brain_surgery/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/internal/brain/target_brain = target.getorganslot(ORGAN_SLOT_BRAIN)

--- a/code/modules/surgery/burn_dressing.dm
+++ b/code/modules/surgery/burn_dressing.dm
@@ -32,9 +32,9 @@
 		TOOL_WIRECUTTER = 40)
 	time = 30
 	repeatable = TRUE
-	preop_sound = 'sound/surgery/scalpel1.ogg'
-	success_sound = 'sound/surgery/retractor2.ogg'
-	failure_sound = 'sound/surgery/organ1.ogg'
+	preop_sound = SURGERY_SOUND_SCALPEL_ONE
+	success_sound = SURGERY_SOUND_RETRACTOR_TWO
+	failure_sound = SURGERY_SOUND_ORGAN_ONE
 	/// How much sanitization is added per step
 	var/sanitization_added = 0.5
 	/// How much infestation is removed per step (positive number)

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -18,8 +18,8 @@
 	implements = list(/obj/item = 100)
 	repeatable = TRUE
 	time = 32
-	preop_sound = 'sound/surgery/organ1.ogg'
-	success_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_ORGAN_ONE
+	success_sound = SURGERY_SOUND_ORGAN_TWO
 	var/obj/item/item_for_cavity
 
 /datum/surgery_step/handle_cavity/tool_check(mob/user, obj/item/tool)

--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -28,9 +28,9 @@
 		/obj/item/knife = 45,
 		/obj/item/shard = 25)
 	time = 16
-	preop_sound = 'sound/surgery/scalpel1.ogg'
-	success_sound = 'sound/surgery/scalpel2.ogg'
-	failure_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_SCALPEL_ONE
+	success_sound = SURGERY_SOUND_SCALPEL_TWO
+	failure_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery_step/incise_heart/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to make an incision in [target]'s heart..."),
@@ -70,9 +70,9 @@
 		/obj/item/stack/package_wrap = 15,
 		/obj/item/stack/cable_coil = 5)
 	time = 90
-	preop_sound = 'sound/surgery/hemostat1.ogg'
-	success_sound = 'sound/surgery/hemostat1.ogg'
-	failure_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_HEMOSTAT
+	success_sound = SURGERY_SOUND_HEMOSTAT
+	failure_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery_step/coronary_bypass/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to graft a bypass onto [target]'s heart..."),

--- a/code/modules/surgery/gastrectomy.dm
+++ b/code/modules/surgery/gastrectomy.dm
@@ -31,9 +31,9 @@
 		/obj/item/knife = 45,
 		/obj/item/shard = 35)
 	time = 52
-	preop_sound = 'sound/surgery/scalpel1.ogg'
-	success_sound = 'sound/surgery/organ1.ogg'
-	failure_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_SCALPEL_ONE
+	success_sound = SURGERY_SOUND_ORGAN_ONE
+	failure_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery_step/gastrectomy/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to cut out a damaged piece of [target]'s stomach..."),

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -40,8 +40,8 @@
 		/obj/item/pen = 55)
 	repeatable = TRUE
 	time = 25
-	success_sound = 'sound/surgery/retractor2.ogg'
-	failure_sound = 'sound/surgery/organ2.ogg'
+	success_sound = SURGERY_SOUND_RETRACTOR_TWO
+	failure_sound = SURGERY_SOUND_ORGAN_TWO
 	var/brutehealing = 0
 	var/burnhealing = 0
 	var/brute_multiplier = 0 //multiplies the damage that the patient has. if 0 the patient wont get any additional healing from the damage he has.

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -30,9 +30,9 @@
 		/obj/item/knife = 45,
 		/obj/item/shard = 35)
 	time = 52
-	preop_sound = 'sound/surgery/scalpel1.ogg'
-	success_sound = 'sound/surgery/organ1.ogg'
-	failure_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_SCALPEL_ONE
+	success_sound = SURGERY_SOUND_ORGAN_ONE
+	failure_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery_step/hepatectomy/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to cut out a damaged piece of [target]'s liver..."),

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -18,7 +18,7 @@
 		TOOL_CROWBAR = 65,
 		/obj/item/kitchen/fork = 35)
 	time = 64
-	success_sound = 'sound/surgery/hemostat1.ogg'
+	success_sound = SURGERY_SOUND_HEMOSTAT
 	var/obj/item/implant/implant
 
 /datum/surgery_step/extract_implant/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/lobectomy.dm
+++ b/code/modules/surgery/lobectomy.dm
@@ -27,9 +27,9 @@
 		/obj/item/knife = 45,
 		/obj/item/shard = 35)
 	time = 42
-	preop_sound = 'sound/surgery/scalpel1.ogg'
-	success_sound = 'sound/surgery/organ1.ogg'
-	failure_sound = 'sound/surgery/organ2.ogg'
+	preop_sound = SURGERY_SOUND_SCALPEL_ONE
+	success_sound = SURGERY_SOUND_ORGAN_ONE
+	failure_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery_step/lobectomy/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to make an incision in [target]'s lungs..."),

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -74,8 +74,8 @@
 	implements = list(
 		/obj/item/organ = 100,
 		/obj/item/borg/apparatus/organ_storage = 100)
-	preop_sound = 'sound/surgery/organ2.ogg'
-	success_sound = 'sound/surgery/organ1.ogg'
+	preop_sound = SURGERY_SOUND_ORGAN_TWO
+	success_sound = SURGERY_SOUND_ORGAN_ONE
 
 	var/implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 55, /obj/item/kitchen/fork = 35)
 	var/current_type
@@ -102,8 +102,8 @@
 		tool = target_organ
 	if(isorgan(tool))
 		current_type = "insert"
-		preop_sound = 'sound/surgery/hemostat1.ogg'
-		success_sound = 'sound/surgery/organ2.ogg'
+		preop_sound = SURGERY_SOUND_HEMOSTAT
+		success_sound = SURGERY_SOUND_ORGAN_TWO
 		target_organ = tool
 		if(target_zone != target_organ.zone || target.getorganslot(target_organ.slot))
 			to_chat(user, span_warning("There is no room for [target_organ] in [target]'s [parse_zone(target_zone)]!"))

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -9,8 +9,8 @@
 		/obj/item/shard = 45,
 		/obj/item = 30) // 30% success with any sharp item.
 	time = 16
-	preop_sound = 'sound/surgery/scalpel1.ogg'
-	success_sound = 'sound/surgery/scalpel2.ogg'
+	preop_sound = SURGERY_SOUND_SCALPEL_ONE
+	success_sound = SURGERY_SOUND_SCALPEL_TWO
 
 /datum/surgery_step/incise/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to make an incision in [target]'s [parse_zone(target_zone)]..."),
@@ -51,7 +51,7 @@
 		/obj/item/stack/package_wrap = 35,
 		/obj/item/stack/cable_coil = 15)
 	time = 24
-	preop_sound = 'sound/surgery/hemostat1.ogg'
+	preop_sound = SURGERY_SOUND_HEMOSTAT
 
 /datum/surgery_step/clamp_bleeders/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to clamp bleeders in [target]'s [parse_zone(target_zone)]..."),
@@ -78,8 +78,8 @@
 		TOOL_WIRECUTTER = 35,
 		/obj/item/stack/rods = 35)
 	time = 24
-	preop_sound = 'sound/surgery/retractor1.ogg'
-	success_sound = 'sound/surgery/retractor2.ogg'
+	preop_sound = SURGERY_SOUND_RETRACTOR_ONE
+	success_sound = SURGERY_SOUND_RETRACTOR_TWO
 
 /datum/surgery_step/retract_skin/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to retract the skin in [target]'s [parse_zone(target_zone)]..."),
@@ -96,8 +96,8 @@
 		TOOL_WELDER = 70,
 		/obj/item = 30) // 30% success with any hot item.
 	time = 24
-	preop_sound = 'sound/surgery/cautery1.ogg'
-	success_sound = 'sound/surgery/cautery2.ogg'
+	preop_sound = SURGERY_SOUND_CAUTERY_ONE
+	success_sound = SURGERY_SOUND_CAUTERY_TWO
 
 /datum/surgery_step/close/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to mend the incision in [target]'s [parse_zone(target_zone)]..."),
@@ -135,14 +135,14 @@
 		/obj/item = 20) //20% success (sort of) with any sharp item with a force>=10
 	time = 54
 	preop_sound = list(
-		/obj/item/circular_saw = 'sound/surgery/saw.ogg',
-		/obj/item/melee/arm_blade = 'sound/surgery/scalpel1.ogg',
-		/obj/item/fireaxe = 'sound/surgery/scalpel1.ogg',
-		/obj/item/hatchet = 'sound/surgery/scalpel1.ogg',
-		/obj/item/knife/butcher = 'sound/surgery/scalpel1.ogg',
-		/obj/item = 'sound/surgery/scalpel1.ogg',
-	) 
-	success_sound = 'sound/surgery/organ2.ogg'
+		/obj/item/circular_saw = SURGERY_SOUND_SAW,
+		/obj/item/melee/arm_blade = SURGERY_SOUND_SCALPEL_ONE,
+		/obj/item/fireaxe = SURGERY_SOUND_SCALPEL_ONE,
+		/obj/item/hatchet = SURGERY_SOUND_SCALPEL_ONE,
+		/obj/item/knife/butcher = SURGERY_SOUND_SCALPEL_ONE,
+		/obj/item = SURGERY_SOUND_SCALPEL_ONE,
+	)
+	success_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to saw through the bone in [target]'s [parse_zone(target_zone)]..."),

--- a/code/modules/surgery/stomachpump.dm
+++ b/code/modules/surgery/stomachpump.dm
@@ -28,7 +28,7 @@
 	accept_hand = TRUE
 	repeatable = TRUE
 	time = 20
-	success_sound = 'sound/surgery/organ2.ogg'
+	success_sound = SURGERY_SOUND_ORGAN_TWO
 
 /datum/surgery_step/stomach_pump/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin pumping [target]'s stomach..."),


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

We had a bunch of these file references spread across several files so I decide to just change them all into define macros so if we decide to ever change up the mix of surgery sounds, it's not much harder than changing the reference in the define (or adding a new define). Worked in game when I did an organ manipulation surgery.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better maintainability, presumably.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing of particular concern to players.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
