### PR TITLE
Fixes syndie bomb uplink text from being inaccurate

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -183,3 +183,6 @@
 #define TLV_OUTSIDE_WARNING_LIMIT 1
 ///the gas is outside the hazard limit, the air alarm will go into hazard mode
 #define TLV_OUTSIDE_HAZARD_LIMIT 2
+
+/// What's the minimum duration of a syndie bomb (in seconds)
+#define SYNDIEBOMB_MIN_TIMER_SECONDS 90

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -17,8 +17,8 @@
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_OFFLINE
 
 	use_power = NO_POWER_USE
-	var/minimum_timer = 90
-	var/timer_set = 90
+	var/minimum_timer = SYNDIEBOMB_MIN_TIMER_SECONDS
+	var/timer_set = SYNDIEBOMB_MIN_TIMER_SECONDS
 	var/maximum_timer = 60000
 
 	var/can_unanchor = TRUE

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -92,13 +92,14 @@
 
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
+	desc = null
 	progression_minimum = 40 MINUTES
 	item = /obj/item/sbeacondrop/bomb
 	cost = 11
 
 /datum/uplink_item/explosives/syndicate_bomb/New()
 	. = ..()
-	desc = "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
+	desc ||= "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
 			with a minimum of [SYNDIEBOMB_MIN_TIMER_SECONDS] seconds, and can be bolted to the floor with a wrench to prevent \
 			movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
 			transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -92,16 +92,16 @@
 
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
-	desc = null
+	desc = "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
+		with a minimum of %MIN_BOMB_TIMER seconds, and can be bolted to the floor with a wrench to prevent \
+		movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
+		transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
+		be defused, and some crew may attempt to do so. \
+		The bomb core can be pried out and manually detonated with other explosives."
 	progression_minimum = 40 MINUTES
 	item = /obj/item/sbeacondrop/bomb
 	cost = 11
 
 /datum/uplink_item/explosives/syndicate_bomb/New()
 	. = ..()
-	desc ||= "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
-			with a minimum of [SYNDIEBOMB_MIN_TIMER_SECONDS] seconds, and can be bolted to the floor with a wrench to prevent \
-			movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
-			transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
-			be defused, and some crew may attempt to do so. \
-			The bomb core can be pried out and manually detonated with other explosives."
+	desc = replacetext(desc, "%MIN_BOMB_TIMER", SYNDIEBOMB_MIN_TIMER_SECONDS)

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -92,12 +92,15 @@
 
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
+	progression_minimum = 40 MINUTES
+	item = /obj/item/sbeacondrop/bomb
+	cost = 11
+
+/datum/uplink_item/explosives/syndicate_bomb/New()
+	. = ..()
 	desc = "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
-			with a minimum of 60 seconds, and can be bolted to the floor with a wrench to prevent \
+			with a minimum of [SYNDIEBOMB_MIN_TIMER_SECONDS] seconds, and can be bolted to the floor with a wrench to prevent \
 			movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
 			transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
 			be defused, and some crew may attempt to do so. \
 			The bomb core can be pried out and manually detonated with other explosives."
-	progression_minimum = 40 MINUTES
-	item = /obj/item/sbeacondrop/bomb
-	cost = 11

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -231,15 +231,18 @@
 
 /datum/uplink_item/role_restricted/clown_bomb
 	name = "Clown Bomb"
-	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
-			with a minimum of 60 seconds, and can be bolted to the floor with a wrench to prevent \
-			movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
-			transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
-			be defused, and some crew may attempt to do so."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/sbeacondrop/clownbomb
 	cost = 15
 	restricted_roles = list(JOB_CLOWN)
+
+/datum/uplink_item/role_restricted/clown_bomb/New()
+	. = ..()
+	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
+		with a minimum of [SYNDIEBOMB_MIN_TIMER_SECONDS] seconds, and can be bolted to the floor with a wrench to prevent \
+		movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
+		transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
+		be defused, and some crew may attempt to do so."
 
 /datum/uplink_item/role_restricted/clowncar
 	name = "Clown Car"

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -231,7 +231,11 @@
 
 /datum/uplink_item/role_restricted/clown_bomb
 	name = "Clown Bomb"
-	desc = null
+	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
+		with a minimum of %MIN_BOMB_TIMER seconds, and can be bolted to the floor with a wrench to prevent \
+		movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
+		transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
+		be defused, and some crew may attempt to do so."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/sbeacondrop/clownbomb
 	cost = 15
@@ -239,11 +243,7 @@
 
 /datum/uplink_item/role_restricted/clown_bomb/New()
 	. = ..()
-	desc ||= "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
-		with a minimum of [SYNDIEBOMB_MIN_TIMER_SECONDS] seconds, and can be bolted to the floor with a wrench to prevent \
-		movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
-		transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
-		be defused, and some crew may attempt to do so."
+	desc = replacetext(desc, "%MIN_BOMB_TIMER", SYNDIEBOMB_MIN_TIMER_SECONDS)
 
 /datum/uplink_item/role_restricted/clowncar
 	name = "Clown Car"

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -231,6 +231,7 @@
 
 /datum/uplink_item/role_restricted/clown_bomb
 	name = "Clown Bomb"
+	desc = null
 	progression_minimum = 30 MINUTES
 	item = /obj/item/sbeacondrop/clownbomb
 	cost = 15
@@ -238,7 +239,7 @@
 
 /datum/uplink_item/role_restricted/clown_bomb/New()
 	. = ..()
-	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
+	desc ||= "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
 		with a minimum of [SYNDIEBOMB_MIN_TIMER_SECONDS] seconds, and can be bolted to the floor with a wrench to prevent \
 		movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
 		transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -427,6 +427,7 @@
 
 /datum/uplink_item/explosives/clown_bomb_clownops
 	name = "Clown Bomb"
+	desc = null
 	item = /obj/item/sbeacondrop/clownbomb
 	cost = 15
 	surplus = 0
@@ -434,7 +435,7 @@
 
 /datum/uplink_item/explosives/clown_bomb_clownops/New()
 	. = ..()
-	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
+	desc ||= "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
 		with a minimum of [SYNDIEBOMB_MIN_TIMER_SECONDS] seconds, and can be bolted to the floor with a wrench to prevent \
 		movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
 		transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -427,15 +427,18 @@
 
 /datum/uplink_item/explosives/clown_bomb_clownops
 	name = "Clown Bomb"
-	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
-			with a minimum of 60 seconds, and can be bolted to the floor with a wrench to prevent \
-			movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
-			transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
-			be defused, and some crew may attempt to do so."
 	item = /obj/item/sbeacondrop/clownbomb
 	cost = 15
 	surplus = 0
 	purchasable_from = UPLINK_CLOWN_OPS
+
+/datum/uplink_item/explosives/clown_bomb_clownops/New()
+	. = ..()
+	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
+		with a minimum of [SYNDIEBOMB_MIN_TIMER_SECONDS] seconds, and can be bolted to the floor with a wrench to prevent \
+		movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
+		transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
+		be defused, and some crew may attempt to do so."
 
 /datum/uplink_item/explosives/buzzkill
 	name = "Buzzkill Grenade Box"

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -427,7 +427,11 @@
 
 /datum/uplink_item/explosives/clown_bomb_clownops
 	name = "Clown Bomb"
-	desc = null
+	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
+		with a minimum of %MIN_BOMB_TIMER seconds, and can be bolted to the floor with a wrench to prevent \
+		movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
+		transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
+		be defused, and some crew may attempt to do so."
 	item = /obj/item/sbeacondrop/clownbomb
 	cost = 15
 	surplus = 0
@@ -435,11 +439,7 @@
 
 /datum/uplink_item/explosives/clown_bomb_clownops/New()
 	. = ..()
-	desc ||= "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
-		with a minimum of [SYNDIEBOMB_MIN_TIMER_SECONDS] seconds, and can be bolted to the floor with a wrench to prevent \
-		movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
-		transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
-		be defused, and some crew may attempt to do so."
+	desc = replacetext(desc, "%MIN_BOMB_TIMER", SYNDIEBOMB_MIN_TIMER_SECONDS)
 
 /datum/uplink_item/explosives/buzzkill
 	name = "Buzzkill Grenade Box"


### PR DESCRIPTION
## About The Pull Request

The uplink text for the syndie bombs state the min timer is 60 seconds, which is wrong, it's 90 seconds. 

## Why It's Good For The Game

Accurate uplink text

## Changelog

:cl: Melbert
spellcheck: Syndicate bomb uplink text is now accurate in that it tells you the minimum timer is 90 seconds and not 60 seconds.
/:cl:

