### PR TITLE
Unit Tests Mice Biting Wires (bonus proc cleanup)

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -94,7 +94,7 @@
 		var/turf/open/floor/position = get_turf(src)
 		if(istype(position) && position.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)
 			var/obj/structure/cable/wire = locate() in position
-			if(wire && cable_chew_probability())
+			if(wire && should_chew_cable())
 				var/powered = wire.avail()
 				if(powered && !HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
 					visible_message(span_warning("[src] chews through the [wire]. It's toast!"))
@@ -117,7 +117,7 @@
 		return
 
 /// Proc to pass the probability of a mouse chewing on a wire to handle_automated_action. Overriden on applicable subtypes.
-/mob/living/simple_animal/mouse/proc/cable_chew_probability()
+/mob/living/simple_animal/mouse/proc/should_chew_cable()
 	return prob(15)
 
 /mob/living/simple_animal/mouse/UnarmedAttack(atom/A, proximity_flag, list/modifiers)
@@ -200,7 +200,7 @@
 /// Subtype that only exists in tests, it fucking loves eating cables.
 /mob/living/simple_animal/mouse/cable_lover
 
-/mob/living/simple_animal/mouse/cable_lover/cable_chew_probability()
+/mob/living/simple_animal/mouse/cable_lover/should_chew_cable()
 	return TRUE // Always chew.
 
 /obj/item/food/deadmouse

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -88,12 +88,13 @@
 		evolve()
 		qdel(AM)
 
-/mob/living/simple_animal/mouse/handle_automated_action()
+/// How miceys go nom nom nom on things. force_chew is used to bypass the probability check (for unit tests).
+/mob/living/simple_animal/mouse/handle_automated_action(force_chew = FALSE)
 	if(prob(chew_probability))
 		var/turf/open/floor/F = get_turf(src)
 		if(istype(F) && F.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)
 			var/obj/structure/cable/C = locate() in F
-			if(C && prob(15))
+			if(C && (prob(15) || force_chew))
 				var/powered = C.avail()
 				if(powered && !HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
 					visible_message(span_warning("[src] chews through the [C]. It's toast!"))

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -31,8 +31,6 @@
 	held_w_class = WEIGHT_CLASS_TINY
 	held_state = "mouse_gray"
 	faction = list(FACTION_RAT)
-	/// Boolean to determine if a mouse will ALWAYS chew on a wire when it sees one, overriding any probabilities.
-	var/always_chew = FALSE
 
 /mob/living/simple_animal/mouse/Initialize(mapload)
 	. = ..()
@@ -96,7 +94,7 @@
 		var/turf/open/floor/position = get_turf(src)
 		if(istype(position) && position.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)
 			var/obj/structure/cable/wire = locate() in position
-			if(wire && should_chew())
+			if(wire && chew_probability())
 				var/powered = wire.avail()
 				if(powered && !HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
 					visible_message(span_warning("[src] chews through the [wire]. It's toast!"))
@@ -118,11 +116,9 @@
 		evolve()
 		return
 
-/// This proc is used to determine if a mouse should chew on a wire or not. Returns TRUE if it should, FALSE if it shouldn't.
-/mob/living/simple_animal/mouse/proc/should_chew()
-	if(prob(15) || always_chew)
-		return TRUE
-	return FALSE
+/// Proc to pass the probability of a mouse chewing on a wire to handle_automated_action. Overriden on applicable subtypes.
+/mob/living/simple_animal/mouse/proc/chew_probability()
+	return prob(15)
 
 /mob/living/simple_animal/mouse/UnarmedAttack(atom/A, proximity_flag, list/modifiers)
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
@@ -203,7 +199,9 @@
 
 /// Subtype that only exists in tests, it fucking loves eating cables.
 /mob/living/simple_animal/mouse/cable_lover
-	always_chew = TRUE
+
+/mob/living/simple_animal/mouse/cable_lover/chew_probability()
+	return TRUE // Always chew.
 
 /obj/item/food/deadmouse
 	name = "dead mouse"

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -94,7 +94,7 @@
 		var/turf/open/floor/position = get_turf(src)
 		if(istype(position) && position.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)
 			var/obj/structure/cable/wire = locate() in position
-			if(wire && chew_probability())
+			if(wire && cable_chew_probability())
 				var/powered = wire.avail()
 				if(powered && !HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
 					visible_message(span_warning("[src] chews through the [wire]. It's toast!"))
@@ -117,7 +117,7 @@
 		return
 
 /// Proc to pass the probability of a mouse chewing on a wire to handle_automated_action. Overriden on applicable subtypes.
-/mob/living/simple_animal/mouse/proc/chew_probability()
+/mob/living/simple_animal/mouse/proc/cable_chew_probability()
 	return prob(15)
 
 /mob/living/simple_animal/mouse/UnarmedAttack(atom/A, proximity_flag, list/modifiers)
@@ -200,7 +200,7 @@
 /// Subtype that only exists in tests, it fucking loves eating cables.
 /mob/living/simple_animal/mouse/cable_lover
 
-/mob/living/simple_animal/mouse/cable_lover/chew_probability()
+/mob/living/simple_animal/mouse/cable_lover/cable_chew_probability()
 	return TRUE // Always chew.
 
 /obj/item/food/deadmouse

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -91,20 +91,20 @@
 /// How miceys go nom nom nom on things. force_chew is used to bypass the probability check (for unit tests).
 /mob/living/simple_animal/mouse/handle_automated_action(force_chew = FALSE)
 	if(prob(chew_probability))
-		var/turf/open/floor/F = get_turf(src)
-		if(istype(F) && F.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)
-			var/obj/structure/cable/C = locate() in F
-			if(C && (prob(15) || force_chew))
-				var/powered = C.avail()
+		var/turf/open/floor/position = get_turf(src)
+		if(istype(position) && position.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)
+			var/obj/structure/cable/wire = locate() in position
+			if(wire && (prob(15) || force_chew))
+				var/powered = wire.avail()
 				if(powered && !HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
-					visible_message(span_warning("[src] chews through the [C]. It's toast!"))
+					visible_message(span_warning("[src] chews through the [wire]. It's toast!"))
 					death(toast = TRUE)
-				else
-					visible_message(span_warning("[src] chews through the [C]."))
-
-				C.deconstruct()
-				if(powered)
+					wire.deconstruct()
 					playsound(src, 'sound/effects/sparks2.ogg', 100, TRUE)
+					return
+				else
+					visible_message(span_warning("[src] chews through the [wire]."))
+					wire.deconstruct()
 
 	for(var/obj/item/food/cheese/cheese in range(1, src))
 		if(prob(10))

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -127,6 +127,7 @@
 #include "mob_spawn.dm"
 #include "modsuit.dm"
 #include "modular_map_loader.dm"
+#include "mouse_bite_cable.dm"
 #include "novaflower_burn.dm"
 #include "ntnetwork_tests.dm"
 #include "nuke_cinematic.dm"

--- a/code/modules/unit_tests/mouse_bite_cable.dm
+++ b/code/modules/unit_tests/mouse_bite_cable.dm
@@ -2,7 +2,7 @@
 /datum/unit_test/mouse_bite_cable
 
 /datum/unit_test/mouse_bite_cable/Run()
-	var/mob/living/simple_animal/mouse/biter = allocate(/mob/living/simple_animal/mouse)
+	var/mob/living/simple_animal/mouse/biter = allocate(/mob/living/simple_animal/mouse/cable_lover) // use special subtype that will bypass the probability check to bite on a cable
 	var/obj/structure/cable/wire = allocate(/obj/structure/cable)
 	biter.chew_probability = 100 // Make sure the mouse bites the cable!
 	wire.powernet = new /datum/powernet() // Make sure the cable has a powernet.
@@ -12,7 +12,7 @@
 	stage.underfloor_accessibility = UNDERFLOOR_INTERACTABLE // the unit tests room has normal flooring so let's just make it be interactable for the sake of this test
 
 	biter.forceMove(stage)
-	biter.handle_automated_action(force_chew = TRUE) // it's not so automated since we're forcing it and doing everything we can to ensure that mice fucking bites that wire but potato potato
+	biter.handle_automated_action() // it's not so automated since we're forcing it and doing everything we can to ensure that mice fucking bites that wire but potato potato
 
 	TEST_ASSERT(QDELETED(biter), "Mouse did not die after biting a powered cable.") // we qdel the mouse mob on death
 	TEST_ASSERT(QDELETED(wire), "Cable was not deleted after being bitten by a mouse.")

--- a/code/modules/unit_tests/mouse_bite_cable.dm
+++ b/code/modules/unit_tests/mouse_bite_cable.dm
@@ -14,7 +14,7 @@
 	biter.forceMove(stage)
 	biter.handle_automated_action(force_chew = TRUE) // it's not so automated since we're forcing it and doing everything we can to ensure that mice fucking bites that wire but potato potato
 
-	TEST_ASSERT(QDELETED(biter), "Mouse did not die after biting a cable.") // we qdel the mouse mob on death
+	TEST_ASSERT(QDELETED(biter), "Mouse did not die after biting a powered cable.") // we qdel the mouse mob on death
 	TEST_ASSERT(QDELETED(wire), "Cable was not deleted after being bitten by a mouse.")
 
 	stage.underfloor_accessibility = initial(stage.underfloor_accessibility) // reset the floor to its original state, to be nice to other tests in case that matters

--- a/code/modules/unit_tests/mouse_bite_cable.dm
+++ b/code/modules/unit_tests/mouse_bite_cable.dm
@@ -1,0 +1,20 @@
+/// Unit Test to ensure that a mouse bites a cable, gets shocked, and dies.
+/datum/unit_test/mouse_bite_cable
+
+/datum/unit_test/mouse_bite_cable/Run()
+	var/mob/living/simple_animal/mouse/biter = allocate(/mob/living/simple_animal/mouse)
+	var/obj/structure/cable/wire = allocate(/obj/structure/cable)
+	biter.chew_probability = 100 // Make sure the mouse bites the cable!
+	wire.powernet = new /datum/powernet() // Make sure the cable has a powernet.
+	wire.powernet.avail = 100000 // Make sure the powernet has a good amount of power! handle_automated_action checks to see if there is ANY power in the powernet and passes fine, but better safe than sorry in this instance.
+
+	var/turf/open/floor/stage = get_turf(wire)
+	stage.underfloor_accessibility = UNDERFLOOR_INTERACTABLE // the unit tests room has normal flooring so let's just make it be interactable for the sake of this test
+
+	biter.forceMove(stage)
+	biter.handle_automated_action(force_chew = TRUE) // it's not so automated since we're forcing it and doing everything we can to ensure that mice fucking bites that wire but potato potato
+
+	TEST_ASSERT(QDELETED(biter), "Mouse did not die after biting a cable.") // we qdel the mouse mob on death
+	TEST_ASSERT(QDELETED(wire), "Cable was not deleted after being bitten by a mouse.")
+
+	stage.underfloor_accessibility = initial(stage.underfloor_accessibility) // reset the floor to its original state, to be nice to other tests in case that matters


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

At the request of the honorable @JohnFulpWillard:

This Unit Test just makes sure that mice bite wires properly, and get fucking dead properly. I had to do some manipulation of the handle_automated_action proc (that I also cleaned up while in the area because it frustrated me that a mouse that we had literally already qdelled was looking for cheese) to ensure that this unit test could even work right, but I think everything's dandy now.

Here's an example of a failure if I add the trait SHOCKIMMUNE to the mouse:

![image](https://user-images.githubusercontent.com/34697715/195689644-54ebe216-4dfc-4e76-a9c0-0ecd0de8cd53.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Micey go nom nom nom. We need to make sure we don't regress on nom nom mousey getting shocked and fucking dying :)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing that particularly concerns players.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
