### PR TITLE
Removes some firedoors in kilo telecomms

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -43823,10 +43823,6 @@
 "mvW" = (
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"mvX" = (
-/obj/effect/turf_decal/box,
-/turf/closed/wall/r_wall,
-/area/station/tcommsat/computer)
 "mwe" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -83348,7 +83344,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "xDE" = (
@@ -115142,7 +115137,7 @@ tLM
 jEd
 bsc
 xDm
-mvX
+vqw
 dAZ
 oHD
 fzL

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -6022,22 +6022,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"bSC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "bSM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -11277,7 +11261,6 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "dsc" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Control Room"
 	},
@@ -27281,6 +27264,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "hMf" = (
@@ -43839,6 +43823,10 @@
 "mvW" = (
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"mvX" = (
+/obj/effect/turf_decal/box,
+/turf/closed/wall/r_wall,
+/area/station/tcommsat/computer)
 "mwe" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -44655,7 +44643,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "mIq" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Server Room"
 	},
@@ -46616,7 +46603,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/starboard)
 "nms" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Server Room"
 	},
@@ -51321,9 +51307,6 @@
 	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -68247,6 +68230,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "tth" = (
@@ -83364,6 +83348,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "xDE" = (
@@ -115157,10 +115142,10 @@ tLM
 jEd
 bsc
 xDm
-vqw
+mvX
 dAZ
 oHD
-bSC
+fzL
 vSq
 qTC
 hZt


### PR DESCRIPTION
## About The Pull Request

- Removes the firedoors located under the doorways in Kilostation's telecomms room.
   - These firedoors went off roundstart because it was cold, so they are bad
- Added like 3 decals to the main hall since I noticed they were weird 
- Removed some misplaced disposals piping in the main hall since I noticed they were wrong

## Why It's Good For The Game

It's very annoying to hear the alarms in telecomms roundstart

## Changelog

:cl: Melbert
fix: Kilostation: No more firedoors in telecomms
/:cl:

