### PR TITLE
Vomiting no longer makes you fall on the ground

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -421,7 +421,7 @@
 			visible_message(span_warning("[src] dry heaves!"), \
 							span_userdanger("You try to throw up, but there's nothing in your stomach!"))
 		if(stun)
-			Paralyze(200)
+			Stun(20 SECONDS)
 		return TRUE
 
 	if(is_mouth_covered()) //make this add a blood/vomit overlay later it'll be hilarious
@@ -437,7 +437,7 @@
 				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "vomit", /datum/mood_event/vomit)
 
 	if(stun)
-		Paralyze(80)
+		Stun(8 SECONDS)
 
 	playsound(get_turf(src), 'sound/effects/splat.ogg', 50, TRUE)
 	var/turf/T = get_turf(src)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -778,7 +778,7 @@
 			visible_message(span_warning("[src] dry heaves!"), \
 							span_userdanger("You try to throw up, but there's nothing in your stomach!"))
 		if(stun)
-			Paralyze(200)
+			Stun(200)
 		return 1
 	..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -778,7 +778,7 @@
 			visible_message(span_warning("[src] dry heaves!"), \
 							span_userdanger("You try to throw up, but there's nothing in your stomach!"))
 		if(stun)
-			Stun(200)
+			Stun(20 SECONDS)
 		return 1
 	..()
 


### PR DESCRIPTION
Back when stuns were refactored everything was rolled into Paralyze which had the unintended effect of making you fall on the ground after vomiting.  As a frequent patron of the bar this always bothered me because it looks stupid and today I am finally doing something about it

This shouldn't have any noteworthy changes to gameplay, you still get stunned and everything you just don't fall on the floor anymore
:cl:
fix: Alcoholics rejoice: the stun from vomiting no longer makes you fall on the floor
/:cl: