### PR TITLE
Fixes Custom Vendor side-effects on delete.

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -262,7 +262,12 @@
 			new /obj/item/stack/sheet/iron(loc, 3)
 		qdel(src)
 	else
-		..()
+		var/turf/T = get_turf(src)
+		if(T)
+			for(var/obj/item/I in contents)
+				I.forceMove(T)
+			explosion(src, devastation_range = -1, light_impact_range = 3)
+		return ..()
 
 /obj/machinery/vending/update_appearance(updates=ALL)
 	. = ..()
@@ -1356,12 +1361,12 @@ GLOBAL_LIST_EMPTY(vending_products)
 /obj/machinery/vending/custom/crowbar_act(mob/living/user, obj/item/I)
 	return FALSE
 
-/obj/machinery/vending/custom/Destroy()
+/obj/machinery/vending/custom/deconstruct(disassembled)
 	unbuckle_all_mobs(TRUE)
-	var/turf/T = get_turf(src)
-	if(T)
-		for(var/obj/item/I in contents)
-			I.forceMove(T)
+	var/turf/current_turf = get_turf(src)
+	if(current_turf)
+		for(var/obj/item/stored_item in contents)
+			stored_item.forceMove(current_turf)
 		explosion(src, devastation_range = -1, light_impact_range = 3)
 	return ..()
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -262,12 +262,7 @@
 			new /obj/item/stack/sheet/iron(loc, 3)
 		qdel(src)
 	else
-		var/turf/T = get_turf(src)
-		if(T)
-			for(var/obj/item/I in contents)
-				I.forceMove(T)
-			explosion(src, devastation_range = -1, light_impact_range = 3)
-		return ..()
+		..()
 
 /obj/machinery/vending/update_appearance(updates=ALL)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

This PR fixes an oversight with custom vendors, where they still had side effects on destroy() which were intended for deconstruct(). Custom vendors are supposed to explode when removed with stock inside of them as a theft deterrent, however as a result of those side effects, admin spawned or admin deleted  custom vendors serve as minor explosives that could be chained together,

## Why It's Good For The Game

Fixes #69444.
There is always a shotgun.
Side effects on destroy are generally to be avoided.

## Changelog

:cl:
fix: Custom vendors now explode on deconstruct as opposed to delete, causing no practical changes to gameplay but admins will notice slightly fewer ahelps if they ever have to get rid of one.
/:cl:
