### PR TITLE
readds toggling firelock thermal sensors via fire alarm

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -278,6 +278,9 @@
 
 		switch(buildstage)
 			if(2)
+				if(tool.tool_behaviour == TOOL_MULTITOOL)
+					toggle_fire_detect(user)
+					return
 				if(tool.tool_behaviour == TOOL_WIRECUTTER)
 					buildstage = 1
 					tool.play_tool_sound(src)
@@ -411,6 +414,9 @@
 	if(obj_flags & EMAGGED)
 		to_chat(user, span_warning("The control circuitry of [src] appears to be malfunctioning."))
 		return
+	toggle_fire_detect(user)
+
+/obj/machinery/firealarm/proc/toggle_fire_detect(mob/user)
 	my_area.fire_detect = !my_area.fire_detect
 	for(var/obj/machinery/firealarm/fire_panel in my_area.firealarms)
 		fire_panel.update_icon()


### PR DESCRIPTION
## About The Pull Request
see title, fixes #70212 
![image](https://user-images.githubusercontent.com/31829017/193738926-35fbdf2c-fddd-48a6-a205-32cc62653982.png)

## Why It's Good For The Game
Sabotage potential, I guess! Alternatively, trolling your fellow spaceman by dooming them to die via atmospherics shenanigans.

## Changelog
:cl:
fix: Multitooling a screwed-open fire alarm - or, if you're a borg/AI, control-clicking a fire alarm - now toggles the atmospherics sensors of firelocks in the area. (Borgs/AIs still had this but it was undocumented.)
/:cl:
