### PR TITLE
Balloonify and removes more `to_chat` spam for miners

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -162,11 +162,17 @@
 		playsound(user, SFX_RUSTLE, 50, TRUE)
 
 		if (box)
-			user.visible_message(span_notice("[user] offloads the ores beneath [user.p_them()] into [box]."), \
-				span_notice("You offload the ores beneath you into your [box]."))
+			balloon_alert(user, "scoops ore into box")
+			user.visible_message(
+				span_notice("[user] offloads the ores beneath [user.p_them()] into [box]."),
+				ignored_mobs = user
+			)
 		else
-			user.visible_message(span_notice("[user] scoops up the ores beneath [user.p_them()]."), \
-				span_notice("You scoop up the ores beneath you with your [name]."))
+			balloon_alert(user, "scoops ore into bag")
+			user.visible_message(
+				span_notice("[user] scoops up the ores beneath [user.p_them()]."),
+				ignored_mobs = user
+			)
 
 	spam_protection = FALSE
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I played 1 round of miner and got mad with more chat spam so here I am doing the second edition of #67816!

Mining ore bags and boxes will use balloon alerts and the visible message won't be send to the user.

This cuts a few lines on the chat tab(that got send there hundred of times each shift) and makes it easier for miners to pay attention to the radio chatter.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Miners mostly play a single player game outside of the core multiplayer loop on the station, this makes it easier for them to at least hear what is going on up there while they brainlessly walk in a straight line shooting the plasma cutter.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
qol: Miners rejoice again!! A few of the mostly useless and spammy messages that get send to your chat were changed to balloon alerts or straight up removed. Hopefully, you will have an easier time listening to the radio chatter now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
