### PR TITLE
Fixes debug omnitool set to screwdriver mode not stabbing eyes.

### DIFF
--- a/code/game/objects/items/debug_items.dm
+++ b/code/game/objects/items/debug_items.dm
@@ -113,3 +113,10 @@
 			tool_behaviour = TOOL_ROLLINGPIN
 		if("Wire Brush")
 			tool_behaviour = TOOL_RUSTSCRAPER
+
+	if(tool_behaviour == TOOL_SCREWDRIVER)
+		AddElement(/datum/element/eyestab)
+	else
+		RemoveElement(/datum/element/eyestab)
+
+


### PR DESCRIPTION
:cl: ShizCalev
admin: Debugging / admin omnitool now stabs eyes when in screwdriver mode.
/:cl: