### PR TITLE
Anchored Objects No Longer Use Ladders

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -253,6 +253,8 @@
 	var/list/moving_movs = get_z_move_affected(z_move_flags)
 
 	for(var/atom/movable/movable as anything in moving_movs)
+		if(movable.anchored)
+			return
 		movable.currently_z_moving = currently_z_moving || CURRENTLY_Z_MOVING_GENERIC
 		movable.forceMove(target)
 		movable.set_currently_z_moving(FALSE, TRUE)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -253,9 +253,12 @@
 	var/list/moving_movs = get_z_move_affected(z_move_flags)
 
 	for(var/atom/movable/movable as anything in moving_movs)
-		if(movable.anchored)
+		if(movable.anchored) // Clear any pulls when we switch a z-level to prevent pulling anchored objects across z-levels.
+			if(!pulledby) // We know it's a pull because that's how it was passed to us via get_z_move_affected(). Something's wayyy fucked up if this runtimes.
+				STACK_TRACE("zMove() called on [src], which was pulling an anchored [movable] but there wasn't any mob pulling it!")
+				continue
 			movable.pulledby.stop_pulling()
-			return
+			continue
 		movable.currently_z_moving = currently_z_moving || CURRENTLY_Z_MOVING_GENERIC
 		movable.forceMove(target)
 		movable.set_currently_z_moving(FALSE, TRUE)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -254,6 +254,7 @@
 
 	for(var/atom/movable/movable as anything in moving_movs)
 		if(movable.anchored)
+			movable.pulledby.stop_pulling()
 			return
 		movable.currently_z_moving = currently_z_moving || CURRENTLY_Z_MOVING_GENERIC
 		movable.forceMove(target)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -255,7 +255,7 @@
 	for(var/atom/movable/movable as anything in moving_movs)
 		if(movable.anchored) // Clear any pulls when we switch a z-level to prevent pulling anchored objects across z-levels.
 			if(!pulledby) // We know it's a pull because that's how it was passed to us via get_z_move_affected(). Something's wayyy fucked up if this runtimes.
-				STACK_TRACE("zMove() called on [src], which was pulling an anchored [movable] but there wasn't any mob pulling it!")
+				STACK_TRACE("zMove() called on an anchored [movable] but there wasn't any mob pulling it!")
 				continue
 			movable.pulledby.stop_pulling()
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

You'd have to do some looney tunes shit for this to occur on production (unwrench an anchored object, pull it, then wrench it again) for this to happen, but it does indeed happen. Let's just ensure that if a movable is anchored, that it _stays_ anchored on the z-level it's on, and that we don't take it with us through a ladder.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #68103.

When the users encounter an un-intended behavior leading to bad UX 😳!!!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: If you somehow find yourself dragging an anchored object, rest assured that it will now stay anchored on the z-level it's anchored to, rather than magickally teleport to your location when you try and use a ladder.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
