### PR TITLE
Blood deficiency quirk now increases oxygen damage for bloodless species

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -67,7 +67,6 @@
 	if(NOBLOOD in bloodless.dna.species.species_traits) // if your species does not have blood, we double oxygen damage instead
 		bloodless.physiology.oxy_mod *= 2
 		bloodless_species = TRUE
-		STOP_PROCESSING(SSquirks, src)
 		processing_quirk = FALSE
 
 /datum/quirk/blooddeficiency/remove()

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -60,17 +60,29 @@
 	medical_record_text = "Patient requires regular treatment for blood loss due to low production of blood."
 	hardcore_value = 8
 	processing_quirk = TRUE
+	var/bloodless_species = FALSE
+
+/datum/quirk/blooddeficiency/add()
+	var/mob/living/carbon/human/bloodless = quirk_holder
+	if(NOBLOOD in bloodless.dna.species.species_traits) // if your species does not have blood, we double oxygen damage instead
+		bloodless.physiology.oxy_mod *= 2
+		bloodless_species = TRUE
+		STOP_PROCESSING(SSquirks, src)
+		processing_quirk = FALSE
+
+/datum/quirk/blooddeficiency/remove()
+	if(bloodless_species)
+		var/mob/living/carbon/human/bloodless = quirk_holder
+		bloodless.physiology.oxy_mod *= 0.5
+
 
 /datum/quirk/blooddeficiency/process(delta_time)
 	if(quirk_holder.stat == DEAD)
 		return
 
-	var/mob/living/carbon/human/H = quirk_holder
-	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
-		return
-
-	if (H.blood_volume > (BLOOD_VOLUME_SAFE - 25)) // just barely survivable without treatment
-		H.blood_volume -= 0.275 * delta_time
+	var/mob/living/carbon/human/human = quirk_holder
+	if (human.blood_volume > (BLOOD_VOLUME_SAFE - 25)) // just barely survivable without treatment
+		human.blood_volume -= 0.275 * delta_time
 
 /datum/quirk/item_quirk/blindness
 	name = "Blind"

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -81,6 +81,9 @@
 		return
 
 	var/mob/living/carbon/human/human = quirk_holder
+	if(NOBLOOD in human.dna.species.species_traits) //can't lose blood if your species doesn't have any - this is needed if we change species after the quirk is added
+		return
+
 	if (human.blood_volume > (BLOOD_VOLUME_SAFE - 25)) // just barely survivable without treatment
 		human.blood_volume -= 0.275 * delta_time
 


### PR DESCRIPTION
## About The Pull Request

Makes it so the blood deficiency doubles the oxygen damage you take instead if it's selected by a species with no blood

## Why It's Good For The Game
This quirk does nothing if your species does not have blood so people have been exploiting it for free points. Since blood loss typically causes oxygen damage this seems like an appropriate alternative abstraction for someone with compromised oxygenation.

## Changelog

:cl:
balance: Bloodless species with the blood deficiency quirk now take increased oxygen damage
/:cl:
