### PR TITLE
Fix an edge case where holding down multiple clicks at once would register attacks as the wrong click

### DIFF
--- a/code/__DEFINES/_click.dm
+++ b/code/__DEFINES/_click.dm
@@ -1,10 +1,14 @@
 //Defines file for byond click related parameters
 //this is mostly for ease of use and for finding all the things that use say RIGHT_CLICK rather then just searching "right"
 
-//Mouse buttons pressed/held/released
+//Mouse buttons held
 #define RIGHT_CLICK "right"
 #define MIDDLE_CLICK "middle"
 #define LEFT_CLICK "left"
+
+///Mouse button that was just clicked/released
+///if(modifiers[BUTTON] == LEFT_CLICK)
+#define BUTTON "button"
 
 //Keys held down during the mouse action
 #define CTRL_CLICK "ctrl"

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -599,7 +599,7 @@
 		balloon_alert(user, "wrong seat for equipment!")
 		return
 	var/obj/item/mecha_parts/mecha_equipment/selected
-	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+	if(modifiers[BUTTON] == RIGHT_CLICK)
 		selected = equip_by_category[MECHA_R_ARM]
 	else
 		selected = equip_by_category[MECHA_L_ARM]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Basically lummox lied in the ref it says "left, middle, right: Mouse buttons pressed/held/released" ("left" = 1)

HOWEVER this is ONLY the buttons held and there is a **undocumented** param added in 513 called "button" which ACTUALLY shows the click that was changed ("button" = "left")

and ALL THE CODE USES THE FIRST INSTEAD OF BUTTON

this is particularily relevant for mousedown()/mouseup() code since it calls the wrong procs if you hold multiple

How nobody noticed this until now is a mystery
## Why It's Good For The Game

I love byonds mouse API so much

Also I changed mech code for testing this + this came up noticed it when debugging something for mechs


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
