### PR TITLE
Logs Player-Based Area Creation

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 
 	SEND_GLOBAL_SIGNAL(COMSIG_AREA_CREATED, newA, oldA, creator)
 	to_chat(creator, span_notice("You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered."))
-	creator.log_message("created a new area: [AREACOORD(creator)]. It was previously known as [oldA.name].", LOG_GAME)
+	creator.log_message("created a new area: [AREACOORD(creator)] (previously \"[oldA.name]\")", LOG_GAME)
 	return TRUE
 
 #undef BP_MAX_ROOM_SIZE

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 
 	SEND_GLOBAL_SIGNAL(COMSIG_AREA_CREATED, newA, oldA, creator)
 	to_chat(creator, span_notice("You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered."))
-	log_game("[key_name(creator)] created a new area: [AREACOORD(creator)]. It was previously known as [oldA.name].")
+	creator.log_message("created a new area: [AREACOORD(creator)]. It was previously known as [oldA.name].", LOG_GAME)
 	return TRUE
 
 #undef BP_MAX_ROOM_SIZE

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -48,7 +48,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
  * range - the max range to check
  *
  * Returns a list of turfs, which is an area of isolated atmos
- */ 
+ */
 /proc/create_atmos_zone(turf/source, range = INFINITY)
 	var/counter = 1 // a counter which increment each loop
 	var/loops = 0
@@ -69,14 +69,14 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 				loops += 1
 				continue
 			if(length(connected_turfs) >= range)
-				return 
+				return
 			if(TURFS_CAN_SHARE(reference_turf, valid_turf))
-				loops = 0 
-				connected_turfs |= valid_turf//add that to the original list				
+				loops = 0
+				connected_turfs |= valid_turf//add that to the original list
 		if(loops >= 7)//if the loop has gone 7 consecutive times with no new turfs added, return the result. Number is arbitrary, subject to change
 			return
 		counter += 1 //increment by one so the next loop will start at the next position in the list
-				
+
 /proc/create_area(mob/creator)
 	// Passed into the above proc as list/break_if_found
 	var/static/list/area_or_turf_fail_types = typecacheof(list(
@@ -138,6 +138,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 
 	SEND_GLOBAL_SIGNAL(COMSIG_AREA_CREATED, newA, oldA, creator)
 	to_chat(creator, span_notice("You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered."))
+	log_game("[key_name(creator)] created a new area at [AREACOORD(creator)]. It was previously known as [oldA.name].")
 	return TRUE
 
 #undef BP_MAX_ROOM_SIZE

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 
 	SEND_GLOBAL_SIGNAL(COMSIG_AREA_CREATED, newA, oldA, creator)
 	to_chat(creator, span_notice("You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered."))
-	log_game("[key_name(creator)] created a new area at [AREACOORD(creator)]. It was previously known as [oldA.name].")
+	log_game("[key_name(creator)] created a new area: [AREACOORD(creator)]. It was previously known as [oldA.name].")
 	return TRUE
 
 #undef BP_MAX_ROOM_SIZE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

One thing that's kinda odd is that we didn't log when a player created an area, we did do a quick to_chat, but it just didn't go anywhere. Let's fix that for the future.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/192057633-66a9109a-b92a-46c6-98d7-2e3ab22bdde8.png)

Adminoration.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: When a player renames (creates) an area from an existing area to a new one, it now logs to game.log (global and individual).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
