### PR TITLE
Fixes dropped brains having the wrong names if the person was disguised

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -96,7 +96,7 @@
 	C.update_body_parts()
 
 /obj/item/organ/internal/brain/proc/transfer_identity(mob/living/L)
-	name = "[L.name]'s brain"
+	name = "[L.real_name]'s brain"
 	if(brainmob || decoy_override)
 		return
 	if(!L.mind)


### PR DESCRIPTION
Fixes #69828

:cl: ShizCalev
fix: Brains removed from mobs will now show the person's TRUE name instead of their disguise's name.
/:cl:
