### PR TITLE
Moving around while non-existent will not give you a message saying you're buckled to the concept of non-existence

### DIFF
--- a/code/game/objects/items/devices/desynchronizer.dm
+++ b/code/game/objects/items/devices/desynchronizer.dm
@@ -81,6 +81,10 @@
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE
 
+/obj/effect/abstract/sync_holder/relaymove(mob/living/user, direction)
+	// while faded out to spacetime, no, you cannot move.
+	return
+
 /obj/effect/abstract/sync_holder/Destroy()
 	for(var/I in contents)
 		var/atom/movable/AM = I

--- a/code/game/objects/items/devices/desynchronizer.dm
+++ b/code/game/objects/items/devices/desynchronizer.dm
@@ -82,7 +82,7 @@
 	resistance_flags = INDESTRUCTIBLE
 
 /obj/effect/abstract/sync_holder/relaymove(mob/living/user, direction)
-	// while faded out to spacetime, no, you cannot move.
+	// While faded out of spacetime, no, you cannot move.
 	return
 
 /obj/effect/abstract/sync_holder/Destroy()

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -444,6 +444,11 @@
 /obj/effect/immortality_talisman/attackby()
 	return
 
+/obj/effect/immortality_talisman/relaymove(mob/living/user, direction)
+	// Won't really come into play since our mob has notransform and cannot move,
+	// but regardless block all relayed moves, becuase no, you cannot move in the void.
+	return
+
 /obj/effect/immortality_talisman/singularity_pull()
 	return
 


### PR DESCRIPTION
## About The Pull Request

Fixes #47218

- Being placed in a sync holder (being non-existed temporarily) no longer triggers the base feedback message for being buckled to an atom when trying to move around.

## Why It's Good For The Game

You cannot be buckled to non-existence, it does not exist

## Changelog

:cl: Melbert
fix: Attempting to move around while in a state of non-existence will not give you a message saying you're buckled to the concept of non-existence
/:cl:

