### PR TITLE
Fixes negative value being passed to runechat fade animation timer

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -185,7 +185,7 @@
 			// scheduled time once the EOL has been executed.
 			if (!m.isFading)
 				var/sched_remaining = timeleft(m.fadertimer, SSrunechat)
-				var/remaining_time = (sched_remaining) * (CHAT_MESSAGE_EXP_DECAY ** idx++) * (CHAT_MESSAGE_HEIGHT_DECAY ** combined_height)
+				var/remaining_time = max(0, (sched_remaining) * (CHAT_MESSAGE_EXP_DECAY ** idx++) * (CHAT_MESSAGE_HEIGHT_DECAY ** combined_height))
 				if (remaining_time)
 					deltimer(m.fadertimer, SSrunechat)
 					m.fadertimer = addtimer(CALLBACK(m, .proc/end_of_life), remaining_time, TIMER_STOPPABLE|TIMER_DELETE_ME, SSrunechat)


### PR DESCRIPTION
Nothing player facing.

```
[20:26:08] Runtime in stack_trace.dm, line 4: addtimer called with a negative wait. Converting to 0.5 (code/controllers/subsystem/timer.dm:579)
proc name: stack trace (/proc/_stack_trace)
usr: Saint1453/(Gor-Rok)
usr.loc: (Pharmacy (141,127,4))
src: null
call stack:
stack trace("addtimer called with a negativ...", "code/controllers/subsystem/tim...", 579)
addtimer(/datum/callback (/datum/callback), -0.278121, 72, Runechat (/datum/controller/subsystem/timer/runechat), "code/datums/chatmessage.dm", 191)
/datum/chatmessage (/datum/chatmessage): generate image("Cool", Gor-Rok (/mob/living/carbon/human), Gor-Rok (/mob/living/carbon/human), /datum/language/common (/datum/language/common), /list (/list), 50)
world: ImmediateInvokeAsync(/datum/chatmessage (/datum/chatmessage), /datum/chatmessage/proc/genera... (/datum/chatmessage/proc/generate_image), "Cool", Gor-Rok (/mob/living/carbon/human), Gor-Rok (/mob/living/carbon/human), /datum/language/common (/datum/language/common), /list (/list), 50)
```