### PR TITLE
Test merge pr to Revert "Add Alt RMB and Ctrl RMB screentips (used for Simple Rotation)"

### DIFF
--- a/code/__DEFINES/screentips.dm
+++ b/code/__DEFINES/screentips.dm
@@ -10,14 +10,8 @@
 /// Context applied to Ctrl-LMB actions
 #define SCREENTIP_CONTEXT_CTRL_LMB "Ctrl-LMB"
 
-/// Context applied to Ctrl-RMB actions
-#define SCREENTIP_CONTEXT_CTRL_RMB "Ctrl-RMB"
-
 /// Context applied to Alt-LMB actions
 #define SCREENTIP_CONTEXT_ALT_LMB "Alt-LMB"
-
-/// Context applied to Alt-RMB actions
-#define SCREENTIP_CONTEXT_ALT_RMB "Alt-RMB"
 
 /// Context applied to Ctrl-Shift-LMB actions
 #define SCREENTIP_CONTEXT_CTRL_SHIFT_LMB "Ctrl-Shift-LMB"

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -19,12 +19,12 @@
 /datum/component/simple_rotation
 	/// Additional stuff to do after rotation
 	var/datum/callback/AfterRotation
-	/// Rotation flags for special behavior
+	/// Rotation flags for special behavior 
 	var/rotation_flags = NONE
 
 /**
  * Adds the ability to rotate an object by Alt-click or using Right-click verbs.
- *
+ * 
  * args:
  * * rotation_flags (optional) Bitflags that determine behavior for rotation (defined at the top of this file)
  * * AfterRotation (optional) Callback proc that is used after the object is rotated (sound effects, balloon alerts, etc.)
@@ -33,9 +33,6 @@
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	var/atom/movable/source = parent
-	source.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
-
 	src.rotation_flags = rotation_flags
 	src.AfterRotation = AfterRotation || CALLBACK(src, .proc/DefaultAfterRotation)
 
@@ -43,7 +40,6 @@
 	RegisterSignal(parent, COMSIG_CLICK_ALT, .proc/RotateLeft)
 	RegisterSignal(parent, COMSIG_CLICK_ALT_SECONDARY, .proc/RotateRight)
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/ExamineMessage)
-	RegisterSignal(parent, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, .proc/on_requesting_context_from_item)
 
 /datum/component/simple_rotation/proc/AddVerbs()
 	var/obj/rotated_obj = parent
@@ -60,7 +56,7 @@
 		rotated_obj.verbs -= /atom/movable/proc/SimpleRotateCounterclockwise
 
 /datum/component/simple_rotation/proc/RemoveSignals()
-	UnregisterSignal(parent, list(COMSIG_CLICK_ALT, COMSIG_CLICK_ALT_SECONDARY, COMSIG_PARENT_EXAMINE, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM))
+	UnregisterSignal(parent, list(COMSIG_CLICK_ALT, COMSIG_CLICK_ALT_SECONDARY, COMSIG_PARENT_EXAMINE))
 
 /datum/component/simple_rotation/RegisterWithParent()
 	AddVerbs()
@@ -89,6 +85,7 @@
 
 /datum/component/simple_rotation/proc/ExamineMessage(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
+	examine_list += span_notice("Alt + Right-click to rotate it clockwise. Alt + Left-click to rotate it counterclockwise.")
 	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		examine_list += span_notice("This requires a wrench to be rotated.")
 
@@ -106,7 +103,7 @@
 	if(!istype(user))
 		CRASH("[src] is being rotated without a user of the wrong type: [user.type]")
 	if(!isnum(degrees))
-		CRASH("[src] is being rotated without providing the amount of degrees needed")
+		CRASH("[src] is being rotated without providing the amount of degrees needed") 
 
 	if(!CanBeRotated(user, degrees) || !CanUserRotate(user, degrees))
 		return
@@ -115,17 +112,17 @@
 	rotated_obj.setDir(turn(rotated_obj.dir, degrees))
 	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		playsound(rotated_obj, 'sound/items/ratchet.ogg', 50, TRUE)
-
+		
 	AfterRotation.Invoke(user, degrees)
 
 /datum/component/simple_rotation/proc/CanUserRotate(mob/user, degrees)
 	if(isliving(user) && user.canUseTopic(parent, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
 		return TRUE
 	if((rotation_flags & ROTATION_GHOSTS_ALLOWED) && isobserver(user) && CONFIG_GET(flag/ghost_interaction))
-		return TRUE
+		return TRUE	
 	return FALSE
 
-/datum/component/simple_rotation/proc/CanBeRotated(mob/user, degrees, silent=FALSE)
+/datum/component/simple_rotation/proc/CanBeRotated(mob/user, degrees)
 	var/obj/rotated_obj = parent
 
 	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
@@ -133,13 +130,12 @@
 			return FALSE
 		var/obj/item/tool = user.get_active_held_item()
 		if(!tool || tool.tool_behaviour != TOOL_WRENCH)
-			if(!silent)
-				rotated_obj.balloon_alert(user, "need a wrench!")
+			rotated_obj.balloon_alert(user, "need a wrench!")
 			return FALSE
 	if(!(rotation_flags & ROTATION_IGNORE_ANCHORED) && rotated_obj.anchored)
-		if(istype(rotated_obj, /obj/structure/window) && !silent)
+		if(istype(rotated_obj, /obj/structure/window))
 			rotated_obj.balloon_alert(user, "need to unscrew!")
-		else if(!silent)
+		else
 			rotated_obj.balloon_alert(user, "need to unwrench!")
 		return FALSE
 
@@ -148,13 +144,12 @@
 		var/obj/structure/window/rotated_window = rotated_obj
 		var/fulltile = istype(rotated_window) ? rotated_window.fulltile : FALSE
 		if(!valid_window_location(rotated_obj.loc, target_dir, is_fulltile = fulltile))
-			if(!silent)
-				rotated_obj.balloon_alert(user, "can't rotate in that direction!")
+			rotated_obj.balloon_alert(user, "can't rotate in that direction!")
 			return FALSE
 	return TRUE
 
 /datum/component/simple_rotation/proc/DefaultAfterRotation(mob/user, degrees)
-	return
+	return 
 
 /atom/movable/proc/SimpleRotateClockwise()
 	set name = "Rotate Clockwise"
@@ -179,21 +174,3 @@
 	var/datum/component/simple_rotation/rotcomp = GetComponent(/datum/component/simple_rotation)
 	if(rotcomp)
 		rotcomp.Rotate(usr, ROTATION_FLIP)
-
-// maybe we don't need the item context proc but instead the hand one? since we don't need to check held_item
-/datum/component/simple_rotation/proc/on_requesting_context_from_item(atom/source, list/context, obj/item/held_item, mob/user)
-	SIGNAL_HANDLER
-
-	var/rotation_screentip = FALSE
-
-	if(CanBeRotated(user, ROTATION_CLOCKWISE, silent=TRUE) && CanUserRotate(user, ROTATION_CLOCKWISE))
-		context[SCREENTIP_CONTEXT_ALT_LMB] = "Rotate left"
-		rotation_screentip = TRUE
-	if(CanBeRotated(user, ROTATION_COUNTERCLOCKWISE, silent=TRUE) && CanUserRotate(user, ROTATION_COUNTERCLOCKWISE))
-		context[SCREENTIP_CONTEXT_ALT_RMB] = "Rotate right"
-		rotation_screentip = TRUE
-
-	if(rotation_screentip)
-		return CONTEXTUAL_SCREENTIP_SET
-
-	return NONE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1951,8 +1951,7 @@
 
 	active_hud.screentip_text.maptext_y = 0
 	var/lmb_rmb_line = ""
-	var/ctrl_lmb_ctrl_rmb_line = ""
-	var/alt_lmb_alt_rmb_line = ""
+	var/ctrl_lmb_alt_lmb_line = ""
 	var/shift_lmb_ctrl_shift_lmb_line = ""
 	var/extra_lines = 0
 	var/extra_context = ""
@@ -1979,31 +1978,20 @@
 				else if (rmb_text)
 					lmb_rmb_line = rmb_text
 
-				// Ctrl-LMB, Ctrl-RMB on one line...
+				// Ctrl-LMB, Alt-LMB on one line...
 				if (lmb_rmb_line != "")
 					lmb_rmb_line += "<br>"
 					extra_lines++
 				if (SCREENTIP_CONTEXT_CTRL_LMB in context)
-					ctrl_lmb_ctrl_rmb_line += "[SCREENTIP_CONTEXT_CTRL_LMB]: [context[SCREENTIP_CONTEXT_CTRL_LMB]]"
-				if (SCREENTIP_CONTEXT_CTRL_RMB in context)
-					if (ctrl_lmb_ctrl_rmb_line != "")
-						ctrl_lmb_ctrl_rmb_line += " | "
-					ctrl_lmb_ctrl_rmb_line += "[SCREENTIP_CONTEXT_CTRL_RMB]: [context[SCREENTIP_CONTEXT_CTRL_RMB]]"
-
-				// Alt-LMB, Alt-RMB on one line...
-				if (ctrl_lmb_ctrl_rmb_line != "")
-					ctrl_lmb_ctrl_rmb_line += "<br>"
-					extra_lines++
+					ctrl_lmb_alt_lmb_line += "[SCREENTIP_CONTEXT_CTRL_LMB]: [context[SCREENTIP_CONTEXT_CTRL_LMB]]"
 				if (SCREENTIP_CONTEXT_ALT_LMB in context)
-					alt_lmb_alt_rmb_line += "[SCREENTIP_CONTEXT_ALT_LMB]: [context[SCREENTIP_CONTEXT_ALT_LMB]]"
-				if (SCREENTIP_CONTEXT_ALT_RMB in context)
-					if (alt_lmb_alt_rmb_line != "")
-						alt_lmb_alt_rmb_line += " | "
-					alt_lmb_alt_rmb_line += "[SCREENTIP_CONTEXT_ALT_RMB]: [context[SCREENTIP_CONTEXT_ALT_RMB]]"
+					if (ctrl_lmb_alt_lmb_line != "")
+						ctrl_lmb_alt_lmb_line += " | "
+					ctrl_lmb_alt_lmb_line += "[SCREENTIP_CONTEXT_ALT_LMB]: [context[SCREENTIP_CONTEXT_ALT_LMB]]"
 
 				// Shift-LMB, Ctrl-Shift-LMB on one line...
-				if (alt_lmb_alt_rmb_line != "")
-					alt_lmb_alt_rmb_line += "<br>"
+				if (ctrl_lmb_alt_lmb_line != "")
+					ctrl_lmb_alt_lmb_line += "<br>"
 					extra_lines++
 				if (SCREENTIP_CONTEXT_SHIFT_LMB in context)
 					shift_lmb_ctrl_shift_lmb_line += "[SCREENTIP_CONTEXT_SHIFT_LMB]: [context[SCREENTIP_CONTEXT_SHIFT_LMB]]"
@@ -2016,7 +2004,7 @@
 					extra_lines++
 
 				if(extra_lines)
-					extra_context = "<br><span style='font-size: 7px'>[lmb_rmb_line][ctrl_lmb_ctrl_rmb_line][alt_lmb_alt_rmb_line][shift_lmb_ctrl_shift_lmb_line]</span>"
+					extra_context = "<br><span style='font-size: 7px'>[lmb_rmb_line][ctrl_lmb_alt_lmb_line][shift_lmb_ctrl_shift_lmb_line]</span>"
 					//first extra line pushes atom name line up 10px, subsequent lines push it up 9px, this offsets that and keeps the first line in the same place
 					active_hud.screentip_text.maptext_y = -10 + (extra_lines - 1) * -9
 


### PR DESCRIPTION
Reverts tgstation/tgstation#69726 for test merge until somebody refactors canrotate to not call canusetopic since this prints error messages to the user and doing this on mouse enter is silly and spammy and not at all what was likely intended.