### PR TITLE
Fixed a couple of errors related to lizard tail DNA.

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -588,7 +588,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	if(dna.features["tail_cat"])
 		dna.features["tail_cat"] = GLOB.tails_list_human[deconstruct_block(get_uni_feature_block(features, DNA_TAIL_BLOCK), GLOB.tails_list_human.len)]
 	if(dna.features["tail_lizard"])
-		dna.features["tail_cat"] = GLOB.tails_list_lizard[deconstruct_block(get_uni_feature_block(features, DNA_LIZARD_TAIL_BLOCK), GLOB.tails_list_lizard.len)]
+		dna.features["tail_lizard"] = GLOB.tails_list_lizard[deconstruct_block(get_uni_feature_block(features, DNA_LIZARD_TAIL_BLOCK), GLOB.tails_list_lizard.len)]
 	if(dna.features["ears"])
 		dna.features["ears"] = GLOB.ears_list[deconstruct_block(get_uni_feature_block(features, DNA_EARS_BLOCK), GLOB.ears_list.len)]
 	if(dna.features["moth_wings"])

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -89,6 +89,7 @@
 	preference = "feature_lizard_tail"
 	feature_key = "tail_lizard"
 	wag_flags = WAG_ABLE
+	dna_block = DNA_LIZARD_TAIL_BLOCK
 	///A reference to the paired_spines, since for some fucking reason tail spines are tied to the spines themselves.
 	var/obj/item/organ/external/spines/paired_spines
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #69713
Fixes #69679 (maybe - I did not observe this behavior in my testing but it seems related)

Fixes a simple, though extremely well-hidden error, in which lizard tails were not set to use their proper DNA block. They instead inherited the parent DNA_TAIL_BLOCK, which caused strange behavior where, in a few circumstances, a lizard's tail would be randomized instead of set to the correct appearance. This happened most notably when admin-spawning a lizard character from a ghost, and when a changeling transforms into a lizard.

![](https://cdn.discordapp.com/attachments/982852284205654046/1030381034447044670/unknown.png)
_These should all have had the tail on the top lizard - this behavior is now fixed._

Also includes a minor fix to updateappearance() - this proc, due to a copy-paste error, was setting the tail_cat feature in a character's DNA to their selected lizard tail, rather than setting tail_lizard. I couldn't tell what effects this actually _had_, but it was wrong.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistency. Also, more importantly, this could be a dead giveaway for a changeling to an astute enough player.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Admin-spawned and changelings transformed into lizards will display the correct tails now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
