### PR TITLE
Space dragon will create a plasma fire when they use their fire breath.

### DIFF
--- a/code/modules/events/ghost_role/space_dragon.dm
+++ b/code/modules/events/ghost_role/space_dragon.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/space_dragon
 	name = "Spawn Space Dragon"
 	typepath = /datum/round_event/ghost_role/space_dragon
-	weight = 7
+	weight = 5
 	max_occurrences = 1
 	min_players = 20
 	dynamic_should_hijack = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -37,9 +37,9 @@
 	//Space carp aren't affected by cold.
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	maxbodytemp = 1500
+	maxbodytemp = INFINITY
 	faction = list("carp")
-	pressure_resistance = 200
+	pressure_resistance = INFINITY
 	gold_core_spawnable = HOSTILE_SPAWN
 	/// If the carp uses random coloring
 	var/random_color = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -343,7 +343,7 @@
 		if(mecha in hit_list)
 			continue
 		hit_list += mecha
-		mecha.take_damage(50, BRUTE, MELEE, 1)
+		mecha.take_damage(50, BRUTE, MELEE)
 
 /**
  * Handles consuming and storing consumed things inside Space Dragon

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -8,6 +8,8 @@
 #define PLASMA_GENERATION_RATE 20
 /// The amount of oxygen that gets released per plasma.
 #define OXYGEN_RATIO 0.4
+/// The temperature of the plasma oxygen gasmixture released from space dragon fire breath in Kelvin.
+#define PLASMA_TEMPERATURE 2000
 
 /**
  * # Space Dragon
@@ -325,14 +327,14 @@
 	hit_list += src
 	if(isopenturf(turf))
 		var/turf/open/open_turf = turf
-		open_turf.atmos_spawn_air("plasma=[total_plasma_released / affected_volume];o2=[OXYGEN_RATIO * total_plasma_released / affected_volume];TEMP=2000")
+		open_turf.atmos_spawn_air("plasma=[total_plasma_released / affected_volume];o2=[OXYGEN_RATIO * total_plasma_released / affected_volume];TEMP=[PLASMA_TEMPERATURE]")
 	new /obj/effect/hotspot(turf)
-	turf.hotspot_expose(2000,50,1)
+	turf.hotspot_expose(exposed_temperature = PLASMA_TEMPERATURE, exposed_volume = 50, soh = 1)
 	for(var/mob/living/living in turf.contents)
 		if(living in hit_list)
 			continue
 		hit_list += living
-		living.adjustFireLoss(30)
+		living.apply_damages(brute = 10, burn = 20)
 		to_chat(living, span_userdanger("You're hit by [src]'s fire breath!"))
 	// deals damage to mechs
 	for(var/obj/vehicle/sealed/mecha/mecha in turf.contents)
@@ -417,3 +419,4 @@
 #undef MAXIMUM_PLASMA_MOLES_RELEASED
 #undef PLASMA_GENERATION_RATE
 #undef OXYGEN_RATIO
+#undef PLASMA_TEMPERATURE

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -305,8 +305,7 @@
 	playsound(get_turf(src),'sound/magic/fireball.ogg', 200, TRUE)
 	var/range = 20
 	var/delayFire = -1.0
-	var/list/stream_turfs = list()
-	stream_turfs = get_stream_turfs(target, range)
+	var/list/stream_turfs = get_stream_turfs(target, range)
 	for(var/turf/turf in stream_turfs)
 		delayFire += 1.5
 		addtimer(CALLBACK(src, .proc/dragon_fire_line, turf, length(stream_turfs), min(plasma, MAXIMUM_PLASMA_MOLES_RELEASED)), delayFire)

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -91,7 +91,7 @@
 	var/devastation_damage_min_percentage = 0.4
 	/// Maximum devastation damage dealt coefficient based on max health
 	var/devastation_damage_max_percentage = 0.75
-	/// The amount of plasma stored. Up to [MAXIMUM_PLASMA_MOLES_RELEASED] moles of plasma can get released.
+	/// The amount of plasma stored. Up to [MAXIMUM_PLASMA_MOLES_RELEASED] moles of plasma can get released in a single fire breath.
 	var/plasma = MAXIMUM_STORED_PLASMA_MOLES
 
 /mob/living/simple_animal/hostile/space_dragon/Initialize(mapload)
@@ -273,9 +273,9 @@
 	return (get_line(src, T) - get_turf(src))
 
 /**
- * Returns a list of open turfs that do not have windows or doors with a density.
+ * Returns a list of open turfs that allow gas to pass in a line.
  * Arguments:
- * * atom/target - The target.
+ * * atom/target - The target for the line.
  * * range - The maximum number of turfs it can return.
 */
 /mob/living/simple_animal/hostile/space_dragon/proc/get_stream_turfs(atom/target, range)

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -331,6 +331,8 @@
 	new /obj/effect/hotspot(turf)
 	turf.hotspot_expose(exposed_temperature = PLASMA_TEMPERATURE, exposed_volume = 50, soh = 1)
 	for(var/mob/living/living in turf.contents)
+		if("carp" in living.faction)
+			hit_list += living
 		if(living in hit_list)
 			continue
 		hit_list += living

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -89,8 +89,8 @@
 	var/devastation_damage_min_percentage = 0.4
 	/// Maximum devastation damage dealt coefficient based on max health
 	var/devastation_damage_max_percentage = 0.75
-	/// The amount of plasma stored. Up to 100 moles of plasma can get
-	var/plasma = 400
+	/// The amount of plasma stored. Up to [MAXIMUM_PLASMA_MOLES_RELEASED] moles of plasma can get released.
+	var/plasma = MAXIMUM_STORED_PLASMA_MOLES
 
 /mob/living/simple_animal/hostile/space_dragon/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -306,9 +306,10 @@
 	var/range = 20
 	var/delayFire = -1.0
 	var/list/stream_turfs = get_stream_turfs(target, range)
+	var/turf_plasma_moles = min(plasma, MAXIMUM_PLASMA_MOLES_RELEASED) / length(stream_turfs)
 	for(var/turf/turf in stream_turfs)
 		delayFire += 1.5
-		addtimer(CALLBACK(src, .proc/dragon_fire_line, turf, length(stream_turfs), min(plasma, MAXIMUM_PLASMA_MOLES_RELEASED)), delayFire)
+		addtimer(CALLBACK(src, .proc/dragon_fire_line, turf, turf_plasma_moles), delayFire)
 	if(length(stream_turfs))
 		plasma -= min(plasma, MAXIMUM_PLASMA_MOLES_RELEASED)
 
@@ -320,14 +321,14 @@
  * It can only hit any given target once.
  * Arguments:
  * * turf/turf - The turf to trigger the effects on.
- * * affected_volume - The number of turfs that got influenced by the fire stream.
+ * * plasma_released - The amount of plasma that gets released into the turf.
  */
-/mob/living/simple_animal/hostile/space_dragon/proc/dragon_fire_line(turf/turf, affected_volume, total_plasma_released)
+/mob/living/simple_animal/hostile/space_dragon/proc/dragon_fire_line(turf/turf, plasma_released)
 	var/list/hit_list = list()
 	hit_list += src
 	if(isopenturf(turf))
 		var/turf/open/open_turf = turf
-		open_turf.atmos_spawn_air("plasma=[total_plasma_released / affected_volume];o2=[OXYGEN_RATIO * total_plasma_released / affected_volume];TEMP=[PLASMA_TEMPERATURE]")
+		open_turf.atmos_spawn_air("plasma=[plasma_released];o2=[OXYGEN_RATIO * plasma_released];TEMP=[PLASMA_TEMPERATURE]")
 	new /obj/effect/hotspot(turf)
 	turf.hotspot_expose(exposed_temperature = PLASMA_TEMPERATURE, exposed_volume = 50, soh = 1)
 	for(var/mob/living/living in turf.contents)
@@ -337,7 +338,7 @@
 			continue
 		hit_list += living
 		living.apply_damages(brute = 10, burn = 20)
-		to_chat(living, span_userdanger("You're hit by [src]'s fire breath!"))
+		balloon_alert(living, "Engulfed by [src]'s fire breath!")
 	// deals damage to mechs
 	for(var/obj/vehicle/sealed/mecha/mecha in turf.contents)
 		if(mecha in hit_list)

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -275,19 +275,20 @@
 /**
  * Returns a list of open turfs that do not have windows or doors with a density.
  * Arguments:
- * * atom/atom - The target.
+ * * atom/target - The target.
  * * range - The maximum number of turfs it can return.
 */
-/mob/living/simple_animal/hostile/space_dragon/proc/get_stream_turfs(atom/atom, range)
+/mob/living/simple_animal/hostile/space_dragon/proc/get_stream_turfs(atom/target, range)
 	var/list/turfs = list()
-	for(var/turf/turf in line_target(0, range, atom))
+	for(var/turf/turf in line_target(0, range, target))
 		if(isclosedturf(turf))
 			return turfs
-		for(var/obj/structure/window/window in turf.contents)
+		if(isspaceturf(turf))
+			for(var/atom/atom in turf)
+				if(!atom.can_atmos_pass(turf))
+					return turfs
+		else if(!TURF_SHARES(turf))
 			return turfs
-		for(var/obj/machinery/door/door in turf.contents)
-			if(door.density)
-				return turfs
 		turfs += turf
 	return turfs
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Space dragons will release plasma and oxygen at 2,000 Kelvin on every turf their fire goes through. The space dragon will store some plasma, up to a maximum of 800 moles, release up to 400 moles of plasma in a single fire breath, and generates 20 moles of plasma per second. The plasma storage thing is to prevent people from having to spam fire breaths in order to achieve optimal plasma fires. 0.4 moles of oxygen gets released per mole of plasma, giving a stoichiometric burn and allowing the plasma to burn in the room instead of spreading too far if too much oxygen got burned. It's not enough plasma to create a station wide plasma flood, and won't be able to spread too far.

Gives space dragon and space carps full heat and pressure resistance, so their plasma fires won't kill themselves or push themselves around.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
### Plasma.
It's a dragon. They should be scary and destructive, filling the room they are in in flames. The chaotic nature of local plasma fires will make the antagonist feel more impactful and the fight more intense.
### Event weight to 5 from 7.
A maintainer said something about dynamic. The dragon got buffed significantly, and carps can live in fire, so it might as well be a rater but more memorable event.
### Dragon and carp fire and pressure immunity.
Well the dragon shoots flaming plasma, which will heat the room and raises pressure. It would suck if the dragon's firebreath killed itself and their carps.
### Dragon firebreath team kill prevention.
Encourages the carps to work with the dragon instead of flying away to grief the station randomly.
### Dragon firebreath blocking generalisation.
Hardcoding random objects to block firebreath is lame. It makes sense to generalise it to whether atmos can pass or not (with the exception of space, because space it weird and blocks atmos).
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Space dragons will now release small plasma fires when they breathe fire.
balance: Space dragons and space carps are now immune to heat, and resist space wind.
balance: Space dragon fire stream will no longer ignore armour, and will deal 10 brute and 20 burn damage.
balance: Reduce space dragon event weight to 5, from 7.
balance: Space dragons will no longer cause friendly fire on carps that are hit by their fire breath.
balance: Space dragon fire breath will now get blocked by anything that blocks atmos, instead of just closed turfs and shut doors and windows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
