### PR TITLE
Game panel is a bit more generous when spawning multiple paths for admins

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1145,12 +1145,13 @@
 		if(!paths)
 			tgui_alert(usr,"The path list you sent is empty.")
 			return
-		if(length(paths) > 5)
-			tgui_alert(usr,"Select fewer object types, (max 5).")
+
+		var/number = clamp(text2num(href_list["object_count"]), 1, ADMIN_SPAWN_CAP)
+		if(length(paths) * number > ADMIN_SPAWN_CAP)
+			tgui_alert(usr,"Select fewer object types!")
 			return
 
 		var/list/offset = splittext(href_list["offset"],",")
-		var/number = clamp(text2num(href_list["object_count"]), 1, ADMIN_SPAWN_CAP)
 		var/X = offset.len > 0 ? text2num(offset[1]) : 0
 		var/Y = offset.len > 1 ? text2num(offset[2]) : 0
 		var/Z = offset.len > 2 ? text2num(offset[3]) : 0


### PR DESCRIPTION
## About The Pull Request

Changes the limit of paths to spawn via game panel from a hardcoded 5 to be based on the admin spawn limit.

## Why It's Good For The Game

5 is a bit limiting, especially as it's easily possible to spawn more than five types of something in other ways. QOL.

## Changelog

:cl: Melbert
admin: The game panel now lets you make more than five different types of something at once. 
/:cl:

