### PR TITLE
Fixes transit tube pod qdel loop

### DIFF
--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -216,7 +216,8 @@
 	occupied_icon_state = "temppod_occupied"
 
 /obj/structure/transit_tube_pod/dispensed/outside_tube()
-	qdel(src)
+	if(!QDELETED(src))
+		qdel(src)
 
 #undef MOVE_ANIMATION_STAGE_ONE
 #undef MOVE_ANIMATION_STAGE_TWO


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a minor runtime when a temporary transit tube exits a loop through a destroyed transit pipe.
/:cl:

```
pod moves through pipe -> calibrate_engine()
calibrate_engine() -> checks for pipe in next location
can't find pipe in next location since it was destroyed -> moves pod to where destroyed pipe would be -> qdels the tube to spit person out
tube qdel deletes movement system for the pod -> movement system can't find a tube in the current turf, calls outside_tube()
parent type's outside_tube() throws people. this subtype's outside tube just calls qdel (redundant safety.) loop.
```
