### PR TITLE
Adds the option to throw a random meteor in admin_setup for stray_meteor event

### DIFF
--- a/code/modules/events/stray_meteor.dm
+++ b/code/modules/events/stray_meteor.dm
@@ -13,11 +13,10 @@
 /datum/round_event_control/stray_meteor/admin_setup()
 	if(!check_rights(R_FUN))
 		return
-
-	var/list/meteor_list = list()
-	meteor_list += subtypesof(/obj/effect/meteor)
-	chosen_meteor = tgui_input_list(usr, "Too lazy for buildmode?","Throw meteor", meteor_list)
-
+	if(tgui_alert(usr, "Throw a random meteor?", "Plasuable Deniability!", list("Yes", "No")) == "Yes")
+		var/list/meteor_list = list()
+		meteor_list += subtypesof(/obj/effect/meteor)
+		chosen_meteor = tgui_input_list(usr, "Too lazy for buildmode?","Throw meteor", meteor_list)
 
 /datum/round_event/stray_meteor
 	announce_when = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I had meant to make this an option but I sorta lost sight of it while trying to get the admin setup functionality to work at all. Oops.

I probably should not get GBP for this because this was already meant to be in the original PR.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

By letting the admin pick the type of meteor, they're assuming far more responsibility for the consequences than if they just wanted to trigger the event and leave it at that. Less responsibility, more !!Fun!!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Stray Meteor trigger now gives the option to throw a random meteor instead of selecting a specific one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
