### PR TITLE
Fixes an area issue in the Medbay Storage of Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -63598,7 +63598,7 @@
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/maintenance/department/medical)
+/area/station/medical/storage)
 "tCF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
@@ -67511,7 +67511,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/maintenance/department/medical)
+/area/station/medical/storage)
 "uOj" = (
 /turf/open/floor/iron,
 /area/station/command/gateway)


### PR DESCRIPTION
## About The Pull Request
![unknown](https://user-images.githubusercontent.com/105393050/192364788-dfb653fd-4e76-4709-934c-4ae5d48cbdea.png)
Fixed an issue where two tiles had the Medbay Maint area instead of Medbay Storage. There are no other instances of the former area.

## Why It's Good For The Game
Area issues are not good, especially when they cover windoors and such.

## Changelog
:cl:
fix: Fixed the rogue Medbay Maintenance area appearing inside Medbay Storage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
