### PR TITLE
Fixes AI Toggle Camera Lights

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -785,7 +785,7 @@
 	for (var/datum/camerachunk/chunk as anything in eyeobj.visibleCameraChunks)
 		for (var/z_key in chunk.cameras)
 			for(var/obj/machinery/camera/camera as anything in chunk.cameras[z_key])
-				if (!camera.can_use() || get_dist(camera, src) > 7 || !camera.internal_light)
+				if (!camera.can_use() || get_dist(camera, eyeobj) > 7 || !camera.internal_light)
 					continue
 				visible |= camera
 


### PR DESCRIPTION
## About The Pull Request
#69115 messed with the ability's code and made it get distance from the camera to the `src` (the AI mob) instead of `eyeobj` (the AI Eye)

## Why It's Good For The Game
Fixes #70240

## Changelog
:cl:
fix: Fixed AI Toggle Camera Lights not working properly
/:cl:
