### PR TITLE
Void Phase won't hurt the caster if cast by a non-heretic

### DIFF
--- a/code/modules/antagonists/heretic/magic/void_phase.dm
+++ b/code/modules/antagonists/heretic/magic/void_phase.dm
@@ -42,12 +42,12 @@
 	playsound(targeted_turf, 'sound/magic/voidblink.ogg', 60, FALSE)
 
 	for(var/mob/living/living_mob in range(damage_radius, source_turf))
-		if(IS_HERETIC_OR_MONSTER(living_mob) || living_mob == cast_on)
+		if(IS_HERETIC_OR_MONSTER(living_mob) || living_mob == owner)
 			continue
 		living_mob.apply_damage(40, BRUTE, wound_bonus = CANT_WOUND)
 
 	for(var/mob/living/living_mob in range(damage_radius, targeted_turf))
-		if(IS_HERETIC_OR_MONSTER(living_mob) || living_mob == cast_on)
+		if(IS_HERETIC_OR_MONSTER(living_mob) || living_mob == owner)
 			continue
 		living_mob.apply_damage(40, BRUTE, wound_bonus = CANT_WOUND)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Noticed while fucking around with spells, the "don't hurt the caster" check on Void Phase fails to trigger appropriately because it checks against `cast_on` (which is generally a turf) rather than `owner`.
This doesn't usually matter while playing the game because before that check is an "am I a heretic or heretic ally?" check to avoid friendly fire, and the only way to get this spell naturally is to be a heretic.

## Why It's Good For The Game

Fixes a bug, even if it's not one which is likely to happen without admin intervention.
It's a cool spell to give to some custom spooky admin event player.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: If an admin gives you Void Phase, you won't be hurt by your own spell whenever you cast it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
