### PR TITLE
Inhand unit test modularity support p2

### DIFF
--- a/code/modules/unit_tests/inhands.dm
+++ b/code/modules/unit_tests/inhands.dm
@@ -68,8 +68,8 @@
 			if(!lefthand_file)
 				TEST_FAIL("Missing left inhand icon file for [item_path].\n\tinhand_icon_state = \"[held_icon_state]\"[match_message]")
 			else
-				missing_left = !("[lefthand_file]" in possible_icon_states[held_icon_state])
-				if(missing_left && ("[lefthand_file]" in possible_icon_states[""]))
+				missing_left = !icon_exists(lefthand_file, held_icon_state)
+				if(missing_left && icon_exists(lefthand_file, ""))
 					left_fallback = TRUE
 
 		var/missing_right
@@ -78,8 +78,8 @@
 			if(!righthand_file)
 				TEST_FAIL("Missing right inhand icon file for [item_path].\n\tinhand_icon_state = \"[held_icon_state]\"[match_message]")
 			else
-				missing_right = !("[righthand_file]" in possible_icon_states[held_icon_state])
-				if(missing_right && ("[righthand_file]" in possible_icon_states[""]))
+				missing_right = !icon_exists(righthand_file, held_icon_state)
+				if(missing_right && icon_exists(righthand_file, ""))
 					right_fallback = TRUE
 
 		if(missing_right && missing_left)


### PR DESCRIPTION
Okay, looking more at the folder structures some of our downstreams, just switching these two checks over to icon_exists is obviously a far better route.

I did play with this method when originally making the test, and while it did work, it was far more performant to cache all the inhand dmi files and compare against that list instead. (With this change, the test's run time has increased from 0.3s to 1s. Still well below some of our other tests.)


### Behavior change (only affects downstreams):
The **test will no longer fail** if `additional_inhands_locations` & `generate_possible_icon_states_list` paths aren't explicitly added for all modularized inhand folder paths **IF the item's inhand_icon is a valid sprite in its defined .dmi file. The test will also now properly detect fallback icons in those files.**

If a path isn't explicitly defined, and an item's inhand_icon var is set to null, but it's icon_state matches w/ an existing sprite in a DMI file, **potential sprite suggestions for files in missing paths will simply be disabled.** This was not a critical feature of the test, and primarily serves to help speed up finding icons which potentially may have been misfiled during dmi splitting.

Setting the path vars as described at the top of the unit test will re-enable the file suggestions.