### PR TITLE
Fixes internals turning themselves off by moving them between slots

### DIFF
--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -167,7 +167,7 @@
 			update_worn_legcuffs()
 
 	// Not an else-if because we're probably equipped in another slot
-	if(I == internal)
+	if(I == internal && (QDELETED(src) || QDELETED(I) || I.loc != src))
 		internal = null
 		if(!QDELETED(src))
 			update_action_buttons_icon(status_only = TRUE)


### PR DESCRIPTION
## About The Pull Request

Fixes #70084 

I assumed internals had a bit more resilience, oops. 

Internals should not `null` themselves when moving between slots, only when being unequippedentirely (the internals are being deleted, the mob is being deleted, or the internals have been dropped).

Ideally internals should probably be handled better than this in general, I.E. not a reference to the tank on the mob / signalized / whatever, this works for now. ~~Annoyingly `doUnEquip` is not called when inserted into backpack~~

I'll unit test this later but I just wanna get the fix out since it is probably annoying 

## Why It's Good For The Game

Internals important

## Changelog

:cl: Melbert
fix: Moving active internals between valid slots no longer de-activates them 
/:cl:
