### PR TITLE
Fixes an `internals` related hard delete

### DIFF
--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -170,7 +170,7 @@
 	if(I == internal)
 		internal = null
 		if(!QDELETED(src))
-			update_action_buttons_icon(TRUE)
+			update_action_buttons_icon(status_only = TRUE)
 
 	update_equipment_speed_mods()
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -165,6 +165,13 @@
 		legcuffed = null
 		if(!QDELETED(src))
 			update_worn_legcuffs()
+
+	// Not an else-if because we're probably equipped in another slot
+	if(I == internal)
+		internal = null
+		if(!QDELETED(src))
+			update_action_buttons_icon(TRUE)
+
 	update_equipment_speed_mods()
 
 //handle stuff to update when a mob equips/unequips a mask.


### PR DESCRIPTION
## About The Pull Request

Fixes a hard delete involving the `internals` var on carbons. 

Internals is a reference to an atom that supplies our internal air supply, and well it seems like nothing clears the value when it gets deleted

`doUnEquip` is how most clothing references are cleared so I implemented `internals` in carbon `doUnEquip`

I think this does have a side effect in that, in the past, we used to check if internals were in our mob's loc every breath tick, and if it wasn't, we'd null it, and that's how we null'd it. Now it does it instantly on unequip. 

## Why It's Good For The Game

Less hard deletes, more accurate behavior(?)

## Changelog

:cl: Melbert
fix: Unequipping an internals tank will immediately unregister it as your internals tank, instead of waiting (maximum) 8 seconds to do so
/:cl:

