### PR TITLE
sanity check for ai_tracking after tgui input

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -73,7 +73,7 @@
 
 	var/datum/weakref/target = (isnull(track.humans[target_name]) ? track.others[target_name] : track.humans[target_name])
 
-	ai_actual_track(target.resolve())
+	ai_actual_track(target?.resolve())
 
 /mob/living/silicon/ai/proc/ai_actual_track(mob/living/target)
 	if(!istype(target))


### PR DESCRIPTION
can no longer be in the list if the input window was kept open for a while

:cl: ShizCalev
fix: Fixed a minor runtime when trying to track a human that's is no longer trackable.
/:cl: