### PR TITLE
Fixes AI verb Jump To Network

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -616,9 +616,9 @@
 	var/mob/living/silicon/ai/U = usr
 
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
-		//in-built silicon cameras won't be needed to build a list of available networks,
-		//and they break the next check by being in a mob, setting their z to 0
-		if(istype(C.loc, /mob/living/silicon))
+		//cameras that are located in an object have their z set to 0, breaking the next check;
+		//mostly an issue for silicons. their cameras are in the end of the list, so it shouldn't affect building the list
+		if(!C.z)
 			continue
 		var/list/tempnetwork = C.network
 		if(!(is_station_level(C.z) || is_mining_level(C.z) || ("ss13" in tempnetwork)))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -616,6 +616,10 @@
 	var/mob/living/silicon/ai/U = usr
 
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
+		//in-built silicon cameras won't be needed to build a list of available networks,
+		//and they break the next check by being in a mob, setting their z to 0
+		if(istype(C.loc, /mob/living/silicon))
+			continue
 		var/list/tempnetwork = C.network
 		if(!(is_station_level(C.z) || is_mining_level(C.z) || ("ss13" in tempnetwork)))
 			continue

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -616,13 +616,14 @@
 	var/mob/living/silicon/ai/U = usr
 
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
-		//cameras that are located in an object have their z set to 0, breaking the next check;
-		//mostly an issue for silicons. their cameras are in the end of the list, so it shouldn't affect building the list
-		if(!C.z)
+		var/turf/camera_turf = get_turf(C)
+		if(!camera_turf || !(is_station_level(camera_turf.z) || is_mining_level(camera_turf.z) || ("ss13" in tempnetwork)))
 			continue
+		if(!C.can_use())
+			continue
+			
 		var/list/tempnetwork = C.network
-		if(!(is_station_level(C.z) || is_mining_level(C.z) || ("ss13" in tempnetwork)))
-			continue
+		tempnetwork.Remove("rd", "ordnance", "prison")
 		if(!C.can_use())
 			continue
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -616,13 +616,14 @@
 	var/mob/living/silicon/ai/U = usr
 
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
-		var/turf/camera_turf = get_turf(C)
+		var/turf/camera_turf = get_turf(C) //get camera's turf in case it's built into something so we don't get z=0
+
+		var/list/tempnetwork = C.network
 		if(!camera_turf || !(is_station_level(camera_turf.z) || is_mining_level(camera_turf.z) || ("ss13" in tempnetwork)))
 			continue
 		if(!C.can_use())
 			continue
-			
-		var/list/tempnetwork = C.network
+
 		tempnetwork.Remove("rd", "ordnance", "prison")
 		if(!C.can_use())
 			continue

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -623,11 +623,6 @@
 			continue
 		if(!C.can_use())
 			continue
-
-		tempnetwork.Remove("rd", "ordnance", "prison")
-		if(!C.can_use())
-			continue
-
 		tempnetwork.Remove("rd", "ordnance", "prison")
 		if(length(tempnetwork))
 			for(var/i in C.network)


### PR DESCRIPTION
## About The Pull Request
This verb was checking all available cameras through `GLOB.cameranet.cameras` to build a list of all available camera networks to jump to with this code:
https://github.com/tgstation/tgstation/blob/ba1b1a3e0404d53878242d265fa548a6f8a0e30f/code/modules/mob/living/silicon/ai/ai.dm#L617-L624

However, cameras that are residing inside an object's contents (currently, these are only cameras built into cyborgs and AIs) have their `z` as 0, which would throw a runtime with an out of bounds list index and prevent the verb from working.

~~This PR adds a check that skips over such cameras in this loop. Since silicon cameras are added to `GLOB.cameranet.cameras` upon mob initialisation (round join),  they will be in the very end of the cameras list and thus shouldn't affect the resulting list of available networks.~~

This PR adds a `get_turf()` step to the process, which lets us avoid using a non-existant `z`. 

## Why It's Good For The Game
Fixes #70228 (the network part)
Functioning verbs is healthy. Less runtimes to comb through is also good.

## Changelog
:cl:
fix: fixed AI Jump To Network verb not functioning
/:cl:
