### PR TITLE
[NO GBP] Cleans up some round_event_control setup variables in certain events

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -55,6 +55,7 @@
 			if(!is_station_level(vendor.z) || !istype(vendor, chosen_vendor))
 				continue
 			vendingMachines.Add(vendor)
+		brand_event.chosen_vendor = null //Event has a max_occurences of 1 but juuust in case
 	if(!length(vendingMachines)) //If no vendors are in vendingMachines, setup defaults back to randomly selecting one.
 		for(var/obj/machinery/vending/vendor in GLOB.machines)
 			if(!is_station_level(vendor.z))

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -12,7 +12,7 @@
 
 /datum/round_event_control/brand_intelligence/admin_setup()
 	if(!check_rights(R_FUN))
-		return
+		return ADMIN_CANCEL_EVENT
 	if(tgui_alert(usr, "Select a specific vendor path?", "Capitalism-ho!", list("Yes", "No")) == "Yes")
 		var/list/vendors = list()
 		vendors += subtypesof(/obj/machinery/vending)

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -21,13 +21,13 @@
 
 /datum/round_event_control/heart_attack/admin_setup()
 	if(!check_rights(R_FUN))
-		return
+		return ADMIN_CANCEL_EVENT
 
 	generate_candidates() //can_spawn_event() is bypassed by admin_setup, so this makes sure that the candidates are still generated
 
 	if(!length(heart_attack_candidates))
 		message_admins("There are no candidates eligible to recieve a heart attack!")
-		return
+		return ADMIN_CANCEL_EVENT
 	quantity = tgui_input_number(usr, "There are [length(heart_attack_candidates)] crewmembers eligible for a heart attack. Please select how many people's days you wish to ruin.", "Shia Hato Atakku!", 1, length(heart_attack_candidates))
 
 /**

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -38,9 +38,6 @@
  * later, at the round_event level, so this proc mostly just checks users for whether or not a heart attack should be possible.
  */
 /datum/round_event_control/heart_attack/proc/generate_candidates()
-	if(length(heart_attack_candidates))
-		heart_attack_candidates.Cut()
-
 	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list))
 		if(candidate.stat == DEAD || HAS_TRAIT(candidate, TRAIT_CRITICAL_CONDITION) || !candidate.can_heartattack() || (/datum/disease/heart_failure in candidate.diseases) || candidate.undergoing_cardiac_arrest())
 			continue
@@ -61,7 +58,8 @@
 	var/datum/round_event_control/heart_attack/heart_attack_event = control
 
 	attacks_left = heart_attack_event.quantity
-	victims = heart_attack_event.heart_attack_candidates
+	victims += heart_attack_event.heart_attack_candidates
+	heart_attack_event.heart_attack_candidates.Cut()
 	heart_attack_event.quantity = 1
 
 	while(attacks_left > 0 && length(victims))

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -38,6 +38,9 @@
  * later, at the round_event level, so this proc mostly just checks users for whether or not a heart attack should be possible.
  */
 /datum/round_event_control/heart_attack/proc/generate_candidates()
+	if(length(heart_attack_candidates))
+		heart_attack_candidates.Cut()
+
 	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list))
 		if(candidate.stat == DEAD || HAS_TRAIT(candidate, TRAIT_CRITICAL_CONDITION) || !candidate.can_heartattack() || (/datum/disease/heart_failure in candidate.diseases) || candidate.undergoing_cardiac_arrest())
 			continue
@@ -59,6 +62,7 @@
 
 	attacks_left = heart_attack_event.quantity
 	victims = heart_attack_event.heart_attack_candidates
+	heart_attack_event.quantity = 1
 
 	while(attacks_left > 0 && length(victims))
 		if(attack_heart())

--- a/code/modules/events/stray_meteor.dm
+++ b/code/modules/events/stray_meteor.dm
@@ -12,7 +12,8 @@
 
 /datum/round_event_control/stray_meteor/admin_setup()
 	if(!check_rights(R_FUN))
-		return
+		return ADMIN_CANCEL_EVENT
+
 	if(tgui_alert(usr, "Select a meteor?", "Plasuable Deniability!", list("Yes", "No")) == "Yes")
 		var/list/meteor_list = list()
 		meteor_list += subtypesof(/obj/effect/meteor)

--- a/code/modules/events/stray_meteor.dm
+++ b/code/modules/events/stray_meteor.dm
@@ -26,6 +26,7 @@
 	var/datum/round_event_control/stray_meteor/meteor_event = control
 	if(meteor_event.chosen_meteor)
 		var/chosen_meteor = meteor_event.chosen_meteor
+		meteor_event.chosen_meteor = null
 		var/list/passed_meteor = list()
 		passed_meteor[chosen_meteor] = 1
 		spawn_meteor(passed_meteor)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In some previous event files I had worked on, I neglected to have certain round_event_control vars clean themselves up after use. This meant that they would stick around between events, leading to malformed candidate lists or admin-set variables acting like a default value for future events. This also makes it so that admin_setup returns ADMIN_CANCEL_EVENT when necessary in these events.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes some doggie doo-doo code I wrote.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Choosing admin setup options on certain events will no longer retain the chosen options for future events.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
