### PR TITLE
Revert Statpanel to use verbs instead of SendMessage

### DIFF
--- a/code/__DEFINES/statpanel.dm
+++ b/code/__DEFINES/statpanel.dm
@@ -1,0 +1,7 @@
+/// Bare minimum required verbs for stat panel operation
+GLOBAL_LIST_INIT(stat_panel_verbs, list(
+	/client/verb/set_tab,
+	/client/verb/send_tabs,
+	/client/verb/remove_tabs,
+	/client/verb/reset_tabs
+))

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -299,6 +299,38 @@ SUBSYSTEM_DEF(statpanels)
 	else if(length(GLOB.sdql2_queries) && target.stat_tab == "SDQL2")
 		set_SDQL2_tab(target)
 
+/// verbs that send information from the browser UI
+/client/verb/set_tab(tab as text|null)
+	set name = "Set Tab"
+	set hidden = TRUE
+
+	stat_tab = tab
+	SSstatpanels.immediate_send_stat_data(src)
+
+/client/verb/send_tabs(tabs as text|null)
+	set name = "Send Tabs"
+	set hidden = TRUE
+
+	panel_tabs |= tabs
+
+/client/verb/remove_tabs(tabs as text|null)
+	set name = "Remove Tabs"
+	set hidden = TRUE
+
+	panel_tabs -= tabs
+
+/client/verb/reset_tabs()
+	set name = "Reset Tabs"
+	set hidden = TRUE
+
+	panel_tabs = list()
+
+/client/verb/update_verbs()
+	set name = "Update Verbs"
+	set hidden = TRUE
+
+	init_verbs()
+
 /// Stat panel window declaration
 /client/var/datum/tgui_window/stat_panel
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -223,7 +223,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	// Instantiate stat panel
 	stat_panel = new(src, "statbrowser")
-	stat_panel.subscribe(src, .proc/on_stat_panel_message)
 
 	// Instantiate tgui panel
 	tgui_panel = new(src, "browseroutput")
@@ -1198,23 +1197,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		SSambience.ambience_listening_clients[src] = world.time + 10 SECONDS //Just wait 10 seconds before the next one aight mate? cheers.
 	else
 		SSambience.remove_ambience_client(src)
-
-/**
- * Handles incoming messages from the stat-panel TGUI.
- */
-/client/proc/on_stat_panel_message(type, payload)
-	switch(type)
-		if("Update-Verbs")
-			init_verbs()
-		if("Remove-Tabs")
-			panel_tabs -= payload["tab"]
-		if("Send-Tabs")
-			panel_tabs |= payload["tab"]
-		if("Reset-Tabs")
-			panel_tabs = list()
-		if("Set-Tab")
-			stat_tab = payload["tab"]
-			SSstatpanels.immediate_send_stat_data(src)
 
 /// Checks if this client has met the days requirement passed in, or if
 /// they are exempt from it.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -177,6 +177,7 @@
 #include "code\__DEFINES\stat.dm"
 #include "code\__DEFINES\stat_tracking.dm"
 #include "code\__DEFINES\station.dm"
+#include "code\__DEFINES\statpanel.dm"
 #include "code\__DEFINES\status_effects.dm"
 #include "code\__DEFINES\storage.dm"
 #include "code\__DEFINES\strippable.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reverts the statpanel back to using verbs instead of Topic calls.
This is done to prevent it hitting the topic limiter when you re(connect) to the server:
![image](https://user-images.githubusercontent.com/33846895/194387527-a1087fd4-8557-416b-a320-f033e85d8699.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Calls from the statpanel getting blocked by the topic limiter is probably a bad thing.
Surprised it didn't break anything.
Stylemistake said reverting the statpanel to verbs is fine.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Gamer025
fix: You should no longer receive "Your previous action was ignored..." messages when you join a server
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
