### PR TITLE
Makes flashers actually flash again!

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -201,7 +201,7 @@
 		if(!flasher)
 			flashers -= flash_ref
 			continue
-		if(flasher.last_flash && (flasher.last_flash + 15 SECONDS) > world.time)
+		if(!COOLDOWN_FINISHED(flasher, flash_cooldown))
 			data["flash_charging"] = TRUE
 			break
 	return data

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -9,7 +9,7 @@
 	max_integrity = 250
 	integrity_failure = 0.4
 	damage_deflection = 10
-	///The contained flasher. Mostly just handles the bulb burning out & needing placement.
+	///The contained flash. Mostly just handles the bulb burning out & needing placement.
 	var/obj/item/assembly/flash/handheld/bulb
 	var/id = null
 	/// How far this flash reaches. Affects both proximity distance and the actual stun effect.
@@ -19,7 +19,7 @@
 	var/strength = 100
 
 	COOLDOWN_DECLARE(flash_cooldown)
-	/// Duration of time betwee flashes.
+	/// Duration of time between flashes.
 	var/flash_cooldown_duration = 15 SECONDS
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/flasher, 26)
@@ -147,7 +147,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/flasher, 26)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(bulb)
 			bulb.forceMove(loc)
-			bulb = null
 		if(disassembled)
 			var/obj/item/wallframe/flasher/F = new(get_turf(src))
 			transfer_fingerprints_to(F)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -16,7 +16,7 @@
 	var/flash_range = 2 //this is roughly the size of a brig cell.
 
 	/// How strong Paralyze()'d targets are when flashed.
-	var/strength = 100
+	var/strength = 10 SECONDS
 
 	COOLDOWN_DECLARE(flash_cooldown)
 	/// Duration of time between flashes.

--- a/code/game/objects/items/wall_mounted.dm
+++ b/code/game/objects/items/wall_mounted.dm
@@ -55,8 +55,8 @@
 
 	qdel(src)
 
-/obj/item/wallframe/proc/after_attach(obj/O)
-	transfer_fingerprints_to(O)
+/obj/item/wallframe/proc/after_attach(obj/attached_to)
+	transfer_fingerprints_to(attached_to)
 
 /obj/item/wallframe/screwdriver_act(mob/living/user, obj/item/tool)
 	// For camera-building borgs


### PR DESCRIPTION
:cl: ShizCalev
fix: Wall mounted & portable flashers now actually flash again!
admin: Flashers can now have their range and cooldown durations vareditted with flash_range and flash_cooldown_duration respectively.
/:cl:

Not sure how long they've been broken tbh. 

Switched them over from doing some weird funky lighting system memes (that didn't work since there's mixed lighting systems) to just using the `flash_lighting_fx()` proc that I made over 4 years ago to literally handle doing this exact thing.

Rest is just code cleanup + better varediting support.