### PR TITLE
Fixes communication being nearly impossible (except over radio) when there's a null client in the global player list

### DIFF
--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -181,7 +181,7 @@
 
 	// Add observers who have ghost radio enabled.
 	for(var/mob/dead/observer/ghost in GLOB.player_list)
-		if(ghost.client.prefs?.chat_toggles & CHAT_GHOSTRADIO)
+		if(ghost.client?.prefs?.chat_toggles & CHAT_GHOSTRADIO)
 			receive |= ghost
 
 	// Render the message and have everybody hear it.

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -181,7 +181,11 @@
 
 	// Add observers who have ghost radio enabled.
 	for(var/mob/dead/observer/ghost in GLOB.player_list)
-		if(ghost.client?.prefs?.chat_toggles & CHAT_GHOSTRADIO)
+		if(ghost.client && !ghost.client.prefs)
+			stack_trace("[ghost] ([ghost.ckey]) had null prefs, which shouldn't be possible!")
+			continue
+
+		if(ghost.client?.prefs.chat_toggles & CHAT_GHOSTRADIO)
 			receive |= ghost
 
 	// Render the message and have everybody hear it.

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -375,9 +375,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 				continue
 			if(player_mob.z != z || get_dist(player_mob, src) > 7) //they're out of range of normal hearing
 				if(eavesdrop_range)
-					if(!(player_mob.client?.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
+					if(!(player_mob.client?.prefs?.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
 						continue
-				else if(!(player_mob.client?.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
+				else if(!(player_mob.client?.prefs?.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
 					continue
 			listening |= player_mob
 			the_dead[player_mob] = TRUE

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -374,10 +374,14 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			if(player_mob.stat != DEAD) //not dead, not important
 				continue
 			if(player_mob.z != z || get_dist(player_mob, src) > 7) //they're out of range of normal hearing
+				if(player_mob.client && !player_mob.client?.prefs)
+					stack_trace("[player_mob] ([player_mob.ckey]) had null prefs, which shouldn't be possible!")
+					continue
+
 				if(eavesdrop_range)
-					if(!(player_mob.client?.prefs?.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
+					if(!(player_mob.client?.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
 						continue
-				else if(!(player_mob.client?.prefs?.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
+				else if(!(player_mob.client?.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
 					continue
 			listening |= player_mob
 			the_dead[player_mob] = TRUE

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -142,11 +142,15 @@
 	// If there is no single listener, broadcast to everyone in the same z level
 		if(!only_listener)
 			// Play voice for all mobs in the z level
-			for(var/mob/M in GLOB.player_list)
-				if(M.can_hear() && (M.client?.prefs?.toggles & SOUND_ANNOUNCEMENTS))
-					var/turf/T = get_turf(M)
+			for(var/mob/player_mob in GLOB.player_list)
+				if(player_mob.client && !player_mob.client?.prefs)
+					stack_trace("[player_mob] ([player_mob.ckey]) has null prefs, which shouldn't be possible!")
+					continue
+
+				if(player_mob.can_hear() && (player_mob.client?.prefs.toggles & SOUND_ANNOUNCEMENTS))
+					var/turf/T = get_turf(player_mob)
 					if(T.z == z_level)
-						SEND_SOUND(M, voice)
+						SEND_SOUND(player_mob, voice)
 		else
 			SEND_SOUND(only_listener, voice)
 		return TRUE

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -143,7 +143,7 @@
 		if(!only_listener)
 			// Play voice for all mobs in the z level
 			for(var/mob/M in GLOB.player_list)
-				if(M.can_hear() && (M.client?.prefs.toggles & SOUND_ANNOUNCEMENTS))
+				if(M.can_hear() && (M.client?.prefs?.toggles & SOUND_ANNOUNCEMENTS))
 					var/turf/T = get_turf(M)
 					if(T.z == z_level)
 						SEND_SOUND(M, voice)

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -307,9 +307,13 @@
 
 	// Show it to ghosts
 	var/ghost_message = span_name("[message_data["name"]] </span><span class='game say'>[rigged ? "Rigged" : ""] PDA Message</span> --> [span_name("[signal.format_target()]")]: <span class='message'>[signal.format_message()]")
-	for(var/mob/M in GLOB.player_list)
-		if(isobserver(M) && (M.client?.prefs?.chat_toggles & CHAT_GHOSTPDA))
-			to_chat(M, "[FOLLOW_LINK(M, user)] [ghost_message]")
+	for(var/mob/player_mob in GLOB.player_list)
+		if(player_mob.client && !player_mob.client?.prefs)
+			stack_trace("[player_mob] ([player_mob.ckey]) had null prefs, which shouldn't be possible!")
+			continue
+
+		if(isobserver(player_mob) && (player_mob.client?.prefs.chat_toggles & CHAT_GHOSTPDA))
+			to_chat(player_mob, "[FOLLOW_LINK(player_mob, user)] [ghost_message]")
 
 	// Log in the talk log
 	user.log_talk(message, LOG_PDA, tag="[rigged ? "Rigged" : ""] PDA: [message_data["name"]] to [signal.format_target()]")

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -308,7 +308,7 @@
 	// Show it to ghosts
 	var/ghost_message = span_name("[message_data["name"]] </span><span class='game say'>[rigged ? "Rigged" : ""] PDA Message</span> --> [span_name("[signal.format_target()]")]: <span class='message'>[signal.format_message()]")
 	for(var/mob/M in GLOB.player_list)
-		if(isobserver(M) && (M.client?.prefs.chat_toggles & CHAT_GHOSTPDA))
+		if(isobserver(M) && (M.client?.prefs?.chat_toggles & CHAT_GHOSTPDA))
 			to_chat(M, "[FOLLOW_LINK(M, user)] [ghost_message]")
 
 	// Log in the talk log


### PR DESCRIPTION
## About The Pull Request
Have you ever been unable to talk IC except over radio for whatever reason, and it lasted for a little while, so you had to stare at people for a while, praying for it to get fixed soon?

Yeah, that's not fun for anyone.

Adds a few null checks to certain checks related to communications that touch `GLOB.player_list` because, as much as this list advertises itself as not containing client-less mobs, it can happen, most likely because clients are fickle bitches, and now they won't cause a major "everyone is mute and can't emote and can only use the radio to talk" moment when they happen.

Fixes https://github.com/tgstation/tgstation/issues/69942 and probably more issues, but I honestly can't be bothered to check through the issues right now.


## Why It's Good For The Game
It's funny the first five seconds but then it's just annoying, and it's more annoying every time.

## Changelog

:cl: GoldenAlpharex
fix: You should no longer suddenly experience a station-wide mutism event (that didn't affect radios), and will now properly be able to express yourself regardless (hopefully).
/:cl: