### PR TITLE
Carries over carded AIs into crafted intellicards

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -1141,25 +1141,27 @@
 	reqs = list(/obj/item/aicard = 1,
 					/obj/item/food/grown/potato = 1,
 					/obj/item/stack/cable_coil = 5)
+	parts = list(/obj/item/aicard = 1)
 	category = CAT_MISC
 
-/datum/crafting_recipe/aitater/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/aicard/aicard = collected_requirements[/obj/item/aicard][1]
-	if(!aicard.AI)
-		return TRUE
-
-	to_chat(user, span_boldwarning("You can't craft an intelliTater with an AI in the card!"))
-	return FALSE
-
-/datum/crafting_recipe/aispook
+/datum/crafting_recipe/aitater/aispook
 	name = "intelliLantern"
 	result = /obj/item/aicard/aispook
-	time = 30
-	tool_behaviors = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/aicard = 1,
 					/obj/item/food/grown/pumpkin = 1,
 					/obj/item/stack/cable_coil = 5)
-	category = CAT_MISC
+
+/datum/crafting_recipe/aitater/on_craft_completion(mob/user, atom/result)
+	var/obj/item/aicard/new_card = result
+	var/obj/item/aicard/base_card = result.contents[1]
+	var/mob/living/silicon/ai = base_card.AI
+
+	if(ai)
+		base_card.AI = null
+		ai.forceMove(new_card)
+		new_card.AI = ai
+		new_card.update_appearance()
+	qdel(base_card)
 
 /datum/crafting_recipe/ghettojetpack
 	name = "Improvised Jetpack"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Crafting an intelliTater/intelliLantern with an intellicard that contains an AI will now carry over the AI (as well as radio/wireless settings) into the crafted card.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #70397
Previously this was prevented by just not letting you use a card containing an AI to craft an intelliTater atall.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Crafting intelliTaters/intelliLanterns now carries over the AI from the card used to craft it.
fix: Crafting intelliLanterns with a card that contains an AI no longer deletes the AI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
