### PR TITLE
Removes inappropriate golden wheelchair usage

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -32676,7 +32676,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/tram/left)
 "lHN" = (
-/obj/item/wheelchair/gold,
+/obj/vehicle/ridden/wheelchair/motorized,
 /turf/open/misc/asteroid/airless,
 /area/mine/explored)
 "lIs" = (

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -394,7 +394,7 @@
 	lose_text = null
 	medical_record_text = "Patient has an untreatable impairment in motor function in the lower extremities."
 	hardcore_value = 15
-	mail_goodies = list(/obj/item/wheelchair/gold)
+	mail_goodies = list(/obj/vehicle/ridden/wheelchair/motorized) //yes a fullsized unfolded motorized wheelchair does fit
 
 /datum/quirk/paraplegic/add_unique()
 	if(quirk_holder.buckled) // Handle late joins being buckled to arrival shuttle chairs.

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -72,6 +72,7 @@
 /obj/vehicle/ridden/wheelchair/proc/make_ridable()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/wheelchair/hand)
 
+///A reward item for obtaining 5K hardcore random points. Do not use for anything else
 /obj/vehicle/ridden/wheelchair/gold
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_AFFECT_STATISTICS
 	desc = "Damn, must've been through a lot."
@@ -96,6 +97,7 @@
 	///The wheelchair vehicle type we create when we unfold this chair
 	var/unfolded_type = /obj/vehicle/ridden/wheelchair
 
+///A reward item for obtaining 5K hardcore random points. Do not use for anything else
 /obj/item/wheelchair/gold
 	name = "gold wheelchair"
 	desc = "A collapsed, shiny wheelchair that can be carried around."


### PR DESCRIPTION
## About The Pull Request

Removes the golden wheelchair from Tramstation and as a paraplegic mail goodie reward, replaces it with T1 motorized wheelchair

Closes: #70367 

## Why It's Good For The Game

Certain objects and concepts in game-design are made with one specific purpose and are not appropriate props. 
The golden wheelchair was made for 5000 Hardcore Random points, but people stumble upon it, think it's cool and use it as props or small player rewards. This devalues the object and ruins the whole point of it being a legendary reward

It's the same thing that went wrong with early maintenance pill scoreboard, because 300 other 'funny methods' were added for obtaining them that were NOT MAINTENANCE. It's also an issue with admins constantly turning people into snails, even though they're only supposed to be for genetic meltdowns

:cl:
del: Golden wheelchairs in Tram maintenance and mail have been replaced by T1 motorized wheelchairs
/:cl:

And no I'm not adding a silver wheelchair