### PR TITLE
Being anchored now makes people stop pulling you

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -939,6 +939,8 @@
 		return
 	. = anchored
 	anchored = anchorvalue
+	if(anchored && pulledby)
+		pulledby.stop_pulling()
 	SEND_SIGNAL(src, COMSIG_MOVABLE_SET_ANCHORED, anchorvalue)
 
 /// Sets the currently_z_moving variable to a new value. Used to allow some zMovement sources to have precedence over others.


### PR DESCRIPTION
## About The Pull Request

Anchoring something, like a machine, now will automatically make people stop pulling the now-anchored object.

## Why It's Good For The Game

Alternative PR to https://github.com/tgstation/tgstation/pull/70472

Closes https://github.com/tgstation/tgstation/issues/68103 - Debatable on whether this is a good thing

Machines already can't be moved while anchored, so I don't see why they are allowed to just pull them anyways when it breaks the second they move. This solves this edge case and possibly some undiscovered ones.

## Changelog

:cl:
fix: Anchoring an object while pulling it will now make you stop pulling said anchored object.
/:cl:
