### PR TITLE
Fixes some incorrect `before_cast`s (personality commune, revenant)

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -195,7 +195,7 @@
 /datum/action/cooldown/spell/aoe/revenant/before_cast(mob/living/simple_animal/revenant/cast_on)
 	. = ..()
 	if(. & SPELL_CANCEL_CAST)
-		return FALSE
+		return
 
 	if(locked)
 		if(!cast_on.unlock(unlock_amount))

--- a/code/modules/spells/spell_types/self/personality_commune.dm
+++ b/code/modules/spells/spell_types/self/personality_commune.dm
@@ -36,8 +36,6 @@
 		reset_cooldown()
 		return . | SPELL_CANCEL_CAST
 
-	return TRUE
-
 // Pillaged and adapted from telepathy code
 /datum/action/cooldown/spell/personality_commune/cast(mob/living/cast_on)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

- `before_cast` returns a bitflag, shouldn't return a bool. Bools will break it, `TRUE` especially cause it's the same as `CANCEL_CAST`. See #69394

Fixes #70302 

I'll see if this can be unit tested as well

## Why It's Good For The Game

Some spells work more accurately.
The revenant fix doesn't change anything, currently, but could break in the future.
However the commune one was a cause of fault. 

## Changelog

:cl: Melbert
fix: Split personalities can commune again, probably
/:cl:

