### PR TITLE
renames compressed matter to RCD matter

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -848,7 +848,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
 
 /obj/item/rcd_ammo
-	name = "rcd matter cartridge"
+	name = "RCD matter cartridge"
 	desc = "Highly compressed matter for the RCD."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcdammo"

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -848,7 +848,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
 
 /obj/item/rcd_ammo
-	name = "compressed matter cartridge"
+	name = "rcd matter cartridge"
 	desc = "Highly compressed matter for the RCD."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcdammo"


### PR DESCRIPTION
## About The Pull Request

Renames compressed matter cartridge to RCD matter cartridge, to better reflect what it actually is, making it less confusing for people who want to print it out. It's already been renamed on its design, just not the item itself.

## Why It's Good For The Game

I would say it's better for consistency between the item and the design, but that's not as good a reason as 'People have no idea what the hell this is and what its for, and people who need it for stuff like crafting or the service RCD cant find what they need without codediving'.

## Changelog

:cl:
spellcheck: The compressed matter cartridge has been renamed to RCD matter cartridge, since it's RCD matter... used to refill an RCD.
/:cl:
