### PR TITLE
Fixes improper hydro `attack_hand_econdary` return

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1079,7 +1079,7 @@
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
 	if(!anchored)
-		return
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	var/warning = tgui_alert(user, "Are you sure you wish to empty the tray's nutrient beaker?","Empty Tray Nutrients?", list("Yes", "No"))
 	if(warning == "Yes" && user.canUseTopic(src, be_close = TRUE, no_dexterity = FALSE, no_tk = TRUE))
 		reagents.clear_reagents()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1079,8 +1079,7 @@
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
 	if(!anchored)
-		update_appearance()
-		return FALSE
+		return
 	var/warning = tgui_alert(user, "Are you sure you wish to empty the tray's nutrient beaker?","Empty Tray Nutrients?", list("Yes", "No"))
 	if(warning == "Yes" && user.canUseTopic(src, be_close = TRUE, no_dexterity = FALSE, no_tk = TRUE))
 		reagents.clear_reagents()


### PR DESCRIPTION
## About The Pull Request

```
[2022-10-13 22:46:27.374] runtime error: resolve_right_click_attack (probably attack_hand_secondary) did not return a SECONDARY_ATTACK_* define.
 - proc name: right click attack chain (/mob/living/proc/right_click_attack_chain)
 -   source file: other_mobs.dm,10
 -   usr: (src)
 -   src: Jan Dabini (/mob/living/carbon/human)
 -   src.loc: the floor (138,114,2) (/turf/open/floor/iron)
 -   call stack:
 - Jan Dabini (/mob/living/carbon/human): right click attack chain(the hydroponics tray (Red-Beet... (/obj/machinery/hydroponics/constructable), /list (/list))
 - Jan Dabini (/mob/living/carbon/human): UnarmedAttack(the hydroponics tray (Red-Beet... (/obj/machinery/hydroponics/constructable), 1, /list (/list))
```
Attack hand secondary should return a `SECONDARY_ATTACK_CALL_x` value, of which `FALSE` is not
I also removed a pointless `update_appearance`, not sure why it did that

## Why It's Good For The Game

Less runtimes

## Changelog

Not player facing, won't change anything noticeable 
