### PR TITLE
You can now splash juice cartons

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -46,11 +46,11 @@
 	if(!target || !isliving(target))
 		return ..()
 
+	if(!isGlass)
+		return ..()
+
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("You don't want to harm [target]!"))
-		return FALSE
-
-	if(!isGlass)
 		return FALSE
 
 	var/mob/living/living_target = target
@@ -135,7 +135,7 @@
 /// Takes the broken bottle to mimic, and the thing the bottle was broken agaisnt as args
 /obj/item/broken_bottle/proc/mimic_broken(obj/item/reagent_containers/cup/glass/to_mimic, atom/target)
 	icon_state = to_mimic.icon_state
-	var/icon/drink_icon = new('icons/obj/drinks.dmi', icon_state)
+	var/icon/drink_icon = new(to_mimic.icon, icon_state)
 	drink_icon.Blend(broken_outline, ICON_OVERLAY, rand(5), 1)
 	drink_icon.SwapColor(rgb(255, 0, 220, 255), rgb(0, 0, 0, 0))
 	icon = drink_icon


### PR DESCRIPTION
## About The Pull Request

Juice cartons now call parent instead of early returning in try_splash, letting them splash their contents like any regular glass.
I also de-hardcoded the icon for broken bottle's mimic_broken, because I hate hardcoded icons.

## Why It's Good For The Game

It's nice that cartons have a use for right-click instead of being the worst of both worlds.
Also a small minor help for downstream bar coders, hopefully.

## Changelog

:cl:
qol: Juice cartons now splash their reagents with right-click.
/:cl:
