### PR TITLE
Fixes lighting overlays from an item sometimes showing up on inventory slots / backpack slots instead of from the mob holding them.

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -448,7 +448,7 @@
 	if(current_holder)
 		remove_dynamic_lumi()
 	overlay_lighting_flags &= ~LIGHTING_ON
-	if(current_holder)
+	if(current_holder && current_holder != parent && current_holder != parent_attached_to)
 		UnregisterSignal(current_holder, COMSIG_MOVABLE_MOVED)
 	clean_old_turfs()
 


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed lighting overlays from an item sometimes showing up on inventory slots / backpack slots instead of from the mob holding them.
/:cl:

Fixes #69936
