### PR TITLE
removes the big oxygen tanks from erts

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -77,6 +77,16 @@
 	new /obj/item/screwdriver/red(src)
 	new /obj/item/weldingtool/mini(src)
 
+/obj/item/storage/box/survival/centcom
+	name = "emergency response survival box"
+	desc = "A box with the bare essentials of ensuring the survival of your team. This one is labelled to contain a double tank."
+	illustration = "extendedtank"
+	internal_type = /obj/item/tank/internals/emergency_oxygen/double
+
+/obj/item/storage/box/survival/centcom/PopulateContents()
+	. = ..()
+	new /obj/item/crowbar(src)
+
 // Security survival box
 /obj/item/storage/box/survival/security
 	mask_type = /obj/item/clothing/mask/gas/sechailer

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -35,12 +35,11 @@
 	name = "ERT Commander"
 
 	id = /obj/item/card/id/advanced/centcom/ert
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/responsory/commander
 	l_hand = /obj/item/gun/energy/e_gun
+	box = /obj/item/storage/box/survival/centcom
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	belt = /obj/item/storage/belt/security/full
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
@@ -61,7 +60,6 @@
 	backpack_contents = list(
 		/obj/item/gun/energy/pulse/pistol/loyalpin = 1,
 		/obj/item/melee/baton/security/loaded = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	glasses = /obj/item/clothing/glasses/thermal/eyepatch
 	l_pocket = /obj/item/melee/energy/sword/saber
@@ -70,13 +68,12 @@
 	name = "ERT Security"
 
 	id = /obj/item/card/id/advanced/centcom/ert/security
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/responsory/security
 	l_hand = /obj/item/gun/energy/e_gun/stun
+	box = /obj/item/storage/box/survival/centcom
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/storage/box/handcuffs = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	belt = /obj/item/storage/belt/security/full
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
@@ -99,21 +96,19 @@
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/storage/box/handcuffs = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 
 /datum/outfit/centcom/ert/medic
 	name = "ERT Medic"
 
 	id = /obj/item/card/id/advanced/centcom/ert/medical
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/responsory/medic
+	box = /obj/item/storage/box/survival/centcom
 	backpack_contents = list(
 		/obj/item/gun/medbeam = 1,
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/reagent_containers/hypospray/combat = 1,
 		/obj/item/storage/box/hug/plushes = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	belt = /obj/item/storage/belt/medical/ert
 	glasses = /obj/item/clothing/glasses/hud/health
@@ -139,7 +134,6 @@
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/reagent_containers/hypospray/combat/nanites = 1,
 		/obj/item/storage/box/hug/plushes = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 
@@ -147,14 +141,13 @@
 	name = "ERT Engineer"
 
 	id = /obj/item/card/id/advanced/centcom/ert/engineer
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/responsory/engineer
 	l_hand = /obj/item/gun/energy/e_gun
+	box = /obj/item/storage/box/survival/centcom
 	backpack_contents = list(
 		/obj/item/construction/rcd/loaded/upgraded = 1,
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/pipe_dispenser = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	belt = /obj/item/storage/belt/utility/full/powertools
 	glasses = /obj/item/clothing/glasses/meson/engine
@@ -178,7 +171,6 @@
 		/obj/item/gun/energy/pulse/pistol/loyalpin = 1,
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/pipe_dispenser = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 
 /datum/outfit/centcom/centcom_official
@@ -218,7 +210,6 @@
 /datum/outfit/centcom/ert/commander/inquisitor
 	name = "Inquisition Commander"
 
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/responsory/inquisitory/commander
 	r_hand = /obj/item/nullrod/scythe/talking/chainsword
 	backpack_contents = list(
@@ -228,24 +219,20 @@
 /datum/outfit/centcom/ert/security/inquisitor
 	name = "Inquisition Security"
 
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/responsory/inquisitory/security
 	backpack_contents = list(
 		/obj/item/construction/rcd/loaded = 1,
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/storage/box/handcuffs = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 
 /datum/outfit/centcom/ert/medic/inquisitor
 	name = "Inquisition Medic"
 
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/responsory/inquisitory/medic
 	backpack_contents = list(
 		/obj/item/gun/medbeam = 1,
 		/obj/item/melee/baton/security/loaded = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 		/obj/item/reagent_containers/hypospray/combat = 1,
 		/obj/item/reagent_containers/hypospray/combat/heresypurge = 1,
 	)
@@ -254,14 +241,13 @@
 	name = "ERT Chaplain"
 
 	id = /obj/item/card/id/advanced/centcom/ert/chaplain
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/responsory/chaplain
 	l_hand = /obj/item/gun/energy/e_gun
 	belt = /obj/item/storage/belt/soulstone
 	glasses = /obj/item/clothing/glasses/hud/health
+	box = /obj/item/storage/box/survival/centcom
 	backpack_contents = list(
 		/obj/item/nullrod = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 
 /datum/outfit/centcom/ert/chaplain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -279,7 +265,6 @@
 	backpack_contents = list(
 		/obj/item/grenade/chem_grenade/holy = 1,
 		/obj/item/nullrod = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	belt = /obj/item/storage/belt/soulstone/full/chappy
 
@@ -287,15 +272,14 @@
 	name = "ERT Janitor"
 
 	id = /obj/item/card/id/advanced/centcom/ert/janitor
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/responsory/janitor
+	box = /obj/item/storage/box/survival/centcom
 	backpack_contents = list(
 		/obj/item/grenade/clusterbuster/cleaner = 1,
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/mop/advanced = 1,
 		/obj/item/reagent_containers/cup/bucket = 1,
 		/obj/item/storage/box/lights/mixed = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	belt = /obj/item/storage/belt/janitor/full
 	glasses = /obj/item/clothing/glasses/night
@@ -320,7 +304,6 @@
 		/obj/item/grenade/clusterbuster/cleaner = 3,
 		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/storage/box/lights/mixed = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	r_hand = /obj/item/reagent_containers/spray/chemsprayer/janitor
 
@@ -328,13 +311,12 @@
 	name = "ERT Clown"
 
 	id = /obj/item/card/id/advanced/centcom/ert/clown
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/responsory/clown
+	box = /obj/item/storage/box/survival/centcom
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/reverse = 1,
 		/obj/item/melee/energy/sword/bananium = 1,
 		/obj/item/shield/energy/bananium = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	belt = /obj/item/storage/belt/champion
 	glasses = /obj/item/clothing/glasses/trickblindfold
@@ -419,7 +401,6 @@
 		/obj/item/mop/advanced = 1,
 		/obj/item/reagent_containers/cup/bucket = 1,
 		/obj/item/storage/box/lights/mixed = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	belt = /obj/item/storage/belt/janitor/full
 	glasses = /obj/item/clothing/glasses/meson
@@ -438,7 +419,6 @@
 	backpack_contents = list(
 		/obj/item/clothing/head/warden/police = 1,
 		/obj/item/storage/box/handcuffs = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	belt = /obj/item/melee/baton/telescopic
 	l_pocket = /obj/item/assembly/flash
@@ -458,7 +438,6 @@
 		/obj/item/stack/sheet/glass/fifty = 1,
 		/obj/item/stack/sheet/iron/fifty = 1,
 		/obj/item/stack/sheet/plasteel/twenty = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	head = /obj/item/clothing/head/hardhat/weldhat
 	mask = /obj/item/clothing/mask/gas/atmos
@@ -474,7 +453,6 @@
 	backpack_contents = list(
 		/obj/item/instrument/piano_synth = 1,
 		/obj/item/shield/energy/bananium = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	glasses = /obj/item/clothing/glasses/chameleon
 	head = /obj/item/clothing/head/chameleon
@@ -489,7 +467,6 @@
 	backpack_contents = list(
 		/obj/item/food/cake/birthday = 1,
 		/obj/item/storage/box/fireworks = 3,
-		/obj/item/storage/box/survival/engineer = 1,
 	)
 	belt = /obj/item/storage/belt/sabre
 	head = /obj/item/clothing/head/coordinator
@@ -502,14 +479,13 @@
 	id = /obj/item/card/id/advanced/black/deathsquad
 	id_trim = /datum/id_trim/centcom/deathsquad
 	uniform = /obj/item/clothing/under/rank/centcom/commander
-	suit_store = /obj/item/tank/internals/oxygen
 	back = /obj/item/mod/control/pre_equipped/apocryphal
+	box = /obj/item/storage/box/survival/centcom
 	backpack_contents = list(
 		/obj/item/ammo_box/a357 = 1,
 		/obj/item/flashlight = 1,
 		/obj/item/grenade/c4/x4 = 1,
 		/obj/item/storage/box/flashbangs = 1,
-		/obj/item/storage/box/survival/engineer = 1,
 		/obj/item/storage/medkit/regular = 1,
 	)
 	belt = /obj/item/gun/ballistic/revolver/mateba


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes blue oxygen tanks from ERT suit storage
Makes a new emergency box for ERTs, containing the double extended emergency tanks and a pocket crowbar.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
the suit storage tank prevents gun storing + looks ugly
the double extended tank can be equipped without that much bulk, can be refilled pretty easily if need be and it lasts for a pretty long time
and erts really need crowbars to not get fucked by whatever thing is happening on station today

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: ERT suit storage oxygen tanks have been removed. Instead, the survival box in their backpack now contains a double extended emergency tank and a pocket crowbar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
