### PR TITLE
Fixes a runtime with map voting

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -94,7 +94,8 @@ SUBSYSTEM_DEF(vote)
 	to_chat(world, span_infoplain(vote_font("\n[to_display]")))
 
 	// Finally, doing any effects on vote completion
-	current_vote.finalize_vote(final_winner)
+	if (final_winner) // if no one voted final_winner will be null
+		current_vote.finalize_vote(final_winner)
 
 /datum/controller/subsystem/vote/proc/submit_vote(mob/voter, their_vote)
 	if(!current_vote)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

```
Thrown by finalize_vote (/datum/vote/map_vote/finalize_vote) at map_vote.dm, line 87             
Source: Map (/datum/vote/map_vote)
Stacktrace:
1 | Map (/datum/vote/map_vote): finalize vote(null)
2 | Vote (/datum/controller/subsystem/vote): process vote result()
3 | Vote (/datum/controller/subsystem/vote): fire(0)
4 | Vote (/datum/controller/subsystem/vote): ignite(0)
5 | Master (/datum/controller/master): RunQueue()
6 | Master (/datum/controller/master): Loop(2)
7 | Master (/datum/controller/master): StartProcessing(0)
```

`get_result_text` which is called before `finalize_vote` has a sanity check for this but for some reason `finalize_vote` doesn't. So if there are no votes given it will runtime due to `final_winner` being null