### PR TITLE
Fixes FOV exploit with gasmasks

### DIFF
--- a/code/datums/components/clothing_fov_visor.dm
+++ b/code/datums/components/clothing_fov_visor.dm
@@ -6,6 +6,8 @@
 	var/visor_up = FALSE
 	/// Because of clothing code not being too good, we need keep track whether we are worn.
 	var/is_worn = FALSE
+	/// The current wearer
+	var/mob/living/wearer
 
 /datum/component/clothing_fov_visor/Initialize(fov_angle)
 	. = ..()
@@ -22,15 +24,23 @@
 
 /datum/component/clothing_fov_visor/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED, COMSIG_CLOTHING_VISOR_TOGGLE))
+	if(wearer)
+		wearer.remove_fov_trait(src, fov_angle)
+		UnregisterSignal(wearer, COMSIG_PARENT_QDELETING)
+		wearer = null
 	return ..()
 
 /// On dropping the item, remove the FoV trait if visor was down.
 /datum/component/clothing_fov_visor/proc/on_drop(datum/source, mob/living/dropper)
 	SIGNAL_HANDLER
 	is_worn = FALSE
+	if(wearer) // Prevent any edge cases where on_drop is called with a different dropper to the one who equipped the visor.
+		UnregisterSignal(wearer, COMSIG_PARENT_QDELETING)
+		wearer.remove_fov_trait(src, fov_angle)
+		wearer = null
 	if(visor_up)
 		return
-	dropper.remove_fov_trait(source.type, fov_angle)
+	dropper.remove_fov_trait(src, fov_angle)
 	dropper.update_fov()
 
 /// On equipping the item, add the FoV trait if visor isn't up.
@@ -39,10 +49,20 @@
 	if(!(source.slot_flags & slot)) //If EQUIPPED TO HANDS FOR EXAMPLE
 		return
 	is_worn = TRUE
+	if(wearer && wearer != equipper)
+		UnregisterSignal(wearer, COMSIG_PARENT_QDELETING)
+		wearer.remove_fov_trait(src, fov_angle)
+	wearer = equipper
+	RegisterSignal(wearer, COMSIG_PARENT_QDELETING, .proc/on_wearer_deleted)
 	if(visor_up)
 		return
-	equipper.add_fov_trait(source.type, fov_angle)
+	equipper.add_fov_trait(src, fov_angle)
 	equipper.update_fov()
+
+/datum/component/clothing_fov_visor/proc/on_wearer_deleted(datum/source)
+	SIGNAL_HANDLER
+	wearer.remove_fov_trait(src, fov_angle)
+	wearer = null
 
 /// On toggling the visor, we may want to add or remove FOV trait from the wearer.
 /datum/component/clothing_fov_visor/proc/on_visor_toggle(datum/source, visor_state)
@@ -51,10 +71,10 @@
 	if(!is_worn)
 		return
 	var/obj/item/clothing/clothing_parent = parent
-	var/mob/living/wearer = clothing_parent.loc //This has to be the case due to equip/dropped keeping track.
+	var/mob/living/current_wearer = clothing_parent.loc //This has to be the case due to equip/dropped keeping track.
 	if(visor_up)
-		wearer.remove_fov_trait(source.type, fov_angle)
-		wearer.update_fov()
+		current_wearer.remove_fov_trait(src, fov_angle)
+		current_wearer.update_fov()
 	else
-		wearer.add_fov_trait(source.type, fov_angle)
-		wearer.update_fov()
+		current_wearer.add_fov_trait(src, fov_angle)
+		current_wearer.update_fov()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
You can bypass FOV by equipping a gasmask, holding another gasmask in your hand and then dropping that gasmask. This is a bug, because the unique 'keys' is stored by type and not by ref.
Closes #67552

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Fixes an exploit

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed bypassing gasmask FOV.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
