### PR TITLE
Tram air and disposal pipe fixes

### DIFF
--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowertunnel_leftup_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowertunnel_leftup_1.dmm
@@ -88,12 +88,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"hD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/template_noop,
-/area/template_noop)
 "iC" = (
 /obj/item/stack/ore/glass,
 /turf/open/misc/asteroid/airless,
@@ -848,7 +842,7 @@ Dh
 Dh
 Dh
 Dh
-hD
+Dh
 Dh
 Dh
 Dh

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowertunnel_leftup_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowertunnel_leftup_1.dmm
@@ -76,8 +76,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/central)
@@ -88,6 +88,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"hD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/template_noop,
+/area/template_noop)
 "iC" = (
 /obj/item/stack/ore/glass,
 /turf/open/misc/asteroid/airless,
@@ -118,12 +124,10 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "oN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "qW" = (
@@ -245,6 +249,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "IB" = (
@@ -841,7 +848,7 @@ Dh
 Dh
 Dh
 Dh
-Dh
+hD
 Dh
 Dh
 Dh

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowertunnel_leftup_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowertunnel_leftup_2.dmm
@@ -481,10 +481,6 @@
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/central)
-"RR" = (
-/obj/structure/disposalpipe/segment,
-/turf/template_noop,
-/area/template_noop)
 "Sz" = (
 /turf/template_noop,
 /area/template_noop)
@@ -859,7 +855,7 @@ ol
 ol
 ME
 Sz
-RR
+Sz
 Sz
 Sz
 Sz

--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowertunnel_leftup_2.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowertunnel_leftup_2.dmm
@@ -293,6 +293,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "vt" = (
@@ -310,13 +313,11 @@
 /area/station/maintenance/port/central)
 "zI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/item/pickaxe/mini,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "zM" = (
@@ -366,8 +367,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/central)
@@ -480,6 +481,10 @@
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/central)
+"RR" = (
+/obj/structure/disposalpipe/segment,
+/turf/template_noop,
+/area/template_noop)
 "Sz" = (
 /turf/template_noop,
 /area/template_noop)
@@ -854,7 +859,7 @@ ol
 ol
 ME
 Sz
-Sz
+RR
 Sz
 Sz
 Sz

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -436,6 +436,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/transit_tube)
+"aiP" = (
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1;
+	sortType = 7;
+	name = "sorting disposal pipe (Security)"
+	},
+/turf/open/floor/iron,
+/area/station/security/office)
 "aiQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -10096,6 +10104,9 @@
 	c_tag = "Security - Main Office South";
 	network = list("ss13","Security")
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/office)
 "dCz" = (
@@ -12281,6 +12292,7 @@
 /area/station/security/courtroom)
 "erP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/office)
 "esc" = (
@@ -16812,6 +16824,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/office)
 "gbZ" = (
@@ -20255,6 +20268,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/office)
 "hpz" = (
@@ -23159,10 +23173,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	name = "sorting disposal pipe (Head of Security's Office)";
-	sortType = 8
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 8;
+	name = "sorting disposal pipe (Head of Security's Office)"
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -28307,6 +28321,7 @@
 /area/station/security/checkpoint/supply)
 "kja" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/office)
 "kjr" = (
@@ -34946,6 +34961,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "mxJ" = (
@@ -36401,15 +36417,6 @@
 /obj/structure/fluff/tram_rail/end,
 /turf/open/openspace,
 /area/station/hallway/primary/tram/right)
-"mWW" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/office)
 "mXa" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -44562,6 +44569,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/office)
 "pVW" = (
@@ -46495,6 +46503,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/office)
 "qDK" = (
@@ -51194,6 +51203,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/security/office)
 "shF" = (
@@ -54838,6 +54850,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"tze" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/security/office)
 "tzJ" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/door/firedoor/border_only{
@@ -56556,6 +56574,9 @@
 /area/station/security/brig)
 "ufY" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/office)
 "ugb" = (
@@ -60361,7 +60382,7 @@
 	network = list("ss13","Security")
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -62095,6 +62116,9 @@
 	name = "Prison Monitor";
 	network = list("prison");
 	pixel_x = 30
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -155007,7 +155031,7 @@ iuO
 wLC
 eTz
 xsL
-yiB
+nLi
 tfp
 nca
 nca
@@ -155264,7 +155288,7 @@ mOn
 shg
 pVT
 mxI
-aIf
+yiB
 bVN
 tTJ
 tTJ
@@ -156282,7 +156306,7 @@ mAT
 mAT
 mAT
 vyM
-wbH
+aiP
 qDz
 hpn
 erP
@@ -156538,8 +156562,8 @@ vMy
 nZS
 hHf
 ykX
-mWW
-wbH
+jXo
+tze
 gRW
 fAg
 oUx

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -8029,6 +8029,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/command/gateway)
+"cTu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "cTE" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -11605,6 +11615,8 @@
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/medical)
 "edC" = (
@@ -16235,6 +16247,7 @@
 	c_tag = "Medical - Main West";
 	network = list("ss13","medbay")
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fQV" = (
@@ -16334,6 +16347,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
+"fSI" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "fSM" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -20329,6 +20349,9 @@
 "hqV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -31501,6 +31524,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"loe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/closed/wall,
+/area/station/medical/surgery/fore)
 "lof" = (
 /obj/item/toy/balloon,
 /turf/open/floor/eighties/red,
@@ -42467,6 +42496,11 @@
 	},
 /obj/machinery/duct,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "pmc" = (
@@ -49362,10 +49396,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rDR" = (
@@ -52434,8 +52466,8 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
-	name = "sorting disposal pipe (Medbay)";
-	sortType = 9
+	name = "sorting disposal pipe (Chemistry)";
+	sortType = 11
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -53406,22 +53438,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"sZo" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sZu" = (
@@ -60594,8 +60610,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "vCZ" = (
@@ -63006,7 +63024,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wyS" = (
@@ -65717,11 +65741,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xuR" = (
@@ -67326,10 +67345,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xZq" = (
@@ -163009,7 +163028,7 @@ qYZ
 qhJ
 iWl
 rrE
-xRx
+loe
 bBy
 vCk
 xhs
@@ -163527,7 +163546,7 @@ hiI
 mrY
 wyH
 fQK
-sZo
+xuE
 mIZ
 plY
 vGB
@@ -163782,11 +163801,11 @@ qws
 wma
 qws
 qws
-qws
+cTu
 lno
 rDJ
 lno
-lno
+cTu
 lno
 xZh
 tam
@@ -165317,7 +165336,7 @@ avr
 rfI
 uPz
 iZh
-dyI
+fSI
 cJL
 xSv
 xSZ


### PR DESCRIPTION

## About The Pull Request

While playing on Tramstation, I have noticed several errors with the various pipes and utilities. This PR contains the following fixes:

- Moved a fire alarm floating above a door one tile lower
- Connected fore operation room to plumbing ducts, and connected both surgery rooms to disposals, distro and waste
- Connected medbay distro and waste to starboard maintenance
- The apothecary had a duplicate medbay sorter instead of chemistry sorter, this is now fixed
- Rotated a disposal pipe under the medbay equipment storage room 
- Fixed two disposals errors in lower port maintenance, so the maintenance loop can once again be traversed
- Security Meeting Area and HoS disposals were in a one way area, they can once again flush down trash

## Why It's Good For The Game

It is not good to have medbay cut off from air, and the disposal network.

## Changelog

:cl:
fix: Various tramstation medbay disposal and air pipe issues have been fixed
fix: Medbay and Chemistry tagged packages will arrive properly to Tramstation's medical equipment storage, and the apothecary, respectively
fix: Gaps have been plugged in the tramstation disposal loop 
fix: Errant fire alarm no longer hovers above the surgery door
fix: Trash flushed down HoS and the Security Meeting area's disposals no longer get ejected below the HoS's door
/:cl:
