### PR TITLE
Fixes linda heat capacity errors

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -670,16 +670,17 @@ GLOBAL_LIST_EMPTY(colored_images)
 		atmos_gen[initial(atmostype.id)] = new atmostype
 
 /// Takes a gas string, returns the matching mutable gas_mixture
-/datum/controller/subsystem/air/proc/parse_gas_string(gas_string)
-	var/datum/gas_mixture/cached = strings_to_mix[gas_string]
+/datum/controller/subsystem/air/proc/parse_gas_string(gas_string, gastype = /datum/gas_mixture)
+	var/datum/gas_mixture/cached = strings_to_mix["[gas_string]-[gastype]"]
+
 	if(cached)
 		if(istype(cached, /datum/gas_mixture/immutable))
 			return cached
 		return cached.copy()
 
-	var/datum/gas_mixture/canonical_mix = new()
+	var/datum/gas_mixture/canonical_mix = new gastype()
 	// We set here so any future key changes don't fuck us
-	strings_to_mix[gas_string] = canonical_mix
+	strings_to_mix["[gas_string]-[gastype]"] = canonical_mix
 	gas_string = preprocess_gas_string(gas_string)
 
 	var/list/gases = canonical_mix.gases

--- a/code/modules/admin/verbs/fix_air.dm
+++ b/code/modules/admin/verbs/fix_air.dm
@@ -15,6 +15,6 @@
 			if(F.blocks_air)
 			//skip walls
 				continue
-			var/datum/gas_mixture/GM = SSair.parse_gas_string(F.initial_gas_mix)
+			var/datum/gas_mixture/GM = SSair.parse_gas_string(F.initial_gas_mix, /datum/gas_mixture/turf)
 			F.copy_air(GM)
 			F.update_visuals()

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -207,7 +207,7 @@
 	if(!text || !air)
 		return
 
-	var/datum/gas_mixture/turf_mixture = SSair.parse_gas_string(text)
+	var/datum/gas_mixture/turf_mixture = SSair.parse_gas_string(text, /datum/gas_mixture/turf)
 
 	air.merge(turf_mixture)
 	archive()

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -77,7 +77,7 @@
 ///Copies all gas info from the turf into a new gas_mixture, along with our temperature
 ///Returns the created gas_mixture
 /turf/proc/create_gas_mixture()
-	var/datum/gas_mixture/mix = SSair.parse_gas_string(initial_gas_mix)
+	var/datum/gas_mixture/mix = SSair.parse_gas_string(initial_gas_mix, /datum/gas_mixture/turf)
 
 	//acounts for changes in temperature
 	var/turf/parent = parent_type


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We make the assumption that a turf's heat capacity will never be 0. This is safe because we've got an override of /datum/gas_mixture for turfs that overrides 0 heat cap with 7000 (SPACE)
This is done to make cold actually flow through empty tiles, because we are hacks.

I forgot to include type in my gas mixture creation logic, so this was being dropped. FIXXXX