### PR TITLE
Prevents DNA vault causing harddels

### DIFF
--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -124,13 +124,17 @@
 		ui.open()
 
 /obj/machinery/dna_vault/proc/roll_powers(mob/user)
-	if(user in power_lottery)
+	if(user in power_lottery || isdead(user))
 		return
 	var/list/L = list()
 	var/list/possible_powers = list(VAULT_TOXIN,VAULT_NOBREATH,VAULT_FIREPROOF,VAULT_STUNTIME,VAULT_ARMOUR,VAULT_SPEED,VAULT_QUICK)
 	L += pick_n_take(possible_powers)
 	L += pick_n_take(possible_powers)
 	power_lottery[user] = L
+	RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/deref_mob)
+
+/obj/machinery/dna_vault/proc/deref_mob(datum/source, force)
+	LAZYREMOVE(power_lottery, source)
 
 /obj/machinery/dna_vault/ui_data(mob/user) //TODO Make it % bars maybe
 	var/list/data = list()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -124,17 +124,14 @@
 		ui.open()
 
 /obj/machinery/dna_vault/proc/roll_powers(mob/user)
-	if(user in power_lottery || isdead(user))
+	var/datum/weakref/user_weakref = WEAKREF(user)
+	if((user_weakref in power_lottery) || isdead(user))
 		return
 	var/list/L = list()
 	var/list/possible_powers = list(VAULT_TOXIN,VAULT_NOBREATH,VAULT_FIREPROOF,VAULT_STUNTIME,VAULT_ARMOUR,VAULT_SPEED,VAULT_QUICK)
 	L += pick_n_take(possible_powers)
 	L += pick_n_take(possible_powers)
-	power_lottery[user] = L
-	RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/deref_mob)
-
-/obj/machinery/dna_vault/proc/deref_mob(datum/source, force)
-	LAZYREMOVE(power_lottery, source)
+	power_lottery[user_weakref] = L
 
 /obj/machinery/dna_vault/ui_data(mob/user) //TODO Make it % bars maybe
 	var/list/data = list()
@@ -149,7 +146,7 @@
 	data["choiceA"] = ""
 	data["choiceB"] = ""
 	if(user && completed)
-		var/list/L = power_lottery[user]
+		var/list/L = power_lottery[WEAKREF(user)]
 		if(L?.len)
 			data["used"] = FALSE
 			data["choiceA"] = L[1]
@@ -193,7 +190,8 @@
 		return ..()
 
 /obj/machinery/dna_vault/proc/upgrade(mob/living/carbon/human/H, upgrade_type)
-	if(!(upgrade_type in power_lottery[H])||(HAS_TRAIT(H, TRAIT_USED_DNA_VAULT)))
+	var/datum/weakref/human_weakref = WEAKREF(H)
+	if(!(upgrade_type in power_lottery[human_weakref])||(HAS_TRAIT(H, TRAIT_USED_DNA_VAULT)))
 		return
 	var/datum/species/S = H.dna.species
 	switch(upgrade_type)
@@ -226,5 +224,5 @@
 			to_chat(H, span_notice("Your arms move as fast as lightning."))
 			H.next_move_modifier = 0.5
 	ADD_TRAIT(H, TRAIT_USED_DNA_VAULT, DNA_VAULT_TRAIT)
-	power_lottery[H] = list()
+	power_lottery[human_weakref] = list()
 	use_power(active_power_usage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #67701 by making the list store weakrefs to the mobs instead. Also adds a check to make sure ghosts looking at the vault don't get added to the list.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gets rid of harddel + stops list filling up with useless items
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->