### PR TITLE
Various Jaunt fixes

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_spell.dm
+++ b/code/__DEFINES/dcs/signals/signals_spell.dm
@@ -53,6 +53,8 @@
 // Jaunt Spells
 /// Sent from datum/action/cooldown/spell/jaunt/enter_jaunt, to the mob jaunting: (obj/effect/dummy/phased_mob/jaunt, datum/action/cooldown/spell/spell)
 #define COMSIG_MOB_ENTER_JAUNT "spell_mob_enter_jaunt"
+/// Set from /obj/effect/dummy/phased_mob after the mob is ejected from its contents: (obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
+#define COMSIG_MOB_EJECTED_FROM_JAUNT "spell_mob_eject_jaunt"
 /// Sent from datum/action/cooldown/spell/jaunt/exit_jaunt, after the mob exited jaunt: (datum/action/cooldown/spell/spell)
 #define COMSIG_MOB_AFTER_EXIT_JAUNT "spell_mob_after_exit_jaunt"
 

--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -79,6 +79,8 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 #define ZMOVE_VENTCRAWLING (1<<8)
 /// Includes movables that're either pulled by the source or mobs buckled to it in the list of moving movables.
 #define ZMOVE_INCLUDE_PULLED (1<<9)
+/// Skips check for whether the moving atom is anchored or not.
+#define ZMOVE_ALLOW_ANCHORED (1<<10)
 
 #define ZMOVE_CHECK_PULLS (ZMOVE_CHECK_PULLING|ZMOVE_CHECK_PULLEDBY)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -312,7 +312,7 @@
 			else
 				to_chat(src, span_warning("You are not Superman."))
 		return FALSE
-	if(!(z_move_flags & ZMOVE_IGNORE_OBSTACLES) && !(start.zPassOut(src, direction, destination) && destination.zPassIn(src, direction, start)))
+	if(!(z_move_flags & ZMOVE_IGNORE_OBSTACLES) && !(start.zPassOut(src, direction, destination, (z_move_flags & ZMOVE_ALLOW_ANCHORED)) && destination.zPassIn(src, direction, start)))
 		if(z_move_flags & ZMOVE_FEEDBACK)
 			to_chat(rider || src, span_warning("You couldn't move there!"))
 		return FALSE

--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -68,7 +68,9 @@
 	var/turf/newloc = phased_check(user, direction)
 	if(!newloc)
 		return
-	setDir(direction)
+
+	if (direction in GLOB.alldirs)
+		setDir(direction)
 	forceMove(newloc)
 
 /// Checks if the conditions are valid to be able to phase. Returns a turf destination if positive.
@@ -76,7 +78,7 @@
 	RETURN_TYPE(/turf)
 	if (movedelay > world.time || !direction)
 		return
-	var/turf/newloc = get_step(src,direction)
+	var/turf/newloc = get_step_multiz(src,direction)
 	if(!newloc)
 		return
 	var/area/destination_area = newloc.loc
@@ -87,4 +89,7 @@
 	if(destination_area.area_flags & NOTELEPORT || SSmapping.level_trait(newloc.z, ZTRAIT_NOPHASE))
 		to_chat(user, span_danger("Some dull, universal force is blocking the way. It's overwhelmingly oppressive force feels dangerous."))
 		return
+	if (direction == UP || direction == DOWN)
+		newloc = can_z_move(direction, get_turf(src), newloc, ZMOVE_INCAPACITATED_CHECKS | ZMOVE_FEEDBACK | ZMOVE_ALLOW_ANCHORED, user)
+
 	return newloc

--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -32,7 +32,7 @@
 /// Removes [jaunter] from our phased mob
 /obj/effect/dummy/phased_mob/proc/eject_jaunter()
 	if(!jaunter)
-		CRASH("Phased mob ([type]) attempted to eject null jaunter.")
+		return // This is weird but it can happen if the jaunt is gibbed by an arriving shuttle
 	var/turf/eject_spot = get_turf(src)
 	if(!eject_spot) //You're in nullspace you clown!
 		return
@@ -48,7 +48,6 @@
 				shake_camera(living_cheaterson, 20, 1)
 				addtimer(CALLBACK(living_cheaterson, /mob/living/carbon.proc/vomit), 2 SECONDS)
 			jaunter.forceMove(find_safe_turf(z))
-
 	else
 		jaunter.forceMove(eject_spot)
 	qdel(src)
@@ -56,6 +55,7 @@
 /obj/effect/dummy/phased_mob/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(gone == jaunter)
+		SEND_SIGNAL(src, COMSIG_MOB_EJECTED_FROM_JAUNT, jaunter)
 		jaunter = null
 
 /obj/effect/dummy/phased_mob/ex_act()

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -18,7 +18,7 @@
 	return FALSE
 
 //direction is direction of travel of A
-/turf/open/zPassOut(atom/movable/A, direction, turf/destination)
+/turf/open/zPassOut(atom/movable/A, direction, turf/destination, allow_anchored_movement)
 	if(direction == UP)
 		for(var/obj/O in contents)
 			if(O.obj_flags & BLOCK_Z_OUT_UP)

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -88,8 +88,8 @@
 		return TRUE
 	return FALSE
 
-/turf/open/openspace/zPassOut(atom/movable/A, direction, turf/destination)
-	if(A.anchored)
+/turf/open/openspace/zPassOut(atom/movable/A, direction, turf/destination, allow_anchored_movement)
+	if(A.anchored && !allow_anchored_movement)
 		return FALSE
 	if(direction == DOWN)
 		for(var/obj/contained_object in contents)

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -254,8 +254,8 @@
 		return TRUE
 	return FALSE
 
-/turf/open/space/openspace/zPassOut(atom/movable/A, direction, turf/destination)
-	if(A.anchored)
+/turf/open/space/openspace/zPassOut(atom/movable/A, direction, turf/destination, allow_anchored_movement)
+	if(A.anchored && !allow_anchored_movement)
 		return FALSE
 	if(direction == DOWN)
 		for(var/obj/contained_object in contents)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -274,7 +274,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	return FALSE
 
 //direction is direction of travel of air
-/turf/proc/zPassOut(atom/movable/A, direction, turf/destination)
+/turf/proc/zPassOut(atom/movable/A, direction, turf/destination, allow_anchored_movement)
 	return FALSE
 
 //direction is direction of travel of air

--- a/code/modules/antagonists/heretic/magic/mirror_walk.dm
+++ b/code/modules/antagonists/heretic/magic/mirror_walk.dm
@@ -21,6 +21,14 @@
 		/obj/structure/mirror,
 	))
 
+/datum/action/cooldown/spell/jaunt/mirror_walk/Grant(mob/grant_to)
+	. = ..()
+	RegisterSignal(grant_to, COMSIG_MOVABLE_MOVED, .proc/update_icon_on_signal)
+
+/datum/action/cooldown/spell/jaunt/mirror_walk/Remove(mob/remove_from)
+	. = ..()
+	UnregisterSignal(remove_from, COMSIG_MOVABLE_MOVED)
+
 /datum/action/cooldown/spell/jaunt/mirror_walk/can_cast_spell(feedback = TRUE)
 	. = ..()
 	if(!.)
@@ -66,7 +74,11 @@
 
 	// Pass the turf of the nearby reflection to the parent call
 	// as that's the location we're actually jaunting into
-	return ..(jaunter, get_turf(nearby_reflection))
+	var/obj/effect/dummy/phased_mob/jaunt = ..(jaunter, get_turf(nearby_reflection))
+	if (!jaunt)
+		return FALSE
+	RegisterSignal(jaunt, COMSIG_MOVABLE_MOVED, .proc/update_icon_on_signal)
+	return jaunt
 
 /datum/action/cooldown/spell/jaunt/mirror_walk/exit_jaunt(mob/living/unjaunter, turf/loc_override)
 	var/turf/phase_turf = get_turf(unjaunter)
@@ -88,21 +100,25 @@
 
 	// We can move around while phasing in, but we'll always end up where we started it.
 	// Pass the jaunter's turf at the start of the proc back to the parent call.
-	. = ..(unjaunter, phase_turf)
-	if(!.)
-		return FALSE
+	return ..(unjaunter, phase_turf)
 
+// Play a spooky noise, provide textual feedback, and make the turf colder.
+/datum/action/cooldown/spell/jaunt/mirror_walk/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
+	. = ..()
+	UnregisterSignal(jaunt, COMSIG_MOVABLE_MOVED)
 	playsound(unjaunter, 'sound/magic/ethereal_exit.ogg', 50, TRUE, -1)
-	unjaunter.visible_message(
-		span_boldwarning("[unjaunter] phases into reality before your very eyes!"),
-		span_notice("You jump out of the reflection coming off of [nearby_reflection], exiting the mirror's realm."),
-	)
+	var/turf/phase_turf = get_turf(unjaunter)
 
 	// Chilly!
-	if(isopenturf(phase_turf))
+	if (isopenturf(phase_turf))
 		phase_turf.TakeTemperature(-20)
 
-	return TRUE
+	var/atom/nearby_reflection = is_reflection_nearby(phase_turf)
+	if (!nearby_reflection) // Should only be true if you're forced out somehow, like by having the spell removed
+		return
+	unjaunter.visible_message(
+		span_boldwarning("[unjaunter] phases into reality before your very eyes!"),
+		span_notice("You jump out of the reflection coming off of [nearby_reflection], exiting the mirror's realm."),)
 
 /**
  * Goes through all nearby atoms in sight of the

--- a/code/modules/antagonists/heretic/magic/mirror_walk.dm
+++ b/code/modules/antagonists/heretic/magic/mirror_walk.dm
@@ -118,7 +118,8 @@
 		return
 	unjaunter.visible_message(
 		span_boldwarning("[unjaunter] phases into reality before your very eyes!"),
-		span_notice("You jump out of the reflection coming off of [nearby_reflection], exiting the mirror's realm."),)
+		span_notice("You jump out of the reflection coming off of [nearby_reflection], exiting the mirror's realm."),
+	)
 
 /**
  * Goes through all nearby atoms in sight of the

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -107,8 +107,8 @@
 		return FALSE
 
 	if(ismovable(mob.loc)) //Inside an object, tell it we moved
-		var/atom/O = mob.loc
-		return O.relaymove(mob, direct)
+		var/atom/loc_atom = mob.loc
+		return loc_atom.relaymove(mob, direct)
 
 	if(!mob.Process_Spacemove(direct))
 		return FALSE
@@ -530,8 +530,8 @@
 		return
 
 	if(ismovable(loc)) //Inside an object, tell it we moved
-		var/atom/O = loc
-		return O.relaymove(src, UP)
+		var/atom/loc_atom = loc
+		return loc_atom.relaymove(src, UP)
 
 	if(can_z_move(DOWN, above_turf, current_turf, ZMOVE_FALL_FLAGS|ventcrawling_flag)) //Will we fall down if we go up?
 		if(buckled)
@@ -549,8 +549,8 @@
 	set category = "IC"
 
 	if(ismovable(loc)) //Inside an object, tell it we moved
-		var/atom/O = loc
-		return O.relaymove(src, DOWN)
+		var/atom/loc_atom = loc
+		return loc_atom.relaymove(src, DOWN)
 
 	var/ventcrawling_flag = HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING) ? ZMOVE_VENTCRAWLING : 0
 	if(zMove(DOWN, z_move_flags = ZMOVE_FLIGHT_FLAGS|ZMOVE_FEEDBACK|ventcrawling_flag))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -106,7 +106,7 @@
 	if(!(L.mobility_flags & MOBILITY_MOVE))
 		return FALSE
 
-	if(isobj(mob.loc) || ismob(mob.loc)) //Inside an object, tell it we moved
+	if(ismovable(mob.loc)) //Inside an object, tell it we moved
 		var/atom/O = mob.loc
 		return O.relaymove(mob, direct)
 
@@ -529,16 +529,16 @@
 		to_chat(src, span_warning("There's nowhere to go in that direction!"))
 		return
 
+	if(ismovable(loc)) //Inside an object, tell it we moved
+		var/atom/O = loc
+		return O.relaymove(src, UP)
+
 	if(can_z_move(DOWN, above_turf, current_turf, ZMOVE_FALL_FLAGS|ventcrawling_flag)) //Will we fall down if we go up?
 		if(buckled)
 			to_chat(src, span_warning("[buckled] is is not capable of flight."))
 		else
 			to_chat(src, span_warning("You are not Superman."))
 		return
-
-	if(isobj(loc) || ismob(loc)) //Inside an object, tell it we moved
-		var/atom/O = loc
-		return O.relaymove(src, UP)
 
 	if(zMove(UP, z_move_flags = ZMOVE_FLIGHT_FLAGS|ZMOVE_FEEDBACK|ventcrawling_flag))
 		to_chat(src, span_notice("You move upwards."))
@@ -548,7 +548,7 @@
 	set name = "Move Down"
 	set category = "IC"
 
-	if(isobj(loc) || ismob(loc)) //Inside an object, tell it we moved
+	if(ismovable(loc)) //Inside an object, tell it we moved
 		var/atom/O = loc
 		return O.relaymove(src, DOWN)
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -536,6 +536,10 @@
 			to_chat(src, span_warning("You are not Superman."))
 		return
 
+	if(isobj(loc) || ismob(loc)) //Inside an object, tell it we moved
+		var/atom/O = loc
+		return O.relaymove(src, UP)
+
 	if(zMove(UP, z_move_flags = ZMOVE_FLIGHT_FLAGS|ZMOVE_FEEDBACK|ventcrawling_flag))
 		to_chat(src, span_notice("You move upwards."))
 
@@ -543,6 +547,10 @@
 /mob/verb/down()
 	set name = "Move Down"
 	set category = "IC"
+
+	if(isobj(loc) || ismob(loc)) //Inside an object, tell it we moved
+		var/atom/O = loc
+		return O.relaymove(src, DOWN)
 
 	var/ventcrawling_flag = HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING) ? ZMOVE_VENTCRAWLING : 0
 	if(zMove(DOWN, z_move_flags = ZMOVE_FLIGHT_FLAGS|ZMOVE_FEEDBACK|ventcrawling_flag))

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -50,6 +50,7 @@
  */
 /datum/action/cooldown/spell/jaunt/proc/enter_jaunt(mob/living/jaunter, turf/loc_override)
 	var/obj/effect/dummy/phased_mob/jaunt = new jaunt_type(loc_override || get_turf(jaunter), jaunter)
+	RegisterSignal(jaunt, COMSIG_MOB_EJECTED_FROM_JAUNT, .proc/on_jaunt_exited)
 	spell_requirements |= SPELL_CASTABLE_WHILE_PHASED
 	ADD_TRAIT(jaunter, TRAIT_MAGICALLY_PHASED, REF(src))
 
@@ -59,6 +60,7 @@
 
 /**
  * Ejects the [unjaunter] from jaunt
+ * The jaunt object in turn should call on_jaunt_exited
  * If [loc_override] is supplied,
  * the jaunt will be moved to that turf
  * before ejecting the unjaunter
@@ -76,12 +78,22 @@
 	if(loc_override)
 		jaunt.forceMove(loc_override)
 	jaunt.eject_jaunter()
+	return TRUE
+
+/**
+ * Called when a mob is ejected from the jaunt holder and goes back to normal.
+ * This is called both fom exit_jaunt() but also if the caster is ejected involuntarily for some reason.
+ * Use this to clear state data applied when jaunting, such as the trait TRAIT_MAGICALLY_PHASED.
+ * Arguments
+ * * jaunt - The mob holder effect the caster has just exited
+ * * unjaunter - The spellcaster who is no longer jaunting
+ */
+/datum/action/cooldown/spell/jaunt/proc/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
+	SHOULD_CALL_PARENT(TRUE)
 	spell_requirements &= ~SPELL_CASTABLE_WHILE_PHASED
 	REMOVE_TRAIT(unjaunter, TRAIT_MAGICALLY_PHASED, REF(src))
-
-	// Ditto - this needs to happen at the end, after all the traits and stuff is handled
+	// This needs to happen at the end, after all the traits and stuff is handled
 	SEND_SIGNAL(unjaunter, COMSIG_MOB_AFTER_EXIT_JAUNT, src)
-	return TRUE
 
 /// Simple helper to check if the passed mob is currently jaunting or not
 /datum/action/cooldown/spell/jaunt/proc/is_jaunting(mob/living/user)
@@ -89,4 +101,8 @@
 
 /datum/action/cooldown/spell/jaunt/Remove(mob/living/remove_from)
 	exit_jaunt(remove_from)
+	if (!is_jaunting(remove_from)) // In case you have made exit_jaunt conditional, as in mirror walk
+		return ..()
+	var/obj/effect/dummy/phased_mob/jaunt = remove_from.loc
+	jaunt.eject_jaunter()
 	return ..()

--- a/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
+++ b/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
@@ -33,21 +33,24 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	for(var/obj/effect/decal/cleanable/blood_nearby in range(blood_radius, get_turf(owner)))
-		if(blood_nearby.can_bloodcrawl_in())
-			return TRUE
+	if(find_nearby_blood(get_turf(owner)))
+		return TRUE
 	if(feedback)
 		to_chat(owner, span_warning("There must be a nearby source of blood!"))
 	return FALSE
 
 /datum/action/cooldown/spell/jaunt/bloodcrawl/cast(mob/living/cast_on)
 	. = ..()
-	for(var/obj/effect/decal/cleanable/blood_nearby in range(blood_radius, get_turf(cast_on)))
-		if(blood_nearby.can_bloodcrawl_in())
-			return do_bloodcrawl(blood_nearby, cast_on)
+	// Should always return something because we checked that in can_cast_spell before arriving here
+	var/obj/effect/decal/cleanable/blood_nearby = find_nearby_blood(get_turf(cast_on))
+	do_bloodcrawl(blood_nearby, cast_on)
 
-	reset_spell_cooldown()
-	to_chat(cast_on, span_warning("There must be a nearby source of blood!"))
+/// Returns a nearby blood decal, or null if there aren't any
+/datum/action/cooldown/spell/jaunt/bloodcrawl/proc/find_nearby_blood(turf/origin)
+	for(var/obj/effect/decal/cleanable/blood_nearby in range(blood_radius, origin))
+		if(blood_nearby.can_bloodcrawl_in())
+			return blood_nearby
+	return null
 
 /**
  * Attempts to enter or exit the passed blood pool.

--- a/code/modules/spells/spell_types/jaunt/shadow_walk.dm
+++ b/code/modules/spells/spell_types/jaunt/shadow_walk.dm
@@ -8,18 +8,34 @@
 	spell_requirements = NONE
 	jaunt_type = /obj/effect/dummy/phased_mob/shadow
 
+/datum/action/cooldown/spell/jaunt/shadow_walk/Grant(mob/grant_to)
+	. = ..()
+	RegisterSignal(grant_to, COMSIG_MOVABLE_MOVED, .proc/update_icon_on_signal)
+
+/datum/action/cooldown/spell/jaunt/shadow_walk/Remove(mob/remove_from)
+	. = ..()
+	UnregisterSignal(remove_from, COMSIG_MOVABLE_MOVED)
+
+/datum/action/cooldown/spell/jaunt/shadow_walk/can_cast_spell(feedback = TRUE)
+	. = ..()
+	if(!.)
+		return FALSE
+	if(is_jaunting())
+		return TRUE
+	var/turf/cast_turf = get_turf(owner)
+	if(cast_turf.get_lumcount() >= SHADOW_SPECIES_LIGHT_THRESHOLD)
+		if(feedback)
+			to_chat(owner, span_warning("It isn't dark enough here!"))
+		return FALSE
+	return TRUE
+
 /datum/action/cooldown/spell/jaunt/shadow_walk/cast(mob/living/cast_on)
 	. = ..()
 	if(is_jaunting(cast_on))
 		exit_jaunt(cast_on)
 		return
 
-	var/turf/cast_turf = get_turf(cast_on)
-	if(cast_turf.get_lumcount() >= SHADOW_SPECIES_LIGHT_THRESHOLD)
-		to_chat(cast_on, span_warning("It isn't dark enough here!"))
-		return
-
-	playsound(cast_turf, 'sound/magic/ethereal_enter.ogg', 50, TRUE, -1)
+	playsound(get_turf(owner), 'sound/magic/ethereal_enter.ogg', 50, TRUE, -1)
 	cast_on.visible_message(span_boldwarning("[cast_on] melts into the shadows!"))
 	cast_on.SetAllImmobility(0)
 	cast_on.setStaminaLoss(0, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This reworks the flow of how Jaunt spells work somewhat to fix a number of bugs I found while fucking around with them downstream.

Fixes https://github.com/tgstation/tgstation/issues/56254
Fixes https://github.com/tgstation/tgstation/issues/49715
Fixes https://github.com/tgstation/tgstation/issues/46620
As well as some unreported bugs I found which were chiefly related to `TRAIT_MAGICALLY_PHASED` persisting after being forced to exit the jaunt when you didn't do it voluntarily.

The mob holder object which does the funny jaunt movement now sends `COMSIG_MOB_EJECTED_FROM_JAUNT` when the mob exits its contents.
The jaunt spell registers to this and calls new proc `on_jaunt_exited` when it receives it. This is where any removal of traits or effects should go, because it will be called any time the mob is ejected rather than only if they did it on purpose.

This also means that the spell will clean itself up more effectively if it is removed from you while it is active, for instance in the above linked issue where someone was ahealed and it ejected the demon heart which gave them the spell.

Additionally, the mob procs to move up or down will now call `relayMove` instead if you are inside an object or mob. I expected this to be more complicated than that, but that seems to have just fixed the issue immediately and now if you are capable of z-travelling you can still do it while jaunted without moving yourself out of the jaunt object and ending it prematurely.

Additionally Mirror Walk's button was fucked up and would display itself as active or inactive arbitrarily, depending on whether you were near a mirror the last time the cooldown ended. Now it also checks this whenever you move, so it will correctly live update. I suspect nobody reported this because the button is already red so tinting it red actually isn't very obvious.
While I was at it, I added the same functionality to Blood Crawl and Shadow Walk for better visual feedback.

## Why It's Good For The Game

It fixes some bugs, most of which were only available in niche circumstances.
Z travelling while jaunting is pretty useful on Icebox and Tram for a Maid in the Mirror and it was weird and sometimes problematic that it would instead just reveal you, which could give away information you didn't intend.
The mirror walk button cooldown effect was fucked up and now it isn't.
Feedback on whether blood crawl or shadow walk will actually do anything before you press it is more user friendly.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Changing z-level while jaunting will no longer reveal you.
fix: If a shuttle lands on you while jaunting you will die rather than be stuck in a weird purgatory state.
fix: Mirror Walk will not appear tinted as if it can be cast when it can't, and vice versa.
qol: Blood Crawl and Shadow Walk will now display whether you can use them or not in the same manner as Mirror Walk.
refactor: Jaunt code which adds and removes temporary traits or effects should hopefully be easier to work with in the future.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
