### PR TITLE
Assistant PDAs start with the bounty board app preinstalled

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -39,6 +39,7 @@ Assistant
 	name = JOB_ASSISTANT
 	jobtype = /datum/job/assistant
 	id_trim = /datum/id_trim/job/assistant
+	belt = /obj/item/modular_computer/tablet/pda/assistant
 
 /datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/target)
 	..()

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -371,6 +371,12 @@
  * Non-roles
  */
 
+/obj/item/modular_computer/tablet/pda/assistant
+	name = "assistant PDA"
+	default_applications = list(
+		/datum/computer_file/program/bounty_board,
+	)
+
 /obj/item/modular_computer/tablet/pda/syndicate
 	name = "military PDA"
 	greyscale_colors = "#891417#80FF80"

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -368,7 +368,7 @@
 			msg.allow_emojis = TRUE
 
 /**
- * Non-roles
+ * No Department
  */
 
 /obj/item/modular_computer/tablet/pda/assistant
@@ -376,6 +376,10 @@
 	default_applications = list(
 		/datum/computer_file/program/bounty_board,
 	)
+
+/**
+ * Non-roles
+ */
 
 /obj/item/modular_computer/tablet/pda/syndicate
 	name = "military PDA"


### PR DESCRIPTION
## About The Pull Request

Makes assistant pdas start with the bounty board app preinstalled

## Why It's Good For The Game
The bounty board is stuck in a vicious cycle where it sits unused because it lacks visibility, and in turn nobody uses it because posting bounties is like screaming into the void. I believe that by knowing for certain that all assistants on station will hear about your bounty this feature will see much more regular use

Secondly, I believe this is exactly the kind of thing that the assistant job should be about: doing odd jobs, answer to a recruitment call from a department head of staff, and so on. We can't force players to do it but we can guide them towards it. By having the app preinstalled, assistants will be naturally more inclined to check for bounties as they are posted.

I believe solving both of these issues has the potential to greatly increase interactions between the crew while giving helpful assistants a much easier time in finding people that need help.

## Changelog

:cl:
qol: Assistant PDAs now start with the bounty board app preinstalled
/:cl:
