### PR TITLE
[webhook] treat github api errors when validating users better.

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -186,7 +186,7 @@ function validate_user($payload) {
 		$querystring .= ($querystring == '' ? '' : '+') . urlencode($key) . ':' . urlencode($value);
 	$res = github_apisend('https://api.github.com/search/issues?q='.$querystring);
 	$res = json_decode($res, TRUE);
-	return $res['total_count'] >= (int)$validation_count;
+	return (isset($res['total_count']) && $res['total_count'] >= (int)$validation_count);
 
 }
 


### PR DESCRIPTION
Proper fix is to make apisend handle retrying but i can't pr that from in bed when i remember i forgot to look into this so here we are

Now if the api request fails we treat the user as if they had no merged prs instead of crashing the entire script