### PR TITLE
Fix spirits, robots, and megafauna being affected by hallucinations

### DIFF
--- a/code/__HELPERS/hallucinations.dm
+++ b/code/__HELPERS/hallucinations.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_EMPTY(all_ongoing_hallucinations)
  * optional_messages - optional list of messages passed. Those affected by pulses will be given one of the messages in said list.
  */
 /proc/visible_hallucination_pulse(atom/center, radius = 7, hallucination_duration = 50 SECONDS, hallucination_max_duration, list/optional_messages)
-	for(var/mob/living/nearby_living in view(center, radius))
+	for(var/mob/living/carbon/human/nearby_living in view(center, radius))
 		if(HAS_TRAIT(nearby_living, TRAIT_MADNESS_IMMUNE) || (nearby_living.mind && HAS_TRAIT(nearby_living.mind, TRAIT_MADNESS_IMMUNE)))
 			continue
 

--- a/code/__HELPERS/hallucinations.dm
+++ b/code/__HELPERS/hallucinations.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_EMPTY(all_ongoing_hallucinations)
 		if(HAS_TRAIT(nearby_living, TRAIT_MADNESS_IMMUNE) || (nearby_living.mind && HAS_TRAIT(nearby_living.mind, TRAIT_MADNESS_IMMUNE)))
 			continue
 
-		if(nearby_living.mob_biotypes & MOB_ROBOTIC|MOB_SPIRIT|MOB_EPIC)
+		if(nearby_living.mob_biotypes & (MOB_ROBOTIC|MOB_SPIRIT|MOB_EPIC))
 			continue
 
 		if(nearby_living.is_blind())

--- a/code/__HELPERS/hallucinations.dm
+++ b/code/__HELPERS/hallucinations.dm
@@ -59,8 +59,11 @@ GLOBAL_LIST_EMPTY(all_ongoing_hallucinations)
  * optional_messages - optional list of messages passed. Those affected by pulses will be given one of the messages in said list.
  */
 /proc/visible_hallucination_pulse(atom/center, radius = 7, hallucination_duration = 50 SECONDS, hallucination_max_duration, list/optional_messages)
-	for(var/mob/living/carbon/nearby_living in view(center, radius))
+	for(var/mob/living/nearby_living in view(center, radius))
 		if(HAS_TRAIT(nearby_living, TRAIT_MADNESS_IMMUNE) || (nearby_living.mind && HAS_TRAIT(nearby_living.mind, TRAIT_MADNESS_IMMUNE)))
+			continue
+
+		if(nearby_living.mob_biotypes & MOB_ROBOTIC|MOB_SPIRIT|MOB_EPIC)
 			continue
 
 		if(nearby_living.is_blind())

--- a/code/__HELPERS/hallucinations.dm
+++ b/code/__HELPERS/hallucinations.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_EMPTY(all_ongoing_hallucinations)
  * optional_messages - optional list of messages passed. Those affected by pulses will be given one of the messages in said list.
  */
 /proc/visible_hallucination_pulse(atom/center, radius = 7, hallucination_duration = 50 SECONDS, hallucination_max_duration, list/optional_messages)
-	for(var/mob/living/carbon/human/nearby_living in view(center, radius))
+	for(var/mob/living/carbon/nearby_living in view(center, radius))
 		if(HAS_TRAIT(nearby_living, TRAIT_MADNESS_IMMUNE) || (nearby_living.mind && HAS_TRAIT(nearby_living.mind, TRAIT_MADNESS_IMMUNE)))
 			continue
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #70262

Revenants were being affected by hallucinations.  (pretty sure this applies to silicons and other simple mobs as well) 
 Alternatively we could add a whitelist for certain mobs, but I don't think that's optimal since we'd have to keep that list updated and prune through every mob manually to decide if it should be affected.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Another consistency bug off the tracker.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Spirits (Revenants), Robotic mobs (drones), and epic mobs (megafauna) are no longer affected by hallucinations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
