### PR TITLE
self-respiration grants its nobreath trait at stage 4 again

### DIFF
--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -50,7 +50,7 @@
 	if(!.)
 		return FALSE
 	var/mob/living/carbon/M = A.affected_mob
-	if(A.stage > 4)
+	if(A.stage >= 4)
 		ADD_TRAIT(M, TRAIT_NOBREATH, DISEASE_TRAIT)
 	else
 		REMOVE_TRAIT(M, TRAIT_NOBREATH, DISEASE_TRAIT)


### PR DESCRIPTION
## About The Pull Request

See title.

((Reverts half of https://github.com/tgstation/tgstation/pull/68152.))

## Why It's Good For The Game

I have no idea why https://github.com/tgstation/tgstation/pull/68152 made this change. All of our healing symptoms (that are subtypes of /datum/symptom/heal) have all of their effects kick in at stage 4, not stage 5. Even self-respiration's oxyloss healing _and messages telling you that you haven't been breathing_ kick in at stage 4.

I strongly suspect that timothy just saw that vomiting and half of old!confusion's effects kick in at stage 5, assumed that was the standard ("Makes virus symptoms more consistent **since most of them happen on stage 5.**"), and changed part of self-respiration to match them. Nobody called him out on this because nobody but me cares about viro code and I was on hiatus, and the PR was silently merged without any discussion.

I'm leaving in Timothy's changes to when confusion's effects kick in because they at least make the confusion symptom internally consistent. His change to self-respiration actively makes the symptom internally _in_consistent and makes it lie to its infectees.

https://github.com/tgstation/tgstation/pull/68152 was a [No GBP] PR, so I'd prefer it if this PR was marked that way as well.

## Changelog
:cl: ATHATH
fix: Self-respiration now makes you no longer need to breath at stage 4 again.
/:cl: