### PR TITLE
Medical kiosk is no longer one of the only machines that displays above mobs

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -18,8 +18,6 @@
 	icon = 'icons/obj/machines/medical_kiosk.dmi'
 	icon_state = "kiosk"
 	base_icon_state = "kiosk"
-	layer = ABOVE_MOB_LAYER
-	plane = GAME_PLANE_UPPER
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/medical_kiosk
 	payment_department = ACCOUNT_MED


### PR DESCRIPTION
## About The Pull Request
I always wondered why that was the case, it looks weird when there's occasions where a mob would somehow be shifted to have its sprite on the same tile as the medical kiosk. It was inconsistent with other machinery, and I couldn't find anything that would explain that behavior, so I made it so it's no longer the case.

## Why It's Good For The Game
Consistency is good, methinks.

## Changelog

:cl: GoldenAlpharex
fix: The Medical Kiosk no longer bends the laws of physics and now properly appears underneath mobs that would somehow end up atop of it, rather than above them.
/:cl: