### PR TITLE
[NO GBP] Fix traitor PDA uplinks to be accessible by illiterate people

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -36,17 +36,20 @@
 		icon_state = icon_state_powered = icon_state_unpowered = "[base_icon_state]-[finish_color]"
 	return ..()
 
-/obj/item/modular_computer/tablet/interact(mob/user)
+/obj/item/modular_computer/tablet/attack_self(mob/user)
 	// bypass literacy checks to access syndicate uplink
-	if(HAS_TRAIT(user, TRAIT_ILLITERATE))
-		var/datum/component/uplink/hidden_uplink = GetComponent(/datum/component/uplink)
-		if(hidden_uplink)
-			if(owner != user?.key) 
-			locked = FALSE
-			hidden_uplink.interact(null, user)
-			return // hidden_uplink.interact(null, user)
+	var/datum/component/uplink/hidden_uplink = GetComponent(/datum/component/uplink)
+	if(hidden_uplink?.owner && HAS_TRAIT(user, TRAIT_ILLITERATE))
+		if(hidden_uplink.owner != user.key)
+			return COMPONENT_CANCEL_ATTACK_CHAIN
+
+		hidden_uplink.locked = FALSE
+		hidden_uplink.interact(null, user)
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	. = ..()
+
+/obj/item/modular_computer/tablet/interact(mob/user)
 	if(HAS_TRAIT(src, TRAIT_PDA_MESSAGE_MENU_RIGGED))
 		explode(usr, from_message_menu = TRUE)
 		return

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -41,7 +41,7 @@
 	var/datum/component/uplink/hidden_uplink = GetComponent(/datum/component/uplink)
 	if(hidden_uplink?.owner && HAS_TRAIT(user, TRAIT_ILLITERATE))
 		if(hidden_uplink.owner != user.key)
-			return COMPONENT_CANCEL_ATTACK_CHAIN
+			return ..()
 
 		hidden_uplink.locked = FALSE
 		hidden_uplink.interact(null, user)

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -47,7 +47,7 @@
 		hidden_uplink.interact(null, user)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	. = ..()
+	return ..()
 
 /obj/item/modular_computer/tablet/interact(mob/user)
 	. = ..()

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -50,6 +50,7 @@
 	. = ..()
 
 /obj/item/modular_computer/tablet/interact(mob/user)
+	. = ..()
 	if(HAS_TRAIT(src, TRAIT_PDA_MESSAGE_MENU_RIGGED))
 		explode(usr, from_message_menu = TRUE)
 		return

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -37,6 +37,15 @@
 	return ..()
 
 /obj/item/modular_computer/tablet/interact(mob/user)
+	// bypass literacy checks to access syndicate uplink
+	if(HAS_TRAIT(user, TRAIT_ILLITERATE))
+		var/datum/component/uplink/hidden_uplink = GetComponent(/datum/component/uplink)
+		if(hidden_uplink)
+			if(owner != user?.key) 
+			locked = FALSE
+			hidden_uplink.interact(null, user)
+			return // hidden_uplink.interact(null, user)
+
 	. = ..()
 	if(HAS_TRAIT(src, TRAIT_PDA_MESSAGE_MENU_RIGGED))
 		explode(usr, from_message_menu = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Taking the illiterate quirk prevented people who spawned as a traitor from using the uplink in their PDAs.  I added some code to bypass these checks, so it unlocks the PDA (only if it belongs to them) and goes directly to the uplink menu.

They still cannot access the regular PDA menu.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

There were lots of complaints and ahelps that this quirk was not allowing people to access their traitor gear.  This should help fix this problem.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix traitor PDA uplinks to be accessible by illiterate people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
