### PR TITLE
Fixes blood being left in a mob's bloodstream after insertion

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -40,6 +40,8 @@
 			else
 				exposed_carbon.blood_volume = min(exposed_carbon.blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM)
 
+			exposed_carbon.reagents.remove_reagent(/datum/reagent/blood, reac_volume) // Because we don't want blood to just lie around in the patient's blood, makes no sense.
+
 
 /datum/reagent/blood/on_new(list/data)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -34,13 +34,13 @@
 
 	if(iscarbon(exposed_mob))
 		var/mob/living/carbon/exposed_carbon = exposed_mob
-		if(exposed_carbon.get_blood_id() == /datum/reagent/blood && ((methods & INJECT) || ((methods & INGEST) && exposed_carbon.dna && exposed_carbon.dna.species && (DRINKSBLOOD in exposed_carbon.dna.species.species_traits))))
+		if(exposed_carbon.get_blood_id() == type && ((methods & INJECT) || ((methods & INGEST) && exposed_carbon.dna && exposed_carbon.dna.species && (DRINKSBLOOD in exposed_carbon.dna.species.species_traits))))
 			if(!data || !(data["blood_type"] in get_safe_blood(exposed_carbon.dna.blood_type)))
 				exposed_carbon.reagents.add_reagent(/datum/reagent/toxin, reac_volume * 0.5)
 			else
 				exposed_carbon.blood_volume = min(exposed_carbon.blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM)
 
-			exposed_carbon.reagents.remove_reagent(/datum/reagent/blood, reac_volume) // Because we don't want blood to just lie around in the patient's blood, makes no sense.
+			exposed_carbon.reagents.remove_reagent(type, reac_volume) // Because we don't want blood to just lie around in the patient's blood, makes no sense.
 
 
 /datum/reagent/blood/on_new(list/data)


### PR DESCRIPTION
## About The Pull Request
I was a bit confused why it showed up when I was inspecting people after injecting them with large amounts of blood, especially since blood in your blood does absolutely nothing.

Now that's a bit more obvious to everyone, as it's just no longer going to show in people's bloodstream post-insertion (either orally for species that drink blood, or by injection).

## Why It's Good For The Game
This is just cursed, especially when your body has already processed said blood.
![image](https://user-images.githubusercontent.com/58045821/194946508-73509af1-26c6-43b6-b551-464985dbac37.png)


## Changelog

:cl: GoldenAlpharex
fix: Blood no longer trail in anyone's bloodstream as a reagent after being inserted in their body.
/:cl: