### PR TITLE
Adds Visual Studio files to the gitignore to avoid issues with users committing things they don't need to commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,17 @@
 #Ignore byond config folder.
 /cfg/**/*
 
+#Ignore IDE files we don't need in the repo.
+/.vs/**/*
+/tgstation/FileContentIndex/**/*
+/FileContentIndex/**/*
+/v17/**/*
+/v18/**/*
+/v19/**/*
+/v20/**/*
+/v21/**/*
+/v22/**/*
+
 # Ignore compiled linux libs in the root folder, e.g. librust_g.so
 /*.so
 


### PR DESCRIPTION
A user recently used Visual Studio 2017 to code for /tg/ and accidentally committed a bunch of stuff they shouldn't of, so let's save future devs from this mistake.