### PR TITLE
Fixes the formatting in the Messenger app's message history and makes the current ringtone appear in the input box when trying to change it

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -114,33 +114,42 @@
 
 	switch(action)
 		if("PDA_ringSet")
-			var/t = tgui_input_text(usr, "Enter a new ringtone", "Ringtone", "", 20)
+			var/new_ringtone = tgui_input_text(usr, "Enter a new ringtone", "Ringtone", ringtone, 20)
 			var/mob/living/usr_mob = usr
-			if(in_range(computer, usr_mob) && computer.loc == usr_mob && t)
-				if(SEND_SIGNAL(computer, COMSIG_TABLET_CHANGE_ID, usr_mob, t) & COMPONENT_STOP_RINGTONE_CHANGE)
-					return
-				else
-					ringtone = t
-					return(UI_UPDATE)
+			if(!new_ringtone || !in_range(computer, usr_mob) || computer.loc != usr_mob)
+				return
+
+			if(SEND_SIGNAL(computer, COMSIG_TABLET_CHANGE_ID, usr_mob, new_ringtone) & COMPONENT_STOP_RINGTONE_CHANGE)
+				return
+
+			ringtone = new_ringtone
+			return UI_UPDATE
+
 		if("PDA_ringer_status")
 			ringer_status = !ringer_status
-			return(UI_UPDATE)
+			return UI_UPDATE
+
 		if("PDA_sAndR")
 			sending_and_receiving = !sending_and_receiving
-			return(UI_UPDATE)
+			return UI_UPDATE
+
 		if("PDA_viewMessages")
 			viewing_messages = !viewing_messages
-			return(UI_UPDATE)
+			return UI_UPDATE
+
 		if("PDA_clearMessages")
 			messages = list()
-			return(UI_UPDATE)
+			return UI_UPDATE
+
 		if("PDA_changeSortStyle")
 			sort_by_job = !sort_by_job
-			return(UI_UPDATE)
+			return UI_UPDATE
+
 		if("PDA_sendEveryone")
 			if(!sending_and_receiving)
 				to_chat(usr, span_notice("ERROR: Device has sending disabled."))
 				return
+
 			if(!spam_mode)
 				to_chat(usr, span_notice("ERROR: Device does not have mass-messaging perms."))
 				return
@@ -153,14 +162,17 @@
 			if(targets.len > 0)
 				send_message(usr, targets, TRUE)
 
-			return(UI_UPDATE)
+			return UI_UPDATE
+
 		if("PDA_sendMessage")
 			if(!sending_and_receiving)
 				to_chat(usr, span_notice("ERROR: Device has sending disabled."))
 				return
+
 			var/obj/item/modular_computer/target = locate(params["ref"])
 			if(!target)
 				return // we don't want tommy sending his messages to nullspace
+
 			if(!(target.saved_identification == params["name"] && target.saved_job == params["job"]))
 				to_chat(usr, span_notice("ERROR: User no longer exists."))
 				return
@@ -171,20 +183,24 @@
 				if(!app.sending_and_receiving && !sending_virus)
 					to_chat(usr, span_notice("ERROR: Device has receiving disabled."))
 					return
+
 				if(sending_virus)
 					var/obj/item/computer_hardware/hard_drive/portable/virus/disk = computer.all_components[MC_SDD]
 					if(istype(disk))
 						disk.send_virus(target, usr)
-						return(UI_UPDATE)
+						return UI_UPDATE
+
 				send_message(usr, list(target))
-				return(UI_UPDATE)
+				return UI_UPDATE
+
 		if("PDA_clearPhoto")
 			computer.saved_image = null
 			photo_path = null
-			return(UI_UPDATE)
+			return UI_UPDATE
+
 		if("PDA_toggleVirus")
 			sending_virus = !sending_virus
-			return(UI_UPDATE)
+			return UI_UPDATE
 
 
 /datum/computer_file/program/messenger/ui_data(mob/user)

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -260,7 +260,7 @@
 		return FALSE
 
 	if((last_text && world.time < last_text + 10) || (everyone && last_text_everyone && world.time < last_text_everyone + 2 MINUTES))
-		user.balloon_alert(user, "on cooldown!")
+		to_chat(user, span_warning("The subspace transmitter of your tablet is still cooling down!"))
 		return FALSE
 
 	var/turf/position = get_turf(computer)

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -349,7 +349,7 @@
 	var/list/message_data = list()
 	message_data["name"] = signal.data["name"]
 	message_data["job"] = signal.data["job"]
-	message_data["contents"] = signal.format_message()
+	message_data["contents"] = html_decode(signal.format_message())
 	message_data["outgoing"] = FALSE
 	message_data["ref"] = signal.data["ref"]
 	message_data["automated"] = signal.data["automated"]

--- a/tgui/packages/tgui/interfaces/NtosMessenger.js
+++ b/tgui/packages/tgui/interfaces/NtosMessenger.js
@@ -29,13 +29,20 @@ const NoIDDimmer = (props, context) => {
 
 export const NtosMessenger = (props, context) => {
   const { act, data } = useBackend(context);
+  const { viewing_messages } = data;
+  if (viewing_messages) {
+    return <MessageListScreen />;
+  }
+  return <ContactsScreen />;
+};
+
+const ContactsScreen = (props, context) => {
+  const { act, data } = useBackend(context);
   const {
     owner,
-    messages = [],
     ringer_status,
     sending_and_receiving,
     messengers = [],
-    viewing_messages,
     sortByJob,
     canSpam,
     isSilicon,
@@ -43,56 +50,6 @@ export const NtosMessenger = (props, context) => {
     virus_attach,
     sending_virus,
   } = data;
-  if (viewing_messages) {
-    return (
-      <NtosWindow width={600} height={800}>
-        <NtosWindow.Content>
-          <Stack vertical>
-            <Section fill>
-              <Button
-                icon="arrow-left"
-                content="Back"
-                onClick={() => act('PDA_viewMessages')}
-              />
-              <Button
-                icon="trash"
-                content="Clear Messages"
-                onClick={() => act('PDA_clearMessages')}
-              />
-            </Section>
-            {messages.map((message) => (
-              <Stack vertical key={message} mt={1}>
-                <Section fill textAlign="left">
-                  <Box italic opacity={0.5}>
-                    {message.outgoing ? '(OUTGOING)' : '(INCOMING)'}
-                  </Box>
-                  {message.outgoing ? (
-                    <Box bold>{message.name + ' (' + message.job + ')'}</Box>
-                  ) : (
-                    <Button
-                      transparent
-                      content={message.name + ' (' + message.job + ')'}
-                      onClick={() =>
-                        act('PDA_sendMessage', {
-                          name: message.name,
-                          job: message.job,
-                          ref: message.ref,
-                        })
-                      }
-                    />
-                  )}
-                </Section>
-                <Section mt={-1}>
-                  <Box italic>{message.contents}</Box>
-                  {!!message.photo && <Box as="img" src={message.photo} />}
-                </Section>
-              </Stack>
-            ))}
-          </Stack>
-        </NtosWindow.Content>
-      </NtosWindow>
-    );
-  }
   return (
     <NtosWindow width={600} height={800}>
       <NtosWindow.Content scrollable>
@@ -198,6 +155,59 @@ export const NtosMessenger = (props, context) => {
           </Section>
         </Stack>
         {!owner && !isSilicon && <NoIDDimmer />}
+      </NtosWindow.Content>
+    </NtosWindow>
+  );
+};
+
+const MessageListScreen = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { messages = [] } = data;
+  return (
+    <NtosWindow width={600} height={800}>
+      <NtosWindow.Content scrollable>
+        <Stack vertical>
+          <Section fill>
+            <Button
+              icon="arrow-left"
+              content="Back"
+              onClick={() => act('PDA_viewMessages')}
+            />
+            <Button
+              icon="trash"
+              content="Clear Messages"
+              onClick={() => act('PDA_clearMessages')}
+            />
+          </Section>
+          {messages.map((message) => (
+            <Stack vertical key={message} mt={1}>
+              <Section textAlign="left">
+                <Box italic opacity={0.5} mb={1}>
+                  {message.outgoing ? '(OUTGOING)' : '(INCOMING)'}
+                </Box>
+                {message.outgoing ? (
+                  <Box bold>{message.name + ' (' + message.job + ')'}</Box>
+                ) : (
+                  <Button
+                    transparent
+                    content={message.name + ' (' + message.job + ')'}
+                    onClick={() =>
+                      act('PDA_sendMessage', {
+                        name: message.name,
+                        job: message.job,
+                        ref: message.ref,
+                      })
+                    }
+                  />
+                )}
+              </Section>
+              <Section fill mt={-1}>
+                <Box italic>{message.contents}</Box>
+                {!!message.photo && <Box as="img" src={message.photo} mt={1} />}
+              </Section>
+            </Stack>
+          ))}
+        </Stack>
       </NtosWindow.Content>
     </NtosWindow>
   );


### PR DESCRIPTION
## About The Pull Request
Does exactly what it says on the tin.

The Message History page was a whole mess, the formatting was all wrong and incoming messages weren't properly HTML decoded, so they looked all weird.

It also really bugged me that trying to change your ringtone didn't show you what your previous ringtone was, so now it does :)

Same goes for the name of the person you're sending a message to, in the input prompt (sometimes I get confused who I'm responding to).

## Why It's Good For The Game
General QoL for the ringtone input, and because it now looks a lot more polished when you look at your messages list now:
![image](https://user-images.githubusercontent.com/58045821/195148913-e338e464-f577-408b-9d5e-14767719231a.png)

This also looks better:
![image](https://user-images.githubusercontent.com/58045821/195161324-8fe37805-c3c6-4a07-bddb-a52f72d5832b.png)
![image](https://user-images.githubusercontent.com/58045821/195161347-7d8db43c-4e5e-4cff-ab48-ff1c1ca5d28f.png)



## Changelog

:cl: GoldenAlpharex
qol: Changing your PDA ringtone now has your current ringtone in your input box, like the previous PDAs used to.
fix: Fixed the incoming Messenger messages not being properly HTML decoded in the Message History, making it display weird stuff instead of apostrophes.
fix: Fixed the formatting of the Messenger's Message History tab.
qol: The prompt to send a PDA message now shows you the person you're trying to send a PDA message to.
/:cl: