### PR TITLE
Nuclear Operatives Can Now Correctly Get Servant Golems

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -34,7 +34,7 @@
 	if(!nukeop_outfit) // this variable is null in instances where an antagonist datum is granted via enslaving the mind (/datum/mind/proc/enslave_mind_to_creator), like in golems.
 		return
 
-	operative.set_species(/datum/species/human) //Plasamen burn up otherwise, and besides, all other species are vulnerable to asimov AIs. Let's standardize all operatives being human.
+	operative.set_species(/datum/species/human) //Plasmamen burn up otherwise, and besides, all other species are vulnerable to asimov AIs. Let's standardize all operatives being human.
 
 	operative.equipOutfit(nukeop_outfit)
 	return TRUE

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -31,8 +31,8 @@
 
 	var/mob/living/carbon/human/operative = owner.current
 
-	if(isgolem(operative)) // Currently, nuclear operatives can create golems, and golems inherit the nuclear operative's faction. So, let's make sure we don't turn them into humans or give them a special suit, but it's still valid for them to be allied.
-		return TRUE
+	if(!nukeop_outfit) // this variable is null in instances where an antagonist datum is granted via enslaving the mind, like in golems.
+		return
 
 	operative.set_species(/datum/species/human) //Plasamen burn up otherwise, and besides, all other species are vulnerable to asimov AIs. Let's standardize all operatives being human.
 

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -28,11 +28,15 @@
 /datum/antagonist/nukeop/proc/equip_op()
 	if(!ishuman(owner.current))
 		return
-	var/mob/living/carbon/human/H = owner.current
 
-	H.set_species(/datum/species/human) //Plasamen burn up otherwise, and lizards are vulnerable to asimov AIs
+	var/mob/living/carbon/human/operative = owner.current
 
-	H.equipOutfit(nukeop_outfit)
+	if(isgolem(operative)) // Currently, nuclear operatives can create golems, and golems inherit the nuclear operative's faction. So, let's make sure we don't turn them into humans or give them a special suit, but it's still valid for them to be allied.
+		return TRUE
+
+	operative.set_species(/datum/species/human) //Plasamen burn up otherwise, and besides, all other species are vulnerable to asimov AIs. Let's standardize all operatives being human.
+
+	operative.equipOutfit(nukeop_outfit)
 	return TRUE
 
 /datum/antagonist/nukeop/greet()

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -31,7 +31,7 @@
 
 	var/mob/living/carbon/human/operative = owner.current
 
-	if(!nukeop_outfit) // this variable is null in instances where an antagonist datum is granted via enslaving the mind, like in golems.
+	if(!nukeop_outfit) // this variable is null in instances where an antagonist datum is granted via enslaving the mind (/datum/mind/proc/enslave_mind_to_creator), like in golems.
 		return
 
 	operative.set_species(/datum/species/human) //Plasamen burn up otherwise, and besides, all other species are vulnerable to asimov AIs. Let's standardize all operatives being human.


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

This was a funny issue a while back caused by how golems inherit antagonist datums, and how the Nuclear Operative Antagonist Datum would _always_, without fail, make you a human. So, let's fix that up a bit by ensuring we cram a cheeky early return in to ensure we don't humanify those golems. I also killed the single letter var while I was in the area because I'm NICE, dammit.

We don't give the golems any equipment because that makes zero logical sense.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/192202054-f5f47400-b547-48c2-a9b2-a944899e3eff.png)

Fixes #67376.

I thought it was pretty funny, but it had to go some time.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: When a Nuclear Operative makes a golem, they no longer immediately turn into a fully functioning reinforcement.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
