### PR TITLE
Fixes IceBox Homestead Ruin to have Proper snow

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_homestead.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_homestead.dmm
@@ -2,7 +2,7 @@
 "bf" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "cP" = (
 /mob/living/simple_animal/hostile/asteroid/polarbear,
 /turf/open/floor/wood/large{
@@ -17,7 +17,7 @@
 	pixel_y = -19
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "fd" = (
 /obj/structure/table/bronze{
 	color = "#666666"
@@ -31,14 +31,14 @@
 "ht" = (
 /obj/structure/flora/tree/dead/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "kj" = (
 /obj/structure/railing{
 	color = "#8a7453";
 	dir = 4
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "mq" = (
 /obj/structure/railing{
 	color = "#8a7453";
@@ -46,7 +46,7 @@
 	},
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "ng" = (
 /turf/open/floor/wood/large{
 	initial_gas_mix = "ICEMOON_ATMOS"
@@ -60,7 +60,7 @@
 	pixel_y = 6
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "ol" = (
 /turf/closed/wall/mineral/wood,
 /area/ruin/powered/shuttle)
@@ -75,14 +75,14 @@
 "qd" = (
 /mob/living/simple_animal/hostile/tree,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "sF" = (
 /turf/open/openspace/icemoon/keep_below,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "tD" = (
 /obj/structure/flora/rock/pile/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "uc" = (
 /obj/structure/table/bronze{
 	color = "#666666"
@@ -103,7 +103,7 @@
 	pixel_y = 13
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "uH" = (
 /obj/structure/closet/cabinet,
 /obj/item/restraints/legcuffs/beartrap,
@@ -122,7 +122,7 @@
 	},
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "vI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -167,10 +167,10 @@
 	pixel_y = 7
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "zd" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "zT" = (
 /obj/structure/bed/dogbed,
 /turf/open/floor/wood/large{
@@ -214,20 +214,20 @@
 	},
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "Fg" = (
 /obj/structure/flora/rock/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "FS" = (
 /obj/structure/railing{
 	color = "#8a7453"
 	},
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "Ht" = (
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "Hv" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -273,7 +273,7 @@
 	},
 /obj/structure/flora/tree/pine/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "Nz" = (
 /obj/structure/bed,
 /obj/item/bedsheet/patriot,
@@ -311,7 +311,7 @@
 	},
 /obj/item/reagent_containers/cup/bucket/wooden,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "RO" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -333,18 +333,18 @@
 	},
 /obj/machinery/hydroponics/soil,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "Tf" = (
 /obj/structure/railing{
 	color = "#8a7453"
 	},
 /obj/machinery/hydroponics/soil,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "TP" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "Vf" = (
 /obj/structure/barricade/wooden/snowed,
 /obj/effect/mapping_helpers/broken_floor,
@@ -355,7 +355,7 @@
 "VV" = (
 /obj/structure/bonfire,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/area/icemoon/surface/outdoors/nospawn)
 "XZ" = (
 /obj/structure/toilet{
 	dir = 8


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the area turfs around the homestead ruin from "mining" to "mining explore" so it can snow properly.

![coo](https://user-images.githubusercontent.com/114047053/191988272-737d0d23-89e8-493b-b023-1ad40cb882d2.PNG)

![snow!](https://user-images.githubusercontent.com/114047053/191990512-0c896b77-23d8-4caa-91d9-514dae206e40.PNG)


## Why It's Good For The Game

Shelter out of thin air does not look good.

![mine](https://user-images.githubusercontent.com/114047053/191986343-51dd5c5a-0838-429c-97ac-9e4e4035163c.PNG)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ice Box snow storms now cover the surroundings of the homestead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
