### PR TITLE
Fixes `null` thrower runtime with plant backfire element

### DIFF
--- a/code/datums/elements/plant_backfire.dm
+++ b/code/datums/elements/plant_backfire.dm
@@ -67,7 +67,7 @@
 	SIGNAL_HANDLER
 
 	var/mob/living/thrower = arguments[4] // the 4th arg = the mob throwing our item
-	if(!thrower.is_holding(source))
+	if(!istype(thrower) || !thrower.is_holding(source))
 		return
 	if(!backfire(source, thrower))
 		return


### PR DESCRIPTION
## About The Pull Request

Throwers don't always exist for when something is thrown, like if something's tossed by a disposals pipe or something. This should null check. 

## Why It's Good For The Game

Though this runtime didn't actually cause anything to break, less runtimes are better

## Changelog

:cl: Melbert
fix: Fixed a plant backfire runtime when throwing plants
/:cl:

