### PR TITLE
Fix: Blood Deficiency removing more blood than intended

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -62,7 +62,7 @@
 	hardcore_value = 8
 	processing_quirk = TRUE
 	mail_goodies = list(/obj/item/reagent_containers/blood/o_minus) // universal blood type that is safe for all
-	var/minimum_blood = BLOOD_VOLUME_SAFE - 25 // just barely survivable without treatment
+	var/min_blood = BLOOD_VOLUME_SAFE - 25 // just barely survivable without treatment
 
 /datum/quirk/blooddeficiency/process(delta_time)
 	if(quirk_holder.stat == DEAD)
@@ -72,14 +72,10 @@
 	if(NOBLOOD in carbon_target.dna.species.species_traits) //can't lose blood if your species doesn't have any
 		return
 
-	if (carbon_target.blood_volume <= minimum_blood)
+	if (carbon_target.blood_volume <= min_blood)
 		return
-	var/reduced_blood_volume = carbon_target.blood_volume - 0.275 * delta_time
-	// Ensures that we don't reduce total blood volume below minimum_blood.
-	if (reduced_blood_volume < minimum_blood)
-		carbon_target.blood_volume = minimum_blood
-	else
-		carbon_target.blood_volume = reduced_blood_volume
+	// Ensures that we don't reduce total blood volume below min_blood.
+	carbon_target.blood_volume = max(min_blood, carbon_target.blood_volume - 0.275 * delta_time)
 
 /datum/quirk/item_quirk/blindness
 	name = "Blind"

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -63,6 +63,7 @@
 	processing_quirk = TRUE
 	mail_goodies = list(/obj/item/reagent_containers/blood/o_minus) // universal blood type that is safe for all
 	var/min_blood = BLOOD_VOLUME_SAFE - 25 // just barely survivable without treatment
+	var/drain_rate = 0.275
 
 /datum/quirk/blooddeficiency/process(delta_time)
 	if(quirk_holder.stat == DEAD)
@@ -75,7 +76,7 @@
 	if (carbon_target.blood_volume <= min_blood)
 		return
 	// Ensures that we don't reduce total blood volume below min_blood.
-	carbon_target.blood_volume = max(min_blood, carbon_target.blood_volume - 0.275 * delta_time)
+	carbon_target.blood_volume = max(min_blood, carbon_target.blood_volume - drain_rate * delta_time)
 
 /datum/quirk/item_quirk/blindness
 	name = "Blind"

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -62,17 +62,24 @@
 	hardcore_value = 8
 	processing_quirk = TRUE
 	mail_goodies = list(/obj/item/reagent_containers/blood/o_minus) // universal blood type that is safe for all
+	var/minimum_blood = BLOOD_VOLUME_SAFE - 25 // just barely survivable without treatment
 
 /datum/quirk/blooddeficiency/process(delta_time)
 	if(quirk_holder.stat == DEAD)
 		return
 
-	var/mob/living/carbon/human/H = quirk_holder
-	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
+	var/mob/living/carbon/human/carbon_target = quirk_holder
+	if(NOBLOOD in carbon_target.dna.species.species_traits) //can't lose blood if your species doesn't have any
 		return
 
-	if (H.blood_volume > (BLOOD_VOLUME_SAFE - 25)) // just barely survivable without treatment
-		H.blood_volume -= 0.275 * delta_time
+	if (carbon_target.blood_volume <= minimum_blood)
+		return
+	var/reduced_blood_volume = carbon_target.blood_volume - 0.275 * delta_time
+	// Ensures that we don't reduce total blood volume below minimum_blood.
+	if (reduced_blood_volume < minimum_blood)
+		carbon_target.blood_volume = minimum_blood
+	else
+		carbon_target.blood_volume = reduced_blood_volume
 
 /datum/quirk/item_quirk/blindness
 	name = "Blind"


### PR DESCRIPTION
## About The Pull Request
This PR fixes a rare bug in the Blood Deficiency quirk which causes it to drain more blood than intended. The bug only affects high-population servers. Players on high-jitter high-population servers reported that their characters sustained excess damage and suddenly "dropped dead" when using the Blood Deficiency quirk or subclasses of it. Upon investigation I found they had lost more blood than the quirk is supposed to remove. The fix is straightforward, we just have to use the `max` proc.

The calculation Blood Deficiency uses to reduce blood volume is highly vulnerable to scheduling delays, although it appears to be fool-proof at first glance: `carbon_target.blood_volume -= 0.275 * delta_time`. On very high-pop servers, and during times when the processing subsystem may wait to execute `process` for extended periods, the critical `delta_time` variable becomes excessively large. The subsequent blood loss caused by the quirk may continue far below `BLOOD_VOLUME_SAFE` and cause the mob to gain excess damage or instantly die. The bug is not specific to the Blood Deficiency quirk, and affects all quirks which utilize processing and `process(delta_time)` to perform time-based stats changes if they don't use `max`, `min`, or similar. For example, the Brain Tumor quirk is also noticeably affected by highly loaded servers with long wait times.

## Why It's Good For The Game 
This PR fixes a rare issue which causes the Blood Deficiency quirk to drain blood past its programmed minimums, which sometimes kills players much earlier than the quirk was intended to. This PR mostly benefits high-pop servers and big (laggy) downstream repos, and I can't imagine this bug ever impacting a TG server unless it had a large amount of players and CPU load.

## Changelog

:cl:
fix: Fixed a bug causing Blood Deficiency to remove more blood than intended.
/:cl:
