### PR TITLE
Fixes pulse rifle sound and converts some text paths

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -42,8 +42,8 @@
 	if((shot.e_cost > 0) && (cell.maxcharge != INFINITY))
 		// What percentage of the full battery a shot will expend
 		var/shot_cost_percent = round(clamp(shot.e_cost / cell.maxcharge, 0, 1) * 100)
-		// The total amount of shots the fully charged energy gun can fire before running out
-		var/max_shots = round(100/shot_cost_percent)
+		// The total amount of shots the fully charged energy gun can fire before running out, 100 if the cost so small it was roundend off
+		var/max_shots = round(100/max(1,shot_cost_percent))
 		// How many shots left before the energy gun's current battery runs out of energy
 		var/shots_left = round((round(clamp(cell.charge / cell.maxcharge, 0, 1) * 100))/shot_cost_percent)
 		frequency_to_use = sin((90/max_shots) * shots_left)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -39,11 +39,12 @@
 	var/frequency_to_use
 
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-	if((shot.e_cost > 0) && (cell.maxcharge != INFINITY))
-		// What percentage of the full battery a shot will expend
-		var/shot_cost_percent = round(clamp(shot.e_cost / cell.maxcharge, 0, 1) * 100)
-		// The total amount of shots the fully charged energy gun can fire before running out, 100 if the cost so small it was roundend off
-		var/max_shots = round(100/max(1,shot_cost_percent))
+	// What percentage of the full battery a shot will expend
+	var/shot_cost_percent = round(clamp(shot.e_cost / cell.maxcharge, 0, 1) * 100)
+	// Ignore this on oversized/infinite cells or ammo without cost
+	if(shot_cost_percent > 0)
+		// The total amount of shots the fully charged energy gun can fire before running out
+		var/max_shots = round(100/shot_cost_percent)
 		// How many shots left before the energy gun's current battery runs out of energy
 		var/shots_left = round((round(clamp(cell.charge / cell.maxcharge, 0, 1) * 100))/shot_cost_percent)
 		frequency_to_use = sin((90/max_shots) * shots_left)

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -10,7 +10,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pulse, /obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser)
-	cell_type = "/obj/item/stock_parts/cell/pulse"
+	cell_type = /obj/item/stock_parts/cell/pulse
 
 /obj/item/gun/energy/pulse/emp_act(severity)
 	return
@@ -39,7 +39,7 @@
 	icon_state = "pulse_carbine"
 	worn_icon_state = "gun"
 	inhand_icon_state = null
-	cell_type = "/obj/item/stock_parts/cell/pulse/carbine"
+	cell_type = /obj/item/stock_parts/cell/pulse/carbine
 
 /obj/item/gun/energy/pulse/carbine/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
@@ -55,7 +55,7 @@
 	name = "pulse destroyer"
 	desc = "A heavy-duty energy rifle built for pure destruction."
 	worn_icon_state = "pulse"
-	cell_type = "/obj/item/stock_parts/cell/infinite"
+	cell_type = /obj/item/stock_parts/cell/infinite
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pulse)
 
 /obj/item/gun/energy/pulse/destroyer/attack_self(mob/living/user)
@@ -69,7 +69,7 @@
 	icon_state = "pulse_pistol"
 	worn_icon_state = "gun"
 	inhand_icon_state = "gun"
-	cell_type = "/obj/item/stock_parts/cell/pulse/pistol"
+	cell_type = /obj/item/stock_parts/cell/pulse/pistol
 
 /obj/item/gun/energy/pulse/pistol/loyalpin
 	pin = /obj/item/firing_pin/implant/mindshield
@@ -79,4 +79,4 @@
 	desc = "A compact pulse core in a classic handgun frame for Nanotrasen officers. It's not the size of the gun, it's the size of the hole it puts through people."
 	icon_state = "m1911"
 	inhand_icon_state = "gun"
-	cell_type = "/obj/item/stock_parts/cell/infinite"
+	cell_type = /obj/item/stock_parts/cell/infinite

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -307,7 +307,7 @@
 	desc = "An LMG that fires 3D-printed flechettes. They are slowly resupplied using the cyborg's internal power source."
 	icon_state = "l6_cyborg"
 	icon = 'icons/obj/weapons/guns/ballistic.dmi'
-	cell_type = "/obj/item/stock_parts/cell/secborg"
+	cell_type = /obj/item/stock_parts/cell/secborg
 	ammo_type = list(/obj/item/ammo_casing/energy/c3dbullet)
 	can_charge = FALSE
 	use_cyborg_cell = TRUE


### PR DESCRIPTION
If energy guns cell was big enough compared to shot cost the frequency code would get confused, which resulted in cool pulse rifle thud not happening. Also cleans up some ancient text paths.

Fixes #70188 