### PR TITLE
Fixes baseball bat throwing qdeleted things runtime

### DIFF
--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -115,16 +115,17 @@
 			span_userdanger("[user]'s punch strikes with force!"))
 		return
 
-	target.apply_damage(force * fist_pressure_setting, BRUTE, wound_bonus = CANT_WOUND)
 	target.visible_message(span_danger("[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!"), \
 		span_userdanger("You cry out in pain as [user]'s punch flings you backwards!"))
 	new /obj/effect/temp_visual/kinetic_blast(target.loc)
-	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, TRUE)
-	playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
+	target.apply_damage(force * fist_pressure_setting, BRUTE, wound_bonus = CANT_WOUND)
+	playsound(src, 'sound/weapons/resonator_blast.ogg', 50, TRUE)
+	playsound(src, 'sound/weapons/genhit2.ogg', 50, TRUE)
 
-	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
+	if(!QDELETED(target))
+		var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 
-	target.throw_at(throw_target, 5 * fist_pressure_setting, 0.5 + (fist_pressure_setting / 2))
+		target.throw_at(throw_target, 5 * fist_pressure_setting, 0.5 + (fist_pressure_setting / 2))
 
 	log_combat(user, target, "power fisted", src)
 

--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -103,16 +103,17 @@
 		span_hear("You hear a heavy electrical crack!"))
 	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 	target.throw_at(throw_target, 200, 4)
-	return
 
-/obj/item/mjollnir/attack(mob/living/M, mob/user)
+/obj/item/mjollnir/attack(mob/living/target_mob, mob/user)
 	..()
+	if(QDELETED(target_mob))
+		return
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		return
 	if(HAS_TRAIT(src, TRAIT_WIELDED))
-		shock(M)
+		shock(target_mob)
 
 /obj/item/mjollnir/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
-	if(isliving(hit_atom))
+	if(!QDELETED(hit_atom) && isliving(hit_atom))
 		shock(hit_atom)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -725,20 +725,21 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	return ..()
 
 /obj/item/melee/baseball_bat/attack(mob/living/target, mob/living/user)
-	. = ..()
-	if(HAS_TRAIT(user, TRAIT_PACIFISM))
-		return
 	// we obtain the relative direction from the bat itself to the target
 	var/relative_direction = get_cardinal_dir(src, target)
 	var/atom/throw_target = get_edge_target_turf(target, relative_direction)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		return
 	if(homerun_ready)
 		user.visible_message(span_userdanger("It's a home run!"))
-		target.throw_at(throw_target, rand(8,10), 14, user)
+		if(!QDELETED(target))
+			target.throw_at(throw_target, rand(8,10), 14, user)
 		SSexplosions.medturf += throw_target
 		playsound(get_turf(src), 'sound/weapons/homerun.ogg', 100, TRUE)
 		homerun_ready = FALSE
 		return
-	else if(!target.anchored)
+	else if(!QDELETED(target) && !target.anchored)
 		var/whack_speed = (prob(60) ? 1 : 4)
 		target.throw_at(throw_target, rand(1, 2), whack_speed, user, gentle = TRUE) // sorry friends, 7 speed batting caused wounds to absolutely delete whoever you knocked your target into (and said target)
 


### PR DESCRIPTION
Attacking stuff can destroy it (ie beepsky) if they have low enough health.

```
The following runtime has occurred 1 time(s).
runtime error: Qdeleted thing being thrown around.
proc name: throw at (/atom/movable/proc/throw_at)
  source file: atoms_movable.dm,1132
  usr: Harold McKormack (as Adam Karl... (/mob/living/carbon/human)
  src: Sergeant-At-Armsky (/mob/living/simple_animal/bot/secbot/beepsky/armsky)

```

