### PR TITLE
Allows late-joiners to have a chance at commending other people

### DIFF
--- a/code/__HELPERS/hearted.dm
+++ b/code/__HELPERS/hearted.dm
@@ -9,7 +9,10 @@
 		return
 	message_admins("Polling [number_to_ask] players for commendations.")
 
-	for(var/i in GLOB.joined_player_list)
+	// We need the list to be random, otherwise we'll end up always asking the same people to give out commendations.
+	var/list/eligible_player_list = shuffle(GLOB.joined_player_list)
+
+	for(var/i in eligible_player_list)
 		var/mob/check_mob = get_mob_by_ckey(i)
 		if(!check_mob?.mind || !check_mob.client)
 			continue


### PR DESCRIPTION
## About The Pull Request
Basically, it was iterating the list of the people that had joined the game, in order. There's only one problem with that: The first entries in that list were always the round-start people, so as soon as you late-join into the shift, you can say goodbye to your chance at commending someone else, which explains why certain players claim to never have had the chance to commend someone else whilst I can oftentimes get the prompt for three or four rounds in a row.

## Why It's Good For The Game
Makes the system work as intended, by _actually_ making everyone that joined the round and is still alive at the end of it, a chance to commend others.

## Changelog

:cl: GoldenAlpharex
fix: The prompt to commend someone else for their good behavior will now properly be given out randomly, allowing those that late-join to give them out as well.
/:cl: