### PR TITLE
Jean shorts are now a subtype of shorts

### DIFF
--- a/code/modules/clothing/under/shorts.dm
+++ b/code/modules/clothing/under/shorts.dm
@@ -8,21 +8,18 @@
 	gender = PLURAL
 	body_parts_covered = GROIN
 	female_sprite_flags = NO_FEMALE_UNIFORM
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+	supports_variations_flags = CLOTHING_NO_VARIATION
 	can_adjust = FALSE
 	species_exception = list(/datum/species/golem)
 	flags_1 = IS_PLAYER_COLORABLE_1
 
-/obj/item/clothing/under/jeanshorts
+/obj/item/clothing/under/shorts/jeanshorts
 	name = "jean shorts"
 	desc = "A nondescript pair of tough jean shorts."
 	icon_state = "jeanshorts"
-	can_adjust = FALSE
-	female_sprite_flags = NO_FEMALE_UNIFORM
 	greyscale_config = /datum/greyscale_config/jeanshorts
 	greyscale_config_worn = /datum/greyscale_config/jeanshorts_worn
 	greyscale_colors = "#787878#723E0E#4D7EAC"
-	flags_1 = IS_PLAYER_COLORABLE_1
 
 /obj/item/clothing/under/shorts/red
 	name = "athletic shorts"

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -61,7 +61,7 @@
 				/obj/item/clothing/under/pants/slacks = 5,
 				/obj/item/clothing/under/shorts = 5,
 				/obj/item/clothing/under/pants/jeans = 5,
-				/obj/item/clothing/under/jeanshorts = 5,
+				/obj/item/clothing/under/shorts/jeanshorts = 5,
 				/obj/item/clothing/under/costume/buttondown/slacks = 4,
 				/obj/item/clothing/under/costume/buttondown/shorts = 4,
 				/obj/item/clothing/under/dress/sundress = 2,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Also, both jean shorts and shorts now use the `CLOTHING_NO_VARIATION` flag instead of the previous `CLOTHING_DIGITIGRADE_VARIATION`. I'm not sure why shorts had this flag as they don't actually have a unique sprite for digitigrade legs, and instead overlay badly on top. This way they change the legs to normal legs instead.

## Why It's Good For The Game

Jean shorts are, in the real world, a kind of shorts. It makes sense that they would be a subtype, and this way they inherit some flags they were missing and don't have to manually define the others. To be frank this PR is a nitpick, but it bothered me.

## Changelog

:cl:
refactor: Scientists have recently reclassified jean shorts as a subtype of the broader shorts clade, instead of a separate genus.
/:cl:
