### PR TITLE
Make Abductors a Light Midround Antagonist

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -663,7 +663,7 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/abductors
 	name = "Abductors"
-	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
+	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
 	antag_datum = /datum/antagonist/abductor
 	antag_flag = ROLE_ABDUCTOR
 	enemy_roles = list(

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -675,7 +675,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 2
 	required_applicants = 2
-	weight = 4
+	weight = 2
 	cost = 7
 	minimum_players = 25
 	repeatable = TRUE


### PR DESCRIPTION
## About The Pull Request

This PR changes abductors' midround ruleset style from Heavy to Light.

## Why It's Good For The Game

Looking at what other threats are contained in the heavy rulesets:

- Blob
- Space Dragon
- Xenomorphs
- Spiders
- Space Ninja
- Sentient Disease
- Pirates

I don't think abductors really belong among them (I don't think 2/3 of the Pirates in their current state do either, but that's neither here nor there for this PR), seeing as the other members of this grouping are considerably more lethal or are capable of summoning a lethal threat in the case of ninja. Current dynamic also has this addiction of only spawning heavy rulesets when the round is almost over, and abductors need a good amount of time to get their objective done, so letting them spawn earlier to allow for that is also good.

## Changelog
:cl:
balance: Abductors are now a light midround as opposed to a heavy midround. This means they can spawn earlier in the round.
/:cl: