### PR TITLE
Converts some remaining varedited lights to directionals

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
@@ -936,7 +936,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/pizzeria/kitchen)
 "Fe" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/toilet{
 	dir = 8
 	},
@@ -1008,9 +1008,7 @@
 /obj/structure/closet/crate/trashcart,
 /obj/item/toy/crayon/spraycan,
 /obj/item/camera,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/spawner/random/trash/botanical_waste,
 /obj/item/seeds/tomato,
 /obj/item/seeds/wheat,

--- a/_maps/RandomRuins/SpaceRuins/derelict8.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict8.dmm
@@ -25,7 +25,7 @@
 /area/template_noop)
 "dS" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/broken,
+/obj/machinery/light/broken/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav)

--- a/_maps/RandomRuins/SpaceRuins/spinwardsmoothies.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spinwardsmoothies.dmm
@@ -1,8 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/spinwardsmoothies)
 "dq" = (
@@ -36,9 +34,7 @@
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/spinwardsmoothies)
 "ri" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/spinwardsmoothies)
@@ -64,7 +60,7 @@
 /area/ruin/space/has_grav/spinwardsmoothies)
 "xc" = (
 /obj/structure/table/wood,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/thinplating/terracotta{
 	dir = 1
 	},
@@ -92,13 +88,11 @@
 /area/ruin/space/has_grav/spinwardsmoothies)
 "CK" = (
 /obj/structure/flora/bush/flowers_br/style_random,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/spinwardsmoothies)
 "CV" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/thinplating/terracotta{
 	dir = 8
 	},
@@ -154,7 +148,7 @@
 /turf/open/floor/bamboo,
 /area/ruin/space/has_grav/spinwardsmoothies)
 "KV" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/spinwardsmoothies)
 "OI" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -66820,7 +66820,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/barber)
 "qlK" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/table,
 /obj/item/fuel_pellet{
 	pixel_x = 8
@@ -76597,9 +76597,7 @@
 "sJd" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8

--- a/_maps/shuttles/starfury_corvette.dmm
+++ b/_maps/shuttles/starfury_corvette.dmm
@@ -318,7 +318,6 @@
 "aR" = (
 /obj/machinery/light/small/directional/west{
 	brightness = 3;
-	
 	},
 /obj/structure/chair/comfy/shuttle{
 	name = "tactical chair"

--- a/_maps/shuttles/starfury_corvette.dmm
+++ b/_maps/shuttles/starfury_corvette.dmm
@@ -118,9 +118,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/sbc_corvette)
 "ao" = (
-/obj/machinery/light/small{
+/obj/machinery/light/small/directional/west{
 	brightness = 3;
-	dir = 8
+	
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1;
@@ -182,7 +182,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/sbc_corvette)
 "aw" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1;
 	name = "tactical chair"
@@ -251,9 +251,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/sbc_corvette)
 "aG" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/chair/comfy/shuttle{
 	name = "tactical chair"
 	},
@@ -319,9 +317,9 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/sbc_corvette)
 "aR" = (
-/obj/machinery/light/small{
+/obj/machinery/light/small/directional/west{
 	brightness = 3;
-	dir = 8
+	
 	},
 /obj/structure/chair/comfy/shuttle{
 	name = "tactical chair"
@@ -345,9 +343,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/sbc_corvette)
 "aT" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
@@ -358,9 +354,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/sbc_corvette)
 "aU" = (
-/obj/machinery/light/small{
+/obj/machinery/light/small/directional/west{
 	brightness = 3;
-	dir = 8
+	
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark{

--- a/_maps/shuttles/starfury_corvette.dmm
+++ b/_maps/shuttles/starfury_corvette.dmm
@@ -120,7 +120,6 @@
 "ao" = (
 /obj/machinery/light/small/directional/west{
 	brightness = 3;
-	
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1;

--- a/_maps/shuttles/starfury_corvette.dmm
+++ b/_maps/shuttles/starfury_corvette.dmm
@@ -355,7 +355,6 @@
 "aU" = (
 /obj/machinery/light/small/directional/west{
 	brightness = 3;
-	
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/siding/thinplating_new/dark{

--- a/_maps/shuttles/starfury_fighter1.dmm
+++ b/_maps/shuttles/starfury_fighter1.dmm
@@ -19,9 +19,7 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/tank/internals/emergency_oxygen/engi,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/sbc_fighter1)
 "q" = (
@@ -51,9 +49,9 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
-/obj/machinery/light/small{
+/obj/machinery/light/small/directional/west{
 	brightness = 3;
-	dir = 8
+	
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/sbc_fighter1)

--- a/_maps/shuttles/starfury_fighter1.dmm
+++ b/_maps/shuttles/starfury_fighter1.dmm
@@ -51,7 +51,6 @@
 /obj/item/multitool,
 /obj/machinery/light/small/directional/west{
 	brightness = 3;
-	
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/sbc_fighter1)

--- a/_maps/shuttles/starfury_fighter2.dmm
+++ b/_maps/shuttles/starfury_fighter2.dmm
@@ -6,9 +6,7 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/sbc_fighter2)
 "j" = (
@@ -94,9 +92,7 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/tank/internals/emergency_oxygen/engi,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/sbc_fighter2)
 "V" = (

--- a/_maps/shuttles/starfury_fighter3.dmm
+++ b/_maps/shuttles/starfury_fighter3.dmm
@@ -18,9 +18,7 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/tank/internals/emergency_oxygen/engi,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/sbc_fighter3)
 "g" = (
@@ -103,9 +101,7 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/sbc_fighter3)
 

--- a/_maps/templates/battlecruiser_starfury.dmm
+++ b/_maps/templates/battlecruiser_starfury.dmm
@@ -117,9 +117,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/sbc_starfury)
 "as" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/thinplating_new{

--- a/tools/UpdatePaths/Scripts/70277_light_direction.txt
+++ b/tools/UpdatePaths/Scripts/70277_light_direction.txt
@@ -1,0 +1,98 @@
+
+/obj/machinery/light{dir = @UNSET} : /obj/machinery/light/directional/south
+/obj/machinery/light{dir = 1} : /obj/machinery/light/directional/north
+/obj/machinery/light{dir = 2} : /obj/machinery/light/directional/south
+/obj/machinery/light{dir = 4} : /obj/machinery/light/directional/east
+/obj/machinery/light{dir = 8} : /obj/machinery/light/directional/west
+
+/obj/machinery/light/broken{dir = @UNSET} : /obj/machinery/light/broken/directional/south
+/obj/machinery/light/broken{dir = 1} : /obj/machinery/light/broken/directional/north
+/obj/machinery/light/broken{dir = 2} : /obj/machinery/light/broken/directional/south
+/obj/machinery/light/broken{dir = 4} : /obj/machinery/light/broken/directional/east
+/obj/machinery/light/broken{dir = 8} : /obj/machinery/light/broken/directional/west
+
+/obj/machinery/light/built{dir = @UNSET} : /obj/machinery/light/built/directional/south
+/obj/machinery/light/built{dir = 1} : /obj/machinery/light/built/directional/north
+/obj/machinery/light/built{dir = 2} : /obj/machinery/light/built/directional/south
+/obj/machinery/light/built{dir = 4} : /obj/machinery/light/built/directional/east
+/obj/machinery/light/built{dir = 8} : /obj/machinery/light/built/directional/west
+
+/obj/machinery/light/warm{dir = @UNSET} : /obj/machinery/light/warm/directional/south
+/obj/machinery/light/warm{dir = 1} : /obj/machinery/light/warm/directional/north
+/obj/machinery/light/warm{dir = 2} : /obj/machinery/light/warm/directional/south
+/obj/machinery/light/warm{dir = 4} : /obj/machinery/light/warm/directional/east
+/obj/machinery/light/warm{dir = 8} : /obj/machinery/light/warm/directional/west
+
+/obj/machinery/light/cold{dir = @UNSET} : /obj/machinery/light/cold/directional/south
+/obj/machinery/light/cold{dir = 1} : /obj/machinery/light/cold/directional/north
+/obj/machinery/light/cold{dir = 2} : /obj/machinery/light/cold/directional/south
+/obj/machinery/light/cold{dir = 4} : /obj/machinery/light/cold/directional/east
+/obj/machinery/light/cold{dir = 8} : /obj/machinery/light/cold/directional/west
+
+/obj/machinery/light/cold/no_nightlight{dir = @UNSET} : /obj/machinery/light/cold/no_nightlight/directional/south
+/obj/machinery/light/cold/no_nightlight{dir = 1} : /obj/machinery/light/cold/no_nightlight/directional/north
+/obj/machinery/light/cold/no_nightlight{dir = 2} : /obj/machinery/light/cold/no_nightlight/directional/south
+/obj/machinery/light/cold/no_nightlight{dir = 4} : /obj/machinery/light/cold/no_nightlight/directional/east
+/obj/machinery/light/cold/no_nightlight{dir = 8} : /obj/machinery/light/cold/no_nightlight/directional/west
+
+/obj/machinery/light/red{dir = @UNSET} : /obj/machinery/light/red/directional/south
+/obj/machinery/light/red{dir = 1} : /obj/machinery/light/red/directional/north
+/obj/machinery/light/red{dir = 2} : /obj/machinery/light/red/directional/south
+/obj/machinery/light/red{dir = 4} : /obj/machinery/light/red/directional/east
+/obj/machinery/light/red{dir = 8} : /obj/machinery/light/red/directional/west
+
+/obj/machinery/light/red/dim{dir = @UNSET} : /obj/machinery/light/red/dim/directional/south
+/obj/machinery/light/red/dim{dir = 1} : /obj/machinery/light/red/dim/directional/north
+/obj/machinery/light/red/dim{dir = 2} : /obj/machinery/light/red/dim/directional/south
+/obj/machinery/light/red/dim{dir = 4} : /obj/machinery/light/red/dim/directional/east
+/obj/machinery/light/red/dim{dir = 8} : /obj/machinery/light/red/dim/directional/west
+
+/obj/machinery/light/blacklight{dir = @UNSET} : /obj/machinery/light/blacklight/directional/south
+/obj/machinery/light/blacklight{dir = 1} : /obj/machinery/light/blacklight/directional/north
+/obj/machinery/light/blacklight{dir = 2} : /obj/machinery/light/blacklight/directional/south
+/obj/machinery/light/blacklight{dir = 4} : /obj/machinery/light/blacklight/directional/east
+/obj/machinery/light/blacklight{dir = 8} : /obj/machinery/light/blacklight/directional/west
+
+/obj/machinery/light/dim{dir = @UNSET} : /obj/machinery/light/dim/directional/south
+/obj/machinery/light/dim{dir = 1} : /obj/machinery/light/dim/directional/north
+/obj/machinery/light/dim{dir = 2} : /obj/machinery/light/dim/directional/south
+/obj/machinery/light/dim{dir = 4} : /obj/machinery/light/dim/directional/east
+/obj/machinery/light/dim{dir = 8} : /obj/machinery/light/dim/directional/west
+
+# small lights
+
+/obj/machinery/light/small{dir = @UNSET} : /obj/machinery/light/small/directional/south
+/obj/machinery/light/small{dir = 1} : /obj/machinery/light/small/directional/north
+/obj/machinery/light/small{dir = 2} : /obj/machinery/light/small/directional/south
+/obj/machinery/light/small{dir = 4} : /obj/machinery/light/small/directional/east
+/obj/machinery/light/small{dir = 8} : /obj/machinery/light/small/directional/west
+
+/obj/machinery/light/small/broken{dir = @UNSET} : /obj/machinery/light/small/broken/directional/south
+/obj/machinery/light/small/broken{dir = 1} : /obj/machinery/light/small/broken/directional/north
+/obj/machinery/light/small/broken{dir = 2} : /obj/machinery/light/small/broken/directional/south
+/obj/machinery/light/small/broken{dir = 4} : /obj/machinery/light/small/broken/directional/east
+/obj/machinery/light/small/broken{dir = 8} : /obj/machinery/light/small/broken/directional/west
+
+/obj/machinery/light/small/built{dir = @UNSET} : /obj/machinery/light/small/built/directional/south
+/obj/machinery/light/small/built{dir = 1} : /obj/machinery/light/small/built/directional/north
+/obj/machinery/light/small/built{dir = 2} : /obj/machinery/light/small/built/directional/south
+/obj/machinery/light/small/built{dir = 4} : /obj/machinery/light/small/built/directional/east
+/obj/machinery/light/small/built{dir = 8} : /obj/machinery/light/small/built/directional/west
+
+/obj/machinery/light/small/red{dir = @UNSET} : /obj/machinery/light/small/red/directional/south
+/obj/machinery/light/small/red{dir = 1} : /obj/machinery/light/small/red/directional/north
+/obj/machinery/light/small/red{dir = 2} : /obj/machinery/light/small/red/directional/south
+/obj/machinery/light/small/red{dir = 4} : /obj/machinery/light/small/red/directional/east
+/obj/machinery/light/small/red{dir = 8} : /obj/machinery/light/small/red/directional/west
+
+/obj/machinery/light/small/red/dim{dir = @UNSET} : /obj/machinery/light/small/red/dim/directional/south
+/obj/machinery/light/small/red/dim{dir = 1} : /obj/machinery/light/small/red/dim/directional/north
+/obj/machinery/light/small/red/dim{dir = 2} : /obj/machinery/light/small/red/dim/directional/south
+/obj/machinery/light/small/red/dim{dir = 4} : /obj/machinery/light/small/red/dim/directional/east
+/obj/machinery/light/small/red/dim{dir = 8} : /obj/machinery/light/small/red/dim/directional/west
+
+/obj/machinery/light/small/blacklight{dir = @UNSET} : /obj/machinery/light/small/blacklight/directional/south
+/obj/machinery/light/small/blacklight{dir = 1} : /obj/machinery/light/small/blacklight/directional/north
+/obj/machinery/light/small/blacklight{dir = 2} : /obj/machinery/light/small/blacklight/directional/south
+/obj/machinery/light/small/blacklight{dir = 4} : /obj/machinery/light/small/blacklight/directional/east
+/obj/machinery/light/small/blacklight{dir = 8} : /obj/machinery/light/small/blacklight/directional/west


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Housekeeping. Noticed when I was doing some work for the wallening that there were some remaining lights with varedits kicking around, so I've changed them to use the directional variants. 

## Why It's Good For The Game
Consistency!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
No player-facing changes

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
