### PR TITLE
Updates the description of rechargers

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "recharger"
 	base_icon_state = "recharger"
-	desc = "A charging dock for energy based weaponry."
+	desc = "A charging dock for energy based weaponry and PDAs."
 	circuit = /obj/item/circuitboard/machine/recharger
 	pass_flags = PASSTABLE
 	var/obj/item/charging = null

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "recharger"
 	base_icon_state = "recharger"
-	desc = "A charging dock for energy based weaponry and PDAs."
+	desc = "A charging dock for energy based weaponry, PDAs, and other devices."
 	circuit = /obj/item/circuitboard/machine/recharger
 	pass_flags = PASSTABLE
 	var/obj/item/charging = null


### PR DESCRIPTION
## About The Pull Request
Changes the description of chargers to mention their ability to charge PDAs.

## Why It's Good For The Game
Makes it more clear how to charge PDAs so people know they can be recharged instead of having to have their cell replaced.
Also makes the rechargers description more accurate.

## Changelog
:cl:
spellcheck: Makes the description of rechargers mention that they can recharge PDAs as well.
/:cl: