### PR TITLE
Fixes minor strobe shield runtime

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -155,7 +155,8 @@
 		update_appearance(UPDATE_ICON)
 
 /obj/item/shield/riot/flash/Destroy(force)
-	QDEL_NULL(embedded_flash)
+	if(embedded_flash)
+		QDEL_NULL(embedded_flash)
 	return ..()
 
 /obj/item/shield/riot/flash/attack(mob/living/target_mob, mob/user)
@@ -193,7 +194,8 @@
 				if(QDELETED(flash) || flash.burnt_out)
 					return
 				playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
-				qdel(embedded_flash)
+				if(embedded_flash)
+					qdel(embedded_flash)
 				flash.forceMove(src)
 				return
 	return ..()

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -155,7 +155,7 @@
 		update_appearance(UPDATE_ICON)
 
 /obj/item/shield/riot/flash/Destroy(force)
-	if(embedded_flash)
+	if(!ispath(embedded_flash))
 		QDEL_NULL(embedded_flash)
 	return ..()
 
@@ -194,8 +194,7 @@
 				if(QDELETED(flash) || flash.burnt_out)
 					return
 				playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
-				if(embedded_flash)
-					qdel(embedded_flash)
+				QDEL_NULL(embedded_flash)
 				flash.forceMove(src)
 				return
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The rest of the strobe shield code supports `embedded_flash` being or becoming `null` except for the 2 spots it's qdel'd. Adds checks to make sure `embedded_flash` is set to something for those since qdel runtimes when given null. Unlikely to happen in gameplay but the support is otherwise there.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Minor bug

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

not player-visible

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
