### PR TITLE
Makes weakpoint objective require both areas to be scanned + bugfixes + harddels

### DIFF
--- a/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
+++ b/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
@@ -146,6 +146,8 @@
 /obj/item/weakpoint_locator/Initialize(mapload, datum/traitor_objective/locate_weakpoint/objective)
 	. = ..()
 	objective_weakref = WEAKREF(objective)
+	if(!objective)
+		return
 	var/area/area1 = objective.scan_areas[1]
 	var/area/area2 = objective.scan_areas[2]
 	desc = replacetext(desc, "%AREA1%", initial(area1.name))

--- a/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
+++ b/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
@@ -21,60 +21,62 @@
 	var/bomb_sent = FALSE
 	/// Have we located the weakpoint yet?
 	var/weakpoint_found = FALSE
-	/// Weakpoint scan areas and the weakpoint itself
-	var/list/weakpoint_areas
+	/// Areas that need to be scanned
+	var/list/area/scan_areas
+	/// Weakpoint where the bomb should be planted
+	var/area/weakpoint_area
 
 /datum/traitor_objective/locate_weakpoint/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	if(handler.get_completion_progression(/datum/traitor_objective) < progression_objectives_minimum)
 		return FALSE
 
-	if(SStraitor.taken_objectives_by_type[/datum/traitor_objective/locate_weakpoint])
-		for(var/datum/traitor_objective/locate_weakpoint/weakpoint_objective in SStraitor.taken_objectives_by_type[type])
-			if(weakpoint_objective.objective_state == OBJECTIVE_STATE_COMPLETED)
-				return FALSE
+	if(SStraitor.get_taken_count(/datum/traitor_objective/locate_weakpoint) > 0)
+		return FALSE
 
-			if(weakpoint_areas)
-				continue
+	scan_areas = list()
+	/// List of high-security areas that we pick required ones from
+	var/list/allowed_areas = typecacheof(list(/area/station/command,
+		/area/station/comms,
+		/area/station/engineering,
+		/area/station/science,
+		/area/station/security,
+	))
 
-			weakpoint_areas = weakpoint_objective.weakpoint_areas.Copy()
-			for(var/weakpoint in weakpoint_areas)
-				weakpoint_areas[weakpoint] = TRUE
+	var/list/blacklisted_areas = typecacheof(list(/area/station/engineering/hallway,
+		/area/station/engineering/lobby,
+		/area/station/engineering/storage,
+		/area/station/science/lobby,
+		/area/station/science/ordnance/bomb,
+		/area/station/security/prison,
+	))
 
-	if(!weakpoint_areas)
-		weakpoint_areas = list()
-		/// List of high-security areas that we pick required ones from
-		var/list/allowed_areas = typecacheof(list(/area/station/command,
-			/area/station/comms,
-			/area/station/engineering,
-			/area/station/science,
-			/area/station/security,
-		))
+	var/list/possible_areas = GLOB.the_station_areas.Copy()
+	for(var/area/possible_area as anything in possible_areas)
+		if(!is_type_in_typecache(possible_area, allowed_areas) || initial(possible_area.outdoors) || is_type_in_typecache(possible_area, blacklisted_areas))
+			possible_areas -= possible_area
 
-		var/list/blacklisted_areas = typecacheof(list(/area/station/engineering/hallway,
-			/area/station/engineering/lobby,
-			/area/station/engineering/storage,
-			/area/station/science/lobby,
-			/area/station/science/ordnance/bomb,
-			/area/station/security/prison,
-		))
+	for(var/i in 1 to 2)
+		scan_areas[pick_n_take(possible_areas)] = TRUE
+	weakpoint_area = pick_n_take(possible_areas)
 
-		var/list/possible_areas = GLOB.the_station_areas.Copy()
-		for(var/area/possible_area as anything in possible_areas)
-			if(!is_type_in_typecache(possible_area, allowed_areas) || initial(possible_area.outdoors) || is_type_in_typecache(possible_area, blacklisted_areas))
-				possible_areas -= possible_area
-
-		for(var/i in 1 to 3)
-			weakpoint_areas[pick_n_take(possible_areas)] = TRUE
-
-	var/area/weakpoint_area1 = weakpoint_areas[1]
-	var/area/weakpoint_area2 = weakpoint_areas[2]
-	replace_in_name("%AREA1%", initial(weakpoint_area1.name))
-	replace_in_name("%AREA2%", initial(weakpoint_area2.name))
+	var/area/scan_area1 = scan_areas[1]
+	var/area/scan_area2 = scan_areas[2]
+	replace_in_name("%AREA1%", initial(scan_area1.name))
+	replace_in_name("%AREA2%", initial(scan_area2.name))
 	RegisterSignal(SSdcs, COMSIG_GLOB_TRAITOR_OBJECTIVE_COMPLETED, .proc/on_global_obj_completed)
 	return TRUE
 
 /datum/traitor_objective/locate_weakpoint/ungenerate_objective()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_TRAITOR_OBJECTIVE_COMPLETED)
+
+/datum/traitor_objective/locate_weakpoint/on_objective_taken(mob/user)
+	. = ..()
+
+	// We don't want multiple people being able to take weakpoint objectives if they get one available at the same time
+	for(var/datum/traitor_objective/locate_weakpoint/other_objective in SStraitor.all_objectives_by_type[/datum/traitor_objective/locate_weakpoint])
+		if(other_objective != src)
+			other_objective.fail_objective()
+
 
 /datum/traitor_objective/locate_weakpoint/proc/on_global_obj_completed(datum/source, datum/traitor_objective/objective)
 	SIGNAL_HANDLER
@@ -96,21 +98,20 @@
 			if(locator_sent)
 				return
 			locator_sent = TRUE
-			var/obj/item/weakpoint_locator/locator = new(user.drop_location())
-			user.put_in_hands(locator, weakpoint_areas[1], weakpoint_areas[2])
+			var/obj/item/weakpoint_locator/locator = new(user.drop_location(), src)
+			user.put_in_hands(locator)
 			locator.balloon_alert(user, "the weakpoint locator materializes in your hand")
 
 		if("shatter_charge")
 			if(bomb_sent)
 				return
 			bomb_sent = TRUE
-			var/obj/item/grenade/c4/es8/bomb = new(user.drop_location())
+			var/obj/item/grenade/c4/es8/bomb = new(user.drop_location(), src)
 			user.put_in_hands(bomb)
 			bomb.balloon_alert(user, "the ES8 charge materializes in your hand")
 
 /datum/traitor_objective/locate_weakpoint/proc/weakpoint_located()
 	description = "Structural weakpoint has been located in %AREA%. Detonate an ES8 explosive charge there to create a shockwave that will severely damage the station."
-	var/area/weakpoint_area = weakpoint_areas[3]
 	replace_in_name("%AREA%", initial(weakpoint_area.name))
 	weakpoint_found = TRUE
 
@@ -140,33 +141,42 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 3
 	throw_range = 5
+	var/datum/weakref/objective_weakref
 
-/obj/item/weakpoint_locator/Initialize(mapload, area/area1, area/area2)
+/obj/item/weakpoint_locator/Initialize(mapload, datum/traitor_objective/locate_weakpoint/objective)
 	. = ..()
+	objective_weakref = WEAKREF(objective)
+	var/area/area1 = objective.scan_areas[1]
+	var/area/area2 = objective.scan_areas[2]
 	desc = replacetext(desc, "%AREA1%", initial(area1.name))
 	desc = replacetext(desc, "%AREA2%", initial(area2.name))
+
+/obj/item/weakpoint_locator/Destroy(force)
+	objective_weakref = null
+	return ..()
 
 /obj/item/weakpoint_locator/attack_self(mob/living/user, modifiers)
 	. = ..()
 	if(!istype(user) || loc != user || !user.mind) //No TK cheese
 		return
 
-	if(!user.mind.has_antag_datum(/datum/antagonist/traitor))
-		to_chat(user, span_warning("You have zero clue how to use [src]."))
-		return
+	var/datum/traitor_objective/locate_weakpoint/objective = objective_weakref.resolve()
 
-	var/datum/traitor_objective/locate_weakpoint/objective = get_weakpoint_objective(user)
 	if(!objective || objective.objective_state == OBJECTIVE_STATE_INACTIVE)
 		to_chat(user, span_warning("Your time to use [src] has not come yet."))
 		return
 
+	if(objective.handler.owner != user.mind)
+		to_chat(user, span_warning("You have zero clue how to use [src]."))
+		return
+
 	var/area/user_area = get_area(user)
-	if(!(user_area.type in objective.weakpoint_areas))
+	if(!(user_area.type in objective.scan_areas))
 		balloon_alert(user, "invalid area!")
 		playsound(user, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
 		return
 
-	if(!objective.weakpoint_areas[user_area.type])
+	if(!objective.scan_areas[user_area.type])
 		balloon_alert(user, "already scanned here!")
 		playsound(user, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
 		return
@@ -182,14 +192,13 @@
 		return
 
 	playsound(user, 'sound/machines/ding.ogg', 100, TRUE)
-	objective.weakpoint_areas[user_area.type] = FALSE
-	for(var/area/scan_area in objective.weakpoint_areas)
-		if(objective.weakpoint_areas[scan_area])
+	objective.scan_areas[user_area.type] = FALSE
+	for(var/area/scan_area as anything in objective.scan_areas)
+		if(objective.scan_areas[scan_area])
 			say("Next scanning location is [initial(scan_area.name)]")
 			return
 
-	var/area/weakpoint_location = objective.weakpoint_areas[3]
-	to_chat(user, span_notice("Scan finished. Structural weakpoint located in [initial(weakpoint_location.name)]."))
+	to_chat(user, span_notice("Scan finished. Structural weakpoint located in [initial(objective.weakpoint_area.name)]."))
 	objective.weakpoint_located()
 
 /obj/item/weakpoint_locator/proc/scan_checks(mob/living/user, area/user_area, datum/traitor_objective/locate_weakpoint/parent_objective)
@@ -208,17 +217,6 @@
 
 	return TRUE
 
-/obj/item/weakpoint_locator/proc/get_weakpoint_objective(mob/living/user)
-	if(!user.mind)
-		return
-
-	for(var/datum/traitor_objective/locate_weakpoint/weakpoint_objective in SStraitor.taken_objectives_by_type[/datum/traitor_objective/locate_weakpoint])
-		var/datum/uplink_handler/handler = weakpoint_objective.handler
-		if(handler.owner != user.mind)
-			continue
-
-		return weakpoint_objective
-
 /obj/item/grenade/c4/es8
 	name = "ES8 explosive charge"
 	desc = "A high-power explosive charge designed to create a shockwave in a structural weakpoint of the station."
@@ -232,6 +230,10 @@
 	/// Weakref to user's objective
 	var/datum/weakref/objective_weakref
 
+/obj/item/grenade/c4/es8/Initialize(mapload, objective)
+	. = ..()
+	objective_weakref = WEAKREF(objective)
+
 /obj/item/grenade/c4/es8/Destroy()
 	objective_weakref = null
 	return ..()
@@ -244,25 +246,15 @@
 		to_chat(user, span_warning("You can't seem to find a way to detonate the charge."))
 		return
 
-	var/datum/traitor_objective/locate_weakpoint/objective
-	for(var/datum/traitor_objective/locate_weakpoint/weakpoint_objective in SStraitor.taken_objectives_by_type[/datum/traitor_objective/locate_weakpoint])
-		var/datum/uplink_handler/handler = weakpoint_objective.handler
-		if(handler.owner != user.mind)
-			continue
-		objective_weakref = WEAKREF(weakpoint_objective)
-		objective = weakpoint_objective
+	var/datum/traitor_objective/locate_weakpoint/objective = objective_weakref.resolve()
 
-	if(!objective)
-		objective = objective_weakref.resolve()
-
-	if(!objective || objective.objective_state == OBJECTIVE_STATE_INACTIVE)
+	if(!objective || objective.objective_state == OBJECTIVE_STATE_INACTIVE || objective.handler.owner != user.mind)
 		to_chat(user, span_warning("You don't think it would be wise to use [src]."))
 		return
 
 	var/area/target_area = get_area(target)
-	if (target_area.type != objective.weakpoint_areas[3])
-		var/area/weakpoint_area = objective.weakpoint_areas[3]
-		to_chat(user, span_warning("[src] can only be detonated in [initial(weakpoint_area.name)]."))
+	if (target_area.type != objective.weakpoint_area)
+		to_chat(user, span_warning("[src] can only be detonated in [initial(objective.weakpoint_area.name)]."))
 		return
 
 	if(!isfloorturf(target) && !iswallturf(target))
@@ -278,7 +270,7 @@
 	if(!objective)
 		return
 
-	if (target_area.type != objective.weakpoint_areas[3])
+	if (target_area.type != objective.weakpoint_area)
 		var/obj/item/grenade/c4/es8/new_bomb = new(target.drop_location())
 		new_bomb.balloon_alert_to_viewers("invalid location!")
 		target.cut_overlay(plastic_overlay, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so you can't get your weakpoint locator/bomb replaced if your old one gets destroyed for consistency with other objectives (Calling card, SM cascade etc all don't give you second chances if you lose the item, no reason this one should)

Fixes a bug that meant the weakpoint objective only required one area to be scanned before you could plant the bomb.
Since this seems to have been in the game since the objective was added and fixing this makes it quite a bit harder I don't mind undoing this or adjusting the rewards if maintainers think this makes it too hard for what the objective currently gives.

Fixes an oversight that meant multiple people could get the weakpoint objective if they had it generate for them at the same time.

Fixes the weakpoint locator missing the locations that needed to be scanned from its description.

Fixes most of the harddels, now that the objective no longer holds a reference to the scanner/bomb and the scanner/bomb only use weakrefs to the objective. I did get one harddel on the charge at one point but I didn't have the ref tracker turned on at that time and I haven't been able to reproduce it after trying multiple times after turning the tracker on. 

Fixes a potential runtime in the charge's detonate method where a null check for the objective happened after a value on the objective was used instead of before it.

Generally cleans up some of the code, such as moving the weakpoint area into its own variable seperate from the list of areas that need to be scanned, and having the locator + bomb store weakrefs to the objective instead of going through SStraitor to find the objective every time they're used.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Harddels + bugs are bad. Not being able to get back destroyed items that are critical to your objective makes this consistent with other similar objectives. Both the original PR and the objective description say that both areas need scanning before you can use the bomb, but as far as I can tell this has been broken since the objective was added.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: You can no longer order new weakpoint locators/bombs if the originals were destroyed.
balance: The weakpoint objective requires both areas to be scanned before you can blow up the weakpoint.
fix: Fixes parts of the weakpoint locator description that were meant to say the scan locations being missing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
