### PR TITLE
The clown box can now eat you again.

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -154,8 +154,8 @@
 /obj/item/storage/box/clown/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] opens [src] and gets consumed by [p_them()]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	playsound(user, 'sound/misc/scary_horn.ogg', 70, vary = TRUE)
+	src.forceMove(user.drop_location())
 	var/obj/item/clothing/head/mob_holder/consumed = new(src, user)
-	user.forceMove(consumed)
 	consumed.desc = "It's [user.real_name]! It looks like [user.p_they()] committed suicide!"
 	return OXYLOSS
 

--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -154,7 +154,7 @@
 /obj/item/storage/box/clown/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] opens [src] and gets consumed by [p_them()]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	playsound(user, 'sound/misc/scary_horn.ogg', 70, vary = TRUE)
-	src.forceMove(user.drop_location())
+	forceMove(user.drop_location())
 	var/obj/item/clothing/head/mob_holder/consumed = new(src, user)
 	consumed.desc = "It's [user.real_name]! It looks like [user.p_they()] committed suicide!"
 	return OXYLOSS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The clown box suicide verb implies that it puts you inside the box, however the code didn't work because it was misusing the mob holder object and just pulled the suicider out of it as soon as it was created.
I made the code work, which turned out to just be a one line fix.

Details for if this sounds like concerning behaviour:
- This is on the suicide act so any mob which does it becomes unrevivable.
- If anyone attempts to search the box, the corpse is dumped on the ground immediately and cannot be put back in the box.

As far as I am aware there aren't any current ways to implant a living human inside another human so I don't think this is a way you can get a living person to be inside a box you can carry around.
This does make it easier to transport a clown who committed suicide to the gibber, but that's probably fine.

## Why It's Good For The Game

It was supposed to do this and presumably did at one point, now it works again.
I couldn't find an issue report for this presumably because trying to commit suicide with the clown box is not a common user behaviour.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Commiting suicide using a box stampled by a clown now does what the description says it will do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
