### PR TITLE
Adds more gulag logging

### DIFF
--- a/code/game/machinery/gulag_item_reclaimer.dm
+++ b/code/game/machinery/gulag_item_reclaimer.dm
@@ -85,4 +85,5 @@
 		stored_items[user] -= W
 		W.forceMove(drop_location)
 	stored_items -= user
+	user.log_message("has reclaimed their items from the gulag item reclaimer.", LOG_GAME)
 	use_power(active_power_usage)

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -120,6 +120,7 @@ GLOBAL_LIST(labor_sheet_values)
 					if(!(obj_flags & EMAGGED))
 						security_radio.set_frequency(FREQ_SECURITY)
 						security_radio.talk_into(src, "A prisoner has returned to the station. Minerals and Prisoner ID card ready for retrieval.", FREQ_SECURITY)
+					user_mob.log_message("has completed their labor points goal and is now sending the gulag shuttle back to the station.", LOG_GAME)
 					to_chat(user_mob, span_notice("Shuttle received message and will be sent shortly."))
 					return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

One thing that's been frustrating me over the last few months is that we have absolutely no data on how long it might take the average person to complete any given gulag sentence. This tends to matter a bit for administrative matters, and especially when there's a disconnect between policy and players in regards to how long any given point-sentence might take a player to complete. This should hopefully allow us to collect more good data in these affairs.

I'm putting it in game.log because the message that displays when you teleport someone to the gulag is there too, so it's nice to have that when you filter by ckey.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/190315913-74bb8005-b52b-4271-bdf5-447859127bac.png)

More data points really do help, because sometimes people clam up and don't talk until well after they're on station since the traumatic gulag experience really did put them through the wringer. I want to clock how long it takes players from teleporter to sending the shuttle, so we can really see if 1 minute = 100 points. The reclaim message also helps in case of shuttle chicanery.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Prisoners returning from the gulag as well as reclaiming their items from the gulag item reclaimer are now both logged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
