### PR TITLE
Regal Pipeguns can be stored in high-vis vests/wet floor signs

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -147,7 +147,7 @@
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
 		/obj/item/t_scanner,
-		/obj/item/gun/ballistic/rifle/boltaction/pipegun,
+		/obj/item/gun/ballistic/rifle/boltaction/pipegun/prime,
 	)
 	resistance_flags = NONE
 	species_exception = list(/datum/species/golem)

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -147,6 +147,7 @@
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
 		/obj/item/t_scanner,
+		/obj/item/gun/ballistic/rifle/boltaction/pipegun,
 	)
 	resistance_flags = NONE
 	species_exception = list(/datum/species/golem)

--- a/code/modules/clothing/suits/wetfloor.dm
+++ b/code/modules/clothing/suits/wetfloor.dm
@@ -19,5 +19,5 @@
 	allowed = list(
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
-		/obj/item/gun/ballistic/rifle/boltaction/pipegun,
+		/obj/item/gun/ballistic/rifle/boltaction/pipegun/prime,
 	)

--- a/code/modules/clothing/suits/wetfloor.dm
+++ b/code/modules/clothing/suits/wetfloor.dm
@@ -16,3 +16,8 @@
 	attack_verb_simple = list("warn", "caution", "smash")
 	armor = list(MELEE = 5, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	species_exception = list(/datum/species/golem)
+	allowed = list(
+		/obj/item/tank/internals/emergency_oxygen,
+		/obj/item/tank/internals/plasmaman,
+		/obj/item/gun/ballistic/rifle/boltaction/pipegun,
+	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can put regal pipeguns into the suit storage of high-vis vests and wet floor signs.

## Why It's Good For The Game

I saw Melbert running around in a high vis vest with the regal pipegun on his back, and I thought 'that's fucking funny' so here we are.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: You can put regal pipeguns into the suit storage of high-vis vests and wet floor signs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
