### PR TITLE
Fixes contextual bare hand element improperly setting up its element ID

### DIFF
--- a/code/datums/elements/screentips/contextual_screentip_bare_hands.dm
+++ b/code/datums/elements/screentips/contextual_screentip_bare_hands.dm
@@ -3,7 +3,7 @@
 /// This stacks with other contextual screentip elements, though you may want to register the signal/flag manually at that point for performance.
 /datum/element/contextual_screentip_bare_hands
 	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
-	id_arg_index = 3
+	id_arg_index = 2
 
 	/// If set, the text to show for LMB
 	var/lmb_text


### PR DESCRIPTION
## About The Pull Request

Fixes #70537

I'm not entirely sure why this element had an `id_arg_index` of 3, but it was causing the second argument to be missed when generating its element ID, which in turn broke a few screentips. 

From what I can see the element has a dummy argument in the second index, `use_named_parameters`, but because most instances of it actually used named parameters it caused the actual second argument (its text) to drop

## Why It's Good For The Game

Accurater screentips 

## Changelog

:cl: Melbert
fix: Fixed some things having inaccurate screentips while holding nothing (Elevators, heaters, bodybags / roller beds)
/:cl:

