### PR TITLE
Ninjas and Traitors can no longer hack consoles located in maintenance

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -776,9 +776,6 @@
 
 /// Begin the process of hacking into the comms console to call in a threat.
 /obj/machinery/computer/communications/proc/try_hack_console(mob/living/hacker, duration = 30 SECONDS)
-	if(!can_hack())
-		return FALSE
-
 	AI_notify_hack()
 	if(!do_after(hacker, duration, src, extra_checks = CALLBACK(src, .proc/can_hack)))
 		return FALSE

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -790,7 +790,9 @@
 /obj/machinery/computer/communications/proc/can_hack()
 	if(machine_stat & (NOPOWER|BROKEN))
 		return FALSE
-
+	var/area/console_area = get_area(src)
+	if(!console_area || !(console_area.area_flags & VALID_TERRITORY))
+		return FALSE
 	return TRUE
 
 /**

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -777,18 +777,22 @@
 /// Begin the process of hacking into the comms console to call in a threat.
 /obj/machinery/computer/communications/proc/try_hack_console(mob/living/hacker, duration = 30 SECONDS)
 	AI_notify_hack()
-	if(!do_after(hacker, duration, src, extra_checks = CALLBACK(src, .proc/can_hack)))
+	if(!do_after(hacker, duration, src, extra_checks = CALLBACK(src, .proc/can_hack, hacker)))
 		return FALSE
 
 	hack_console(hacker)
 	return TRUE
 
 /// Checks if this console is hackable. Used as a callback during try_hack_console's doafter as well.
-/obj/machinery/computer/communications/proc/can_hack()
+/obj/machinery/computer/communications/proc/can_hack(mob/living/hacker, feedback = FALSE)
 	if(machine_stat & (NOPOWER|BROKEN))
+		if(feedback && hacker)
+			balloon_alert(hacker, "can't hack this console!")
 		return FALSE
 	var/area/console_area = get_area(src)
 	if(!console_area || !(console_area.area_flags & VALID_TERRITORY))
+		if(feedback && hacker)
+			balloon_alert(hacker, "signal too weak, can't hack here!")
 		return FALSE
 	return TRUE
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -776,6 +776,9 @@
 
 /// Begin the process of hacking into the comms console to call in a threat.
 /obj/machinery/computer/communications/proc/try_hack_console(mob/living/hacker, duration = 30 SECONDS)
+	if(!can_hack(hacker, feedback = TRUE))
+		return
+
 	AI_notify_hack()
 	if(!do_after(hacker, duration, src, extra_checks = CALLBACK(src, .proc/can_hack, hacker)))
 		return FALSE

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -790,12 +790,12 @@
 /obj/machinery/computer/communications/proc/can_hack(mob/living/hacker, feedback = FALSE)
 	if(machine_stat & (NOPOWER|BROKEN))
 		if(feedback && hacker)
-			balloon_alert(hacker, "can't hack this console!")
+			balloon_alert(hacker, "can't hack!")
 		return FALSE
 	var/area/console_area = get_area(src)
 	if(!console_area || !(console_area.area_flags & VALID_TERRITORY))
 		if(feedback && hacker)
-			balloon_alert(hacker, "signal too weak, can't hack here!")
+			balloon_alert(hacker, "signal too weak!")
 		return FALSE
 	return TRUE
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -777,7 +777,7 @@
 /// Begin the process of hacking into the comms console to call in a threat.
 /obj/machinery/computer/communications/proc/try_hack_console(mob/living/hacker, duration = 30 SECONDS)
 	if(!can_hack(hacker, feedback = TRUE))
-		return
+		return FALSE
 
 	AI_notify_hack()
 	if(!do_after(hacker, duration, src, extra_checks = CALLBACK(src, .proc/can_hack, hacker)))

--- a/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
+++ b/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
@@ -44,8 +44,7 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /datum/traitor_objective/hack_comm_console/proc/begin_hack(mob/user, obj/machinery/computer/communications/target)
-	if(!target.can_hack())
-		target.balloon_alert(user, "can't hack this console!")
+	if(!target.can_hack(user, feedback = TRUE))
 		return
 
 	if(!target.try_hack_console(user))

--- a/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
+++ b/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
@@ -44,9 +44,6 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /datum/traitor_objective/hack_comm_console/proc/begin_hack(mob/user, obj/machinery/computer/communications/target)
-	if(!target.can_hack(user, feedback = TRUE))
-		return
-
 	if(!target.try_hack_console(user))
 		return
 

--- a/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
+++ b/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
@@ -45,6 +45,7 @@
 
 /datum/traitor_objective/hack_comm_console/proc/begin_hack(mob/user, obj/machinery/computer/communications/target)
 	if(!target.try_hack_console(user))
+		target.balloon_alert(user, "can't hack here!")
 		return
 
 	succeed_objective()

--- a/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
+++ b/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
@@ -44,8 +44,11 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /datum/traitor_objective/hack_comm_console/proc/begin_hack(mob/user, obj/machinery/computer/communications/target)
+	if(!target.can_hack())
+		target.balloon_alert(user, "can't hack this console!")
+		return
+
 	if(!target.try_hack_console(user))
-		target.balloon_alert(user, "can't hack here!")
 		return
 
 	succeed_objective()

--- a/code/modules/ninja/ninjaDrainAct.dm
+++ b/code/modules/ninja/ninjaDrainAct.dm
@@ -146,9 +146,8 @@
 /obj/machinery/computer/secure_data/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!ninja || !hacking_module)
 		return NONE
-	var/area/console_area = get_area(src)
-	if(!console_area || !(console_area.area_flags & VALID_TERRITORY))
-		balloon_alert(ninja, "can't hack here!")
+	if(!can_hack())
+		balloon_alert(ninja, "can't hack this console!")
 		return NONE
 
 	AI_notify_hack()
@@ -156,7 +155,7 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/computer/secure_data/proc/ninjadrain_charge(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	if(!do_after(ninja, 20 SECONDS))
+	if(!do_after(ninja, 20 SECONDS, src, extra_checks = CALLBACK(src, .proc/can_hack)))
 		return
 	for(var/datum/data/record/rec in sort_record(GLOB.data_core.general, sortBy, order))
 		for(var/datum/data/record/security_record in GLOB.data_core.security)
@@ -167,6 +166,14 @@
 	var/datum/objective/security_scramble/objective = locate() in ninja_antag.objectives
 	if(objective)
 		objective.completed = TRUE
+
+/obj/machinery/computer/secure_data/proc/can_hack()
+	if(machine_stat & (NOPOWER|BROKEN))
+		return FALSE
+	var/area/console_area = get_area(src)
+	if(!console_area || !(console_area.area_flags & VALID_TERRITORY))
+		return FALSE
+	return TRUE
 
 //COMMUNICATIONS CONSOLE//
 /obj/machinery/computer/communications/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)

--- a/code/modules/ninja/ninjaDrainAct.dm
+++ b/code/modules/ninja/ninjaDrainAct.dm
@@ -188,9 +188,6 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/computer/communications/proc/ninjadrain_charge(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	if(!can_hack(ninja, feedback = TRUE))
-		return
-
 	if(!try_hack_console(ninja))
 		return
 

--- a/code/modules/ninja/ninjaDrainAct.dm
+++ b/code/modules/ninja/ninjaDrainAct.dm
@@ -169,12 +169,12 @@
 /obj/machinery/computer/secure_data/proc/can_hack(mob/living/hacker, feedback = FALSE)
 	if(machine_stat & (NOPOWER|BROKEN))
 		if(feedback && hacker)
-			balloon_alert(hacker, "can't hack this console!")
+			balloon_alert(hacker, "can't hack!")
 		return FALSE
 	var/area/console_area = get_area(src)
 	if(!console_area || !(console_area.area_flags & VALID_TERRITORY))
 		if(feedback && hacker)
-			balloon_alert(hacker, "signal too weak, can't hack here!")
+			balloon_alert(hacker, "signal too weak!")
 		return FALSE
 	return TRUE
 

--- a/code/modules/ninja/ninjaDrainAct.dm
+++ b/code/modules/ninja/ninjaDrainAct.dm
@@ -178,8 +178,11 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/computer/communications/proc/ninjadrain_charge(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	if(!can_hack())
+		balloon_alert(ninja, "can't hack this console!")
+		return
+
 	if(!try_hack_console(ninja))
-		balloon_alert(ninja, "can't hack here!")
 		return
 
 	hacking_module.communication_console_hack_success = TRUE

--- a/code/modules/ninja/ninjaDrainAct.dm
+++ b/code/modules/ninja/ninjaDrainAct.dm
@@ -148,6 +148,7 @@
 		return NONE
 	var/area/console_area = get_area(src)
 	if(!console_area || !(console_area.area_flags & VALID_TERRITORY))
+		balloon_alert(ninja, "can't hack here!")
 		return NONE
 
 	AI_notify_hack()
@@ -178,6 +179,7 @@
 
 /obj/machinery/computer/communications/proc/ninjadrain_charge(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!try_hack_console(ninja))
+		balloon_alert(ninja, "can't hack here!")
 		return
 
 	hacking_module.communication_console_hack_success = TRUE

--- a/code/modules/ninja/ninjaDrainAct.dm
+++ b/code/modules/ninja/ninjaDrainAct.dm
@@ -146,8 +146,7 @@
 /obj/machinery/computer/secure_data/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!ninja || !hacking_module)
 		return NONE
-	if(!can_hack())
-		balloon_alert(ninja, "can't hack this console!")
+	if(!can_hack(ninja, feedback = TRUE))
 		return NONE
 
 	AI_notify_hack()
@@ -155,7 +154,7 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/computer/secure_data/proc/ninjadrain_charge(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	if(!do_after(ninja, 20 SECONDS, src, extra_checks = CALLBACK(src, .proc/can_hack)))
+	if(!do_after(ninja, 20 SECONDS, src, extra_checks = CALLBACK(src, .proc/can_hack, ninja)))
 		return
 	for(var/datum/data/record/rec in sort_record(GLOB.data_core.general, sortBy, order))
 		for(var/datum/data/record/security_record in GLOB.data_core.security)
@@ -167,11 +166,15 @@
 	if(objective)
 		objective.completed = TRUE
 
-/obj/machinery/computer/secure_data/proc/can_hack()
+/obj/machinery/computer/secure_data/proc/can_hack(mob/living/hacker, feedback = FALSE)
 	if(machine_stat & (NOPOWER|BROKEN))
+		if(feedback && hacker)
+			balloon_alert(hacker, "can't hack this console!")
 		return FALSE
 	var/area/console_area = get_area(src)
 	if(!console_area || !(console_area.area_flags & VALID_TERRITORY))
+		if(feedback && hacker)
+			balloon_alert(hacker, "signal too weak, can't hack here!")
 		return FALSE
 	return TRUE
 
@@ -185,8 +188,7 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/computer/communications/proc/ninjadrain_charge(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	if(!can_hack())
-		balloon_alert(ninja, "can't hack this console!")
+	if(!can_hack(ninja, feedback = TRUE))
 		return
 
 	if(!try_hack_console(ninja))

--- a/code/modules/ninja/ninjaDrainAct.dm
+++ b/code/modules/ninja/ninjaDrainAct.dm
@@ -146,6 +146,10 @@
 /obj/machinery/computer/secure_data/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!ninja || !hacking_module)
 		return NONE
+	var/area/console_area = get_area(src)
+	if(!console_area || !(console_area.area_flags & VALID_TERRITORY))
+		return NONE
+
 	AI_notify_hack()
 	INVOKE_ASYNC(src, .proc/ninjadrain_charge, ninja, hacking_module)
 	return COMPONENT_CANCEL_ATTACK_CHAIN


### PR DESCRIPTION
## About The Pull Request

- Ninja hacking and Traitor console hacking can only be done in areas with the `VALID_TERRITORY` flag set. This excludes maintenance and solar arrays. 
   - Basically, they will abide by the same rules Space Dragon abide by. 

## Why It's Good For The Game

The hacking objectives are designed at their core to get the antagonist to get involved somewhere deep in the center of the station - they're committing an act of corporate espionage, hacking databases and stuff, it's cool

Printing a board from engineering and making it in the corner of maint is boring, it doesn't encourage the antag to go fight or get involved or sneak around.

At the very least if a traitor wants to build a console to accomplish their objectives, they'll have to build it in a station area, which will likely be in camera range of the AI, allowing them to interject. 

## Changelog

:cl: Melbert
balance: Ninja and Traitors can no longer hack consoles located in maintenance for their objectives. (Basically, it abides by the same rules that Space Dragons have on where they can put their portal.)
fix: Secure Data consoles abide by the same hacking rules as comms consoles - getting de-powered mid-hack will stop hack progress.
/:cl:


