### PR TITLE
Fixes permanent sechud from ablative trenchcoat hood

### DIFF
--- a/code/modules/clothing/suits/ablativecoat.dm
+++ b/code/modules/clothing/suits/ablativecoat.dm
@@ -39,14 +39,14 @@
 		return TRUE
 
 /obj/item/clothing/suit/hooded/ablative/ToggleHood()
-	if (hood_up)
-		return ..()
+	. = ..()
+	if (!hood_up)
+		return
 	var/mob/living/carbon/user = loc
 	var/datum/atom_hud/hud = GLOB.huds[DATA_HUD_SECURITY_ADVANCED]
 	ADD_TRAIT(user, TRAIT_SECURITY_HUD, HELMET_TRAIT)
 	hud.show_to(user)
 	balloon_alert(user, "you put on the hood, and enable the hud")
-	return ..()
 
 /obj/item/clothing/suit/hooded/ablative/RemoveHood()
 	if (!hood_up)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -71,6 +71,7 @@
 /// A trait source when adding traits through unit tests
 #define TRAIT_SOURCE_UNIT_TESTS "unit_tests"
 
+#include "ablative_hud.dm"
 #include "achievements.dm"
 #include "anchored_mobs.dm"
 #include "anonymous_themes.dm"

--- a/code/modules/unit_tests/ablative_hud.dm
+++ b/code/modules/unit_tests/ablative_hud.dm
@@ -1,9 +1,9 @@
-// Check that player gains and loses sec hud when toggling the ablative hood
+/// Check that player gains and loses sec hud when toggling the ablative hood
 /datum/unit_test/ablative_hood_hud
 
 /datum/unit_test/ablative_hood_hud/Run()
 	var/mob/living/carbon/human/person = allocate(/mob/living/carbon/human)
-	var/obj/item/clothing/suit/hooded/ablative/coat = allocate(/obj/item/clothing/suit/hooded/ablative/)
+	var/obj/item/clothing/suit/hooded/ablative/coat = allocate(/obj/item/clothing/suit/hooded/ablative)
 	person.equip_to_slot(coat, ITEM_SLOT_OCLOTHING)
 	TEST_ASSERT(!HAS_TRAIT(person, TRAIT_SECURITY_HUD), "Person already had a sechud before trying to equip the ablative hood.")
 	coat.ToggleHood()
@@ -12,11 +12,11 @@
 	TEST_ASSERT(!HAS_TRAIT(person, TRAIT_SECURITY_HUD), "Person lowered their ablative hood but still has a sechud.")
 
 // Check that player doesn't gain sec hud if the hood is toggled when already wearing a helmet
-/datum/unit_test/ablative_hood_hud_with_helmet/
+/datum/unit_test/ablative_hood_hud_with_helmet
 
 /datum/unit_test/ablative_hood_hud_with_helmet/Run()
 	var/mob/living/carbon/human/person = allocate(/mob/living/carbon/human)
-	var/obj/item/clothing/suit/hooded/ablative/coat = allocate(/obj/item/clothing/suit/hooded/ablative/)
+	var/obj/item/clothing/suit/hooded/ablative/coat = allocate(/obj/item/clothing/suit/hooded/ablative)
 	var/obj/item/clothing/head/helmet/hat = allocate(/obj/item/clothing/head/helmet)
 	person.equip_to_slot(coat, ITEM_SLOT_OCLOTHING)
 	person.equip_to_slot(hat, ITEM_SLOT_HEAD)

--- a/code/modules/unit_tests/ablative_hud.dm
+++ b/code/modules/unit_tests/ablative_hud.dm
@@ -1,5 +1,5 @@
 // Check that player gains and loses sec hud when toggling the ablative hood
-/datum/unit_test/ablative_hood_hud/
+/datum/unit_test/ablative_hood_hud
 
 /datum/unit_test/ablative_hood_hud/Run()
 	var/mob/living/carbon/human/person = allocate(/mob/living/carbon/human)

--- a/code/modules/unit_tests/ablative_hud.dm
+++ b/code/modules/unit_tests/ablative_hud.dm
@@ -1,0 +1,25 @@
+// Check that player gains and loses sec hud when toggling the ablative hood
+/datum/unit_test/ablative_hood_hud/
+
+/datum/unit_test/ablative_hood_hud/Run()
+	var/mob/living/carbon/human/person = allocate(/mob/living/carbon/human)
+	var/obj/item/clothing/suit/hooded/ablative/coat = allocate(/obj/item/clothing/suit/hooded/ablative/)
+	person.equip_to_slot(coat, ITEM_SLOT_OCLOTHING)
+	TEST_ASSERT(!HAS_TRAIT(person, TRAIT_SECURITY_HUD), "Person already had a sechud before trying to equip the ablative hood.")
+	coat.ToggleHood()
+	TEST_ASSERT(HAS_TRAIT(person, TRAIT_SECURITY_HUD), "Person toggled the ablative hood but didn't gain a sechud.")
+	coat.ToggleHood()
+	TEST_ASSERT(!HAS_TRAIT(person, TRAIT_SECURITY_HUD), "Person lowered their ablative hood but still has a sechud.")
+
+// Check that player doesn't gain sec hud if the hood is toggled when already wearing a helmet
+/datum/unit_test/ablative_hood_hud_with_helmet/
+
+/datum/unit_test/ablative_hood_hud_with_helmet/Run()
+	var/mob/living/carbon/human/person = allocate(/mob/living/carbon/human)
+	var/obj/item/clothing/suit/hooded/ablative/coat = allocate(/obj/item/clothing/suit/hooded/ablative/)
+	var/obj/item/clothing/head/helmet/hat = allocate(/obj/item/clothing/head/helmet)
+	person.equip_to_slot(coat, ITEM_SLOT_OCLOTHING)
+	person.equip_to_slot(hat, ITEM_SLOT_HEAD)
+	TEST_ASSERT(!HAS_TRAIT(person, TRAIT_SECURITY_HUD), "Person already had a sechud before trying to equip the ablative hood.")
+	coat.ToggleHood()
+	TEST_ASSERT(!HAS_TRAIT(person, TRAIT_SECURITY_HUD), "Person has gained a sechud from toggling the ablative hood despite already wearing a helmet.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #70403 by making it so toggling the ablative hood actually checks if it managed to put the hood up before giving you the HUD.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ablative trenchcoat no longer gives a permanent sechud if toggled while you already had a helmet on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
