### PR TITLE
Prevent mice from randomly spawning when we're running unit tests

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -11,6 +11,9 @@ SUBSYSTEM_DEF(minor_mapping)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10)
+	#ifdef UNIT_TESTS // Basically, mice biting on cables could cause a powernet to become disconnected before the unit test cable_powernets would check to make sure that the entire station's powernet is all connected and good.
+	return // A powernet being disconnected causes that unit test to fail, even if a station map is perfectly valid. It's a source of randomness that we do not need or want to deal with.
+	#endif // They also might cause some more completely random behavior, so let's ensure we never get random mice migrations when we compile for UNIT_TESTS.
 	var/list/exposed_wires = find_exposed_wires()
 
 	var/mob/living/simple_animal/mouse/mouse

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -6,14 +6,14 @@ SUBSYSTEM_DEF(minor_mapping)
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/minor_mapping/Initialize()
+	#ifdef UNIT_TESTS // This whole subsystem just introduces a lot of odd confounding variables into unit test situations, so let's just not bother with doing an initialize here.
+	return SS_INIT_NO_NEED
+	#endif // the mice are easily the bigger problem, but let's just avoid anything that could cause some bullshit.
 	trigger_migration(CONFIG_GET(number/mice_roundstart))
 	place_satchels()
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10)
-	#ifdef UNIT_TESTS // Basically, mice biting on cables could cause a powernet to become disconnected before the unit test cable_powernets would check to make sure that the entire station's powernet is all connected and good.
-	return // A powernet being disconnected causes that unit test to fail, even if a station map is perfectly valid. It's a source of randomness that we do not need or want to deal with.
-	#endif // They also might cause some more completely random behavior, so let's ensure we never get random mice migrations when we compile for UNIT_TESTS.
 	var/list/exposed_wires = find_exposed_wires()
 
 	var/mob/living/simple_animal/mouse/mouse

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -89,9 +89,6 @@
 		qdel(AM)
 
 /mob/living/simple_animal/mouse/handle_automated_action()
-	#ifdef UNIT_TESTS // Basically, mice biting on cables could cause a powernet to become disconnected before the unit test cable_powernets would check to make sure that the entire station's powernet is all connected and good.
-	return // A powernet being disconnected causes that unit test to fail, even if a station map is perfectly valid. It's a source of randomness that we do not need or want to deal with.
-	#endif // At the end of the day, lol. lmao.
 	if(prob(chew_probability))
 		var/turf/open/floor/F = get_turf(src)
 		if(istype(F) && F.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -89,6 +89,9 @@
 		qdel(AM)
 
 /mob/living/simple_animal/mouse/handle_automated_action()
+	#ifdef UNIT_TESTS // Basically, mice biting on cables could cause a powernet to become disconnected before the unit test (cable_powernets) to check to make sure that the entire station's powernet is all connected and good.
+		return // A powernet initializing disconnected causes that unit test to fail, even if a station map is perfectly valid. It's a source of randomness that we do not need or want to deal with.
+	#endif // At the end of the day, lol. lmao.
 	if(prob(chew_probability))
 		var/turf/open/floor/F = get_turf(src)
 		if(istype(F) && F.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -90,7 +90,7 @@
 
 /mob/living/simple_animal/mouse/handle_automated_action()
 	#ifdef UNIT_TESTS // Basically, mice biting on cables could cause a powernet to become disconnected before the unit test cable_powernets would check to make sure that the entire station's powernet is all connected and good.
-		return // A powernet being disconnected causes that unit test to fail, even if a station map is perfectly valid. It's a source of randomness that we do not need or want to deal with.
+	return // A powernet being disconnected causes that unit test to fail, even if a station map is perfectly valid. It's a source of randomness that we do not need or want to deal with.
 	#endif // At the end of the day, lol. lmao.
 	if(prob(chew_probability))
 		var/turf/open/floor/F = get_turf(src)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -89,6 +89,9 @@
 		qdel(AM)
 
 /mob/living/simple_animal/mouse/handle_automated_action()
+	#ifdef UNIT_TESTS // Basically, mice biting on cables could cause a powernet to become disconnected before the unit test cable_powernets would check to make sure that the entire station's powernet is all connected and good.
+		return // A powernet being disconnected causes that unit test to fail, even if a station map is perfectly valid. It's a source of randomness that we do not need or want to deal with.
+	#endif // At the end of the day, lol. lmao.
 	if(prob(chew_probability))
 		var/turf/open/floor/F = get_turf(src)
 		if(istype(F) && F.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Issue report came through saying that we had inconsistent failures in regards to powernets being disconnected, but that's likely because mice will bite on cables- causing a powernet to become disconnected. This would create a false warning (because the map is perfectly fine otherwise) in a weird state that would only happen randomly and erratically.

So, if we compile with UNIT_TESTS flag set, let's prevent mice from introducing weird variables into our powernets unit test.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #70360.

I based this off mothblocks' comment here: https://github.com/tgstation/tgstation/issues/70360#issuecomment-1270854110, let me know if I should tackle it a different way somehow (I don't think there is a much better way).

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing that concerns players.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
