### PR TITLE
Fix an invalid string macro

### DIFF
--- a/code/modules/experisci/experiment/types/scanning_plants.dm
+++ b/code/modules/experisci/experiment/types/scanning_plants.dm
@@ -18,7 +18,7 @@
 			required_genes[req_atom] = chosen_gene
 
 /datum/experiment/scanning/random/plants/serialize_progress_stage(atom/target, list/seen_instances)
-	return EXPERIMENT_PROG_INT("Scan samples of \a harvested plant.", \
+	return EXPERIMENT_PROG_INT("Scan samples of a harvested plant.", \
 		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target])
 
 /datum/experiment/scanning/random/plants/traits/final_contributing_index_checks(atom/target, typepath)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There's no interpolated expression so the string macro doesn't do anything. 

Found by OpenDream (credit to Altoids specifically).