### PR TITLE
Gives pocket protectors their inventory back, also fixes an allowed contents display error

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -374,7 +374,8 @@
 	atom_storage = new cloning.type(src, cloning.max_slots, cloning.max_specific_storage, cloning.max_total_storage, cloning.numerical_stacking, cloning.allow_quick_gather, cloning.collection_mode, cloning.attack_hand_interact)
 
 	if(cloning.can_hold || cloning.cant_hold)
-		atom_storage.set_holdable(cloning.can_hold, cloning.cant_hold)
+		if(!atom_storage.can_hold && !atom_storage.cant_hold) //In the event that the can/can't hold lists are already in place (such as from storage objects added on initialize).
+			atom_storage.set_holdable(cloning.can_hold, cloning.cant_hold)
 
 	return atom_storage
 

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -362,6 +362,7 @@
 
 /obj/item/clothing/accessory/pocketprotector/Initialize(mapload)
 	. = ..()
+
 	create_storage(type = /datum/storage/pockets/pocketprotector)
 
 /obj/item/clothing/accessory/pocketprotector/full/Initialize(mapload)

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -360,10 +360,12 @@
 	desc = "Can protect your clothing from ink stains, but you'll look like a nerd if you're using one."
 	icon_state = "pocketprotector"
 
+/obj/item/clothing/accessory/pocketprotector/Initialize(mapload)
+	. = ..()
+	create_storage(type = /datum/storage/pockets/pocketprotector)
+
 /obj/item/clothing/accessory/pocketprotector/full/Initialize(mapload)
 	. = ..()
-
-	create_storage(type = /datum/storage/pockets/pocketprotector)
 
 	new /obj/item/pen/red(src)
 	new /obj/item/pen(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So, apparently create_storage was only getting called on the Full subtype of pocket protectors instead of all pocket protectors, making them the only functioning ones. Create_storage is now a part of the base subtype's initialize.

Additionally, wearing a pocket protector would make it display the names of all possible objects that could be stored inside (~40 line long examine), instead of just the names of the 5 general types of objects. Clone_storage was calling set_holdable on the atom_storage object, however set_holdable is called in the object's init. The can/cant hold list is already established at this point, and does not need to be set again -- Doing so seemed to be the cause of the bad description list.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Pocket protectors increase work efficiency in any office space, and I'm willing to argue that Space Station 13 is just one giant space-office.

Also, closes #70464.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: checking a pocket protector's insertable items list no longer lists the names of ALL possible objects.
fix: normal/cosmetology pocket protectors now work again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
