### PR TITLE
Adds Support For Exotic Bloodtypes To Operating Computer

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -110,7 +110,15 @@
 			data["patient"]["stat"] = "Dead"
 			data["patient"]["statstate"] = "bad"
 	data["patient"]["health"] = patient.health
-	data["patient"]["blood_type"] = patient.dna?.blood_type
+
+	// check here to see if the patient has standard blood reagent, or special blood (like how ethereals bleed liquid electricity) to show the proper name in the computer
+	var/blood_id = patient.get_blood_id()
+	if(blood_id == /datum/reagent/blood)
+		data["patient"]["blood_type"] = patient.dna?.blood_type
+	else
+		var/datum/reagent/special_blood = GLOB.chemical_reagents_list[blood_id]
+		data["patient"]["blood_type"] = special_blood ? special_blood.name : blood_id
+
 	data["patient"]["maxHealth"] = patient.maxHealth
 	data["patient"]["minHealth"] = HEALTH_THRESHOLD_DEAD
 	data["patient"]["bruteLoss"] = patient.getBruteLoss()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

So basically, whenever you had an ethereal or some other species with an exotic blood type (ethereals bleed liquid electricity)- you would get a standard blood type that came from... somewhere? No idea what that was reading. Anyways, this PR just fixes the DM-side code to pass either the actual Rhesus blood type if it's genuine blood, or if it's something special (like a clown on April Fool's day)- it'll say that instead. Splendid!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #68606.

![image](https://user-images.githubusercontent.com/34697715/192361286-8751d339-2c56-4e07-b052-d351c89d239c.png)

It's more correct to be more correct.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Whenever you put a species with some type of exotic, non-human blood on a surgery table: the corresponding blood type should no longer report it as if the patient in question had a Rhesus blood type, and will instead declare the name of the actual reagent circulating within their system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
