### PR TITLE
Fixes the skill cape drop pod's murderous tendancies

### DIFF
--- a/code/datums/skills/_skill.dm
+++ b/code/datums/skills/_skill.dm
@@ -74,7 +74,6 @@ GLOBAL_LIST_INIT(skill_types, subtypesof(/datum/skill))
 		return
 	podspawn(list(
 		"target" = get_turf(mind.current),
-		"path" = /obj/structure/closet/supplypod/mechpod,
 		"style" = STYLE_BLUESPACE,
 		"spawn" = skill_cape_path,
 		"delays" = list(POD_TRANSIT = 150, POD_FALLING = 4, POD_OPENING = 30, POD_LEAVING = 30)


### PR DESCRIPTION
## About The Pull Request
It was funny, but also a bug. It was also an incredible noobtrap, where only those that didn't know would get killed and get their organs yeeted out one by one.

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/58045821/192401805-f2ea4a1e-d05f-4193-8f89-43c1e1a728c4.png)
I didn't move, and here I am.
![image](https://user-images.githubusercontent.com/58045821/192401826-3bbfe289-01f7-4eca-899c-a98d4a629df6.png)


## Changelog

:cl: GoldenAlpharex
fix: The ExperTrack Professional Skill Associations have finally fixed the plans of their drop pods, sabotaged by an intern many moons ago, resulting in a Totally Safe Skill Cape Delivery!
/:cl: