### PR TITLE
Fixes research servers disappearing on deconstruction

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -175,6 +175,7 @@
 /// Master R&D server. As long as this still exists and still holds the HDD for the theft objective, research points generate at normal speed. Destroy it or an antag steals the HDD? Half research speed.
 /obj/machinery/rnd/server/master
 	max_integrity = 1800 //takes roughly ~15s longer to break then full deconstruction.
+	circuit = null
 	var/obj/item/computer_hardware/hard_drive/cluster/hdd_theft/source_code_hdd
 	var/deconstruction_state = HDD_PANEL_CLOSED
 	var/front_panel_screws = 4

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -17,6 +17,7 @@
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "RD-server-on"
 	base_icon_state = "RD-server"
+	circuit = /obj/item/circuitboard/machine/rdserver
 	req_access = list(ACCESS_RD)
 
 	/// if TRUE, we are currently operational and giving out research points.


### PR DESCRIPTION
## About The Pull Request
RnD servers were being immediately deleted when trying to `default_deconstruction_crowbar`, because there were no stock parts or circuitboards in them, causing the following steps to skip over to `Destroy`. This PR adds the missing circuitboard and the stock parts that come with it upon `Initialize`.

## Why It's Good For The Game
You can now properly move the RnD Server.

## Changelog
:cl:
fix: Fixed RnD Servers not dropping their components & completely vanishing when deconstructed
/:cl:

