### PR TITLE
Holymelons are more melon-like

### DIFF
--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -59,6 +59,9 @@
 	desc = "The water within this melon has been blessed by some deity that's particularly fond of watermelon."
 	icon_state = "holymelon"
 	bite_consumption_mod = 2
+	w_class = WEIGHT_CLASS_NORMAL
+	foodtypes = FRUIT
+	juice_results = list(/datum/reagent/water/holywater = 0)
 	wine_power = 70 //Water to wine, baby.
 	wine_flavor = "divinity"
 


### PR DESCRIPTION
## About The Pull Request

- Holy melons are fruit
- Holy melons are normal weight class
- Holy melons juice into holy water

## Why It's Good For The Game

Holymelons aren't subtypes of melon so they weren't very melon like (they weren't even fruit)
So this resolves some of that

## Changelog

:cl: Melbert
balance: Holy melons are now more melon like - they are now fruits (instead of no food type), normal weight class, and can be juiced into holy water
/:cl:
