### PR TITLE
Fixes showcase microwave's missing sprite

### DIFF
--- a/code/game/objects/structures/showcase.dm
+++ b/code/game/objects/structures/showcase.dm
@@ -77,8 +77,8 @@
 /obj/structure/showcase/machinery/microwave
 	name = "\improper Nanotrasen-brand microwave"
 	desc = "The famous Nanotrasen-brand microwave, the multi-purpose cooking appliance every station needs! This one appears to be drawn onto a cardboard box."
-	icon = 'icons/obj/kitchen.dmi'
-	icon_state = "mw"
+	icon = 'icons/obj/machines/microwave.dmi'
+	icon_state = "map_icon"
 
 /obj/structure/showcase/machinery/cloning_pod
 	name = "cloning pod exhibit"


### PR DESCRIPTION
## About The Pull Request
#70203 changed the microwave's dmi path but did not replace the showcase variant's icon with the new dmi.

## Why It's Good For The Game
It's very hard to showcase something that's invisible.

## Changelog
:cl:
fix: Fixed showcase microwaves lacking sprites
/:cl:
