### PR TITLE
/datum/element/climbable signal override

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -18,10 +18,10 @@
 	if(climb_stun)
 		src.climb_stun = climb_stun
 
-	RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND, .proc/attack_hand)
-	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/on_examine)
-	RegisterSignal(target, COMSIG_MOUSEDROPPED_ONTO, .proc/mousedrop_receive)
-	RegisterSignal(target, COMSIG_ATOM_BUMPED, .proc/try_speedrun)
+	RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND, .proc/attack_hand, override = TRUE)
+	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/on_examine, override = TRUE)
+	RegisterSignal(target, COMSIG_MOUSEDROPPED_ONTO, .proc/mousedrop_receive, override = TRUE)
+	RegisterSignal(target, COMSIG_ATOM_BUMPED, .proc/try_speedrun, override = TRUE)
 	ADD_TRAIT(target, TRAIT_CLIMBABLE, ELEMENT_TRAIT(type))
 
 /datum/element/climbable/Detach(datum/target)


### PR DESCRIPTION
silences more signal override warnings.