### PR TITLE
Adds extended tooltip information to observables in the orbit ui

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -106,7 +106,26 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		misc += list(list(
 			"ref" = REF(atom_poi),
 			"name" = name,
+			"extra" = null, // Just in case you want to add anything
 		))
+
+		// Display the supermatter crystal integrity
+		if(istype(atom_poi, /obj/machinery/power/supermatter_crystal))
+			var/obj/machinery/power/supermatter_crystal/crystal = atom_poi
+			misc[length(misc)]["extra"] = "Integrity: [crystal.get_integrity_percent()]%"
+			continue
+		// Display the nuke timer
+		if(istype(atom_poi, /obj/machinery/nuclearbomb))
+			var/obj/machinery/nuclearbomb/bomb = atom_poi
+			if(bomb.timing)
+				misc[length(misc)]["extra"] = "Timer: [bomb.countdown?.displayed_text]s"
+			continue
+		// Display the holder if its a nuke disk
+		if(istype(atom_poi, /obj/item/disk/nuclear))
+			var/obj/item/disk/nuclear/disk = atom_poi
+			var/mob/holder = disk.pulledby || get(disk, /mob)
+			misc[length(misc)]["extra"] = "Location: [holder?.real_name || "Unsecured"]"
+			continue
 
 	return list(
 		"alive" = alive,

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -57,7 +57,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 
 		var/poi_ref = REF(mob_poi)
 		serialized["ref"] = poi_ref
-		serialized["name"] = name
+		serialized["full_name"] = name
 
 		if(isobserver(mob_poi))
 			var/number_of_orbiters = length(mob_poi.get_all_orbiters())
@@ -80,6 +80,15 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 
 		var/datum/mind/mind = mob_poi.mind
 		var/was_antagonist = FALSE
+
+		serialized["job"] = mind?.assigned_role?.title
+		serialized["name"] = mob_poi.real_name
+		serialized["health"] = null
+		// Cast the mob so we can get health
+		var/mob/living/player
+		if(isliving(mob_poi)) // Kind of silly here since we've already checked for dead mobs
+			player = mob_poi
+			serialized["health"] = FLOOR((player.health / player.maxHealth * 100), 1)
 
 		for(var/datum/antagonist/antag_datum as anything in mind.antag_datums)
 			if (antag_datum.show_to_ghosts)

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -110,7 +110,7 @@ const ObservableSearch = (props, context) => {
         isJobOrNameMatch(observable, searchQuery)
       ),
       // Sorts descending by orbiters
-      sortBy<Observable>((poi) => -(poi.orbiters || 0)),
+      sortBy<Observable>((observable) => -(observable.orbiters || 0)),
       // Makes a single Observables list for an easy search
     ])([alive, antagonists, dead, ghosts, misc, npcs].flat())[0];
     if (mostRelevant !== undefined) {
@@ -351,10 +351,11 @@ const getThreat = (orbiters: number) => {
 
 /** Checks if a full name or job title matches the search. */
 const isJobOrNameMatch = (observable: Observable, searchQuery: string) => {
-  const { full_name, job } = observable;
+  const { full_name, name, job } = observable;
+  const displayName = full_name ?? name;
 
   return (
-    full_name?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
+    displayName?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
     job?.toLowerCase().includes(searchQuery?.toLowerCase())
   );
 };

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -280,12 +280,12 @@ const ObservableItem = (
 /** Displays some info on the mob as a tooltip. */
 const LivingTooltip = (props: { item: Observable }) => {
   const {
-    item: { job, name, health },
+    item: { job, full_name, health },
   } = props;
 
   return (
     <LabeledList>
-      <LabeledList.Item label="Name">{name}</LabeledList.Item>
+      <LabeledList.Item label="Name">{full_name}</LabeledList.Item>
       <LabeledList.Item label="Job">{job}</LabeledList.Item>
       <LabeledList.Item label="Health">
         {getHealthLabel(health)}

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -1,6 +1,6 @@
 import { useBackend, useLocalState } from '../backend';
 import { filter, sortBy } from 'common/collections';
-import { multiline } from 'common/string';
+import { capitalizeFirst, multiline } from 'common/string';
 import { Box, Button, Collapsible, Icon, Input, LabeledList, Section, Stack } from '../components';
 import { Window } from '../layouts';
 import { flow } from 'common/fp';
@@ -264,7 +264,7 @@ const ObservableItem = (
       onClick={() => act('orbit', { auto_observe: autoObserve, ref: ref })}
       tooltip={health && <LivingTooltip item={item} />}
       tooltipPosition="bottom-start">
-      {displayName}
+      {capitalizeFirst(displayName)}
       {!!orbiters && (
         <>
           {' '}
@@ -317,11 +317,18 @@ const collateAntagonists = (antagonists: Antags) => {
 
 /** Returns a disguised name in case the person is wearing someone else's ID */
 const getDisplayName = (name: string, full_name: string) => {
-  if (!full_name?.includes('[') || full_name.includes('(as ')) {
+  if (!name) {
+    return full_name;
+  }
+  if (
+    !full_name?.includes('[') ||
+    full_name.match(/\(as /) ||
+    full_name.match(/^Unknown/)
+  ) {
     return name;
   }
-  // return only the name before the first ' ['
-  return `"${full_name.split(' [')[0]}"`;
+  // return only the name before the first ' [' or ' ('
+  return `"${full_name.split(/ \[| \(/)[0]}"`;
 };
 
 /** Returns some labels for a player's health */

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -29,32 +29,32 @@ type Observable = {
 
 type POIs = Array<Observable>;
 
-enum ANTAG2COLOR {
-  'Abductors' = 'pink',
-  'Ash Walkers' = 'olive',
-  'Biohazards' = 'brown',
-  'CentCom' = 'teal',
-}
+const ANTAG2COLOR = {
+  'Abductors': 'pink',
+  'Ash Walkers': 'olive',
+  'Biohazards': 'brown',
+  'CentCom': 'teal',
+} as const;
 
-enum ANTAG2GROUP {
-  'Abductor Agent' = 'Abductors',
-  'Abductor Scientist' = 'Abductors',
-  'Ash Walker' = 'Ash Walkers',
-  'Blob' = 'Biohazards',
-  'Sentient Disease' = 'Biohazards',
-  'CentCom Commander' = 'CentCom',
-  'CentCom Head Intern' = 'CentCom',
-  'CentCom Intern' = 'CentCom',
-  'CentCom Official' = 'CentCom',
-  'Central Command' = 'CentCom',
-  'Clown Operative' = 'Clown Operatives',
-  'Clown Operative Leader' = 'Clown Operatives',
-  'Nuclear Operative' = 'Nuclear Operatives',
-  'Nuclear Operative Leader' = 'Nuclear Operatives',
-  'Space Wizard' = 'Wizard Federation',
-  'Wizard Apprentice' = 'Wizard Federation',
-  'Wizard Minion' = 'Wizard Federation',
-}
+const ANTAG2GROUP = {
+  'Abductor Agent': 'Abductors',
+  'Abductor Scientist': 'Abductors',
+  'Ash Walker': 'Ash Walkers',
+  'Blob': 'Biohazards',
+  'Sentient Disease': 'Biohazards',
+  'CentCom Commander': 'CentCom',
+  'CentCom Head Intern': 'CentCom',
+  'CentCom Intern': 'CentCom',
+  'CentCom Official': 'CentCom',
+  'Central Command': 'CentCom',
+  'Clown Operative': 'Clown Operatives',
+  'Clown Operative Leader': 'Clown Operatives',
+  'Nuclear Operative': 'Nuclear Operatives',
+  'Nuclear Operative Leader': 'Nuclear Operatives',
+  'Space Wizard': 'Wizard Federation',
+  'Wizard Apprentice': 'Wizard Federation',
+  'Wizard Minion': 'Wizard Federation',
+} as const;
 
 enum THREAT {
   None,

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -317,13 +317,11 @@ const collateAntagonists = (antagonists: Antags) => {
 
 /** Returns a disguised name in case the person is wearing someone else's ID */
 const getDisplayName = (name: string, full_name: string) => {
-  if (!full_name?.includes('[')) {
+  if (!full_name?.includes('[') || full_name.includes('(as ')) {
     return name;
   }
-  // This wild bit of regex is to extract the name from the ID
-  const match =
-    full_name.match(/\(as (.*?)\)/)?.[1] ?? full_name.match(/.*?(?= \[)/)?.[1];
-  return `"${match}"` ?? name;
+  // This bit of regex extracts names before the first ' ['
+  return `"${full_name.match(/.*?(?= \[)/)?.[1]}"` ?? name;
 };
 
 /** Returns some labels for a player's health */

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -255,7 +255,7 @@ const ObservableItem = (
   const { color, item } = props;
   const { full_name, health, name, orbiters, ref } = item;
   const [autoObserve] = useLocalState<boolean>(context, 'autoObserve', false);
-  const threat = getThreat(orbiters || 0);
+  const threat = getThreat(orbiters ?? 0);
   const displayName = getDisplayName(name, full_name);
 
   return (
@@ -320,8 +320,8 @@ const getDisplayName = (name: string, full_name: string) => {
   if (!full_name?.includes('[') || full_name.includes('(as ')) {
     return name;
   }
-  // This bit of regex extracts names before the first ' ['
-  return `"${full_name.match(/.*?(?= \[)/)?.[1]}"` ?? name;
+  // return only the name before the first ' ['
+  return `"${full_name.split(' [')[0]}"`;
 };
 
 /** Returns some labels for a player's health */

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -4,7 +4,6 @@ import { capitalizeFirst, multiline } from 'common/string';
 import { Box, Button, Collapsible, Icon, Input, LabeledList, Section, Stack } from '../components';
 import { Window } from '../layouts';
 import { flow } from 'common/fp';
-import { logger } from '../logging';
 
 type AntagGroup = [string, Antags];
 
@@ -249,7 +248,7 @@ const ObservableSection = (
   );
 };
 
-/** Renders an observable button */
+/** Renders an observable button that has tooltip info for living POIs*/
 const ObservableItem = (
   props: { color: string; item: Observable },
   context

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -10,12 +10,12 @@ type AntagGroup = [string, Antags];
 type Antags = Array<Observable & { antag: string }>;
 
 type Data = {
-  alive: POIs;
+  alive: Array<Observable>;
   antagonists: Antags;
-  dead: POIs;
-  ghosts: POIs;
-  misc: POIs;
-  npcs: POIs;
+  dead: Array<Observable>;
+  ghosts: Array<Observable>;
+  misc: Array<Observable>;
+  npcs: Array<Observable>;
 };
 
 type Observable = {
@@ -26,8 +26,6 @@ type Observable = {
   orbiters?: number;
   ref: string;
 };
-
-type POIs = Array<Observable>;
 
 const ANTAG2COLOR = {
   'Abductors': 'pink',
@@ -103,7 +101,7 @@ const ObservableSearch = (props, context) => {
     'searchQuery',
     ''
   );
-  /** Gets a list of POIs, then filters the most relevant to orbit */
+  /** Gets a list of Observables, then filters the most relevant to orbit */
   const orbitMostRelevant = (searchQuery: string): void => {
     /** Returns the most orbited observable that matches the search. */
     const mostRelevant: Observable = flow([
@@ -113,7 +111,7 @@ const ObservableSearch = (props, context) => {
       ),
       // Sorts descending by orbiters
       sortBy<Observable>((poi) => -(poi.orbiters || 0)),
-      // Makes a single POIs list for an easy search
+      // Makes a single Observables list for an easy search
     ])([alive, antagonists, dead, ghosts, misc, npcs].flat())[0];
     if (mostRelevant !== undefined) {
       act('orbit', {
@@ -213,7 +211,7 @@ const ObservableContent = (props, context) => {
 const ObservableSection = (
   props: {
     color?: string;
-    section: POIs;
+    section: Array<Observable>;
     title: string;
   },
   context
@@ -223,7 +221,7 @@ const ObservableSection = (
     return null;
   }
   const [searchQuery] = useLocalState<string>(context, 'searchQuery', '');
-  const filteredSection: POIs = flow([
+  const filteredSection: Array<Observable> = flow([
     filter<Observable>((poi) =>
       poi.name?.toLowerCase().includes(searchQuery?.toLowerCase())
     ),
@@ -248,7 +246,7 @@ const ObservableSection = (
   );
 };
 
-/** Renders an observable button that has tooltip info for living POIs*/
+/** Renders an observable button that has tooltip info for living Observables*/
 const ObservableItem = (
   props: { color: string; item: Observable },
   context

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -107,7 +107,7 @@ const ObservableSearch = (props, context) => {
     const mostRelevant: Observable = flow([
       // Filters out anything that doesn't match search
       filter<Observable>((observable) =>
-        observable.full_name?.toLowerCase().includes(searchQuery?.toLowerCase())
+        isJobOrNameMatch(observable, searchQuery)
       ),
       // Sorts descending by orbiters
       sortBy<Observable>((poi) => -(poi.orbiters || 0)),
@@ -223,7 +223,7 @@ const ObservableSection = (
   const [searchQuery] = useLocalState<string>(context, 'searchQuery', '');
   const filteredSection: Array<Observable> = flow([
     filter<Observable>((observable) =>
-      observable.full_name?.toLowerCase().includes(searchQuery?.toLowerCase())
+      isJobOrNameMatch(observable, searchQuery)
     ),
     sortBy<Observable>((observable) => observable.name?.toLowerCase()),
   ])(section);
@@ -253,7 +253,7 @@ const ObservableItem = (
 ) => {
   const { act } = useBackend<Data>(context);
   const { color, item } = props;
-  const { health, name, orbiters, ref } = item;
+  const { full_name, health, name, orbiters, ref } = item;
   const [autoObserve] = useLocalState<boolean>(context, 'autoObserve', false);
   const threat = getThreat(orbiters || 0);
 
@@ -263,7 +263,7 @@ const ObservableItem = (
       onClick={() => act('orbit', { auto_observe: autoObserve, ref: ref })}
       tooltip={health && <LivingTooltip item={item} />}
       tooltipPosition="bottom-start">
-      {capitalizeFirst(name).slice(0, 44)}
+      {capitalizeFirst(name ?? full_name).slice(0, 44)}
       {!!orbiters && (
         <>
           {' '}
@@ -347,4 +347,14 @@ const getThreat = (orbiters: number) => {
   } else {
     return THREAT.Large;
   }
+};
+
+/** Checks if a full name or job title matches the search. */
+const isJobOrNameMatch = (observable: Observable, searchQuery: string) => {
+  const { full_name, job } = observable;
+
+  return (
+    full_name?.toLowerCase().includes(searchQuery?.toLowerCase()) ||
+    job?.toLowerCase().includes(searchQuery?.toLowerCase())
+  );
 };

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -107,7 +107,7 @@ const ObservableSearch = (props, context) => {
     const mostRelevant: Observable = flow([
       // Filters out anything that doesn't match search
       filter<Observable>((observable) =>
-        observable.name?.toLowerCase().includes(searchQuery?.toLowerCase())
+        observable.full_name?.toLowerCase().includes(searchQuery?.toLowerCase())
       ),
       // Sorts descending by orbiters
       sortBy<Observable>((poi) => -(poi.orbiters || 0)),

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -222,10 +222,10 @@ const ObservableSection = (
   }
   const [searchQuery] = useLocalState<string>(context, 'searchQuery', '');
   const filteredSection: Array<Observable> = flow([
-    filter<Observable>((poi) =>
-      poi.name?.toLowerCase().includes(searchQuery?.toLowerCase())
+    filter<Observable>((observable) =>
+      observable.full_name?.toLowerCase().includes(searchQuery?.toLowerCase())
     ),
-    sortBy<Observable>((poi) => poi.name.toLowerCase()),
+    sortBy<Observable>((observable) => observable.name?.toLowerCase()),
   ])(section);
   if (!filteredSection.length) {
     return null;
@@ -263,7 +263,7 @@ const ObservableItem = (
       onClick={() => act('orbit', { auto_observe: autoObserve, ref: ref })}
       tooltip={health && <LivingTooltip item={item} />}
       tooltipPosition="bottom-start">
-      {capitalizeFirst(name).slice(0, 44) /** prevents it from overflowing */}
+      {capitalizeFirst(name).slice(0, 44)}
       {!!orbiters && (
         <>
           {' '}

--- a/tgui/packages/tgui/interfaces/Orbit.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit.tsx
@@ -288,15 +288,14 @@ const ObservableItem = (
  * ie: Nuclear Operatives. See: ANTAG_GROUPS.
  */
 const collateAntagonists = (antagonists: Antags) => {
-  const collatedAntagonists = new Map<string, Antags>();
+  const collatedAntagonists = {};
   antagonists.map((player) => {
     const { antag } = player;
     const resolvedName: string = ANTAG2GROUP[antag] || antag;
-    collatedAntagonists.set(resolvedName, [
-      // If the group already exists, add the player to it
-      ...(collatedAntagonists.get(resolvedName) || []),
-      player,
-    ]);
+    if (!collatedAntagonists[resolvedName]) {
+      collatedAntagonists[resolvedName] = [];
+    }
+    collatedAntagonists[resolvedName].push(player);
   });
   const sortedAntagonists = sortBy<AntagGroup>(([key]) => key)(
     Object.entries(collatedAntagonists)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A continuation of #68389 which addresses an issue that still bothers me to this day:

The orbit menu displays a player's name as a combo of name id transform. It can get lengthy to a point where the names clip the entire screen (as buttons do not multiline).

This PR shortens excessively long player names on the orbit menu and adds a tooltip that will show extended info like full name, health and job titles.

Mostly drawn from concerns brought up in the original.

<details>
<summary>Screenshots</summary>
Health percentages, full names (what you currently see on live), and jobs

![C5GcBXEgU8](https://user-images.githubusercontent.com/42397676/196016602-e847187c-7df8-48fd-8f5b-cab6fa1f8b6a.gif)

Full disguises show up in buttons
![rukdQmmh69](https://user-images.githubusercontent.com/42397676/196016528-e26fcdf4-0612-4ff8-b553-1a7473a9044a.gif)

Some misc items get data **Suggestion via** @thebestcodertoevercode 
![ytwj2WfAAt](https://user-images.githubusercontent.com/42397676/196016659-2cb99d72-3c89-4545-9eee-fcd4cdf0e061.gif)
Typo was nuked after this gif
</details>
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better observer experience
Bug fix (huge clipping names)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The orbit UI now brings up tooltips to show health, job, and full name information.
add: The orbit UI now puts disguised names in quotes. "John Doe". Hover to get real name.
add: Orbit UI now gives tooltips on SM crystal, nuke disk, and nuclear devices.
add: You can now search by job in the orbit UI.
fix: Orbit UI buttons (should) no longer clip on extra long names.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
