### PR TITLE
Add hotkeys, screentips, and sounds for flashlights

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -19,12 +19,15 @@
 	light_on = FALSE
 	var/on = FALSE
 
-
 /obj/item/flashlight/Initialize(mapload)
 	. = ..()
 	if(icon_state == "[initial(icon_state)]-on")
 		on = TRUE
 	update_brightness()
+	AddElement( \
+		/datum/element/contextual_screentip_bare_hands, \
+		rmb_text = "Toggle light", \
+	)
 
 /obj/item/flashlight/proc/update_brightness(mob/user)
 	if(on)
@@ -35,13 +38,18 @@
 	if(light_system == STATIC_LIGHT)
 		update_light()
 
-
-/obj/item/flashlight/attack_self(mob/user)
+/obj/item/flashlight/proc/toggle_light(mob/user)
 	on = !on
 	playsound(user, on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
 	update_brightness(user)
 	update_action_buttons()
-	return 1
+
+/obj/item/flashlight/attack_self(mob/user)
+	toggle_light(user)
+
+/obj/item/flashlight/attack_hand_secondary(mob/user, list/modifiers)
+	toggle_light(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/flashlight/suicide_act(mob/living/carbon/human/user)
 	if (user.is_blind())

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -17,6 +17,13 @@
 	light_range = 4
 	light_power = 1
 	light_on = FALSE
+	/// Can we toggle this light on and off
+	var/can_toggle = TRUE
+	/// The sound the light makes when it's turned on
+	var/sound_on = 'sound/weapons/magin.ogg'
+	/// The sound the light makes when it's turned off
+	var/sound_off = 'sound/weapons/magout.ogg'
+	/// Is the light turned on or off currently
 	var/on = FALSE
 
 /obj/item/flashlight/Initialize(mapload)
@@ -24,7 +31,19 @@
 	if(icon_state == "[initial(icon_state)]-on")
 		on = TRUE
 	update_brightness()
-	AddElement(/datum/element/contextual_screentip_bare_hands, rmb_text = "Toggle light")
+	register_context()
+
+/obj/item/flashlight/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	// single use lights can be toggled on once
+	if(isnull(held_item) && (can_toggle || !on))
+		context[SCREENTIP_CONTEXT_RMB] = "Toggle light"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(istype(held_item, /obj/item/flashlight) && (can_toggle || !on))
+		context[SCREENTIP_CONTEXT_LMB] = "Toggle light"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	return NONE
 
 /obj/item/flashlight/proc/update_brightness(mob/user)
 	if(on)
@@ -37,7 +56,7 @@
 
 /obj/item/flashlight/proc/toggle_light(mob/user)
 	on = !on
-	playsound(user, on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, TRUE)
+	playsound(user, on ? sound_on : sound_off, 40, TRUE)
 	update_brightness(user)
 	update_action_buttons()
 
@@ -270,6 +289,8 @@
 	light_color = LIGHT_COLOR_FLARE
 	light_system = MOVABLE_LIGHT
 	grind_results = list(/datum/reagent/sulfur = 15)
+	sound_on = 'sound/items/match_strike.ogg'
+	can_toggle = FALSE
 	/// How many seconds of fuel we have left
 	var/fuel = 0
 	var/on_damage = 7
@@ -451,6 +472,8 @@
 	inhand_icon_state = null
 	worn_icon_state = "lightstick"
 	grind_results = list(/datum/reagent/phenol = 15, /datum/reagent/hydrogen = 10, /datum/reagent/oxygen = 5) //Meth-in-a-stick
+	sound_on = 'sound/effects/wounds/crack2.ogg' // the cracking sound isn't just for wounds silly
+	can_toggle = FALSE
 	/// How many seconds of fuel we have left
 	var/fuel = 0
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -45,7 +45,7 @@
 	toggle_light(user)
 
 /obj/item/flashlight/attack_hand_secondary(mob/user, list/modifiers)
-	toggle_light(user)
+	attack_self(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/flashlight/suicide_act(mob/living/carbon/human/user)
@@ -215,7 +215,6 @@
 	if(creator)
 		visible_message(span_danger("[creator] created a medical hologram!"))
 
-
 /obj/item/flashlight/seclite
 	name = "seclite"
 	desc = "A robust flashlight used by security."
@@ -244,22 +243,11 @@
 	custom_materials = null
 	on = TRUE
 
-
 // green-shaded desk lamp
 /obj/item/flashlight/lamp/green
 	desc = "A classic green-shaded desk lamp."
 	icon_state = "lampgreen"
 	inhand_icon_state = "lampgreen"
-
-
-
-/obj/item/flashlight/lamp/verb/toggle_light()
-	set name = "Toggle light"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!usr.stat)
-		attack_self(usr)
 
 //Bananalamp
 /obj/item/flashlight/lamp/bananalamp
@@ -269,7 +257,6 @@
 	inhand_icon_state = null
 
 // FLARES
-
 /obj/item/flashlight/flare
 	name = "flare"
 	desc = "A red Nanotrasen issued flare. There are instructions on the side, it reads 'pull cord, make light'."
@@ -279,14 +266,14 @@
 	inhand_icon_state = "flare"
 	worn_icon_state = "flare"
 	actions_types = list()
-	/// How many seconds of fuel we have left
-	var/fuel = 0
-	var/on_damage = 7
-	var/produce_heat = 1500
 	heat = 1000
 	light_color = LIGHT_COLOR_FLARE
 	light_system = MOVABLE_LIGHT
 	grind_results = list(/datum/reagent/sulfur = 15)
+	/// How many seconds of fuel we have left
+	var/fuel = 0
+	var/on_damage = 7
+	var/produce_heat = 1500
 
 /obj/item/flashlight/flare/Initialize(mapload)
 	. = ..()
@@ -322,7 +309,6 @@
 		inhand_icon_state = "[initial(inhand_icon_state)]"
 
 /obj/item/flashlight/flare/attack_self(mob/user)
-
 	// Usual checks
 	if(fuel <= 0)
 		to_chat(user, span_warning("[src] is out of fuel!"))
@@ -468,17 +454,14 @@
 	/// How many seconds of fuel we have left
 	var/fuel = 0
 
-
 /obj/item/flashlight/glowstick/Initialize(mapload)
 	fuel = rand(3200, 4000)
 	set_light_color(color)
 	return ..()
 
-
 /obj/item/flashlight/glowstick/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
-
 
 /obj/item/flashlight/glowstick/process(delta_time)
 	fuel = max(fuel - delta_time, 0)
@@ -513,7 +496,6 @@
 	var/mutable_appearance/glowstick_overlay = mutable_appearance(icon, "glowstick-glow")
 	glowstick_overlay.color = color
 	. += glowstick_overlay
-
 
 /obj/item/flashlight/glowstick/attack_self(mob/user)
 	if(fuel <= 0)
@@ -581,7 +563,6 @@
 	///Base light_range that can be set on Initialize to use in smooth light range expansions and contractions.
 	var/base_light_range = 4
 
-
 /obj/item/flashlight/spotlight/Initialize(mapload, _light_range, _light_power, _light_color)
 	. = ..()
 	if(!isnull(_light_range))
@@ -591,7 +572,6 @@
 		set_light_power(_light_power)
 	if(!isnull(_light_color))
 		set_light_color(_light_color)
-
 
 /obj/item/flashlight/flashdark
 	name = "flashdark"
@@ -604,7 +584,6 @@
 	var/dark_light_range = 2.5
 	///Variable to preserve old lighting behavior in flashlights, to handle darkness.
 	var/dark_light_power = -3
-
 
 /obj/item/flashlight/flashdark/update_brightness(mob/user)
 	. = ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -17,8 +17,8 @@
 	light_range = 4
 	light_power = 1
 	light_on = FALSE
-	/// Can we toggle this light on and off
-	var/can_toggle = TRUE
+	/// Can we toggle this light on and off (used for contexual screentips only)
+	var/toggle_context = TRUE
 	/// The sound the light makes when it's turned on
 	var/sound_on = 'sound/weapons/magin.ogg'
 	/// The sound the light makes when it's turned off
@@ -35,11 +35,11 @@
 
 /obj/item/flashlight/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	// single use lights can be toggled on once
-	if(isnull(held_item) && (can_toggle || !on))
+	if(isnull(held_item) && (toggle_context || !on))
 		context[SCREENTIP_CONTEXT_RMB] = "Toggle light"
 		return CONTEXTUAL_SCREENTIP_SET
 
-	if(istype(held_item, /obj/item/flashlight) && (can_toggle || !on))
+	if(istype(held_item, /obj/item/flashlight) && (toggle_context || !on))
 		context[SCREENTIP_CONTEXT_LMB] = "Toggle light"
 		return CONTEXTUAL_SCREENTIP_SET
 
@@ -290,7 +290,7 @@
 	light_system = MOVABLE_LIGHT
 	grind_results = list(/datum/reagent/sulfur = 15)
 	sound_on = 'sound/items/match_strike.ogg'
-	can_toggle = FALSE
+	toggle_context = FALSE
 	/// How many seconds of fuel we have left
 	var/fuel = 0
 	var/on_damage = 7
@@ -473,7 +473,7 @@
 	worn_icon_state = "lightstick"
 	grind_results = list(/datum/reagent/phenol = 15, /datum/reagent/hydrogen = 10, /datum/reagent/oxygen = 5) //Meth-in-a-stick
 	sound_on = 'sound/effects/wounds/crack2.ogg' // the cracking sound isn't just for wounds silly
-	can_toggle = FALSE
+	toggle_context = FALSE
 	/// How many seconds of fuel we have left
 	var/fuel = 0
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -24,10 +24,7 @@
 	if(icon_state == "[initial(icon_state)]-on")
 		on = TRUE
 	update_brightness()
-	AddElement( \
-		/datum/element/contextual_screentip_bare_hands, \
-		rmb_text = "Toggle light", \
-	)
+	AddElement(/datum/element/contextual_screentip_bare_hands, rmb_text = "Toggle light")
 
 /obj/item/flashlight/proc/update_brightness(mob/user)
 	if(on)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This adds:
- RMB hotkey to flashlights to be able to toggle them on/off without having to pick them up
- Contextual screentips to help players
- The sound for flares and glowsticks were changed to be more realistic as well

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

I always hated having to pick up lamps and flashlights to turn them on.  It would be so much better if I could just right click them to save time.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Add RMB hotkey to toggle lighting for flashlights.  Add contextual screentips for flashlights.
soundadd: Reuse existing sounds for flares to use `sound/items/match_strike.ogg` and glowsticks to use `sound/effects/wounds/crack2.ogg`
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
