### PR TITLE
Tramstation crossing signals won't turn red when it's on the other side of the station

### DIFF
--- a/code/modules/industrial_lift/crossing_signal.dm
+++ b/code/modules/industrial_lift/crossing_signal.dm
@@ -32,7 +32,7 @@
 	/// Proximity threshold for amber warning (slow people may be in danger)
 	var/amber_distance_threshold = 60
 	/// Proximity threshold for red warning (running people will likely not be able to cross)
-	var/red_distance_threshold = 35
+	var/red_distance_threshold = 33
 
 /obj/machinery/crossing_signal/Initialize(mapload)
 	. = ..()

--- a/code/modules/industrial_lift/crossing_signal.dm
+++ b/code/modules/industrial_lift/crossing_signal.dm
@@ -31,7 +31,7 @@
 	var/datum/weakref/tram_ref
 	/// Proximity threshold for amber warning (slow people may be in danger) This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops.
 	var/amber_distance_threshold = 60
-	/// Proximity threshold for red warning (running people will likely not be able to cross) This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops.
+	/// Proximity threshold for red warning (running people will likely not be able to cross) This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops. This checks the distance between the tram and the signal, and based on the current Tramstation map this is the optimal number to prevent the lights from turning red for no reason for a few moments. If the value is set too high, it will cause the lights to turn red when the tram arrives at another station. You want to optimize the amount of warning without turning it red unnessecarily.
 	var/red_distance_threshold = 33
 
 /obj/machinery/crossing_signal/Initialize(mapload)

--- a/code/modules/industrial_lift/crossing_signal.dm
+++ b/code/modules/industrial_lift/crossing_signal.dm
@@ -29,9 +29,9 @@
 	var/tram_id = MAIN_STATION_TRAM
 	/// Weakref to the tram piece we control
 	var/datum/weakref/tram_ref
-	/// Proximity threshold for amber warning (slow people may be in danger)
+	/// Proximity threshold for amber warning (slow people may be in danger) This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops.
 	var/amber_distance_threshold = 60
-	/// Proximity threshold for red warning (running people will likely not be able to cross)
+	/// Proximity threshold for red warning (running people will likely not be able to cross) This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops.
 	var/red_distance_threshold = 33
 
 /obj/machinery/crossing_signal/Initialize(mapload)

--- a/code/modules/industrial_lift/crossing_signal.dm
+++ b/code/modules/industrial_lift/crossing_signal.dm
@@ -29,7 +29,8 @@
 	var/tram_id = MAIN_STATION_TRAM
 	/// Weakref to the tram piece we control
 	var/datum/weakref/tram_ref
-	/// Proximity threshold for amber warning (slow people may be in danger) This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops.
+	/// Proximity threshold for amber warning (slow people may be in danger).
+	/// This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops.
 	var/amber_distance_threshold = 60
 	/** Proximity threshold for red warning (running people will likely not be able to cross) This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops.
 	* This checks the distance between the tram and the signal, and based on the current Tramstation map this is the optimal number to prevent the lights from turning red for no reason for a few moments.

--- a/code/modules/industrial_lift/crossing_signal.dm
+++ b/code/modules/industrial_lift/crossing_signal.dm
@@ -31,7 +31,10 @@
 	var/datum/weakref/tram_ref
 	/// Proximity threshold for amber warning (slow people may be in danger) This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops.
 	var/amber_distance_threshold = 60
-	/// Proximity threshold for red warning (running people will likely not be able to cross) This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops. This checks the distance between the tram and the signal, and based on the current Tramstation map this is the optimal number to prevent the lights from turning red for no reason for a few moments. If the value is set too high, it will cause the lights to turn red when the tram arrives at another station. You want to optimize the amount of warning without turning it red unnessecarily.
+	/** Proximity threshold for red warning (running people will likely not be able to cross) This is specific to Tramstation and may need to be adjusted if the map changes in the distance between tram stops.
+	* This checks the distance between the tram and the signal, and based on the current Tramstation map this is the optimal number to prevent the lights from turning red for no reason for a few moments.
+	* If the value is set too high, it will cause the lights to turn red when the tram arrives at another station. You want to optimize the amount of warning without turning it red unnessecarily.
+	*/
 	var/red_distance_threshold = 33
 
 /obj/machinery/crossing_signal/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After my last PR for Tramstation crossing lights, for some reason the lights are changing to red on West when you send the tram from East to Central, which obviously shouldn't happen. This changes the red distance so that doesn't happen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
fix: Tramstation's crossing signals are actually fixed this time. Honest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
