### PR TITLE
Crab-17 No Longer Breaks Economy If You Swipe Too Fast

### DIFF
--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -50,6 +50,7 @@
 	max_integrity = 5000
 	var/list/accounts_to_rob
 	var/mob/living/bogdanoff
+	/// Are we able to start moving?
 	var/canwalk = FALSE
 
 /obj/structure/checkoutmachine/examine(mob/living/user)
@@ -76,6 +77,10 @@
 		user.safe_throw_at(throwtarget, 1, 1, force = MOVE_FORCE_EXTREMELY_STRONG)
 		playsound(get_turf(src),'sound/magic/repulse.ogg', 100, TRUE)
 
+		return
+
+	if(!canwalk)
+		to_chat(user, span_warning("Space-Coin only accepts transactions while mobile!"))
 		return
 
 	if(!card.registered_account)
@@ -166,8 +171,8 @@
 	add_overlay("screen_lines")
 	cut_overlay("text")
 	add_overlay("text")
+	START_PROCESSING(SSfastprocess, src) // we only start doing economy draining stuff once our machinery is initialized, thematically
 	canwalk = TRUE
-	START_PROCESSING(SSfastprocess, src)
 
 /obj/structure/checkoutmachine/Destroy()
 	stop_dumping()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Remember swiping credit cards, before everything was chipped? You know how sometimes if you went too slow, the transaction might fail, the cashier had to plonk in some digits on their machine, and you had to go again? That kinda sucked.

If you're too young to get that reference, just imagine the card swiping task in AMONG US. Doesn't that minigame suck? You know exactly what that is. Same principle.

Anyways, that's pretty much what was going on here. The reason why SS.Economy would break so god damn hard if you swiped an ID before the machine's "boot up" slowflake animation was complete is probably due to the line where it starts fast processing. I added an early return to check for if the animation was complete by leveraging a var we already set at the end of the process, because I am lazy.

There's probably a few other ways you can tackle this issue, but this feels right to me in a thematic sense. I'm willing to change it if needed though.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #69045
Fixes #69953 (duplicate)

Summoning the Crab-17:
![image](https://user-images.githubusercontent.com/34697715/192042106-4331c400-9569-440f-b4b9-8e78f3586baa.png)

The error message if you try and swipe before it's done "setting up" (disregard the "safe from draining", I was doing it with the character that summoned the Crab-17):
![image](https://user-images.githubusercontent.com/34697715/192042116-7a809c37-46b1-4bd5-85d0-6018e0ac8ba2.png)

Another character cashing out the funds after losing a bit to the almighty market:
![image](https://user-images.githubusercontent.com/34697715/192042128-69719bcc-da65-42de-8131-c7c7cf9cc621.png)

The market's demise and destruction after that cash-out:
![image](https://user-images.githubusercontent.com/34697715/192042140-a9623554-0cac-427f-aead-b535b576c342.png)

SSEconomy (or at least paychecks) working fine and well in the aftermath:
![image](https://user-images.githubusercontent.com/34697715/192042146-42fab752-c8f9-44cc-8e83-1378ff40dc35.png)


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The developers of Space-Coin decided to renege on their exit scheme with a new advertisement: Space-coin is the mobile currency of the future! As such, you can not cash out of their famous space coin market machines until the machine starts moving. They immediately ran away after that though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
