### PR TITLE
Fixes revolution auto shuttle call not accounting for mindless players (observers) and runtiming 

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -507,8 +507,8 @@
 	var/total_revs = ex_revs.len + ex_headrevs.len
 	var/total_candidates = 0
 
-	for (var/mob/player as anything in GLOB.player_list)
-		if (player.mind.has_antag_datum(/datum/antagonist/enemy_of_the_revolution))
+	for (var/datum/mind/crewmember as anything in get_crewmember_minds())
+		if (crewmember.has_antag_datum(/datum/antagonist/enemy_of_the_revolution))
 			continue
 
 		total_candidates += 1


### PR DESCRIPTION
## About The Pull Request

In the global player list, it is possible for there to be mindless mobs - roundstart observers don't get minds

This caused the revolution auto shuttle call to fail if there was any roundstart observers, which is like always

## Why It's Good For The Game

I wonder how many times this has actually worked in practice, this runtime may have completely stopped it from working

## Changelog

:cl: Melbert
fix: Fixes runtime preventing revolution auto shuttle call
/:cl:
