### PR TITLE
Refactors disease_outbreak, bisects disease event into the "Classic" and "Advanced" disease events

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -929,7 +929,6 @@ GLOBAL_PROTECT(admin_verbs_poll)
 		// Finally, ensure the minds are tracked and in the manifest.
 		SSticker.minds += character.mind
 		GLOB.player_list += character //DEBUG CODE :)
-		priority_announce("good evening")
 		if(ishuman(character))
 			GLOB.data_core.manifest_inject(character)
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -928,6 +928,8 @@ GLOBAL_PROTECT(admin_verbs_poll)
 
 		// Finally, ensure the minds are tracked and in the manifest.
 		SSticker.minds += character.mind
+		GLOB.player_list += character //DEBUG CODE :)
+		priority_announce("good evening")
 		if(ishuman(character))
 			GLOB.data_core.manifest_inject(character)
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -928,7 +928,6 @@ GLOBAL_PROTECT(admin_verbs_poll)
 
 		// Finally, ensure the minds are tracked and in the manifest.
 		SSticker.minds += character.mind
-		GLOB.player_list += character //DEBUG CODE :)
 		if(ishuman(character))
 			GLOB.data_core.manifest_inject(character)
 

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -39,6 +39,7 @@
 			break
 		if(foundAlready)
 			continue
+		disease_candidates += candidate
 
 /datum/round_event/disease_outbreak
 	announce_when = 15

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -66,6 +66,8 @@
 		//The wacky ones
 		virus_candidates += list(/datum/disease/dnaspread, /datum/disease/magnitis)
 
+		virus_type = pick(virus_candidates)
+
 	var/datum/disease/new_disease
 	new_disease = new virus_type()
 	new_disease.carrier = TRUE

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -88,10 +88,10 @@
 		virus_type = pick(virus_candidates)
 
 	var/datum/disease/new_disease
-	new_disease = new virus_type()
+	new_disease = new virus_type() //DO NOT SUBMIT A PR WITHOUT TESTING THE DNA SPREAD VIRUS DUMMY
 	new_disease.carrier = TRUE
 
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 2) //Good things come in pairs
 		if(!length(afflicted)) //In case we somehow run out of people
 			break
 		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
@@ -133,11 +133,10 @@
 	var/datum/disease/advance/advanced_disease = new /datum/disease/advance/random(max_severity, max_severity)
 
 	var/list/name_symptoms = list() //for feedback
-
 	for(var/datum/symptom/new_symptom in advanced_disease.symptoms)
 		name_symptoms += new_symptom.name
 
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 2)
 		if(!length(afflicted))
 			break
 		var/mob/living/carbon/human/victim = pick_n_take(afflicted)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -9,9 +9,9 @@
 
 /datum/round_event/disease_outbreak
 	announce_when = 15
-
-	var/virus_type
-
+	//The disease type we will be spawning
+	var/datum/disease/virus_type
+	//Number of symptoms for our virus
 	var/max_severity = 3
 
 

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -82,7 +82,7 @@
 		virus_candidates += list(/datum/disease/beesease, /datum/disease/brainrot, /datum/disease/fluspanish)
 
 		//The wacky ones
-		virus_candidates += list(/datum/disease/dnaspread, /datum/disease/magnitis, /datum/disease/anxiety)
+		virus_candidates += list(/datum/disease/dnaspread, /datum/disease/magnitis, /datum/disease/anxiety, /datum/disease/pierrot_throat)
 
 		//The rest of the diseases either aren't conventional "diseases" or are too unique/extreme to be considered for a normal event
 		virus_type = pick(virus_candidates)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -91,16 +91,13 @@
 	new_disease = new virus_type()
 	new_disease.carrier = TRUE
 
-	for(var/i in 1 to 2) //Good things come in pairs
-		if(!length(afflicted)) //In case we somehow run out of people
-			break
-		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
-		if(victim.ForceContractDisease(new_disease, FALSE))
-			log_game("An event has given [key_name(victim)] the [new_disease]")
-			message_admins("An event has triggered a [new_disease.name] virus outbreak on [ADMIN_LOOKUPFLW(victim)]!")
-			announce_to_ghosts(victim)
-		else
-			log_game("An event attempted to trigger a [new_disease.name] virus outbreak on [key_name(victim)], but failed.")
+	var/mob/living/carbon/human/victim = pick_n_take(afflicted)
+	if(victim.ForceContractDisease(new_disease, FALSE))
+		log_game("An event has given [key_name(victim)] the [new_disease]")
+		message_admins("An event has triggered a [new_disease.name] virus outbreak on [ADMIN_LOOKUPFLW(victim)]!")
+		announce_to_ghosts(victim)
+	else
+		log_game("An event attempted to trigger a [new_disease.name] virus outbreak on [key_name(victim)], but failed.")
 
 /datum/round_event_control/disease_outbreak/advanced
 	name = "Disease Outbreak: Advanced"
@@ -136,13 +133,10 @@
 	for(var/datum/symptom/new_symptom in advanced_disease.symptoms)
 		name_symptoms += new_symptom.name
 
-	for(var/i in 1 to 2)
-		if(!length(afflicted))
-			break
-		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
-		if(victim.ForceContractDisease(advanced_disease, FALSE))
-			message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]")
-			log_game("An event has triggered a random advanced virus outbreak on [key_name(victim)]! It has these symptoms: [english_list(name_symptoms)].")
-			announce_to_ghosts(victim)
-		else
-			log_game("An event attempted to trigger a random advanced virus outbreak on [key_name(victim)], but failed.")
+	var/mob/living/carbon/human/victim = pick_n_take(afflicted)
+	if(victim.ForceContractDisease(advanced_disease, FALSE))
+		message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]")
+		log_game("An event has triggered a random advanced virus outbreak on [key_name(victim)]! It has these symptoms: [english_list(name_symptoms)].")
+		announce_to_ghosts(victim)
+	else
+		log_game("An event attempted to trigger a random advanced virus outbreak on [key_name(victim)], but failed.")

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -26,8 +26,8 @@
 	if(!length(disease_candidates))
 		message_admins("No disease candidates found!")
 		return FALSE
-	else
-		message_admins("[length(disease_candidates)] candidates found!")
+
+	message_admins("[length(disease_candidates)] candidates found!")
 
 	if(tgui_alert(usr, "Select a specific disease?", "Sickening behavior", list("Yes", "No")) == "Yes")
 		var/list/disease_list = list()
@@ -108,6 +108,8 @@
 	if(!length(disease_candidates))
 		message_admins("No disease candidates found!")
 		return FALSE
+
+	message_admins("[length(disease_candidates)] candidates found!")
 
 /datum/round_event/disease_outbreak/advanced
 	///Number of symptoms for our virus

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -17,7 +17,17 @@
 	if(length(disease_candidates))
 		return TRUE
 
-/datum/round_event_control/disease_outbreak/proc/generate_candidates()
+/datum/round_event_control/disease_outbreak/admin_setup()
+	if(!check_rights(R_FUN))
+		return
+
+	generate_candidates()
+
+	if(!length(disease_candidates))
+		message_admins("No disease candidates found!")
+		return
+
+/datum/round_event_control/disease_outbreak/proc/generate_candidates() //this is fucked up rn fix it tomorrow
 	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list)) //Player list is much more up to date and requires less checks(?)
 		if(!(candidate.mind.assigned_role.job_flags & JOB_CREW_MEMBER) || candidate.stat == DEAD)
 			continue
@@ -29,6 +39,7 @@
 			break
 		if(foundAlready)
 			continue
+
 /datum/round_event/disease_outbreak
 	announce_when = 15
 	///The disease type we will be spawning
@@ -44,7 +55,6 @@
 
 /datum/round_event/disease_outbreak/start()
 	var/datum/round_event_control/disease_outbreak/disease_event = control
-
 	afflicted = disease_event.disease_candidates //Pick our NUMBER here (do this later)
 
 	if(!virus_type)
@@ -65,6 +75,7 @@
 	for(var/mob/living/carbon/human/victim in afflicted)
 		victim.ForceContractDisease(new_disease, FALSE, TRUE)
 		log_game("An event has given [key_name(victim)] the [new_disease]")
+		message_admins("An event has triggered a [new_disease.name] virus outbreak on [ADMIN_LOOKUPFLW(victim)]!")
 
 /datum/round_event_control/disease_outbreak/advanced
 	name = "Disease Outbreak: Advanced"

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -91,7 +91,9 @@
 	new_disease = new virus_type()
 	new_disease.carrier = TRUE
 
-	for(var/i in 1 to 3) //This runtimes whenever the event fires with < 3 candidates pls fix
+	for(var/i in 1 to 3)
+		if(!length(afflicted)) //In case we somehow run out of people
+			break
 		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
 		victim.ForceContractDisease(new_disease, FALSE)
 		log_game("An event has given [key_name(victim)] the [new_disease]")
@@ -133,6 +135,8 @@
 		name_symptoms += new_symptom.name
 
 	for(var/i in 1 to 3)
+		if(!length(afflicted))
+			break
 		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
 		victim.ForceContractDisease(advanced_disease, FALSE)
 		message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]")

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -79,7 +79,7 @@
 		virus_candidates += list(/datum/disease/flu, /datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/cold9, /datum/disease/cold)
 
 		//The more dangerous ones
-		virus_candidates += list(/datum/disease/beesease, /datum/disease/brainrot, /datum/disease/tuberculosis, /datum/disease/fluspanish)
+		virus_candidates += list(/datum/disease/beesease, /datum/disease/brainrot, /datum/disease/fluspanish)
 
 		//The wacky ones
 		virus_candidates += list(/datum/disease/dnaspread, /datum/disease/magnitis, /datum/disease/anxiety)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -122,7 +122,7 @@
 	message_admins("[length(disease_candidates)] candidates found!")
 
 	if(tgui_alert(usr,"Customize your virus?", "Glorified Debug Tool", list("Yes", "No")) == "Yes")
-		chosen_severity = tgui_input_number(usr, "Select a custom severity for your virus!", "Plague Incorporation!", 3, 15)
+		chosen_severity = tgui_input_number(usr, "Select a custom severity for your virus!", "Plague Incorporation!", 3, 8)
 		chosen_max_symptoms = tgui_input_number(usr, "How many symptoms do you want your virus to have?", "A pox upon ye!", 3, 15)
 
 /datum/round_event/disease_outbreak/advanced

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -21,13 +21,13 @@
 
 /datum/round_event_control/disease_outbreak/admin_setup()
 	if(!check_rights(R_FUN))
-		return FALSE
+		return ADMIN_CANCEL_EVENT
 
 	generate_candidates()
 
 	if(!length(disease_candidates))
 		message_admins("No disease candidates found!")
-		return FALSE
+		return ADMIN_CANCEL_EVENT
 
 	message_admins("[length(disease_candidates)] candidates found!")
 
@@ -93,7 +93,7 @@
 
 	for(var/i in 1 to 3) //This runtimes whenever the event fires with < 3 candidates pls fix
 		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
-		victim.ForceContractDisease(new_disease, FALSE, FALSE)
+		victim.ForceContractDisease(new_disease, FALSE)
 		log_game("An event has given [key_name(victim)] the [new_disease]")
 		message_admins("An event has triggered a [new_disease.name] virus outbreak on [ADMIN_LOOKUPFLW(victim)]!")
 
@@ -105,13 +105,13 @@
 
 /datum/round_event_control/disease_outbreak/advanced/admin_setup()
 	if(!check_rights(R_FUN))
-		return FALSE
+		return ADMIN_CANCEL_EVENT
 
 	generate_candidates()
 
 	if(!length(disease_candidates))
 		message_admins("No disease candidates found!")
-		return FALSE
+		return ADMIN_CANCEL_EVENT
 
 	message_admins("[length(disease_candidates)] candidates found!")
 
@@ -134,6 +134,6 @@
 
 	for(var/i in 1 to 3)
 		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
-		victim.ForceContractDisease(advanced_disease, FALSE, FALSE)
+		victim.ForceContractDisease(advanced_disease, FALSE)
 		message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]")
 		log_game("An event has triggered a random advanced virus outbreak on [key_name(victim)]! It has these symptoms: [english_list(name_symptoms)].")

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -63,6 +63,7 @@
 	afflicted = disease_event.disease_candidates
 	if(disease_event.chosen_disease)
 		virus_type = disease_event.chosen_disease
+		disease_event.chosen_disease = null
 
 	if(!virus_type) //I wanted to handle this by searching through the presets and checking by disease severity defines but we'd still need to filter out some of them anyways.
 		var/list/virus_candidates = list()

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -72,14 +72,6 @@
 
 	var/datum/disease/new_disease
 	new_disease = new virus_type()
-	//if(virus_type == /datum/disease/dnaspread) //Dnaspread needs strain_data set to work.
-	//	if(!H.dna || (HAS_TRAIT(H, TRAIT_BLIND))) //A blindness disease would be the worst.
-	//		continue
-	//	new_disease = new virus_type()
-	//	var/datum/disease/dnaspread/DS = new_disease
-	//	DS.strain_data["name"] = H.real_name
-	//	DS.strain_data["UI"] = H.dna.unique_identity
-	//	DS.strain_data["SE"] = H.dna.mutation_index
 	new_disease.carrier = TRUE //fuck you virus code I'm not dealing with your dna spread snowflake bullshit right now
 	for(var/mob/living/carbon/human/victim in afflicted)
 		victim.ForceContractDisease(new_disease, FALSE, TRUE)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -40,7 +40,7 @@
 	priority_announce("Confirmed outbreak of level 7 viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", ANNOUNCER_OUTBREAK7)
 
 /datum/round_event/disease_outbreak/setup()
-	announce_when = rand(15, 30)
+	announce_when = rand(60, 180)
 
 /datum/round_event/disease_outbreak/start()
 	var/datum/round_event_control/disease_outbreak/disease_event = control

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -1,19 +1,40 @@
 /datum/round_event_control/disease_outbreak
-	name = "Disease Outbreak"
+	name = "Disease Outbreak: Classic"
 	typepath = /datum/round_event/disease_outbreak
 	max_occurrences = 1
 	min_players = 10
 	weight = 5
 	category = EVENT_CATEGORY_HEALTH
-	description = "A classic or advanced disease will infect some crewmembers."
+	description = "A 'classic' virus will infect some members of the crew." //These are the ones with PERSONALITY
+	///Disease recipient candidates
+	var/list/disease_candidates = list()
 
+/datum/round_event_control/disease_outbreak/can_spawn_event(players_amt)
+	. = ..()
+	if(!.)
+		return .
+	generate_candidates()
+	if(length(disease_candidates))
+		return TRUE
+
+/datum/round_event_control/disease_outbreak/proc/generate_candidates()
+	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list)) //Player list is much more up to date and requires less checks(?)
+		if(!(candidate.mind.assigned_role.job_flags & JOB_CREW_MEMBER) || candidate.stat == DEAD)
+			continue
+		if(HAS_TRAIT(candidate, TRAIT_VIRUSIMMUNE)) //Don't pick someone who's virus immune, only for it to not do anything.
+			continue
+		var/foundAlready = FALSE // don't infect someone that already has a disease
+		for(var/thing in candidate.diseases)
+			foundAlready = TRUE
+			break
+		if(foundAlready)
+			continue
 /datum/round_event/disease_outbreak
 	announce_when = 15
-	//The disease type we will be spawning
+	///The disease type we will be spawning
 	var/datum/disease/virus_type
-	//Number of symptoms for our virus
-	var/max_severity = 3
-
+	///Disease recipient candidates, passed from the round_event_control object
+	var/list/afflicted = list()
 
 /datum/round_event/disease_outbreak/announce(fake)
 	priority_announce("Confirmed outbreak of level 7 viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", ANNOUNCER_OUTBREAK7)
@@ -21,57 +42,51 @@
 /datum/round_event/disease_outbreak/setup()
 	announce_when = rand(15, 30)
 
-
 /datum/round_event/disease_outbreak/start()
-	var/advanced_virus = FALSE
-	max_severity = 3 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
-	if(!virus_type && prob(20 + (10 * max_severity)))
-		advanced_virus = TRUE
+	var/datum/round_event_control/disease_outbreak/disease_event = control
 
-	if(!virus_type && !advanced_virus)
+	afflicted = disease_event.disease_candidates //Pick our NUMBER here (do this later)
+
+	if(!virus_type)
 		virus_type = pick(/datum/disease/dnaspread, /datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis)
 
-	for(var/mob/living/carbon/human/H in shuffle(GLOB.alive_mob_list))
-		var/turf/T = get_turf(H)
-		if(!T)
-			continue
-		if(!is_station_level(T.z))
-			continue
-		if(!H.client)
-			continue
-		if(H.stat == DEAD)
-			continue
-		if(HAS_TRAIT(H, TRAIT_VIRUSIMMUNE)) //Don't pick someone who's virus immune, only for it to not do anything.
-			continue
-		var/foundAlready = FALSE // don't infect someone that already has a disease
-		for(var/thing in H.diseases)
-			foundAlready = TRUE
-			break
-		if(foundAlready)
-			continue
 
-		var/datum/disease/D
-		if(!advanced_virus)
-			if(virus_type == /datum/disease/dnaspread) //Dnaspread needs strain_data set to work.
-				if(!H.dna || (HAS_TRAIT(H, TRAIT_BLIND))) //A blindness disease would be the worst.
-					continue
-				D = new virus_type()
-				var/datum/disease/dnaspread/DS = D
-				DS.strain_data["name"] = H.real_name
-				DS.strain_data["UI"] = H.dna.unique_identity
-				DS.strain_data["SE"] = H.dna.mutation_index
-			else
-				D = new virus_type()
-		else
-			D = new /datum/disease/advance/random(max_severity, max_severity)
-		D.carrier = TRUE
-		H.ForceContractDisease(D, FALSE, TRUE)
+	var/datum/disease/new_disease
+	new_disease = new virus_type()
+	//if(virus_type == /datum/disease/dnaspread) //Dnaspread needs strain_data set to work.
+	//	if(!H.dna || (HAS_TRAIT(H, TRAIT_BLIND))) //A blindness disease would be the worst.
+	//		continue
+	//	new_disease = new virus_type()
+	//	var/datum/disease/dnaspread/DS = new_disease
+	//	DS.strain_data["name"] = H.real_name
+	//	DS.strain_data["UI"] = H.dna.unique_identity
+	//	DS.strain_data["SE"] = H.dna.mutation_index
+	new_disease.carrier = TRUE //fuck you virus code I'm not dealing with your dna spread snowflake bullshit right now
+	for(var/mob/living/carbon/human/victim in afflicted)
+		victim.ForceContractDisease(new_disease, FALSE, TRUE)
+		log_game("An event has given [key_name(victim)] the [new_disease]")
 
-		if(advanced_virus)
-			var/datum/disease/advance/A = D
-			var/list/name_symptoms = list() //for feedback
-			for(var/datum/symptom/S in A.symptoms)
-				name_symptoms += S.name
-			message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(H)]! It has these symptoms: [english_list(name_symptoms)]")
-			log_game("An event has triggered a random advanced virus outbreak on [key_name(H)]! It has these symptoms: [english_list(name_symptoms)].")
-		break
+/datum/round_event_control/disease_outbreak/advanced
+	name = "Disease Outbreak: Advanced"
+	typepath = /datum/round_event/disease_outbreak/advanced
+	category = EVENT_CATEGORY_HEALTH
+	description = "An advanced disease will infect some crewmembers."
+
+/datum/round_event/disease_outbreak/advanced
+	///Number of symptoms for our virus
+	var/max_severity = 3
+
+/datum/round_event_control/disease_outbreak/advanced/generate_candidates()
+	return TRUE
+
+/datum/round_event/disease_outbreak/advanced/start()
+	max_severity = 3 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
+	var/datum/disease/advance/advanced_disease = new /datum/disease/advance/random(max_severity, max_severity)
+	var/list/name_symptoms = list() //for feedback
+	for(var/datum/symptom/new_symptom in advanced_disease.symptoms)
+		name_symptoms += new_symptom.name
+
+	for(var/mob/living/carbon/human/victim in afflicted)
+		victim.ForceContractDisease(advanced_disease, FALSE, TRUE)
+		message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]")
+		log_game("An event has triggered a random advanced virus outbreak on [key_name(victim)]! It has these symptoms: [english_list(name_symptoms)].")

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -19,13 +19,13 @@
 
 /datum/round_event_control/disease_outbreak/admin_setup()
 	if(!check_rights(R_FUN))
-		return
+		return FALSE
 
 	generate_candidates()
 
 	if(!length(disease_candidates))
 		message_admins("No disease candidates found!")
-		return
+		return FALSE
 
 /datum/round_event_control/disease_outbreak/proc/generate_candidates() //this is fucked up rn fix it tomorrow
 	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list)) //Player list is much more up to date and requires less checks(?)
@@ -42,7 +42,7 @@
 		disease_candidates += candidate
 
 /datum/round_event/disease_outbreak
-	announce_when = 15
+	announce_when = 120
 	///The disease type we will be spawning
 	var/datum/disease/virus_type
 	///Disease recipient candidates, passed from the round_event_control object
@@ -58,9 +58,14 @@
 	var/datum/round_event_control/disease_outbreak/disease_event = control
 	afflicted = disease_event.disease_candidates //Pick our NUMBER here (do this later)
 
-	if(!virus_type)
-		virus_type = pick(/datum/disease/dnaspread, /datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis)
-
+	if(!virus_type) //I wanted to handle this by searching through the presets and checking by disease severity defines but we'd still need to filter out some of them anyways.
+		switch(rand(1,3)) //This is UGLY please change later
+			if(1) //Not particularly harmful diseases
+				virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis)
+			if(2) //The more dangerous ones
+				virus_type = pick(/datum/disease/beesease)
+			if(3) //The wacky ones
+				virus_type = pick(/datum/disease/dnaspread)
 
 	var/datum/disease/new_disease
 	new_disease = new virus_type()
@@ -87,9 +92,6 @@
 /datum/round_event/disease_outbreak/advanced
 	///Number of symptoms for our virus
 	var/max_severity = 3
-
-/datum/round_event_control/disease_outbreak/advanced/generate_candidates()
-	return TRUE
 
 /datum/round_event/disease_outbreak/advanced/start()
 	max_severity = 3 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -13,7 +13,6 @@
 
 /datum/round_event_control/disease_outbreak/can_spawn_event(players_amt)
 	. = ..()
-		return .
 	generate_candidates()
 	if(length(disease_candidates))
 		return TRUE

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -33,11 +33,7 @@
 			continue
 		if(HAS_TRAIT(candidate, TRAIT_VIRUSIMMUNE)) //Don't pick someone who's virus immune, only for it to not do anything.
 			continue
-		var/foundAlready = FALSE // don't infect someone that already has a disease
-		for(var/thing in candidate.diseases)
-			foundAlready = TRUE
-			break
-		if(foundAlready)
+		if(length(candidate.diseases)) //Is our candidate already sick?
 			continue
 		disease_candidates += candidate
 
@@ -72,7 +68,11 @@
 
 	var/datum/disease/new_disease
 	new_disease = new virus_type()
-	new_disease.carrier = TRUE //fuck you virus code I'm not dealing with your dna spread snowflake bullshit right now
+	new_disease.carrier = TRUE
+
+	infect_players(new_disease)
+
+/datum/round_event/disease_outbreak/proc/infect_players(var/datum/disease/new_disease)
 	for(var/mob/living/carbon/human/victim in afflicted)
 		victim.ForceContractDisease(new_disease, FALSE, TRUE)
 		log_game("An event has given [key_name(victim)] the [new_disease]")
@@ -91,6 +91,10 @@
 /datum/round_event/disease_outbreak/advanced/start()
 	max_severity = 3 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
 	var/datum/disease/advance/advanced_disease = new /datum/disease/advance/random(max_severity, max_severity)
+
+	infect_players(advanced_disease)
+
+/datum/round_event/disease_outbreak/advanced/infect_players(var/datum/disease/advance/advanced_disease)
 	var/list/name_symptoms = list() //for feedback
 	for(var/datum/symptom/new_symptom in advanced_disease.symptoms)
 		name_symptoms += new_symptom.name

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -60,7 +60,8 @@
 
 /datum/round_event/disease_outbreak/start()
 	var/datum/round_event_control/disease_outbreak/disease_event = control
-	afflicted = disease_event.disease_candidates
+	afflicted += disease_event.disease_candidates
+	disease_event.disease_candidates.Cut() //Clean the list after use
 	if(disease_event.chosen_disease)
 		virus_type = disease_event.chosen_disease
 		disease_event.chosen_disease = null
@@ -77,6 +78,7 @@
 		//The wacky ones
 		virus_candidates += list(/datum/disease/dnaspread, /datum/disease/magnitis, /datum/disease/anxiety)
 
+		//The rest of the diseases either aren't conventional "disease" or are too unique/extreme to be considered for a normal event
 		virus_type = pick(virus_candidates)
 
 	var/datum/disease/new_disease
@@ -115,6 +117,10 @@
 	var/max_severity = 3
 
 /datum/round_event/disease_outbreak/advanced/start()
+	var/datum/round_event_control/disease_outbreak/disease_event = control
+	afflicted += disease_event.disease_candidates
+	disease_event.disease_candidates.Cut() //Clean the list after use
+
 	max_severity = 3 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
 	var/datum/disease/advance/advanced_disease = new /datum/disease/advance/random(max_severity, max_severity)
 

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -95,15 +95,18 @@
 		if(!length(afflicted)) //In case we somehow run out of people
 			break
 		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
-		victim.ForceContractDisease(new_disease, FALSE)
-		log_game("An event has given [key_name(victim)] the [new_disease]")
-		message_admins("An event has triggered a [new_disease.name] virus outbreak on [ADMIN_LOOKUPFLW(victim)]!")
+		if(victim.ForceContractDisease(new_disease, FALSE))
+			log_game("An event has given [key_name(victim)] the [new_disease]")
+			message_admins("An event has triggered a [new_disease.name] virus outbreak on [ADMIN_LOOKUPFLW(victim)]!")
+			announce_to_ghosts(victim)
+		else
+			log_game("An event attempted to trigger a [new_disease.name] virus outbreak on [key_name(victim)], but failed.")
 
 /datum/round_event_control/disease_outbreak/advanced
 	name = "Disease Outbreak: Advanced"
 	typepath = /datum/round_event/disease_outbreak/advanced
 	category = EVENT_CATEGORY_HEALTH
-	description = "An 'advanced' disease will infect some members of the crew."
+	description = "An 'advanced' disease will infect some members of the crew." //These are the ones that get viro lynched!
 
 /datum/round_event_control/disease_outbreak/advanced/admin_setup()
 	if(!check_rights(R_FUN))
@@ -138,6 +141,9 @@
 		if(!length(afflicted))
 			break
 		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
-		victim.ForceContractDisease(advanced_disease, FALSE)
-		message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]")
-		log_game("An event has triggered a random advanced virus outbreak on [key_name(victim)]! It has these symptoms: [english_list(name_symptoms)].")
+		if(victim.ForceContractDisease(advanced_disease, FALSE))
+			message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]")
+			log_game("An event has triggered a random advanced virus outbreak on [key_name(victim)]! It has these symptoms: [english_list(name_symptoms)].")
+			announce_to_ghosts(victim)
+		else
+			log_game("An event attempted to trigger a random advanced virus outbreak on [key_name(victim)], but failed.")

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -59,13 +59,16 @@
 	afflicted = disease_event.disease_candidates //Pick our NUMBER here (do this later)
 
 	if(!virus_type) //I wanted to handle this by searching through the presets and checking by disease severity defines but we'd still need to filter out some of them anyways.
-		switch(rand(1,3)) //This is UGLY please change later
-			if(1) //Not particularly harmful diseases
-				virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis)
-			if(2) //The more dangerous ones
-				virus_type = pick(/datum/disease/beesease)
-			if(3) //The wacky ones
-				virus_type = pick(/datum/disease/dnaspread)
+		var/list/virus_candidates = list()
+
+		//Practically harmless diseases. Mostly just gives medical something to do.
+		virus_candidates += list(/datum/disease/flu, /datum/disease/advance/flu, /datum/disease/advance/cold)
+
+		//The more dangerous ones
+		virus_candidates += list(/datum/disease/beesease, /datum/disease/brainrot)
+
+		//The wacky ones
+		virus_candidates += list(/datum/disease/dnaspread, /datum/disease/magnitis)
 
 	var/datum/disease/new_disease
 	new_disease = new virus_type()

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -32,7 +32,7 @@
 	if(tgui_alert(usr, "Select a specific disease?", "Sickening behavior", list("Yes", "No")) == "Yes")
 		var/list/disease_list = list()
 		disease_list += subtypesof(/datum/disease)
-		chosen_disease = tgui_input_list(usr, "Pick your poison!","Bacteria Hysteria", disease_list)
+		chosen_disease = tgui_input_list(usr, "Warning: Some of these are EXTREMELY dangerous.","Bacteria Hysteria", disease_list)
 
 /datum/round_event_control/disease_outbreak/proc/generate_candidates()
 	if(length(disease_candidates))
@@ -87,7 +87,7 @@
 	infect_players(new_disease)
 
 /datum/round_event/disease_outbreak/proc/infect_players(var/datum/disease/new_disease)
-	for(var/i in 1 to 3) //do this better
+	for(var/i in 1 to 3) //This runtimes whenever the event fires with < 3 candidates pls fix
 		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
 		victim.ForceContractDisease(new_disease, FALSE, FALSE)
 		log_game("An event has given [key_name(victim)] the [new_disease]")
@@ -98,8 +98,6 @@
 	typepath = /datum/round_event/disease_outbreak/advanced
 	category = EVENT_CATEGORY_HEALTH
 	description = "An advanced disease will infect some members of the crew."
-	///The admin-selected virus severity, passed down to the round_event (might not be used)
-	var/severity
 
 /datum/round_event_control/disease_outbreak/advanced/admin_setup()
 	if(!check_rights(R_FUN))
@@ -118,12 +116,7 @@
 	var/max_severity = 3
 
 /datum/round_event/disease_outbreak/advanced/start()
-	var/datum/round_event_control/disease_outbreak/advanced/disease_event = control
-	afflicted = disease_event.disease_candidates
-	if(disease_event.severity)
-		max_severity = disease_event.severity
-	else
-		max_severity = 3 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
+	max_severity = 3 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
 	var/datum/disease/advance/advanced_disease = new /datum/disease/advance/random(max_severity, max_severity)
 
 	infect_players(advanced_disease)
@@ -133,7 +126,7 @@
 	for(var/datum/symptom/new_symptom in advanced_disease.symptoms)
 		name_symptoms += new_symptom.name
 
-	for(var/i in 1 to 3) //Find a cooler way of doing this
+	for(var/i in 1 to 3)
 		var/mob/living/carbon/human/victim = pick_n_take(afflicted)
 		victim.ForceContractDisease(advanced_disease, FALSE, FALSE)
 		message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]")

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -70,13 +70,13 @@
 		var/list/virus_candidates = list()
 
 		//Practically harmless diseases. Mostly just gives medical something to do.
-		virus_candidates += list(/datum/disease/flu, /datum/disease/advance/flu, /datum/disease/advance/cold)
+		virus_candidates += list(/datum/disease/flu, /datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/cold9, /datum/disease/cold)
 
 		//The more dangerous ones
-		virus_candidates += list(/datum/disease/beesease, /datum/disease/brainrot)
+		virus_candidates += list(/datum/disease/beesease, /datum/disease/brainrot, /datum/disease/tuberculosis, /datum/disease/fluspanish)
 
 		//The wacky ones
-		virus_candidates += list(/datum/disease/dnaspread, /datum/disease/magnitis)
+		virus_candidates += list(/datum/disease/dnaspread, /datum/disease/magnitis, /datum/disease/anxiety)
 
 		virus_type = pick(virus_candidates)
 
@@ -97,7 +97,7 @@
 	name = "Disease Outbreak: Advanced"
 	typepath = /datum/round_event/disease_outbreak/advanced
 	category = EVENT_CATEGORY_HEALTH
-	description = "An advanced disease will infect some members of the crew."
+	description = "An 'advanced' disease will infect some members of the crew."
 
 /datum/round_event_control/disease_outbreak/advanced/admin_setup()
 	if(!check_rights(R_FUN))
@@ -108,8 +108,6 @@
 	if(!length(disease_candidates))
 		message_admins("No disease candidates found!")
 		return FALSE
-	else
-		message_admins("[length(disease_candidates)] candidates found!")
 
 /datum/round_event/disease_outbreak/advanced
 	///Number of symptoms for our virus

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -88,7 +88,7 @@
 		virus_type = pick(virus_candidates)
 
 	var/datum/disease/new_disease
-	new_disease = new virus_type() //DO NOT SUBMIT A PR WITHOUT TESTING THE DNA SPREAD VIRUS DUMMY
+	new_disease = new virus_type()
 	new_disease.carrier = TRUE
 
 	for(var/i in 1 to 2) //Good things come in pairs

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -30,9 +30,7 @@
 	message_admins("[length(disease_candidates)] candidates found!")
 
 	if(tgui_alert(usr, "Select a specific disease?", "Sickening behavior", list("Yes", "No")) == "Yes")
-		var/list/disease_list = list()
-		disease_list += subtypesof(/datum/disease)
-		chosen_disease = tgui_input_list(usr, "Warning: Some of these are EXTREMELY dangerous.","Bacteria Hysteria", disease_list)
+		chosen_disease = tgui_input_list(usr, "Warning: Some of these are EXTREMELY dangerous.","Bacteria Hysteria", subtypesof(/datum/disease))
 
 /datum/round_event_control/disease_outbreak/proc/generate_candidates()
 	if(length(disease_candidates))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm back with, wouldn't you believe it, another rewrite of an old and crusty event file. This gets rid of some REAL ugly code. Not particularly bad or inefficient, but just ugly. This isn't to say my code is any better, but I'm getting ahead of myself.

The disease_outbreak event is now two different events. No more probability check, no more tangled if-statements checking the advanced_disease var. They're now just two separate events, that can roll independently.

The "classic" disease event picks from a list of pre-baked viruses and infects someone as a carrier. The roster of potential diseases the event can roll for has had a few more candidates added, with their severity ranging from benign to dangerous to wacky. 

The "advanced" disease event works the same as the event did pre-split if the advanced_virus var had been set to true. Summarily, it still generates a random advanced virus, with a severity/symptom count based on the round time, and infects a random person as the carrier.

Following suit with the Heart Attack event, this event now generates a candidate list in can_spawn_event and uses it to ensure that the event will be able to act prior to firing. This means that if virology has already spread their god virus to literally everyone, the event won't be wasted.

Functionally, very little player-facing stuff has been seriously changed here. The event can roll twice in a given round now, since two events now exist, but for a 5 weight event it really shouldn't happen often enough to become a problem. I have, however, unapologetically tweaked the announce time to be a bit longer. Now crewmembers at least have a chance to feel symptoms and maybe go to medical before the cat gets out of the bag.

Admin setup functionality has also been implemented, allowing admins to pick from the ENTIRE disease list and unleash their choice upon the crew. Yes, this includes the ones that make people explode or turn into dust. The advanced disease variant allows you to pick a custom number of symptoms, as well as a maximum severity.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Cleans up and provides some TLC another event file. Allows admins to abuse the players in new and exciting ways.

More diseases for the classic disease list should make the event a more memorable experience for the crew and add some variety to an otherwise fairly straightforward event.

Making the event not a tangled mess gives room for new stuff, easier improvements, and helps with reader comprehension.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The disease outbreak events will no longer attempt to fire if there are no valid players to infect.
balance: The disease outbreak events now take a fair bit longer to announce themselves to the crew.
balance: The 'classic' disease outbreak has an expanded roster of diseases to be selected from.
admin: Admins can now pick which classic disease they wish to loose upon the crew (BE CAREFUL WITH THESE).
code: The disease outbreak event has been split into two different events -- "Classic" and "Advanced". The code should be a bit easier to read as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
