### PR TITLE
Fixes emergency pods not working

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -580,7 +580,7 @@
 	var/obj/machinery/computer/shuttle/connected_computer = get_control_console()
 	if(!istype(connected_computer, /obj/machinery/computer/shuttle/pod))
 		return FALSE
-	if(!(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED) || (connected_computer.obj_flags & EMAGGED))
+	if(!(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED) || !(connected_computer.obj_flags & EMAGGED))
 		to_chat(usr, span_warning("Escape pods will only launch during \"Code Red\" security alert."))
 		return FALSE
 	if(launch_status == UNLAUNCHED)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -579,14 +579,13 @@
 /obj/docking_port/mobile/pod/request(obj/docking_port/stationary/S)
 	var/obj/machinery/computer/shuttle/connected_computer = get_control_console()
 	if(!istype(connected_computer, /obj/machinery/computer/shuttle/pod))
-		return ..()
-	if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED || (connected_computer && (connected_computer.obj_flags & EMAGGED)))
-		if(launch_status == UNLAUNCHED)
-			launch_status = EARLY_LAUNCHED
-			return ..()
-	else
+		return FALSE
+	if(!(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED) || (connected_computer.obj_flags & EMAGGED))
 		to_chat(usr, span_warning("Escape pods will only launch during \"Code Red\" security alert."))
-		return TRUE
+		return FALSE
+	if(launch_status == UNLAUNCHED)
+		launch_status = EARLY_LAUNCHED
+		return ..()
 
 /obj/docking_port/mobile/pod/cancel()
 	return

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -580,7 +580,7 @@
 	var/obj/machinery/computer/shuttle/connected_computer = get_control_console()
 	if(!istype(connected_computer, /obj/machinery/computer/shuttle/pod))
 		return FALSE
-	if(!(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED) || !(connected_computer.obj_flags & EMAGGED))
+	if(!(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED) && !(connected_computer.obj_flags & EMAGGED))
 		to_chat(usr, span_warning("Escape pods will only launch during \"Code Red\" security alert."))
 		return FALSE
 	if(launch_status == UNLAUNCHED)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -901,10 +901,11 @@
 // attempts to locate /obj/machinery/computer/shuttle with matching ID inside the shuttle
 /obj/docking_port/mobile/proc/get_control_console()
 	for(var/area/shuttle/shuttle_area as anything in shuttle_areas)
-		for(var/obj/machinery/computer/shuttle/shuttle_computers as anything in shuttle_area)
-			if(shuttle_computers.shuttleId != shuttle_id)
-				continue
-			return shuttle_computers
+		var/obj/machinery/computer/shuttle/shuttle_computer = locate(/obj/machinery/computer/shuttle) in shuttle_area
+		if(!shuttle_computer)
+			continue
+		if(shuttle_computer.shuttleId == shuttle_id)
+			return shuttle_computer
 	return null
 
 /obj/docking_port/mobile/proc/hyperspace_sound(phase, list/areas)


### PR DESCRIPTION
## About The Pull Request

``get_control_console()`` currently doesn't work because it's runtiming instead of properly finding the shuttle computer, which would cause pod's request() to return and call parent, but parent handles sending the pods off...

I fixed it by not calling parent if they didn't have a console, and I fixed the console finding proc as well.

## Why It's Good For The Game

Pods should consistently work as expected to, now.

## Changelog

:cl:
fix: Pods should now properly know whether or not to send itself off, and won't break other pods at the same time.
/:cl: