### PR TITLE
Station trait "Bot language malfunction" triggers on newly created station bots

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -876,6 +876,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_FILLED_MAINT "station_trait_filled_maint"
 #define STATION_TRAIT_EMPTY_MAINT "station_trait_empty_maint"
 #define STATION_TRAIT_PDA_GLITCHED "station_trait_pda_glitched"
+#define STATION_TRAIT_BOTS_GLITCHED "station_trait_bot_glitch"
 
 ///From the market_crash event
 #define MARKET_CRASH_EVENT_TRAIT "crashed_market_event"

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -140,7 +140,7 @@
 /datum/station_trait/bot_languages/New()
 	. = ..()
 	// What "caused" our robots to go haywire (fluff)
-	var/event_source = pick(list("an ion storm", "a syndicate hacking attempt", "a malfunction", "issues with your onboard AI", "an intern's mistakes", "budget cuts"))
+	var/event_source = pick("an ion storm", "a syndicate hacking attempt", "a malfunction", "issues with your onboard AI", "an intern's mistakes", "budget cuts")
 	report_message = "Your station's friendly bots have had their language matrix fried due to [event_source], resulting in some strange and unfamiliar speech patterns."
 
 /datum/station_trait/bot_languages/on_round_start()

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -132,23 +132,22 @@
 /datum/station_trait/bot_languages
 	name = "Bot Language Matrix Malfunction"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 3
+	weight = 4
 	show_in_report = TRUE
 	report_message = "Your station's friendly bots have had their language matrix fried due to an event, resulting in some strange and unfamiliar speech patterns."
+	trait_to_give = STATION_TRAIT_BOTS_GLITCHED
 
 /datum/station_trait/bot_languages/New()
 	. = ..()
-	/// What "caused" our robots to go haywire (fluff)
+	// What "caused" our robots to go haywire (fluff)
 	var/event_source = pick(list("an ion storm", "a syndicate hacking attempt", "a malfunction", "issues with your onboard AI", "an intern's mistakes", "budget cuts"))
 	report_message = "Your station's friendly bots have had their language matrix fried due to [event_source], resulting in some strange and unfamiliar speech patterns."
 
 /datum/station_trait/bot_languages/on_round_start()
 	. = ..()
-	//All bots that exist round start have their set language randomized.
-	for(var/mob/living/simple_animal/bot/found_bot in GLOB.alive_mob_list)
-		/// The bot's language holder - so we can randomize and change their language
-		var/datum/language_holder/bot_languages = found_bot.get_language_holder()
-		bot_languages.selected_language = bot_languages.get_random_spoken_language()
+	// All bots that exist round start on station Z OR on the escape shuttle have their set language randomized.
+	for(var/mob/living/simple_animal/bot/found_bot as anything in GLOB.bots_list)
+		found_bot.randomize_language_if_on_station()
 
 /datum/station_trait/revenge_of_pun_pun
 	name = "Revenge of Pun Pun"

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -183,6 +183,18 @@ Key procs
 /datum/language_holder/proc/get_random_spoken_language()
 	return pick(spoken_languages)
 
+/// Gets a random spoken language, trying to get a non-common language.
+/datum/language_holder/proc/get_random_spoken_uncommon_language()
+	var/list/languages_minus_common = assoc_to_keys(spoken_languages) - /datum/language/common
+
+	// They have a language other than common
+	if(length(languages_minus_common))
+		return pick(languages_minus_common)
+
+	// They can only speak common, oh well.
+	else
+		return /datum/language/common
+
 /// Opens a language menu reading from the language holder.
 /datum/language_holder/proc/open_language_menu(mob/user)
 	if(!language_menu)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -194,6 +194,8 @@
 		path_hud.add_atom_to_hud(src)
 		path_hud.show_to(src)
 
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_BOTS_GLITCHED))
+		randomize_language_if_on_station()
 
 /mob/living/simple_animal/bot/Destroy()
 	if(path_hud)
@@ -1079,3 +1081,22 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 /mob/living/simple_animal/bot/rust_heretic_act()
 	adjustBruteLoss(400)
+
+/**
+ * Randomizes our bot's language if:
+ * - They are on the setation Z level
+ * OR
+ * - They are on the escape shuttle
+ */
+/mob/living/simple_animal/bot/proc/randomize_language_if_on_station()
+	var/turf/bot_turf = get_turf(src)
+	var/area/bot_area = get_area(src)
+	if(!is_station_level(bot_turf.z) && !istype(bot_area, /area/shuttle/escape))
+		// Why snowflake check for escape shuttle? Well, a lot of shuttles spawn with bots
+		// but docked at centcom, and I wanted those bots to also speak funny languages
+		return FALSE
+
+	/// The bot's language holder - so we can randomize and change their language
+	var/datum/language_holder/bot_languages = get_language_holder()
+	bot_languages.selected_language = bot_languages.get_random_spoken_uncommon_language()
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

- Bot Language Malfunction station trait triggers on newly created station bots as well
- Ups the weight of the trait by 1
- Guarantees the picked language isn't common

## Why It's Good For The Game

- Language is a funny trait that I added, but it's not entirely impactful if the station chosen doesn't have a lot of roundstart robots. So, by making it so all simplebots created on station get modified, it should add a bit of impact to it. 
- It's still relatively low impact and funny, so I bumped the weight up by 1. 
- There was a chance the random roll could be common, which is dumb. So now it tries to pick a non-common language when possible.

## Changelog

:cl: Melbert
add: "Bot Language Malfunction" trait (random languages for simple bots) is now a smidge more common, and affects all simple robots created on the station rather than just roundstart ones. Also, it tries to pick a language that isn't galactic common if possible.
/:cl:
