### PR TITLE
Stops erroneous manifest prices decreasing exponentially to negative infinity

### DIFF
--- a/code/modules/cargo/exports/manifest.dm
+++ b/code/modules/cargo/exports/manifest.dm
@@ -41,6 +41,7 @@
 // Substracts the package cost.
 /datum/export/manifest_error
 	unit_name = "erroneously approved manifest"
+	k_elasticity = 0
 	export_types = list(/obj/item/paper/fluff/jobs/cargo/manifest)
 	allow_negative_cost = TRUE
 
@@ -62,6 +63,7 @@
 // Substracts the package cost minus the cost of crate.
 /datum/export/manifest_correct_denied
 	cost = -CARGO_CRATE_VALUE
+	k_elasticity = 0
 	unit_name = "erroneously denied manifest"
 	export_types = list(/obj/item/paper/fluff/jobs/cargo/manifest)
 	allow_negative_cost = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Working version of #69294 . I misunderstood how cargo export prices' elasticity worked. This fixes the infinite negative bug by basically disabling the elasticity system to these manifests.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #69020 without accidentally removing the entire cargo elasticity system.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Stops the export value for erroneous manifests from decreasing into the deep negatives exponentially over time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
