### PR TITLE
Stops hydroponics tray from wasting piped in water

### DIFF
--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -124,6 +124,10 @@
 	else if(reagents.total_volume > 0) //take whatever
 		return TRUE
 
+///returns TRUE if the source's reagents has only one entry
+/datum/component/plumbing/proc/is_pure_source()
+	return reagents.reagent_list.len == 1
+
 ///this is where the reagent is actually transferred and is thus the finish point of our process()
 /datum/component/plumbing/proc/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net)
 	if(!reagents || !target || !target.reagents)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -180,8 +180,8 @@
 	returned_message += "\nWeed level: [span_notice("[scanned_tray.weedlevel] / [MAX_TRAY_WEEDS]")]"
 	returned_message += "\nPest level: [span_notice("[scanned_tray.pestlevel] / [MAX_TRAY_PESTS]")]"
 	returned_message += "\nToxicity level: [span_notice("[scanned_tray.toxic] / [MAX_TRAY_TOXINS]")]"
-	returned_message += "\nWater level: [span_notice("[scanned_tray.waterlevel] / [scanned_tray.maxwater]")]"
-	returned_message += "\nNutrition level: [span_notice("[scanned_tray.reagents.total_volume] / [scanned_tray.maxnutri]")]"
+	returned_message += "\nWater level: [span_notice("[round(scanned_tray.waterlevel,0.1)] / [scanned_tray.maxwater]")]"
+	returned_message += "\nNutrition level: [span_notice("[round(scanned_tray.reagents.total_volume,0.1)] / [scanned_tray.maxnutri]")]"
 	if(scanned_tray.yieldmod != 1)
 		returned_message += "\nYield modifier on harvest: [span_notice("[scanned_tray.yieldmod]x")]"
 


### PR DESCRIPTION
## About The Pull Request

As currently implemented, hydroponics trays will draw water in from a duct network every processing tick and then discard it if the water is full but the nutrient tray has space in it--which is extremely common.  This was capable of wasting thousands of units of water in minutes, emptying water tanks and leaving only tears behind.

To make this work, I made the duct network act a little smarter than it actually is--drawing water and nutrients separately from separate sources.  Ultimately, it would be better if the duct network acted as storage and you could draw out a sample and put back what you don't use, only for it to refill later or in the next cycle, but I'm not willing to try that refactor and find out what it does to all of chemistry.

I also decided that I wanted to support an edge case where a single source on the network (a storage tank of some kind) contained both water and nutrients, which is about the most complicated edge case we can have here.  Doing so without wasting egregious amounts of stuff required me to work around the duct network's use of round robin reagent transfer, or else add some kind of "transfer all reagents except X" to reagent holders, which was not going to happen.  This workaround will cause ugly floating point numbers to show up in that edge case, but works, and the workaround does not seem to affect the nominal use case.

The nominal test case, though, was with pure water in one source and all non-water reagents in another.  This is handled just fine.

## Why It's Good For The Game

This is mostly a fix for functionality already there.  Arguably there's not a whole lot of reason for you to pipe in nutrients, unless you really know what you're doing or only want bog-standard plants, as it leaves no room in the nutrient tray for you to add things yourself.  (I guess I could add a cap to piped-in nutrients to fix this, if asked)  As it stands, however, there is no reason to pipe anything into hydroponics.  If you have a regenerating supply, it will have so little on hand that it can't fill up very many trays, and if you have a fixed supply, the leaking water will waste it.

## Changelog

:cl:
fix: Using ducts to connect a water tank to one or more hydroponics trays is no longer a monumental waste of resources.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
