### PR TITLE
Unit tests powernets to make sure the whole station is connected.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54516,7 +54516,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "njg" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -96103,7 +96102,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "xvE" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7084,19 +7084,6 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/maintenance/disposal/incinerator)
-"bFy" = (
-/obj/structure/cable,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "cargoload"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor{
-	id = "cargoload";
-	name = "Supply Dock Loading Door"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/storage)
 "bFS" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/cable,
@@ -145870,7 +145857,7 @@ xDW
 hDJ
 tDx
 hDJ
-bFy
+sSh
 tDx
 aaa
 aaa

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54527,6 +54527,7 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "njs" = (
@@ -96108,6 +96109,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "xvM" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -57175,6 +57175,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "nQY" = (
@@ -73840,6 +73841,7 @@
 /obj/item/storage/box/deputy{
 	pixel_y = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "rYj" = (
@@ -90524,6 +90526,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "wdD" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -46141,7 +46141,7 @@
 /area/station/science/xenobiology)
 "ocF" = (
 /mob/living/simple_animal/hostile/retaliate/goat{
-	atmos_requirements = list("min_oxy" = 1, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=1,"max_oxy"=0,"min_plas"=0,"max_plas"=1,"min_co2"=0,"max_co2"=5,"min_n2"=0,"max_n2"=0);
 	desc = "Not known for their pleasant disposition. This one seems a bit more hardy to the cold.";
 	minbodytemp = 150;
 	name = "Snowy Pete"
@@ -71495,6 +71495,7 @@
 /obj/item/taperecorder{
 	pixel_x = -5
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "vZS" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1473,6 +1473,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "axF" = (
@@ -11101,6 +11102,7 @@
 	name = "Xenobio Pen 11 Blast DOors";
 	req_access = list("xenobiology")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "dms" = (
@@ -40388,6 +40390,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
 "msi" = (
@@ -76571,6 +76574,7 @@
 	name = "Containment Blast Door"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xyx" = (
@@ -188281,7 +188285,7 @@ pMF
 sfv
 xyn
 dmj
-pMF
+wPd
 fwC
 asb
 ega

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16020,6 +16020,7 @@
 "eNl" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/head_of_security,
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/hos)
 "eNm" = (
@@ -36569,6 +36570,7 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ldr" = (
@@ -47412,6 +47414,7 @@
 "oxJ" = (
 /obj/structure/bed/dogbed/lia,
 /mob/living/simple_animal/hostile/carp/lia,
+/obj/structure/cable,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/hos)
 "oxO" = (
@@ -72839,6 +72842,7 @@
 /area/station/service/chapel)
 "wtg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hos)
 "wtj" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -92570,7 +92570,7 @@ tFn
 ajw
 ajw
 hvB
-cOf
+aDD
 kkV
 sAv
 sAv
@@ -93341,7 +93341,7 @@ woG
 bMw
 xlA
 vhZ
-mqC
+ssF
 ezC
 iQg
 smC

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -428,6 +428,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
+"adT" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/station/maintenance/department/electrical)
 "aed" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3269,6 +3273,7 @@
 /area/station/security/prison/garden)
 "aVx" = (
 /obj/effect/spawner/random/structure/tank_holder,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "aVC" = (
@@ -5356,6 +5361,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"bFu" = (
+/obj/structure/cable,
+/turf/closed/wall/rust,
+/area/station/maintenance/department/electrical)
 "bFv" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -11931,6 +11940,7 @@
 	pixel_y = 4
 	},
 /obj/item/stock_parts/cell/high,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "dBg" = (
@@ -14087,9 +14097,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eki" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -14609,7 +14616,6 @@
 "era" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
@@ -14722,10 +14728,10 @@
 /area/station/security/warden)
 "esO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "esZ" = (
@@ -15415,6 +15421,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "eCU" = (
@@ -18154,6 +18161,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/electrical)
 "fpG" = (
@@ -18746,6 +18754,7 @@
 "fxd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "fxt" = (
@@ -20034,6 +20043,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "fNe" = (
@@ -20975,6 +20985,7 @@
 "gau" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "gaE" = (
@@ -22682,6 +22693,7 @@
 	pixel_x = -8;
 	pixel_y = -5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "gzA" = (
@@ -24291,6 +24303,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "gUZ" = (
@@ -24302,7 +24315,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "gVc" = (
-/obj/machinery/power/terminal,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -25866,6 +25878,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "hqW" = (
@@ -27455,6 +27468,7 @@
 "hOs" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "hOt" = (
@@ -28413,6 +28427,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "iaH" = (
@@ -28488,7 +28503,6 @@
 "ibm" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "ibJ" = (
@@ -28924,6 +28938,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "ihU" = (
@@ -29642,6 +29657,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/old,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "irj" = (
@@ -30195,6 +30211,7 @@
 "iyB" = (
 /obj/machinery/atmospherics/components/binary/valve/layer4,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "iyF" = (
@@ -30343,8 +30360,8 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "iAU" = (
@@ -33596,6 +33613,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "jwi" = (
@@ -33901,6 +33919,7 @@
 /obj/structure/door_assembly/door_assembly_eng{
 	anchored = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "jBT" = (
@@ -34180,6 +34199,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "jGW" = (
@@ -39170,7 +39190,6 @@
 	name = "Electrical Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
@@ -39379,6 +39398,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "lgu" = (
@@ -39744,6 +39764,7 @@
 /area/station/engineering/supermatter/room)
 "lme" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "lmh" = (
@@ -39981,6 +40002,7 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "lqy" = (
@@ -44283,7 +44305,6 @@
 	dir = 4
 	},
 /obj/structure/spider/stickyweb,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
@@ -49262,6 +49283,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/tile/wood,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "ocn" = (
@@ -50774,6 +50796,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "ozz" = (
@@ -51649,6 +51672,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /obj/item/t_scanner,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "oLH" = (
@@ -55574,6 +55598,7 @@
 "pQT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood/old,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "pRu" = (
@@ -55685,10 +55710,13 @@
 "pSu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "pSE" = (
@@ -56589,6 +56617,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
 /obj/structure/sign/poster/random/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "qgz" = (
@@ -57241,6 +57270,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "qpj" = (
@@ -57363,6 +57393,7 @@
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qrP" = (
@@ -57560,7 +57591,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
@@ -59658,6 +59688,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/xeno_spawn,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "raM" = (
@@ -60522,6 +60553,9 @@
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/power/terminal{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -62766,6 +62800,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "rRJ" = (
@@ -62832,7 +62867,6 @@
 "rSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /mob/living/simple_animal/hostile/giant_spider/hunter/scrawny,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
@@ -63169,6 +63203,7 @@
 "rZi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "rZE" = (
@@ -63191,7 +63226,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "rZN" = (
@@ -66395,6 +66429,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "sTO" = (
@@ -74219,6 +74254,7 @@
 	anchored = 1
 	},
 /obj/structure/barricade/wooden/crude,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "vfO" = (
@@ -79972,6 +80008,7 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "wGx" = (
@@ -81143,6 +81180,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "wWD" = (
@@ -81262,6 +81300,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "wYR" = (
@@ -81642,6 +81681,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "xeP" = (
@@ -84377,6 +84417,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "xTG" = (
@@ -127718,12 +127759,12 @@ aeu
 aeu
 aeu
 rpl
-rpl
-asj
-rpl
-asj
-rpl
-rpl
+adT
+bFu
+adT
+bFu
+adT
+adT
 vOX
 dJo
 mua

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -20699,7 +20699,6 @@
 /area/station/command/heads_quarters/cmo)
 "hGm" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
@@ -24399,7 +24398,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
@@ -27354,7 +27352,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "jNp" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4
@@ -39277,7 +39274,6 @@
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Lab"
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/effect/turf_decal/siding/purple{
@@ -40973,13 +40969,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"oCx" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
 "oCN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -46698,7 +46687,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
@@ -49209,6 +49197,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable/layer3,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "ryL" = (
@@ -56728,6 +56717,7 @@
 "tXz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable/layer3,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "tXD" = (
@@ -66051,7 +66041,6 @@
 /area/station/engineering/atmos)
 "xkY" = (
 /obj/structure/table,
-/obj/structure/cable,
 /obj/item/instrument/harmonica,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -122996,7 +122985,7 @@ aaa
 aaa
 gfU
 aTV
-oCx
+aVl
 oFC
 phN
 jEr

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -25684,7 +25684,6 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "jkT" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1976,7 +1976,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aTl" = (
@@ -8903,7 +8902,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "dki" = (
@@ -9664,7 +9662,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/tram/right)
 "dwj" = (
@@ -11610,7 +11607,6 @@
 	},
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/medical)
 "edC" = (
@@ -11969,7 +11965,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/greater)
 "ekx" = (
@@ -20315,7 +20310,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/tram/right)
 "hqz" = (
@@ -23015,6 +23009,17 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"ipk" = (
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/tram/right)
 "iqh" = (
 /obj/machinery/door/window{
 	name = "Captain's Desk";
@@ -33139,7 +33144,6 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/greater)
 "lRr" = (
@@ -35778,7 +35782,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/landmark/start/hangover,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/tram/right)
 "mLp" = (
@@ -42472,7 +42475,6 @@
 	dir = 8
 	},
 /obj/machinery/duct,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "pmc" = (
@@ -49622,15 +49624,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"rHY" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/tram/right)
 "rIi" = (
 /obj/machinery/door/airlock{
 	name = "Permabrig Showers"
@@ -56007,6 +56000,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"tWt" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/lower)
 "tWw" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -57485,16 +57489,6 @@
 /mob/living/simple_animal/bot/secbot/beepsky,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
-"uxg" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/tram/right)
 "uxk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -65733,6 +65727,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -111093,7 +111088,7 @@ hFC
 vgn
 hFC
 bsK
-uxg
+iwJ
 qxm
 afH
 afH
@@ -111111,7 +111106,7 @@ aeb
 aeb
 oaj
 iIm
-iIm
+tWt
 iIm
 lxW
 kxB
@@ -111350,7 +111345,7 @@ hFC
 hFC
 hFC
 bsK
-rHY
+vSV
 qxm
 afH
 afH
@@ -111601,13 +111596,13 @@ arE
 iRL
 iRL
 mbJ
-gUE
+ipk
 mMa
 hFC
 hFC
 hFC
 bsK
-rHY
+vSV
 qxm
 afH
 afH
@@ -111858,7 +111853,7 @@ vWx
 dhe
 dhe
 mbJ
-gUE
+ipk
 mMa
 hFC
 hFC

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1976,6 +1976,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aTl" = (
@@ -8902,6 +8903,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "dki" = (
@@ -9662,6 +9664,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/tram/right)
 "dwj" = (
@@ -11607,6 +11610,7 @@
 	},
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/medical)
 "edC" = (
@@ -11965,6 +11969,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/greater)
 "ekx" = (
@@ -20310,6 +20315,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/tram/right)
 "hqz" = (
@@ -23009,17 +23015,6 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"ipk" = (
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/tram/right)
 "iqh" = (
 /obj/machinery/door/window{
 	name = "Captain's Desk";
@@ -33144,6 +33139,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/greater)
 "lRr" = (
@@ -35782,6 +35778,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/tram/right)
 "mLp" = (
@@ -42475,6 +42472,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "pmc" = (
@@ -49624,6 +49622,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"rHY" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/tram/right)
 "rIi" = (
 /obj/machinery/door/airlock{
 	name = "Permabrig Showers"
@@ -56000,17 +56007,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
-"tWt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/lower)
 "tWw" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -57489,6 +57485,16 @@
 /mob/living/simple_animal/bot/secbot/beepsky,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
+"uxg" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/tram/right)
 "uxk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -65727,7 +65733,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -111088,7 +111093,7 @@ hFC
 vgn
 hFC
 bsK
-iwJ
+uxg
 qxm
 afH
 afH
@@ -111106,7 +111111,7 @@ aeb
 aeb
 oaj
 iIm
-tWt
+iIm
 iIm
 lxW
 kxB
@@ -111345,7 +111350,7 @@ hFC
 hFC
 hFC
 bsK
-vSV
+rHY
 qxm
 afH
 afH
@@ -111596,13 +111601,13 @@ arE
 iRL
 iRL
 mbJ
-ipk
+gUE
 mMa
 hFC
 hFC
 hFC
 bsK
-vSV
+rHY
 qxm
 afH
 afH
@@ -111853,7 +111858,7 @@ vWx
 dhe
 dhe
 mbJ
-ipk
+gUE
 mMa
 hFC
 hFC

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1702,8 +1702,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/light/directional/west,
-/obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "aNd" = (
@@ -4579,7 +4579,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/obj/structure/cable/layer1,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
@@ -8045,7 +8044,7 @@
 "cTT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "cTU" = (
@@ -20833,7 +20832,6 @@
 	pixel_x = 29
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hCe" = (
@@ -23064,7 +23062,6 @@
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
 	},
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "iqX" = (
@@ -25154,8 +25151,8 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "jcI" = (
@@ -25732,6 +25729,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "joe" = (
@@ -26348,7 +26346,7 @@
 	dir = 4;
 	mapping_id = "main_turbine"
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "jyQ" = (
@@ -28913,7 +28911,6 @@
 "ksR" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/light/directional/north,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "ksY" = (
@@ -35793,6 +35790,7 @@
 "mLv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "mLH" = (
@@ -36890,6 +36888,7 @@
 /obj/machinery/power/turbine/inlet_compressor{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "nfB" = (
@@ -48426,7 +48425,6 @@
 /area/station/commons/dorms)
 "rnA" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/cable/layer1,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -51007,10 +51005,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "seQ" = (
-/obj/structure/cable/layer1,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "seR" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -53199,7 +53197,6 @@
 	dir = 1
 	},
 /obj/machinery/holopad/secure,
-/obj/structure/cable/layer1,
 /obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
@@ -55311,7 +55308,7 @@
 /obj/machinery/computer/turbine_computer{
 	mapping_id = "main_turbine"
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "tGW" = (
@@ -63157,7 +63154,6 @@
 "wAQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/directional/north,
-/obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
@@ -63810,8 +63806,8 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/structure/cable/layer1,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "wMY" = (
@@ -63879,10 +63875,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/tram/left)
-"wOq" = (
-/obj/structure/cable/layer1,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "wOw" = (
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
@@ -107536,7 +107528,7 @@ rCd
 wcc
 vde
 jnU
-gqV
+seQ
 mLv
 mLv
 aMV
@@ -180813,12 +180805,12 @@ lwj
 tqN
 tqN
 rva
-wOq
-wOq
+gFf
+gFf
 ksR
 sVz
 bNr
-seQ
+aoh
 fyX
 ffe
 mgi

--- a/code/__DEFINES/power.dm
+++ b/code/__DEFINES/power.dm
@@ -14,5 +14,3 @@
 #define JOULES * 0.002
 
 GLOBAL_VAR_INIT(CHARGELEVEL, 0.001) // Cap for how fast cells charge, as a percentage-per-tick (.001 means cellcharge is capped to 1% per second)
-
-GLOBAL_LIST_EMPTY(powernets)

--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -5,7 +5,8 @@ SUBSYSTEM_DEF(machines)
 	wait = 2 SECONDS
 	var/list/processing = list()
 	var/list/currentrun = list()
-	var/list/powernets = list()
+	///List of all powernets on the server.
+	var/list/datum/powernet/powernets = list()
 
 /datum/controller/subsystem/machines/Initialize()
 	makepowernets()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -367,7 +367,13 @@ Used by the AI doomsday and the self-destruct nuke.
 GLOBAL_LIST_EMPTY(the_station_areas)
 
 /datum/controller/subsystem/mapping/proc/generate_station_area_list()
-	var/static/list/station_areas_blacklist = typecacheof(list(/area/space, /area/mine, /area/ruin, /area/centcom/asteroid/nearstation))
+	var/static/list/station_areas_blacklist = typecacheof(list(
+		/area/space,
+		/area/mine,
+		/area/ruin,
+		/area/centcom/asteroid/nearstation,
+		/area/icemoon,
+	))
 	for(var/area/A in world)
 		if (is_type_in_typecache(A, station_areas_blacklist))
 			continue

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -33,7 +33,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Check Power") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	var/list/results = list()
 
-	for (var/datum/powernet/PN in GLOB.powernets)
+	for (var/datum/powernet/PN in SSmachines.powernets)
 		if (!PN.nodes || !PN.nodes.len)
 			if(PN.cables && (PN.cables.len > 1))
 				var/obj/structure/cable/C = PN.cables[1]

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -11,11 +11,14 @@
 	icon = 'icons/obj/power.dmi'
 	anchored = TRUE
 	obj_flags = CAN_BE_HIT
-	var/datum/powernet/powernet = null
 	use_power = NO_POWER_USE
 	idle_power_usage = 0
 	active_power_usage = 0
-	var/machinery_layer = MACHINERY_LAYER_1 //cable layer to which the machine is connected
+
+	///The powernet our machine is connected to.
+	var/datum/powernet/powernet
+	///Cable layer to which the machine is connected.
+	var/machinery_layer = MACHINERY_LAYER_1
 
 /obj/machinery/power/Initialize(mapload)
 	. = ..()

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -75,7 +75,6 @@
 #include "binary_insert.dm"
 #include "bloody_footprints.dm"
 #include "breath.dm"
-#include "cable_powernets.dm"
 #include "card_mismatch.dm"
 #include "chain_pull_through_space.dm"
 #include "chat_filter.dm"

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -75,6 +75,7 @@
 #include "binary_insert.dm"
 #include "bloody_footprints.dm"
 #include "breath.dm"
+#include "cable_powernets.dm"
 #include "card_mismatch.dm"
 #include "chain_pull_through_space.dm"
 #include "chat_filter.dm"

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -6,8 +6,7 @@
 
 		//nodes (machines, which includes APCs and SMES)
 		if(!length(powernets.nodes))
-			if(!length(powernets.cables)) //find a cable to give coordinates
-				TEST_ASSERT(!powernets.nodes, "CABLE: [powernets] found with no nodes OR cables connected, something has gone horribly wrong.")
+			TEST_ASSERT(!length(powernets.nodes), "CABLE: [powernets] found with no nodes OR cables connected, something has gone horribly wrong.")
 
 			var/obj/structure/cable/found_cable = powernets.cables[1]
 			//There's no way to check powernets for their Z level, so we do it here.
@@ -17,11 +16,14 @@
 
 		//cables
 		if(!length(powernets.cables))
-			if(!length(powernets.cables)) //find a machine to give coordinates
-				TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables OR nodes connected, something has gone horribly wrong.")
+			TEST_ASSERT(!length(powernets.cables), "CABLE: [powernets] found with no cables OR nodes connected, something has gone horribly wrong.")
 
 			var/obj/machinery/power/found_machine = powernets.nodes[1]
 			//There's no way to check powernets for their Z level, so we do it here.
 			if(!is_station_level(found_machine.z) && !is_centcom_level(found_machine.z))
 				continue
 			TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
+
+		if(!powernets.avail)
+			var/obj/structure/cable/random_cable = powernets.cables[1]
+			TEST_FAIL("CABLE: [powernets] found with no power roundstart, connected to a cable at ([random_cable.x], [random_cable.y], [random_cable.z]).")

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -10,7 +10,7 @@
 
 			var/obj/structure/cable/found_cable = powernets.cables[1]
 			//There's no way to check powernets for their Z level, so we do it here.
-			if(!is_station_level(found_cable.z) && !is_centcom_level(found_cable.z))
+			if(!is_station_level(found_cable.z))
 				continue
 			TEST_ASSERT(!powernets.nodes, "CABLE: [powernets] found with no nodes connected([found_cable.x], [found_cable.y], [found_cable.z])).")
 
@@ -20,13 +20,13 @@
 
 			var/obj/machinery/power/found_machine = powernets.nodes[1]
 			//There's no way to check powernets for their Z level, so we do it here.
-			if(!is_station_level(found_machine.z) && !is_centcom_level(found_machine.z))
+			if(!is_station_level(found_machine.z))
 				continue
 			TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
 
 		if(!powernets.avail)
 			var/obj/structure/cable/random_cable = powernets.cables[1]
 			//There's no way to check powernets for their Z level, so we do it here.
-			if(!is_station_level(random_cable.z) && !is_centcom_level(random_cable.z))
+			if(!is_station_level(random_cable.z))
 				continue
 			TEST_FAIL("CABLE: [powernets] found with no power roundstart, connected to a cable at ([random_cable.x], [random_cable.y], [random_cable.z]).")

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -13,7 +13,7 @@
 			var/area/cable_area = get_area(found_cable)
 			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
 				continue
-			TEST_FAIL("[powernets] found with no nodes connected([found_cable.x], [found_cable.y], [found_cable.z])).")
+			TEST_FAIL("[powernets] found with no nodes connected ([found_cable.x], [found_cable.y], [found_cable.z])).")
 
 		//cables
 		if(!length(powernets.cables))

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -21,15 +21,15 @@
 
 			var/obj/machinery/power/found_machine = powernets.nodes[1]
 			//Check if they're a station area
-			var/area/cable_area = get_area(found_cable)
-			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
+			var/area/machine_area = get_area(found_machine)
+			if(!(machine_area.type in GLOB.the_station_areas) || istype(machine_area, /area/station/solars))
 				continue
 			TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
 
 		if(!powernets.avail)
 			var/obj/structure/cable/random_cable = powernets.cables[1]
 			//Check if they're a station area
-			var/area/cable_area = get_area(found_cable)
+			var/area/cable_area = get_area(random_cable)
 			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
 				continue
 			TEST_FAIL("CABLE: [powernets] found with no power roundstart, connected to a cable at ([random_cable.x], [random_cable.y], [random_cable.z]).")

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -26,7 +26,7 @@
 				continue
 			TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
 
-		if(!powernets.avail && !(locate(/obj/machinery/power/smes) in powernets.nodes)) //No power roundstart, and not connected to an SMES (Solars, Turbine).
+		if(!powernets.avail && !(locate(/obj/machinery/power/terminal) in powernets.nodes)) //No power roundstart, so check for an SMES connection (Solars, Turbine).
 			var/obj/structure/cable/random_cable = powernets.cables[1]
 			//Check if they're a station area
 			var/area/cable_area = get_area(random_cable)

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -11,7 +11,7 @@
 			var/obj/structure/cable/found_cable = powernets.cables[1]
 			//Check if they're a station area
 			var/area/cable_area = get_area(found_cable)
-			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
+			if(!(cable_area.type in GLOB.the_station_areas) || !cable_area.requires_power)
 				continue
 			TEST_FAIL("[powernets] found with no nodes connected ([found_cable.x], [found_cable.y], [found_cable.z])).")
 
@@ -22,7 +22,7 @@
 			var/obj/machinery/power/found_machine = powernets.nodes[1]
 			//Check if they're a station area
 			var/area/machine_area = get_area(found_machine)
-			if(!(machine_area.type in GLOB.the_station_areas) || istype(machine_area, /area/station/solars))
+			if(!(machine_area.type in GLOB.the_station_areas) || !machine_area.requires_power))
 				continue
 			TEST_FAIL("[powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
 
@@ -30,6 +30,6 @@
 			var/obj/structure/cable/random_cable = powernets.cables[1]
 			//Check if they're a station area
 			var/area/cable_area = get_area(random_cable)
-			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
+			if(!(cable_area.type in GLOB.the_station_areas) || !cable_area.requires_power)
 				continue
 			TEST_FAIL("[powernets] found with no power roundstart, connected to a cable at ([random_cable.x], [random_cable.y], [random_cable.z]).")

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -1,0 +1,6 @@
+///Checks if all cables on the map are connected to a powernet roundstart
+/datum/unit_test/cable_powernets
+
+/datum/unit_test/cable_powernets/Run()
+	for(var/obj/structure/cable/cables as anything in GLOB.cable_list)
+		TEST_ASSERT(!cables.powernet, "CABLE: [cables.name] has no powernet at ([cables.x] [cables.y] [cables.z])")

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -9,8 +9,9 @@
 			TEST_ASSERT(!length(powernets.nodes), "CABLE: [powernets] found with no nodes OR cables connected, something has gone horribly wrong.")
 
 			var/obj/structure/cable/found_cable = powernets.cables[1]
-			//There's no way to check powernets for their Z level, so we do it here.
-			if(!is_station_level(found_cable.z))
+			//Check if they're a station area
+			var/area/cable_area = get_area(found_cable)
+			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
 				continue
 			TEST_ASSERT(!powernets.nodes, "CABLE: [powernets] found with no nodes connected([found_cable.x], [found_cable.y], [found_cable.z])).")
 
@@ -19,14 +20,16 @@
 			TEST_ASSERT(!length(powernets.cables), "CABLE: [powernets] found with no cables OR nodes connected, something has gone horribly wrong.")
 
 			var/obj/machinery/power/found_machine = powernets.nodes[1]
-			//There's no way to check powernets for their Z level, so we do it here.
-			if(!is_station_level(found_machine.z))
+			//Check if they're a station area
+			var/area/cable_area = get_area(found_cable)
+			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
 				continue
 			TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
 
 		if(!powernets.avail)
 			var/obj/structure/cable/random_cable = powernets.cables[1]
-			//There's no way to check powernets for their Z level, so we do it here.
-			if(!is_station_level(random_cable.z))
+			//Check if they're a station area
+			var/area/cable_area = get_area(found_cable)
+			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
 				continue
 			TEST_FAIL("CABLE: [powernets] found with no power roundstart, connected to a cable at ([random_cable.x], [random_cable.y], [random_cable.z]).")

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -1,6 +1,27 @@
-///Checks if all cables on the map are connected to a powernet roundstart
+///Checking all powernets to see if they are properly connected and powered.
 /datum/unit_test/cable_powernets
 
 /datum/unit_test/cable_powernets/Run()
-	for(var/obj/structure/cable/cables as anything in GLOB.cable_list)
-		TEST_ASSERT(!cables.powernet, "CABLE: [cables.name] has no powernet at ([cables.x] [cables.y] [cables.z])")
+	for(var/datum/powernet/powernets as anything in GLOB.powernets)
+
+		//nodes (machines, which includes APCs and SMES)
+		if(!length(powernets.nodes))
+			if(!length(powernets.cables)) //find a cable to give coordinates
+				TEST_ASSERT(!powernets.nodes, "CABLE: [powernets] found with no nodes OR cables connected, something has gone horribly wrong.")
+
+			var/obj/structure/cable/found_cable = powernets.cables[1]
+			//There's no way to check powernets for their Z level, so we do it here.
+			if(!is_station_level(found_cable.z) || !is_centcom_level(found_cable.z))
+				continue
+			TEST_ASSERT(!powernets.nodes, "CABLE: [powernets] found with no nodes connected([found_cable.x], [found_cable.y], [found_cable.z])).")
+
+		//cables
+		if(!length(powernets.cables))
+			if(!length(powernets.cables)) //find a machine to give coordinates
+				TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables OR nodes connected, something has gone horribly wrong.")
+
+			var/obj/machinery/power/found_machine = powernets.nodes[1]
+			//There's no way to check powernets for their Z level, so we do it here.
+			if(!is_station_level(found_machine.z) || !is_centcom_level(found_machine.z))
+				continue
+			TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -6,25 +6,25 @@
 
 		//nodes (machines, which includes APCs and SMES)
 		if(!length(powernets.nodes))
-			TEST_ASSERT(!length(powernets.cables), "CABLE: [powernets] found with no nodes OR cables connected, something has gone horribly wrong.")
+			TEST_ASSERT(length(powernets.cables), "[powernets] found with no nodes OR cables connected, something has gone horribly wrong.")
 
 			var/obj/structure/cable/found_cable = powernets.cables[1]
 			//Check if they're a station area
 			var/area/cable_area = get_area(found_cable)
 			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
 				continue
-			TEST_FAIL("CABLE: [powernets] found with no nodes connected([found_cable.x], [found_cable.y], [found_cable.z])).")
+			TEST_FAIL("[powernets] found with no nodes connected([found_cable.x], [found_cable.y], [found_cable.z])).")
 
 		//cables
 		if(!length(powernets.cables))
-			TEST_ASSERT(!length(powernets.nodes), "CABLE: [powernets] found with no cables OR nodes connected, something has gone horribly wrong.")
+			TEST_ASSERT(length(powernets.nodes), "[powernets] found with no cables OR nodes connected, something has gone horribly wrong.")
 
 			var/obj/machinery/power/found_machine = powernets.nodes[1]
 			//Check if they're a station area
 			var/area/machine_area = get_area(found_machine)
 			if(!(machine_area.type in GLOB.the_station_areas) || istype(machine_area, /area/station/solars))
 				continue
-			TEST_FAIL("CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
+			TEST_FAIL("[powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
 
 		if(!powernets.avail && !(locate(/obj/machinery/power/terminal) in powernets.nodes)) //No power roundstart, so check for an SMES connection (Solars, Turbine).
 			var/obj/structure/cable/random_cable = powernets.cables[1]
@@ -32,4 +32,4 @@
 			var/area/cable_area = get_area(random_cable)
 			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
 				continue
-			TEST_FAIL("CABLE: [powernets] found with no power roundstart, connected to a cable at ([random_cable.x], [random_cable.y], [random_cable.z]).")
+			TEST_FAIL("[powernets] found with no power roundstart, connected to a cable at ([random_cable.x], [random_cable.y], [random_cable.z]).")

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -1,6 +1,0 @@
-///Checks if all cables on the map are connected to a powernet roundstart
-/datum/unit_test/cable_powernets
-
-/datum/unit_test/cable_powernets/Run()
-	for(var/obj/structure/cable/cables as anything in GLOB.cable_list)
-		TEST_ASSERT(!cables.powernet, "CABLE: [cables.name] has no powernet at ([cables.x] [cables.y] [cables.z])")

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -26,7 +26,7 @@
 				continue
 			TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
 
-		if(!powernets.avail)
+		if(!powernets.avail && !(locate(/obj/machinery/power/smes) in powernets.nodes)) //No power roundstart, and not connected to an SMES (Solars, Turbine).
 			var/obj/structure/cable/random_cable = powernets.cables[1]
 			//Check if they're a station area
 			var/area/cable_area = get_area(random_cable)

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -26,4 +26,7 @@
 
 		if(!powernets.avail)
 			var/obj/structure/cable/random_cable = powernets.cables[1]
+			//There's no way to check powernets for their Z level, so we do it here.
+			if(!is_station_level(random_cable.z) && !is_centcom_level(random_cable.z))
+				continue
 			TEST_FAIL("CABLE: [powernets] found with no power roundstart, connected to a cable at ([random_cable.x], [random_cable.y], [random_cable.z]).")

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -2,7 +2,7 @@
 /datum/unit_test/cable_powernets
 
 /datum/unit_test/cable_powernets/Run()
-	for(var/datum/powernet/powernets as anything in GLOB.powernets)
+	for(var/datum/powernet/powernets as anything in SSmachines.powernets)
 
 		//nodes (machines, which includes APCs and SMES)
 		if(!length(powernets.nodes))

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -6,25 +6,25 @@
 
 		//nodes (machines, which includes APCs and SMES)
 		if(!length(powernets.nodes))
-			TEST_ASSERT(!length(powernets.nodes), "CABLE: [powernets] found with no nodes OR cables connected, something has gone horribly wrong.")
+			TEST_ASSERT(!length(powernets.cables), "CABLE: [powernets] found with no nodes OR cables connected, something has gone horribly wrong.")
 
 			var/obj/structure/cable/found_cable = powernets.cables[1]
 			//Check if they're a station area
 			var/area/cable_area = get_area(found_cable)
 			if(!(cable_area.type in GLOB.the_station_areas) || istype(cable_area, /area/station/solars))
 				continue
-			TEST_ASSERT(!powernets.nodes, "CABLE: [powernets] found with no nodes connected([found_cable.x], [found_cable.y], [found_cable.z])).")
+			TEST_FAIL("CABLE: [powernets] found with no nodes connected([found_cable.x], [found_cable.y], [found_cable.z])).")
 
 		//cables
 		if(!length(powernets.cables))
-			TEST_ASSERT(!length(powernets.cables), "CABLE: [powernets] found with no cables OR nodes connected, something has gone horribly wrong.")
+			TEST_ASSERT(!length(powernets.nodes), "CABLE: [powernets] found with no cables OR nodes connected, something has gone horribly wrong.")
 
 			var/obj/machinery/power/found_machine = powernets.nodes[1]
 			//Check if they're a station area
 			var/area/machine_area = get_area(found_machine)
 			if(!(machine_area.type in GLOB.the_station_areas) || istype(machine_area, /area/station/solars))
 				continue
-			TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
+			TEST_FAIL("CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
 
 		if(!powernets.avail && !(locate(/obj/machinery/power/terminal) in powernets.nodes)) //No power roundstart, so check for an SMES connection (Solars, Turbine).
 			var/obj/structure/cable/random_cable = powernets.cables[1]

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -22,7 +22,7 @@
 			var/obj/machinery/power/found_machine = powernets.nodes[1]
 			//Check if they're a station area
 			var/area/machine_area = get_area(found_machine)
-			if(!(machine_area.type in GLOB.the_station_areas) || !machine_area.requires_power))
+			if(!(machine_area.type in GLOB.the_station_areas) || !machine_area.requires_power)
 				continue
 			TEST_FAIL("[powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")
 

--- a/code/modules/unit_tests/cable_powernets.dm
+++ b/code/modules/unit_tests/cable_powernets.dm
@@ -11,7 +11,7 @@
 
 			var/obj/structure/cable/found_cable = powernets.cables[1]
 			//There's no way to check powernets for their Z level, so we do it here.
-			if(!is_station_level(found_cable.z) || !is_centcom_level(found_cable.z))
+			if(!is_station_level(found_cable.z) && !is_centcom_level(found_cable.z))
 				continue
 			TEST_ASSERT(!powernets.nodes, "CABLE: [powernets] found with no nodes connected([found_cable.x], [found_cable.y], [found_cable.z])).")
 
@@ -22,6 +22,6 @@
 
 			var/obj/machinery/power/found_machine = powernets.nodes[1]
 			//There's no way to check powernets for their Z level, so we do it here.
-			if(!is_station_level(found_machine.z) || !is_centcom_level(found_machine.z))
+			if(!is_station_level(found_machine.z) && !is_centcom_level(found_machine.z))
 				continue
 			TEST_ASSERT(!powernets.cables, "CABLE: [powernets] found with no cables connected ([found_machine.x], [found_machine.y], [found_machine.z]).")


### PR DESCRIPTION
## About The Pull Request

I played a round on Tramstation where Medbay, Cargo, and Science were all disconnected from the powernet roundstart, and I was wandering around with a multitool figuring out why.
With modular maint rooms, I have no idea how to tell which room isn't connecting properly in maps, so now I made a unit test for it, to catch all occurrences of it, so at the very least it won't be gamebreaking.

I also fixed some problems with powernets and the_station_areas:

- GLOB.powernets was never used. Literally. The currently existing admin verb just runtimed. I just removed it in favor of SSmachines.powernets.
- GLOB.the_station_areas included Icemoon because they were never actually added to the blacklist (why isn't this just a whitelist for /area/station instead???)

I had to fix all our station-maps for this to work since they all had minor problems, here's the ones I found funny, from Kilo and Box
![image](https://user-images.githubusercontent.com/53777086/192622868-0462645c-1c9e-4262-9fd3-c656e85b7f42.png)
![image](https://user-images.githubusercontent.com/53777086/192622888-9af73208-1164-4911-a0a1-a18243764d43.png)
![image](https://user-images.githubusercontent.com/53777086/192622899-a389bf2e-832c-4b45-ba25-a767648b2a89.png)

I was hoping to include CentCom too, but the nukie outpost has cables with ZERO apcs, SMES, or anything to generate power attached to any of it. San told me it's used purely to look at through catwalk floor. I hate mappers.

## Why It's Good For The Game

I hope roundstart cable placement will be much more sane, and mappers can avoid blame of breaking powernets on maps.

## Changelog

:cl:
fix: Tramstation's departments should all be connected to the powernet at the start of a round now.
admin: Admin's power check mapping verb now actually works.
fix: Icemoon is no longer considered part of the station.
/:cl: