### PR TITLE
[Code Bounty] Adds a new kudzu mutation timid and lowers severity of the mutation temperature stabilisation from average to minor

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -199,7 +199,7 @@
 	name = "Temperature stabilisation"
 	hue = "#B09856"
 	quality = POSITIVE
-	severity = SEVERITY_AVERAGE
+	severity = SEVERITY_MINOR
 
 /datum/spacevine_mutation/temp_stabilisation/add_mutation_to_vinepiece(obj/structure/spacevine/holder)
 	. = ..()
@@ -389,6 +389,21 @@
 	else
 		. = expected_damage
 
+/datum/spacevine_mutation/timid
+	name = "Timid"
+	hue = "#a4a9ac"
+	quality = POSITIVE
+	severity = SEVERITY_MINOR
+
+//This specific mutation only covers floors instead of structures, items, mobs
+/datum/spacevine_mutation/timid/on_birth(obj/structure/spacevine/holder)
+	holder.plane = FLOOR_PLANE
+	return ..()
+
+//This Kudzu cant tangle mobs anymore
+/datum/spacevine_mutation/timid/on_buckle(obj/structure/spacevine/holder, mob/living/buckled)
+	holder.can_tangle = FALSE
+
 /datum/spacevine_mutation/flowering
 	name = "Flowering"
 	hue = "#66DE93"
@@ -419,6 +434,7 @@
 	max_integrity = 50
 	var/energy = 0
 	var/can_spread = TRUE //Can this kudzu spread?
+	var/can_tangle = TRUE //Can this kudzu tangle
 	var/datum/spacevine_controller/master = null
 	/// List of mutations for a specific vine
 	var/list/mutations = list()
@@ -684,7 +700,7 @@
 		return
 	for(var/datum/spacevine_mutation/mutation in mutations)
 		mutation.on_buckle(src, victim)
-	if((victim.stat != DEAD) && (victim.buckled != src)) //not dead or captured
+	if((victim.stat != DEAD) && (victim.buckled != src) && can_tangle) //not dead and not captured and can tangle
 		to_chat(victim, span_userdanger("The vines [pick("wind", "tangle", "tighten")] around you!"))
 		buckle_mob(victim, 1)
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -395,14 +395,11 @@
 	quality = POSITIVE
 	severity = SEVERITY_MINOR
 
-//This specific mutation only covers floors instead of structures, items, mobs
+//This specific mutation only covers floors instead of structures, items, mobs and cant tangle mobs
 /datum/spacevine_mutation/timid/on_birth(obj/structure/spacevine/holder)
 	holder.plane = FLOOR_PLANE
-	return ..()
-
-//This Kudzu cant tangle mobs anymore
-/datum/spacevine_mutation/timid/on_buckle(obj/structure/spacevine/holder, mob/living/buckled)
 	holder.can_tangle = FALSE
+	return ..()
 
 /datum/spacevine_mutation/flowering
 	name = "Flowering"

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -430,8 +430,10 @@
 	pass_flags = PASSTABLE | PASSGRILLE
 	max_integrity = 50
 	var/energy = 0
-	var/can_spread = TRUE //Can this kudzu spread?
-	var/can_tangle = TRUE //Can this kudzu tangle
+	/// Can this kudzu spread?
+	var/can_spread = TRUE
+	/// Can this kudzu buckle mobs in?
+	var/can_tangle = TRUE
 	var/datum/spacevine_controller/master = null
 	/// List of mutations for a specific vine
 	var/list/mutations = list()


### PR DESCRIPTION
## About The Pull Request

Completes this bounty: https://tgstation13.org/phpBB/viewtopic.php?f=5&t=32530

Adds a new mutation called timid, they only cover tiles up and cant buckle mobs in.
Lowers the severity of the kudzu mutaton temperature stabilisation from average to minor.

https://user-images.githubusercontent.com/33989683/193906623-c5d02d49-8b26-4e37-bd7e-69d5f99ae777.mp4


## Why It's Good For The Game
from the bounty page:
Although it is currently possible to ensure only positive mutations are present in kudzu, the inherent qualities of buckling mobs and existing on a higher than average layer make it annoying to the point of antagonism, even when meant to be a benefit to the station. By making a mutation that restricts these behaviors, it will be possible to make truly beneficial kudzu that people won't lynch botany for spreading(maybe). It also slightly nerfs harmful kudzu by introducing the possibility of a mutation that would make it less of an obstruction to the crew.

In regards to the severity reduction to the 'temperature stabilization' mutation, it isn't a very noteworthy mutation in the first place, and this minor adjustment would help the new mutation fit in with current severity limits.

## Changelog

:cl:
add: Adds a new kudzu mutation called timid
balance: lowers severity of the kudzu mutation temperature stabilisation from average to minor
/:cl:
