### PR TITLE
fixes ant runtime

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -323,6 +323,9 @@
 		return ..()
 
 	var/datum/component/caltrop/caltrop_comp = GetComponent(/datum/component/caltrop)
+	if(!caltrop_comp)
+		return ..()
+
 	switch(caltrop_comp.max_damage)
 		if(0 to 1)
 			icon_state = initial(icon_state)


### PR DESCRIPTION
Sanity check for the component
```
call stack:
the space ants (/obj/effect/decal/cleanable/ants): update icon state()
the space ants (/obj/effect/decal/cleanable/ants): update icon(16777215)
the space ants (/obj/effect/decal/cleanable/ants): update appearance(16777215)
the space ants (/obj/effect/decal/cleanable/ants): on changed z level(the floor (130,134,3) (/turf/open/floor/iron/dark), null, 0, 1)
the space ants (/obj/effect/decal/cleanable/ants): Moved(the floor (130,134,3) (/turf/open/floor/iron/dark), 0, 1, null, 1)
the space ants (/obj/effect/decal/cleanable/ants): doMove(null)
the space ants (/obj/effect/decal/cleanable/ants): moveToNullspace()
the space ants (/obj/effect/decal/cleanable/ants): Destroy(0)
the space ants (/obj/effect/decal/cleanable/ants): Destroy(0)
the space ants (/obj/effect/decal/cleanable/ants): Destroy(0)
...
the space ants (/obj/effect/decal/cleanable/ants): New(0)
/datum/component/decomposition (/datum/component/decomposition): decompose()
```