### PR TITLE
Fixes bileworms being unable to act

### DIFF
--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/try_mob_ability.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/try_mob_ability.dm
@@ -4,7 +4,7 @@
 
 	var/datum/action/cooldown/mob_cooldown/ability = controller.blackboard[ability_key]
 	var/datum/weakref/weak_target = controller.blackboard[target_key]
-	var/mob/living/target = weak_target.resolve()
+	var/mob/living/target = weak_target?.resolve()
 	if(!ability || QDELETED(target))
 		finish_action(controller, FALSE, ability_key, target_key)
 	var/mob/pawn = controller.pawn
@@ -14,7 +14,7 @@
 /datum/ai_behavior/try_mob_ability/finish_action(datum/ai_controller/controller, succeeded, ability_key, target_key)
 	. = ..()
 	var/datum/weakref/weak_target = controller.blackboard[target_key]
-	var/mob/living/target = weak_target.resolve()
+	var/mob/living/target = weak_target?.resolve()
 	if(QDELETED(target) || target.stat >= UNCONSCIOUS)
 		controller.blackboard[target_key] = null
 

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/try_mob_ability.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/try_mob_ability.dm
@@ -5,7 +5,7 @@
 	var/datum/action/cooldown/mob_cooldown/ability = controller.blackboard[ability_key]
 	var/datum/weakref/weak_target = controller.blackboard[target_key]
 	var/mob/living/target = weak_target.resolve()
-	if(!ability || !target)
+	if(!ability || QDELETED(target))
 		finish_action(controller, FALSE, ability_key, target_key)
 	var/mob/pawn = controller.pawn
 	var/result = ability.InterceptClickOn(pawn, null, target)

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/try_mob_ability.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/try_mob_ability.dm
@@ -3,7 +3,8 @@
 /datum/ai_behavior/try_mob_ability/perform(delta_time, datum/ai_controller/controller, ability_key, target_key)
 
 	var/datum/action/cooldown/mob_cooldown/ability = controller.blackboard[ability_key]
-	var/mob/living/target = controller.blackboard[target_key]
+	var/datum/weakref/weak_target = controller.blackboard[target_key]
+	var/mob/living/target = weak_target.resolve()
 	if(!ability || !target)
 		finish_action(controller, FALSE, ability_key, target_key)
 	var/mob/pawn = controller.pawn
@@ -12,7 +13,8 @@
 
 /datum/ai_behavior/try_mob_ability/finish_action(datum/ai_controller/controller, succeeded, ability_key, target_key)
 	. = ..()
-	var/mob/living/target = controller.blackboard[target_key]
+	var/datum/weakref/weak_target = controller.blackboard[target_key]
+	var/mob/living/target = weak_target.resolve()
 	if(!target || QDELETED(target) || target.stat >= UNCONSCIOUS)
 		controller.blackboard[target_key] = null
 

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/try_mob_ability.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/try_mob_ability.dm
@@ -15,7 +15,7 @@
 	. = ..()
 	var/datum/weakref/weak_target = controller.blackboard[target_key]
 	var/mob/living/target = weak_target.resolve()
-	if(!target || QDELETED(target) || target.stat >= UNCONSCIOUS)
+	if(QDELETED(target) || target.stat >= UNCONSCIOUS)
 		controller.blackboard[target_key] = null
 
 ///subtype of normal mob ability that moves the target into a special execution targetting.

--- a/code/modules/mob/living/basic/lavaland/bileworm/bileworm_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/bileworm_ai.dm
@@ -15,7 +15,7 @@
 
 	var/datum/weakref/weak_target = controller.blackboard[BB_BASIC_MOB_CURRENT_TARGET]
 	var/mob/living/target = weak_target.resolve()
-	if(!target || QDELETED(target))
+	if(QDELETED(target))
 		return
 
 	var/datum/action/cooldown/mob_cooldown/resurface = controller.blackboard[BB_BILEWORM_RESURFACE]
@@ -34,7 +34,7 @@
 
 	var/datum/weakref/weak_target = controller.blackboard[BB_BASIC_MOB_EXECUTION_TARGET]
 	var/mob/living/target = weak_target.resolve()
-	if(!target || QDELETED(target) || target.stat < UNCONSCIOUS)
+	if(QDELETED(target) || target.stat < UNCONSCIOUS)
 		return
 
 	controller.queue_behavior(/datum/ai_behavior/try_mob_ability, BB_BILEWORM_DEVOUR, BB_BASIC_MOB_EXECUTION_TARGET)

--- a/code/modules/mob/living/basic/lavaland/bileworm/bileworm_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/bileworm_ai.dm
@@ -14,7 +14,7 @@
 /datum/ai_planning_subtree/bileworm_attack/SelectBehaviors(datum/ai_controller/controller, delta_time)
 
 	var/datum/weakref/weak_target = controller.blackboard[BB_BASIC_MOB_CURRENT_TARGET]
-	var/mob/living/target = weak_target.resolve()
+	var/mob/living/target = weak_target?.resolve()
 	if(QDELETED(target))
 		return
 
@@ -33,7 +33,7 @@
 /datum/ai_planning_subtree/bileworm_execute/SelectBehaviors(datum/ai_controller/controller, delta_time)
 
 	var/datum/weakref/weak_target = controller.blackboard[BB_BASIC_MOB_EXECUTION_TARGET]
-	var/mob/living/target = weak_target.resolve()
+	var/mob/living/target = weak_target?.resolve()
 	if(QDELETED(target) || target.stat < UNCONSCIOUS)
 		return
 

--- a/code/modules/mob/living/basic/lavaland/bileworm/bileworm_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/bileworm_ai.dm
@@ -13,7 +13,8 @@
 
 /datum/ai_planning_subtree/bileworm_attack/SelectBehaviors(datum/ai_controller/controller, delta_time)
 
-	var/atom/target = controller.blackboard[BB_BASIC_MOB_CURRENT_TARGET]
+	var/datum/weakref/weak_target = controller.blackboard[BB_BASIC_MOB_CURRENT_TARGET]
+	var/mob/living/target = weak_target.resolve()
 	if(!target || QDELETED(target))
 		return
 
@@ -31,7 +32,8 @@
 
 /datum/ai_planning_subtree/bileworm_execute/SelectBehaviors(datum/ai_controller/controller, delta_time)
 
-	var/mob/living/target = controller.blackboard[BB_BASIC_MOB_EXECUTION_TARGET]
+	var/datum/weakref/weak_target = controller.blackboard[BB_BASIC_MOB_EXECUTION_TARGET]
+	var/mob/living/target = weak_target.resolve()
 	if(!target || QDELETED(target) || target.stat < UNCONSCIOUS)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an issue where bileworms couldn't do anything as their code assumed their target would be a direct reference to the mob, but #69253 changed basic mob AI to use weakrefs instead and didn't update the bileworm code to handle this.

Fixes #69608

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed bileworms being unable to act.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
