### PR TITLE
Makes medibeams more resilient to lag

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -118,8 +118,7 @@
 	for(N in 0 to length-1 step 32)//-1 as we want < not <=, but we want the speed of X in Y to Z and step X
 		if(QDELETED(src))
 			break
-		var/obj/effect/ebeam/segment = new beam_type(origin_turf)
-		segment.owner = src
+		var/obj/effect/ebeam/segment = new beam_type(origin_turf, src)
 		elements += segment
 
 		//Assign our single visual ebeam to each ebeam's vis_contents
@@ -164,6 +163,10 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	anchored = TRUE
 	var/datum/beam/owner
+
+/obj/effect/ebeam/New(loc, beam_owner)
+	owner = beam_owner
+	return ..()
 
 /obj/effect/ebeam/update_overlays()
 	. = ..()

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -164,7 +164,7 @@
 	anchored = TRUE
 	var/datum/beam/owner
 
-/obj/effect/ebeam/New(loc, beam_owner)
+/obj/effect/ebeam/Initialize(mapload, beam_owner)
 	owner = beam_owner
 	return ..()
 

--- a/code/modules/projectiles/guns/special/medbeam.dm
+++ b/code/modules/projectiles/guns/special/medbeam.dm
@@ -128,7 +128,6 @@
 			if(QDELETED(B))
 				continue
 			if(!B.owner)
-				message_admins("BEAM WITHOUT AN OWNER. SOMETHING IS TERRIBLY WRONG, YELL AT A CODER")
 				stack_trace("beam without an owner! [B]")
 				continue
 			if(B.owner.origin != current_beam.origin)

--- a/code/modules/projectiles/guns/special/medbeam.dm
+++ b/code/modules/projectiles/guns/special/medbeam.dm
@@ -123,6 +123,14 @@
 				qdel(dummy)
 				return FALSE
 		for(var/obj/effect/ebeam/medical/B in next_step)// Don't cross the str-beams!
+			if(QDELETED(current_beam))
+				break //We shouldn't be processing anymore.
+			if(QDELETED(B))
+				continue
+			if(!B.owner)
+				message_admins("BEAM WITHOUT AN OWNER. SOMETHING IS TERRIBLY WRONG, YELL AT A CODER")
+				stack_trace("beam without an owner! [B]")
+				continue
 			if(B.owner.origin != current_beam.origin)
 				explosion(B.loc, heavy_impact_range = 3, light_impact_range = 5, flash_range = 8, explosion_cause = src)
 				qdel(dummy)


### PR DESCRIPTION
Fixes #38632

:cl: ShizCalev
fix: Fixed medibeams sometimes crossing themselves!
/:cl:

owner is set to null during destroy. the `for()` checking for beams in a turf wasn't checking if the current beam, nor the target beam was QDELing, leading to it potentially checking against that null value during it's QDEL
also moved setting the beam's owner to new() to make sure it's a bit more resilient to lag.
