### PR TITLE
Changes compile_changelogs to use comfyoranges

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -31,9 +31,10 @@ jobs:
           sudo apt-get install  dos2unix
       - name: "Checkout"
         if: steps.value_holder.outputs.ACTIONS_ENABLED
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           fetch-depth: 25
+          persist-credentials: false
       - name: "Compile"
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |
@@ -50,4 +51,4 @@ jobs:
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.COMFY_ORANGE_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses COMFY_ORANGE_PAT as the primary secret key, and falls back to GITHUB_TOKEN. As a result of me changing some branch protection settings to allow for auto merging, actions can no longer merge directly to master (even though admins, maintainers, etc can...). People on StackOverflow are saying the solution is to use a separate account, which we have.

Already tested as working because I accidentally merged it to master.