### PR TITLE
Adds weather protection to things inside disposals pipes

### DIFF
--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -16,6 +16,10 @@
 	var/tomail = FALSE // contains wrapped package
 	var/hasmob = FALSE // contains a mob
 
+/obj/structure/disposalholder/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_WEATHER_IMMUNE, REF(src))
+
 /obj/structure/disposalholder/Destroy()
 	active = FALSE
 	last_pipe = null


### PR DESCRIPTION
Being inside of a massive pipe lined with lead should protect you from ashstorms, rad storms, ect n stuff. 

:cl: ShizCalev
balance: Things inside disposals pipes are now protected from weather (ashstorms, radstorms, ect.)
/:cl:
