### PR TITLE
Stops people from removing infinite power cell from combat defib

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -146,9 +146,9 @@
 
 	cell.update_appearance()
 	cell.forceMove(get_turf(src))
+	balloon_alert(user, "removed [cell]")
 	cell = null
 	tool.play_tool_sound(src, 50)
-	to_chat(user, span_notice("You remove the cell from [src]."))
 	update_power()
 	return TRUE
 

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -22,6 +22,7 @@
 	var/on = FALSE //if the paddles are equipped (1) or on the defib (0)
 	var/safety = TRUE //if you can zap people with the defibs on harm mode
 	var/powered = FALSE //if there's a cell in the defib with enough power for a revive, blocks paddles from reviving otherwise
+	var/cell_removable = TRUE //Can the cell be removed?
 	var/obj/item/shockpaddles/paddles
 	var/obj/item/stock_parts/cell/high/cell
 	var/combat = FALSE //if true, revive through space suits, allow for combat shocking
@@ -53,6 +54,8 @@
 
 /obj/item/defibrillator/examine(mob/user)
 	. = ..()
+	if(!cell_removable)
+		return
 	if(cell)
 		. += span_notice("Use a screwdriver to remove the cell.")
 	else
@@ -132,13 +135,16 @@
 			M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
 /obj/item/defibrillator/screwdriver_act(mob/living/user, obj/item/tool)
-	if(cell)
-		cell.update_appearance()
-		cell.forceMove(get_turf(src))
-		cell = null
-		tool.play_tool_sound(src, 50)
-		to_chat(user, span_notice("You remove the cell from [src]."))
-		update_power()
+	if(!(cell && cell_removable))
+		return FALSE
+
+	cell.update_appearance()
+	cell.forceMove(get_turf(src))
+	cell = null
+	tool.play_tool_sound(src, 50)
+	to_chat(user, span_notice("You remove the cell from [src]."))
+	update_power()
+	return TRUE
 
 /obj/item/defibrillator/attackby(obj/item/W, mob/user, params)
 	if(W == paddles)
@@ -300,6 +306,9 @@
 	paddle_state = "defibcombat-paddles"
 	powered_state = null
 	emagged_state = null
+
+/obj/item/defibrillator/compact/combat/loaded
+	cell_removable = FALSE // Don't let people just have an infinite power cell
 
 /obj/item/defibrillator/compact/combat/loaded/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -19,14 +19,20 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 50, ACID = 50)
 
 	var/obj/item/shockpaddles/paddle_type = /obj/item/shockpaddles
-	var/on = FALSE //if the paddles are equipped (1) or on the defib (0)
-	var/safety = TRUE //if you can zap people with the defibs on harm mode
-	var/powered = FALSE //if there's a cell in the defib with enough power for a revive, blocks paddles from reviving otherwise
-	var/cell_removable = TRUE //Can the cell be removed?
+	/// If the paddles are equipped (1) or on the defib (0)
+	var/on = FALSE
+	/// If you can zap people with the defibs on harm mode
+	var/safety = TRUE
+	/// If there's a cell in the defib with enough power for a revive, blocks paddles from reviving otherwise
+	var/powered = FALSE
+	/// If the cell can be removed via screwdriver
+	var/cell_removable = TRUE
 	var/obj/item/shockpaddles/paddles
 	var/obj/item/stock_parts/cell/high/cell
-	var/combat = FALSE //if true, revive through space suits, allow for combat shocking
-	var/cooldown_duration = 5 SECONDS//how long does it take to recharge
+	/// If true, revive through space suits, allow for combat shocking
+	var/combat = FALSE
+	/// How long does it take to recharge
+	var/cooldown_duration = 5 SECONDS
 	/// The icon state for the paddle overlay, not applied if null
 	var/paddle_state = "defibunit-paddles"
 	/// The icon state for the powered on overlay, not applied if null
@@ -135,7 +141,7 @@
 			M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
 /obj/item/defibrillator/screwdriver_act(mob/living/user, obj/item/tool)
-	if(!(cell && cell_removable))
+	if(!cell || !cell_removable)
 		return FALSE
 
 	cell.update_appearance()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The loaded combat defibrillator has an infinite power cell. You can remove it and have an infinite power cell to use as use please as a player.

This is probably bad.

Makes the combat defib's cell not removable.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Balance?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: ERT and nuke ops players can no longer remove the power cell from a combat defibrillator.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
