### PR TITLE
Goodie lockbox contents can no longer go missing

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -526,8 +526,11 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 ///Marks the item as having been transmuted. Functionally blacklists the item from being recycled or sold for materials.
 #define TRAIT_MAT_TRANSMUTED "transmuted"
 
+// cargo traits
 ///If the item will block the cargo shuttle from flying to centcom
 #define TRAIT_BANNED_FROM_CARGO_SHUTTLE "banned_from_cargo_shuttle"
+///If the item's contents are immune to the missing item manifest error
+#define TRAIT_NO_MISSING_ITEM_ERROR "no_missing_item_error"
 
 ///SSeconomy trait, if the market is crashing and people can't withdraw credits from ID cards.
 #define TRAIT_MARKET_CRASHING "market_crashing"

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -223,6 +223,7 @@
 /obj/item/storage/lockbox/order/Initialize(mapload, datum/bank_account/_buyer_account)
 	. = ..()
 	buyer_account = _buyer_account
+	ADD_TRAIT(src, TRAIT_NO_MISSING_ITEM_ERROR, TRAIT_GENERIC)
 
 /obj/item/storage/lockbox/order/attackby(obj/item/W, mob/user, params)
 	if(!isidcard(W))

--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -17,6 +17,10 @@
 	// Stops people from "diving into" a crate you can't open normally
 	divable = FALSE
 
+/obj/structure/closet/crate/large/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NO_MISSING_ITEM_ERROR, TRAIT_GENERIC)
+
 /obj/structure/closet/crate/large/attack_hand(mob/user, list/modifiers)
 	add_fingerprint(user)
 	if(manifest)

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -9,6 +9,10 @@
 	var/tamperproof = 0
 	damage_deflection = 25
 
+/obj/structure/closet/crate/secure/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NO_MISSING_ITEM_ERROR, TRAIT_GENERIC)
+
 /obj/structure/closet/crate/secure/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
 	if(prob(tamperproof) && damage_amount >= DAMAGE_PRECISION)
 		boom()

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -110,7 +110,7 @@
 	manifest_paper.add_raw_text(manifest_text)
 
 	if(manifest_paper.errors & MANIFEST_ERROR_ITEM)
-		if(istype(container, /obj/structure/closet/crate/secure) || istype(container, /obj/structure/closet/crate/large))
+		if(HAS_TRAIT(container, TRAIT_NO_MISSING_ITEM_ERROR))
 			manifest_paper.errors &= ~MANIFEST_ERROR_ITEM
 		else
 			var/lost = max(round(container.contents.len / 10), 1)


### PR DESCRIPTION

## About The Pull Request

Goodie pack lockboxes were not among the types that were immune to the manifest error that deleted items from the crate.  In this PR, I have added the TRAIT_NO_MISSING_ITEM_ERROR, and applied it to these lockboxes, which will prevent this from happening. I have also replaced the existing isType checks for the secure and large wooden crates with a check for this trait.

## Why It's Good For The Game

If your orders go missing, not only your hard earned cash is lost, but the refund for the denied manifest goes to the cargo budget. As the items are secure locked behind an ID lock, it felt right to follow the mechanics of the secure boxes.

Also replaces an isType check for a trait check, which is a bonus.

## Changelog

:cl:
fix: Goodie lockbox contents can no longer go missing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
