### PR TITLE
Fix admin transforms transfering the wrong client

### DIFF
--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -50,8 +50,14 @@
 		client?.prefs.safe_transfer_prefs_to(new_human)
 		new_human.dna.update_dna_identity()
 		new_human.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
-
-	if(mind && isliving(desired_mob))
+	
+	//Ghosts have copys of their minds, but if an admin put somebody else in their og body, the mind will have a new mind.key
+	//	and transfer_to will transfer the wrong person since it uses mind.key
+	if(mind && isliving(desired_mob) && (!isobserver(src) || mind.current == src || QDELETED(mind.current)))
+		if (ckey(mind.key) != ckey) 
+			//we could actually prevent the bug from happening here, but then nobody would know to look for the stack trace we are about to print.
+			stack_trace("DEBUG: The bug where mob transfers or transforms sometimes kick unrelated people out of mobs has happened again. mob [type](\ref[src]) owned by [ckey] is being changed into a [new_type] but has a mind owned by [ckey(mind.key)].")
+		
 		mind.transfer_to(desired_mob, 1) // second argument to force key move to new mob
 	else
 		desired_mob.key = key

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -56,7 +56,7 @@
 	if(mind && isliving(desired_mob) && (!isobserver(src) || mind.current == src || QDELETED(mind.current)))
 		if (ckey(mind.key) != ckey) 
 			//we could actually prevent the bug from happening here, but then nobody would know to look for the stack trace we are about to print.
-			stack_trace("DEBUG: The bug where mob transfers or transforms sometimes kick unrelated people out of mobs has happened again. mob [type](\ref[src]) owned by [ckey] is being changed into a [new_type] but has a mind owned by [ckey(mind.key)].")
+			stack_trace("DEBUG: The bug where mob transfers or transforms sometimes kick unrelated people out of mobs has happened again. mob [src]([type])\ref[src] owned by [ckey] is being changed into a [new_type] but has a mind owned by [ckey(mind.key)].")
 		
 		mind.transfer_to(desired_mob, 1) // second argument to force key move to new mob
 	else


### PR DESCRIPTION
Ghost copies of minds should not get cloned onto a new mob because the original body could have been taken over (via offer body to ghost or other fuckary) and then transfer_to will transfer the controller of the og body instead of the ghost body.

I could more thoroughly fix this bug from happening with more raw ckey checks, like the debug line I added, but this is part of code that controls when antag status transfers between bodies while admin bussing, and so i want it's behavior to either be intentional or clearly buggy, no in between, so i'm not adding a check to verify the mind key is the same as the mob key, or rather, i did, but it doesn't stop the bug from happening, it just stack_traces.

## Changelog

:cl: MSO, Dopamiin, Ryll
fix: fixed an edge case where admins spawning ghosts in as mobs would sometimes give the wrong person control of the new mob.
/:cl:

fixes #8988
fixes #16639
fixes #26902
fixes #35937
fixes #42573
completes #47826