### PR TITLE
Does something Fikou asked me to involving the captain jetpack PR

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -179,7 +179,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	volume = 90
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //steal objective items are hard to destroy.
-	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
+	slot_flags = ITEM_SLOT_BACK
 
 /obj/item/tank/jetpack/oxygen/security
 	name = "security jetpack (oxygen)"

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -38,7 +38,7 @@
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
 		/obj/item/tank/jetpack/oxygen/captain,
-		)
+	)
 	slowdown = 1
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 80, ACID = 70)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -8,7 +8,7 @@
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
 		/obj/item/tank/jetpack/oxygen/captain,
-		)
+	)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -21,7 +21,7 @@
 		/obj/item/tank/internals,
 		/obj/item/flashlight,
 		/obj/item/tank/jetpack/oxygen/captain,
-		)
+	)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0, WOUND = 0)
 	body_parts_covered = CHEST|GROIN
 	heat_protection = CHEST|GROIN


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/51863163/192171913-79c48bbc-f0e3-43bb-a5bb-0fa4a7a9b26a.png)

Removes `ITEM_SLOT_SUITSTORE` from the captain's jetpack, Pretty sure it still works in modsuit suits still since it's in the allowed list?

## Why It's Good For The Game

Not sure

## Changelog

I'll fill this in when Fikou explains what this means
