### PR TITLE
Back reason to withdrawal in ntpay. Remove all about commission

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -102,12 +102,6 @@
 	/// Boolean value. If TRUE, the [Intern] tag gets prepended to this ID card when the label is updated.
 	var/is_intern = FALSE
 
-	///Way to use NT pay. Or how to save money. 1 - 100%, 0.05 - 5%
-	var/commission =  0.05
-
-	///Payment under >99 credits withdraw. (this + 1 = min value to withdraw)
-	var/commission_minimal = 5
-
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
 
@@ -676,7 +670,7 @@
 		return
 	if(!alt_click_can_use_id(user))
 		return
-	if(registered_account.adjust_money(-amount_to_remove))
+	if(registered_account.adjust_money(-amount_to_remove, "System: Withdrawal"))
 		var/obj/item/holochip/holochip = new (user.drop_location(), amount_to_remove)
 		user.put_in_hands(holochip)
 		to_chat(user, span_notice("You withdraw [amount_to_remove] credits into a holochip."))


### PR DESCRIPTION
## About The Pull Request

PR back reason in adjust_money procedure(i dont know whiy it was deleted).
And removes useless variables which earlier was used to commission(5 credits tax)

## Why It's Good For The Game

More transaction logs.

## Changelog

:cl: Vishenka0704
fix: restores withdrawal log in NT Pay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
