### PR TITLE
Fixes Bread Smite Causing Some Fucked Up Shit

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -676,6 +676,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define QUIRK_TRAIT "quirk_trait"
 /// (B)admins only.
 #define ADMIN_TRAIT "admin"
+/// Any traits given through a smite.
+#define SMITE_TRAIT "smite"
 #define CHANGELING_TRAIT "changeling"
 #define CULT_TRAIT "cult"
 #define LICH_TRAIT "lich"

--- a/code/datums/components/itembound.dm
+++ b/code/datums/components/itembound.dm
@@ -5,17 +5,17 @@
 	/// Detect any movement of the container
 	var/datum/movement_detector/move_tracker
 
-/datum/component/itembound/Initialize(container)
+/datum/component/itembound/Initialize(passed_container)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
-	src.container = container
+	container = passed_container
 	move_tracker = new(parent, CALLBACK(src, .proc/verify_containment))
 
 	ADD_TRAIT(parent, TRAIT_INCAPACITATED, SMITE_TRAIT)
 
 /// Ensure that when we move, we still are in the container. If not in the container, remove all the traits.
 /datum/component/itembound/proc/verify_containment()
-	if(container.contains(parent) || !QDELETED(container))
+	if(!QDELETED(container) && container.contains(parent))
 		return
 	REMOVE_TRAIT(parent, TRAIT_INCAPACITATED, SMITE_TRAIT)
 	qdel(src)

--- a/code/datums/components/itembound.dm
+++ b/code/datums/components/itembound.dm
@@ -21,6 +21,7 @@
 	qdel(src)
 
 /datum/component/itembound/Destroy(force, silent)
+	container = null
 	QDEL_NULL(move_tracker)
 	return ..()
 

--- a/code/datums/components/itembound.dm
+++ b/code/datums/components/itembound.dm
@@ -1,29 +1,30 @@
 /// When a movable has this component AND they are in the contents of a container, they will no longer be able to use their hands and be immobilized until they are removed from the container. So far, this is only useful for smites.
 /datum/component/itembound
-	/// The container that the subject is inside of
-	var/atom/movable/container
+	/// Weak reference to the container that the movable is inside of.
+	var/datum/weakref/containerref
 	/// Detect any movement of the container
 	var/datum/movement_detector/move_tracker
 
-/datum/component/itembound/Initialize(passed_container)
+/datum/component/itembound/Initialize(atom/movable/passed_container)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
-	container = passed_container
-	if(QDELETED(container))
+	if(QDELETED(passed_container))
 		return
+	containerref = WEAKREF(passed_container)
 	move_tracker = new(parent, CALLBACK(src, .proc/verify_containment))
 
 	ADD_TRAIT(parent, TRAIT_INCAPACITATED, SMITE_TRAIT)
 
 /// Ensure that when we move, we still are in the container. If not in the container, remove all the traits.
 /datum/component/itembound/proc/verify_containment()
+	var/atom/movable/container = containerref.resolve()
 	if(!QDELETED(container) && container.contains(parent))
 		return
 	REMOVE_TRAIT(parent, TRAIT_INCAPACITATED, SMITE_TRAIT)
 	qdel(src)
 
 /datum/component/itembound/Destroy(force, silent)
-	container = null
+	containerref = null
 	QDEL_NULL(move_tracker)
 	return ..()
 

--- a/code/datums/components/itembound.dm
+++ b/code/datums/components/itembound.dm
@@ -1,0 +1,30 @@
+/// When a movable has this component AND they are in the contents of a container, they will no longer be able to use their hands and be immobilized until they are removed from the container. So far, this is only useful for smites.
+/datum/component/itembound
+	/// The movable that is inside to the container
+	var/atom/movable/subject
+	/// The container that the subject is inside of
+	var/atom/movable/container
+	/// Detect any movement of the container
+	var/datum/movement_detector/move_tracker
+	/// Should we be actively preve
+
+/datum/component/itembound/Initialize(tomb)
+	if(!ismovable(parent))
+		return COMPONENT_INCOMPATIBLE
+	subject = parent
+	container = tomb
+	move_tracker = new(parent,CALLBACK(src,.proc/verify_containment))
+
+	ADD_TRAIT(subject, TRAIT_HANDS_BLOCKED, SMITE_TRAIT)
+
+/// Ensure that when we move, we still are in the container. If not in the container, remove all the signals.
+/datum/component/itembound/proc/verify_containment()
+	if(container.contains(subject))
+		return
+	REMOVE_TRAIT(subject, TRAIT_HANDS_BLOCKED, SMITE_TRAIT)
+	QDEL_NULL(move_tracker)
+
+/datum/component/itembound/Destroy(force, silent)
+	QDEL_NULL(move_tracker)
+	. = ..()
+

--- a/code/datums/components/itembound.dm
+++ b/code/datums/components/itembound.dm
@@ -6,7 +6,6 @@
 	var/atom/movable/container
 	/// Detect any movement of the container
 	var/datum/movement_detector/move_tracker
-	/// Should we be actively preve
 
 /datum/component/itembound/Initialize(tomb)
 	if(!ismovable(parent))

--- a/code/datums/components/itembound.dm
+++ b/code/datums/components/itembound.dm
@@ -9,6 +9,8 @@
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
 	container = passed_container
+	if(QDELETED(container))
+		return
 	move_tracker = new(parent, CALLBACK(src, .proc/verify_containment))
 
 	ADD_TRAIT(parent, TRAIT_INCAPACITATED, SMITE_TRAIT)

--- a/code/datums/components/itembound.dm
+++ b/code/datums/components/itembound.dm
@@ -1,7 +1,5 @@
 /// When a movable has this component AND they are in the contents of a container, they will no longer be able to use their hands and be immobilized until they are removed from the container. So far, this is only useful for smites.
 /datum/component/itembound
-	/// The movable that is inside to the container
-	var/atom/movable/subject
 	/// The container that the subject is inside of
 	var/atom/movable/container
 	/// Detect any movement of the container
@@ -10,18 +8,17 @@
 /datum/component/itembound/Initialize(tomb)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
-	subject = parent
 	container = tomb
 	move_tracker = new(parent,CALLBACK(src,.proc/verify_containment))
 
-	ADD_TRAIT(subject, TRAIT_HANDS_BLOCKED, SMITE_TRAIT)
+	ADD_TRAIT(parent, TRAIT_INCAPACITATED, SMITE_TRAIT)
 
 /// Ensure that when we move, we still are in the container. If not in the container, remove all the signals.
 /datum/component/itembound/proc/verify_containment()
-	if(container.contains(subject))
+	if(container.contains(parent))
 		return
-	REMOVE_TRAIT(subject, TRAIT_HANDS_BLOCKED, SMITE_TRAIT)
-	QDEL_NULL(move_tracker)
+	REMOVE_TRAIT(parent, TRAIT_INCAPACITATED, SMITE_TRAIT)
+	qdel(src)
 
 /datum/component/itembound/Destroy(force, silent)
 	QDEL_NULL(move_tracker)

--- a/code/datums/components/itembound.dm
+++ b/code/datums/components/itembound.dm
@@ -5,22 +5,22 @@
 	/// Detect any movement of the container
 	var/datum/movement_detector/move_tracker
 
-/datum/component/itembound/Initialize(tomb)
+/datum/component/itembound/Initialize(container)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
-	container = tomb
-	move_tracker = new(parent,CALLBACK(src,.proc/verify_containment))
+	src.container = container
+	move_tracker = new(parent, CALLBACK(src, .proc/verify_containment))
 
 	ADD_TRAIT(parent, TRAIT_INCAPACITATED, SMITE_TRAIT)
 
-/// Ensure that when we move, we still are in the container. If not in the container, remove all the signals.
+/// Ensure that when we move, we still are in the container. If not in the container, remove all the traits.
 /datum/component/itembound/proc/verify_containment()
-	if(container.contains(parent))
+	if(container.contains(parent) || !QDELETED(container))
 		return
 	REMOVE_TRAIT(parent, TRAIT_INCAPACITATED, SMITE_TRAIT)
 	qdel(src)
 
 /datum/component/itembound/Destroy(force, silent)
 	QDEL_NULL(move_tracker)
-	. = ..()
+	return ..()
 

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -40,6 +40,10 @@
 /obj/item/food/bread/plain/MakeProcessable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/breadslice/plain, 5, 3 SECONDS, table_required = TRUE)
 
+// special subtype we use for the "Bread" Admin Smite (or the breadify proc)
+/obj/item/food/bread/plain/smite
+	desc = "If you hold it up to your ear, you can hear the screams of the damned."
+
 /obj/item/food/breadslice/plain
 	name = "bread slice"
 	desc = "A slice of home."

--- a/code/modules/admin/smites/bread.dm
+++ b/code/modules/admin/smites/bread.dm
@@ -9,6 +9,6 @@
 	var/mutable_appearance/bread_appearance = mutable_appearance('icons/obj/food/burgerbread.dmi', "bread")
 	var/mutable_appearance/transform_scanline = mutable_appearance('icons/effects/effects.dmi', "transform_effect")
 	target.transformation_animation(bread_appearance,time = BREADIFY_TIME, transform_overlay=transform_scanline, reset_after=TRUE)
-	addtimer(CALLBACK(GLOBAL_PROC, .proc/breadify, target, TRUE), BREADIFY_TIME)
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/breadify, target), BREADIFY_TIME)
 
 #undef BREADIFY_TIME

--- a/code/modules/admin/smites/bread.dm
+++ b/code/modules/admin/smites/bread.dm
@@ -9,6 +9,6 @@
 	var/mutable_appearance/bread_appearance = mutable_appearance('icons/obj/food/burgerbread.dmi', "bread")
 	var/mutable_appearance/transform_scanline = mutable_appearance('icons/effects/effects.dmi', "transform_effect")
 	target.transformation_animation(bread_appearance,time = BREADIFY_TIME, transform_overlay=transform_scanline, reset_after=TRUE)
-	addtimer(CALLBACK(GLOBAL_PROC, .proc/breadify, target), BREADIFY_TIME)
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/breadify, target, TRUE), BREADIFY_TIME)
 
 #undef BREADIFY_TIME

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -217,9 +217,18 @@
 		return
 	smite.effect(src, target)
 
-/proc/breadify(atom/movable/target)
+/**
+ *  "Turns" people into bread. Really, we just add them to the contents of the bread food item.
+ *
+ * * smite - Are we calling this proc from the smite verb (on a mob)? If so, we need to do some extra stuff in order to ensure the mob can't engage in cursed activity while they are still stuck in the bread (such as holding themself).
+ */
+/proc/breadify(atom/movable/target, smite = FALSE)
 	var/obj/item/food/bread/plain/bread = new(get_turf(target))
 	target.forceMove(bread)
+	if(smite)
+		if(!ismob(target)) // sanity check
+			return
+		ADD_TRAIT(target, TRAIT_HANDS_BLOCKED, SMITE_TRAIT)
 
 /**
  * firing_squad is a proc for the :B:erforate smite to shoot each individual bullet at them, so that we can add actual delays without sleep() nonsense

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -219,9 +219,9 @@
 
 ///"Turns" people into bread. Really, we just add them to the contents of the bread food item.
 /proc/breadify(atom/movable/target, smite = FALSE)
-	var/obj/item/food/bread/plain/bread = new(get_turf(target))
-	target.forceMove(bread)
-	ADD_TRAIT(target, TRAIT_HANDS_BLOCKED, SMITE_TRAIT)
+	var/obj/item/food/bread/plain/smite/tomb = new(get_turf(target))
+	target.forceMove(tomb)
+	target.AddComponent(/datum/component/itembound, tomb)
 
 /**
  * firing_squad is a proc for the :B:erforate smite to shoot each individual bullet at them, so that we can add actual delays without sleep() nonsense

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -217,18 +217,13 @@
 		return
 	smite.effect(src, target)
 
-/**
- *  "Turns" people into bread. Really, we just add them to the contents of the bread food item.
- *
- * * smite - Are we calling this proc from the smite verb (on a mob)? If so, we need to do some extra stuff in order to ensure the mob can't engage in cursed activity while they are still stuck in the bread (such as holding themself).
- */
+///"Turns" people into bread. Really, we just add them to the contents of the bread food item.
 /proc/breadify(atom/movable/target, smite = FALSE)
 	var/obj/item/food/bread/plain/bread = new(get_turf(target))
 	target.forceMove(bread)
-	if(smite)
-		if(!ismob(target)) // sanity check
-			return
-		ADD_TRAIT(target, TRAIT_HANDS_BLOCKED, SMITE_TRAIT)
+	if(!ismob(target)) // sanity check
+		return
+	ADD_TRAIT(target, TRAIT_HANDS_BLOCKED, SMITE_TRAIT)
 
 /**
  * firing_squad is a proc for the :B:erforate smite to shoot each individual bullet at them, so that we can add actual delays without sleep() nonsense

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -218,7 +218,7 @@
 	smite.effect(src, target)
 
 ///"Turns" people into bread. Really, we just add them to the contents of the bread food item.
-/proc/breadify(atom/movable/target, smite = FALSE)
+/proc/breadify(atom/movable/target)
 	var/obj/item/food/bread/plain/smite/tomb = new(get_turf(target))
 	target.forceMove(tomb)
 	target.AddComponent(/datum/component/itembound, tomb)

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -221,8 +221,6 @@
 /proc/breadify(atom/movable/target, smite = FALSE)
 	var/obj/item/food/bread/plain/bread = new(get_turf(target))
 	target.forceMove(bread)
-	if(!ismob(target)) // sanity check
-		return
 	ADD_TRAIT(target, TRAIT_HANDS_BLOCKED, SMITE_TRAIT)
 
 /**

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -811,6 +811,7 @@
 #include "code\datums\components\igniter.dm"
 #include "code\datums\components\infective.dm"
 #include "code\datums\components\irradiated.dm"
+#include "code\datums\components\itembound.dm"
 #include "code\datums\components\itempicky.dm"
 #include "code\datums\components\jetpack.dm"
 #include "code\datums\components\jousting.dm"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

So basically, when you had the bread smite done on you, you were _just_ added to the contents of the bread. Nothing more. That means that you could pick it up. You couldn't add it to your bag (it would always return back into your hand(?)), but it would create some weird oddities that was just cursed in general. Let's make it so you can't hold the container that you are contained within by giving you HANDS_BLOCKED (if you're a mob since i don't wanna bother with trait buildup bullshit, because apparently you can call Breadify on all atom movables i believe?).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #69809.

This was just fucked up.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: When you are smited into an enbreaded tomb, you can no longer pick up said tomb.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
