### PR TITLE
traitor bugs no longer get inserted into their objective targets

### DIFF
--- a/code/modules/antagonists/traitor/objectives/bug_room.dm
+++ b/code/modules/antagonists/traitor/objectives/bug_room.dm
@@ -192,6 +192,9 @@
 		UnregisterSignal(planted_on, COMSIG_PARENT_QDELETING)
 		planted_on = null
 
+/obj/item/traitor_bug/attackby_storage_insert(datum/storage, atom/storage_holder, mob/user)
+	return !istype(storage_holder, target_object_type)
+
 /obj/structure/traitor_bug
 	name = "suspicious device"
 	desc = "It looks dangerous. Best you leave this alone."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

traitor bugs no longer get put in storage if the storage item is their target
fixes #68601

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
![image](https://user-images.githubusercontent.com/23585223/195825344-d11557f1-3d7e-41b2-a94a-a2653aa26ef6.png)
so that was a lie

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: you can plant traitor bugs on clown shoes as God intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
