### PR TITLE
nerfs shotgun darts

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -137,7 +137,7 @@
 	desc = "A dart for use in shotguns. Can be injected with up to 30 units of any chemical."
 	icon_state = "cshell"
 	projectile_type = /obj/projectile/bullet/dart
-	var/reagent_amount = 30
+	var/reagent_amount = 15
 
 /obj/item/ammo_casing/shotgun/dart/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -147,7 +147,7 @@
 	return
 
 /obj/item/ammo_casing/shotgun/dart/bioterror
-	desc = "A shotgun dart filled with deadly toxins."
+	desc = "An improved shotgun dart filled with deadly toxins. Can be injected with up to 30 units of any chemical."
 
 /obj/item/ammo_casing/shotgun/dart/bioterror/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -134,7 +134,7 @@
 
 /obj/item/ammo_casing/shotgun/dart
 	name = "shotgun dart"
-	desc = "A dart for use in shotguns. Can be injected with up to 30 units of any chemical."
+	desc = "A dart for use in shotguns. Can be injected with up to 15 units of any chemical."
 	icon_state = "cshell"
 	projectile_type = /obj/projectile/bullet/dart
 	var/reagent_amount = 15

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -148,6 +148,7 @@
 
 /obj/item/ammo_casing/shotgun/dart/bioterror
 	desc = "An improved shotgun dart filled with deadly toxins. Can be injected with up to 30 units of any chemical."
+	reagent_amount = 30
 
 /obj/item/ammo_casing/shotgun/dart/bioterror/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
reduces reagent amount of shotgun darts to 15
## Why It's Good For The Game
shotguns and the darts much easier to get ahold of than syringe guns, and for some reason the darts hold 2x the amount of syringes
I believe they're a tad strong for being roundstart equipment that can be turned into deadly equipment in 10ish minutes.
shotguns can be made but syringe guns cant.
## Changelog

:cl:
balance: reduced shotgun dart reagent amount
/:cl:
