### PR TITLE
Simplifies SM damage calculation, tweaks the numbers.

### DIFF
--- a/code/__DEFINES/supermatter.dm
+++ b/code/__DEFINES/supermatter.dm
@@ -20,8 +20,6 @@
 #define CRITICAL_POWER_PENALTY_THRESHOLD 9000 //+1 bolt of electricity.
 #define HEAT_PENALTY_THRESHOLD 40 //Higher == Crystal safe operational temperature is higher.
 
-#define DAMAGE_HARDCAP 1.8
-
 #define THERMAL_RELEASE_MODIFIER 4 //Higher == less heat released during reaction, not to be confused with the above values
 #define PLASMA_RELEASE_MODIFIER 650 //Higher == less plasma released by reaction
 #define OXYGEN_RELEASE_MODIFIER 340 //Higher == less oxygen released at high temperature/power

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -686,7 +686,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		var/turf/local_turf = src.loc
 		for (var/turf/open/space/turf in ((local_turf.atmos_adjacent_turfs || list()) + local_turf))
 			additive_damage[SM_DAMAGE_SPACED] = clamp(internal_energy * 0.00125, 0, 10)
-			is_spaced = true
+			is_spaced = TRUE
 			break
 
 	if(total_moles > 0 && !is_spaced)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -681,8 +681,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	additive_damage[SM_DAMAGE_POWER] = clamp((internal_energy - POWER_PENALTY_THRESHOLD) / 2000, 0, 1)
 	additive_damage[SM_DAMAGE_MOLES] = clamp((total_moles - MOLE_PENALTY_THRESHOLD) / 320, 0, 1)
 
-	for(var/turf/open/space/turf_to_check in RANGE_TURFS(1, loc))
-		if(LAZYLEN(turf_to_check.atmos_adjacent_turfs))
+	if(isturf(src.loc))
+		var/turf/local_turf = src.loc
+		for (var/turf/open/space/turf in ((local_turf.atmos_adjacent_turfs || list()) + local_turf))
 			additive_damage[SM_DAMAGE_SPACED] = clamp(internal_energy * 0.00125, 0, 10)
 			break
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -678,7 +678,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	external_damage_immediate = 0
 
 	additive_damage[SM_DAMAGE_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 2400, 0, 1.5)
-	additive_damage[SM_DAMAGE_POWER] = clamp((internal_energy - POWER_PENALTY_THRESHOLD) / 2000, 0, 1)
+	additive_damage[SM_DAMAGE_POWER] = clamp((internal_energy - POWER_PENALTY_THRESHOLD) / 4000, 0, 1)
 	additive_damage[SM_DAMAGE_MOLES] = clamp((total_moles - MOLE_PENALTY_THRESHOLD) / 320, 0, 1)
 
 	var/is_spaced = FALSE

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -668,33 +668,22 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 /obj/machinery/power/supermatter_crystal/proc/calculate_damage()
 	if(disable_damage)
 		return
-	/// Multiplier to our mole and power damage limits.
-	var/list/additive_damage = list()
-	var/mole_power_damage_limit = delamination_strategy.mole_power_damage_limit()
-	var/total_moles = absorbed_gasmix.total_moles()
-	additive_damage[SM_DAMAGE_HEAT] = max((absorbed_gasmix.temperature - temp_limit) * max(total_moles / 350, 0.25) / 600, 0)
-	additive_damage[SM_DAMAGE_POWER] = max((internal_energy - POWER_PENALTY_THRESHOLD * mole_power_damage_limit) / 2000, 0)
-	additive_damage[SM_DAMAGE_MOLES] = max((total_moles - MOLE_PENALTY_THRESHOLD * mole_power_damage_limit) / 320, 0)
-	if(total_moles)
-		additive_damage[SM_DAMAGE_HEAL_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 300, -2, 0)
 
-	/// Damage from internal factors.
-	var/total_internal_damage = 0
-	for (var/damage_type in additive_damage)
-		total_internal_damage += additive_damage[damage_type]
-	if(total_internal_damage > DAMAGE_HARDCAP)
-		// Scale each of the damages according to the hardcap.
-		// This means we lie a bit about each of the factors, but the final addition is honest.
-		for (var/damage_type in additive_damage)
-			// shorter way of writing damage = damage / total_internal_damage * damage_hardcap.
-			additive_damage[damage_type] *= DAMAGE_HARDCAP / total_internal_damage
-		total_internal_damage = DAMAGE_HARDCAP
+	var/list/additive_damage = list()
 
 	// We dont let external factors deal more damage than the emergency point.
-	// Evaluates the current damage and not the damage + internal damage though.
+	// Only cares about current damage (last tick) and not the damage + damage this tick.
 	// Helps us decouple this and make it discrete.
 	additive_damage[SM_DAMAGE_EXTERNAL] = external_damage_immediate * clamp((emergency_point - damage) / emergency_point, 0, 1)
 	external_damage_immediate = 0
+
+	additive_damage[SM_DAMAGE_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 2400, 0, 1.5)
+	additive_damage[SM_DAMAGE_POWER] = clamp((internal_energy - POWER_PENALTY_THRESHOLD) / 2000, 0, 1)
+	additive_damage[SM_DAMAGE_MOLES] = clamp((total_moles - MOLE_PENALTY_THRESHOLD) / 320, 0, 1)
+	// Can be unified with [SM_DAMAGE_HEAT] but splitting heating and healing is better for presentation.
+	// Lets us tack on additional logic too.
+	if(total_moles)
+		additive_damage[SM_DAMAGE_HEAL_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 600, -1, 0)
 
 	for(var/turf/open/space/turf_to_check in RANGE_TURFS(1, loc))
 		if(LAZYLEN(turf_to_check.atmos_adjacent_turfs))

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -670,6 +670,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		return
 
 	var/list/additive_damage = list()
+	var/total_moles = absorbed_gasmix.total_moles()
 
 	// We dont let external factors deal more damage than the emergency point.
 	// Only cares about var/damage (last tick) and not the var/damage + damage this tick.

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -681,13 +681,15 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	additive_damage[SM_DAMAGE_POWER] = clamp((internal_energy - POWER_PENALTY_THRESHOLD) / 2000, 0, 1)
 	additive_damage[SM_DAMAGE_MOLES] = clamp((total_moles - MOLE_PENALTY_THRESHOLD) / 320, 0, 1)
 
+	var/is_spaced = FALSE
 	if(isturf(src.loc))
 		var/turf/local_turf = src.loc
 		for (var/turf/open/space/turf in ((local_turf.atmos_adjacent_turfs || list()) + local_turf))
 			additive_damage[SM_DAMAGE_SPACED] = clamp(internal_energy * 0.00125, 0, 10)
+			is_spaced = true
 			break
 
-	if(total_moles > 0 && !additive_damage[SM_DAMAGE_SPACED])
+	if(total_moles > 0 && !spaced)
 		additive_damage[SM_DAMAGE_HEAL_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 600, -1, 0)
 
 	var/total_damage = 0

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -689,7 +689,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			is_spaced = true
 			break
 
-	if(total_moles > 0 && !spaced)
+	if(total_moles > 0 && !is_spaced)
 		additive_damage[SM_DAMAGE_HEAL_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 600, -1, 0)
 
 	var/total_damage = 0

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -672,7 +672,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/list/additive_damage = list()
 
 	// We dont let external factors deal more damage than the emergency point.
-	// Only cares about current damage (last tick) and not the damage + damage this tick.
+	// Only cares about var/damage (last tick) and not the var/damage + damage this tick.
 	// Helps us decouple this and make it discrete.
 	additive_damage[SM_DAMAGE_EXTERNAL] = external_damage_immediate * clamp((emergency_point - damage) / emergency_point, 0, 1)
 	external_damage_immediate = 0

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -681,16 +681,14 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	additive_damage[SM_DAMAGE_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 2400, 0, 1.5)
 	additive_damage[SM_DAMAGE_POWER] = clamp((internal_energy - POWER_PENALTY_THRESHOLD) / 2000, 0, 1)
 	additive_damage[SM_DAMAGE_MOLES] = clamp((total_moles - MOLE_PENALTY_THRESHOLD) / 320, 0, 1)
-	// Can be unified with [SM_DAMAGE_HEAT] but splitting heating and healing is better for presentation.
-	// Lets us tack on additional logic too.
-	if(total_moles)
-		additive_damage[SM_DAMAGE_HEAL_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 600, -1, 0)
 
 	for(var/turf/open/space/turf_to_check in RANGE_TURFS(1, loc))
 		if(LAZYLEN(turf_to_check.atmos_adjacent_turfs))
 			additive_damage[SM_DAMAGE_SPACED] = clamp(internal_energy * 0.00125, 0, 10)
-			additive_damage[SM_DAMAGE_HEAL_HEAT] = 0
 			break
+
+	if(total_moles > 0 && !additive_damage[SM_DAMAGE_SPACED])
+		additive_damage[SM_DAMAGE_HEAL_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 600, -1, 0)
 
 	var/total_damage = 0
 	for (var/damage_type in additive_damage)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -673,8 +673,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/total_moles = absorbed_gasmix.total_moles()
 
 	// We dont let external factors deal more damage than the emergency point.
-	// Only cares about var/damage (last tick) and not the var/damage + damage this tick.
-	// Helps us decouple this and make it discrete.
+	// Only cares about the damage before this proc is run. We ignore soon-to-be-applied damage.
 	additive_damage[SM_DAMAGE_EXTERNAL] = external_damage_immediate * clamp((emergency_point - damage) / emergency_point, 0, 1)
 	external_damage_immediate = 0
 

--- a/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
@@ -93,7 +93,3 @@ GLOBAL_LIST_INIT(sm_delam_list, list(
 	messages += "Crystalline hyperstructure returning to safe operating parameters. Failsafe has been disengaged."
 	messages += "remain before causality stabilization."
 	return messages
-
-/// Adjusts the damage and mole limit at which we start taking damage.
-/datum/sm_delam/proc/mole_power_damage_limit(obj/machinery/power/supermatter_crystal/sm)
-	return 1

--- a/code/modules/power/supermatter/supermatter_delamination/cascade_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/cascade_delam.dm
@@ -81,9 +81,6 @@
 	messages += "remain before resonance-induced stabilization."
 	return messages
 
-/datum/sm_delam/cascade/mole_power_damage_limit(obj/machinery/power/supermatter_crystal/sm)
-	return 0.25
-
 /datum/sm_delam/cascade/proc/announce_cascade(obj/machinery/power/supermatter_crystal/sm)
 	if(QDELETED(sm))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
We apply the damage hardcap individually now, split off the old flat 1.8 into individual caps for heat, moles, and power.

Set it to 1.5 for heat, 1 for mole and 1 for power. This means for most delams it'll be a tad slower! But its possible to make SM delam nearly twice as fast if you combine all 3. (3.5). Be pretty hard tho.

Set the heat healing to -1 so you can counteract one factor at most (except heat since you'll never get both heat healing and heat damage at the same time anyway).

**I'm not hell bent on any of the numbers, just picked round even ones and ones that i think will make sense. If you want them changed lmk.**

Got rid of the cascade mole and power multipliers since there's probably like three people that are aware that it even exists. Ideally we just add another entry to the CIMS but its already pretty crowded. Figured nobody is gonna miss it anyway? Sorry ghil.

Got rid of the moles multiplier thing since its nicer to keep the temp damage fully based on temp damage instead of adding another multiplier. I just applied the .25 to the damage flatly, meaning it slows down delams again!

And some space exposure stuff: https://github.com/tgstation/tgstation/pull/70347#issuecomment-1270029768

## Why It's Good For The Game
Hardcap: Discrete, less randomly interconnected factors are easier to present and remember. The calculation procs are also made to be additive so we had to hack a bit and do some rescaling to accomodate the old behavior in my original PR #69240. Can remove the hack if this pr goes through.

Cascade and mole multiplier: The rest are just getting rid of underutilized factors so we have a cleaner behavior to maintain, present, and understand. (In a perfect world modifiers that aren't visible to the players shouldn't have been merged in the first place smh smh)

## Changelog
:cl:
fix: Fixed sm space exposure damage going through walls
del: got rid of the molar multiplier for sm heating damage. It will now only impact molar damage and temp limit. We apply the lowest value directly so this slows down sm delams a tiny bit.
del: got rid of cascades making sm delam at 450 moles and 1250 mev. It delams normally now.
balance: Applied the sm damage hardcap of 1.8 individually to heat (1.5), moles (1), power (1). Meaning most sm delams are slower now, but the really bad ones can be faster.
balance: Halved sm temp healing across the board. Temp limits are still the same though so you shouldn't notice it that much.
balance: Halved SM power damage across the board.
balance: Changed sm space exposure damage to just check for the current tile and adjacent atmos connected tiles.
/:cl: