### PR TITLE
Fixes holopad teleport bug

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -132,7 +132,7 @@ Possible to do for anyone motivated enough:
 	for(var/obj/effect/overlay/holoray/ray as anything in holorays)
 		ray.abstract_move(loc)
 	var/list/non_call_masters = masters?.Copy()
-	for(var/datum/holocall/holocall as anything in holo_calls)
+	for(var/datum/holocall/holocall in holo_calls)
 		if(!holocall.user || !LAZYACCESS(masters, holocall.user))
 			continue
 		non_call_masters -= holocall.user

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -129,10 +129,10 @@ Possible to do for anyone motivated enough:
 	// move any relevant holograms, basically non-AI, and rays with the pad
 	if(replay_holo)
 		replay_holo.abstract_move(loc)
-	for(var/obj/effect/overlay/holoray/ray as anything in holorays)
+	for(var/obj/effect/overlay/holoray/ray in holorays)
 		ray.abstract_move(loc)
 	var/list/non_call_masters = masters?.Copy()
-	for(var/datum/holocall/holocall in holo_calls)
+	for(var/datum/holocall/holocall as anything in holo_calls)
 		if(!holocall.user || !LAZYACCESS(masters, holocall.user))
 			continue
 		non_call_masters -= holocall.user

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -129,7 +129,8 @@ Possible to do for anyone motivated enough:
 	// move any relevant holograms, basically non-AI, and rays with the pad
 	if(replay_holo)
 		replay_holo.abstract_move(loc)
-	for(var/obj/effect/overlay/holoray/ray in holorays)
+	for(var/mob/living/user as anything in holorays)
+		var/obj/effect/overlay/holoray/ray = holorays[user]
 		ray.abstract_move(loc)
 	var/list/non_call_masters = masters?.Copy()
 	for(var/datum/holocall/holocall as anything in holo_calls)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes holopads taking you with them when moved.
This fix also uncovered an issue with holorays not correcting for the new holopad location so it looks like the hologram is projected from the original spot. No idea how to fix it as of now.
That being said everything mechanically works as intended - AI eye stays fixed, but holopad calls and disk projections follow the holopad as it is moved.

## Why It's Good For The Game

Fixes #68746

## Changelog

2 words

:cl:
fix: fixed holopad teleporting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
