### PR TITLE
Fix melee mecha equipment ignoring adjacency

### DIFF
--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -28,6 +28,8 @@
 	var/harmful = FALSE
 	///Sound file: Sound to play when this equipment is destroyed while still attached to the mech
 	var/destroy_sound = 'sound/mecha/critdestr.ogg'
+	///Whether this equipment piece should require the mech to stand in one place to work (see drills, clamps, RCD)
+	var/requires_stationary = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/Destroy()
 	if(chassis)
@@ -121,8 +123,11 @@
 
 /// do after checks for the mecha equipment do afters
 /obj/item/mecha_parts/mecha_equipment/proc/do_after_checks(atom/target, prev_chassis_loc)
+	if(!requires_stationary)
+		return (chassis) && (get_dir(chassis, target) & chassis.dir)
 	return chassis && (get_dir(chassis, target) & chassis.dir) && check_chassis_loc(prev_chassis_loc)
 
+///Checks for whether the mech is still in the same spot as it was when starting the do_after. do_after checks for user.loc, which is always the mech
 /obj/item/mecha_parts/mecha_equipment/proc/check_chassis_loc(chassis_loc)
 	if(chassis.loc != chassis_loc)
 		return FALSE

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -113,15 +113,20 @@
 	if(!chassis)
 		return FALSE
 	chassis.use_power(energy_drain)
-	return do_after(user, equip_cooldown, target, extra_checks = CALLBACK(src, .proc/do_after_checks, target), interaction_key = interaction_key)
+	return do_after(user, equip_cooldown, target, extra_checks = CALLBACK(src, .proc/do_after_checks, target, chassis.loc), interaction_key = interaction_key)
 
 ///Do after wrapper for mecha equipment
 /obj/item/mecha_parts/mecha_equipment/proc/do_after_mecha(atom/target, mob/user, delay)
-	return do_after(user, delay, target, extra_checks = CALLBACK(src, .proc/do_after_checks, target))
+	return do_after(user, delay, target, extra_checks = CALLBACK(src, .proc/do_after_checks, target, chassis.loc))
 
 /// do after checks for the mecha equipment do afters
-/obj/item/mecha_parts/mecha_equipment/proc/do_after_checks(atom/target)
-	return chassis && (get_dir(chassis, target) & chassis.dir)
+/obj/item/mecha_parts/mecha_equipment/proc/do_after_checks(atom/target, prev_chassis_loc)
+	return chassis && (get_dir(chassis, target) & chassis.dir) && check_chassis_loc(prev_chassis_loc)
+
+/obj/item/mecha_parts/mecha_equipment/proc/check_chassis_loc(chassis_loc)
+	if(chassis.loc != chassis_loc)
+		return FALSE
+	return TRUE
 
 /obj/item/mecha_parts/mecha_equipment/proc/can_attach(obj/vehicle/sealed/mecha/M, attach_right = FALSE)
 	return default_can_attach(M, attach_right)

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -17,6 +17,7 @@
 	tool_behaviour = TOOL_DRILL
 	toolspeed = 0.9
 	mech_flags = EXOSUIT_MODULE_WORKING | EXOSUIT_MODULE_COMBAT
+	requires_stationary = TRUE
 	var/drill_delay = 7
 	var/drill_level = DRILL_BASIC
 

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -13,6 +13,7 @@
 	toolspeed = 0.8
 	harmful = TRUE
 	mech_flags = EXOSUIT_MODULE_RIPLEY
+	requires_stationary = TRUE
 	///Bool for whether we beat the hell out of things we punch (and tear off their arms)
 	var/killer_clamp = FALSE
 	///How much base damage this clamp does
@@ -228,6 +229,7 @@
 	energy_drain = 250
 	range = MECHA_MELEE|MECHA_RANGED
 	item_flags = NO_MAT_REDEMPTION
+	requires_stationary = TRUE
 	///determines what we'll so when clicking on a turf
 	var/mode = MODE_DECONSTRUCT
 


### PR DESCRIPTION
## About The Pull Request
Fixes this:

https://user-images.githubusercontent.com/75863639/190873524-11b15f5a-6e0d-405f-96f6-9bc27580ba79.mp4

_Melee mecha equipment now stops `do_after` procs when the mech changes it's position. Previously, a mech could start drilling/clamping an object and move avay from said object without stopping the tool's process, so long as the mech kept facing the object._

## Why It's Good For The Game
TK-like functionality does not belong on all currently present melee-range mecha equipment. 
Fixes #66874

## Changelog
:cl:
fix: fixed melee-range mecha equipment (drills, clamp etc.) ignoring adjacency to the object it's working on, i.e. start drilling an object and walk away facing it, while still drilling it
/:cl:
