### PR TITLE
Fixes invalid path in the garbage spawner

### DIFF
--- a/code/game/objects/effects/spawners/random/trash.dm
+++ b/code/game/objects/effects/spawners/random/trash.dm
@@ -11,7 +11,7 @@
 		/obj/item/shard = 10,
 		/obj/effect/spawner/random/trash/cigbutt = 10,
 		/obj/effect/spawner/random/trash/botanical_waste = 5,
-		/obj/item/reagent_containers/cup = 5,
+		/obj/item/reagent_containers/cup/glass/drinkingglass = 5,
 		/obj/item/broken_bottle = 5,
 		/obj/item/reagent_containers/cup/bowl = 5,
 		/obj/item/light/tube/broken = 5,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Among the swath of changes in #69081, the line for a drinking glass in `/obj/effect/spawner/random/trash/garbage` got clobbered into just `/obj/item/reagent_containers/cup` which is a base class with no icon.
Fixes it to have an icon.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes invisible and unusable bottom tier loot into visible bottom tier loot.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

So minor I don't think anyone noticed.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
