### PR TITLE
Fixes runtime when ghosts press the deathgasp emote hotkey

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -116,6 +116,8 @@
 	stat_allowed = HARD_CRIT
 
 /datum/emote/living/deathgasp/run_emote(mob/living/user, params, type_override, intentional)
+	if(!is_type_in_typecache(user, mob_type_allowed_typecache))
+		return
 	if(user.death_message)
 		message_simple = user.death_message
 	. = ..()


### PR DESCRIPTION
```
The following runtime has occurred 1 time(s).
runtime error: undefined variable /mob/dead/observer/var/death_message
proc name: run emote (/datum/emote/living/deathgasp/run_emote)
  source file: emote.dm,119
  usr: Jimmy Little (/mob/dead/observer)
  src: /datum/emote/living/deathgasp (/datum/emote/living/deathgasp)

```

#69007 removed the living sanity check. 
