### PR TITLE
Changeling lesserforms doesn't break when you monkify yourself from genetics

### DIFF
--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -52,8 +52,8 @@
  * source - Monkey user who is now turning into a human
  */
 /datum/action/changeling/humanform/from_monkey/proc/give_lesserform(mob/living/carbon/source)
-   SIGNAL_HANDLER
-   
+	SIGNAL_HANDLER
+
 	var/datum/antagonist/changeling/changeling = source.mind.has_antag_datum(/datum/antagonist/changeling)
 	var/datum/action/changeling/lesserform/monkey_form_ability = new()
 	changeling.purchased_powers += monkey_form_ability

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -33,17 +33,26 @@
 /datum/action/changeling/humanform/from_monkey
 	desc = "We change back into a human. Costs 5 chemicals."
 
-/datum/action/changeling/humanform/from_monkey/sting_action(mob/living/carbon/user)
+/datum/action/changeling/humanform/from_monkey/Grant(mob/granted_to)
 	. = ..()
-	if(!.)
-		return
+	RegisterSignal(granted_to, COMSIG_MONKEY_HUMANIZE, .proc/give_lesserform)
 
-	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+/datum/action/changeling/humanform/from_monkey/Destroy()
+	UnregisterSignal(owner, COMSIG_MONKEY_HUMANIZE)
+	return ..()
+
+/**
+ * Called on COMSIG_MONKEY_HUMANIZE
+ * Handles giving the new lesserform ability
+ * Removing ourselves is handled by parent already, so it's not needed here like it is on lesserform.
+ *
+ * Args:
+ * source - Monkey user who is now turning into a human
+ */
+/datum/action/changeling/humanform/from_monkey/proc/give_lesserform(mob/living/carbon/source)
+	var/datum/antagonist/changeling/changeling = source.mind.has_antag_datum(/datum/antagonist/changeling)
 	var/datum/action/changeling/lesserform/monkey_form_ability = new()
 	changeling.purchased_powers += monkey_form_ability
 
-	monkey_form_ability.Grant(user)
-
-	// Delete ourselves when we're done.
+	monkey_form_ability.Grant(source)
 	qdel(src)
-	return TRUE

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -27,6 +27,8 @@
 
 	changeling.transform(user, chosen_prof)
 	user.regenerate_icons()
+	// Delete ourselves when we're done.
+	qdel(src)
 	return TRUE
 
 // Subtype used when a changeling uses lesser form.
@@ -55,4 +57,3 @@
 	changeling.purchased_powers += monkey_form_ability
 
 	monkey_form_ability.Grant(source)
-	qdel(src)

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -40,7 +40,7 @@
 	RegisterSignal(granted_to, COMSIG_MONKEY_HUMANIZE, .proc/give_lesserform)
 
 /datum/action/changeling/humanform/from_monkey/Remove(mob/remove_from)
-	UnregisterSignal(owner, COMSIG_MONKEY_HUMANIZE)
+	UnregisterSignal(remove_from, COMSIG_MONKEY_HUMANIZE)
 	return ..()
 
 /**

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -37,7 +37,7 @@
 	. = ..()
 	RegisterSignal(granted_to, COMSIG_MONKEY_HUMANIZE, .proc/give_lesserform)
 
-/datum/action/changeling/humanform/from_monkey/Destroy()
+/datum/action/changeling/humanform/from_monkey/Remove(mob/remove_from)
 	UnregisterSignal(owner, COMSIG_MONKEY_HUMANIZE)
 	return ..()
 

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -52,6 +52,8 @@
  * source - Monkey user who is now turning into a human
  */
 /datum/action/changeling/humanform/from_monkey/proc/give_lesserform(mob/living/carbon/source)
+   SIGNAL_HANDLER
+   
 	var/datum/antagonist/changeling/changeling = source.mind.has_antag_datum(/datum/antagonist/changeling)
 	var/datum/action/changeling/lesserform/monkey_form_ability = new()
 	changeling.purchased_powers += monkey_form_ability

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -12,7 +12,7 @@
 	RegisterSignal(granted_to, COMSIG_HUMAN_MONKEYIZE, .proc/swap_powers)
 
 /datum/action/changeling/lesserform/Remove(mob/remove_from)
-	UnregisterSignal(owner, COMSIG_HUMAN_MONKEYIZE)
+	UnregisterSignal(remove_from, COMSIG_HUMAN_MONKEYIZE)
 	return ..()
 
 //Transform into a monkey.

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -11,7 +11,7 @@
 	. = ..()
 	RegisterSignal(granted_to, COMSIG_HUMAN_MONKEYIZE, .proc/swap_powers)
 
-/datum/action/changeling/lesserform/Destroy()
+/datum/action/changeling/lesserform/Remove(mob/remove_from)
 	UnregisterSignal(owner, COMSIG_HUMAN_MONKEYIZE)
 	return ..()
 

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -7,31 +7,45 @@
 	dna_cost = 1
 	req_human = TRUE
 
+/datum/action/changeling/lesserform/Grant(mob/granted_to)
+	. = ..()
+	RegisterSignal(granted_to, COMSIG_HUMAN_MONKEYIZE, .proc/swap_powers)
+
+/datum/action/changeling/lesserform/Destroy()
+	UnregisterSignal(owner, COMSIG_HUMAN_MONKEYIZE)
+	return ..()
+
 //Transform into a monkey.
 /datum/action/changeling/lesserform/sting_action(mob/living/carbon/human/user)
 	if(!user || user.notransform)
 		return FALSE
-	to_chat(user, span_warning("Our genes cry out!"))
 	..()
-
+	to_chat(user, span_warning("Our genes cry out!"))
 	user.monkeyize()
+	return TRUE
 
-	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+/**
+ * Called on COMSIG_HUMAN_MONKEYIZE
+ * Handles giving the new human force ability and removing ourselves
+ *
+ * Args:
+ * source - Human user who is now turning into a monkey
+ */
+/datum/action/changeling/lesserform/proc/swap_powers(mob/living/carbon/source)
+	var/datum/antagonist/changeling/changeling = source.mind.has_antag_datum(/datum/antagonist/changeling)
+	// Drops all flesh disguise items after monkeyizing, because they don't drop automatically like real clothing.
+	for(var/slot in changeling.slot2type)
+		if(istype(source.vars[slot], changeling.slot2type[slot]))
+			qdel(source.vars[slot])
+	for(var/datum/scar/iter_scar as anything in source.all_scars)
+		if(iter_scar.fake)
+			qdel(iter_scar)
+	source.regenerate_icons()
+
 	var/datum/action/changeling/humanform/from_monkey/human_form_ability = new()
 	changeling.purchased_powers += human_form_ability
 	changeling.purchased_powers -= src
-	
-	// Drops all flesh disguise items after monkeyizing, because they don't drop automatically like real clothing.
-	for(var/slot in changeling.slot2type)
-		if(istype(user.vars[slot], changeling.slot2type[slot]))
-			qdel(user.vars[slot])
-	for(var/datum/scar/iter_scar as anything in user.all_scars)
-		if(iter_scar.fake)
-			qdel(iter_scar)
-	user.regenerate_icons()
 
-	Remove(user)
-	human_form_ability.Grant(user)
-
+	human_form_ability.Grant(source)
+	Remove(source)
 	qdel(src)
-	return TRUE

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -32,8 +32,8 @@
  * source - Human user who is now turning into a monkey
  */
 /datum/action/changeling/lesserform/proc/swap_powers(mob/living/carbon/source)
-   SIGNAL_HANDLER
-   
+	SIGNAL_HANDLER
+
 	var/datum/antagonist/changeling/changeling = source.mind.has_antag_datum(/datum/antagonist/changeling)
 	// Drops all flesh disguise items after monkeyizing, because they don't drop automatically like real clothing.
 	for(var/slot in changeling.slot2type)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -32,6 +32,8 @@
  * source - Human user who is now turning into a monkey
  */
 /datum/action/changeling/lesserform/proc/swap_powers(mob/living/carbon/source)
+   SIGNAL_HANDLER
+   
 	var/datum/antagonist/changeling/changeling = source.mind.has_antag_datum(/datum/antagonist/changeling)
 	// Drops all flesh disguise items after monkeyizing, because they don't drop automatically like real clothing.
 	for(var/slot in changeling.slot2type)


### PR DESCRIPTION
## About The Pull Request

Changeling's monkey form and returning back human now uses the monkify/humanify signals instead of sting_action stuff, meaning it now takes genetic species changings into account, so the power doesn't break if a changeling manually (or forcefully by someone else) turns into a monkey.

## Why It's Good For The Game

Bug fix is pretty nice, the more we can support monkey changelings the better, I like expanding on monkey as a species.

## Changelog

:cl:
fix: Changeling's lesser form ability now takes turning into a monkey from other sources (genetics) into account, and will now properly give you your human form ability when it occurs.
/:cl: