### PR TITLE
Misc PDA code improvements

### DIFF
--- a/code/modules/asset_cache/assets/headers.dm
+++ b/code/modules/asset_cache/assets/headers.dm
@@ -26,5 +26,5 @@
 		"smmon_5.gif" = 'icons/program_icons/smmon_5.gif',
 		"smmon_6.gif" = 'icons/program_icons/smmon_6.gif',
 		"borg_mon.gif" = 'icons/program_icons/borg_mon.gif',
-		"robotact.gif" = 'icons/program_icons/robotact.gif'
+		"robotact.gif" = 'icons/program_icons/robotact.gif',
 	)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -169,7 +169,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		if(!istype(src, /obj/item/modular_computer/tablet))
 			return FALSE
 
-// Gets IDs/access levels from card slot. Would be useful when/if PDAs would become modular PCs.
+// Gets IDs/access levels from card slot. Would be useful when/if PDAs would become modular PCs. //guess what
 /obj/item/modular_computer/GetAccess()
 	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
 	if(card_slot)
@@ -411,7 +411,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 			to_chat(user, span_notice("You press the power button and start up \the [src]."))
 		if(looping_sound)
 			soundloop.start()
-		enabled = 1
+		enabled = TRUE
 		update_appearance()
 		if(open_ui)
 			ui_interact(user)
@@ -434,26 +434,23 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		return
 
 	if(active_program && active_program.requires_ntnet && !get_ntnet_status(active_program.requires_ntnet_feature))
-		active_program.event_networkfailure(0) // Active program requires NTNet to run but we've just lost connection. Crash.
+		active_program.event_networkfailure(FALSE) // Active program requires NTNet to run but we've just lost connection. Crash.
 
-	for(var/I in idle_threads)
-		var/datum/computer_file/program/P = I
-		if(P.requires_ntnet && !get_ntnet_status(P.requires_ntnet_feature))
-			P.event_networkfailure(1)
+	for(var/datum/computer_file/program/idle_programs as anything in idle_threads)
+		if(idle_programs.program_state == PROGRAM_STATE_KILLED)
+			idle_threads.Remove(idle_programs)
+			continue
+		idle_programs.process_tick(delta_time)
+		idle_programs.ntnet_status = get_ntnet_status(idle_programs.requires_ntnet_feature)
+		if(idle_programs.requires_ntnet && !idle_programs.ntnet_status)
+			idle_programs.event_networkfailure(TRUE)
 
 	if(active_program)
-		if(active_program.program_state != PROGRAM_STATE_KILLED)
+		if(active_program.program_state == PROGRAM_STATE_KILLED)
+			active_program = null
+		else
 			active_program.process_tick(delta_time)
 			active_program.ntnet_status = get_ntnet_status()
-		else
-			active_program = null
-
-	for(var/datum/computer_file/program/P as anything in idle_threads)
-		if(P.program_state != PROGRAM_STATE_KILLED)
-			P.process_tick(delta_time)
-			P.ntnet_status = get_ntnet_status()
-		else
-			idle_threads.Remove(P)
 
 	handle_power(delta_time) // Handles all computer power interaction
 	//check_update_ui_need()
@@ -494,6 +491,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 
 	var/obj/item/computer_hardware/battery/battery_module = all_components[MC_CELL]
 
+	data["PC_showbatteryicon"] = !!battery_module
 	if(battery_module && battery_module.battery)
 		switch(battery_module.battery.percent())
 			if(80 to 200) // 100 should be maximal but just in case..
@@ -509,37 +507,31 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 			else
 				data["PC_batteryicon"] = "batt_5.gif"
 		data["PC_batterypercent"] = "[round(battery_module.battery.percent())]%"
-		data["PC_showbatteryicon"] = 1
 	else
 		data["PC_batteryicon"] = "batt_5.gif"
 		data["PC_batterypercent"] = "N/C"
-		data["PC_showbatteryicon"] = battery_module ? 1 : 0
 
 	switch(get_ntnet_status())
 		if(NTNET_NO_SIGNAL)
 			data["PC_ntneticon"] = "sig_none.gif"
-		if(NTNET_LOW_SIGNAL)
+		else if(NTNET_LOW_SIGNAL)
 			data["PC_ntneticon"] = "sig_low.gif"
-		if(NTNET_GOOD_SIGNAL)
+		else if(NTNET_GOOD_SIGNAL)
 			data["PC_ntneticon"] = "sig_high.gif"
-		if(NTNET_ETHERNET_SIGNAL)
+		else if(NTNET_ETHERNET_SIGNAL)
 			data["PC_ntneticon"] = "sig_lan.gif"
 
 	if(length(idle_threads))
 		var/list/program_headers = list()
-		for(var/I in idle_threads)
-			var/datum/computer_file/program/P = I
-			if(!P.ui_header)
+		for(var/datum/computer_file/program/idle_programs as anything in idle_threads)
+			if(!idle_programs.ui_header)
 				continue
-			program_headers.Add(list(list(
-				"icon" = P.ui_header
-			)))
+			program_headers.Add(list(list("icon" = idle_programs.ui_header)))
 
 		data["PC_programheaders"] = program_headers
 
 	data["PC_stationtime"] = station_time_timestamp()
-	data["PC_hasheader"] = 1
-	data["PC_showexitprogram"] = active_program ? 1 : 0 // Hides "Exit Program" button on mainscreen
+	data["PC_showexitprogram"] = !!active_program // Hides "Exit Program" button on mainscreen
 	return data
 
 ///Wipes the computer's current program. Doesn't handle any of the niceties around doing this
@@ -566,9 +558,6 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		to_chat(user, span_danger("\The [src]'s screen shows \"I/O ERROR - Unable to run program\" warning."))
 		return FALSE
 
-	if(!program.is_supported_by_hardware(hardware_flag, 1, user))
-		return FALSE
-
 	// The program is already running. Resume it.
 	if(program in idle_threads)
 		program.program_state = PROGRAM_STATE_ACTIVE
@@ -578,6 +567,9 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		update_appearance()
 		updateUsrDialog()
 		return TRUE
+
+	if(!program.is_supported_by_hardware(hardware_flag, 1, user))
+		return FALSE
 
 	if(idle_threads.len > max_idle_programs)
 		to_chat(user, span_danger("\The [src] displays a \"Maximal CPU load reached. Unable to run another program.\" error."))
@@ -600,7 +592,6 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 /obj/item/modular_computer/proc/get_ntnet_status(specific_action = 0)
 	if(!SSnetworks.station_network || !SSnetworks.station_network.check_function(specific_action)) // NTNet is down and we are not connected via wired connection. No signal.
 		return NTNET_NO_SIGNAL
-
 
 	// computers are connected through ethernet
 	if(hardware_flag & PROGRAM_CONSOLE)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -514,11 +514,11 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	switch(get_ntnet_status())
 		if(NTNET_NO_SIGNAL)
 			data["PC_ntneticon"] = "sig_none.gif"
-		else if(NTNET_LOW_SIGNAL)
+		if(NTNET_LOW_SIGNAL)
 			data["PC_ntneticon"] = "sig_low.gif"
-		else if(NTNET_GOOD_SIGNAL)
+		if(NTNET_GOOD_SIGNAL)
 			data["PC_ntneticon"] = "sig_high.gif"
-		else if(NTNET_ETHERNET_SIGNAL)
+		if(NTNET_ETHERNET_SIGNAL)
 			data["PC_ntneticon"] = "sig_lan.gif"
 
 	if(length(idle_threads))

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -66,14 +66,10 @@
 	data["device_theme"] = device_theme
 	data["login"] = list()
 
-	data["disk"] = null
-
 	var/obj/item/computer_hardware/card_slot/cardholder = all_components[MC_CARD]
-	data["cardholder"] = FALSE
+	data["cardholder"] = !!cardholder
 
 	if(cardholder)
-		data["cardholder"] = TRUE
-
 		var/stored_name = saved_identification
 		var/stored_title = saved_job
 		if(!stored_name)
@@ -107,7 +103,13 @@
 		if(P in idle_threads)
 			running = TRUE
 
-		data["programs"] += list(list("name" = P.filename, "desc" = P.filedesc, "running" = running, "icon" = P.program_icon, "alert" = P.alert_pending))
+		data["programs"] += list(list(
+			"name" = P.filename,
+			"desc" = P.filedesc,
+			"running" = running,
+			"icon" = P.program_icon,
+			"alert" = P.alert_pending,
+		))
 
 	data["has_light"] = has_light
 	data["light_on"] = light_on
@@ -157,10 +159,6 @@
 			to_chat(user, span_notice("Program [P.filename].[P.filetype] with PID [rand(100,999)] has been killed."))
 
 		if("PC_runprogram")
-			// only function of the last implementation (?)
-			if(params["is_disk"])
-				return
-
 			open_program(usr, hard_drive.find_file_by_name(params["name"]))
 
 		if("PC_toggle_light")

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -1,13 +1,20 @@
 /datum/computer_file
-	var/filename = "NewFile" // Placeholder. No spacebars
-	var/filetype = "XXX" // File full names are [filename].[filetype] so like NewFile.XXX in this case
-	var/size = 1 // File size in GQ. Integers only!
-	var/obj/item/computer_hardware/hard_drive/holder // Holder that contains this file.
-	var/obj/item/modular_computer/computer
-	var/unsendable = FALSE // Whether the file may be sent to someone via NTNet transfer or other means.
-	var/undeletable = FALSE // Whether the file may be deleted. Setting to TRUE prevents deletion/renaming/etc.
-	var/uid // UID of this file
+	///The name of the internal file shown in file management.
+	var/filename = "NewFile"
+	///The type of file format the file is in, placed after filename. PNG, TXT, ect. This would be NewFile.XXX
+	var/filetype = "XXX"
+	///How much GQ storage space the file will take to store. Integers only!
+	var/size = 1
+	///Whether the file may be deleted. Setting to TRUE prevents deletion/renaming/etc.
+	var/undeletable = FALSE
+	///The computer file's personal ID
+	var/uid
+	///Static ID to ensure all IDs are unique.
 	var/static/file_uid = 0
+	///The hard drive that has this computer file stored.
+	var/obj/item/computer_hardware/hard_drive/holder
+	///The modular computer hosting the file.
+	var/obj/item/modular_computer/computer
 
 /datum/computer_file/New()
 	..()
@@ -28,7 +35,6 @@
 // Returns independent copy of this file.
 /datum/computer_file/proc/clone(rename = FALSE)
 	var/datum/computer_file/temp = new type
-	temp.unsendable = unsendable
 	temp.undeletable = undeletable
 	temp.size = size
 	if(rename)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -203,8 +203,8 @@
 		var/obj/item/computer_hardware/card_slot/card_holder = computer.all_components[MC_CARD]
 		if(card_holder)
 			ID = card_holder.GetID()
-		generate_network_log("Connection closed -- Program ID: [filename] User:[ID?"[ID.registered_name]":"None"]")
-	return 1
+		generate_network_log("Connection closed -- Program ID: [filename] User:[ID ? "[ID.registered_name]" : "None"]")
+	return TRUE
 
 /datum/computer_file/program/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -247,7 +247,6 @@
 
 				if(user && istype(user))
 					computer.ui_interact(user) // Re-open the UI on this computer. It should show the main screen now.
-
 
 /datum/computer_file/program/ui_host()
 	if(computer.physical)

--- a/code/modules/modular_computers/file_system/programs/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/configurator.dm
@@ -7,11 +7,10 @@
 	filedesc = "Hardware Configuration Tool"
 	extended_desc = "This program allows configuration of computer's hardware"
 	program_icon_state = "generic"
-	unsendable = 1
-	undeletable = 1
+	undeletable = TRUE
 	size = 4
-	available_on_ntnet = 0
-	requires_ntnet = 0
+	available_on_ntnet = FALSE
+	requires_ntnet = FALSE
 	tgui_id = "NtosConfiguration"
 	program_icon = "cog"
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -3,7 +3,6 @@
 	filedesc = "NT Software Hub"
 	program_icon_state = "generic"
 	extended_desc = "This program allows downloads of software from official NT repositories"
-	unsendable = TRUE
 	undeletable = TRUE
 	size = 4
 	requires_ntnet = TRUE

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -7,7 +7,6 @@
 	program_icon_state = "command"
 	requires_ntnet = FALSE
 	available_on_ntnet = FALSE
-	unsendable = TRUE
 	undeletable = TRUE
 	usage_flags = PROGRAM_TABLET
 	size = 5

--- a/code/modules/research/ordnance/_scipaper.dm
+++ b/code/modules/research/ordnance/_scipaper.dm
@@ -113,9 +113,9 @@
  * Things to check: tier, gain, and partner here. ex_path and record datums in subtypes.
  */
 /datum/scientific_paper/proc/allowed_to_publish(datum/techweb/techweb_to_check)
-	if(!tier || !gains || !partner_path || (0 in gains))
+	if(!tier || !gains || !partner_path || !gains.len)
 		return FALSE
-	return techweb_to_check.published_papers[experiment_path][tier] ? FALSE : TRUE
+	return !techweb_to_check.published_papers[experiment_path][tier]
 
 /datum/scientific_paper/proc/publish_paper(datum/techweb/techweb_to_publish)
 	autofill()
@@ -206,14 +206,15 @@
 			var/datum/data/tachyon_record/record_to_check = papers.explosion_record
 			if(explosion_record.explosion_identifier == record_to_check.explosion_identifier)
 				return FALSE
-	. = ..()
+	return ..()
 
 /datum/scientific_paper/explosive/set_experiment(ex_path = null, variable = null, data = null)
 	var/invalid = FALSE
 
-	invalid = invalid || !ispath(ex_path, /datum/experiment/ordnance/explosive)
-	invalid = invalid || !variable
-	invalid = invalid || !istype(data, /datum/data/tachyon_record)
+	invalid = (invalid \
+		|| !ispath(ex_path, /datum/experiment/ordnance/explosive) \
+		|| !variable \
+		|| !istype(data, /datum/data/tachyon_record))
 
 	if(invalid)
 		experiment_path = null
@@ -284,6 +285,7 @@
 
 /// Various informations on companies/scientific programs/journals etc that the players can sign on to.
 /datum/scientific_partner
+	/// Name of the partner, shown in the Science program's UI.
 	var/name
 	/// Brief explanation of the associated program. Can be used for lore.
 	var/flufftext
@@ -312,10 +314,10 @@
 	return TRUE
 
 /datum/computer_file/data/ordnance
-	/// List of experiments filtered by doppler array or populated by the tank compressor. Experiment path as key, score as value.
-	var/list/possible_experiments
 	size = 4
 	filetype = "ORD"
+	/// List of experiments filtered by doppler array or populated by the tank compressor. Experiment path as key, score as value.
+	var/list/possible_experiments
 
 /datum/computer_file/data/ordnance/proc/return_data()
 	return null
@@ -326,9 +328,9 @@
 	return temp
 
 /datum/computer_file/data/ordnance/explosive
+	filetype = "DOP"
 	/// Tachyon record, used for an explosive experiment.
 	var/datum/data/tachyon_record/explosion_record
-	filetype = "DOP"
 
 /datum/computer_file/data/ordnance/explosive/return_data()
 	return explosion_record

--- a/code/modules/research/ordnance/_scipaper.dm
+++ b/code/modules/research/ordnance/_scipaper.dm
@@ -209,14 +209,7 @@
 	return ..()
 
 /datum/scientific_paper/explosive/set_experiment(ex_path = null, variable = null, data = null)
-	var/invalid = FALSE
-
-	invalid = (invalid \
-		|| !ispath(ex_path, /datum/experiment/ordnance/explosive) \
-		|| !variable \
-		|| !istype(data, /datum/data/tachyon_record))
-
-	if(invalid)
+	if(!ispath(ex_path, /datum/experiment/ordnance/explosive) || !variable || !istype(data, /datum/data/tachyon_record))
 		experiment_path = null
 		tracked_variable = null
 		explosion_record = null

--- a/code/modules/research/ordnance/_scipaper.dm
+++ b/code/modules/research/ordnance/_scipaper.dm
@@ -113,7 +113,7 @@
  * Things to check: tier, gain, and partner here. ex_path and record datums in subtypes.
  */
 /datum/scientific_paper/proc/allowed_to_publish(datum/techweb/techweb_to_check)
-	if(!tier || !gains || !partner_path || !gains.len)
+	if(!tier || !gains || !partner_path || (0 in gains))
 		return FALSE
 	return !techweb_to_check.published_papers[experiment_path][tier]
 

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -15,9 +15,6 @@ export const NtosMain = (props, context) => {
     cardholder,
     login = [],
     proposed_login = [],
-    disk,
-    disk_name,
-    disk_programs = [],
     pai,
   } = data;
   return (
@@ -143,7 +140,6 @@ export const NtosMain = (props, context) => {
                     onClick={() =>
                       act('PC_runprogram', {
                         name: program.name,
-                        is_disk: false,
                       })
                     }
                   />
@@ -167,59 +163,6 @@ export const NtosMain = (props, context) => {
             ))}
           </Table>
         </Section>
-        {!!disk && (
-          <Section
-            // pain
-            title={
-              disk_name
-                ? disk_name.substring(0, disk_name.length - 5)
-                : 'No Job Disk Inserted'
-            }
-            buttons={
-              <Button
-                icon="eject"
-                content="Eject Disk"
-                disabled={!disk_name}
-                onClick={() => act('PC_Eject_Disk', { name: 'remove_disk' })}
-              />
-            }>
-            <Table>
-              {disk_programs.map((program) => (
-                <Table.Row key={program.name}>
-                  <Table.Cell>
-                    <Button
-                      fluid
-                      color={program.alert ? 'yellow' : 'transparent'}
-                      icon={program.icon}
-                      content={program.desc}
-                      onClick={() =>
-                        act('PC_runprogram', {
-                          name: program.name,
-                          is_disk: true,
-                        })
-                      }
-                    />
-                  </Table.Cell>
-                  <Table.Cell collapsing width="18px">
-                    {!!program.running && (
-                      <Button
-                        color="transparent"
-                        icon="times"
-                        tooltip="Close program"
-                        tooltipPosition="left"
-                        onClick={() =>
-                          act('PC_killprogram', {
-                            name: program.name,
-                          })
-                        }
-                      />
-                    )}
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-            </Table>
-          </Section>
-        )}
       </NtosWindow.Content>
     </NtosWindow>
   );


### PR DESCRIPTION
## About The Pull Request

* Removes unnecessary support for the now-removed job disks from Tablet's TGUI menu, and tablet's ui_act.
* Adds autodoc comments to computer files
* Removes the unused 'unsendable' var on computer files
* Generally improves code on tablets, now process isn't looping through every idle thread twice!
* Moves the check for program in idle_threads above checking if supported by hardware, because it's already running, so there's no need to check.

## Why It's Good For The Game

Every time I look at PDA's code, I am disappointed. I started the hardware removal PRs to make it a little less depressing to look at, but this is just a more general cleanup with no specific target.

## Changelog

Not necessary