### PR TITLE
Fix: Runtimes in CharacterPrefsUI

### DIFF
--- a/code/__HELPERS/admin.dm
+++ b/code/__HELPERS/admin.dm
@@ -1,3 +1,5 @@
 /// Returns if the given client is an admin, REGARDLESS of if they're deadminned or not.
 /proc/is_admin(client/client)
+	if(isnull(client))
+		return FALSE
 	return !isnull(GLOB.admin_datums[client.ckey]) || !isnull(GLOB.deadmins[client.ckey])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -127,7 +127,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		character_preview_view = create_character_preview_view(user)
+		create_character_preview_view(user)
+		if(isnull(character_preview_view))
+			return FALSE
 
 		ui = new(user, src, "PreferencesMenu")
 		ui.set_autoupdate(FALSE)
@@ -293,8 +295,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	character_preview_view.generate_view("character_preview_[REF(character_preview_view)]")
 	character_preview_view.update_body()
 	character_preview_view.display_to(user)
-
-	return character_preview_view
 
 /datum/preferences/proc/compile_character_preferences(mob/user)
 	var/list/preferences = list()

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -246,13 +246,13 @@
 		"window" = list(
 			"key" = window_key,
 			"size" = window_size,
-			"fancy" = user.client.prefs.read_preference(/datum/preference/toggle/tgui_fancy),
-			"locked" = user.client.prefs.read_preference(/datum/preference/toggle/tgui_lock),
+			"fancy" = user.client?.prefs.read_preference(/datum/preference/toggle/tgui_fancy),
+			"locked" = user.client?.prefs.read_preference(/datum/preference/toggle/tgui_lock),
 		),
 		"client" = list(
-			"ckey" = user.client.ckey,
-			"address" = user.client.address,
-			"computer_id" = user.client.computer_id,
+			"ckey" = user.client?.ckey,
+			"address" = user.client?.address,
+			"computer_id" = user.client?.computer_id,
 		),
 		"user" = list(
 			"name" = "[user]",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes runtimes when character_preview_view fails to load in CharacterPrefsUI.
If UI opens with null character_preview_view, then several runtimes may occur, such as "rotate" ui_act for it.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Removing runtimes. The runtimes appear in Skyrat fork,  their occurance weren't tested in pure TG.
