### PR TITLE
organ fridges now freeze the organs in severed bodyparts e.g. heads

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -451,6 +451,10 @@
 	if(isorgan(O))
 		var/obj/item/organ/organ = O
 		organ.organ_flags |= ORGAN_FROZEN
+	if(isbodypart(O))
+		var/obj/item/bodypart/bodypart = O
+		for(var/obj/item/organ/stored in bodypart.contents)
+			stored.organ_flags |= ORGAN_FROZEN
 
 /obj/machinery/smartfridge/organ/RefreshParts()
 	. = ..()
@@ -467,6 +471,10 @@
 	if(isorgan(gone))
 		var/obj/item/organ/O = gone
 		O.organ_flags &= ~ORGAN_FROZEN
+	if(isbodypart(gone))
+		var/obj/item/bodypart/bodypart = gone
+		for(var/obj/item/organ/stored in bodypart.contents)
+			stored.organ_flags &= ~ORGAN_FROZEN
 
 // -----------------------------
 // Chemistry Medical Smartfridge


### PR DESCRIPTION
## About The Pull Request
closes #70414
## Why It's Good For The Game
Shoving a guy's head in a fridge should probably freeze the stuff in there too; temperature isn't skin-deep, after all!

## Changelog
:cl:
fix: Bodyparts (e.g. severed heads) stored in organ fridges now freeze the organs stored inside them, if any are present.
/:cl:
