### PR TITLE
Russian revolver now lets you suicide with it

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -383,7 +383,6 @@
 	return FALSE
 
 /obj/item/gun/ballistic/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-
 	if(magazine && chambered.loaded_projectile && can_misfire && misfire_probability > 0)
 		if(prob(misfire_probability))
 			if(blow_up(user))
@@ -391,14 +390,13 @@
 
 	if (sawn_off)
 		bonus_spread += SAWN_OFF_ACC_PENALTY
-	. = ..()
+	return ..()
 
 /obj/item/gun/ballistic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
 	if(can_misfire)
 		misfire_probability += misfire_percentage_increment
 		misfire_probability = clamp(misfire_probability, 0, misfire_probability_cap)
-
-	. = ..()
+	return ..()
 
 ///Installs a new suppressor, assumes that the suppressor is already in the contents of src
 /obj/item/gun/ballistic/proc/install_suppressor(obj/item/suppressor/S)
@@ -539,6 +537,7 @@
 
 #define BRAINS_BLOWN_THROW_RANGE 3
 #define BRAINS_BLOWN_THROW_SPEED 1
+
 /obj/item/gun/ballistic/suicide_act(mob/user)
 	var/obj/item/organ/internal/brain/B = user.getorganslot(ORGAN_SLOT_BRAIN)
 	if (B && chambered && chambered.loaded_projectile && can_trigger_gun(user) && !chambered.loaded_projectile.nodamage)
@@ -561,6 +560,7 @@
 		user.visible_message(span_suicide("[user] is pretending to blow [user.p_their()] brain[user.p_s()] out with [src]! It looks like [user.p_theyre()] trying to commit suicide!</b>"))
 		playsound(src, dry_fire_sound, 30, TRUE)
 		return (OXYLOSS)
+
 #undef BRAINS_BLOWN_THROW_SPEED
 #undef BRAINS_BLOWN_THROW_RANGE
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -190,11 +190,10 @@
 		if(!can_trigger_gun(user))
 			return
 	if(target != user)
-		if(ismob(target))
-			playsound(src, dry_fire_sound, 30, TRUE)
-			user.visible_message(
-				span_danger("[user.name] tries to fire \the [src] at the same time, but only succeeds at looking like an idiot."), \
-				span_danger("\The [src]'s anti-combat mechanism prevents you from firing it at the same time!"))
+		playsound(src, dry_fire_sound, 30, TRUE)
+		user.visible_message(
+			span_danger("[user.name] tries to fire \the [src] at the same time, but only succeeds at looking like an idiot."), \
+			span_danger("\The [src]'s anti-combat mechanism prevents you from firing it at the same time!"))
 		return
 
 	if(ishuman(user))

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -178,7 +178,7 @@
 		return
 	..()
 
-/obj/item/gun/ballistic/revolver/russian/afterattack(atom/target, mob/living/user, flag, params)
+/obj/item/gun/ballistic/revolver/russian/fire_gun(atom/target, mob/living/user, flag, params)
 	. = ..(null, user, flag, params)
 
 	if(flag)
@@ -191,7 +191,10 @@
 			return
 	if(target != user)
 		if(ismob(target))
-			to_chat(user, span_warning("A mechanism prevents you from shooting anyone but yourself!"))
+			playsound(src, dry_fire_sound, 30, TRUE)
+			user.visible_message(
+				span_danger("[user.name] tries to fire \the [src] at the same time, but only succeeds at looking like an idiot."), \
+				span_danger("\The [src]'s anti-combat mechanism prevents you from firing it at the same time!"))
 		return
 
 	if(ishuman(user))
@@ -240,11 +243,6 @@
 
 		user.visible_message(span_danger("*click*"))
 		playsound(src, dry_fire_sound, 30, TRUE)
-
-/obj/item/gun/ballistic/revolver/russian/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-	add_fingerprint(user)
-	playsound(src, dry_fire_sound, 30, TRUE)
-	user.visible_message(span_danger("[user.name] tries to fire \the [src] at the same time, but only succeeds at looking like an idiot."), span_danger("\The [src]'s anti-combat mechanism prevents you from firing it at the same time!"))
 
 /obj/item/gun/ballistic/revolver/russian/proc/shoot_self(mob/living/carbon/human/user, affecting = BODY_ZONE_HEAD)
 	user.apply_damage(300, BRUTE, affecting)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -193,7 +193,7 @@
 		playsound(src, dry_fire_sound, 30, TRUE)
 		user.visible_message(
 			span_danger("[user.name] tries to fire \the [src] at the same time, but only succeeds at looking like an idiot."), \
-			span_danger("\The [src]'s anti-combat mechanism prevents you from firing it at the same time!"))
+			span_danger("\The [src]'s anti-combat mechanism prevents you from firing it at anyone but yourself!"))
 		return
 
 	if(ishuman(user))


### PR DESCRIPTION
## About The Pull Request

Russian revolvers now use fire_gun instead of afterattack, so the gun's suicide (which uses process_fire) will now work.

I haven't tested if it's still broken, but this seems to fix https://github.com/tgstation/tgstation/issues/66152 too (Monkeys getting aggro on people pointing the gun at them).

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/66152
Russian revolvers now lets you play russian roulette to blow your brains out.

## Changelog

:cl:
fix: Russian revolvers can now be suicided with.
fix: Russian revolvers won't get monkeys pissed at you for pointing it at them, even if you can't fire it.
/:cl: