### PR TITLE
Latejoin/Midround Revolutions can only occur on Bastille Day.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -126,6 +126,8 @@
 		required_heads_of_staff = 1
 	if(!..())
 		return FALSE
+	if(!("Bastille Day" in SSevents.holidays))
+		return FALSE
 	var/head_check = 0
 	for(var/mob/player in GLOB.alive_player_list)
 		if (player.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)


### PR DESCRIPTION
## About The Pull Request

Latejoin/Midround Revolutions can only occur on Bastille Day.

## Why It's Good For The Game

Midround revs is funny once in a blue moon but not every single day, and this is a good way to handle that.

## Changelog

:cl:
balance: Latejoin/Midround Revolutions can only occur on Bastille Day.
/:cl:
