### PR TITLE
Makes mechs unable to face the opposite direction instantly. 

### DIFF
--- a/code/modules/vehicles/mecha/mecha_movement.dm
+++ b/code/modules/vehicles/mecha/mecha_movement.dm
@@ -112,6 +112,8 @@
 
 	//if we're not facing the way we're going rotate us
 	if(dir != direction && !strafe || forcerotate || keyheld)
+		if(direction == REVERSE_DIR(dir) && !forcerotate)
+			direction = turn(direction, pick(90, -90))
 		if(dir != direction && !(mecha_flags & QUIET_TURNS) && !step_silent)
 			playsound(src,turnsound,40,TRUE)
 		setDir(direction)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes mechs unable to face the opposite direction instantly. Instead they will pick either left or right and turn there first before fully turning around.

## Why It's Good For The Game
Mechs have multiple mechanics relating to direction (increased damage, cant shoot, etc) but can just negate these quickly due to just being able to flip around, this fixes that.

## Changelog
:cl:
balance: mechs can no longer flip directions instantly
/:cl: