### PR TITLE
Cleans up a mistake in SSair init

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -543,7 +543,7 @@ SUBSYSTEM_DEF(air)
 		// This way we can make setting up adjacent turfs O(n) rather then O(n^2)
 		T.Initalize_Atmos(time)
 		if(CHECK_TICK)
-			time++
+			time--
 
 	if(active_turfs.len)
 		var/starting_ats = active_turfs.len

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -86,7 +86,9 @@
 			continue
 		// The assumption is that ONLY DURING INIT if two tiles have the same cycle, there's no way canpass(a->b) will be different then canpass(b->a), so this is faster
 		// Saves like 1.2 seconds
-		if(current_turf.current_cycle >= current_cycle)
+		// Note: current cycle here goes DOWN as we sleep. this is to ensure we can use the >= logic in the first step of process_cell
+		// It's not a massive thing, and I'm sorry for the cursed code, but it be this way
+		if(current_turf.current_cycle <= current_cycle)
 			continue
 
 		//Can you and me form a deeper relationship, or is this just a passing wind


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ok so in linda turfs use current_cycle to tell if they've been visited by process_cell yet.
In a recent pr of mine, I expanded its use to init, so I could make sure we don't double visit tiles.
However, I did this in such a way that it could in theory overrun into a number that you might find in ssair. So I've changed the logic to make it decrement, so it's safe in the worst case

## Why It's Good For The Game
sanity