### PR TITLE
Disambiguates a ternary

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -683,7 +683,7 @@
 				//figure out which pair type the character belongs to
 				pair_str = ((at_str[1] == char || at_str[2] == char) ? at_str : ((cg_str[1] == char || cg_str[2] == char) ? cg_str : null))
 				//Valid pair from character
-				new_pair = (pair_str ? char + (pair_str[1]==char?pair_str[2]:pair_str[1]) : null)
+				new_pair = (pair_str ? char + (pair_str[1] == char ? pair_str[2] : pair_str[1]) : null)
 				// every second letter in the sequence represents a valid pair of the new sequence, otherwise it belongs to old
 				if(new_pair)
 					if(i%2==0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Have you ever wondered how BYOND parses ternaries? Here's how (we think)!
```
                 /* DM has some really strange behavior when it comes to proc calls (or list indexes) and dereferences inside ternaries
                 * Consider the following expression:
                 *      a ? foo():pixel_x
                 * This is ambiguous, it could be either a ternary or a dereference (and an error)
                 *
                 * What DM does here is parse `foo():pixel_x` as a dereference, and attempts to split it into a correct ternary
                 * Everything past the last proc call followed by a dereference becomes "c"
                 * This last dereference must also be a search, otherwise it's a "Expected ':'" error
                 *
                 * None of this happens if there is a whitespace followed by a colon after the "b" expression:
                 *      a ? foo():pixel_x : 2
                 */
```

After countless hours by multiple people the lads over at OpenDream _can't_ figure out how to parse ternaries in quite the same way as BYOND. Frankly we've sunk so much time into an issue that occurs at most 1 time depending on the codebase, that it's beginning to detract from our ability to work on the runtime.

So I'm just going to concede that BYOND can be cursed at ternary parsing better than us. Plus I think it improves readability anyways.

![image](https://user-images.githubusercontent.com/5714543/192129204-5662eb9d-1f92-47ce-8e88-5bf98bdadd01.png)

## Changelog

Not player facing.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
