### PR TITLE
Fixes displayed advanced manipulator requirements

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -52,8 +52,13 @@
 		nice_list += list("[req_components[component]] [req_component_names[component]]\s")
 	. += span_info("It requires [english_list(nice_list, "no more components")].")
 
-
-/obj/structure/frame/machine/proc/update_namelist()
+/**
+ * Collates the displayed names of the machine's components
+ *
+ * Arguments:
+ * * specific_parts - If true, the component should not use base name, but a specific tier
+ */
+/obj/structure/frame/machine/proc/update_namelist(specific_parts)
 	if(!req_components)
 		return
 
@@ -72,8 +77,10 @@
 
 		if(ispath(component_path, /obj/item/stock_parts))
 			var/obj/item/stock_parts/stock_part = component_path
-			if(initial(stock_part.base_name))
+			if(!specific_parts && initial(stock_part.base_name))
 				req_component_names[component_path] = initial(stock_part.base_name)
+			else
+				req_component_names[component_path] = initial(stock_part.name)
 
 /obj/structure/frame/machine/proc/get_req_components_amt()
 	var/amt = 0
@@ -133,23 +140,23 @@
 				return
 
 			if(istype(P, /obj/item/circuitboard/machine))
-				var/obj/item/circuitboard/machine/B = P
-				if(!B.build_path)
+				var/obj/item/circuitboard/machine/board = P
+				if(!board.build_path)
 					to_chat(user, span_warning("This circuitboard seems to be broken."))
 					return
-				if(!anchored && B.needs_anchored)
+				if(!anchored && board.needs_anchored)
 					to_chat(user, span_warning("The frame needs to be secured first!"))
 					return
-				if(!user.transferItemToLoc(B, src))
+				if(!user.transferItemToLoc(board, src))
 					return
 				playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 				to_chat(user, span_notice("You add the circuit board to the frame."))
-				circuit = B
+				circuit = board
 				icon_state = "box_2"
 				state = 3
 				components = list()
-				req_components = B.req_components.Copy()
-				update_namelist()
+				req_components = board.req_components.Copy()
+				update_namelist(board.specific_parts)
 				return
 
 			else if(istype(P, /obj/item/circuitboard))

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -646,6 +646,7 @@
 
 /obj/item/circuitboard/machine/chem_dispenser/fullupgrade
 	build_path = /obj/machinery/chem_dispenser/fullupgrade
+	specific_parts = TRUE
 	req_components = list(
 		/obj/item/stock_parts/matter_bin/bluespace = 2,
 		/obj/item/stock_parts/capacitor/quadratic = 2,
@@ -656,6 +657,7 @@
 
 /obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter
 	build_path = /obj/machinery/chem_dispenser/mutagensaltpeter
+	specific_parts = TRUE
 	req_components = list(
 		/obj/item/stock_parts/matter_bin/bluespace = 2,
 		/obj/item/stock_parts/capacitor/quadratic = 2,
@@ -669,6 +671,7 @@
 	name_extension = "(Abductor Machine Board)"
 	icon_state = "abductor_mod"
 	build_path = /obj/machinery/chem_dispenser/abductor
+	specific_parts = TRUE
 	req_components = list(
 		/obj/item/stock_parts/matter_bin/bluespace = 2,
 		/obj/item/stock_parts/capacitor/quadratic = 2,

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -295,7 +295,6 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	rating = 2
 	energy_rating = 3
 	custom_materials = list(/datum/material/iron=30)
-	base_name = null
 
 /obj/item/stock_parts/micro_laser/high
 	name = "high-power micro-laser"
@@ -338,7 +337,6 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	rating = 3
 	energy_rating = 5
 	custom_materials = list(/datum/material/iron=30)
-	base_name = null
 
 /obj/item/stock_parts/micro_laser/ultra
 	name = "ultra-high-power micro-laser"
@@ -381,7 +379,6 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	rating = 4
 	energy_rating = 10
 	custom_materials = list(/datum/material/iron=30)
-	base_name = null
 
 /obj/item/stock_parts/micro_laser/quadultra
 	name = "quad-ultra micro-laser"

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -295,6 +295,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	rating = 2
 	energy_rating = 3
 	custom_materials = list(/datum/material/iron=30)
+	base_name = null
 
 /obj/item/stock_parts/micro_laser/high
 	name = "high-power micro-laser"
@@ -337,6 +338,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	rating = 3
 	energy_rating = 5
 	custom_materials = list(/datum/material/iron=30)
+	base_name = null
 
 /obj/item/stock_parts/micro_laser/ultra
 	name = "ultra-high-power micro-laser"
@@ -379,6 +381,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	rating = 4
 	energy_rating = 10
 	custom_materials = list(/datum/material/iron=30)
+	base_name = null
 
 /obj/item/stock_parts/micro_laser/quadultra
 	name = "quad-ultra micro-laser"


### PR DESCRIPTION
## About The Pull Request

 A few months ago, base_name has been added to make micro-manipulators be displayed as manipulators, to make it clearer that any manipulator will work. This is good, however, this base_name got inherited by all the manipulator children. This means that certain items like the DNA vault's circuitboard, which requires at least a pico manipulator, has been displayed as "manipulator" while inside machine frames (it works properly when you examine the circuitboards themselves).  

## Why It's Good For The Game

Minimum requirements for manipulators should be displayed properly, to avoid confusion.

## Changelog

:cl:
fix: Circuitboards that require a minimum level of manipulators tiers no longer display just "manipulator" when examining machine frames that contain them
fix: Marked a few more admin only chem dispenser boards to display their proper manipulator requirements
/:cl:
