### PR TITLE
Adds Missing Mining GPSs to Icebox Public Mining

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -32346,6 +32346,7 @@
 /obj/item/mining_scanner,
 /obj/item/flashlight,
 /obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/gps/mining,
 /turf/open/floor/iron,
 /area/station/commons/storage/mining)
 "jQS" = (
@@ -44539,6 +44540,7 @@
 /obj/item/flashlight,
 /obj/machinery/light/directional/west,
 /obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/gps/mining,
 /turf/open/floor/iron,
 /area/station/commons/storage/mining)
 "nFU" = (
@@ -46141,7 +46143,7 @@
 /area/station/science/xenobiology)
 "ocF" = (
 /mob/living/simple_animal/hostile/retaliate/goat{
-	atmos_requirements = list("min_oxy" = 1, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=1,"max_oxy"=0,"min_plas"=0,"max_plas"=1,"min_co2"=0,"max_co2"=5,"min_n2"=0,"max_n2"=0);
 	desc = "Not known for their pleasant disposition. This one seems a bit more hardy to the cold.";
 	minbodytemp = 150;
 	name = "Snowy Pete"
@@ -67350,6 +67352,7 @@
 /obj/item/flashlight,
 /obj/machinery/light/directional/east,
 /obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/gps/mining,
 /turf/open/floor/iron,
 /area/station/commons/storage/mining)
 "uLp" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 6 mining GPSs to Icebox public mining, 1 for each set of mining equipment.

![image](https://user-images.githubusercontent.com/62126254/191388038-3ab29970-953b-4def-97b6-100ea8fb0878.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1. Icebox is a very dangerous map to mine on without a weapon compared to lavaland and the chance of dieing and never being found seems to be a lot higher on this map.

2. Chemists need GPSs to see the geysers that the miners marked for them. 

3. While differences in maps can add flavor to the game, the lack of publicly available GPSs on icebox encouraged certain "strategies" that involved hiding either a communication console (and spamming recall) or AI upload console. Outside of that I don`t yet see any other effects this pr has on "pvp"

4. Bounty cubes (as far as I know) have a gps signal such that cargo/the person doing bounties is not as easily griefed and can easily track their un-redeemed hard work. This Pr makes that security measure more relevant on Icebox. (I would have this tacked onto reason 3 but usually bounty cube theft is not antagonist related pvp)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Adds Missing GPSs to Icebox Public Mining.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
