### PR TITLE
Makes Delta Station EVA Toolbelt Actually A Toolbelt And Also The Ashwalker Ruin and Also Makes It More Obvious That The Base Type Of Belt Is Not A Toolbelt

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -541,7 +541,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/spear,
-/obj/item/storage/belt,
+/obj/item/storage/belt/utility,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "cL" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -88200,10 +88200,10 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "vyP" = (
-/obj/item/storage/belt,
 /obj/item/radio,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/storage/belt/utility,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "vyX" = (

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1,6 +1,6 @@
 /obj/item/storage/belt
-	name = "belt"
-	desc = "Can hold various things."
+	name = "not actually a toolbelt"
+	desc = "Can hold various things. This is the base type of /belt, are you sure you should have this?"
 	icon = 'icons/obj/clothing/belts.dmi'
 	icon_state = "utility"
 	inhand_icon_state = "utility"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In this PR I replace the simple "belt" in Delta's EVA with the /utility (toolbelt) subtype, as well as the ashwalker nest, and also updates the name and description of the base belt to make it clearer that its purpose is purely as a base type, and not as a usable item. A case where the base type is also an item that can be intentionally used in game is the police baton.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The current belt can hold basically everything and assistants should not be given an operative belt at roundstart.*
Also makes it easier to tell the difference between a "belt" and a toolbelt" when they both look the same.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Deltastation's EVA now contains a real toolbelt, that can only hold tools.
fix: The Ashwalker Nest now contains a real toolbelt, that can only hold tools.
spellcheck: The base type of /belt is now more obviously NOT a toolbelt.
/:cl:

*I don't have any evidence that this is the case.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
