### PR TITLE
Fixes the tonal indicator for sign language

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -484,16 +484,18 @@
 	speech_args[SPEECH_MESSAGE] = new_message
 
 	// Cut our last overlay before we replace it
-	if(timeleft(tonal_timerid) > 0 && (question_found || exclamation_found))
+	if(timeleft(tonal_timerid) > 0)
 		remove_tonal_indicator()
 		deltimer(tonal_timerid)
-	if(question_found) // Prioritize questions
+	// Prioritize questions
+	if(question_found)
 		tonal_indicator = mutable_appearance('icons/mob/effects/talk.dmi', "signlang1", TYPING_LAYER)
 		owner.visible_message(span_notice("[owner] lowers [owner.p_their()] eyebrows."))
 	else if(exclamation_found)
 		tonal_indicator = mutable_appearance('icons/mob/effects/talk.dmi', "signlang2", TYPING_LAYER)
 		owner.visible_message(span_notice("[owner] raises [owner.p_their()] eyebrows."))
-	if(!isnull(tonal_indicator) && owner?.client.typing_indicators)
+	// If either an exclamation or question are found
+	if(!isnull(tonal_indicator) && owner.client?.typing_indicators)
 		owner.add_overlay(tonal_indicator)
 		tonal_timerid = addtimer(CALLBACK(src, .proc/remove_tonal_indicator), 2.5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE | TIMER_DELETE_ME)
 	else // If we're not gonna use it, just be sure we get rid of it


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #69229

I originally had it so the indicator would only be forcibly removed whenever a new message with a tone would be sent, so people could more easily see what mood was being conveyed on the little emoji. That didn't turn out to work as well as I thought it would, as it turns out it just caused an error whenever you sent a normal message right after a tonal one.
Now, every message sent will remove the previous tonal indicator
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more walking around with your brows furrowed 24/7, officially curing Resting Bitch Face.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Wallem
fix: Fixes a bug where the tonal indictor for sign language would get stuck on your character for an extended period of time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
