### PR TITLE
Fixes a closet harddel

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -21,10 +21,9 @@
 	anchored = TRUE
 
 /obj/structure/closet/emcloset/Initialize(mapload)
-	. = ..()
-
 	if (prob(1))
 		return INITIALIZE_HINT_QDEL
+	return ..()
 
 /obj/structure/closet/emcloset/PopulateContents()
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -21,9 +21,10 @@
 	anchored = TRUE
 
 /obj/structure/closet/emcloset/Initialize(mapload)
+	. = ..()
+
 	if (prob(1))
 		return INITIALIZE_HINT_QDEL
-	return ..()
 
 /obj/structure/closet/emcloset/PopulateContents()
 	..()

--- a/code/modules/unit_tests/closets.dm
+++ b/code/modules/unit_tests/closets.dm
@@ -9,11 +9,11 @@
 
 	for(var/closet_type in all_closets)
 		var/obj/structure/closet/closet = allocate(closet_type)
+		if (QDELETED(closet)) // this is here because the emcloset subtype has a chance of returning a qdel hint on initialize
+			continue
 
 		// Copy is necessary otherwise closet.contents - immediate_contents returns an empty list
 		var/list/immediate_contents = closet.contents.Copy()
-		if (QDELETED(closet))
-			continue
 		closet.PopulateContents()
 		var/contents_len = length(closet.contents)
 

--- a/code/modules/unit_tests/closets.dm
+++ b/code/modules/unit_tests/closets.dm
@@ -9,8 +9,8 @@
 
 	for(var/closet_type in all_closets)
 		var/obj/structure/closet/closet = allocate(closet_type)
-	if(istype(closet_type, /obj/structure/closet/emcloset) && QDELETED(closet)) // this is here because the emcloset subtype has a chance of returning a qdel hint on initialize
-		continue
+		if(istype(closet_type, /obj/structure/closet/emcloset) && QDELETED(closet)) // this is here because the emcloset subtype has a chance of returning a qdel hint on initialize
+			continue
 
 		// Copy is necessary otherwise closet.contents - immediate_contents returns an empty list
 		var/list/immediate_contents = closet.contents.Copy()

--- a/code/modules/unit_tests/closets.dm
+++ b/code/modules/unit_tests/closets.dm
@@ -9,8 +9,8 @@
 
 	for(var/closet_type in all_closets)
 		var/obj/structure/closet/closet = allocate(closet_type)
-		if (QDELETED(closet)) // this is here because the emcloset subtype has a chance of returning a qdel hint on initialize
-			continue
+	if(istype(closet_type, /obj/structure/closet/emcloset) && QDELETED(closet)) // this is here because the emcloset subtype has a chance of returning a qdel hint on initialize
+		continue
 
 		// Copy is necessary otherwise closet.contents - immediate_contents returns an empty list
 		var/list/immediate_contents = closet.contents.Copy()

--- a/code/modules/unit_tests/closets.dm
+++ b/code/modules/unit_tests/closets.dm
@@ -12,7 +12,8 @@
 
 		// Copy is necessary otherwise closet.contents - immediate_contents returns an empty list
 		var/list/immediate_contents = closet.contents.Copy()
-
+		if (QDELETED(closet))
+			continue
 		closet.PopulateContents()
 		var/contents_len = length(closet.contents)
 


### PR DESCRIPTION
## About The Pull Request

PopulateContents is called in init which means that the closet is being qdelled but it's contents are not being properly removed when the prob(1) is called and it returns the qdel hint. This returns the qdel hint BEFORE parents init is called to stop this from happening
Caused by https://github.com/tgstation/tgstation/pull/69587
