### PR TITLE
Fixes custom material examine runtime

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -694,7 +694,7 @@
 
 	if(custom_materials)
 		var/list/materials_list = list()
-		for(var/custom_material as anything in custom_materials)
+		for(var/custom_material in custom_materials)
 			var/datum/material/current_material = GET_MATERIAL_REF(custom_material)
 			materials_list += "[current_material.name]"
 		. += "<u>It is made out of [english_list(materials_list)]</u>."

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -694,9 +694,11 @@
 
 	if(custom_materials)
 		var/list/materials_list = list()
-		for(var/datum/material/current_material as anything in custom_materials)
+		for(var/custom_material as anything in custom_materials)
+			var/datum/material/current_material = GET_MATERIAL_REF(custom_material)
 			materials_list += "[current_material.name]"
 		. += "<u>It is made out of [english_list(materials_list)]</u>."
+
 	if(reagents)
 		if(reagents.flags & TRANSPARENT)
 			. += "It contains:"

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -334,7 +334,7 @@
 /obj/structure/table/greyscale/set_custom_materials(list/materials, multiplier)
 	. = ..()
 	var/list/materials_list = list()
-	for(var/custom_material as anything in custom_materials)
+	for(var/custom_material in custom_materials)
 		var/datum/material/current_material = GET_MATERIAL_REF(custom_material)
 		materials_list += "[current_material.name]"
 	desc = "A square [(materials_list.len > 1) ? "amalgamation" : "piece"] of [english_list(materials_list)] on four legs. It can not move."

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -335,7 +335,7 @@
 	. = ..()
 	var/list/materials_list = list()
 	for(var/custom_material as anything in custom_materials)
-			var/datum/material/current_material = GET_MATERIAL_REF(custom_material)
+		var/datum/material/current_material = GET_MATERIAL_REF(custom_material)
 		materials_list += "[current_material.name]"
 	desc = "A square [(materials_list.len > 1) ? "amalgamation" : "piece"] of [english_list(materials_list)] on four legs. It can not move."
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -334,7 +334,8 @@
 /obj/structure/table/greyscale/set_custom_materials(list/materials, multiplier)
 	. = ..()
 	var/list/materials_list = list()
-	for(var/datum/material/current_material as anything in custom_materials)
+	for(var/custom_material as anything in custom_materials)
+			var/datum/material/current_material = GET_MATERIAL_REF(custom_material)
 		materials_list += "[current_material.name]"
 	desc = "A square [(materials_list.len > 1) ? "amalgamation" : "piece"] of [english_list(materials_list)] on four legs. It can not move."
 


### PR DESCRIPTION
old
![image](https://user-images.githubusercontent.com/6209658/189785892-d32410c0-9f1a-4341-9ba2-ce08410d3687.png)
fixed
![image](https://user-images.githubusercontent.com/6209658/189785916-7e700acd-e0c2-4b66-be87-64c04f0b93c7.png)


:cl: ShizCalev
fix: Fixed examine messages stating what materials something is made out of not working properly.
/:cl:
