### PR TITLE
flagellant's hoods now have negative armor again

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -324,13 +324,14 @@ Striking a noncultist, however, will tear their flesh."}
 	desc = "Blood-soaked robes infused with dark magic; allows the user to move at inhuman speeds, but at the cost of increased damage."
 	allowed = list(/obj/item/tome, /obj/item/melee/cultblade)
 	armor = list(MELEE = -45, BULLET = -45, LASER = -45,ENERGY = -55, BOMB = -45, BIO = 0, FIRE = 0, ACID = 0)
-	slowdown = -0.6
+	slowdown = -0.3 //the hood gives an additional -0.3 if you have it flipped up, for a total of -0.6
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/berserkerhood
 
 /obj/item/clothing/head/hooded/cult_hoodie/berserkerhood
 	name = "flagellant's hood"
 	desc = "Blood-soaked hood infused with dark magic."
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	armor = list(MELEE = -45, BULLET = -45, LASER = -45,ENERGY = -55, BOMB = -45, BIO = 0, FIRE = 0, ACID = 0)
+	slowdown = -0.3
 
 /obj/item/clothing/suit/hooded/cultrobes/berserker/equipped(mob/living/user, slot)
 	..()

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -321,7 +321,7 @@ Striking a noncultist, however, will tear their flesh."}
 
 /obj/item/clothing/suit/hooded/cultrobes/berserker
 	name = "flagellant's robes"
-	desc = "Blood-soaked robes infused with dark magic; allows the user to move at inhuman speeds, but at the cost of increased damage."
+	desc = "Blood-soaked robes infused with dark magic; allows the user to move at inhuman speeds, but at the cost of increased damage. Provides an even greater speed boost if its hood is worn."
 	allowed = list(/obj/item/tome, /obj/item/melee/cultblade)
 	armor = list(MELEE = -45, BULLET = -45, LASER = -45,ENERGY = -55, BOMB = -45, BIO = 0, FIRE = 0, ACID = 0)
 	slowdown = -0.3 //the hood gives an additional -0.3 if you have it flipped up, for a total of -0.6
@@ -329,7 +329,7 @@ Striking a noncultist, however, will tear their flesh."}
 
 /obj/item/clothing/head/hooded/cult_hoodie/berserkerhood
 	name = "flagellant's hood"
-	desc = "Blood-soaked hood infused with dark magic."
+	desc = "A blood-soaked hood infused with dark magic."
 	armor = list(MELEE = -45, BULLET = -45, LASER = -45,ENERGY = -55, BOMB = -45, BIO = 0, FIRE = 0, ACID = 0)
 	slowdown = -0.3
 


### PR DESCRIPTION
## About The Pull Request

The armor values of the hoods of flagellant's robes now match the armor values of the non-hood parts of the robes.

Half of the speed boost from wearing flagellant's robes has been moved to wearing the flagellant's hoods that come with said robes.

The description of the robes has been edited to reflect this change.

also I added an "A" to the description of the hood because that was bothering me

## Why It's Good For The Game

A long time ago, flagellant's hoods had negative armor like the robes they're drawn from. Life made sense, ~~the game had soul~~, and all was good.

Then someone realized that this made it optimal to always keep your flagellant's hood flipped down, as you don't need it for the speed boost and you're directly penalized for wearing it. To fix this, the hood's armor values were set to 0.

The problem here is that that fix didn't entirely work- you're still penalized for wearing the hood because it blocks you from wearing literally any other head gear that actually gives you armor (or some utility effect, like the flash protection of welding helmets).

This PR fixes that problem by moving half of the speed boost to the hood. If you want the full speed boost, you'll need to flip the hood up (and accept the negative armor on your noggin), but if you're a plasmaman or really want to wear that cool beret, you can keep it flipped down and still get half of the speed boost.

I suppose I should also explicitly state as a reminder that you can't wear flagellant's hoods without wearing the robes along with them, as the hoods are physically attached to the robes.

N.B.: There is an argument here for moving the entire speed boost to the hood, as new cultists who don't flip up the hood (and are too overwhelmed to read the description) could mistakenly believe that they already have the whole speed boost. That would kind of screw over plasmaman cultists, cultists with HARS, and cultists who want to wear cool hats, though.

I'd also appreciate it if I didn't lose GBP over this PR, since it's kind of on the borderline between being a fix and a balance change.

## Changelog
:cl: ATHATH
balance: Half of the speed boost from wearing flagellant's robes has been moved to wearing the hoods that come with said robes.
balance: Flagellant's hoods now have the same (negative) armor values as the robes they're attached to.
spellcheck: The descriptions of flagellant's robes and hoods have been updated.
/:cl: