### PR TITLE
Removes ghost check for battlecruiser objective and fixes players being able to roll it multiple times in a row

### DIFF
--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	var/list/datum/mind/members = list()
 	///Common objectives, these won't be added or removed automatically, subtypes handle this, this is here for bookkeeping purposes.
 	var/list/datum/objective/objectives = list()
-	var/list/players_spawned = new
+	var/list/players_spawned = list()
 
 /datum/team/New(starting_members)
 	. = ..()

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	var/list/datum/mind/members = list()
 	///Common objectives, these won't be added or removed automatically, subtypes handle this, this is here for bookkeeping purposes.
 	var/list/datum/objective/objectives = list()
+	///List of players in a team, mainly used to make sure someone cant spawn ghost roll more then once in a row
 	var/list/players_spawned = list()
 
 /datum/team/New(starting_members)

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	var/list/datum/mind/members = list()
 	///Common objectives, these won't be added or removed automatically, subtypes handle this, this is here for bookkeeping purposes.
 	var/list/datum/objective/objectives = list()
+	var/list/players_spawned = new
 
 /datum/team/New(starting_members)
 	. = ..()

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -1,7 +1,6 @@
 /datum/team/ashwalkers
 	name = "Ashwalkers"
 	show_roundend_report = FALSE
-	var/list/players_spawned = new
 
 /datum/antagonist/ashwalker
 	name = "\improper Ash Walker"

--- a/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
@@ -1,6 +1,3 @@
-/// The minimum number of ghosts and observers needed before handing out battlecruiser objectives.
-#define MIN_GHOSTS_FOR_BATTLECRUISER 8
-
 /datum/traitor_objective/final/battlecruiser
 	name = "Reveal Station Coordinates to nearby Syndicate Battlecruiser"
 	description = "Use a special upload card on a communications console to send the coordinates \
@@ -17,12 +14,6 @@
 		return FALSE
 	// There's no empty space to load a battlecruiser in...
 	if(!SSmapping.empty_space)
-		return FALSE
-	// Check how many observers + ghosts (dead players) we have.
-	// If there's not a ton of observers and ghosts to populate the battlecruiser,
-	// We won't bother giving the objective out.
-	var/num_ghosts = length(GLOB.current_observers_list) + length(GLOB.dead_player_list)
-	if(num_ghosts < MIN_GHOSTS_FOR_BATTLECRUISER)
 		return FALSE
 
 	return TRUE
@@ -58,5 +49,3 @@
 				"style" = STYLE_SYNDICATE,
 				"spawn" = emag_card,
 			))
-
-#undef MIN_GHOSTS_FOR_BATTLECRUISER

--- a/code/modules/mob_spawn/ghost_roles/space_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/space_roles.dm
@@ -118,9 +118,9 @@
 	var/antag_datum_to_give = /datum/antagonist/battlecruiser
 
 /obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser/allow_spawn(mob/user, silent = FALSE)
-	if(!(user.ckey in antag_team.players_spawned))//one per person unless you get a bonus spawn
+	if(!(user.ckey in antag_team.players_spawned))
 		return TRUE
-	to_chat(user, span_warning("<b>You have already used up your chance to roll as Battlecruiser</b>."))
+	to_chat(user, span_boldwarning("You have already used up your chance to roll as Battlecruiser."))
 	return FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser/special(mob/living/spawned_mob, mob/possesser)
@@ -129,7 +129,7 @@
 		spawned_mob.mind_initialize()
 	var/datum/mind/mob_mind = spawned_mob.mind
 	mob_mind.add_antag_datum(antag_datum_to_give, antag_team)
-	antag_team.players_spawned += (spawned_mob.key)
+	antag_team.players_spawned += (spawned_mob.ckey)
 
 /datum/team/battlecruiser
 	name = "\improper Battlecruiser Crew"

--- a/code/modules/mob_spawn/ghost_roles/space_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/space_roles.dm
@@ -118,7 +118,7 @@
 	var/antag_datum_to_give = /datum/antagonist/battlecruiser
 
 /obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser/allow_spawn(mob/user, silent = FALSE)
-	if(!(user.key in antag_team.players_spawned))//one per person unless you get a bonus spawn
+	if(!(user.ckey in antag_team.players_spawned))//one per person unless you get a bonus spawn
 		return TRUE
 	to_chat(user, span_warning("<b>You have already used up your chance to roll as Battlecruiser</b>."))
 	return FALSE

--- a/code/modules/mob_spawn/ghost_roles/space_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/space_roles.dm
@@ -117,12 +117,19 @@
 	/// The antag datum to give to the player spawned
 	var/antag_datum_to_give = /datum/antagonist/battlecruiser
 
+/obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser/allow_spawn(mob/user, silent = FALSE)
+	if(!(user.key in antag_team.players_spawned))//one per person unless you get a bonus spawn
+		return TRUE
+	to_chat(user, span_warning("<b>You have already used up your chance to roll as Battlecruiser</b>."))
+	return FALSE
+
 /obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser/special(mob/living/spawned_mob, mob/possesser)
 	. = ..()
 	if(!spawned_mob.mind)
 		spawned_mob.mind_initialize()
 	var/datum/mind/mob_mind = spawned_mob.mind
 	mob_mind.add_antag_datum(antag_datum_to_give, antag_team)
+	antag_team.players_spawned += (spawned_mob.key)
 
 /datum/team/battlecruiser
 	name = "\improper Battlecruiser Crew"

--- a/code/modules/shuttle/battlecruiser_starfury.dm
+++ b/code/modules/shuttle/battlecruiser_starfury.dm
@@ -172,6 +172,7 @@
 			if(candidates.len > 0)
 				var/mob/our_candidate = candidates[1]
 				spawner.create(our_candidate)
+				spawner.antag_team.players_spawned += (our_candidate.ckey)
 				candidates.Splice(1, 2)
 				notify_ghosts(
 					"The battlecruiser has an object of interest: [our_candidate]!",


### PR DESCRIPTION
## About The Pull Request

Removes the ghost check for the battlecruiser objective
Fixes the same player being able to reroll battlecruiser

## Why It's Good For The Game

The codeowner has stated he doesnt like the check because final objectives should not have volatile checks that can easily change within 10-15 minutes.

## Changelog

:cl:
balance: Removes the ghost check for the battlecruiser objective to appear
fix: Same player cant reroll battlecruiser multiple times anymore
/:cl:
