### PR TITLE
Fixes two status effect related hard deletes

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -303,6 +303,11 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	var/mob/living/carbon/offerer
 	var/obj/item/receiving
 
+/atom/movable/screen/alert/give/Destroy()
+	offerer = null
+	receiving = null
+	return ..()
+
 /**
  * Handles assigning most of the variables for the alert that pops up when an item is offered
  *

--- a/code/datums/status_effects/_status_effect.dm
+++ b/code/datums/status_effects/_status_effect.dm
@@ -110,6 +110,7 @@
 /// or when a status effect with on_remove_on_mob_delete
 /// set to FALSE has its mob deleted
 /datum/status_effect/proc/be_replaced()
+	linked_alert = null
 	owner.clear_alert(id)
 	LAZYREMOVE(owner.status_effects, src)
 	owner = null


### PR DESCRIPTION
## About The Pull Request

- Status effects which replaced instead of deleting like normal would cause their alert to hard delete, due to the fact that they never cleared their alert reference after deleting it. 
- Giving status effects never cleared their references to their item and offered.

## Why It's Good For The Game

Hard deletes bad
