### PR TITLE
fixes check power mapping debug option w/ multilayer wire support

### DIFF
--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -45,12 +45,12 @@
 				results += "Powernet with fewer than 10 cables! (number [PN.number]) - example cable at [ADMIN_VERBOSEJMP(C)]"
 
 	for(var/turf/T in world.contents)
-		var/found_one = FALSE
+		var/cable_layers //cache all cable layers (which are bitflags) present
 		for(var/obj/structure/cable/C in T.contents)
-			if(found_one)
+			if(cable_layers & C.cable_layer)
 				results += "Doubled wire at [ADMIN_VERBOSEJMP(C)]"
 			else
-				found_one = TRUE
+				cable_layers |= C.cable_layer
 		var/obj/machinery/power/terminal/term = locate(/obj/machinery/power/terminal) in T.contents
 		if(term)
 			var/obj/structure/cable/C = locate(/obj/structure/cable) in T.contents


### PR DESCRIPTION
Fixes #69818

:cl:
fix: Check power mapping debug option now properly supports multilayer wiring.
/:cl:
