### PR TITLE
Fixes Space Carp DNA objective not starting a carp migration

### DIFF
--- a/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
@@ -11,8 +11,8 @@
 
 /datum/traitor_objective/final/space_dragon/on_objective_taken(mob/user)
 	. = ..()
-	var/datum/round_event/carp_migration/carp_event = locate(/datum/round_event_control/carp_migration) in SSevents.control
-	carp_event.start()
+	var/datum/round_event_control/carp_migration/carp_event = locate(/datum/round_event_control/carp_migration) in SSevents.control
+	carp_event.runEvent()
 
 /datum/traitor_objective/final/space_dragon/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	if(!can_take_final_objective())


### PR DESCRIPTION
`[13:57:02] Runtime in space_dragon.dm, line 15: undefined proc or verb /datum/round_event_control/carp_migration/start(). `

:cl: ShizCalev
fix: Fixed the Space Carp DNA harvest traitor objective not starting a carp migration when taken
/:cl:

