### PR TITLE
Adds the ability to focus on a specific virus symptom using chemicals (makes virology actually good)

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -198,7 +198,9 @@
 /datum/disease/advance/proc/get_silver_focus(datum/reagents/container)
 	if (!container.has_reagent(/datum/reagent/silver))
 		return null
-	return symptoms[min(ROUND_UP(container.get_reagent_amount(/datum/reagent/silver)), symptoms.len)]
+	. = symptoms[min(ROUND_UP(container.get_reagent_amount(/datum/reagent/silver)), symptoms.len)]
+	container.del_reagent(/datum/reagent/silver)
+	return .
 
 /// Returns the currently focused symptoms, if there are any. Determined by the reagents in the container. Maximum returned symptom amount is dependent on the symptom limit.
 /datum/disease/advance/proc/get_focused_symptoms(datum/reagents/container, level_min, level_max)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -215,7 +215,7 @@
 				if(!not_focused.len) // If a chemical has all of it's focuses matched, the if statement will pass, adding it to the pool.
 					possible_focuses += S
 	if(possible_focuses.len + symptoms.len > VIRUS_SYMPTOM_LIMIT) // If there are too many focused symptoms in the pool to add, we simply remove some until we're under the cap again.
-		for(var/i = possible_focuses.len, i > 0, i--)
+		for(var/i = possible_focuses.len, i > 0, i--) // Guh C-style loop, had to do it because the entire purpose of the loop is to remove things from the list determining it's length.
 			if (possible_focuses.len <= VIRUS_SYMPTOM_LIMIT)
 				break
 			pick_n_take(possible_focuses)

--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -18,6 +18,7 @@
 	severity = 1
 	symptom_delay_min = 18
 	symptom_delay_max = 36
+	focuses = list(/datum/reagent/concentrated_barbers_aid)
 
 	var/list/beard_order = list("Beard (Jensen)", "Beard (Full)", "Beard (Dwarf)", "Beard (Very Long)")
 

--- a/code/datums/diseases/advance/symptoms/chills.dm
+++ b/code/datums/diseases/advance/symptoms/chills.dm
@@ -20,6 +20,7 @@
 	symptom_delay_min = 10
 	symptom_delay_max = 30
 	var/unsafe = FALSE //over the cold threshold
+	focuses = list(/datum/reagent/cryostylane)
 	threshold_descs = list(
 		"Stage Speed 5" = "Increases the intensity of the cooling; the host can fall below safe temperature levels.",
 		"Stage Speed 10" = "Increases the intensity of the cooling even further."

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -19,6 +19,7 @@
 	base_message_chance = 15
 	symptom_delay_min = 10
 	symptom_delay_max = 30
+	focuses = list(/datum/reagent/toxin/lexorin)
 	threshold_descs = list(
 		"Stage Speed 8" = "Causes choking more frequently.",
 		"Stealth 4" = "The symptom remains hidden until active."
@@ -94,6 +95,7 @@ Bonus
 	symptom_delay_min = 14
 	symptom_delay_max = 30
 	var/paralysis = FALSE
+	focuses = list(/datum/reagent/toxin/lexorin, /datum/reagent/toxin/cyanide)
 	threshold_descs = list(
 		"Stage Speed 8" = "Additionally synthesizes pancuronium and sodium thiopental inside the host.",
 		"Transmission 8" = "Doubles the damage caused by the symptom."

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -95,7 +95,7 @@ Bonus
 	symptom_delay_min = 14
 	symptom_delay_max = 30
 	var/paralysis = FALSE
-	focuses = list(/datum/reagent/toxin/lexorin, /datum/reagent/toxin/cyanide)
+	focuses = list(/datum/reagent/toxin/lexorin)
 	threshold_descs = list(
 		"Stage Speed 8" = "Additionally synthesizes pancuronium and sodium thiopental inside the host.",
 		"Transmission 8" = "Doubles the damage caused by the symptom."

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -18,7 +18,7 @@
 	base_message_chance = 25
 	symptom_delay_min = 10
 	symptom_delay_max = 30
-	focuses = list(/datum/reagent/impedrezene, /datum/reagent/mercury)
+	focuses = list(/datum/reagent/impedrezene)
 	threshold_descs = list(
 		"Stage Speed 6" = "Prevents any form of reading or writing.",
 		"Resistance 6" = "Causes brain damage over time.",

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -18,6 +18,7 @@
 	base_message_chance = 25
 	symptom_delay_min = 10
 	symptom_delay_max = 30
+	focuses = list(/datum/reagent/impedrezene, /datum/reagent/mercury)
 	threshold_descs = list(
 		"Stage Speed 6" = "Prevents any form of reading or writing.",
 		"Resistance 6" = "Causes brain damage over time.",

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -19,7 +19,7 @@
 	symptom_delay_min = 2
 	symptom_delay_max = 15
 	var/spread_range = 1
-	focuses = list(/datum/reagent/toxin/itching_powder, /datum/reagent/consumable/salt)
+	focuses = list(/datum/reagent/drug/nicotine)
 	threshold_descs = list(
 		"Resistance 11" = "The host will drop small items when coughing.",
 		"Resistance 15" = "Occasionally causes coughing fits that stun the host. The extra coughs do not spread the virus.",

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -19,6 +19,7 @@
 	symptom_delay_min = 2
 	symptom_delay_max = 15
 	var/spread_range = 1
+	focuses = list(/datum/reagent/toxin/itching_powder, /datum/reagent/consumable/salt)
 	threshold_descs = list(
 		"Resistance 11" = "The host will drop small items when coughing.",
 		"Resistance 15" = "Occasionally causes coughing fits that stun the host. The extra coughs do not spread the virus.",

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -18,6 +18,7 @@
 	base_message_chance = 100
 	symptom_delay_min = 25
 	symptom_delay_max = 80
+	focuses = list(/datum/reagent/medicine/inacusiate, /datum/reagent/fuel/oil)
 	threshold_descs = list(
 		"Resistance 9" = "Causes permanent deafness, instead of intermittent.",
 		"Stealth 4" = "The symptom remains hidden until active.",

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -18,7 +18,7 @@
 	base_message_chance = 100
 	symptom_delay_min = 25
 	symptom_delay_max = 80
-	focuses = list(/datum/reagent/medicine/inacusiate, /datum/reagent/fuel/oil)
+	focuses = list(/datum/reagent/sonic_powder)
 	threshold_descs = list(
 		"Resistance 9" = "Causes permanent deafness, instead of intermittent.",
 		"Stealth 4" = "The symptom remains hidden until active.",

--- a/code/datums/diseases/advance/symptoms/disfiguration.dm
+++ b/code/datums/diseases/advance/symptoms/disfiguration.dm
@@ -17,6 +17,7 @@
 	severity = 1
 	symptom_delay_min = 25
 	symptom_delay_max = 75
+	focuses = list(/datum/reagent/toxin/acid/fluacid)
 
 /datum/symptom/disfiguration/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -19,6 +19,7 @@
 	base_message_chance = 50
 	symptom_delay_min = 15
 	symptom_delay_max = 30
+	focuses = list(/datum/reagent/impedrezene, /datum/reagent/toxin/mindbreaker)
 	threshold_descs = list(
 		"Transmission 6" = "Also causes druggy vision.",
 		"Stealth 4" = "The symptom remains hidden until active.",

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -19,7 +19,7 @@
 	base_message_chance = 50
 	symptom_delay_min = 15
 	symptom_delay_max = 30
-	focuses = list(/datum/reagent/impedrezene, /datum/reagent/toxin/mindbreaker)
+	focuses = list(/datum/reagent/cryptobiolin)
 	threshold_descs = list(
 		"Transmission 6" = "Also causes druggy vision.",
 		"Stealth 4" = "The symptom remains hidden until active.",

--- a/code/datums/diseases/advance/symptoms/fever.dm
+++ b/code/datums/diseases/advance/symptoms/fever.dm
@@ -21,6 +21,7 @@
 	symptom_delay_min = 10
 	symptom_delay_max = 30
 	var/unsafe = FALSE //over the heat threshold
+	focuses = list(/datum/reagent/pyrosium)
 	threshold_descs = list(
 		"Resistance 5" = "Increases fever intensity, fever can overheat and harm the host.",
 		"Resistance 10" = "Further increases fever intensity.",

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -20,6 +20,7 @@
 	symptom_delay_min = 20
 	symptom_delay_max = 75
 	var/infective = FALSE
+	focuses = list(/datum/reagent/phlogiston)
 	threshold_descs = list(
 		"Stage Speed 4" = "Increases the intensity of the flames.",
 		"Stage Speed 8" = "Further increases flame intensity.",
@@ -101,6 +102,7 @@ Bonus
 	symptom_delay_max = 90
 	var/chems = FALSE
 	var/explosion_power = 1
+	focuses = list(/datum/reagent/water, /datum/reagent/napalm)
 	threshold_descs = list(
 		"Resistance 9" = "Doubles the intensity of the immolation effect, but reduces the frequency of all of this symptom's effects.",
 		"Stage Speed 8" = "Increases explosion radius and explosion damage to the host when the host is wet.",

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -20,7 +20,7 @@
 	symptom_delay_min = 20
 	symptom_delay_max = 75
 	var/infective = FALSE
-	focuses = list(/datum/reagent/phlogiston)
+	focuses = list(/datum/reagent/napalm)
 	threshold_descs = list(
 		"Stage Speed 4" = "Increases the intensity of the flames.",
 		"Stage Speed 8" = "Further increases flame intensity.",
@@ -102,7 +102,7 @@ Bonus
 	symptom_delay_max = 90
 	var/chems = FALSE
 	var/explosion_power = 1
-	focuses = list(/datum/reagent/water, /datum/reagent/napalm)
+	focuses = list(/datum/reagent/phlogiston)
 	threshold_descs = list(
 		"Resistance 9" = "Doubles the intensity of the immolation effect, but reduces the frequency of all of this symptom's effects.",
 		"Stage Speed 8" = "Increases explosion radius and explosion damage to the host when the host is wet.",

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -22,6 +22,7 @@ Bonus
 	symptom_delay_max = 60
 	var/bleed = FALSE
 	var/pain = FALSE
+	focuses = list(/datum/reagent/toxin/heparin)
 	threshold_descs = list(
 		"Resistance 7" = "Host will bleed profusely during necrosis.",
 		"Transmission 8" = "Causes extreme pain to the host, weakening it.",
@@ -93,6 +94,7 @@ Bonus
 	symptom_delay_max = 6
 	var/chems = FALSE
 	var/zombie = FALSE
+	focuses = list(/datum/reagent/drug/krokodil)
 	threshold_descs = list(
 		"Stage Speed 7" = "Synthesizes Heparin and Lipolicide inside the host, causing increased bleeding and hunger.",
 		"Stealth 5" = "The symptom remains hidden until active.",

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -22,6 +22,7 @@
 	var/excludemuts = NONE
 	var/no_reset = FALSE
 	var/mutadone_proof = NONE
+	focuses = list(/datum/reagent/medicine/mutadone, /datum/reagent/chlorine)
 	threshold_descs = list(
 		"Resistance 8" = "The negative and mildly negative mutations caused by the virus are mutadone-proof (but will still be undone when the virus is cured if the resistance 14 threshold is not met).",
 		"Resistance 14" = "The host's genetic alterations are not undone when the virus is cured.",

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -22,7 +22,7 @@
 	var/excludemuts = NONE
 	var/no_reset = FALSE
 	var/mutadone_proof = NONE
-	focuses = list(/datum/reagent/medicine/mutadone, /datum/reagent/chlorine)
+	focuses = list(/datum/reagent/medicine/mutadone)
 	threshold_descs = list(
 		"Resistance 8" = "The negative and mildly negative mutations caused by the virus are mutadone-proof (but will still be undone when the virus is cured if the resistance 14 threshold is not met).",
 		"Resistance 14" = "The host's genetic alterations are not undone when the virus is cured.",

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -20,6 +20,7 @@
 	symptom_delay_min = 25
 	symptom_delay_max = 90
 	var/fake_healthy = FALSE
+	focuses = list(/datum/reagent/toxin/mindbreaker, /datum/reagent/consumable/sugar)
 	threshold_descs = list(
 		"Stage Speed 7" = "Increases the amount of hallucinations.",
 		"Stealth 4" = "The virus mimics positive symptoms.",

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -20,7 +20,7 @@
 	symptom_delay_min = 25
 	symptom_delay_max = 90
 	var/fake_healthy = FALSE
-	focuses = list(/datum/reagent/toxin/mindbreaker, /datum/reagent/consumable/sugar)
+	focuses = list(/datum/reagent/toxin/mindbreaker)
 	threshold_descs = list(
 		"Stage Speed 7" = "Increases the amount of hallucinations.",
 		"Stealth 4" = "The virus mimics positive symptoms.",

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -18,6 +18,7 @@
 	base_message_chance = 100
 	symptom_delay_min = 15
 	symptom_delay_max = 30
+	focuses = list(/datum/reagent/toxin/acid, /datum/reagent/medicine/mannitol)
 	threshold_descs = list(
 		"Stage Speed 6" = "Headaches will cause severe pain, that weakens the host.",
 		"Stage Speed 9" = "Headaches become less frequent but far more intense, preventing any action from the host.",

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -18,7 +18,7 @@
 	base_message_chance = 100
 	symptom_delay_min = 15
 	symptom_delay_max = 30
-	focuses = list(/datum/reagent/toxin/acid, /datum/reagent/medicine/mannitol)
+	focuses = list(/datum/reagent/mercury)
 	threshold_descs = list(
 		"Stage Speed 6" = "Headaches will cause severe pain, that weakens the host.",
 		"Stage Speed 9" = "Headaches become less frequent but far more intense, preventing any action from the host.",

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -55,6 +55,7 @@
 	level = 6
 	passive_message = "<span class='notice'>You miss the feeling of starlight on your skin.</span>"
 	var/nearspace_penalty = 0.3
+	focuses = list(/datum/reagent/flash_powder, /datum/reagent/stable_plasma)
 	threshold_descs = list(
 		"Stage Speed 6" = "Increases healing speed.",
 		"Transmission 6" = "Removes penalty for only being close to space.",
@@ -188,6 +189,7 @@
 	level = 7
 	var/food_conversion = FALSE
 	desc = "The virus rapidly breaks down any foreign chemicals in the bloodstream."
+	focuses = list(/datum/reagent/medicine/pen_acid)
 	threshold_descs = list(
 		"Resistance 7" = "Increases chem removal speed.",
 		"Stage Speed 6" = "Consumed chemicals nourish the host.",
@@ -231,6 +233,7 @@
 	var/reduced_hunger = FALSE
 	desc = "The virus causes the host's metabolism to accelerate rapidly, making them process chemicals twice as fast,\
 		but also causing increased hunger."
+	focuses = list(/datum/reagent/toxin/lipolicide, /datum/reagent/consumable/sugar)
 	threshold_descs = list(
 		"Stealth 3" = "Reduces hunger rate.",
 		"Stage Speed 10" = "Chemical metabolization is tripled instead of doubled.",
@@ -272,6 +275,7 @@
 	transmittable = -1
 	level = 6
 	passive_message = "<span class='notice'>You feel tingling on your skin as light passes over it.</span>"
+	focuses = list(/datum/reagent/flash_powder, /datum/reagent/stabilizing_agent)
 	threshold_descs = list(
 		"Stage Speed 8" = "Doubles healing speed.",
 	)
@@ -331,6 +335,7 @@
 	var/deathgasp = FALSE
 	var/stabilize = FALSE
 	var/active_coma = FALSE //to prevent multiple coma procs
+	focuses = list(/datum/reagent/medicine/atropine, /datum/reagent/toxin/chloralhydrate)
 	threshold_descs = list(
 		"Stealth 2" = "Host appears to die when falling into a coma.",
 		"Resistance 4" = "The virus also stabilizes the host while they are in critical condition.",
@@ -427,6 +432,7 @@
 	level = 6
 	passive_message = "<span class='notice'>Your skin feels oddly dry...</span>"
 	var/absorption_coeff = 1
+	focuses = list(/datum/reagent/drying_agent)
 	threshold_descs = list(
 		"Resistance 5" = "Water is consumed at a much slower rate.",
 		"Stage Speed 7" = "Increases healing speed.",
@@ -489,6 +495,7 @@
 	level = 8
 	passive_message = "<span class='notice'>You feel an odd attraction to plasma.</span>"
 	var/temp_rate = 1
+	focuses = list(/datum/reagent/stable_plasma, /datum/reagent/medicine/c2/seiver)
 	threshold_descs = list(
 		"Transmission 6" = "Increases temperature adjustment rate.",
 		"Stage Speed 7" = "Increases healing speed.",
@@ -562,6 +569,7 @@
 	symptom_delay_max = 1
 	passive_message = "<span class='notice'>Your skin glows faintly for a moment.</span>"
 	var/cellular_damage = FALSE
+	focuses = list(/datum/reagent/medicine/clonexadone)
 	threshold_descs = list(
 		"Transmission 6" = "Additionally heals cellular damage.",
 		"Resistance 7" = "Increases healing speed.",

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -55,7 +55,7 @@
 	level = 6
 	passive_message = "<span class='notice'>You miss the feeling of starlight on your skin.</span>"
 	var/nearspace_penalty = 0.3
-	focuses = list(/datum/reagent/flash_powder, /datum/reagent/stable_plasma)
+	focuses = list(/datum/reagent/medicine/c2/seiver)
 	threshold_descs = list(
 		"Stage Speed 6" = "Increases healing speed.",
 		"Transmission 6" = "Removes penalty for only being close to space.",
@@ -275,7 +275,7 @@
 	transmittable = -1
 	level = 6
 	passive_message = "<span class='notice'>You feel tingling on your skin as light passes over it.</span>"
-	focuses = list(/datum/reagent/flash_powder, /datum/reagent/stabilizing_agent)
+	focuses = list(/datum/reagent/medicine/sal_acid)
 	threshold_descs = list(
 		"Stage Speed 8" = "Doubles healing speed.",
 	)
@@ -335,7 +335,7 @@
 	var/deathgasp = FALSE
 	var/stabilize = FALSE
 	var/active_coma = FALSE //to prevent multiple coma procs
-	focuses = list(/datum/reagent/medicine/atropine, /datum/reagent/toxin/chloralhydrate)
+	focuses = list(/datum/reagent/toxin/chloralhydrate)
 	threshold_descs = list(
 		"Stealth 2" = "Host appears to die when falling into a coma.",
 		"Resistance 4" = "The virus also stabilizes the host while they are in critical condition.",
@@ -495,7 +495,7 @@
 	level = 8
 	passive_message = "<span class='notice'>You feel an odd attraction to plasma.</span>"
 	var/temp_rate = 1
-	focuses = list(/datum/reagent/stable_plasma, /datum/reagent/medicine/c2/seiver)
+	focuses = list(/datum/reagent/medicine/leporazine)
 	threshold_descs = list(
 		"Transmission 6" = "Increases temperature adjustment rate.",
 		"Stage Speed 7" = "Increases healing speed.",

--- a/code/datums/diseases/advance/symptoms/itching.dm
+++ b/code/datums/diseases/advance/symptoms/itching.dm
@@ -18,6 +18,7 @@
 	symptom_delay_min = 5
 	symptom_delay_max = 25
 	var/scratch = FALSE
+	focuses = list(/datum/reagent/toxin/itching_powder, /datum/reagent/toxin/acid)
 	threshold_descs = list(
 		"Transmission 6" = "Increases frequency of itching.",
 		"Stage Speed 7" = "The host will scrath itself when itching, causing superficial damage.",

--- a/code/datums/diseases/advance/symptoms/itching.dm
+++ b/code/datums/diseases/advance/symptoms/itching.dm
@@ -18,7 +18,7 @@
 	symptom_delay_min = 5
 	symptom_delay_max = 25
 	var/scratch = FALSE
-	focuses = list(/datum/reagent/toxin/itching_powder, /datum/reagent/toxin/acid)
+	focuses = list(/datum/reagent/toxin/itching_powder)
 	threshold_descs = list(
 		"Transmission 6" = "Increases frequency of itching.",
 		"Stage Speed 7" = "The host will scrath itself when itching, causing superficial damage.",

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -18,6 +18,7 @@
 	symptom_delay_max = 85
 	severity = 4
 	var/yawning = FALSE
+	focuses = list(/datum/reagent/medicine/c2/tirimol)
 	threshold_descs = list(
 		"Transmission 4" = "Causes the host to periodically emit a yawn that spreads the virus in a manner similar to that of a sneeze.",
 		"Stage Speed 10" = "Causes narcolepsy more often, increasing the chance of the host falling asleep.",

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -18,7 +18,7 @@
 	symptom_delay_max = 85
 	severity = 4
 	var/yawning = FALSE
-	focuses = list(/datum/reagent/medicine/c2/tirimol)
+	focuses = list(/datum/reagent/medicine/morphine)
 	threshold_descs = list(
 		"Transmission 4" = "Causes the host to periodically emit a yawn that spreads the virus in a manner similar to that of a sneeze.",
 		"Stage Speed 10" = "Causes narcolepsy more often, increasing the chance of the host falling asleep.",

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -18,7 +18,7 @@
 	symptom_delay_min = 1
 	symptom_delay_max = 1
 	var/regenerate_blood = FALSE
-	focuses = list(/datum/reagent/iron, /datum/reagent/medicine/salbutamol)
+	focuses = list(/datum/reagent/medicine/salbutamol)
 	threshold_descs = list(
 		"Resistance 8" = "Additionally regenerates lost blood."
 	)

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -18,6 +18,7 @@
 	symptom_delay_min = 1
 	symptom_delay_max = 1
 	var/regenerate_blood = FALSE
+	focuses = list(/datum/reagent/iron, /datum/reagent/medicine/salbutamol)
 	threshold_descs = list(
 		"Resistance 8" = "Additionally regenerates lost blood."
 	)

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -18,6 +18,7 @@
 	var/purge_alcohol = FALSE
 	var/trauma_heal_mild = FALSE
 	var/trauma_heal_severe = FALSE
+	focuses = list(/datum/reagent/medicine/antihol, /datum/reagent/medicine/mannitol)
 	threshold_descs = list(
 		"Resistance 6" = "Heals minor brain traumas.",
 		"Resistance 9" = "Heals severe brain traumas.",
@@ -83,6 +84,7 @@
 	base_message_chance = 7
 	symptom_delay_min = 1
 	symptom_delay_max = 1
+	focuses = list(/datum/reagent/medicine/inacusiate, /datum/reagent/medicine/oculine)
 
 /datum/symptom/sensory_restoration/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -18,7 +18,7 @@
 	var/purge_alcohol = FALSE
 	var/trauma_heal_mild = FALSE
 	var/trauma_heal_severe = FALSE
-	focuses = list(/datum/reagent/medicine/antihol, /datum/reagent/medicine/mannitol)
+	focuses = list(/datum/reagent/medicine/neurine)
 	threshold_descs = list(
 		"Resistance 6" = "Heals minor brain traumas.",
 		"Resistance 9" = "Heals severe brain traumas.",

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -18,6 +18,7 @@
 	base_message_chance = 50
 	symptom_delay_min = 45
 	symptom_delay_max = 90
+	focuses = list(/datum/reagent/baldium)
 
 /datum/symptom/shedding/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -17,7 +17,7 @@
 	severity = 1
 	symptom_delay_min = 7
 	symptom_delay_max = 14
-	focuses = list(/datum/reagent/colorful_reagent, /datum/reagent/toxin/mindbreaker)
+	focuses = list(/datum/reagent/colorful_reagent)
 
 /datum/symptom/polyvitiligo/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -17,6 +17,7 @@
 	severity = 1
 	symptom_delay_min = 7
 	symptom_delay_max = 14
+	focuses = list(/datum/reagent/colorful_reagent, /datum/reagent/toxin/mindbreaker)
 
 /datum/symptom/polyvitiligo/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -19,7 +19,7 @@
 	symptom_delay_max = 35
 	var/spread_range = 4
 	var/cartoon_sneezing = FALSE //ah, ah, AH, AH-CHOO!!
-	focuses = list(/datum/reagent/toxin/itching_powder, /datum/reagent/fuel/oil)
+	focuses = list(/datum/reagent/smoke_powder)
 	threshold_descs = list(
 		"Transmission 9" = "Increases sneezing range, spreading the virus over 6 meter cone instead of over a 4 meter cone.",
 		"Stealth 4" = "The symptom remains hidden until active.",

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -19,6 +19,7 @@
 	symptom_delay_max = 35
 	var/spread_range = 4
 	var/cartoon_sneezing = FALSE //ah, ah, AH, AH-CHOO!!
+	focuses = list(/datum/reagent/toxin/itching_powder, /datum/reagent/fuel/oil)
 	threshold_descs = list(
 		"Transmission 9" = "Increases sneezing range, spreading the virus over 6 meter cone instead of over a 4 meter cone.",
 		"Stealth 4" = "The symptom remains hidden until active.",

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -15,6 +15,7 @@
 	transmittable = 0
 	level = 5
 	severity = 0
+	focuses = list(/datum/reagent/medicine/epinephrine, /datum/reagent/consumable/sugar)
 
 /datum/symptom/undead_adaptation/OnAdd(datum/disease/advance/A)
 	A.process_dead = TRUE
@@ -41,6 +42,7 @@
 	transmittable = 3
 	level = 5
 	severity = 0
+	focuses = list(/datum/reagent/gold, /datum/reagent/consumable/sugar)
 
 /datum/symptom/inorganic_adaptation/OnAdd(datum/disease/advance/A)
 	A.infectable_biotypes |= MOB_MINERAL //Mineral covers plasmamen and golems.

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -15,7 +15,7 @@
 	transmittable = 0
 	level = 5
 	severity = 0
-	focuses = list(/datum/reagent/medicine/epinephrine, /datum/reagent/consumable/sugar)
+	focuses = list(/datum/reagent/medicine/strange_reagent)
 
 /datum/symptom/undead_adaptation/OnAdd(datum/disease/advance/A)
 	A.process_dead = TRUE
@@ -42,7 +42,7 @@
 	transmittable = 3
 	level = 5
 	severity = 0
-	focuses = list(/datum/reagent/gold, /datum/reagent/consumable/sugar)
+	focuses = list(/datum/reagent/iron)
 
 /datum/symptom/inorganic_adaptation/OnAdd(datum/disease/advance/A)
 	A.infectable_biotypes |= MOB_MINERAL //Mineral covers plasmamen and golems.

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -32,6 +32,8 @@
 	///A neutered symptom has no effect, and only affects statistics.
 	var/neutered = FALSE
 	var/list/thresholds
+	///A list of all reagents required to target this symptom. Only affects naturally occuring symptoms. Make sure none of these are reagents that can mutate viruses or conflict with other focuses. (Eg. unstable mutagen.)
+	var/list/focuses = list()
 	///If this symptom can appear from /datum/disease/advance/GenerateSymptoms()
 	var/naturally_occuring = TRUE
 

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -106,4 +106,11 @@
 	data["level"] = level
 	data["neutered"] = neutered
 	data["threshold_desc"] = threshold_descs
+	if (!focuses.len)
+		data["focus_desc"] = " This symptom cannot be focused on."
+		return data
+	var/list/focus_names = list()
+	for(var/datum/reagent/focus as anything in focuses)
+		focus_names += initial(focus.name)
+	data["focus_desc"] = " This symptom can be focused on by adding " + 	lowertext(english_list(focus_names, nothing_text = "error")) + " before the mutation agent."
 	return data

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -112,5 +112,5 @@
 	var/list/focus_names = list()
 	for(var/datum/reagent/focus as anything in focuses)
 		focus_names += initial(focus.name)
-	data["focus_desc"] = " This symptom can be focused on by adding " + 	lowertext(english_list(focus_names, nothing_text = "error")) + " before the mutation agent."
+	data["focus_desc"] = " This symptom can be focused on by adding " + lowertext(english_list(focus_names, nothing_text = "error")) + " before the mutation agent."
 	return data

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -14,7 +14,7 @@
 	stage_speed = -3
 	transmittable = 0
 	level = 3
-	focuses = list(/datum/reagent/consumable/ice)
+	focuses = list(/datum/reagent/inverse/technetium)
 
 /*Viral evolution
  * Reduces stealth
@@ -33,4 +33,4 @@
 	stage_speed = 5
 	transmittable = 3
 	level = 3
-	focuses = list(/datum/reagent/smoke_powder)
+	focuses = list(/datum/reagent/fluorosurfactant)

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -14,6 +14,7 @@
 	stage_speed = -3
 	transmittable = 0
 	level = 3
+	focuses = list(/datum/reagent/consumable/ice)
 
 /*Viral evolution
  * Reduces stealth
@@ -32,3 +33,4 @@
 	stage_speed = 5
 	transmittable = 3
 	level = 3
+	focuses = list(/datum/reagent/smoke_powder)

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -19,7 +19,7 @@
 	symptom_delay_min = 25
 	symptom_delay_max = 80
 	var/remove_eyes = FALSE
-	focuses = list(/datum/reagent/medicine/oculine, /datum/reagent/toxin/acid)
+	focuses = list(/datum/reagent/inverse/oculine)
 	threshold_descs = list(
 		"Resistance 12" = "Weakens extraocular muscles, eventually leading to complete detachment of the eyes.",
 		"Stealth 4" = "The symptom remains hidden until active.",

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -19,6 +19,7 @@
 	symptom_delay_min = 25
 	symptom_delay_max = 80
 	var/remove_eyes = FALSE
+	focuses = list(/datum/reagent/medicine/oculine, /datum/reagent/toxin/acid)
 	threshold_descs = list(
 		"Resistance 12" = "Weakens extraocular muscles, eventually leading to complete detachment of the eyes.",
 		"Stealth 4" = "The symptom remains hidden until active.",

--- a/code/datums/diseases/advance/symptoms/voice_change.dm
+++ b/code/datums/diseases/advance/symptoms/voice_change.dm
@@ -21,6 +21,7 @@
 	symptom_delay_max = 120
 	var/scramble_language = FALSE
 	var/datum/language/current_language
+	focuses = list(/datum/reagent/toxin/mutetoxin)
 	threshold_descs = list(
 		"Transmission 14" = "The host's language center of the brain is damaged, leading to complete inability to speak or understand any language.",
 		"Stage Speed 7" = "Changes voice more often.",

--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -21,6 +21,7 @@ and your disease can spread via people walking on vomit.
 	symptom_delay_max = 80
 	var/vomit_blood = FALSE
 	var/proj_vomit = 0
+	focuses = list(/datum/reagent/yuck)
 	threshold_descs = list(
 		"Resistance 7" = "Host will vomit blood, causing internal damage.",
 		"Transmission 7" = "Host will projectile vomit, increasing vomiting range.",

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -17,6 +17,7 @@
 	base_message_chance = 100
 	symptom_delay_min = 15
 	symptom_delay_max = 45
+	focuses = list(/datum/reagent/toxin/lipolicide, /datum/reagent/toxin/acid)
 	threshold_descs = list(
 		"Stealth 4" = "The symptom is less noticeable."
 	)

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -17,7 +17,7 @@
 	base_message_chance = 100
 	symptom_delay_min = 15
 	symptom_delay_max = 45
-	focuses = list(/datum/reagent/toxin/lipolicide, /datum/reagent/toxin/acid)
+	focuses = list(/datum/reagent/medicine/c2/probital)
 	threshold_descs = list(
 		"Stealth 4" = "The symptom is less noticeable."
 	)

--- a/code/datums/diseases/advance/symptoms/youth.dm
+++ b/code/datums/diseases/advance/symptoms/youth.dm
@@ -19,6 +19,7 @@
 	base_message_chance = 100
 	symptom_delay_min = 25
 	symptom_delay_max = 50
+	focuses = list(/datum/reagent/colorful_reagent, /datum/reagent/medicine/mannitol)
 
 /datum/symptom/youth/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/youth.dm
+++ b/code/datums/diseases/advance/symptoms/youth.dm
@@ -19,7 +19,7 @@
 	base_message_chance = 100
 	symptom_delay_min = 25
 	symptom_delay_max = 50
-	focuses = list(/datum/reagent/colorful_reagent, /datum/reagent/medicine/mannitol)
+	focuses = list(/datum/reagent/medicine/mannitol)
 
 /datum/symptom/youth/Activate(datum/disease/advance/A)
 	. = ..()

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -298,7 +298,7 @@
 	if(B?.data)
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
-			D.Devolve()
+			D.Devolve(holder)
 
 /datum/chemical_reaction/mix_virus/neuter_virus
 	required_reagents = list(/datum/reagent/toxin/formaldehyde = 1)
@@ -309,7 +309,7 @@
 	if(B?.data)
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
-			D.Neuter()
+			D.Neuter(holder)
 
 
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -231,7 +231,7 @@
 	if(B?.data)
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
-			D.Evolve(level_min, level_max)
+			D.Evolve(holder, level_min, level_max)
 
 
 /datum/chemical_reaction/mix_virus/mix_virus_2

--- a/tgui/packages/tgui/interfaces/Pandemic/Symptom.tsx
+++ b/tgui/packages/tgui/interfaces/Pandemic/Symptom.tsx
@@ -15,12 +15,12 @@ export const SymptomDisplay = (props, context) => {
   return (
     <Section fill title="Symptoms">
       {symptoms.map((symptom) => {
-        const { name, desc, threshold_desc } = symptom;
+        const { name, desc, focus_desc, threshold_desc } = symptom;
         return (
           <Collapsible key={name} title={name}>
             <Stack fill>
               <Stack.Item grow={3}>
-                {desc}
+                {desc + focus_desc}
                 <Thresholds thresholds={threshold_desc} />
               </Stack.Item>
               <Stack.Divider />
@@ -62,7 +62,7 @@ const Thresholds = (props, context) => {
 /** Displays the numerical trait modifiers for a virus symptom */
 const Traits = (props, context) => {
   const {
-    symptom: { level, resistance, stage_speed, stealth, transmission },
+    symptom: { level, resistance, stage_speed, stealth, transmission, focuses },
   } = props;
 
   return (

--- a/tgui/packages/tgui/interfaces/Pandemic/types.ts
+++ b/tgui/packages/tgui/interfaces/Pandemic/types.ts
@@ -49,6 +49,7 @@ export type Symptom = {
   stage_speed: number;
   transmission: number;
   level: number;
+  focus_desc: string;
   neutered: BooleanLike;
   threshold_desc: Threshold[];
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This is a big change, any and all code improvements or pieces of advice are heavily apperciated.

This PR adds the ability to focus on a specific symptom or group of symptoms using specific reagents. Every symptom has it's own list of reagents required to focus on it. I may not be able to interpret reactions between like 60 reagents so finding any conflicts is of top priority.

There is also an additional focus type that uses silver to determine which symptom to neuter/remove when adding formaldehyde or synaptizine, respectively. The rounded up amount of silver in the container is what's used to determine the index of what is neutered/removed. If you added 5u of silver to a beaker with a virus that has 6 symptoms and then tried to neuter or remove a symptom from it, it would neuter/remove the fifth symptom. The same would happen all the way down to 4u of silver, after which it would focus the 4th symptom so on and so forth. Silver focusing works the same as normal focusing in terms of reagent removal.

This does NOT affect the normal way of getting a symptom, you can still do that just fine. However, adding specific reagents to the solution before adding the mutating agent itself will cause it to mutate it's focused symptoms instead of randomly generated ones. This still respects the level range of whatever mutating agent you're using and only combs through ordinarily available.

When a virus mutates focused symptoms it can mutate as many symptoms at once as it physically can hold. Focusing does nothing if the virus symptom cap is reached and any extra symptoms will simply be removed from the return value.

Once a focus has been applied the reagent used is simply deleted from the beaker. This prevents blood duplication issues, a bunch of reaction conflicts and doesn't make you have to go out of your way to separate out the focus reagents.

Currently the only way to see the recipes is through code diving or finding a symptom in-game and then looking at it's description, however I do plan on also adding a completely new section to the https://tgstation13.org/wiki/Infections table of symptoms detailing the reagents required for each symptom.

This is going to be a draft until I get GBP from my other PRs. You can rate it and find bugs in the meanwhile.

## Why It's Good For The Game

This is rather obvious. I don't think there's anyone who enjoys wasting hours clicking on beakers and hoping for RNG to be on your side, like holy shit, it's so fucking boring. Now you have a reason to go explore the station or learn more chemistry to get whatever the hell you need for your god viruses. This does NOT affect balance in regards to the symptoms themselves, only the methods in which you acquire them.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a completely new method for getting specific symptoms called "focusing" which is achieved through specific reagents unique to each symptom.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
