### PR TITLE
Fixes some `pretty_string_from_reagent_list` runtimes

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -173,7 +173,7 @@
 					return
 				to_chat(user, span_notice("You add [item] to the [initial(name)] assembly."))
 				beakers += item
-				var/reagent_list = pretty_string_from_reagent_list(item.reagents)
+				var/reagent_list = pretty_string_from_reagent_list(item.reagents.reagent_list)
 				user.log_message("inserted [item] ([reagent_list]) into [src]", LOG_GAME)
 			else
 				to_chat(user, span_warning("[item] is empty!"))

--- a/code/modules/reagents/reagent_containers/misc.dm
+++ b/code/modules/reagents/reagent_containers/misc.dm
@@ -143,7 +143,7 @@
 		return
 	if(iscarbon(A) && reagents?.total_volume)
 		var/mob/living/carbon/C = A
-		var/reagentlist = pretty_string_from_reagent_list(reagents)
+		var/reagentlist = pretty_string_from_reagent_list(reagents.reagent_list)
 		var/log_object = "containing [reagentlist]"
 		if(user.combat_mode && !C.is_mouth_covered())
 			reagents.trans_to(C, reagents.total_volume, transfered_by = user, methods = INGEST)


### PR DESCRIPTION
## About The Pull Request

The first argument of `pretty_string_from_reagent_list` is a `list/reagent_list`, instead of a reagents datum, so some things runtime error'd 

This proc should really accept either, but eh

## Why It's Good For The Game

No runtimes

## Changelog

:cl: Melbert
fix: Fixes runtimes in damp rag and chem grenade logging
/:cl:

