### PR TITLE
Add chat notification for shoes & glove protection when mousetraps triggered

### DIFF
--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -125,7 +125,7 @@
 					affecting = victim.get_bodypart(pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
 					victim.Paralyze(60)
 				else
-					to_chat(victim, span_notice("Your [victim.shoes] protects you from the [src]."))
+					to_chat(victim, span_notice("Your [victim.shoes] protects you from [src]."))
 			if(BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND)
 				if(!victim.gloves)
 					affecting = victim.get_bodypart(type)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -114,23 +114,27 @@
 	update_appearance()
 	var/obj/item/bodypart/affecting = null
 	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(HAS_TRAIT(H, TRAIT_PIERCEIMMUNE))
+		var/mob/living/carbon/human/victim = target
+		if(HAS_TRAIT(victim, TRAIT_PIERCEIMMUNE))
 			playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 			pulse(FALSE)
 			return FALSE
 		switch(type)
 			if("feet")
-				if(!H.shoes)
-					affecting = H.get_bodypart(pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
-					H.Paralyze(60)
+				if(!victim.shoes)
+					affecting = victim.get_bodypart(pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
+					victim.Paralyze(60)
+				else
+					to_chat(user, span_notice("Your [victim.shoes] protects you from the [src]."))
 			if(BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND)
-				if(!H.gloves)
-					affecting = H.get_bodypart(type)
-					H.Stun(60)
+				if(!victim.gloves)
+					affecting = victim.get_bodypart(type)
+					victim.Stun(60)
+				else
+					to_chat(user, span_notice("Your [victim.gloves] protects you from the [src]."))
 		if(affecting)
 			if(affecting.receive_damage(1, 0))
-				H.update_damage_overlays()
+				victim.update_damage_overlays()
 	else if(ismouse(target))
 		var/mob/living/simple_animal/mouse/M = target
 		visible_message(span_boldannounce("SPLAT!"))

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -125,13 +125,13 @@
 					affecting = victim.get_bodypart(pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
 					victim.Paralyze(60)
 				else
-					to_chat(user, span_notice("Your [victim.shoes] protects you from the [src]."))
+					to_chat(victim, span_notice("Your [victim.shoes] protects you from the [src]."))
 			if(BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND)
 				if(!victim.gloves)
 					affecting = victim.get_bodypart(type)
 					victim.Stun(60)
 				else
-					to_chat(user, span_notice("Your [victim.gloves] protects you from the [src]."))
+					to_chat(victim, span_notice("Your [victim.gloves] protects you from the [src]."))
 		if(affecting)
 			if(affecting.receive_damage(1, 0))
 				victim.update_damage_overlays()

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -131,7 +131,7 @@
 					affecting = victim.get_bodypart(type)
 					victim.Stun(60)
 				else
-					to_chat(victim, span_notice("Your [victim.gloves] protects you from the [src]."))
+					to_chat(victim, span_notice("Your [victim.gloves] protects you from [src]."))
 		if(affecting)
 			if(affecting.receive_damage(1, 0))
 				victim.update_damage_overlays()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #67651

Mousetraps that would trigger would not give any kind of indication that protection was used to nullify damage and stun.  There is now a notification that this is intended for players.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Better awareness for players.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Add chat notification for shoes & glove protection when mousetrap triggered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
