### PR TITLE
The Living Heart ritual kickstarts your heart for you, if it's not beating

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -146,11 +146,6 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	if(our_new_heart.status != ORGAN_ORGANIC || (our_new_heart.organ_flags & ORGAN_SYNTHETIC))
 		var/obj/item/organ/our_replacement_heart = locate(required_organ_type) in selected_atoms
 		if(our_replacement_heart)
-			// Icky snowflake but if the organ is a heart, it needs to be restarted / start beating again
-			if(istype(our_replacement_heart, /obj/item/organ/internal/heart))
-				var/obj/item/organ/internal/heart/actually_a_heart_replacement = our_replacement_heart
-				actually_a_heart_replacement.Restart()
-
 			// Throw our current heart out of our chest, violently
 			user.visible_message(span_boldwarning("[user]'s [our_new_heart.name] bursts suddenly out of [user.p_their()] chest!"))
 			INVOKE_ASYNC(user, /mob/proc/emote, "scream")
@@ -161,6 +156,15 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 			our_new_heart = our_replacement_heart
 		else
 			CRASH("[type] required a replacement organic heart in on_finished_recipe, but did not find one.")
+
+	if(!our_new_heart)
+		CRASH("[type] somehow made it to on_finished_recipe without a heart. What?")
+
+	// Snowflakey, but if the user used a heart that wasn't beating
+	// they'll immediately collapse into a heart attack. Funny but not ideal.
+	if(iscarbon(user))
+		var/mob/living/carbon/carbon_user = user
+		carbon_user.set_heartattack(FALSE)
 
 	// Don't delete our shiny new heart
 	selected_atoms -= our_new_heart

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -146,6 +146,11 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	if(our_new_heart.status != ORGAN_ORGANIC || (our_new_heart.organ_flags & ORGAN_SYNTHETIC))
 		var/obj/item/organ/our_replacement_heart = locate(required_organ_type) in selected_atoms
 		if(our_replacement_heart)
+			// Icky snowflake but if the organ is a heart, it needs to be restarted / start beating again
+			if(istype(our_replacement_heart, /obj/item/organ/internal/heart))
+				var/obj/item/organ/internal/heart/actually_a_heart_replacement = our_replacement_heart
+				actually_a_heart_replacement.Restart()
+
 			// Throw our current heart out of our chest, violently
 			user.visible_message(span_boldwarning("[user]'s [our_new_heart.name] bursts suddenly out of [user.p_their()] chest!"))
 			INVOKE_ASYNC(user, /mob/proc/emote, "scream")
@@ -157,13 +162,9 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 		else
 			CRASH("[type] required a replacement organic heart in on_finished_recipe, but did not find one.")
 
-	if(!our_new_heart)
-		CRASH("[type] somehow made it to on_finished_recipe without a heart. What?")
-
 	// Don't delete our shiny new heart
-	if(our_new_heart in selected_atoms)
-		selected_atoms -= our_new_heart
-
+	selected_atoms -= our_new_heart
+	// Make it the living heart
 	our_new_heart.AddComponent(/datum/component/living_heart)
 	to_chat(user, span_warning("You feel your [our_new_heart.name] begin pulse faster and faster as it awakens!"))
 	playsound(user, 'sound/magic/demon_consume.ogg', 50, TRUE)


### PR DESCRIPTION
## About The Pull Request

- Completing the Living Heart ritual with a replacement heart that isn't beating will stop the oncoming heart attack. 

## Why It's Good For The Game

- It's funny to see a heretic instantly drop dead after replacing their heart with a new one, but it's kind of a noob trap to expect them to MANUALLY pump the heart before doing the ritual. 

## Changelog

:cl: Melbert
qol: Completing "The Living Heart" ritual with a replacement heart will restart a heart if it's not beating.
/:cl: