### PR TITLE
Fixes radio implant chilling in Icebox tool storage

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -59381,7 +59381,7 @@
 	dir = 8
 	},
 /obj/item/crowbar,
-/obj/item/implant/radio,
+/obj/item/radio,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
 "snj" = (


### PR DESCRIPTION

## About The Pull Request

There was a radio implant item present in tool storage on icebox. Now its a standard radio which you can use normally.

## Why It's Good For The Game

Fixes: #70057 

## Changelog

:cl:
fix: The radio in icebox tool storage is no longer an implant
/:cl:
