### PR TITLE
Fixes `async_fire_ranged_attack` failing to get `target_mob` for targeting body zone

### DIFF
--- a/code/datums/elements/ranged_attacks.dm
+++ b/code/datums/elements/ranged_attacks.dm
@@ -37,7 +37,7 @@
 		playsound(firer, projectilesound, 100, TRUE)
 		var/target_zone
 		if(ismob(target))
-			var/mob/target_mob
+			var/mob/target_mob = target
 			target_zone = target_mob.get_random_valid_zone()
 		else
 			target_zone = ran_zone()


### PR DESCRIPTION
## About The Pull Request
Fixes #69997 and probably some other mobs using this maybe possibly?

## Why It's Good For The Game
Runtime begone, death via glockroach restored

## Changelog
:cl:
fix: glockroaches (and maybe other unreported simplemobs that can shoot) now properly shoot
/:cl:
