### PR TITLE
Improvised shotgun shells can now only be loaded into modified shotguns, and have misfire chances now.

### DIFF
--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -36,6 +36,8 @@
 #define CALIBER_A762 "a762"
 /// The caliber used by shotguns.
 #define CALIBER_SHOTGUN "shotgun"
+/// The caliber used by improvised shotgun shells.
+#define CALIBER_IMPROV_SHOTGUN "improvised_shotgun"
 /// The caliber used by grenade launchers.
 #define CALIBER_40MM "40mm"
 /// The caliber used by rocket launchers.

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -106,6 +106,7 @@
 	icon_state = "improvshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
 	custom_materials = list(/datum/material/iron=250)
+	caliber = CALIBER_IMPROV_SHOTGUN
 	pellets = 10
 	variance = 25
 

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -102,7 +102,8 @@
 
 /obj/item/ammo_casing/shotgun/improvised
 	name = "improvised shell"
-	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
+	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards. The casing isn't sized correctly for most shotguns, \
+	so you'll probably have to modify the barrel if you want to load these."
 	icon_state = "improvshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
 	custom_materials = list(/datum/material/iron=250)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -26,6 +26,14 @@
 	weapon_weight = WEAPON_HEAVY
 
 	pb_knockback = 2
+	
+	initial_caliber = CALIBER_SHOTGUN
+	alternative_caliber = CALIBER_IMPROV_SHOTGUN
+	can_modify_ammo = TRUE
+	alternative_ammo_misfires = TRUE
+	can_misfire = FALSE
+	misfire_probability = 10 // 10% chance for your improvised shells to blow up in your face on the first fire.
+	misfire_percentage_increment = 25 //about 1 in 4 rounds, which increases rapidly every shot
 
 /obj/item/gun/ballistic/shotgun/blow_up(mob/user)
 	. = 0


### PR DESCRIPTION
## About The Pull Request

Improvised shotgun shells can now only be loaded into modified shotguns, and have misfire chances now.
Shotguns can be modified the same as detective revolvers and cleaned in the same way.

## Why It's Good For The Game

Security has migrated entirely to using shotguns loaded with improvised shells and this negates the purpose of the buckshot removal. This resolves that by making improvised shells risky to used because they're made from literal scrap.

## Changelog
:cl:
balance: Improvised shotgun shells can now only be loaded into modified shotguns, and have misfire chances now.
/:cl:
