### PR TITLE
you can no longer steal your shoes from yourself just in general

### DIFF
--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -365,8 +365,11 @@
 	if (user.body_position != LYING_DOWN)
 		return
 	var/obj/item/item_to_strip = target_human.shoes
-	if(target_human.shoes.chained && target_human == user)
-		to_chat(user, span_warning("Despite your best efforts, you still need help taking these off!"))
+	if(target_human == user)
+		to_chat(user, span_notice("Why would you try stealing your own shoes?"))
+		return
+	if(target_human.shoes.chained)
+		to_chat(user, span_warning("[item_to_strip] has been chained up! Stealing these is going to be more involved than expected."))
 		return
 	user.visible_message(span_warning("[user] starts stealing [target_human]'s [item_to_strip.name]!"), \
 		span_danger("You start stealing [target_human]'s [item_to_strip.name]..."))

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -365,6 +365,9 @@
 	if (user.body_position != LYING_DOWN)
 		return
 	var/obj/item/item_to_strip = target_human.shoes
+	if(target_human.shoes.chained && target_human == user)
+		to_chat(user, span_warning("Despite your best efforts, you still need help taking these off!"))
+		return
 	user.visible_message(span_warning("[user] starts stealing [target_human]'s [item_to_strip.name]!"), \
 		span_danger("You start stealing [target_human]'s [item_to_strip.name]..."))
 	to_chat(target_human, span_userdanger("[user] starts stealing your [item_to_strip.name]!"))

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -360,14 +360,14 @@
 	if (!ishuman(target_mob))
 		return
 	var/mob/living/carbon/human/target_human = target_mob
+	if(target_human == user)
+		to_chat(user, span_notice("Why would you try stealing your own shoes?"))
+		return
 	if (!target_human.shoes)
 		return
 	if (user.body_position != LYING_DOWN)
 		return
 	var/obj/item/clothing/shoes/item_to_strip = target_human.shoes
-	if(target_human == user)
-		to_chat(user, span_notice("Why would you try stealing your own shoes?"))
-		return
 	if(item_to_strip.chained)
 		to_chat(user, span_warning("[target_human]'s [item_to_strip.name] are chained up! Stealing these is going to be more involved than expected."))
 		return

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -369,7 +369,7 @@
 		to_chat(user, span_notice("Why would you try stealing your own shoes?"))
 		return
 	if(target_human.shoes.chained)
-		to_chat(user, span_warning("[item_to_strip] has been chained up! Stealing these is going to be more involved than expected."))
+		to_chat(user, span_warning("[target_human]'s [item_to_strip.name] are chained up! Stealing these is going to be more involved than expected."))
 		return
 	user.visible_message(span_warning("[user] starts stealing [target_human]'s [item_to_strip.name]!"), \
 		span_danger("You start stealing [target_human]'s [item_to_strip.name]..."))

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -368,9 +368,6 @@
 	if (user.body_position != LYING_DOWN)
 		return
 	var/obj/item/clothing/shoes/item_to_strip = target_human.shoes
-	if(item_to_strip.chained)
-		to_chat(user, span_warning("[target_human]'s [item_to_strip.name] are chained up! Stealing these is going to be more involved than expected."))
-		return
 	user.visible_message(span_warning("[user] starts stealing [target_human]'s [item_to_strip.name]!"), \
 		span_danger("You start stealing [target_human]'s [item_to_strip.name]..."))
 	to_chat(target_human, span_userdanger("[user] starts stealing your [item_to_strip.name]!"))

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -364,11 +364,11 @@
 		return
 	if (user.body_position != LYING_DOWN)
 		return
-	var/obj/item/item_to_strip = target_human.shoes
+	var/obj/item/clothing/shoes/item_to_strip = target_human.shoes
 	if(target_human == user)
 		to_chat(user, span_notice("Why would you try stealing your own shoes?"))
 		return
-	if(target_human.shoes.chained)
+	if(item_to_strip.chained)
 		to_chat(user, span_warning("[target_human]'s [item_to_strip.name] are chained up! Stealing these is going to be more involved than expected."))
 		return
 	user.visible_message(span_warning("[user] starts stealing [target_human]'s [item_to_strip.name]!"), \


### PR DESCRIPTION
## About The Pull Request
~~fixes #70279 by adding a two-part check that checks if the shoes are chained AND if the target is the user.
if they are, gives a funny little message.~~

alright you just can't steal your own shoes anymore
## Why It's Good For The Game
~~This looks like an oversight. A really specific, niche oversight, but that's what makes it an oversight. So have a fix.~~
Just take your own shoes off bro it's not hard.
## Changelog
:cl:
fix: You can no longer steal shoes off of yourself. Just take them off normally.
/:cl: