### PR TITLE
Fixes runtime preventing mafia from starting if a player disconnects during signup.

### DIFF
--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -959,6 +959,7 @@
 		if(!C)//vice versa but in a variable we use later
 			GLOB.mafia_signup -= key
 			GLOB.mafia_bad_signup += key
+			continue
 		if(!isobserver(C.mob))
 			//they are back to playing the game, remove them from the signups
 			GLOB.mafia_signup -= key


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a runtime preventing mafia from starting if a player disconnected during signups.
/:cl: