### PR TITLE
Fixes facehugger exploit

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movement.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movement.dm
@@ -20,6 +20,7 @@
 ///called on /living, when pull is attempted, but before it completes, from base of [/mob/living/start_pulling]: (atom/movable/thing, force)
 #define COMSIG_LIVING_TRY_PULL "living_try_pull"
 	#define COMSIG_LIVING_CANCEL_PULL (1 << 0)
+#define COMSIG_LIVING_TRYING_TO_PULL "living_tried_pulling"
 /// Called from /mob/living/update_pull_movespeed
 #define COMSIG_LIVING_UPDATING_PULL_MOVESPEED "living_updating_pull_movespeed"
 /// Called from /mob/living/PushAM -- Called when this mob is about to push a movable, but before it moves

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -41,6 +41,8 @@
 	AddElement(/datum/element/connect_loc, loc_connections)
 	AddElement(/datum/element/atmos_sensitive, mapload)
 
+	RegisterSignal(src, COMSIG_LIVING_TRYING_TO_PULL, .proc/react_to_mob)
+
 /obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	..()
 	if(atom_integrity < 90)
@@ -48,6 +50,12 @@
 
 /obj/item/clothing/mask/facehugger/attackby(obj/item/O, mob/user, params)
 	return O.attack_atom(src, user, params)
+
+/obj/item/clothing/mask/facehugger/proc/react_to_mob(datum/source, mob/user)
+	SIGNAL_HANDLER
+	if((stat == CONSCIOUS && !sterile) && !isalien(user))
+		if(Leap(user))
+			return COMSIG_LIVING_CANCEL_PULL
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/clothing/mask/facehugger/attack_hand(mob/user, list/modifiers)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -279,6 +279,8 @@
 		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_LIVING_TRY_PULL, AM, force) & COMSIG_LIVING_CANCEL_PULL)
 		return FALSE
+	if(SEND_SIGNAL(AM, COMSIG_LIVING_TRYING_TO_PULL, src, force) & COMSIG_LIVING_CANCEL_PULL)
+		return FALSE
 
 	AM.add_fingerprint(src)
 


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed an exploit allowing non-alien mobs to move facehuggers without triggering them.
/:cl: