### PR TITLE
Tramstation crossing lights actually indicate the danger of crossing

### DIFF
--- a/code/modules/industrial_lift/crossing_signal.dm
+++ b/code/modules/industrial_lift/crossing_signal.dm
@@ -30,9 +30,9 @@
 	/// Weakref to the tram piece we control
 	var/datum/weakref/tram_ref
 	/// Proximity threshold for amber warning (slow people may be in danger)
-	var/amber_distance_threshold = 40
+	var/amber_distance_threshold = 60
 	/// Proximity threshold for red warning (running people will likely not be able to cross)
-	var/red_distance_threshold = 20
+	var/red_distance_threshold = 35
 
 /obj/machinery/crossing_signal/Initialize(mapload)
 	. = ..()
@@ -140,9 +140,12 @@
 	// Check for stopped state.
 	// Will kill the process since tram starting up will restart process.
 	if(!tram.travelling)
-		// if super close, show red anyway since tram could suddenly start moving
+		// If super close, show red anyway since tram could suddenly start moving. If the tram could be approaching, show amber.
 		if(abs(approach_distance) < red_distance_threshold)
 			set_signal_state(XING_STATE_RED)
+			return PROCESS_KILL
+		if(abs(approach_distance) < amber_distance_threshold)
+			set_signal_state(XING_STATE_AMBER)
 			return PROCESS_KILL
 		set_signal_state(XING_STATE_GREEN)
 		return PROCESS_KILL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When we did our tram code rework, it resulted in the tram being much faster. The crossing signals were not adjusted to match.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While it's amusing to be hit by the tram, you shouldn't start crossing on green thinking it's safe, and it quickly goes amber and red and the tram hits you in the middle of your crossing. Since the tram speed is increased, this increases the distance to set the crossing lights, so there's a reasonable reason to believe the lights if it's safe, caution, or don't try. It will reflect the actual safety of the crossing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
fix: Tramstation crossing lights will now properly indicate if you're going to get smacked by the tram if you try to cross.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
