### PR TITLE
[s] Dead people can no longer communicate with the living

### DIFF
--- a/code/modules/wiremod/components/bci/thought_listener.dm
+++ b/code/modules/wiremod/components/bci/thought_listener.dm
@@ -48,7 +48,7 @@
 
 	var/mob/living/owner = bci.owner
 
-	if(!owner || !istype(owner) || !owner.client || (owner.stat == DEAD))
+	if(!owner || !istype(owner) || !owner.client || (owner.stat >= UNCONSCIOUS))
 		failure.set_output(COMPONENT_SIGNAL)
 		return
 

--- a/code/modules/wiremod/components/bci/thought_listener.dm
+++ b/code/modules/wiremod/components/bci/thought_listener.dm
@@ -48,11 +48,11 @@
 
 	var/mob/living/owner = bci.owner
 
-	if(!owner || !istype(owner) || !owner.client)
+	if(!owner || !istype(owner) || !owner.client || (owner.stat == DEAD))
 		failure.set_output(COMPONENT_SIGNAL)
 		return
 
-	INVOKE_ASYNC(src, .proc/thought_listen, owner)
+	INVOKE_ASYNC(src, .proc/thought_listen, owner)	
 	ready = FALSE
 
 /obj/item/circuit_component/thought_listener/proc/thought_listen(mob/living/owner)

--- a/code/modules/wiremod/components/bci/thought_listener.dm
+++ b/code/modules/wiremod/components/bci/thought_listener.dm
@@ -52,7 +52,7 @@
 		failure.set_output(COMPONENT_SIGNAL)
 		return
 
-	INVOKE_ASYNC(src, .proc/thought_listen, owner)	
+	INVOKE_ASYNC(src, .proc/thought_listen, owner)
 	ready = FALSE
 
 /obj/item/circuit_component/thought_listener/proc/thought_listen(mob/living/owner)


### PR DESCRIPTION
Remember: [s] means either [spam](https://github.com/tgstation/tgstation/issues/62349) (Oranges) or [secret](https://discord.com/channels/326822144233439242/326831214667235328/960687157087965185) (MSO). It never means *security*, although we might think it's used that way, it's just not what it means.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Man fuck this shit

Thought listener, through chicanery, could let you still pass through valid strings (and not fail) if you were a mob/dead/observer occupying your mob/living body. god dammit. check and return if the owner (i presume the mob/living with the BCI installed) has a dead status.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #70442

less exploitables the better. this was my first time ever fucking around with wiremod to try and debug to see if the fix worked (and it seemed to work), so let's assume all things are good in this world.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can no longer pierce the veil between the living and the dead with the power of circuitry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
