### PR TITLE
Cyborg Model Advertisement Update, or How I Stopped Having To Guess Your Model

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -88,6 +88,7 @@
 	savedName = user.name
 	user.name = friendlyName
 	user.model.cyborg_base_icon = disguise
+	user.model.name = capitalize(disguise)
 	user.bubble_icon = "robot"
 	active = TRUE
 	user.update_icons()
@@ -107,6 +108,7 @@
 	do_sparks(5, FALSE, user)
 	user.name = savedName
 	user.model.cyborg_base_icon = initial(user.model.cyborg_base_icon)
+	user.model.name = initial(user.model.name)
 	user.bubble_icon = "syndibot"
 	active = FALSE
 	user.update_icons()

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -4,7 +4,7 @@
 		. += "[desc]"
 
 	var/model_name = model ? "\improper [model.name]" : "\improper Default"
-	. += "\nIt is currently \a \"[model_name]\"-type cyborg.\n"
+	. += "\nIt is currently \a \"[span_bold(model_name)]\"-type cyborg.\n"
 
 	var/obj/act_module = get_active_held_item()
 	if(act_module)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -3,6 +3,9 @@
 	if(desc)
 		. += "[desc]"
 
+	var/model_name = model ? "\improper [model.name]" : "\improper Default"
+	. += "\nIt is currently \a \"[model_name]\"-type cyborg.\n"
+
 	var/obj/act_module = get_active_held_item()
 	if(act_module)
 		. += "It is holding [icon2html(act_module, user)] \a [act_module]."

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -4,7 +4,7 @@
 		. += "[desc]"
 
 	var/model_name = model ? "\improper [model.name]" : "\improper Default"
-	. += "\nIt is currently \a \"[span_bold(model_name)]\"-type cyborg.\n"
+	. += "\nIt is currently \a \"[span_bold("[model_name]")]\"-type cyborg.\n"
 
 	var/obj/act_module = get_active_held_item()
 	if(act_module)


### PR DESCRIPTION
## About The Pull Request
Have you ever looked at a borg and shift-clicked to figure out what kind of borg they were, and subsequently went like "fuck, how do I know which model they are???" as you noticed that nothing was indicating their model in there?

Well, boy do I have the solution for you.

### Introducing: Cyborg Models In Examine
![image](https://user-images.githubusercontent.com/58045821/193474353-80da2647-8d07-4b3f-92cb-d83beb3d8077.png)


It's simple, it's slick, it's incredibly convenient and useful!

It even properly switches between `a` and `an` accordingly! (BYOND text macros my beloved)
![image](https://user-images.githubusercontent.com/58045821/193474369-c23647ad-911a-4898-ba6a-cb444dbfc650.png)


It also works with the borg chameleon module, which means it won't give out that you're a syndicate saboteur!
![image](https://user-images.githubusercontent.com/58045821/193474411-65590d90-9d3b-419c-896a-c220d58b27e9.png)
![image](https://user-images.githubusercontent.com/58045821/193474414-d326d688-4e1b-468f-aba7-8e792e915a79.png)


## Why It's Good For The Game
Having players rely on just the sprite to figure out what model a cyborg is isn't very great for accessibility, especially for models that also have different color scheme variants, such as the syndicate borgs. We show a lot of information on humans over examine, I was surprised nobody ever has ever thought of adding it to cyborgs yet. I guess it counts as consistency too, since, y'know, you'd expect to be able to tell what model they are from examining them.

## Changelog

:cl: GoldenAlpharex
qol: After several incidents related to miscommunications regarding robot models, Nanotrasen's Robotic Appearance Normalization Department has decided to make it extra-obvious which model each cyborg is - Just give them a closer look, it's that easy!
/:cl: