### PR TITLE
Adds the installed message phrase for voice analyzers to logging (bonus runtime fix)

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -235,6 +235,8 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 
 #define isprox(O) (istype(O, /obj/item/assembly/prox_sensor))
 
+#define isvoice(O) (istype(O, /obj/item/assembly/voice))
+
 #define issignaler(O) (istype(O, /obj/item/assembly/signaler))
 
 GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -235,8 +235,6 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 
 #define isprox(O) (istype(O, /obj/item/assembly/prox_sensor))
 
-#define isvoice(O) (istype(O, /obj/item/assembly/voice))
-
 #define issignaler(O) (istype(O, /obj/item/assembly/signaler))
 
 GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -63,7 +63,7 @@
 	var/obj/item/grenade/chem_grenade/grenade = holder
 	var/obj/item/assembly/pulser = get_attached(get_wire(1))
 	var/message = "\An [pulser] has pulsed [grenade] ([grenade.type]), which was installed by [fingerprint]"
-	if(isvoice(pulser))
+	if(istype(pulser, /obj/item/assembly/voice))
 		var/obj/item/assembly/voice/spoken_trigger = pulser
 		message +=  " with the following activation message: \"[spoken_trigger.recorded]\""
 	if(!grenade.dud_flags)

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -61,10 +61,14 @@
 
 /datum/wires/explosive/chem_grenade/explode()
 	var/obj/item/grenade/chem_grenade/grenade = holder
-	var/obj/item/assembly/assembly = get_attached(get_wire(1))
+	var/obj/item/assembly/pulser = get_attached(get_wire(1))
+	var/message = "\An [pulser] has pulsed [grenade] ([grenade.type]), which was installed by [fingerprint]"
+	if(isvoice(pulser))
+		var/obj/item/assembly/voice/spoken_trigger = pulser
+		message +=  " with the following activation message: \"[spoken_trigger.recorded]\""
 	if(!grenade.dud_flags)
-		message_admins("\An [assembly] has pulsed [grenade] ([grenade.type]), which was installed by [fingerprint].")
-	log_game("\An [assembly] has pulsed [grenade] ([grenade.type]), which was installed by [fingerprint].")
+		message_admins(message)
+	log_game(message)
 	var/mob/M = get_mob_by_ckey(fingerprint)
 	grenade.log_grenade(M) //Used in arm_grenade() too but this one conveys where the mob who triggered the bomb is
 	if(grenade.landminemode)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -195,7 +195,7 @@
 			admin_bomber_message = "The bomb's most recent set of fingerprints indicate it was last touched by [ADMIN_LOOKUPFLW(bomber)]"
 			bomber_message = " - Last touched by: [key_name_admin(bomber)]"
 
-		if(isvoice(attachment))
+		if(istype(attachment, /obj/item/assembly/voice))
 			var/obj/item/assembly/voice/spoken_trigger = attachment
 			attachment_message += " with the following activation message: \"[spoken_trigger.recorded]\""
 			admin_attachment_message += " with the following activation message: \"[spoken_trigger.recorded]\""

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -194,6 +194,7 @@
 		if(bomber)
 			admin_bomber_message = "The bomb's most recent set of fingerprints indicate it was last touched by [ADMIN_LOOKUPFLW(bomber)]"
 			bomber_message = " - Last touched by: [key_name_admin(bomber)]"
+			bomber.log_message("opened bomb valve", LOG_GAME, log_globally = FALSE)
 
 		if(istype(attachment, /obj/item/assembly/voice))
 			var/obj/item/assembly/voice/spoken_trigger = attachment
@@ -204,7 +205,6 @@
 		GLOB.bombers += admin_bomb_message
 		message_admins(admin_bomb_message)
 		log_game("Bomb valve opened in [AREACOORD(bombturf)][attachment_message][bomber_message]")
-		bomber.log_message("opened bomb valve", LOG_GAME, log_globally = FALSE)
 
 		valve_open = merge_gases(target, change_volume)
 

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -195,6 +195,11 @@
 			admin_bomber_message = "The bomb's most recent set of fingerprints indicate it was last touched by [ADMIN_LOOKUPFLW(bomber)]"
 			bomber_message = " - Last touched by: [key_name_admin(bomber)]"
 
+		if(isvoice(attachment))
+			var/obj/item/assembly/voice/spoken_trigger = attachment
+			attachment_message += " with the following activation message: \"[spoken_trigger.recorded]\""
+			admin_attachment_message += " with the following activation message: \"[spoken_trigger.recorded]\""
+
 		var/admin_bomb_message = "Bomb valve opened in [ADMIN_VERBOSEJMP(bombturf)]<br>[admin_attachment_message]<br>[admin_bomber_message]<br>[attachment_signal_log]"
 		GLOB.bombers += admin_bomb_message
 		message_admins(admin_bomb_message)

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -13,7 +13,8 @@
 	verb_ask = "beeps"
 	verb_exclaim = "beeps"
 	var/listening = FALSE
-	var/recorded = "" //the activation message
+	/// The activation message is tracked using this var.
+	var/recorded = ""
 	var/mode = INCLUSIVE_MODE
 	var/static/list/modes = list(
 		"inclusive",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Sometimes, it's CBT to figure out what exactly made a bomb go off, especially when a voice analyzer is involved. Now, when a voice analyzer is involved in TTV Bomb/Grenade explosions (already logged), it will also output the recorded phrase when present.

To do this, I also had to fix this following runtime, which would occur since voice analyzers didn't pass `bomber`:

![image](https://user-images.githubusercontent.com/34697715/191871302-58f6cdad-e1c8-4f45-be40-24ab03143098.png)

Also, that would result in the whole proc failing and the voice analyzer _never_ exploding the TTV. That's fucked up! I had to fix it in this PR because otherwise, the voice analyzer would _never_ explode the bomb, and what's the point of all that logging?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For chemical grenades:
![image](https://user-images.githubusercontent.com/34697715/191642190-94646a7c-1891-4815-9676-1f2ffad71faf.png)

For TTV bombs (forgot to get a screenshot, so have an excerpt of the game.log from that round)
```txt
[2022-09-22 00:35:08.128] GAME: Bomb valve opened in Ordnance Testing Lab (191,102,2) with the voice analyzer attached by <a href='?priv_msg=san7890'>San7890</a>/(Katie Yossarian) with the following message: "Deez nuts." - Last touched by: <a href='?priv_msg=san7890'>San7890</a>/(Katie Yossarian)
[2022-09-22 00:35:09.842] GAME: /obj/item/tank/internals/oxygen exploded with a power of 231.346 and a mix of TEMP=1544.11, MOL=197.675, VOL=140 o2=179.56;plasma=16.4251;co2=1.26777;water_vapor=0.422589;
[2022-09-22 00:35:09.842] GAME: Explosion with size (5, 10, 20, 0) in (Ordnance Testing Lab (191,102,2)).  Possible cause: the oxygen tank. Last fingerprints: *null*.
```

Keep in mind that I tweaked the messages a bit since I tested to ensure they worked in game.

Just allows for better administration rather than having to scroll up and down to figure out what specific phrase could have set it off.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: When a voice analyzer is attached to a bomb or a chemical grenade, the respective logs to game as well as the message_admins will contain the recorded phrase on that voice analyzer.
fix: Voice analyzers should now properly trigger TTVs to blow up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
