### PR TITLE
Prevents welding multiple disposals machines to the same trunk

### DIFF
--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -49,20 +49,23 @@
 	return INITIALIZE_HINT_LATELOAD //we need turfs to have air
 
 /obj/machinery/disposal/proc/trunk_check()
-	trunk = locate() in loc
-	if(!trunk)
+	var/obj/structure/disposalpipe/trunk/found_trunk = locate() in loc
+	if(!found_trunk)
 		pressure_charging = FALSE
 		flush = FALSE
 	else
 		if(initial(pressure_charging))
 			pressure_charging = TRUE
 		flush = initial(flush)
-		trunk.linked = src // link the pipe trunk to self
+
+		found_trunk.set_linked(src) // link the pipe trunk to self
+		trunk = found_trunk
 
 /obj/machinery/disposal/Destroy()
 	eject()
 	if(trunk)
 		trunk.linked = null
+		trunk = null
 	return ..()
 
 /obj/machinery/disposal/handle_atom_del(atom/A)
@@ -466,12 +469,6 @@
 	density = TRUE
 	icon_state = "intake"
 	pressure_charging = FALSE // the chute doesn't need charging and always works
-
-/obj/machinery/disposal/delivery_chute/Initialize(mapload, obj/structure/disposalconstruct/make_from)
-	. = ..()
-	trunk = locate() in loc
-	if(trunk)
-		trunk.linked = src // link the pipe trunk to self
 
 /obj/machinery/disposal/delivery_chute/place_item_in_disposal(obj/item/I, mob/user)
 	if(I.CanEnterDisposals())

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -149,6 +149,11 @@
 /obj/structure/disposalconstruct/welder_act(mob/living/user, obj/item/I)
 	..()
 	if(anchored)
+		var/turf/T = get_turf(src)
+		if(!is_pipe() && ((locate(/obj/machinery/disposal) in T) || ((locate(/obj/structure/disposaloutlet) in T))))
+			to_chat(user, span_warning("A disposals machine already exists here!"))
+			return TRUE
+
 		if(!I.tool_start_check(user, amount=0))
 			return TRUE
 

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -61,7 +61,7 @@
 // start the movement process
 // argument is the disposal unit the holder started in
 /obj/structure/disposalholder/proc/start(obj/machinery/disposal/D)
-	if(!D.trunk)
+	if(QDELETED(D.trunk))
 		D.expel(src) // no trunk connected, so expel immediately
 		return
 	forceMove(D.trunk)

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -36,9 +36,10 @@
 
 	target = get_ranged_target_turf(src, dir, 10)
 
-	trunk = locate() in loc
-	if(trunk)
-		trunk.linked = src // link the pipe trunk to self
+	var/obj/structure/disposalpipe/trunk/found_trunk = locate() in loc
+	if(found_trunk)
+		found_trunk.set_linked(src) // link the pipe trunk to self
+		trunk = found_trunk
 
 /obj/structure/disposaloutlet/Destroy()
 	if(trunk)

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -226,6 +226,11 @@
 	getlinked()
 
 /obj/structure/disposalpipe/trunk/Destroy()
+	null_linked_ref_to_us()
+	linked = null
+	return ..()
+
+/obj/structure/disposalpipe/trunk/proc/null_linked_ref_to_us()
 	if(linked)
 		if(istype(linked, /obj/structure/disposaloutlet))
 			var/obj/structure/disposaloutlet/D = linked
@@ -233,20 +238,21 @@
 		else if(istype(linked, /obj/machinery/disposal))
 			var/obj/machinery/disposal/D = linked
 			D.trunk = null
-	return ..()
+
+/obj/structure/disposalpipe/trunk/proc/set_linked(obj/to_link)
+	null_linked_ref_to_us()
+	linked = to_link
 
 /obj/structure/disposalpipe/trunk/proc/getlinked()
+	null_linked_ref_to_us()
 	linked = null
 	var/turf/T = get_turf(src)
 	var/obj/machinery/disposal/D = locate() in T
 	if(D)
-		linked = D
-		if (!D.trunk)
-			D.trunk = src
-
+		set_linked(D)
 	var/obj/structure/disposaloutlet/O = locate() in T
 	if(O)
-		linked = O
+		set_linked(O)
 
 
 /obj/structure/disposalpipe/trunk/can_be_deconstructed(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check to make sure that there isn't already existing disposals machinery on a tile when you try to weld a chute/bin/outlet to a trunk. Also changes how disposal machinery connects to trunks to make sure this doesn't happen even if admin tools/bad mapping create multiple on the same tile and prevent a possible hanging reference.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #70323
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed being able to weld multiple disposal machines to the same pipe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
