### PR TITLE
Improves Gibtonite Explosion Logging (The Fourth Time Is The Charm?)

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -539,7 +539,7 @@
 		defuse()
 	..()
 
-/turf/closed/mineral/gibtonite/proc/explosive_reaction(mob/user = null, triggered_by_explosion = 0)
+/turf/closed/mineral/gibtonite/proc/explosive_reaction(mob/user = null)
 	if(stage == GIBTONITE_UNSTRUCK)
 		activated_overlay = mutable_appearance('icons/turf/smoothrocks.dmi', "rock_Gibtonite_inactive", ON_EDGED_TURF_LAYER) //shows in gaps between pulses if there are any
 		SET_PLANE(activated_overlay, GAME_PLANE_UPPER, src)
@@ -551,8 +551,8 @@
 
 		var/notify_admins = !is_mining_level(z)
 
-		if(!triggered_by_explosion)
-			log_bomber(user, "has trigged a gibtonite deposit reaction via", src, null, notify_admins)
+		if(user)
+			log_bomber(user, "has triggered a gibtonite deposit reaction via", src, null, notify_admins)
 		else
 			log_bomber(null, "An explosion has triggered a gibtonite deposit reaction via", src, null, notify_admins)
 
@@ -585,7 +585,7 @@
 /turf/closed/mineral/gibtonite/gets_drilled(mob/user, give_exp = FALSE, triggered_by_explosion = FALSE)
 	if(stage == GIBTONITE_UNSTRUCK && mineralAmt >= 1) //Gibtonite deposit is activated
 		playsound(src,'sound/effects/hit_on_shattered_glass.ogg',50,TRUE)
-		explosive_reaction(user, triggered_by_explosion)
+		explosive_reaction(user)
 		return
 	if(stage == GIBTONITE_ACTIVE && mineralAmt >= 1) //Gibtonite deposit goes kaboom
 		var/turf/bombturf = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

This was some really old stuff in this logging proc (as well as a grammar error), and it would just cause some weird malformed logs like these that are completely unhelpful to anyone:

![image](https://user-images.githubusercontent.com/34697715/193365851-8650c939-b923-482f-a51f-b042093343dc.png)

From what I can tell, the only difference between the two is that one passes user while the other does not, but it has some weird check for something that is NOT user, and it... always passes false? I'm not very sure, but this seems much cleaner. I removed it from the proc arguments as well since it seemed like nothing used it, let me know if I should change that.

I also renamed "trigged" to "triggered", since that's actually words, I think.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/193365928-1907c750-5666-49fd-96f7-ded18cd5e176.png)

This looks better and I am hoping and praying that something doesn't break or that there's not some deep consideration that I am completely blanking on. Was it always passing false or something, and there was no user so it couldn't write properly? I've no idea.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Gibtonite logging has been improved to actually pass the name of the user when a user blows it up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
