### PR TITLE
Fixes hallucination destroy runtime

### DIFF
--- a/code/modules/hallucination/_hallucination.dm
+++ b/code/modules/hallucination/_hallucination.dm
@@ -137,7 +137,7 @@
 
 /obj/effect/client_image_holder/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
 	. = ..()
-	if(same_z_layer)
+	if(QDELETED(src) || same_z_layer)
 		return
 	SET_PLANE(shown_image, PLANE_TO_TRUE(shown_image.plane), new_turf)
 


### PR DESCRIPTION
shown_image is null'd during Destroy()

```
[01:38:51] Runtime in _hallucination.dm, line 142: Cannot read null.plane
proc name: on changed z level (/obj/effect/client_image_holder/on_changed_z_level)
src: the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly)
src.loc: null
call stack:
the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly): on changed z level(the catwalk floor (96,89,2) (/turf/open/floor/catwalk_floor), null, 0, null)
the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly): Moved(the catwalk floor (96,89,2) (/turf/open/floor/catwalk_floor), 0, 1, null, 1)
the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly): Moved(the catwalk floor (96,89,2) (/turf/open/floor/catwalk_floor), 0, 1, null, 1)
the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly): doMove(null)
the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly): moveToNullspace()
the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly): Destroy(0)
the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly): Destroy(0)
the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly): Destroy(0)
the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly): Destroy(0)
the flux wave anomaly (/obj/effect/client_image_holder/hallucination/danger/anomaly): Destroy(0)
/datum/hallucination/hazard/an... (/datum/hallucination/hazard/anomaly): SendSignal("parent_qdeleting", /list (/list))
qdel(/datum/hallucination/hazard/an... (/datum/hallucination/hazard/anomaly), 0)
/datum/weakref (/datum/weakref): Destroy(0)
qdel(/datum/weakref (/datum/weakref), 0)
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): StartProcessing(0)
```

:cl: ShizCalev
fix: Fixed a minor runtime when hallucinations are ending.
/:cl:

