### PR TITLE
Removes extra fax machine from the Cargo Office on Tram Station

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -4428,10 +4428,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"bLM" = (
-/obj/machinery/fax,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "bLP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -177622,7 +177618,7 @@ akr
 akr
 cTU
 ett
-bLM
+uax
 uax
 qpG
 bTx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/7483112/190941956-ddefbf4b-74f5-4b42-a997-c871c14ef932.png)
There was a fax machine here. There isn't supposed to be a fax machine here. It's gone now.

Here's where the fax machine for the cargo lobby is supposed to be and still is, I left this one in place:
![image](https://user-images.githubusercontent.com/7483112/190942235-d26b90fc-2fcb-4f41-af4c-80ede0cab707.png)

## Why It's Good For The Game

Removes an anchored device lying on the ground which you would constantly trip over while trying to use the cargo console.
You can't even unwrench it and sell it because fax machines are shuttle banned.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Removes a duplicated fax machine from the tram cargo lobby which wasn't supposed to be there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
