### PR TITLE
fixes firedoors trying to do stuff while being qdel'd

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -101,6 +101,7 @@
 
 /obj/machinery/door/firedoor/Destroy()
 	remove_from_areas()
+	unregister_adjacent_turfs(loc)
 	QDEL_NULL(soundloop)
 	return ..()
 
@@ -437,13 +438,13 @@
 	return FALSE //No bumping to open, not even in mechs
 
 /obj/machinery/door/firedoor/proc/on_power_loss()
-	SIGNAL_HANDLER 
-	
+	SIGNAL_HANDLER
+
 	soundloop.stop()
 
 /obj/machinery/door/firedoor/proc/on_power_restore()
-	SIGNAL_HANDLER 
-	
+	SIGNAL_HANDLER
+
 	correct_state()
 
 	if(is_playing_alarm)


### PR DESCRIPTION
Wasn't being unregistered from the turfs around em
```
[18:07:55] Runtime in firedoor.dm, line 305: Cannot execute null.start().
proc name: start activation process (/obj/machinery/door/firedoor/proc/start_activation_process)
src: the firelock (/obj/machinery/door/firedoor)
src.loc: the ice chasm (112,90,4) (/turf/open/openspace/icemoon/keep_below)
call stack:
the firelock (/obj/machinery/door/firedoor): start activation process("firelock_alarm_type_cold")
the firelock (/obj/machinery/door/firedoor): process results(the ice chasm (112,90,4) (/turf/open/openspace/icemoon/keep_below))
the ice chasm (112,90,4) (/turf/open/openspace/icemoon/keep_below): SendSignal("turf_calculated_adjacent_atmos", /list (/list))
the ice chasm (112,90,4) (/turf/open/openspace/icemoon/keep_below): immediate calculate adjacent turfs()
the ice chasm (112,90,4) (/turf/open/openspace/icemoon/keep_below): air update turf(1, 0)
the firelock (/obj/machinery/door/firedoor): air update turf(1, 0)
the firelock (/obj/machinery/door/firedoor): Destroy(0)
the firelock (/obj/machinery/door/firedoor): Destroy(0)
qdel(the firelock (/obj/machinery/door/firedoor), 0)
the firelock (/obj/machinery/door/firedoor): deconstruct(0)
the firelock (/obj/machinery/door/firedoor): atom destruction("bomb")
the firelock (/obj/machinery/door/firedoor): take damage(7e+030, "brute", "bomb", 0, null, 0)
the firelock (/obj/machinery/door/firedoor): take damage(1e+031, "brute", "bomb", 0, null)
the firelock (/obj/machinery/door/firedoor): ex act(3, null)
the firelock (/obj/machinery/door/firedoor): ex act(2, null)
Explosions (/datum/controller/subsystem/explosions): fire(0)
Explosions (/datum/controller/subsystem/explosions): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```