### PR TITLE
Creates a proper CentCom group for orbit UI

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -4,6 +4,7 @@ import { capitalizeFirst, multiline } from 'common/string';
 import { Button, Collapsible, Icon, Input, Section, Stack } from '../components';
 import { Window } from '../layouts';
 import { flow } from 'common/fp';
+import { COLORS } from '../constants';
 
 type AntagGroup = [string, Observable[]];
 
@@ -33,6 +34,7 @@ const ANTAG2COLOR = {
   'Abductors': 'pink',
   'Ash Walkers': 'olive',
   'Biohazards': 'brown',
+  'CentCom': COLORS.department.centcom,
 } as const;
 
 const ANTAG2GROUP = {
@@ -41,6 +43,11 @@ const ANTAG2GROUP = {
   'Ash Walker': 'Ash Walkers',
   'Blob': 'Biohazards',
   'Sentient Disease': 'Biohazards',
+  'CentCom Commander': 'CentCom',
+  'CentCom Head Intern': 'CentCom',
+  'CentCom Intern': 'CentCom',
+  'CentCom Official': 'CentCom',
+  'Central Command': 'CentCom',
   'Clown Operative': 'Clown Operatives',
   'Clown Operative Leader': 'Clown Operatives',
   'Nuclear Operative': 'Nuclear Operatives',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Red is the default for antagonist group colors. 
This is on current:
![Screenshot 2022-09-23 193252](https://user-images.githubusercontent.com/42397676/192076450-c3863ee7-9939-4dc5-b413-655545b55187.png)

This PR groups them into "CentCom" and gives it the centcom green color. All buttons and labels will be this color until more ghosts etc.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
CentCom isn't really an "antagonist" per se, perhaps only philosophically. With this PR it's a little more obvious that they're not on murderbone orders (unless they are I guess??)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new grouping to orbit menu for CentCom agents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
