### PR TITLE
Moves signal overrride warnings to it's own log file

### DIFF
--- a/code/__HELPERS/logging/debug.dm
+++ b/code/__HELPERS/logging/debug.dm
@@ -62,3 +62,6 @@
 /// Logging for lua scripting
 /proc/log_lua(text)
 	WRITE_LOG(GLOB.lua_log, text)
+
+/proc/log_signal(text)
+	WRITE_LOG(GLOB.signals_log, text)

--- a/code/__HELPERS/logging/debug.dm
+++ b/code/__HELPERS/logging/debug.dm
@@ -17,6 +17,10 @@
 	if (CONFIG_GET(flag/log_job_debug))
 		WRITE_LOG(GLOB.world_job_debug_log, "JOB: [text]")
 
+/// Logging for lua scripting
+/proc/log_lua(text)
+	WRITE_LOG(GLOB.lua_log, text)
+
 /// Logging for mapping errors
 /proc/log_mapping(text, skip_world_log)
 #ifdef UNIT_TESTS
@@ -40,6 +44,13 @@
 /proc/log_query_debug(text)
 	WRITE_LOG(GLOB.query_debug_log, "SQL: [text]")
 
+/* Log to the logfile only. */
+/proc/log_runtime(text)
+	WRITE_LOG(GLOB.world_runtime_log, text)
+
+/proc/log_signal(text)
+	WRITE_LOG(GLOB.signals_log, text)
+
 /// Logging for DB errors
 /proc/log_sql(text)
 	WRITE_LOG(GLOB.sql_error_log, "SQL: [text]")
@@ -48,20 +59,9 @@
 /proc/log_topic(text)
 	WRITE_LOG(GLOB.world_game_log, "TOPIC: [text]")
 
-/* Log to the logfile only. */
-/proc/log_runtime(text)
-	WRITE_LOG(GLOB.world_runtime_log, text)
-
 /// Log to both DD and the logfile.
 /proc/log_world(text)
 #ifdef USE_CUSTOM_ERROR_HANDLER
 	WRITE_LOG(GLOB.world_runtime_log, text)
 #endif
 	SEND_TEXT(world.log, text)
-
-/// Logging for lua scripting
-/proc/log_lua(text)
-	WRITE_LOG(GLOB.lua_log, text)
-
-/proc/log_signal(text)
-	WRITE_LOG(GLOB.signals_log, text)

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -144,3 +144,6 @@ GLOBAL_PROTECT(world_uplink_log)
 
 GLOBAL_VAR(world_virus_log)
 GLOBAL_PROTECT(world_virus_log)
+
+GLOBAL_VAR(signals_log)
+GLOBAL_PROTECT(signals_log)

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -21,24 +21,24 @@ GLOBAL_PROTECT(demo_log)
 GLOBAL_VAR(dynamic_log)
 GLOBAL_PROTECT(dynamic_log)
 
+GLOBAL_VAR(filter_log)
+GLOBAL_PROTECT(filter_log)
+
 #ifdef REFERENCE_DOING_IT_LIVE
 GLOBAL_LIST_EMPTY(harddel_log)
 GLOBAL_PROTECT(harddel_log)
 #endif
 
-GLOBAL_VAR(filter_log)
-GLOBAL_PROTECT(filter_log)
-
 GLOBAL_LIST_EMPTY(IClog)
 GLOBAL_PROTECT(IClog)
-
-/// Keeps last 100 signals here in format: "[src] used [REF(src)] @ location [src.loc]: [freq]/[code]"
-GLOBAL_LIST_EMPTY(lastsignalers)
-GLOBAL_PROTECT(lastsignalers)
 
 /// Stores who uploaded laws to which silicon-based lifeform, and what the law was
 GLOBAL_LIST_EMPTY(lawchanges)
 GLOBAL_PROTECT(lawchanges)
+
+/// Keeps last 100 signals here in format: "[src] used [REF(src)] @ location [src.loc]: [freq]/[code]"
+GLOBAL_LIST_EMPTY(lastsignalers)
+GLOBAL_PROTECT(lastsignalers)
 
 GLOBAL_VAR(log_directory)
 GLOBAL_PROTECT(log_directory)
@@ -52,9 +52,6 @@ GLOBAL_PROTECT(OOClog)
 GLOBAL_VAR(perf_log)
 GLOBAL_PROTECT(perf_log)
 
-GLOBAL_VAR(query_debug_log)
-GLOBAL_PROTECT(query_debug_log)
-
 /// Picture logging
 GLOBAL_VAR(picture_log_directory)
 GLOBAL_PROTECT(picture_log_directory)
@@ -65,8 +62,14 @@ GLOBAL_PROTECT(picture_logging_id)
 GLOBAL_VAR(picture_logging_prefix)
 GLOBAL_PROTECT(picture_logging_prefix)
 
+GLOBAL_VAR(query_debug_log)
+GLOBAL_PROTECT(query_debug_log)
+
 GLOBAL_VAR(round_id)
 GLOBAL_PROTECT(round_id)
+
+GLOBAL_VAR(signals_log)
+GLOBAL_PROTECT(signals_log)
 
 GLOBAL_VAR(sql_error_log)
 GLOBAL_PROTECT(sql_error_log)
@@ -145,5 +148,3 @@ GLOBAL_PROTECT(world_uplink_log)
 GLOBAL_VAR(world_virus_log)
 GLOBAL_PROTECT(world_virus_log)
 
-GLOBAL_VAR(signals_log)
-GLOBAL_PROTECT(signals_log)

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -32,14 +32,13 @@ GLOBAL_PROTECT(harddel_log)
 GLOBAL_LIST_EMPTY(IClog)
 GLOBAL_PROTECT(IClog)
 
-/// Stores who uploaded laws to which silicon-based lifeform, and what the law was
-GLOBAL_LIST_EMPTY(lawchanges)
-GLOBAL_PROTECT(lawchanges)
-
 /// Keeps last 100 signals here in format: "[src] used [REF(src)] @ location [src.loc]: [freq]/[code]"
 GLOBAL_LIST_EMPTY(lastsignalers)
 GLOBAL_PROTECT(lastsignalers)
 
+/// Stores who uploaded laws to which silicon-based lifeform, and what the law was
+GLOBAL_LIST_EMPTY(lawchanges)
+GLOBAL_PROTECT(lawchanges)
 GLOBAL_VAR(log_directory)
 GLOBAL_PROTECT(log_directory)
 

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -192,7 +192,7 @@
 
 	for(var/sig_type in (islist(sig_type_or_types) ? sig_type_or_types : list(sig_type_or_types)))
 		if(!override && target_procs[sig_type])
-			stack_trace("[sig_type] overridden. Use override = TRUE to suppress this warning")
+			log_signal("[sig_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Proc: [proctype]")
 
 		target_procs[sig_type] = proctype
 		var/list/looked_up = lookup[sig_type]

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -132,8 +132,10 @@ GLOBAL_VAR(restart_counter)
 	GLOB.demo_log = "[GLOB.log_directory]/demo.log"
 	GLOB.dynamic_log = "[GLOB.log_directory]/dynamic.log"
 	GLOB.filter_log = "[GLOB.log_directory]/filters.log"
-	GLOB.sql_error_log = "[GLOB.log_directory]/sql.log"
+	GLOB.lua_log = "[GLOB.log_directory]/lua.log"
 	GLOB.query_debug_log = "[GLOB.log_directory]/query_debug.log"
+	GLOB.signals_log = "[GLOB.log_directory]/signals.log"
+	GLOB.sql_error_log = "[GLOB.log_directory]/sql.log"
 	GLOB.tgui_log = "[GLOB.log_directory]/tgui.log"
 	GLOB.world_asset_log = "[GLOB.log_directory]/asset.log"
 	GLOB.world_attack_log = "[GLOB.log_directory]/attack.log"
@@ -159,8 +161,6 @@ GLOBAL_VAR(restart_counter)
 	GLOB.world_uplink_log = "[GLOB.log_directory]/uplink.log"
 	GLOB.world_virus_log = "[GLOB.log_directory]/virus.log"
 
-	GLOB.lua_log = "[GLOB.log_directory]/lua.log"
-	GLOB.signals_log = "[GLOB.log_directory]/signals.log"
 
 #ifdef UNIT_TESTS
 	GLOB.test_log = "[GLOB.log_directory]/tests.log"

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -160,6 +160,7 @@ GLOBAL_VAR(restart_counter)
 	GLOB.world_virus_log = "[GLOB.log_directory]/virus.log"
 
 	GLOB.lua_log = "[GLOB.log_directory]/lua.log"
+	GLOB.signals_log = "[GLOB.log_directory]/signals.log"
 
 #ifdef UNIT_TESTS
 	GLOB.test_log = "[GLOB.log_directory]/tests.log"


### PR DESCRIPTION
I'm tired of seeing it in the runtime log. If the signals_log file exists, that means something needs to be fixed. Enjoy.

:cl: ShizCalev
admin: Moved signal overriden stack_trace warnings to it's own log file.
/:cl:

Log example:
```
[2022-09-19 23:42:22.311] movable_ztransit overridden. Use override = TRUE to suppress this warning.
 - Target: ShizCalev (/mob/dead/new_player) Proc: /datum/element/weather_listener/proc/handle_z_level_change
```
More than enough to find what you need to silence.