### PR TITLE
Fixes gravity pulse and transparent floor plane sharing a layer

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -12,10 +12,8 @@
 #define PLANE_SPACE -95
 #define PLANE_SPACE_PARALLAX -90
 
-#define GRAVITY_PULSE_PLANE -11
+#define GRAVITY_PULSE_PLANE -12
 #define GRAVITY_PULSE_RENDER_TARGET "*GRAVPULSE_RENDER_TARGET"
-
-#define OPENSPACE_LAYER 600 //Openspace layer over all
 
 #define TRANSPARENT_FLOOR_PLANE -11 //Transparent plane that shows openspace underneath the floor
 #define OPENSPACE_PLANE -10 //Openspace plane below all turfs
@@ -122,6 +120,7 @@
 #define GASFIRE_LAYER 5.05
 #define RIPPLE_LAYER 5.1
 
+#define OPENSPACE_LAYER 600 //Openspace layer over all
 
 #define BLACKNESS_PLANE 0 //To keep from conflicts with SEE_BLACKNESS internals
 


### PR DESCRIPTION
Broken by #69642 , sorry
I'll open up a seperate PR later today with a unit test to catch these cases
(my later today is in like 10 hours)

![image](https://user-images.githubusercontent.com/7501474/192134017-570e0cf6-cf7d-40c0-9d59-9901fa12fcae.png)

closes #70123

:cl:
fix: gravity distortion effects no longer break over glass tiles
/:cl: