### PR TITLE
Make Rat King Not Scrape and Lick, Just Lick

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -140,6 +140,7 @@
 		if (do_mob(src, target, 2 SECONDS, interaction_key = REGALRAT_INTERACTION))
 			target.reagents.add_reagent(/datum/reagent/rat_spit,rand(1,3),no_react = TRUE)
 			to_chat(src, span_notice("You finish licking [target]."))
+			return
 	else
 		SEND_SIGNAL(target, COMSIG_RAT_INTERACT, src)
 


### PR DESCRIPTION
## About The Pull Request

This PR makes it so Rat King doesn't attack a living lick target after he finishes licking them, mainly because licking someone's main purpose is to convert them or make your rats not attack them or something, and the attacking them part seems unintentional.

## Why It's Good For The Game

![scrape-and-lick](https://user-images.githubusercontent.com/47086570/194153895-c74d5594-29d1-4057-9e6e-2c9d1afe1ef2.gif)

Our codebase is heavily against vampires, so I don't think we should support any vampire-taught tactics either. 


Also, pretty sure this is a bug.

## Changelog
:cl:
fix: Rat King no longer attacks living lick targets after he finishes licking them.
/:cl: