### PR TITLE
Adds the Command Intercom, kills off the varedited freerange intercoms on some maps.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9122,7 +9122,7 @@
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
 /obj/item/disk/nuclear,
-/obj/item/radio/intercom/directional/west,
+/obj/item/radio/intercom/captain/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain/private)
 "cbY" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9122,7 +9122,7 @@
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
 /obj/item/disk/nuclear,
-/obj/item/radio/intercom/captain/directional/west,
+/obj/item/radio/intercom/command/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain/private)
 "cbY" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -88256,7 +88256,6 @@
 "vzD" = (
 /obj/structure/table/wood,
 /obj/structure/cable,
-/obj/item/radio/intercom/command,
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_showroom)
 "vzK" = (
@@ -98174,6 +98173,7 @@
 "xVo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
+/obj/item/radio/intercom/command,
 /turf/open/floor/carpet,
 /area/station/command/meeting_room/council)
 "xVr" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9122,7 +9122,7 @@
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
 /obj/item/disk/nuclear,
-/obj/item/radio/intercom/command/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain/private)
 "cbY" = (
@@ -88256,7 +88256,7 @@
 "vzD" = (
 /obj/structure/table/wood,
 /obj/structure/cable,
-/obj/item/radio/intercom,
+/obj/item/radio/intercom/command,
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_showroom)
 "vzK" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -88256,6 +88256,7 @@
 "vzD" = (
 /obj/structure/table/wood,
 /obj/structure/cable,
+/obj/item/radio/intercom,
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_showroom)
 "vzK" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -39017,11 +39017,7 @@
 /area/station/medical/break_room)
 "lVZ" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom/captain{
-	desc = "A conference intercom with an extended frequency range. Useful for discussing business with the higher-ups, or just gossiping about the crew.";
-	dir = 8;
-	name = "Station Intercom (Command)"
-	},
+/obj/item/radio/intercom/command,
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "lWb" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -28571,8 +28571,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "iLu" = (
-/obj/item/radio/intercom/directional/west,
 /obj/machinery/suit_storage_unit/captain,
+/obj/item/radio/intercom/captain/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "iLv" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -39017,9 +39017,9 @@
 /area/station/medical/break_room)
 "lVZ" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/captain{
+	desc = "A conference intercom with an extended frequency range. Useful for discussing business with the higher-ups, or just gossiping about the crew.";
 	dir = 8;
-	freerange = 1;
 	name = "Station Intercom (Command)"
 	},
 /turf/open/floor/carpet,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -28572,7 +28572,7 @@
 /area/station/service/chapel)
 "iLu" = (
 /obj/machinery/suit_storage_unit/captain,
-/obj/item/radio/intercom/captain/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "iLv" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3292,7 +3292,7 @@
 	},
 /obj/effect/landmark/start/captain,
 /obj/structure/sign/poster/contraband/random/directional/north,
-/obj/item/radio/intercom/command/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
 "aVI" = (
@@ -44749,8 +44749,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
 /obj/structure/chair/comfy,
+/obj/item/radio/intercom/command/directional/north,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "mKw" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3291,11 +3291,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/captain,
-/obj/item/radio/intercom/directional/west{
-	freerange = 1;
-	name = "Captain's Intercom"
-	},
 /obj/structure/sign/poster/contraband/random/directional/north,
+/obj/item/radio/intercom/captain/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
 "aVI" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -7910,12 +7910,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Command)";
-	pixel_x = 1
-	},
+/obj/item/radio/intercom,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "csk" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3292,7 +3292,7 @@
 	},
 /obj/effect/landmark/start/captain,
 /obj/structure/sign/poster/contraband/random/directional/north,
-/obj/item/radio/intercom/captain/directional/west,
+/obj/item/radio/intercom/command/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain/private)
 "aVI" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10935,7 +10935,7 @@
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_y = 3
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/item/radio/intercom/command/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "eau" = (
@@ -55895,7 +55895,7 @@
 /obj/item/camera{
 	pixel_y = 4
 	},
-/obj/item/radio/intercom/command/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "tJb" = (
@@ -66107,6 +66107,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
+"xmg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/item/radio/intercom/command/directional/north,
+/turf/open/floor/plating,
+/area/station/hallway/primary/central)
 "xml" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -96768,7 +96773,7 @@ wtZ
 vpQ
 iLk
 tGL
-tKN
+xmg
 aaf
 dho
 oYd

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -40086,8 +40086,8 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/item/radio/intercom/directional/west,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "onr" = (
@@ -55895,10 +55895,7 @@
 /obj/item/camera{
 	pixel_y = 4
 	},
-/obj/item/radio/intercom/directional/west{
-	freerange = 1;
-	name = "Captain's Intercom"
-	},
+/obj/item/radio/intercom/captain/directional/west,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "tJb" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -66107,11 +66107,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
-"xmg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/item/radio/intercom/command/directional/north,
-/turf/open/floor/plating,
-/area/station/hallway/primary/central)
 "xml" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -96773,7 +96768,7 @@ wtZ
 vpQ
 iLk
 tGL
-xmg
+tKN
 aaf
 dho
 oYd

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55895,7 +55895,7 @@
 /obj/item/camera{
 	pixel_y = 4
 	},
-/obj/item/radio/intercom/captain/directional/west,
+/obj/item/radio/intercom/command/directional/west,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "tJb" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -53308,7 +53308,7 @@
 	pixel_x = 26
 	},
 /obj/machinery/status_display/ai/directional/north,
-/obj/item/radio/intercom/directional/east,
+/obj/item/radio/intercom/captain/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "sXa" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -53308,7 +53308,7 @@
 	pixel_x = 26
 	},
 /obj/machinery/status_display/ai/directional/north,
-/obj/item/radio/intercom/captain/directional/east,
+/obj/item/radio/intercom/command/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "sXa" = (

--- a/code/__HELPERS/radio.dm
+++ b/code/__HELPERS/radio.dm
@@ -1,5 +1,5 @@
 /// Ensure the frequency is within bounds of what it should be sending/receiving at
-/proc/sanitize_frequency(frequency, free = FALSE)
+/proc/sanitize_frequency(frequency, free = FALSE, syndie = FALSE)
 	frequency = round(frequency)
 	if(free)
 		. = clamp(frequency, MIN_FREE_FREQ, MAX_FREE_FREQ)
@@ -7,6 +7,8 @@
 		. = clamp(frequency, MIN_FREQ, MAX_FREQ)
 	if(!(. % 2)) // Ensure the last digit is an odd number
 		. += 1
+	if(. == FREQ_SYNDICATE && !syndie) // Prevents people from picking (or rounding up) into the syndie frequency
+		. = FREQ_COMMON
 
 /// Format frequency by moving the decimal.
 /proc/format_frequency(frequency)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -163,7 +163,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 	remove_radio(src, frequency)
 	if(new_frequency)
 		if(new_frequency == FREQ_SYNDICATE && !syndie)
-			frequency = FREQ_COMMON
 			say("Unable to connect to this encrypted radio network!")
 		else
 			frequency = new_frequency

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -154,7 +154,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 
 /obj/item/radio/intercom/command
 	name = "Command Intercom"
-	desc = "The command team's special extended-frequency intercom. Useful for eavesdropping, gossiping about subordinates, and complaining about the higher-ups."
+	desc = "The command team's special extended-frequency intercom. Mostly just used for eavesdropping, gossiping about subordinates, and complaining about the higher-ups."
 	icon_state = "intercom_command"
 	freerange = TRUE
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -164,7 +164,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 	if(new_frequency)
 		if(new_frequency == FREQ_SYNDICATE && !syndie)
 			frequency = FREQ_COMMON
-			say("Unable to connect to this encrypted radio network!", range=3)
+			say("Unable to connect to this encrypted radio network!")
 		else
 			frequency = new_frequency
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -152,12 +152,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 	set_frequency(1481)
 	set_broadcasting(TRUE)
 
-/obj/item/radio/intercom/captain
-	name = "Captain's Intercom"
-	desc = "The Captain's special intercom. Comes with an extended frequency range for optimal eavesdropping."
-	icon_state = "intercom_captain"
+/obj/item/radio/intercom/command
+	name = "Command Intercom"
+	desc = "The command team's special extended-frequency intercom. Useful for eavesdropping, gossiping about subordinates, and complaining about the higher-ups."
+	icon_state = "intercom_command"
 	freerange = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/prison, 26)
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/chapel, 26)
-MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/captain, 26)
+MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/command, 26)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -152,5 +152,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 	set_frequency(1481)
 	set_broadcasting(TRUE)
 
+/obj/item/radio/intercom/captain
+	name = "Captain's Intercom"
+	desc = "The Captain's special intercom. Comes with an extended frequency range for optimal eavesdropping."
+	freerange = TRUE
+
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/prison, 26)
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/chapel, 26)
+MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/captain, 26)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -158,6 +158,19 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 	icon_state = "intercom_command"
 	freerange = TRUE
 
+/obj/item/radio/intercom/command/set_frequency(new_frequency)
+	SEND_SIGNAL(src, COMSIG_RADIO_NEW_FREQUENCY, args)
+	remove_radio(src, frequency)
+	if(new_frequency)
+		if(new_frequency == FREQ_SYNDICATE && !syndie)
+			frequency = FREQ_COMMON
+			say("Unable to connect to this encrypted radio network!", range=3)
+		else
+			frequency = new_frequency
+
+	if(listening && on)
+		add_radio(src, frequency)
+
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/prison, 26)
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/chapel, 26)
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/command, 26)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -155,6 +155,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 /obj/item/radio/intercom/captain
 	name = "Captain's Intercom"
 	desc = "The Captain's special intercom. Comes with an extended frequency range for optimal eavesdropping."
+	icon_state = "intercom_captain"
 	freerange = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/prison, 26)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -158,18 +158,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 	icon_state = "intercom_command"
 	freerange = TRUE
 
-/obj/item/radio/intercom/command/set_frequency(new_frequency)
-	SEND_SIGNAL(src, COMSIG_RADIO_NEW_FREQUENCY, args)
-	remove_radio(src, frequency)
-	if(new_frequency)
-		if(new_frequency == FREQ_SYNDICATE && !syndie)
-			say("Unable to connect to this encrypted radio network!")
-		else
-			frequency = new_frequency
-
-	if(listening && on)
-		add_radio(src, frequency)
-
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/prison, 26)
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/chapel, 26)
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/command, 26)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -153,7 +153,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 	set_broadcasting(TRUE)
 
 /obj/item/radio/intercom/command
-	name = "Command Intercom"
+	name = "command intercom"
 	desc = "The command team's special extended-frequency intercom. Mostly just used for eavesdropping, gossiping about subordinates, and complaining about the higher-ups."
 	icon_state = "intercom_command"
 	freerange = TRUE

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -90,7 +90,7 @@
 
 	set_listening(listening)
 	set_broadcasting(broadcasting)
-	set_frequency(sanitize_frequency(frequency, freerange))
+	set_frequency(sanitize_frequency(frequency, freerange, syndie))
 	set_on(on)
 
 	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
@@ -401,7 +401,7 @@
 				tune = tune * 10
 				. = TRUE
 			if(.)
-				set_frequency(sanitize_frequency(tune, freerange))
+				set_frequency(sanitize_frequency(tune, freerange, syndie))
 		if("listen")
 			set_listening(!listening)
 			. = TRUE

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -288,7 +288,7 @@
 		if("toggle_speaker")
 			radio.set_listening(!radio.get_listening())
 		if("set_frequency")
-			radio.set_frequency(sanitize_frequency(params["new_frequency"], radio.freerange))
+			radio.set_frequency(sanitize_frequency(params["new_frequency"], radio.freerange, radio.syndie))
 		if("repair_int_damage")
 			ui.close() //if doing this you're likely want to watch for bad people so close the UI
 			try_repair_int_damage(usr, params["flag"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Originally, the purpose of this PR was to convert the varedited free-range intercom map objects into their own subtype -- The "captain's intercom" objects on Kilo/Meta, and the "station intercom (command)" objects on Icebox/Kilo. After going back and forth on it a bit, I decided that I like how Icebox does it better.

Introducing: The Command Intercom -- Now a a legitimate tool instead of a map quirk. It is a subtype of the intercom, with freerange set to TRUE by default. It comes with a unique sprite and description as well (the old, varedited instances never actually indicated what made them special). They have been implemented at the expense of the varedited freerange intercoms, which have all been reverted to normal intercoms.

Where can you find them? Only one instance exists per map, in the conference rooms of Icebox, Metastation, Kilostation and Deltastation. Tramstation lacks the appropriate facilities, so it is stored where it would formerly be (in the captain's office).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Provides mechanical enrichment for a room that is otherwise mostly ornamental. Now you can have REAL CONFERENCES in the conference room.

Provides a way for command players to (provisionally) communicate directly to other departments. It's only through an intercom, so I'm hoping that'll be inconvenient enough to only see use when necessary. It's stationary as well, so if someone's really abusing it, intervening shouldn't be too difficult.

Speaking of intervention, this also provides another nexus for petty crime. Gives bored assistants a shiny new toy to get into trouble with (if they're brave enough).

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds the command intercom -- Coming to a conference room near you!
imageadd: Adds a sprite for the command intercom.
fix: Sanitize_frequency now has a new argument for whether or not the connecting radio has "syndie" set to true. If false, it will disallow connection to 121.3 (syndicate radio network)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
