### PR TITLE
Fixes health analyzers displaying missing lungs and missing livers on species that don't have them due to their inherent_traits

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -270,9 +270,9 @@
 				missing_organs += "brain"
 			if(!(NOBLOOD in the_dudes_species.species_traits) && !humantarget.getorganslot(ORGAN_SLOT_HEART))
 				missing_organs += "heart"
-			if(!(TRAIT_NOBREATH in the_dudes_species.species_traits) && !humantarget.getorganslot(ORGAN_SLOT_LUNGS))
+			if(!(TRAIT_NOBREATH in the_dudes_species.inherent_traits) && !humantarget.getorganslot(ORGAN_SLOT_LUNGS))
 				missing_organs += "lungs"
-			if(!(TRAIT_NOMETABOLISM in the_dudes_species.species_traits) && !humantarget.getorganslot(ORGAN_SLOT_LIVER))
+			if(!(TRAIT_NOMETABOLISM in the_dudes_species.inherent_traits) && !humantarget.getorganslot(ORGAN_SLOT_LIVER))
 				missing_organs += "liver"
 			if(!(NOSTOMACH in the_dudes_species.species_traits) && !humantarget.getorganslot(ORGAN_SLOT_STOMACH))
 				missing_organs += "stomach"


### PR DESCRIPTION
## About The Pull Request
It was simply checking in the wrong list to see if they had the trait, and that meant that they wouldn't behave as expected on health scans, as they would never find a string in a list of integers.

## Why It's Good For The Game
This looks a lot better.
![image](https://user-images.githubusercontent.com/58045821/194936255-41fad1b8-5d3b-4417-ae5c-42c0722a8323.png)


## Changelog

:cl: GoldenAlpharex
fix: Health scanners no longer show someone as missing lungs or a liver if their species don't breathe or don't process chemicals, respectively.
/:cl: