### PR TITLE
Replaces two airlocks on a Mafia Snow arena with glass airlocks

### DIFF
--- a/_maps/map_files/Mafia/mafia_snow.dmm
+++ b/_maps/map_files/Mafia/mafia_snow.dmm
@@ -100,10 +100,6 @@
 /turf/open/lava/plasma/mafia,
 /area/centcom/mafia)
 "x" = (
-/obj/machinery/door/airlock/external/ruin{
-	max_integrity = 9999;
-	opacity = 0
-	},
 /obj/machinery/door/poddoor/preopen{
 	desc = "When it's time to sleep, the lights will go out. Remember - no one in space can hear you scream.";
 	id = "mafia";
@@ -111,6 +107,9 @@
 	name = "Station Night Shutters"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass/ruin{
+	max_integrity = 9999
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/mafia)
 "y" = (
@@ -122,9 +121,6 @@
 /turf/open/lava/plasma/mafia,
 /area/centcom/mafia)
 "A" = (
-/obj/machinery/door/airlock/external/ruin{
-	max_integrity = 9999
-	},
 /obj/machinery/door/poddoor/preopen{
 	desc = "When it's time to sleep, the lights will go out. Remember - no one in space can hear you scream.";
 	id = "mafia";
@@ -132,6 +128,9 @@
 	name = "Station Night Shutters"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass/ruin{
+	max_integrity = 9999
+	},
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "B" = (


### PR DESCRIPTION
## About The Pull Request
On the tin.
### Before
Can not see the opposing player

![image](https://user-images.githubusercontent.com/75863639/189696683-76c64e37-47fb-413d-bd31-9eec01e27721.png)

### After
Can see the opposing player

![image](https://user-images.githubusercontent.com/75863639/189696819-6824cb2a-e402-433f-9f31-1356ac0e9594.png)


## Why It's Good For The Game
It's usually good to see every player in a mafia game, I think.

## Changelog
:cl:
fix: Mafia Snow map now has glass external airlocks for the two top players, allowing them to see the players directly oppoiste of them
/:cl:
