### PR TITLE
removes jammer from glob on destroy

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -292,6 +292,10 @@ effective or pretty fucking useless.
 
 	update_appearance()
 
+/obj/item/jammer/Destroy()
+	GLOB.active_jammers -= src
+	. = ..()
+
 /obj/item/storage/toolbox/emergency/turret
 	desc = "You feel a strange urge to hit this with a wrench."
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -294,7 +294,7 @@ effective or pretty fucking useless.
 
 /obj/item/jammer/Destroy()
 	GLOB.active_jammers -= src
-	. = ..()
+	return ..()
 
 /obj/item/storage/toolbox/emergency/turret
 	desc = "You feel a strange urge to hit this with a wrench."


### PR DESCRIPTION
Having destroyed things stay in global lists is bad m'kay
I'm surprised this has never come up until now because it could reliably be used to do bad things