### PR TITLE
Functionality for custom human examine messages when possessed by an AI controller. Implements on humans with monkey AI

### DIFF
--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -276,3 +276,8 @@ multiple modular subtrees with behaviors
 		if(iter_behavior.required_distance < minimum_distance)
 			minimum_distance = iter_behavior.required_distance
 	return minimum_distance
+
+/// If this controller is applied to a human subtype, this proc will be called to generate examine text
+/datum/ai_controller/proc/get_human_examine_text()
+	var/text = "[span_deadsay("[pawn.p_they(TRUE)] do[pawn.p_es()]n't appear to be [pawn.p_them()]self.")]"
+	return text

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -99,6 +99,10 @@ have ways of interacting with a specific mob and control it.
 		return FALSE
 	return ..()
 
+/datum/ai_controller/monkey/get_human_examine_text()
+	var/text = "[span_monkey("[pawn.p_they(TRUE)] have a primal look in [pawn.p_their()] eyes.")]"
+	return text
+
 /datum/ai_controller/monkey/proc/set_trip_mode(mode = TRUE)
 	var/mob/living/carbon/regressed_monkey = pawn
 	var/brain = regressed_monkey.getorganslot(ORGAN_SLOT_BRAIN)
@@ -228,3 +232,5 @@ have ways of interacting with a specific mob and control it.
 /datum/ai_controller/monkey/proc/target_del(target)
 	SIGNAL_HANDLER
 	blackboard[BB_MONKEY_BLACKLISTITEMS] -= target
+
+

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -232,5 +232,3 @@ have ways of interacting with a specific mob and control it.
 /datum/ai_controller/monkey/proc/target_del(target)
 	SIGNAL_HANDLER
 	blackboard[BB_MONKEY_BLACKLISTITEMS] -= target
-
-

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -6,7 +6,6 @@
 	var/t_him = p_them()
 	var/t_has = p_have()
 	var/t_is = p_are()
-	var/t_es = p_es()
 	var/obscure_name
 
 	if(isliving(user))
@@ -330,7 +329,7 @@
 		if(getorgan(/obj/item/organ/internal/brain))
 			if(ai_controller?.ai_status == AI_STATUS_ON)
 				if(!dna.species.ai_controlled_species)
-					msg += "[span_deadsay("[t_He] do[t_es]n't appear to be [t_him]self.")]\n"
+					msg += "[ai_controller.get_human_examine_text()]\n"
 			else if(!key)
 				msg += "[span_deadsay("[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.")]\n"
 			else if(!client)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The "They don't appear to be themselves" line on humans that have AI controllers is now controllable by the AI controller, and is only "They don't appear to be themselves" by default.
Monkeized human now have the line
![image](https://user-images.githubusercontent.com/55666666/194391868-b2684a70-65aa-49f9-b9c0-8e8f9cd4c8ec.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No tangible gameplay effects, offers an opportunity for coders of the future to have AI controlled with custom examine text.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: itseasytosee
code: Changed the examine text on monkeized humans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
