### PR TITLE
Adds a button to player panel that allows for admins to easily re-create a playermob (while providing debug information for later)

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -215,7 +215,7 @@
 
 		var/debug_dump = tgui_alert(usr, "I'm assuming you're doing this because something has majorly fucked up and not even \
 			aheal will fix it, create a debug dump file for coders to look over afterwards?", "Recreate", list("Yes", "No", "Cancel"))
-		if(debug_dump == "Cancel")
+		if(!debug_dump || debug_dump == "Cancel")
 			return
 		debug_dump = (debug_dump == "Yes")
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -232,6 +232,10 @@
 		log_admin("[key_name(usr)] recreated the mob of [key_name(old_mob)][debug_dump ? ", creating a debug dump file":""].")
 		message_admins(span_adminnotice("[key_name_admin(usr)] recreated the mob of [key_name_admin(old_mob)][debug_dump ? ", creating a debug dump file":""]."))
 
+		// Dump all vars to a new file so people can dig in later to see what was messed up
+		if(debug_dump)
+			rustg_file_write(json_encode(old_mob.vars), "[GLOB.log_directory]/debug_vardump_[REF(old_mob)].json")
+
 		// Create an identical type in the same loc
 		var/mob/living/new_mob = new old_mob.type(old_mob.loc)
 		// Track the equipment and stuff it's got
@@ -295,9 +299,6 @@
 			old_mob.mind.transfer_to(new_mob, TRUE)
 		else
 			new_mob.key = old_mob.key
-
-		if(debug_dump)
-			rustg_file_write(json_encode(old_mob.vars), "[GLOB.log_directory]/debug_vardump_[REF(old_mob)].json")
 
 		// clean up the old mob in a tick
 		// we probably don't need to wait a tick but you never know

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -257,6 +257,23 @@
 			passover_implant.removed(old_mob, silent = TRUE, special = TRUE)
 			passover_implant.implant(new_mob, silent = TRUE, force = TRUE)
 
+		// I'm also making a special case for skillchips since they can include job related stuff
+		var/obj/item/organ/internal/brain/old_brain = old_mob.getorgan(/obj/item/organ/internal/brain)
+		var/obj/item/organ/internal/brain/new_brain = new_mob.getorgan(/obj/item/organ/internal/brain)
+		if(old_brain && new_brain)
+			for(var/obj/item/skillchip/passover_chip as anything in old_brain.skillchips)
+				// Deactivate chip from the old body
+				passover_chip.try_deactivate_skillchip(silent = TRUE, force = TRUE)
+				// Slam it in the new brain
+				passover_chip.holding_brain = new_brain
+				passover_chip.forceMove(new_brain)
+				LAZYADD(new_brain.skillchips, passover_chip)
+				// Activate it again
+				passover_chip.try_activate_skillchip(silent = TRUE, force = TRUE)
+
+			// Clear out the old
+			LAZYCLEARLIST(old_brain.skillchips)
+
 		// Quirks should pass over too
 		for(var/datum/quirk/passover_quirk as anything in old_mob.quirks)
 			new_mob.add_quirk(passover_quirk.type)

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -97,7 +97,8 @@
 	body += "<A href='?_src_=holder;[HrefToken()];narrateto=[REF(M)]'>Narrate to</A> | "
 	body += "<A href='?_src_=holder;[HrefToken()];subtlemessage=[REF(M)]'>Subtle message</A> | "
 	body += "<A href='?_src_=holder;[HrefToken()];playsoundto=[REF(M)]'>Play sound to</A> | "
-	body += "<A href='?_src_=holder;[HrefToken()];languagemenu=[REF(M)]'>Language Menu</A>"
+	body += "<A href='?_src_=holder;[HrefToken()];languagemenu=[REF(M)]'>Language Menu</A> | "
+	body += "<A href='?_src_=holder;[HrefToken()];simplerecreate=[REF(M)]'>Recreate Mob</A>"
 
 	if(M.client)
 		if(!isnewplayer(M))


### PR DESCRIPTION
## About The Pull Request

- Adds a button to player panel, "recreate mob". This button will delete the player's existing mob and then re-create a duplicate instance of it at its place, passing over equipment / held items / implants / quirks. 
- This button has an optional alert for the admin using it to create a debug dump file. Doing so will dump all of the mob's vars into a json so that an investigation into why the mob was troublesome can follow later. (Suggestion by MSO)

## Why It's Good For The Game

- Somewhat over, a player manages to screw up their mob so bad that most admins not experienced with the code has one option: Just delete the guy and respawn them. This provides a much easier avenue for them to do that, keeping clothing and equipment, as well as some other important facets like quirks and implants. 
- At the same time, if there genuinely is an issue with the mob, this allows a snapshot of the mob's vars to be saved, so that a coder can, later, look through it to see what the issue was. 

## Changelog

:cl: Melbert
admin: Added a new button to the player panel, "Recreate Mob". Pressing it will (after a confirmation box) delete the selected player's mob and duplicate it in their place, keeping their equipment / quirks / implants mostly intact. This is designed to be used for cases in which a player's mob is FUBAR and you must respawn them (NOT for a ghetto aheal). The button comes with the ability to create a dump file for you to hand off to coders after the round, so they can investigate what was wrong.
/:cl:

