### PR TITLE
Illiterate human-like mobs can send shuttles to a random destination + refactors snowflake checks on the shuttle consoles

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -502,13 +502,20 @@ SUBSYSTEM_DEF(shuttle)
 			return DOCKING_IMMOBILIZED
 	return DOCKING_SUCCESS //dock successful
 
-
+/**
+ * Moves a shuttle to a new location
+ *
+ * Arguments:
+ * * shuttle_id - The ID of the shuttle (mobile docking port) to move
+ * * dock_id - The ID of the destination (stationary docking port) to move to
+ * * timed - If true, have the shuttle follow normal spool-up, jump, dock process. If false, immediately move to the new location.
+ */
 /datum/controller/subsystem/shuttle/proc/moveShuttle(shuttle_id, dock_id, timed)
 	var/obj/docking_port/mobile/shuttle_port = getShuttle(shuttle_id)
 	var/obj/docking_port/stationary/docking_target = getDock(dock_id)
 
 	if(!shuttle_port)
-		return DOCKING_BLOCKED
+		return DOCKING_NULL_SOURCE
 	if(timed)
 		if(shuttle_port.request(docking_target))
 			return DOCKING_IMMOBILIZED

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -76,7 +76,6 @@
 	shuttleId = "mining"
 	possible_destinations = "mining_home;mining_away;landing_zone_dock;mining_public"
 	no_destination_swap = TRUE
-	var/static/list/dumb_rev_heads = list()
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/machinery/computer/shuttle/mining/attack_hand(mob/user, list/modifiers)
@@ -88,31 +87,6 @@
 	if (HAS_TRAIT(user, TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION) && !is_station_level(user.z))
 		to_chat(user, span_warning("You get the feeling you shouldn't mess with this."))
 		return
-
-	if(HAS_TRAIT(user, TRAIT_ILLITERATE))
-		to_chat(user, span_warning("You start mashing buttons at random!"))
-		if(do_after(user, 10 SECONDS, target = src))
-			var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)
-			if(no_destination_swap)
-				if(M.mode == SHUTTLE_RECHARGING)
-					to_chat(usr, span_warning("Shuttle engines are not ready for use."))
-					return
-				if(M.mode != SHUTTLE_IDLE)
-					to_chat(usr, span_warning("Shuttle already in transit."))
-					return
-			var/destionation = M.getDockedId() == "mining_home" ? "mining_away" : "mining_home"
-			switch(SSshuttle.moveShuttle(shuttleId, destionation, 1))
-				if(0)
-					say("Shuttle departing. Please stand away from the doors.")
-					log_shuttle("[key_name(usr)] has sent shuttle \"[M]\" towards \"[destionation]\", using [src].")
-					return TRUE
-				if(1)
-					to_chat(usr, span_warning("Invalid shuttle requested."))
-				else
-					to_chat(usr, span_warning("Unable to comply."))
-
-		return
-
 	return ..()
 
 /obj/machinery/computer/shuttle/mining/common

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -141,13 +141,13 @@
 /obj/machinery/computer/shuttle/proc/send_shuttle(dest_id, mob/user)
 	if(!launch_check(user))
 		return SHUTTLE_CONSOLE_ACCESSDENIED
-	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)
-	if(M.launch_status == ENDGAME_LAUNCHED)
+	var/obj/docking_port/mobile/shuttle_port = SSshuttle.getShuttle(shuttleId)
+	if(shuttle_port.launch_status == ENDGAME_LAUNCHED)
 		return SHUTTLE_CONSOLE_ENDGAME
 	if(no_destination_swap)
-		if(M.mode == SHUTTLE_RECHARGING)
+		if(shuttle_port.mode == SHUTTLE_RECHARGING)
 			return SHUTTLE_CONSOLE_RECHARGING
-		if(M.mode != SHUTTLE_IDLE)
+		if(shuttle_port.mode != SHUTTLE_IDLE)
 			return SHUTTLE_CONSOLE_INTRANSIT
 	var/list/dest_list = get_valid_destinations()
 	var/validdest = FALSE

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -48,8 +48,8 @@
 		to_chat(user, span_warning("You start mashing buttons at random!"))
 		if(do_after(user, 10 SECONDS, target = src))
 			var/list/dest_list = get_valid_destinations()
-			if(!dest_list.len)
-				to_chat(user, span_warning("Nothing seems to happen."))
+			if(!dest_list.len) //No valid destinations
+				to_chat(user, span_warning("The console shows a flashing error message, but you can't comprehend it."))
 				return
 			var/list/destination = pick(dest_list)
 			switch (send_shuttle(destination["id"], user))
@@ -149,13 +149,14 @@
 			return SHUTTLE_CONSOLE_RECHARGING
 		if(shuttle_port.mode != SHUTTLE_IDLE)
 			return SHUTTLE_CONSOLE_INTRANSIT
+	//check to see if the dest_id passed from tgui is actually a valid destination
 	var/list/dest_list = get_valid_destinations()
 	var/validdest = FALSE
 	for(var/list/dest_data in dest_list)
 		if(dest_data["id"] == dest_id)
-			validdest = TRUE
+			validdest = TRUE //Found our destination, we can skip ahead now
 			break
-	if(!validdest)
+	if(!validdest) //Didn't find our destination in the list of valid destinations, something bad happening
 		log_admin("[user] attempted to href dock exploit on [src] with target location \"[dest_id]\"")
 		message_admins("[user] just attempted to href dock exploit on [src] with target location \"[dest_id]\"")
 		return SHUTTLE_CONSOLE_DESTINVALID
@@ -177,7 +178,7 @@
 
 	switch(action)
 		if("move")
-			switch (send_shuttle(params["shuttle_id"], usr))
+			switch (send_shuttle(params["shuttle_id"], usr)) //Try to send the shuttle, tell the user what happened
 				if (SHUTTLE_CONSOLE_ACCESSDENIED)
 					to_chat(usr, span_warning("Access denied."))
 					return

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -39,6 +39,9 @@
 	if(!user.can_read(src, check_for_light = FALSE)) //Illiterate mobs which aren't otherwise blocked from using computers will send the shuttle to a random valid destination
 		to_chat(user, span_warning("You start mashing buttons at random!"))
 		if(do_after(user, 10 SECONDS, target = src))
+			if(!allowed(usr))
+				to_chat(usr, span_danger("Access denied."))
+				return
 			var/obj/docking_port/mobile/mobile_docking_port = SSshuttle.getShuttle(shuttleId)
 			if(no_destination_swap)
 				if(mobile_docking_port.mode == SHUTTLE_RECHARGING)

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -29,14 +29,14 @@
 
 /obj/machinery/computer/shuttle/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
-	if(is_station_level(user.z) && user.mind && IS_HEAD_REVOLUTIONARY(user) && !(user.mind in dumb_rev_heads))
+	if(is_station_level(user.z) && user.mind && IS_HEAD_REVOLUTIONARY(user) && !(user.mind in dumb_rev_heads)) //Rev heads will get a one-time warning that they shouldn't leave
 		to_chat(user, span_warning("You get a feeling that leaving the station might be a REALLY dumb idea..."))
 		dumb_rev_heads += user.mind
 		return
-	if (HAS_TRAIT(user, TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION) && !is_station_level(user.z))
+	if (HAS_TRAIT(user, TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION) && !is_station_level(user.z)) //Free golems and other mobs with this trait will not be able to use the shuttle from outside the station Z
 		to_chat(user, span_warning("You get the feeling you shouldn't mess with this."))
 		return
-	if(!user.can_read(src, check_for_light = FALSE))
+	if(!user.can_read(src, check_for_light = FALSE)) //Illiterate mobs which aren't otherwise blocked from using computers will send the shuttle to a random valid destination
 		to_chat(user, span_warning("You start mashing buttons at random!"))
 		if(do_after(user, 10 SECONDS, target = src))
 			var/obj/docking_port/mobile/mobile_docking_port = SSshuttle.getShuttle(shuttleId)
@@ -109,6 +109,10 @@
 /obj/machinery/computer/shuttle/proc/launch_check(mob/user)
 	return TRUE
 
+/**
+ * Returns a list of currently valid destinations for this shuttle console,
+ * taking into account its list of allowed destinations, their current state, and the shuttle's current location
+**/
 /obj/machinery/computer/shuttle/proc/get_valid_destinations()
 	var/list/destination_list = params2list(possible_destinations)
 	var/obj/docking_port/mobile/mobile_docking_port = SSshuttle.getShuttle(shuttleId)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -545,32 +545,37 @@
 /obj/docking_port/mobile/proc/transit_failure()
 	message_admins("Shuttle [src] repeatedly failed to create transit zone.")
 
-//call the shuttle to destination S
-/obj/docking_port/mobile/proc/request(obj/docking_port/stationary/S)
-	if(!check_dock(S))
+/**
+ * Calls the shuttle to the destination port, respecting its ignition and call timers
+ *
+ * Arguments:
+ * * destination_port - Stationary docking port to move the shuttle to
+ */
+/obj/docking_port/mobile/proc/request(obj/docking_port/stationary/destination_port)
+	if(!check_dock(destination_port))
 		testing("check_dock failed on request for [src]")
 		return
 
-	if(mode == SHUTTLE_IGNITING && destination == S)
+	if(mode == SHUTTLE_IGNITING && destination == destination_port)
 		return
 
 	switch(mode)
 		if(SHUTTLE_CALL)
-			if(S == destination)
+			if(destination_port == destination)
 				if(timeLeft(1) < callTime * engine_coeff)
 					setTimer(callTime * engine_coeff)
 			else
-				destination = S
+				destination = destination_port
 				setTimer(callTime * engine_coeff)
 		if(SHUTTLE_RECALL)
-			if(S == destination)
+			if(destination_port == destination)
 				setTimer(callTime * engine_coeff - timeLeft(1))
 			else
-				destination = S
+				destination = destination_port
 				setTimer(callTime * engine_coeff)
 			mode = SHUTTLE_CALL
 		if(SHUTTLE_IDLE, SHUTTLE_IGNITING)
-			destination = S
+			destination = destination_port
 			mode = SHUTTLE_IGNITING
 			setTimer(ignitionTime)
 
@@ -641,6 +646,10 @@
 
 	qdel(src, force=TRUE)
 
+/**
+ * Ghosts and marks as escaped (for greentext purposes) all mobs, then deletes the shuttle.
+ * Used by the Shuttle Manipulator
+ */
 /obj/docking_port/mobile/proc/intoTheSunset()
 	// Loop over mobs
 	for(var/turf/turfs as anything in return_turfs())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Currently there are a bunch of snowflake checks on the mining shuttle console's attack_hand proc, including a check for TRAIT_ILLITERATE which is hardcoded to specific destinations and is causing issues with the public lavaland shuttle in #69641. When I started looking at that issue I realized that this should all probably be done in ui_interact() instead, and also that checking specifically for TRAIT_ILLITERATE when there's a proc for this (can_read) makes little sense. So I moved it all to ui_interact and cleaned up the TRAIT_ILLITERATE check. I also moved some code related to getting the list of destinations of shuttle consoles into a proc which is shared between the ui_data proc and the can_read check.

Now any illiterate mob which isn't otherwise blocked from interacting (such as monkies, ash lizards, and humans with a quirk) which interact with the shuttle console will spend 10 seconds "randomly mashing buttons" before sending it to a random valid destination. This is (essentially) the current behavior for humans with illiteracy and was (per @timothymtorres ) the intended behavior for ash lizards when he added the illiteracy quirk to begin with in #66648. I'm just making it less snowflakey and I guess technically adding it to monkies too since they could also use the shuttle before that PR and it doesn't make sense to exclude them arbitrarily.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Fixes #69641

Generally makes the code more standardized, attack_hand checks are legacy from before ui interact was unified into can_interact and ui_interact. Making the code apply to all shuttle consoles and randomly pick a valid destination makes the more maintainable and less prone to random issues than a hardcoded list.

Also makes the other existing checks more consistent, for example the labor shuttle will now also warn rev heads, block free golems, and let illiterates move them just like the mining and public lavaland shuttles do.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: VexingRaven
fix: The illiteracy quirk will no longer break the mining shuttle
refactor: Refactored some checks on the shuttle console to apply to all consoles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
