### PR TITLE
Exclude statbrowser from seconds topic limiter

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			return
 
 	var/stl = CONFIG_GET(number/second_topic_limit)
-	if (!holder && stl)
+	if (!holder && stl && !(href_list["window_id"] == "statbrowser"))
 		var/second = round(world.time, 10)
 		if (!topiclimiter)
 			topiclimiter = new(LIMITER_SIZE)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			return
 
 	var/stl = CONFIG_GET(number/second_topic_limit)
-	if (!holder && stl && !(href_list["window_id"] == "statbrowser"))
+	if (!holder && stl && href_list["window_id"] != "statbrowser")
 		var/second = round(world.time, 10)
 		if (!topiclimiter)
 			topiclimiter = new(LIMITER_SIZE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alternative to the revert statpanel to use verbs PR.
Closes #70354 
Like Stylemistake commented in the other PR some system where you can configure limits for each TGUI window would be nice.
However that would be kinda complex to implement + all the overhead of needing to keep track of every windows messages per second/minute could make the code kinda inefficient and /client/Topic is kinda hot code.
So for now just excluding stat_browser should be fine:
![image](https://user-images.githubusercontent.com/33846895/194717789-8735d144-9ed4-4253-b41d-1e1f4e90fd44.png)
This doesn't exclude statbrowser from the minute check, so someone trying to abuse the stat panel for spamming topic calls will still be stopped.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents stat panel from getting limited on (re)connect:
![image](https://user-images.githubusercontent.com/33846895/194717837-784c47ad-ee74-4fbb-aebc-4b9baaebc420.png)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Gamer025
fix: You should no longer receive "Your previous action was ignored..." messages when you join a server
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
