### PR TITLE
Fixes inconsistencies in engine thrust

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -33,9 +33,9 @@
 		return FALSE
 	connected_ship_ref = WEAKREF(port)
 	port.engine_list += src
-	port.current_engines++
+	port.current_engine_power += engine_power
 	if(mapload)
-		port.initial_engines++
+		port.initial_engine_power += engine_power
 
 /obj/structure/shuttle/engine/Destroy()
 	if(engine_state == ENGINE_WELDED)
@@ -50,7 +50,7 @@
 	var/obj/docking_port/mobile/port = connected_ship_ref?.resolve()
 	if(port)
 		port.engine_list -= src
-		port.current_engines--
+		port.current_engine_power -= initial(engine_power)
 	connected_ship_ref = null
 
 //Ugh this is a lot of copypasta from emitters, welding need some boilerplate reduction

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -382,8 +382,15 @@
 
 	///List of all areas our shuttle holds.
 	var/list/shuttle_areas = list()
-	///List of all currently used engines that propels us.
+	///List of all engines connected to the shuttle.
 	var/list/obj/structure/shuttle/engine/engine_list = list()
+
+	///How fast the shuttle should be, taking engine thrust into account.
+	var/engine_coeff = 1
+	///How much engine power (thrust) the shuttle currently has.
+	var/current_engine_power = 0
+	///How much engine power (thrust) the shuttle starts with at mapload.
+	var/initial_engine_power = 0
 
 	///used as a timer (if you want time left to complete move, use timeLeft proc)
 	var/timer
@@ -411,16 +418,12 @@
 
 	var/launch_status = NOLAUNCH
 
+	var/list/ripples = list()
 	///Whether or not you want your ship to knock people down, and also whether it will throw them several tiles upon launching.
 	var/list/movement_force = list(
 		"KNOCKDOWN" = 3,
 		"THROW" = 0,
 	)
-
-	var/list/ripples = list()
-	var/engine_coeff = 1
-	var/current_engines = 0
-	var/initial_engines = 0
 
 	///if this shuttle can move docking ports other than the one it is docked at
 	var/can_move_docking_ports = FALSE
@@ -958,8 +961,8 @@
 	if(!mod)
 		return
 	var/old_coeff = engine_coeff
-	engine_coeff = get_engine_coeff(current_engines,mod)
-	current_engines = max(0, current_engines + mod)
+	engine_coeff = get_engine_coeff(mod)
+	current_engine_power = max(0, current_engine_power + mod)
 	if(in_flight())
 		var/delta_coeff = engine_coeff / old_coeff
 		modTimer(delta_coeff)
@@ -967,22 +970,22 @@
 // Double initial engines to get to 0.5 minimum
 // Lose all initial engines to get to 2
 //For 0 engine shuttles like BYOS 5 engines to get to doublespeed
-/obj/docking_port/mobile/proc/get_engine_coeff(current,engine_mod)
-	var/new_value = max(0, current + engine_mod)
-	if(new_value == initial_engines)
+/obj/docking_port/mobile/proc/get_engine_coeff(engine_mod)
+	var/new_value = max(0, current_engine_power + engine_mod)
+	if(new_value == initial_engine_power)
 		return 1
-	if(new_value > initial_engines)
-		var/delta = new_value - initial_engines
+	if(new_value > initial_engine_power)
+		var/delta = new_value - initial_engine_power
 		var/change_per_engine = (1 - ENGINE_COEFF_MIN) / ENGINE_DEFAULT_MAXSPEED_ENGINES // 5 by default
-		if(initial_engines > 0)
-			change_per_engine = (1 - ENGINE_COEFF_MIN) / initial_engines // or however many it had
-		return clamp(1 - delta * change_per_engine,ENGINE_COEFF_MIN,ENGINE_COEFF_MAX)
-	if(new_value < initial_engines)
-		var/delta = initial_engines - new_value
+		if(initial_engine_power > 0)
+			change_per_engine = (1 - ENGINE_COEFF_MIN) / initial_engine_power // or however many it had
+		return clamp(1 - delta * change_per_engine,ENGINE_COEFF_MIN, ENGINE_COEFF_MAX)
+	if(new_value < initial_engine_power)
+		var/delta = initial_engine_power - new_value
 		var/change_per_engine = 1 //doesn't really matter should not be happening for 0 engine shuttles
-		if(initial_engines > 0)
-			change_per_engine = (ENGINE_COEFF_MAX - 1) / initial_engines //just linear drop to max delay
-		return clamp(1 + delta * change_per_engine,ENGINE_COEFF_MIN,ENGINE_COEFF_MAX)
+		if(initial_engine_power > 0)
+			change_per_engine = (ENGINE_COEFF_MAX - 1) / initial_engine_power //just linear drop to max delay
+		return clamp(1 + delta * change_per_engine, ENGINE_COEFF_MIN, ENGINE_COEFF_MAX)
 
 
 /obj/docking_port/mobile/proc/in_flight()


### PR DESCRIPTION
## About The Pull Request

I was looking around at what caused https://github.com/tgstation/tgstation/issues/69823 and found that current_engines and initial_engines were actually their thrust power, which I was unaware of because of undocumented vars.

I renamed the vars, documented them, and fixed them.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/69823 - though mostly the issue was because they bought the Build your own shuttle, so likely someone removed some engines, because I was able to replicate it by removing engines, an intentional feature

![image](https://user-images.githubusercontent.com/53777086/189489695-39a240f4-ed2d-4f80-bf20-d2b4178debfd.png)

![image](https://user-images.githubusercontent.com/53777086/189489601-b2b22150-88d6-4590-a9bf-6df9cf261179.png)


## Changelog

:cl:
fix: Engines now calculate their thrust power as they used to, preventing edge cases of inconsistent shuttle call timers.
/:cl: