### PR TITLE
Fixes runtime when removing beakers from a chem grenade

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -145,7 +145,7 @@
 			beaker.forceMove(drop_location())
 			if(!beaker.reagents)
 				continue
-			var/reagent_list = pretty_string_from_reagent_list(beaker.reagents)
+			var/reagent_list = pretty_string_from_reagent_list(beaker.reagents.reagent_list)
 			user.log_message("removed [beaker] ([reagent_list]) from [src]", LOG_GAME)
 		beakers = list()
 		to_chat(user, span_notice("You open the [initial(name)] assembly and remove the payload."))


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a runtime when removing beakers from a chem grenade with a wrench.
/:cl:
