### PR TITLE
Unit tests say signal gets the correct list passed with it

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -232,6 +232,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		spans |= SPAN_SINGING
 
 	// Leaving this here so that anything that handles speech this way will be able to have spans affecting it and all that.
+	// Make sure the arglist is passed exactly, don't pass a copy of it or something - say signal handlers will modify some of the parameters.
 	var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args, message_range)
 	if (sigreturn & COMPONENT_UPPERCASE_SPEECH)
 		message = uppertext(message)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -231,8 +231,14 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		message = "[randomnote] [message] [randomnote]"
 		spans |= SPAN_SINGING
 
+	#ifdef UNIT_TESTS
+	// Saves a ref() to our arglist specifically.
+	// We do this because we need to check that COMSIG_MOB_SAY is getting EXACTLY this list.
+	last_say_args_ref = REF(args)
+	#endif
+
 	// Leaving this here so that anything that handles speech this way will be able to have spans affecting it and all that.
-	// Make sure the arglist is passed exactly, don't pass a copy of it or something - say signal handlers will modify some of the parameters.
+	// Make sure the arglist is passed exactly - don't pass a copy of it. Say signal handlers will modify some of the parameters.
 	var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args, message_range)
 	if (sigreturn & COMPONENT_UPPERCASE_SPEECH)
 		message = uppertext(message)

--- a/code/modules/unit_tests/say.dm
+++ b/code/modules/unit_tests/say.dm
@@ -25,31 +25,21 @@
 /// Test to verify COMSIG_MOB_SAY is sent the exact same list as the message args, as they're operated on
 /datum/unit_test/say_signal
 	var/test_message = "Make sure the say signal gets the arglist say is past, no copies!"
-	var/arg_list_ref
-	var/list/arglist_full
 
 /datum/unit_test/say_signal/Run()
-	var/mob/living/say_dummy/dummy = allocate(/mob/living/say_dummy)
-	dummy.linked_test = src
+	var/mob/living/dummy = allocate(/mob/living)
 
 	RegisterSignal(dummy, COMSIG_MOB_SAY, .proc/check_say)
 	dummy.say(test_message)
 
-/datum/unit_test/say_signal/proc/check_say(datum/source, list/say_args)
+/datum/unit_test/say_signal/proc/check_say(mob/living/source, list/say_args)
 	SIGNAL_HANDLER
 
 	TEST_ASSERT_EQUAL(say_args[SPEECH_MESSAGE], test_message, "Say signal's first arg of the arglist wasn't the expected message.")
 
-	TEST_ASSERT_EQUAL(REF(say_args), arg_list_ref, "Say signal didn't get the argslist of say as a reference. \
+	TEST_ASSERT_EQUAL(REF(say_args), source.last_say_args_ref, "Say signal didn't get the argslist of say as a reference. \
 		This is required for the signal to function in most places - do not create a new instance of a list when passing it in to the signal.")
 
-/mob/living/say_dummy
-	var/datum/unit_test/say_signal/linked_test
-
-/mob/living/say_dummy/Destroy()
-	linked_test = null
-	return ..()
-
-/mob/living/say_dummy/say(message, bubble_type, list/spans, sanitize, datum/language/language, ignore_spam, forced, filterproof)
-	linked_test.arg_list_ref = REF(args)
-	return ..()
+// For the above test to track the last use of say's message args.
+/mob/living
+	var/last_say_args_ref

--- a/code/modules/unit_tests/say.dm
+++ b/code/modules/unit_tests/say.dm
@@ -21,3 +21,35 @@
 
 	TEST_ASSERT(!expected_mods.len,
 		"Some message mods were expected, but were not returned by get_message_mods: [json_encode(expected_mods)]. Message: [message]")
+
+/// Test to verify COMSIG_MOB_SAY is sent the exact same list as the message args, as they're operated on
+/datum/unit_test/say_signal
+	var/test_message = "Make sure the say signal gets the arglist say is past, no copies!"
+	var/arg_list_ref
+	var/list/arglist_full
+
+/datum/unit_test/say_signal/Run()
+	var/mob/living/say_dummy/dummy = allocate(/mob/living/say_dummy)
+	dummy.linked_test = src
+
+	RegisterSignal(dummy, COMSIG_MOB_SAY, .proc/check_say)
+	dummy.say(test_message)
+
+/datum/unit_test/say_signal/proc/check_say(datum/source, list/say_args)
+	SIGNAL_HANDLER
+
+	TEST_ASSERT_EQUAL(say_args[SPEECH_MESSAGE], test_message, "Say signal's first arg of the arglist wasn't the expected message.")
+
+	TEST_ASSERT_EQUAL(REF(say_args), arg_list_ref, "Say signal didn't get the argslist of say as a reference. \
+		This is required for the signal to function in most places - do not create a new instance of a list when passing it in to the signal.")
+
+/mob/living/say_dummy
+	var/datum/unit_test/say_signal/linked_test
+
+/mob/living/say_dummy/Destroy()
+	linked_test = null
+	return ..()
+
+/mob/living/say_dummy/say(message, bubble_type, list/spans, sanitize, datum/language/language, ignore_spam, forced, filterproof)
+	linked_test.arg_list_ref = REF(args)
+	return ..()

--- a/code/modules/unit_tests/say.dm
+++ b/code/modules/unit_tests/say.dm
@@ -24,18 +24,15 @@
 
 /// Test to verify COMSIG_MOB_SAY is sent the exact same list as the message args, as they're operated on
 /datum/unit_test/say_signal
-	var/test_message = "Make sure the say signal gets the arglist say is past, no copies!"
 
 /datum/unit_test/say_signal/Run()
 	var/mob/living/dummy = allocate(/mob/living)
 
 	RegisterSignal(dummy, COMSIG_MOB_SAY, .proc/check_say)
-	dummy.say(test_message)
+	dummy.say("Make sure the say signal gets the arglist say is past, no copies!")
 
 /datum/unit_test/say_signal/proc/check_say(mob/living/source, list/say_args)
 	SIGNAL_HANDLER
-
-	TEST_ASSERT_EQUAL(say_args[SPEECH_MESSAGE], test_message, "Say signal's first arg of the arglist wasn't the expected message.")
 
 	TEST_ASSERT_EQUAL(REF(say_args), source.last_say_args_ref, "Say signal didn't get the argslist of say as a reference. \
 		This is required for the signal to function in most places - do not create a new instance of a list when passing it in to the signal.")


### PR DESCRIPTION
## About The Pull Request

#63939 broke this once, #69844 almost broke this again, so I decided to unit test this

`COMSIG_MOB_SAY` signal handlers override the arglist it is passed to change parameters of the say. Such as changing the message (adding a stutter or capslocking), changing language, adding spans, etc. 

This means it needs to get the arglist, exactly, by reference - not a copy of it or anything, otherwise the overriding parameter aspect won't work and a lot of say stuff breaks 

In the meanwhile I learned some byond knowledge, in that every child call of a proc-call has its own arglist, which is its own reference. So, attempting to use a dummy mob instead of doing it on the `/living` level results in two different refs. 

## Why It's Good For The Game

Making sure message modifiers work is pretty neat

