### PR TITLE
The curator's PDA now works in space

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -317,6 +317,9 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	else if(atom_integrity < max_integrity)
 		. += span_warning("It is damaged.")
 
+	if(long_ranged)
+		. += "It is upgraded with an experimental long-ranged network capabilities, picking up NTNet frequencies while further away."
+
 	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
 	var/obj/item/computer_hardware/card_slot/card_slot2 = all_components[MC_CARD2]
 	var/multiple_slots = istype(card_slot) && istype(card_slot2)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -65,6 +65,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	var/allow_chunky = FALSE
 
 	var/honkamnt = 0 /// honk honk honk honk honk honkh onk honkhnoohnk
+	///Whether the PDA can still use NTNet while out of NTNet's reach.
+	var/long_ranged = FALSE
 
 	var/list/idle_threads // Idle programs on background. They still receive process calls but can't be interacted with.
 	var/obj/physical = null // Object that represents our computer. It's used for Adjacent() and UI visibility checks.
@@ -610,7 +612,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		return NTNET_GOOD_SIGNAL
 	else if(is_mining_level(current_turf.z))
 		return NTNET_LOW_SIGNAL
-
+	else if(long_ranged)
+		return NTNET_LOW_SIGNAL
 	return NTNET_NO_SIGNAL
 
 /obj/item/modular_computer/proc/add_log(text)

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -395,3 +395,4 @@
 	icon_state = "pda-clear"
 	greyscale_config = null
 	greyscale_colors = null
+	long_ranged = TRUE

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -351,6 +351,7 @@
 
 /obj/item/modular_computer/tablet/pda/curator
 	name = "curator PDA"
+	desc = "A small experimental microcomputer."
 	greyscale_config = null
 	greyscale_colors = null
 	icon_state = "pda-library"

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -355,6 +355,7 @@
 	greyscale_colors = null
 	icon_state = "pda-library"
 	inserted_item = /obj/item/pen/fountain
+	long_ranged = TRUE
 	default_applications = list(
 		/datum/computer_file/program/newscaster,
 	)


### PR DESCRIPTION
## About The Pull Request

The Curator's PDA, while out in space, will have low-signal, rather than none. This means that their apps (Messenger, Newscaster, ect) will still work.

## Why It's Good For The Game

Originally I was going to make the newscaster app work without NTNet, but thought this was the better solution. I also recently removed the modular computer upgrades that allow low-signal connections to NTNet from space, so this is my alternative to that as well.

Curators are many things, but is also the only job we expect to explore space. Because of this, I think it's necessary for the Curator to still be able to talk with crew members, and use their Newscaster app, to hopefully make space exploration feel like you're just on a private singleplayer world.

## Changelog

:cl:
balance: The Curator and Crystal PDA is now upgraded to have long-distance NTnet connections, they are able to use their apps in space.
/:cl:
