### PR TITLE
fixes scrubber event runtimes on runtime station

### DIFF
--- a/code/modules/events/scrubber_clog.dm
+++ b/code/modules/events/scrubber_clog.dm
@@ -92,7 +92,7 @@
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber in GLOB.machines)
 		var/turf/scrubber_turf = get_turf(scrubber)
 		if(scrubber_turf && is_station_level(scrubber_turf.z) && !scrubber.welded && !scrubber.clogged)
-			return //make sure we have a valid scrubber to spawn from.
+			return TRUE //make sure we have a valid scrubber to spawn from.
 	return FALSE
 
 /**

--- a/code/modules/events/scrubber_clog.dm
+++ b/code/modules/events/scrubber_clog.dm
@@ -85,6 +85,16 @@
 			scrubber_list += scrubber
 	return pick(scrubber_list)
 
+/datum/round_event_control/scrubber_clog/canSpawnEvent(players_amt)
+	. = ..()
+	if(!.)
+		return
+	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber in GLOB.machines)
+		var/turf/scrubber_turf = get_turf(scrubber)
+		if(scrubber_turf && is_station_level(scrubber_turf.z) && !scrubber.welded && !scrubber.clogged)
+			return //make sure we have a valid scrubber to spawn from.
+	return FALSE
+
 /**
  * Checks which mobs in the mob spawn list are alive.
  *

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -86,7 +86,7 @@
 			continue
 		if(temp_vent.welded)
 			continue
-		return //there's at least one. we'll let the codergods handle the rest with prob() i guess.
+		return TRUE //there's at least one. we'll let the codergods handle the rest with prob() i guess.
 	return FALSE
 
 

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -74,6 +74,23 @@
 	if(!scrubbers.len)
 		return kill()
 
+/datum/round_event_control/scrubber_overflow/canSpawnEvent(players_amt)
+	. = ..()
+	if(!.)
+		return
+	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/temp_vent in GLOB.machines)
+		var/turf/scrubber_turf = get_turf(temp_vent)
+		if(!scrubber_turf)
+			continue
+		if(!is_station_level(scrubber_turf.z))
+			continue
+		if(temp_vent.welded)
+			continue
+		return //there's at least one. we'll let the codergods handle the rest with prob() i guess.
+	return FALSE
+
+
+
 /datum/round_event/scrubber_overflow/start()
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/vent as anything in scrubbers)
 		if(!vent.loc)


### PR DESCRIPTION
sanity check.
:cl: ShizCalev
fix: Scrubber events will no longer trigger if there are no valid scrubbers on the station.
/:cl:
