### PR TITLE
Slightly rewords customizable reagent holder examine message

### DIFF
--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -96,7 +96,7 @@
 					if (i == ingredients.len - 1)
 						ending = ", and "
 			ingredients_listed += "\a [ingredient.name][ending]"
-	examine_list += "It contains [LAZYLEN(ingredients) ? "[ingredients_listed]" : " no ingredients, "]making a [custom_adjective()]-sized [initial(atom_parent.name)]."
+	examine_list += "It [LAZYLEN(ingredients) ? "contains [ingredients_listed]making a [custom_adjective()]-sized [initial(atom_parent.name)]" : "does not contain any ingredients"]."
 
 
 ///Handles when the customizable food is attacked by something.


### PR DESCRIPTION
old
![image](https://user-images.githubusercontent.com/6209658/189808089-6ba00072-f3e4-47d4-9cb8-a185df46c4f2.png)
```
it contains nothing
it contains  no ingredients
it is a small sized bowl
it is a normal sized item
```

new
![image](https://user-images.githubusercontent.com/6209658/189807980-c7ab38ca-7660-4900-b797-7fb195f2dfb2.png)

:cl: ShizCalev
spellcheck: Slightly reworded the examine text on bowls / customizable reagent containers.
/:cl:
