### PR TITLE
Fixes weather listener and area sound manager runtime when brains are inserted into corpses.

### DIFF
--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -20,6 +20,12 @@
 		ADD_TRAIT(src, TRAIT_HANDS_BLOCKED, BRAIN_UNAIDED)
 
 
+/mob/living/brain/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
+	var/obj/item/organ/internal/brain/brain_loc = loc
+	if(brain_loc && isnull(new_turf) && brain_loc.owner) //we're actively being put inside a new body.
+		return ..(old_turf, get_turf(brain_loc.owner), same_z_layer, notify_contents)
+	return ..()
+
 /mob/living/brain/proc/create_dna()
 	stored_dna = new /datum/dna/stored(src)
 	if(!stored_dna.species)


### PR DESCRIPTION
Essentially, the brain is set to nullspace for a second when inserted into a body, which was messing with brain mobs since z_level_change wasn't expecting the loc to be a null turf. (**mobs in nullspace are bad.**) 

At this very same moment though, the brain obj's owner (carbon) is set, so we can just report that since that's going to be the loc sent to the signal again in half a moment anyway.


```
[2022-10-05 04:45:43.188] runtime error: Cannot read null.z
 - proc name: handle z level change (/datum/element/weather_listener/proc/handle_z_level_change)
 -   source file: weather_listener.dm,37
 -   usr: Scoops-The-Ore (/mob/living/carbon/human)
 -   src: /datum/element/weather_listene... (/datum/element/weather_listener)
 -   usr.loc: the floor (113,99,3) (/turf/open/floor/iron/white)
 -   call stack:
 - /datum/element/weather_listene... (/datum/element/weather_listener): handle z level change(Vents-Hot-Air (/mob/living/brain), the floor (113,99,3) (/turf/open/floor/iron/white), null, 1)
 - Vents-Hot-Air (/mob/living/brain):  SendSignal("movable_ztransit", /list (/list))
 - Vents-Hot-Air (/mob/living/brain): on changed z level(the floor (113,99,3) (/turf/open/floor/iron/white), null, 1, 1)
 - Vents-Hot-Air (/mob/living/brain): on changed z level(the floor (113,99,3) (/turf/open/floor/iron/white), null, 1, null)
 - Vents-Hot-Air (/mob/living/brain): on changed z level(the floor (113,99,3) (/turf/open/floor/iron/white), null, 1, null)
 - Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain): on changed z level(the floor (113,99,3) (/turf/open/floor/iron/white), null, 1, 1)
 - Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain): Moved(Scoops-The-Ore (/mob/living/carbon/human), 0, 1, null, 1)
 - Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain): doMove(null)
 - Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain): doMove(null)
 - Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain): moveToNullspace()
 - Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain): Insert(Eiuus-Hathei (/mob/living/carbon/human), 0, 1, 0)
 - Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain): Insert(Eiuus-Hathei (/mob/living/carbon/human), 0, 1, 0)
 - Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain): Insert(Eiuus-Hathei (/mob/living/carbon/human), 0, 1, 0)
 - manipulate organs (/datum/surgery_step/manipulate_organs/internal): success(Scoops-The-Ore (/mob/living/carbon/human), Eiuus-Hathei (/mob/living/carbon/human), "head", Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain), Organ manipulation (/datum/surgery/organ_manipulation), null)
 - manipulate organs (/datum/surgery_step/manipulate_organs/internal): initiate(Scoops-The-Ore (/mob/living/carbon/human), Eiuus-Hathei (/mob/living/carbon/human), "head", Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain), Organ manipulation (/datum/surgery/organ_manipulation), 0)
 - manipulate organs (/datum/surgery_step/manipulate_organs/internal): try op(Scoops-The-Ore (/mob/living/carbon/human), Eiuus-Hathei (/mob/living/carbon/human), "head", Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain), Organ manipulation (/datum/surgery/organ_manipulation), 0)
 - Organ manipulation (/datum/surgery/organ_manipulation): next step(Scoops-The-Ore (/mob/living/carbon/human), /list (/list))
 - Eiuus-Hathei (/mob/living/carbon/human): attackby(Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain), Scoops-The-Ore (/mob/living/carbon/human), "icon-x=17;icon-y=23;vis-x=10;v...")
 - Vents-Hot-Air\'s brain (/obj/item/organ/internal/brain): melee attack chain(Scoops-The-Ore (/mob/living/carbon/human), Eiuus-Hathei (/mob/living/carbon/human), "icon-x=17;icon-y=23;vis-x=10;v...")
 - Scoops-The-Ore (/mob/living/carbon/human): ClickOn(Eiuus-Hathei (/mob/living/carbon/human), "icon-x=17;icon-y=23;vis-x=10;v...")
 - Eiuus-Hathei (/mob/living/carbon/human): Click(the floor (113,98,3) (/turf/open/floor/iron/white), "mapwindow.map", "icon-x=17;icon-y=23;vis-x=10;v...")
```