### PR TITLE
Makes the Sepia/Timefreeze cameras not burn out after a single use.

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -12,7 +12,6 @@ Slimecrossing Items
 	pictures_max = 1
 	can_customise = FALSE
 	default_picture_name = "A nostalgic picture"
-	var/used = FALSE
 
 /datum/saved_bodypart
 	var/obj/item/bodypart/old_part
@@ -58,16 +57,15 @@ Slimecrossing Items
 /obj/item/camera/rewind/afterattack(atom/target, mob/user, flag)
 	if(!on || !pictures_left || !isturf(target.loc))
 		return
-	if(!used)//selfie time
-		if(user == target)
-			to_chat(user, span_notice("You take a selfie!"))
-		else
-			to_chat(user, span_notice("You take a photo with [target]!"))
-			to_chat(target, span_notice("[user] takes a photo with you!"))
-		to_chat(target, span_boldnotice("You'll remember this moment forever!"))
 
-		used = TRUE
-		target.AddComponent(/datum/component/dejavu, 2)
+	if(user == target)
+		to_chat(user, span_notice("You take a selfie!"))
+	else
+		to_chat(user, span_notice("You take a photo with [target]!"))
+		to_chat(target, span_notice("[user] takes a photo with you!"))
+	to_chat(target, span_boldnotice("You'll remember this moment forever!"))
+
+	target.AddComponent(/datum/component/dejavu, 2)
 	.=..()
 
 
@@ -78,15 +76,11 @@ Slimecrossing Items
 	desc = "They say a picture is like a moment stopped in time."
 	pictures_left = 1
 	pictures_max = 1
-	var/used = FALSE
 
 /obj/item/camera/timefreeze/afterattack(atom/target, mob/user, flag)
 	if(!on || !pictures_left || !isturf(target.loc))
 		return
-	if(!used) //refilling the film does not refill the timestop
-		new /obj/effect/timestop(get_turf(target), 2, 50, list(user))
-		used = TRUE
-		desc = "This camera has seen better days."
+	new /obj/effect/timestop(get_turf(target), 2, 50, list(user))
 	. = ..()
 
 //Hypercharged slime cell - Charged Yellow


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the "used" variable from the sepia/timefreeze cameras. This does not increase the camera's film capacity at all, but they can be refilled for another single shot using camera film.

Yes, I am aware that I'm opening a **Xenobio Crossbreed Buff** in the year 2022. Hear me out on this one.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The sepia camera is a prime item for shenanigans. The deja-vu component has some potential for really funny stuff that I've seen other players WANT to explore. Problems arise when the only (crew-accessible) way to engage with it requires churning out large amounts of slimes for an economically unfair payoff. It isn't a particularly powerful tool, so I don't see a reason why it should be so limited in its uses.

Originally this also addressed the issue of how much inventory space carrying around a bunch of cameras would take up, but I was informed that you can just store the extracts in a bio bag. Go figure.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Sepia and Timefreeze cameras are no longer single use. Refilling them with camera film now restores their ability to rewind/freeze targets (you still only get one picture before you run out of film).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
