### PR TITLE
Fixes pirate ships being able to fly around

### DIFF
--- a/_maps/shuttles/hunter_bounty.dmm
+++ b/_maps/shuttles/hunter_bounty.dmm
@@ -193,7 +193,7 @@
 /obj/docking_port/stationary{
 	dwidth = 11;
 	height = 16;
-	shuttle_id = "pirateship_home";
+	shuttle_id = "pirate_home";
 	name = "Deep Space";
 	width = 17
 	},

--- a/_maps/shuttles/hunter_russian.dmm
+++ b/_maps/shuttles/hunter_russian.dmm
@@ -507,7 +507,7 @@
 /obj/docking_port/stationary{
 	dwidth = 11;
 	height = 16;
-	shuttle_id = "pirateship_home";
+	shuttle_id = "pirate_home";
 	name = "Deep Space";
 	width = 17
 	},

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -1083,7 +1083,7 @@
 /obj/docking_port/stationary{
 	dwidth = 11;
 	height = 16;
-	shuttle_id = "pirateship_home";
+	shuttle_id = "pirate_home";
 	name = "Deep Space";
 	width = 17
 	},

--- a/_maps/shuttles/pirate_dutchman.dmm
+++ b/_maps/shuttles/pirate_dutchman.dmm
@@ -766,7 +766,7 @@
 	dir = 8;
 	dwidth = 11;
 	height = 16;
-	shuttle_id = "pirateship_home";
+	shuttle_id = "pirate_home";
 	name = "Deep Space";
 	width = 17
 	},

--- a/_maps/shuttles/pirate_silverscale.dmm
+++ b/_maps/shuttles/pirate_silverscale.dmm
@@ -516,7 +516,7 @@
 	dir = 4;
 	dwidth = 13;
 	height = 3;
-	shuttle_id = "pirateship_home";
+	shuttle_id = "pirate_home";
 	name = "Deep Space";
 	width = 26
 	},

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -185,18 +185,18 @@
 
 /obj/machinery/computer/shuttle/pirate
 	name = "pirate shuttle console"
-	shuttleId = "pirateship"
+	shuttleId = "pirate"
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	light_color = COLOR_SOFT_RED
-	possible_destinations = "pirateship_away;pirateship_home;pirateship_custom"
+	possible_destinations = "pirate_away;pirate_home;pirate_custom"
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate
 	name = "pirate shuttle navigation computer"
 	desc = "Used to designate a precise transit location for the pirate shuttle."
-	shuttleId = "pirateship"
+	shuttleId = "pirate"
 	lock_override = CAMERA_LOCK_STATION
-	shuttlePortId = "pirateship_custom"
+	shuttlePortId = "pirate_custom"
 	x_offset = 9
 	y_offset = 0
 	see_hidden = FALSE


### PR DESCRIPTION
## About The Pull Request

I changed the dock ID from pirateship to pirate, but I forgot to change shuttle IDs for the ship's docking ports so they would work. The change was made so pirate ships loading in would replace eachother like it now does for emergency/arrival/cargo shuttles when Admin's shuttle manipulator uses 'Replace' instead of 'Load', as per https://github.com/tgstation/tgstation/pull/69516

## Why It's Good For The Game

Pirates can use their ships again
Closes https://github.com/tgstation/tgstation/issues/69776

## Changelog

:cl:
fix: Pirate ships now work again.
/:cl: