### PR TITLE
Removes canuserrotate from simple rotation's screentip

### DIFF
--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -186,10 +186,10 @@
 
 	var/rotation_screentip = FALSE
 
-	if(CanBeRotated(user, ROTATION_CLOCKWISE, silent=TRUE) && CanUserRotate(user, ROTATION_CLOCKWISE))
+	if(CanBeRotated(user, ROTATION_CLOCKWISE, silent=TRUE))
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Rotate left"
 		rotation_screentip = TRUE
-	if(CanBeRotated(user, ROTATION_COUNTERCLOCKWISE, silent=TRUE) && CanUserRotate(user, ROTATION_COUNTERCLOCKWISE))
+	if(CanBeRotated(user, ROTATION_COUNTERCLOCKWISE, silent=TRUE))
 		context[SCREENTIP_CONTEXT_ALT_RMB] = "Rotate right"
 		rotation_screentip = TRUE
 


### PR DESCRIPTION
## About The Pull Request

Removes the check on whether the user can rotate a chair or not, in the screentip context message.

## Why It's Good For The Game

We shouldn't check to see if a person can or can't rotate a chair or not, they will instead get the feedback when they try to rotate but fail, it's better for the screentip to let them know it's a mechanic that exists, even if they can't always do it, because we give more context on attempts.

This closes https://github.com/tgstation/tgstation/pull/69983 without refactoring canusetopic into doing something we shouldn't want.

## Changelog

:cl:
fix: Items that rotate will no longer spam you with error messages when you hover your mouse over them.
/:cl:
