### PR TITLE
Fixed airlock shells made from airlock electronics not triggering AAE circuit component

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -81,9 +81,9 @@
 
 #define COMSIG_OBJ_ALLOWED "door_try_to_activate"
 	#define COMPONENT_OBJ_ALLOW (1<<0)
+	#define COMPONENT_OBJ_DISALLOW (1<<1)
 
 #define COMSIG_AIRLOCK_SHELL_ALLOWED "airlock_shell_try_allowed"
-	#define COMPONENT_AIRLOCK_SHELL_ALLOW (1<<0)
 
 // /obj/machinery/door/airlock signals
 

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -1,8 +1,11 @@
 
 //returns TRUE if this mob has sufficient access to use this object
 /obj/proc/allowed(mob/accessor)
-	if(SEND_SIGNAL(src, COMSIG_OBJ_ALLOWED, accessor) & COMPONENT_OBJ_ALLOW)
+	var/result_bitflags = SEND_SIGNAL(src, COMSIG_OBJ_ALLOWED, accessor)
+	if(result_bitflags & COMPONENT_OBJ_ALLOW)
 		return TRUE
+	if(result_bitflags & COMPONENT_OBJ_DISALLOW) // override all other checks
+		return FALSE
 	//check if it doesn't require any access at all
 	if(check_access(null))
 		return TRUE

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -31,7 +31,7 @@
 	return FALSE
 
 /obj/machinery/door/airlock/shell/allowed(mob/user)
-	if(SEND_SIGNAL(src, COMSIG_AIRLOCK_SHELL_ALLOWED, user) & COMPONENT_AIRLOCK_SHELL_ALLOW)
+	if(SEND_SIGNAL(src, COMSIG_AIRLOCK_SHELL_ALLOWED, user) & COMPONENT_OBJ_ALLOW)
 		return TRUE
 	return isAdminGhostAI(user)
 
@@ -156,12 +156,12 @@
 	. = ..()
 	if(istype(shell, /obj/machinery/door/airlock))
 		attached_airlock = shell
-		RegisterSignal(shell, COMSIG_AIRLOCK_SHELL_ALLOWED , .proc/handle_allowed)
+		RegisterSignal(shell, COMSIG_OBJ_ALLOWED, .proc/handle_allowed)
 
 /obj/item/circuit_component/airlock_access_event/unregister_shell(atom/movable/shell)
 	attached_airlock = null
 	UnregisterSignal(shell, list(
-		COMSIG_AIRLOCK_SHELL_ALLOWED ,
+		COMSIG_OBJ_ALLOWED,
 	))
 	return ..()
 
@@ -193,4 +193,6 @@
 		return
 
 	if(result["should_open"])
-		return COMPONENT_AIRLOCK_SHELL_ALLOW
+		return COMPONENT_OBJ_ALLOW
+	else
+		return COMPONENT_OBJ_DISALLOW

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -156,12 +156,16 @@
 	. = ..()
 	if(istype(shell, /obj/machinery/door/airlock))
 		attached_airlock = shell
-		RegisterSignal(shell, COMSIG_OBJ_ALLOWED, .proc/handle_allowed)
+		RegisterSignal(shell, list(
+			COMSIG_OBJ_ALLOWED,
+			COMSIG_AIRLOCK_SHELL_ALLOWED,
+		), .proc/handle_allowed)
 
 /obj/item/circuit_component/airlock_access_event/unregister_shell(atom/movable/shell)
 	attached_airlock = null
 	UnregisterSignal(shell, list(
 		COMSIG_OBJ_ALLOWED,
+		COMSIG_AIRLOCK_SHELL_ALLOWED
 	))
 	return ..()
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Airlock shells made from airlock electronic and door assemblies would not trigger the 'Airlock Access Event' circuit component because the registered signals did not include the signals called by regular airlocks. This fixes that.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Bugfix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed non-printed airlock shells from not triggering the 'Airlock Access Event' circuit component.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
