### PR TITLE
Fix ghost follow link being on a different line than binarysay on light mode

### DIFF
--- a/code/modules/mob/living/silicon/silicon_say.dm
+++ b/code/modules/mob/living/silicon/silicon_say.dm
@@ -49,9 +49,12 @@
 				var/mob/living/silicon/ai/ai = src
 				following = ai.eyeobj
 
+			var/follow_link = FOLLOW_LINK(M, following)
+
 			to_chat(
 				M,
-				FOLLOW_LINK(M, following) + span_binarysay(" \
+				 span_binarysay("\
+				 	[follow_link] \
 					Robotic Talk, \
 					[span_name("[name]")] <span class='message'>[quoted_message]</span>\
 				"),

--- a/code/modules/mob/living/silicon/silicon_say.dm
+++ b/code/modules/mob/living/silicon/silicon_say.dm
@@ -54,7 +54,7 @@
 			to_chat(
 				M,
 				span_binarysay("\
-				 	[follow_link] \
+					[follow_link] \
 					Robotic Talk, \
 					[span_name("[name]")] <span class='message'>[quoted_message]</span>\
 				"),

--- a/code/modules/mob/living/silicon/silicon_say.dm
+++ b/code/modules/mob/living/silicon/silicon_say.dm
@@ -53,7 +53,7 @@
 
 			to_chat(
 				M,
-				 span_binarysay("\
+				span_binarysay("\
 				 	[follow_link] \
 					Robotic Talk, \
 					[span_name("[name]")] <span class='message'>[quoted_message]</span>\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Oversight from #69871:

![image](https://user-images.githubusercontent.com/12202230/190287369-f03d36b2-5890-475a-8104-f81cea80852b.png)

On light mode, and in light mode only, `.binarysay` is `display: block`. This generates a newline because I moved the follow link outside of the relevant span.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Light mode is a sin, but so is unintended behavior

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: ghost follow links no longer appear above binary messages using light theme
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
