### PR TITLE
Silver slime extract created food isn't toxic to jellypeople

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -484,8 +484,9 @@ Behavior that's still missing from this component that original food items had t
 			food_taste_reaction = FOOD_DISLIKED
 		else if(foodtypes & H.dna.species.liked_food)
 			food_taste_reaction = FOOD_LIKED
+
 	if(food_flags & FOOD_SILVER_SPAWNED) // it's not real food
-		food_taste_reaction = FOOD_TOXIC
+		food_taste_reaction = isjellyperson(H) ? FOOD_LIKED : FOOD_TOXIC
 
 	switch(food_taste_reaction)
 		if(FOOD_TOXIC)


### PR DESCRIPTION
## About The Pull Request

- Food created by silver slimes are not toxic to slimepeople. 

## Why It's Good For The Game

Somewhat of an oversight of the silver food PR. Jellypeople are supposed to be able to eat any food (see #58698), and it's kinda lame that they can't now. Gives silver food a single purpose.

## Changelog

:cl: Melbert
fix: Jellypeople (species) can consume food created by silver slimes
/:cl:
