### PR TITLE
Fixes a harddel related to the supermatter cascade

### DIFF
--- a/code/modules/power/supermatter/supermatter_delamination/cascade_delam_objects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/cascade_delam_objects.dm
@@ -90,6 +90,7 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/crystal_mass/Destroy()
+	STOP_PROCESSING(SSsupermatter_cascade, src)
 	sm_comp = null
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
It was bugging me because it'd show up and make CI fail every so often. So I went ahead and fixed it.

The `/obj/crystal_mass` wasn't being removed from the process queue of the supermatter cascade subsystem when destroyed. Now it will be. 

## Why It's Good For The Game
Less random CI failures is good.

## Changelog

:cl: GoldenAlpharex
fix: Removes a hard-deletion from the supermatter cascade's crystal mass.
/:cl: