### PR TITLE
Changing species now maintains Brain traumas, Cybernetic implants, Liver traits, organ damage, and Heretic Living Heart

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -10,6 +10,8 @@
 #define COMSIG_ORGAN_WAG_TAIL "comsig_wag_tail"
 /// Called on the organ when it is removed from someone (mob/living/carbon/old_owner)
 #define COMSIG_ORGAN_REMOVED "comsig_organ_removed"
+/// Called when an organ is being regenerated with a new copy in species regenerate_organs (obj/item/organ/replacement)
+#define COMSIG_ORGAN_BEING_REPLACED "organ_being_replaced"
 
 ///from base of mob/update_transform()
 #define COMSIG_LIVING_POST_UPDATE_TRANSFORM "living_post_update_transform"

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -16,12 +16,11 @@
 	var/resilience = TRAUMA_RESILIENCE_BASIC //how hard is this to cure?
 
 /datum/brain_trauma/Destroy()
-	if(brain?.traumas)
-		brain.traumas -= src
+	// Handles our references with our brain
+	brain?.remove_trauma_from_traumas(src)
 	if(owner)
 		on_lose()
-	brain = null
-	owner = null
+		owner = null
 	return ..()
 
 //Called on life ticks

--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -4,59 +4,37 @@
  * Applied to a heart to turn it into a heretic's 'living heart'.
  * The living heart is what they use to track people they need to sacrifice.
  *
- * This component handles adding the associated action, as well as updating the heart's icon.
- *
- * Must be attached to an organ located within a heretic.
- * If removed from the body of a heretic, it will self-delete and become a normal heart again.
+ * This component handles the action associated with it -
+ * if the organ is removed, the action should be deleted
  */
 /datum/component/living_heart
 	/// The action we create and give to our heart.
-	var/datum/action/item_action/organ_action/track_target/action
-	/// The icon of the heart before we made it a living heart.
-	var/old_icon
+	var/datum/action/cooldown/track_target/action
 
 /datum/component/living_heart/Initialize()
 	if(!isorgan(parent))
 		return COMPONENT_INCOMPATIBLE
 
 	var/obj/item/organ/organ_parent = parent
-	// These are incompatible for "balance" reasons, not due to code limitations.
-	if(organ_parent.status != ORGAN_ORGANIC || (organ_parent.organ_flags & ORGAN_SYNTHETIC))
-		return COMPONENT_INCOMPATIBLE
-
-	if(!IS_HERETIC(organ_parent.owner))
-		return COMPONENT_INCOMPATIBLE
-
-	action = new(organ_parent)
+	action = new(src)
 	action.Grant(organ_parent.owner)
-
-	ADD_TRAIT(parent, TRAIT_LIVING_HEART, REF(src))
-	RegisterSignal(parent, COMSIG_ORGAN_REMOVED, .proc/on_organ_removed)
-
-	// The heart's not technically visible (and is never visible to anyone besides the heretic),
-	// but the organ sprite shows up in the organ action  - so we'll do this anyways
-	parent.AddElement(/datum/element/update_icon_blocker)
-	old_icon = organ_parent.icon
-
-	organ_parent.icon = 'icons/obj/eldritch.dmi'
-	organ_parent.icon_state = "living_heart"
-	action.UpdateButtons()
 
 /datum/component/living_heart/Destroy(force, silent)
 	QDEL_NULL(action)
-	REMOVE_TRAIT(parent, TRAIT_LIVING_HEART, REF(src))
-	UnregisterSignal(parent, COMSIG_ORGAN_REMOVED)
-
-	// Restore the heart to look normal
-	parent.RemoveElement(/datum/element/update_icon_blocker)
-	var/obj/item/organ/organ_parent = parent
-	organ_parent.icon = old_icon
-	organ_parent.icon_state = initial(organ_parent.icon_state)
-
-	// Sets the icon state to be the correct state
-	organ_parent.update_appearance(UPDATE_ICON_STATE)
-
 	return ..()
+
+/datum/component/living_heart/RegisterWithParent()
+	ADD_TRAIT(parent, TRAIT_LIVING_HEART, REF(src))
+	RegisterSignal(parent, COMSIG_ORGAN_REMOVED, .proc/on_organ_removed)
+	RegisterSignal(parent, COMSIG_ORGAN_BEING_REPLACED, .proc/on_organ_replaced)
+
+/datum/component/living_heart/UnregisterFromParent()
+	REMOVE_TRAIT(parent, TRAIT_LIVING_HEART, REF(src))
+	UnregisterSignal(parent, list(COMSIG_ORGAN_REMOVED, COMSIG_ORGAN_BEING_REPLACED))
+
+/datum/component/living_heart/PostTransfer()
+	if(!isorgan(parent))
+		return COMPONENT_INCOMPATIBLE
 
 /**
  * Signal proc for [COMSIG_ORGAN_REMOVED].
@@ -69,55 +47,72 @@
 	to_chat(old_owner, span_userdanger("As your living [source.name] leaves your body, you feel less connected to the Mansus!"))
 	qdel(src)
 
-/*
+/**
+ * Signal proc for [COMSIG_ORGAN_BEING_REPLACED].
+ *
+ * If the organ is replaced, before it's done transfer the component over
+ */
+/datum/component/living_heart/proc/on_organ_replaced(obj/item/organ/source, obj/item/organ/replacement)
+	SIGNAL_HANDLER
+
+	if(replacement.status != ORGAN_ORGANIC || (replacement.organ_flags & ORGAN_SYNTHETIC))
+		qdel(src)
+		return
+
+	replacement.TakeComponent(src)
+
+/**
  * The action associated with the living heart.
  * Allows a heretic to track sacrifice targets.
  */
-/datum/action/item_action/organ_action/track_target
+/datum/action/cooldown/track_target
 	name = "Living Heartbeat"
 	desc = "LMB: Chose one of your sacrifice targets to track. RMB: Repeats last target you chose to track."
 	check_flags = AB_CHECK_CONSCIOUS
 	background_icon_state = "bg_ecult"
+	icon_icon = 'icons/obj/eldritch.dmi'
+	button_icon_state = "living_heart"
+	cooldown_time = 4 SECONDS
+
+	/// Tracks whether we were right clicked or left clicked in our last trigger
+	var/right_clicked = FALSE
 	/// The real name of the last mob we tracked
 	var/last_tracked_name
 	/// Whether the target radial is currently opened.
 	var/radial_open = FALSE
-	/// How long we have to wait between tracking uses.
-	var/track_cooldown_lenth = 4 SECONDS
-	/// The cooldown between button uses.
-	COOLDOWN_DECLARE(track_cooldown)
+	/// Tracks the name of our sacrifice knowledge ritual.
+	var/sacrifice_knowlege_name
 
-/datum/action/item_action/organ_action/track_target/Grant(mob/granted)
-	if(!IS_HERETIC(granted))
+/datum/action/cooldown/track_target/Grant(mob/granted)
+	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(granted)
+	if(!heretic_datum)
 		return
 
+	var/datum/heretic_knowledge/sac_knowledge = heretic_datum.get_knowledge(/datum/heretic_knowledge/hunt_and_sacrifice)
+	sacrifice_knowlege_name = sac_knowledge.name
 	return ..()
 
-/datum/action/item_action/organ_action/track_target/IsAvailable()
+/datum/action/cooldown/track_target/IsAvailable()
 	. = ..()
 	if(!.)
 		return
 
 	if(!IS_HERETIC(owner))
 		return FALSE
-	if(!HAS_TRAIT(target, TRAIT_LIVING_HEART))
-		return FALSE
-	if(!COOLDOWN_FINISHED(src, track_cooldown))
-		return FALSE
 	if(radial_open)
 		return FALSE
 
 	return TRUE
 
-/datum/action/item_action/organ_action/track_target/Trigger(trigger_flags)
-	. = ..()
-	if(!.)
-		return
+/datum/action/cooldown/track_target/Trigger(trigger_flags)
+	right_clicked = !!(trigger_flags & TRIGGER_SECONDARY_ACTION)
+	return ..()
 
+/datum/action/cooldown/track_target/Activate(atom/target)
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(owner)
-	var/datum/heretic_knowledge/sac_knowledge = heretic_datum.get_knowledge(/datum/heretic_knowledge/hunt_and_sacrifice)
 	if(!LAZYLEN(heretic_datum.sac_targets))
 		owner.balloon_alert(owner, "no targets, visit a rune!")
+		StartCooldown(1 SECONDS)
 		return TRUE
 
 	var/list/targets_to_choose = list()
@@ -128,7 +123,7 @@
 
 	// If we don't have a last tracked name, open a radial to set one.
 	// If we DO have a last tracked name, we skip the radial if they right click the action.
-	if(isnull(last_tracked_name) || !(trigger_flags & TRIGGER_SECONDARY_ACTION))
+	if(isnull(last_tracked_name) || !right_clicked)
 		radial_open = TRUE
 		last_tracked_name = show_radial_menu(
 			owner,
@@ -150,31 +145,27 @@
 		last_tracked_name = null
 		return FALSE
 
-	COOLDOWN_START(src, track_cooldown, track_cooldown_lenth)
-	UpdateButtons()
-	addtimer(CALLBACK(src, .proc/UpdateButtons), track_cooldown_lenth + 1)
 	playsound(owner, 'sound/effects/singlebeat.ogg', 50, TRUE, SILENCED_SOUND_EXTRARANGE)
 	owner.balloon_alert(owner, get_balloon_message(tracked_mob))
 
 	// Let them know how to sacrifice people if they're able to be sac'd
 	if(tracked_mob.stat == DEAD)
 		to_chat(owner, span_hierophant("[tracked_mob] is dead. Bring them to a transmutation rune \
-			and invoke \"[sac_knowledge.name]\" to sacrifice them!"))
+			and invoke \"[sacrifice_knowlege_name]\" to sacrifice them!"))
 
+	StartCooldown()
 	return TRUE
 
 /// Callback for the radial to ensure it's closed when not allowed.
-/datum/action/item_action/organ_action/track_target/proc/check_menu()
+/datum/action/cooldown/track_target/proc/check_menu()
 	if(QDELETED(src))
 		return FALSE
 	if(!IS_HERETIC(owner))
 		return FALSE
-	if(!HAS_TRAIT(target, TRAIT_LIVING_HEART))
-		return FALSE
 	return TRUE
 
 /// Gets the balloon message for who we're tracking.
-/datum/action/item_action/organ_action/track_target/proc/get_balloon_message(mob/living/carbon/human/tracked_mob)
+/datum/action/cooldown/track_target/proc/get_balloon_message(mob/living/carbon/human/tracked_mob)
 	var/balloon_message = "error text!"
 	var/turf/their_turf = get_turf(tracked_mob)
 	var/turf/our_turf = get_turf(owner)

--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -80,16 +80,11 @@
 	var/last_tracked_name
 	/// Whether the target radial is currently opened.
 	var/radial_open = FALSE
-	/// Tracks the name of our sacrifice knowledge ritual.
-	var/sacrifice_knowlege_name
 
 /datum/action/cooldown/track_target/Grant(mob/granted)
-	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(granted)
-	if(!heretic_datum)
+	if(!IS_HERETIC(granted))
 		return
 
-	var/datum/heretic_knowledge/sac_knowledge = heretic_datum.get_knowledge(/datum/heretic_knowledge/hunt_and_sacrifice)
-	sacrifice_knowlege_name = sac_knowledge.name
 	return ..()
 
 /datum/action/cooldown/track_target/IsAvailable()
@@ -110,6 +105,7 @@
 
 /datum/action/cooldown/track_target/Activate(atom/target)
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(owner)
+	var/datum/heretic_knowledge/sac_knowledge = heretic_datum.get_knowledge(/datum/heretic_knowledge/hunt_and_sacrifice)
 	if(!LAZYLEN(heretic_datum.sac_targets))
 		owner.balloon_alert(owner, "no targets, visit a rune!")
 		StartCooldown(1 SECONDS)
@@ -151,7 +147,7 @@
 	// Let them know how to sacrifice people if they're able to be sac'd
 	if(tracked_mob.stat == DEAD)
 		to_chat(owner, span_hierophant("[tracked_mob] is dead. Bring them to a transmutation rune \
-			and invoke \"[sacrifice_knowlege_name]\" to sacrifice them!"))
+			and invoke \"[sac_knowledge.name]\" to sacrifice them!"))
 
 	StartCooldown()
 	return TRUE

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -56,6 +56,9 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 
 	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
 	var/obj/item/organ/where_to_put_our_heart = user.getorganslot(our_heretic.living_heart_organ_slot)
+	// Our heart slot is not valid to put a heart
+	if(!is_valid_heart(where_to_put_our_heart))
+		where_to_put_our_heart = null
 
 	// If a heretic is made from a species without a heart, we need to find a backup.
 	if(!where_to_put_our_heart)
@@ -67,12 +70,16 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 
 		for(var/backup_slot in backup_organs)
 			var/obj/item/organ/look_for_backup = user.getorganslot(backup_slot)
-			if(look_for_backup)
-				where_to_put_our_heart = look_for_backup
-				our_heretic.living_heart_organ_slot = backup_slot
-				required_organ_type = backup_organs[backup_slot]
-				to_chat(user, span_boldnotice("As your species does not have a heart, your Living Heart is located in your [look_for_backup.name]."))
-				break
+			// This backup slot is not a valid slot to put a heart
+			if(!is_valid_heart(look_for_backup))
+				continue
+
+			// We found a replacement place to put our heart
+			where_to_put_our_heart = look_for_backup
+			our_heretic.living_heart_organ_slot = backup_slot
+			required_organ_type = backup_organs[backup_slot]
+			to_chat(user, span_boldnotice("As your species does not have a heart, your Living Heart is located in your [look_for_backup.name]."))
+			break
 
 	if(where_to_put_our_heart)
 		where_to_put_our_heart.AddComponent(/datum/component/living_heart)
@@ -114,7 +121,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 
 	// By this point they are making a new heart
 	// If their current heart is organic / not synthetic, we can continue the ritual as normal
-	if(our_living_heart.status == ORGAN_ORGANIC && !(our_living_heart.organ_flags & ORGAN_SYNTHETIC))
+	if(is_valid_heart(our_living_heart))
 		return TRUE
 
 	// If their current heart is not organic / is synthetic, they need an organic replacement
@@ -127,9 +134,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	for(var/obj/item/organ/nearby_organ in atoms)
 		if(!istype(nearby_organ, required_organ_type))
 			continue
-		if(!nearby_organ.useable)
-			continue
-		if(nearby_organ.status != ORGAN_ORGANIC || (nearby_organ.organ_flags & (ORGAN_SYNTHETIC|ORGAN_FAILING)))
+		if(!is_valid_heart(nearby_organ))
 			continue
 
 		selected_atoms += nearby_organ
@@ -143,7 +148,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	var/obj/item/organ/our_new_heart = user.getorganslot(our_heretic.living_heart_organ_slot)
 
 	// Our heart is robotic or synthetic - we need to replace it, and we fortunately should have one by here
-	if(our_new_heart.status != ORGAN_ORGANIC || (our_new_heart.organ_flags & ORGAN_SYNTHETIC))
+	if(!is_valid_heart(our_new_heart))
 		var/obj/item/organ/our_replacement_heart = locate(required_organ_type) in selected_atoms
 		if(our_replacement_heart)
 			// Throw our current heart out of our chest, violently
@@ -172,6 +177,19 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	our_new_heart.AddComponent(/datum/component/living_heart)
 	to_chat(user, span_warning("You feel your [our_new_heart.name] begin pulse faster and faster as it awakens!"))
 	playsound(user, 'sound/magic/demon_consume.ogg', 50, TRUE)
+	return TRUE
+
+/// Checks if the passed heart is a valid heart to become a living heart
+/datum/heretic_knowledge/living_heart/proc/is_valid_heart(obj/item/organ/new_heart)
+	if(!new_heart)
+		return FALSE
+	if(!new_heart.useable)
+		return FALSE
+	if(new_heart.status != ORGAN_ORGANIC)
+		return FALSE
+	if(new_heart.organ_flags & (ORGAN_SYNTHETIC|ORGAN_FAILING))
+		return FALSE
+
 	return TRUE
 
 /**

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -67,10 +67,20 @@
 	else
 		C.set_suicide(suicided)
 
-	for(var/X in traumas)
-		var/datum/brain_trauma/BT = X
-		BT.owner = owner
-		BT.on_gain()
+	for(var/datum/brain_trauma/trauma as anything in traumas)
+		if(trauma.owner)
+			if(trauma.owner == owner)
+				// if we're being special replaced, the trauma is already applied, so this is expected
+				// but if we're not... this is likely a bug, and should be reported
+				if(!special)
+					stack_trace("A brain trauma ([trauma]) is being re-applied to its owning mob ([owner])!")
+				continue
+
+			stack_trace("A brain trauma ([trauma]) is being applied to a new mob ([owner]) when it's owned by someone else ([trauma.owner])!")
+			continue
+
+		trauma.owner = owner
+		trauma.on_gain()
 
 	//Update the body's icon so it doesnt appear debrained anymore
 	C.update_body_parts()
@@ -415,7 +425,7 @@
 		WARNING("gain_trauma was given an already active trauma.")
 		return FALSE
 
-	add_trauma_to_traumas(trauma)
+	add_trauma_to_traumas(actual_trauma)
 	if(owner)
 		actual_trauma.owner = owner
 		SEND_SIGNAL(owner, COMSIG_CARBON_GAIN_TRAUMA, trauma)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -282,6 +282,8 @@
 	if(!istype(replacement_brain))
 		return
 
+	// Transfer over skillcips to the new brain
+
 	// If we have some sort of brain type or subtype change and have skillchips, engage the failsafe procedure!
 	if(owner && length(skillchips) && (replacement_brain.type != type))
 		activate_skillchip_failsafe(FALSE)
@@ -307,6 +309,11 @@
 
 	// Any skillchips has been transferred over, time to empty the list.
 	LAZYCLEARLIST(skillchips)
+
+	// Transfer over traumas as well
+	for(var/datum/brain_trauma/trauma as anything in traumas)
+		remove_trauma_from_traumas(trauma)
+		replacement_brain.add_trauma_to_traumas(trauma)
 
 /obj/item/organ/internal/brain/machine_wash(obj/machinery/washing_machine/brainwasher)
 	. = ..()
@@ -408,8 +415,7 @@
 		WARNING("gain_trauma was given an already active trauma.")
 		return FALSE
 
-	traumas += actual_trauma
-	actual_trauma.brain = src
+	add_trauma_to_traumas(trauma)
 	if(owner)
 		actual_trauma.owner = owner
 		SEND_SIGNAL(owner, COMSIG_CARBON_GAIN_TRAUMA, trauma)
@@ -418,6 +424,14 @@
 		actual_trauma.resilience = resilience
 	SSblackbox.record_feedback("tally", "traumas", 1, actual_trauma.type)
 	return actual_trauma
+
+/obj/item/organ/internal/brain/proc/add_trauma_to_traumas(datum/brain_trauma/trauma)
+	trauma.brain = src
+	traumas += trauma
+
+/obj/item/organ/internal/brain/proc/remove_trauma_from_traumas(datum/brain_trauma/trauma)
+	trauma.brain = null
+	traumas -= trauma
 
 //Add a random trauma of a certain subtype
 /obj/item/organ/internal/brain/proc/gain_trauma_type(brain_trauma_type = /datum/brain_trauma, resilience, natural_gain = FALSE)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -435,10 +435,14 @@
 	SSblackbox.record_feedback("tally", "traumas", 1, actual_trauma.type)
 	return actual_trauma
 
+/// Adds the passed trauma instance to our list of traumas and links it to our brain.
+/// DOES NOT handle setting up the trauma, that's done by [proc/brain_gain_trauma]!
 /obj/item/organ/internal/brain/proc/add_trauma_to_traumas(datum/brain_trauma/trauma)
 	trauma.brain = src
 	traumas += trauma
 
+/// Removes the passed trauma instance to our list of traumas and links it to our brain
+/// DOES NOT handle removing the trauma's effects, that's done by [/datum/brain_trauma/Destroy()]!
 /obj/item/organ/internal/brain/proc/remove_trauma_from_traumas(datum/brain_trauma/trauma)
 	trauma.brain = null
 	traumas -= trauma

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -354,11 +354,19 @@ GLOBAL_LIST_EMPTY(features_by_species)
  */
 /datum/species/proc/regenerate_organs(mob/living/carbon/C, datum/species/old_species, replace_current = TRUE, list/excluded_zones, visual_only = FALSE)
 	//what should be put in if there is no mutantorgan (brains handled separately)
-	var/list/slot_mutantorgans = list(ORGAN_SLOT_BRAIN = mutantbrain, ORGAN_SLOT_HEART = mutantheart, ORGAN_SLOT_LUNGS = mutantlungs, ORGAN_SLOT_APPENDIX = mutantappendix, \
-	ORGAN_SLOT_EYES = mutanteyes, ORGAN_SLOT_EARS = mutantears, ORGAN_SLOT_TONGUE = mutanttongue, ORGAN_SLOT_LIVER = mutantliver, ORGAN_SLOT_STOMACH = mutantstomach)
+	var/list/slot_mutantorgans = list(
+		ORGAN_SLOT_BRAIN = mutantbrain,
+		ORGAN_SLOT_HEART = mutantheart,
+		ORGAN_SLOT_LUNGS = mutantlungs,
+		ORGAN_SLOT_APPENDIX = mutantappendix,
+		ORGAN_SLOT_EYES = mutanteyes,
+		ORGAN_SLOT_EARS = mutantears,
+		ORGAN_SLOT_TONGUE = mutanttongue,
+		ORGAN_SLOT_LIVER = mutantliver,
+		ORGAN_SLOT_STOMACH = mutantstomach,
+	)
 
-	for(var/slot in list(ORGAN_SLOT_BRAIN, ORGAN_SLOT_HEART, ORGAN_SLOT_LUNGS, ORGAN_SLOT_APPENDIX, \
-	ORGAN_SLOT_EYES, ORGAN_SLOT_EARS, ORGAN_SLOT_TONGUE, ORGAN_SLOT_LIVER, ORGAN_SLOT_STOMACH))
+	for(var/slot in assoc_to_keys(slot_mutantorgans))
 
 		var/obj/item/organ/oldorgan = C.getorganslot(slot) //used in removing
 		var/obj/item/organ/neworgan = slot_mutantorgans[slot] //used in adding
@@ -370,7 +378,15 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		neworgan = SSwardrobe.provide_type(neworgan)
 		var/should_have = neworgan.get_availability(src) //organ proc that points back to a species trait (so if the species is supposed to have this organ)
 
-		if(oldorgan && (!should_have || replace_current) && !(oldorgan.zone in excluded_zones) && !(oldorgan.organ_flags & ORGAN_UNREMOVABLE))
+		/*
+		 * There is an existing organ in this slot, what should we do with it? Probably remove it!
+		 *
+		 * We will removit if and only if:
+		 * - We should not have the organ OR replace_current is passed to force old organs to regenerate
+		 * - The replaced organ is not in an excluded zone
+		 * - The replaced organ is not unremovable or synthetic (an implant)
+		 */
+		if(oldorgan && (!should_have || replace_current) && !(oldorgan.zone in excluded_zones) && !(oldorgan.organ_flags & (ORGAN_UNREMOVABLE|ORGAN_SYNTHETIC)))
 			if(slot == ORGAN_SLOT_BRAIN)
 				var/obj/item/organ/internal/brain/brain = oldorgan
 				if(!brain.decoy_override)//"Just keep it if it's fake" - confucius, probably

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -295,7 +295,13 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 /// Called before organs are replaced in regenerate_organs with new ones
 /obj/item/organ/proc/before_organ_replacement(obj/item/organ/replacement)
-	return
+	SHOULD_CALL_PARENT(TRUE)
+
+	SEND_SIGNAL(src, COMSIG_ORGAN_BEING_REPLACED, replacement)
+
+	// If we're being replace with an identical type we should take organ damage
+	if(replacement.type == type)
+		replacement.setOrganDamage(damage)
 
 /// Called by medical scanners to get a simple summary of how healthy the organ is. Returns an empty string if things are fine.
 /obj/item/organ/proc/get_status_text()

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -68,7 +68,20 @@
 		else if(HAS_TRAIT(src, TRAIT_PRETENDER_ROYAL_METABOLISM))
 			. += "A diet of imitation caviar, and signs of insomnia, implies that this is the liver of <em>someone who wants to be a head of staff</em>."
 
+/obj/item/organ/internal/liver/before_organ_replacement(obj/item/organ/replacement)
+	. = ..()
+	if(!istype(replacement, type))
+		return
 
+	var/datum/job/owner_job = owner.mind?.assigned_role
+	if(!owner_job || !LAZYLEN(owner_job.liver_traits))
+		return
+
+	// Transfer over liver traits from jobs, if we should have them
+	for(var/readded_trait in owner_job.liver_traits)
+		if(!HAS_TRAIT_FROM(src, readded_trait, JOB_TRAIT))
+			continue
+		ADD_TRAIT(replacement, readded_trait, JOB_TRAIT)
 
 #define HAS_SILENT_TOXIN 0 //don't provide a feedback message if this is the only toxin present
 #define HAS_NO_TOXIN 1
@@ -255,5 +268,3 @@
 		COOLDOWN_START(src, severe_cooldown, 10 SECONDS)
 	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
 		organ_flags |= ORGAN_SYNTHETIC_EMP //Starts organ faliure - gonna need replacing soon.
-
-

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -163,6 +163,7 @@
 #include "spawn_humans.dm"
 #include "spawn_mobs.dm"
 #include "species_change_clothing.dm"
+#include "species_change_organs.dm"
 #include "species_config_sanity.dm"
 #include "species_unique_id.dm"
 #include "species_whitelists.dm"

--- a/code/modules/unit_tests/species_change_organs.dm
+++ b/code/modules/unit_tests/species_change_organs.dm
@@ -1,3 +1,8 @@
+/**
+ * Unit test to ensure that, when a mob changes species,
+ * certain aspects are carried over between their old and new set of organs
+ * (brain traumas, cybernetics, and organ damage)
+ */
 /datum/unit_test/species_change_organs
 
 /datum/unit_test/species_change_organs/Run()
@@ -19,15 +24,23 @@
 
 	// Set up a species to pass over
 	var/datum/species/lizard/changed_species = new()
-	// But make sure the lizard's mutantheart is a normal heart
-	changed_species.mutantheart = /obj/item/organ/internal/heart
-	changed_species.mutantappendix = /obj/item/organ/internal/appendix
+	// But make sure the lizard's mutant organs are "normal"
+	changed_species.mutantheart = dummy.dna.species.mutantheart
+	changed_species.mutantappendix = dummy.dna.species.mutantappendix
+	// and make sure they're not a NOBLOOD species so they need a heart
+	changed_species.species_traits -= NOBLOOD
 
 	// Now make them a lizard
 	dummy.set_species(changed_species)
-	// Grab the lizard's appendix
+	TEST_ASSERT(istype(dummy.dna.species, /datum/species/lizard), "Dummy didn't transform into a lizard when testing species organ changes. ")
+
+	// Grab the lizard's appendix for comparison later
+	// They should've been given a new one, but our damage should also have transferred over
 	var/obj/item/organ/internal/appendix/lizard_appendix = dummy.getorganslot(ORGAN_SLOT_APPENDIX)
 
+	// They should have the trauma still
 	TEST_ASSERT(dummy.has_trauma_type(/datum/brain_trauma/severe/blindness), "Dummy, upon changing species, did not carry over their brain trauma!")
+	// They should have their cybernetic heart still
 	TEST_ASSERT_EQUAL(dummy.getorganslot(ORGAN_SLOT_HEART), cyber_heart, "Dummy, upon changing species, did not carry over their cybernetic organs!")
+	// They should have appendix damage still
 	TEST_ASSERT_EQUAL(lizard_appendix.damage, 25, "Dummy, upon changing species, did not carry over appendix damage!")

--- a/code/modules/unit_tests/species_change_organs.dm
+++ b/code/modules/unit_tests/species_change_organs.dm
@@ -12,7 +12,7 @@
 	dummy.gain_trauma(/datum/brain_trauma/severe/blindness)
 	// Give a cyber heart
 	var/obj/item/organ/internal/heart/cybernetic/cyber_heart = new()
-	cyber_heart.Insert(dummy, TRUE, FALSE)
+	cyber_heart.Insert(dummy, special = TRUE, drop_if_replaced = FALSE)
 	// Give one of their organs a bit of damage
 	var/obj/item/organ/internal/appendix/existing_appendix = dummy.getorganslot(ORGAN_SLOT_APPENDIX)
 	existing_appendix.setOrganDamage(25)
@@ -32,7 +32,7 @@
 
 	// Now make them a lizard
 	dummy.set_species(changed_species)
-	TEST_ASSERT(istype(dummy.dna.species, /datum/species/lizard), "Dummy didn't transform into a lizard when testing species organ changes. ")
+	TEST_ASSERT(istype(dummy.dna.species, /datum/species/lizard), "Dummy didn't transform into a lizard when testing species organ changes.")
 
 	// Grab the lizard's appendix for comparison later
 	// They should've been given a new one, but our damage should also have transferred over

--- a/code/modules/unit_tests/species_change_organs.dm
+++ b/code/modules/unit_tests/species_change_organs.dm
@@ -11,7 +11,7 @@
 	// Give a trauma
 	dummy.gain_trauma(/datum/brain_trauma/severe/blindness)
 	// Give a cyber heart
-	var/obj/item/organ/internal/heart/cybernetic/cyber_heart = new()
+	var/obj/item/organ/internal/heart/cybernetic/cyber_heart = allocate(/obj/item/organ/internal/heart/cybernetic)
 	cyber_heart.Insert(dummy, special = TRUE, drop_if_replaced = FALSE)
 	// Give one of their organs a bit of damage
 	var/obj/item/organ/internal/appendix/existing_appendix = dummy.getorganslot(ORGAN_SLOT_APPENDIX)

--- a/code/modules/unit_tests/species_change_organs.dm
+++ b/code/modules/unit_tests/species_change_organs.dm
@@ -4,7 +4,7 @@
 	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human)
 
 	// Give a trauma
-	dummy.gain_trauma_type(/datum/brain_trauma/severe/blindness)
+	dummy.gain_trauma(/datum/brain_trauma/severe/blindness)
 	// Give a cyber heart
 	var/obj/item/organ/internal/heart/cybernetic/cyber_heart = new()
 	cyber_heart.Insert(dummy, TRUE, FALSE)

--- a/code/modules/unit_tests/species_change_organs.dm
+++ b/code/modules/unit_tests/species_change_organs.dm
@@ -1,0 +1,33 @@
+/datum/unit_test/species_change_organs
+
+/datum/unit_test/species_change_organs/Run()
+	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human)
+
+	// Give a trauma
+	dummy.gain_trauma_type(/datum/brain_trauma/severe/blindness)
+	// Give a cyber heart
+	var/obj/item/organ/internal/heart/cybernetic/cyber_heart = new()
+	cyber_heart.Insert(dummy, TRUE, FALSE)
+	// Give one of their organs a bit of damage
+	var/obj/item/organ/internal/appendix/existing_appendix = dummy.getorganslot(ORGAN_SLOT_APPENDIX)
+	existing_appendix.setOrganDamage(25)
+
+	// Changing species should
+	// - Persist brain traumas
+	// - Persist cybernetic implants
+	// - Persist organ damage to identical types
+
+	// Set up a species to pass over
+	var/datum/species/lizard/changed_species = new()
+	// But make sure the lizard's mutantheart is a normal heart
+	changed_species.mutantheart = /obj/item/organ/internal/heart
+	changed_species.mutantappendix = /obj/item/organ/internal/appendix
+
+	// Now make them a lizard
+	dummy.set_species(changed_species)
+	// Grab the lizard's appendix
+	var/obj/item/organ/internal/appendix/lizard_appendix = dummy.getorganslot(ORGAN_SLOT_APPENDIX)
+
+	TEST_ASSERT(dummy.has_trauma_type(/datum/brain_trauma/severe/blindness), "Dummy, upon changing species, did not carry over their brain trauma!")
+	TEST_ASSERT_EQUAL(dummy.getorganslot(ORGAN_SLOT_HEART), cyber_heart, "Dummy, upon changing species, did not carry over their cybernetic organs!")
+	TEST_ASSERT_EQUAL(lizard_appendix.damage, 25, "Dummy, upon changing species, did not carry over appendix damage!")


### PR DESCRIPTION
## About The Pull Request

- Implements additional code in `before_organ_replacement` in additional places, to better maintain cohesion when species changes take place. 
   - Brain traumas will now carry over on species change
   - Having synthetic / cybernetic organs will now carry over on species change
   - Liver job traits will also carry over on species change
   - Organ damage will, in most cases, carry over on species change (only if the new organ is identical to the old)
   - The heretic's Living Heart will attempt to carry over to species change, if it's valid
      - Some species will still not, as it will attempt to give heart -> liver or something and be invalid

- Heretic Living Heart is now a cooldown action. Still not really content with the current state of it, it could use some improvements. 

Fixes #42308
Fixes #35539
Fixes #69574

## Why It's Good For The Game

Removes a lot of exploits involving using forced species change to get rid of stuff like quirks / permanent brain traumas and similar. 

## Changelog

:cl: Melbert
fix: Changing species will now carry over brain traumas, liver traits, cybernetic organs, organ damage, and the heretic living heart.
/:cl:
