### PR TITLE
Fixes Shuttle Collision on Runtime Station

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1968,6 +1968,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"lH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "lX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -7461,7 +7467,7 @@ fI
 ga
 ga
 ga
-aa
+ga
 aa
 aa
 aa
@@ -7552,8 +7558,8 @@ cS
 fO
 fO
 fO
+fO
 gf
-aa
 aa
 aa
 aa
@@ -7644,8 +7650,8 @@ cS
 fO
 fO
 fO
+fO
 fb
-aa
 aa
 aa
 aa
@@ -7736,8 +7742,8 @@ cS
 fO
 fO
 fO
+fO
 gf
-aa
 aa
 aa
 aa
@@ -7828,8 +7834,8 @@ cS
 fP
 fO
 fO
+fO
 fb
-aa
 aa
 aa
 aa
@@ -7920,8 +7926,8 @@ cS
 gz
 fO
 fO
+fO
 gf
-aa
 aa
 aa
 aa
@@ -8012,8 +8018,8 @@ cS
 fQ
 fO
 fO
+fO
 ga
-aa
 aa
 aa
 aa
@@ -8102,10 +8108,10 @@ dJ
 dJ
 cS
 fS
-fO
+lH
+gb
 fO
 gk
-aa
 aa
 aa
 aa
@@ -8194,10 +8200,10 @@ eH
 fH
 fR
 fW
-gb
+lH
+fO
 fO
 ga
-aa
 aa
 aa
 aa
@@ -8288,8 +8294,8 @@ cS
 pv
 fO
 fO
+fO
 gf
-aa
 aa
 aa
 aa
@@ -8380,9 +8386,9 @@ cS
 Ih
 fO
 fO
+fO
 fb
 fp
-aa
 aa
 aa
 aa
@@ -8472,8 +8478,8 @@ et
 Sp
 fO
 fO
+fO
 gf
-aa
 aa
 aa
 aa
@@ -8564,8 +8570,8 @@ et
 fO
 fO
 fO
+fO
 fb
-aa
 aa
 aa
 aa
@@ -8656,8 +8662,8 @@ et
 fO
 fO
 fO
+fO
 gf
-aa
 aa
 aa
 aa
@@ -8749,7 +8755,7 @@ ga
 ga
 ga
 ga
-aa
+ga
 aa
 aa
 aa

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1678,27 +1678,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"fU" = (
-/obj/machinery/airalarm/unlocked{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"fV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "fW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 9
+	dir = 6
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -1862,14 +1844,6 @@
 /obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"gA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "gB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -1907,14 +1881,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/construction)
-"gH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/camera/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "gI" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north,
@@ -2047,6 +2013,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
+"pv" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "pA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -2342,6 +2312,10 @@
 /obj/machinery/rnd/production/techfab/department,
 /turf/open/floor/iron,
 /area/station/science)
+"Ih" = (
+/obj/machinery/camera/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "Ir" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2491,6 +2465,13 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/medical/medbay)
+"Sp" = (
+/obj/machinery/airalarm/unlocked{
+	dir = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "Td" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -7108,10 +7089,10 @@ cS
 cS
 cS
 cS
-fI
-ga
-ga
-ga
+Tt
+Rb
+aa
+aa
 aa
 aa
 aa
@@ -7200,10 +7181,10 @@ dl
 dp
 dE
 cS
-fO
-fO
-fO
-gf
+Tt
+bL
+aa
+aa
 aa
 aa
 aa
@@ -7292,10 +7273,10 @@ dC
 dC
 eW
 vv
-fO
-fO
-fO
-fb
+Tt
+bL
+aa
+aa
 aa
 aa
 aa
@@ -7384,10 +7365,10 @@ dJ
 dJ
 dJ
 cS
-fO
-fO
-fO
-gf
+Tt
+bL
+aa
+aa
 aa
 aa
 aa
@@ -7476,10 +7457,10 @@ dJ
 dJ
 ny
 cS
-fP
-fO
-fO
-fb
+fI
+ga
+ga
+ga
 aa
 aa
 aa
@@ -7568,7 +7549,7 @@ dJ
 dJ
 dO
 cS
-gz
+fO
 fO
 fO
 gf
@@ -7660,10 +7641,10 @@ dJ
 dJ
 jU
 cS
-fQ
 fO
 fO
-ga
+fO
+fb
 aa
 aa
 aa
@@ -7752,10 +7733,10 @@ dJ
 dJ
 ea
 cS
-fS
 fO
 fO
-gk
+fO
+gf
 aa
 aa
 aa
@@ -7844,10 +7825,10 @@ dJ
 dJ
 sH
 cS
-fU
-gb
+fP
 fO
-ga
+fO
+fb
 aa
 aa
 aa
@@ -7936,7 +7917,7 @@ dJ
 dJ
 dQ
 cS
-gA
+gz
 fO
 fO
 gf
@@ -8028,11 +8009,11 @@ dJ
 dJ
 dN
 cS
-gH
+fQ
 fO
 fO
-fb
-fp
+ga
+aa
 aa
 aa
 aa
@@ -8120,10 +8101,10 @@ dJ
 dJ
 dJ
 cS
-fV
+fS
 fO
 fO
-gf
+gk
 aa
 aa
 aa
@@ -8213,9 +8194,9 @@ eH
 fH
 fR
 fW
+gb
 fO
-fO
-fb
+ga
 aa
 aa
 aa
@@ -8304,7 +8285,7 @@ dl
 dx
 dE
 cS
-fO
+pv
 fO
 fO
 gf
@@ -8396,11 +8377,11 @@ cS
 cS
 cS
 cS
-ga
-ga
-ga
-ga
-aa
+Ih
+fO
+fO
+fb
+fp
 aa
 aa
 aa
@@ -8488,10 +8469,10 @@ eu
 eu
 eu
 et
-aa
-aa
-aa
-aa
+Sp
+fO
+fO
+gf
 aa
 aa
 aa
@@ -8580,10 +8561,10 @@ fo
 eu
 eu
 et
-aa
-aa
-aa
-aa
+fO
+fO
+fO
+fb
 aa
 aa
 aa
@@ -8672,10 +8653,10 @@ fm
 fm
 ev
 et
-aa
-aa
-aa
-aa
+fO
+fO
+fO
+gf
 aa
 aa
 aa
@@ -8764,10 +8745,10 @@ fh
 fh
 fh
 et
-aa
-aa
-aa
-aa
+ga
+ga
+ga
+ga
 aa
 aa
 aa


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

I was testing some code, and noticed this chicanery where the _default shuttle_ for Runtime Station would collide like this:

![image](https://user-images.githubusercontent.com/34697715/194428994-e0f55743-7651-4d09-9545-a2f959541a72.png)

That fucking blows! I want undamaged stations, especially during test environments. Let's increase the distance between the evacuation docks and that small circuits... bulge... to prevent collosions like this happening, while still maintaining some kind of symmetry.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/194429023-3e883775-b7a1-404f-a7a0-3addcab7b7fa.png)

Maintains whatever semblance of design we want to have here, while also preventing stupid collisions like this.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: On RuntimeStation, should you chance upon it, the emergency shuttle should no longer collide by the with the circuits lab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
