### PR TITLE
Expands mob_tags logging

### DIFF
--- a/code/__HELPERS/logging/mob.dm
+++ b/code/__HELPERS/logging/mob.dm
@@ -1,5 +1,10 @@
-/proc/log_mob_tag(text)
-	WRITE_LOG(GLOB.world_mob_tag_log, "TAG: [text]")
+/**
+ * Logs a mesage to the mob_tags log, including the mobs tag
+ * Arguments:
+ * * text - text to log.
+ */
+/mob/proc/log_mob_tag(text)
+	WRITE_LOG(GLOB.world_mob_tag_log, "TAG: \[[tag]\] [text]")
 
 /proc/log_silicon(text)
 	if (CONFIG_GET(flag/log_silicon))

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -484,6 +484,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 			var/species_holder = initial(mrace.species_language_holder)
 			language_holder = new species_holder(src)
 		update_atom_languages()
+		log_mob_tag("\[[tag]\] SPECIES: [key_name(src)] \[[mrace]\]")
 
 /mob/living/carbon/human/set_species(datum/species/mrace, icon_update = TRUE, pref_load = FALSE)
 	..()

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 			var/species_holder = initial(mrace.species_language_holder)
 			language_holder = new species_holder(src)
 		update_atom_languages()
-		log_mob_tag("\[[tag]\] SPECIES: [key_name(src)] \[[mrace]\]")
+		log_mob_tag("SPECIES: [key_name(src)] \[[mrace]\]")
 
 /mob/living/carbon/human/set_species(datum/species/mrace, icon_update = TRUE, pref_load = FALSE)
 	..()

--- a/code/modules/client/preferences/names.dm
+++ b/code/modules/client/preferences/names.dm
@@ -42,6 +42,7 @@
 /datum/preference/name/real_name/apply_to_human(mob/living/carbon/human/target, value)
 	target.real_name = value
 	target.name = value
+	log_mob_tag("\[[target.tag]\] RENAMED: [key_name(target)]")
 
 /datum/preference/name/real_name/create_informed_default_value(datum/preferences/preferences)
 	var/species_type = preferences.read_preference(/datum/preference/choiced/species)

--- a/code/modules/client/preferences/names.dm
+++ b/code/modules/client/preferences/names.dm
@@ -42,7 +42,7 @@
 /datum/preference/name/real_name/apply_to_human(mob/living/carbon/human/target, value)
 	target.real_name = value
 	target.name = value
-	log_mob_tag("\[[target.tag]\] RENAMED: [key_name(target)]")
+	target.log_mob_tag("RENAMED: [key_name(target)]")
 
 /datum/preference/name/real_name/create_informed_default_value(datum/preferences/preferences)
 	var/species_type = preferences.read_preference(/datum/preference/choiced/species)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -22,6 +22,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 		add_verb(src, /mob/dead/proc/server_hop)
 	set_focus(src)
 	become_hearing_sensitive()
+	log_mob_tag("CREATED: [key_name(src)] \[[src.type]\]")
 	return INITIALIZE_HINT_NORMAL
 
 /mob/dead/canUseStorage()

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -80,6 +80,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	dna.initialize_dna(skip_index = TRUE) //Skip stuff that requires full round init.
 
 /mob/living/carbon/human/dummy/log_mob_tag(text)
+	return
 
 /// Provides a dummy that is consistently bald, white, naked, etc.
 /mob/living/carbon/human/dummy/consistent

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -79,6 +79,8 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	randomize_human(src)
 	dna.initialize_dna(skip_index = TRUE) //Skip stuff that requires full round init.
 
+/mob/living/carbon/human/dummy/log_mob_tag(text)
+
 /// Provides a dummy that is consistently bald, white, naked, etc.
 /mob/living/carbon/human/dummy/consistent
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -108,7 +108,7 @@
 		auto_deadmin_on_login()
 
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
-	log_mob_tag("\[[tag]\] NEW OWNER: [key_name(src)]")
+	log_mob_tag("NEW OWNER: [key_name(src)]")
 	SEND_SIGNAL(src, COMSIG_MOB_CLIENT_LOGIN, client)
 	client.init_verbs()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -93,7 +93,7 @@
 	initialize_actionspeed()
 	update_movespeed(TRUE)
 	become_hearing_sensitive()
-	log_mob_tag("\[[tag]\] CREATED: [key_name(src)] \[[src.type]\]")
+	log_mob_tag("CREATED: [key_name(src)] \[[src.type]\]")
 
 /**
  * Generate the tag for this mob
@@ -1063,7 +1063,7 @@
 				if(obj.target && obj.target.current && obj.target.current.real_name == name)
 					obj.update_explanation_text()
 
-	log_mob_tag("\[[tag]\] RENAMED: [key_name(src)]")
+	log_mob_tag("RENAMED: [key_name(src)]")
 
 	return TRUE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -93,7 +93,7 @@
 	initialize_actionspeed()
 	update_movespeed(TRUE)
 	become_hearing_sensitive()
-	log_mob_tag("CREATED: [key_name(src)] \[[src.type]\]")
+	log_mob_tag("CREATED: [key_name(src)] \[[type]\]")
 
 /**
  * Generate the tag for this mob

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -93,7 +93,7 @@
 	initialize_actionspeed()
 	update_movespeed(TRUE)
 	become_hearing_sensitive()
-	log_mob_tag("\[[tag]\] CREATED: [key_name(src)]")
+	log_mob_tag("\[[tag]\] CREATED: [key_name(src)] \[[src.type]\]")
 
 /**
  * Generate the tag for this mob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Expands mob_tags logging by the following items:

- When a players spawns and their mobs name is getting set via preferences this is now logged as RENAME
- Mob creating now logs the typepath so you now what kind of mob got created
- Changes to the species of a mob are also logged

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Missing rename logging is bad because it makes the log kinda confusing why suddenly a mob is named differently
Adding the typepath to the CREATED log is just a nice way of easily seeing what kind of mob actually got created
Before:
`TAG: [mob_45] CREATED: *no key*/(Poly)`
After:
`TAG: [mob_45] CREATED: *no key*/(Poly) [/mob/living/simple_animal/parrot/poly]`
Logging species changes seems like it could be helpful for admins (I feel like this should already be logged)
Could also maybe be used to make stats about most played species but would probably require some parsing since stuff like player selector creates dummy mobs etc.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Gamer025
admin: Expanded mob_tag logging. Logs spawn renames, typepaths and species changes now!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
