### PR TITLE
Fixes Weird Vending Machine Untipping Behavior (Cyborg Edition)

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -854,10 +854,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	obj_flags |= EMAGGED
 	to_chat(user, span_notice("You short out the product lock on [src]."))
 
-/obj/machinery/vending/_try_interact(mob/user)
-	if(!user.Adjacent(src))
-		return
-
+/obj/machinery/vending/interact(mob/user)
 	if(seconds_electrified && !(machine_stat & NOPOWER))
 		if(shock(user, 100))
 			return

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -855,12 +855,12 @@ GLOBAL_LIST_EMPTY(vending_products)
 	to_chat(user, span_notice("You short out the product lock on [src]."))
 
 /obj/machinery/vending/_try_interact(mob/user)
+	if(!user.Adjacent(src))
+		return
+
 	if(seconds_electrified && !(machine_stat & NOPOWER))
 		if(shock(user, 100))
 			return
-
-	if(!user.Adjacent(src))
-		return
 
 	if(tilted && !user.buckled && !isAI(user))
 		to_chat(user, span_notice("You begin righting [src]."))

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -859,6 +859,9 @@ GLOBAL_LIST_EMPTY(vending_products)
 		if(shock(user, 100))
 			return
 
+	if(!user.Adjacent(src))
+		return
+
 	if(tilted && !user.buckled && !isAI(user))
 		to_chat(user, span_notice("You begin righting [src]."))
 		if(do_after(user, 50, target=src))

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -859,7 +859,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		if(shock(user, 100))
 			return
 
-	if(tilted && !user.buckled && !isAI(user))
+	if(tilted && !user.buckled && !isAdminGhostAI(user))
 		to_chat(user, span_notice("You begin righting [src]."))
 		if(do_after(user, 50, target=src))
 			untilt(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Basically, if you were a cyborg, you could untip a vending machine from halfway across the world. There was no adjacency check for pretty much anyone to untip a vending machine, and since a cyborg will always pass through on anything that interacts with an `/obj/machinery`, it would always untip no matter how far away the person was. In fact, we even have an `isAI` check down the line because I think AI's could remotely untip any vending machine (lol).

Let's just pass in an adjacency check for this. Phew.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #70371. Cyborgs shouldn't be able to untip things they are halfway across the world on.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Cyborgs can now no longer untip vending machines that they are not directly next to.
fix: Those with the technoshy/technovert trait are now able to untip vending machines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
