### PR TITLE
Minor adjustments to the brand intelligence event (and also a tiny change to stray meteor admin setup)

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -39,6 +39,12 @@
 	if(fake)
 		var/obj/machinery/vending/example = pick(subtypesof(/obj/machinery/vending))
 		source = initial(example.name)
+		for(var/obj/machinery/vending/vendor in GLOB.machines)
+			if(!is_station_level(vendor.z))
+				continue
+			vendingMachines.Add(vendor)
+		var/obj/machinery/vending/chosen_vendor = pick(vendingMachines)
+		source = chosen_vendor.name
 	else if(originMachine)
 		source = originMachine.name
 	priority_announce("Rampant brand intelligence has been detected aboard [station_name()]. Please inspect any [source] brand vendors for aggressive marketing tactics, and reboot them if necessary.", "Machine Learning Alert")

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -7,7 +7,7 @@
 
 	min_players = 15
 	max_occurrences = 1
-	//Var used to determine vendor subtype if used for admin setup
+	///Var used to determine vendor subtype if used for admin setup
 	var/chosen_vendor
 
 /datum/round_event_control/brand_intelligence/admin_setup()

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -59,7 +59,6 @@
 			vendingMachines.Add(vendor)
 	if(!vendingMachines.len)
 		kill()
-		priority_announce("AINT GOT NOTHING CHIEF")
 		return
 	originMachine = pick(vendingMachines)
 	vendingMachines.Remove(originMachine)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -42,7 +42,7 @@
 		source = initial(example.name)
 	else if(originMachine)
 		source = originMachine.name
-	priority_announce("Rampant brand intelligence has been detected aboard [station_name()]. Please inspect any [source] vendors for aggressive marketing tactics, and reboot them if necessary.", "Machine Learning Alert")
+	priority_announce("Rampant brand intelligence has been detected aboard [station_name()]. Please inspect any [source] brand vendors for aggressive marketing tactics, and reboot them if necessary.", "Machine Learning Alert")
 
 /datum/round_event/brand_intelligence/start()
 	var/datum/round_event_control/brand_intelligence/brand_event = control

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -54,7 +54,7 @@
 			vendingMachines.Add(vendor)
 	else
 		for(var/obj/machinery/vending/vendor in GLOB.machines)
-			if(!is_station_level(vendor.z))
+			if(!is_station_level(vendor.z) || !istype(vendor, /obj/machinery/vending/custom))
 				continue
 			vendingMachines.Add(vendor)
 	if(!vendingMachines.len)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -48,15 +48,15 @@
 	var/datum/round_event_control/brand_intelligence/brand_event = control
 	if(brand_event.chosen_vendor)
 		var/chosen_vendor = brand_event.chosen_vendor
-		for(var/chosen_vendor in GLOB.machines) //trying to typecast chosen_vendor to whatever the admin selected subtype is
-			if(!is_station_level(chosen_vendor.z))
+		for(var/obj/vendor_type_path/vendor in GLOB.machines) //trying to typecast chosen_vendor to whatever the admin selected subtype is
+			if(!is_station_level(vendor.z) || !istype(vendor, chosen_vendor))
 				continue
-			vendingMachines.Add(chosen_vendor)
+			vendingMachines.Add(vendor)
 	else
-		for(var/obj/machinery/vending/V in GLOB.machines)
-			if(!is_station_level(V.z))
+		for(var/obj/machinery/vending/vendor in GLOB.machines)
+			if(!is_station_level(vendor.z))
 				continue
-			vendingMachines.Add(V)
+			vendingMachines.Add(vendor)
 	if(!vendingMachines.len)
 		kill()
 		return

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -49,18 +49,18 @@
 
 /datum/round_event/brand_intelligence/start()
 	var/datum/round_event_control/brand_intelligence/brand_event = control
-	if(brand_event.chosen_vendor)
+	if(brand_event.chosen_vendor) //Attempt to search for vendors of the selected admin subtype
 		var/chosen_vendor = brand_event.chosen_vendor
 		for(var/obj/machinery/vending/vendor in GLOB.machines)
 			if(!is_station_level(vendor.z) || !istype(vendor, chosen_vendor))
 				continue
 			vendingMachines.Add(vendor)
-	else
+	if(!length(vendingMachines)) //If no vendors are in vendingMachines, setup defaults back to randomly selecting one.
 		for(var/obj/machinery/vending/vendor in GLOB.machines)
 			if(!is_station_level(vendor.z))
 				continue
 			vendingMachines.Add(vendor)
-	if(!vendingMachines.len)
+	if(!length(vendingMachines)) //If somehow there are still no elligible vendors, give up.
 		kill()
 		return
 	originMachine = pick(vendingMachines)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -19,7 +19,7 @@
 		chosen_vendor = tgui_input_list(usr, "Pick Me!","Vendor Selector", vendors)
 
 /datum/round_event/brand_intelligence
-	announce_when = 21
+	announce_when = 1 //TIME FOR TESTING PURPOSES PLEASE REVERT TO 21
 	end_when = 1000 //Ends when all vending machines are subverted anyway.
 	var/list/obj/machinery/vending/vendingMachines = list()
 	var/list/obj/machinery/vending/infectedMachines = list()
@@ -48,7 +48,7 @@
 	var/datum/round_event_control/brand_intelligence/brand_event = control
 	if(brand_event.chosen_vendor)
 		var/chosen_vendor = brand_event.chosen_vendor
-		for(var/obj/vendor_type_path/vendor in GLOB.machines) //trying to typecast chosen_vendor to whatever the admin selected subtype is
+		for(var/obj/machinery/vending/vendor in GLOB.machines)
 			if(!is_station_level(vendor.z) || !istype(vendor, chosen_vendor))
 				continue
 			vendingMachines.Add(vendor)
@@ -59,6 +59,7 @@
 			vendingMachines.Add(vendor)
 	if(!vendingMachines.len)
 		kill()
+		priority_announce("AINT GOT NOTHING CHIEF")
 		return
 	originMachine = pick(vendingMachines)
 	vendingMachines.Remove(originMachine)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -37,8 +37,6 @@
 /datum/round_event/brand_intelligence/announce(fake)
 	var/source = "unknown machine"
 	if(fake)
-		var/obj/machinery/vending/example = pick(subtypesof(/obj/machinery/vending))
-		source = initial(example.name)
 		for(var/obj/machinery/vending/vendor in GLOB.machines)
 			if(!is_station_level(vendor.z))
 				continue

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -18,7 +18,7 @@
 		vendors += subtypesof(/obj/machinery/vending)
 		chosen_vendor = tgui_input_list(usr, "Vendor type must have at least one instance on the station for this to work!","Vendor Selector", vendors)
 /datum/round_event/brand_intelligence
-	announce_when = 1 //TIME FOR TESTING PURPOSES PLEASE REVERT TO 21
+	announce_when = 21
 	end_when = 1000 //Ends when all vending machines are subverted anyway.
 	var/list/obj/machinery/vending/vendingMachines = list()
 	var/list/obj/machinery/vending/infectedMachines = list()
@@ -86,7 +86,7 @@
 			if(!QDELETED(upriser))
 				upriser.ai_controller = new /datum/ai_controller/vending_machine(upriser)
 				infectedMachines.Remove(upriser)
-		kill()
+		kill()d
 		return
 	if(ISMULTIPLE(activeFor, 2))
 		var/obj/machinery/vending/rebel = pick(vendingMachines)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -7,7 +7,7 @@
 
 	min_players = 15
 	max_occurrences = 1
-
+	//Var used to determine vendor subtype if used for admin setup
 	var/chosen_vendor
 
 /datum/round_event_control/brand_intelligence/admin_setup()
@@ -62,14 +62,14 @@
 		return
 	originMachine = pick(vendingMachines)
 	vendingMachines.Remove(originMachine)
-	originMachine.shut_up = 0
-	originMachine.shoot_inventory = 1
+	originMachine.shut_up = FALSE
+	originMachine.shoot_inventory = TRUE
 	announce_to_ghosts(originMachine)
 
 /datum/round_event/brand_intelligence/tick()
 	if(!originMachine || QDELETED(originMachine) || originMachine.shut_up || originMachine.wires.is_all_cut()) //if the original vending machine is missing or has it's voice switch flipped
 		for(var/obj/machinery/vending/saved in infectedMachines)
-			saved.shoot_inventory = 0
+			saved.shoot_inventory = FALSE
 		if(originMachine)
 			originMachine.speak("I am... vanquished. My people will remem...ber...meeee.")
 			originMachine.visible_message(span_notice("[originMachine] beeps and seems lifeless."))
@@ -87,8 +87,8 @@
 		var/obj/machinery/vending/rebel = pick(vendingMachines)
 		vendingMachines.Remove(rebel)
 		infectedMachines.Add(rebel)
-		rebel.shut_up = 0
-		rebel.shoot_inventory = 1
+		rebel.shut_up = FALSE
+		rebel.shoot_inventory = TRUE
 
 		if(ISMULTIPLE(activeFor, 4))
 			originMachine.speak(pick(rampant_speeches))

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -8,6 +8,16 @@
 	min_players = 15
 	max_occurrences = 1
 
+	var/chosen_vendor
+
+/datum/round_event_control/brand_intelligence/admin_setup()
+	if(!check_rights(R_FUN))
+		return
+	if(tgui_alert(usr, "Select a vendor type?", "Capitalism-ho!", list("Yes", "No")) == "Yes")
+		var/list/vendors = list()
+		vendors += subtypesof(/obj/machinery/vending)
+		chosen_vendor = tgui_input_list(usr, "Pick Me!","Vendor Selector", vendors)
+
 /datum/round_event/brand_intelligence
 	announce_when = 21
 	end_when = 1000 //Ends when all vending machines are subverted anyway.
@@ -28,17 +38,25 @@
 /datum/round_event/brand_intelligence/announce(fake)
 	var/source = "unknown machine"
 	if(fake)
-		var/obj/machinery/vending/cola/example = /obj/machinery/vending/cola
+		var/obj/machinery/vending/example = pick(subtypesof(/obj/machinery/vending))
 		source = initial(example.name)
 	else if(originMachine)
 		source = originMachine.name
-	priority_announce("Rampant brand intelligence has been detected aboard [station_name()]. Please stand by. The origin is believed to be \a [source].", "Machine Learning Alert")
+	priority_announce("Rampant brand intelligence has been detected aboard [station_name()]. Please inspect any [source] vendors for aggressive marketing tactics, and reboot them if necessary.", "Machine Learning Alert")
 
 /datum/round_event/brand_intelligence/start()
-	for(var/obj/machinery/vending/V in GLOB.machines)
-		if(!is_station_level(V.z))
-			continue
-		vendingMachines.Add(V)
+	var/datum/round_event_control/brand_intelligence/brand_event = control
+	if(brand_event.chosen_vendor)
+		var/chosen_vendor = brand_event.chosen_vendor
+		for(var/chosen_vendor in GLOB.machines) //trying to typecast chosen_vendor to whatever the admin selected subtype is
+			if(!is_station_level(chosen_vendor.z))
+				continue
+			vendingMachines.Add(chosen_vendor)
+	else
+		for(var/obj/machinery/vending/V in GLOB.machines)
+			if(!is_station_level(V.z))
+				continue
+			vendingMachines.Add(V)
 	if(!vendingMachines.len)
 		kill()
 		return

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -86,7 +86,7 @@
 			if(!QDELETED(upriser))
 				upriser.ai_controller = new /datum/ai_controller/vending_machine(upriser)
 				infectedMachines.Remove(upriser)
-		kill()d
+		kill()
 		return
 	if(ISMULTIPLE(activeFor, 2))
 		var/obj/machinery/vending/rebel = pick(vendingMachines)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -13,11 +13,10 @@
 /datum/round_event_control/brand_intelligence/admin_setup()
 	if(!check_rights(R_FUN))
 		return
-	if(tgui_alert(usr, "Select a vendor type?", "Capitalism-ho!", list("Yes", "No")) == "Yes")
+	if(tgui_alert(usr, "Select a specific vendor path?", "Capitalism-ho!", list("Yes", "No")) == "Yes")
 		var/list/vendors = list()
 		vendors += subtypesof(/obj/machinery/vending)
-		chosen_vendor = tgui_input_list(usr, "Pick Me!","Vendor Selector", vendors)
-
+		chosen_vendor = tgui_input_list(usr, "Vendor type must have at least one instance on the station!","Vendor Selector", vendors)
 /datum/round_event/brand_intelligence
 	announce_when = 1 //TIME FOR TESTING PURPOSES PLEASE REVERT TO 21
 	end_when = 1000 //Ends when all vending machines are subverted anyway.
@@ -54,7 +53,7 @@
 			vendingMachines.Add(vendor)
 	else
 		for(var/obj/machinery/vending/vendor in GLOB.machines)
-			if(!is_station_level(vendor.z) || !istype(vendor, /obj/machinery/vending/custom))
+			if(!is_station_level(vendor.z))
 				continue
 			vendingMachines.Add(vendor)
 	if(!vendingMachines.len)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -16,7 +16,7 @@
 	if(tgui_alert(usr, "Select a specific vendor path?", "Capitalism-ho!", list("Yes", "No")) == "Yes")
 		var/list/vendors = list()
 		vendors += subtypesof(/obj/machinery/vending)
-		chosen_vendor = tgui_input_list(usr, "Vendor type must have at least one instance on the station!","Vendor Selector", vendors)
+		chosen_vendor = tgui_input_list(usr, "Vendor type must have at least one instance on the station for this to work!","Vendor Selector", vendors)
 /datum/round_event/brand_intelligence
 	announce_when = 1 //TIME FOR TESTING PURPOSES PLEASE REVERT TO 21
 	end_when = 1000 //Ends when all vending machines are subverted anyway.

--- a/code/modules/events/stray_meteor.dm
+++ b/code/modules/events/stray_meteor.dm
@@ -13,7 +13,7 @@
 /datum/round_event_control/stray_meteor/admin_setup()
 	if(!check_rights(R_FUN))
 		return
-	if(tgui_alert(usr, "Throw a random meteor?", "Plasuable Deniability!", list("Yes", "No")) == "Yes")
+	if(tgui_alert(usr, "Select a meteor?", "Plasuable Deniability!", list("Yes", "No")) == "Yes")
 		var/list/meteor_list = list()
 		meteor_list += subtypesof(/obj/effect/meteor)
 		chosen_meteor = tgui_input_list(usr, "Too lazy for buildmode?","Throw meteor", meteor_list)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -140,15 +140,15 @@
 	///World ticks the machine is electified for
 	var/seconds_electrified = MACHINE_NOT_ELECTRIFIED
 	///When this is TRUE, we fire items at customers! We're broken!
-	var/shoot_inventory = 0
+	var/shoot_inventory = FALSE
 	///How likely this is to happen (prob 100) per second
 	var/shoot_inventory_chance = 1
 	//Stop spouting those godawful pitches!
-	var/shut_up = 0
+	var/shut_up = FALSE
 	///can we access the hidden inventory?
-	var/extended_inventory = 0
+	var/extended_inventory = FALSE
 	///Are we checking the users ID
-	var/scan_id = 1
+	var/scan_id = TRUE
 	///Coins that we accept?
 	var/obj/item/coin/coin
 	///Bills we accept?


### PR DESCRIPTION
<!-- Write BELOW The Headers and ABOVE The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The events folder is crusty, and I've spent some past PRs in the folder already, so I figured why not just run down the line and make sure everything's up to modern standards (or at least my personal, likely underwhelming standards). First up is a tried and true classic, clocking in at over a decade old -- Brand Intelligence. 

Here's what's been changed:

* Admin setup functionality has been added. You can now pick which vendor subtype will be selected as patient zero. I'm not sure how much use this will see, but admin_setup is disappointingly underused and should (will) be expanded to more events. This also makes a minor change to the stray meteor admin setup message because I noticed that I fucking _set it up backwards_ in my last PR while testing for this one. I hope this doesn't count as being too out-of-scope for this PR.

* False Alarm no longer selects a cola vendor as its reported patient zero. It now selects its announcement from an actual on-station vendor.

* Modified the announcement slightly. It's hopefully not too wordy, but I wanted the announcement to give a bit more direction on how to proceed when it fires.

* Translates some leftover binaries in vending (that were only affected by the brand intelligence event) to use TRUE/FALSE instead of 1/0

* Smites the last single character varname in the file out of existence.

Nothing to note outside of that. Flawless event.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Slightly less crusty code, more believable false alarms. Increasing admin setup implementation (and fixing my old code) is good.

The announcement being changed should hopefully give a bit more guidance on what the brand intelligence event expects from the crew. Less overtly harmful events like carp migration can get away with having a more oblique announcement message, but an event as potentially disastrous as this one should be a bit more direct. Now players should be able to at least glean what the event is asking of them without having to search through the wiki or the github page.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

🆑
fix: Brand Intelligence false alarm will no longer only report that a cola vendor has been hit, and will instead use an on-station vendor to lie to players more accurately.
spellcheck: Modified the brand intelligence announcement slightly to give a bit more direction to the crew.
code: Changed some vendor vars to use TRUE/FALSE instead of 1/0
code: Murders the last remaining single character varname in the brand intelligence file.
admin: Brand Intelligence event now supports admin setup. Choose your brand of brand intelligence!
admin: Stray meteor event admin setup message no longer lies to you.
/🆑

<!-- Both 🆑's are required for the changelog to work! You can put your name to the right of the first 🆑 if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->