### PR TITLE
Fixes Unreadable APC Balloon Alerts for Ethereals

### DIFF
--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -223,5 +223,3 @@
 				ui_interact(user)
 		else
 			balloon_alert(user, "access denied!")
-			if(isethereal(user))
-				sleep(1 SECONDS) // sleep here to prevent later balloon alerts that show up to ethereals from overlapping and making it completely unreadable

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -223,3 +223,5 @@
 				ui_interact(user)
 		else
 			balloon_alert(user, "access denied!")
+			if(isethereal(user))
+				sleep(1 SECONDS) // sleep here to prevent later balloon alerts that show up to ethereals from overlapping and making it completely unreadable


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

So basically, when an ethereal on combat mode would try and discharge an APC, they would get this, which is completely unreadable:

![image](https://user-images.githubusercontent.com/34697715/195017953-2b9cf5f2-5bf0-4ffe-b731-85bdbce5dfd6.png)

So, let's add a small sleep at the end of `togglelock()` for ethereals, and then proceed to continue on with the proc chain of whatever an ethereal might want to do with an APC.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #68332. Small disclaimer here, it happened on both recharging and discharging an APC when I was testing it on my local.

![image](https://user-images.githubusercontent.com/34697715/195018029-93c51f18-ca11-42e7-9f66-5debd9b14496.png)

![image](https://user-images.githubusercontent.com/34697715/195018043-a8e69520-adf9-4f76-b7a8-fe2b7a25f858.png)

Ah, two crystal clear messages.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ethereals can now actually read the balloon alerts they get whenever they try and recharge/discharge an APC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Let me know if adding the sleep there was cringe, I stewed on the problem for a solid ten minutes and this is the only one that worked 100% of the time in all my prototypes.