### PR TITLE
Change infectious zombies to be illitearate

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -319,6 +319,12 @@
 	else
 		setOrganDamage(BRAIN_DAMAGE_DEATH)
 
+/obj/item/organ/internal/brain/zombie
+	name = "zombie brain"
+	desc = "This glob of green mass can't have much intelligence inside it."
+	icon_state = "brain-x"
+	organ_traits = list(TRAIT_CAN_STRIP, TRAIT_PRIMITIVE)
+
 /obj/item/organ/internal/brain/alien
 	name = "alien brain"
 	desc = "We barely understand the brains of terrestial animals. Who knows what we may find in the brain of such an advanced species?"

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -77,29 +77,12 @@
 /datum/species/zombie/infectious
 	name = "Infectious Zombie"
 	id = SPECIES_ZOMBIE_INFECTIOUS
-	inherent_traits = list(
-		TRAIT_EASILY_WOUNDED,
-		TRAIT_EASYDISMEMBER,
-		TRAIT_FAKEDEATH,
-		TRAIT_LIMBATTACHMENT,
-		TRAIT_NOBREATH,
-		TRAIT_NOCLONELOSS,
-		TRAIT_NODEATH,
-		TRAIT_NOHUNGER,
-		TRAIT_NOMETABOLISM,
-		TRAIT_RADIMMUNE,
-		TRAIT_RESISTCOLD,
-		TRAIT_RESISTHIGHPRESSURE,
-		TRAIT_RESISTLOWPRESSURE,
-		TRAIT_TOXIMMUNE,
-		// all the above are normal traits for high functioning zombies
-		TRAIT_ILLITERATE,
-	)
 	examine_limb_id = SPECIES_ZOMBIE
 	mutanthands = /obj/item/zombie_hand
 	armor = 20 // 120 damage to KO a zombie, which kills it
 	speedmod = 1.6
 	mutanteyes = /obj/item/organ/internal/eyes/night_vision/zombie
+	mutantbrain = /obj/item/organ/internal/brain/zombie
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 	/// The rate the zombies regenerate at
 	var/heal_rate = 0.5

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -77,6 +77,24 @@
 /datum/species/zombie/infectious
 	name = "Infectious Zombie"
 	id = SPECIES_ZOMBIE_INFECTIOUS
+	inherent_traits = list(
+		TRAIT_EASILY_WOUNDED,
+		TRAIT_EASYDISMEMBER,
+		TRAIT_FAKEDEATH,
+		TRAIT_LIMBATTACHMENT,
+		TRAIT_NOBREATH,
+		TRAIT_NOCLONELOSS,
+		TRAIT_NODEATH,
+		TRAIT_NOHUNGER,
+		TRAIT_NOMETABOLISM,
+		TRAIT_RADIMMUNE,
+		TRAIT_RESISTCOLD,
+		TRAIT_RESISTHIGHPRESSURE,
+		TRAIT_RESISTLOWPRESSURE,
+		TRAIT_TOXIMMUNE,
+		// all the above are normal traits for high functioning zombies
+		TRAIT_ILLITERATE,
+	)
 	examine_limb_id = SPECIES_ZOMBIE
 	mutanthands = /obj/item/zombie_hand
 	armor = 20 // 120 damage to KO a zombie, which kills it


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

There are currently two types of zombies:

- High-Functioning (aka smart)
- Infectious Romerol

High-functioning are supposed to act like normal crew and have higher intelligence.  Infectious romerol zombies however are lower base intelligence and cannot do many things normal high functioning zombies can do.  Their claws already prevent them from accessing computers, using pens, or holding books.

My PR goes a step further and prevents them from examining books and paper.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Consistency.  The smart zombies should be smart, and the dumb zombies should be dumb.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Change infectious zombies to be illiterate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
