### PR TITLE
Fixes directional light overlay leaking the lighting mask and not updating direction correctly

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -251,7 +251,8 @@
 			RegisterSignal(new_holder, COMSIG_MOVABLE_MOVED, .proc/on_holder_moved)
 		if(directional)
 			RegisterSignal(new_holder, COMSIG_ATOM_DIR_CHANGE, .proc/on_holder_dir_change)
-			set_direction(new_holder.dir)
+	if(directional && current_direction != new_holder.dir)
+		current_direction = new_holder.dir
 	if(overlay_lighting_flags & LIGHTING_ON)
 		add_dynamic_lumi()
 		make_luminosity_update()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There were a couple of bugs happening regarding directional light overlays and setting the holder.

- When changing the holder from a non-parent holder (like a player) to the parent (like a flashlight) the light overlay's direction wasn't updated, resulting in overlay direction desyncs such as this:

### Dropping a flashlight, with the cone pointing south (flashlight direction) but the mask facing east
![Dropping a flashlight resulting in broken lighting overlay](https://user-images.githubusercontent.com/1185434/196058296-5c6c7acd-d89d-4b78-bd53-542dc5b2c096.png)

- Likewise, if the flashlight went between 2 holders and DID call set_direction(), there ended up being leaked underlays stuck to the player or whatever holder involved because `set_direction()` adds an underlay, and then `add_dynamic_lumi()` was called adding a second underlay and leaking the first one.
  - This may have been the cause of #66097 but I'm honestly not sure due to lack of details.

Fixes this by always updating direction on holder change, and specifically not calling `set_direction()` since I don't want the update code to trigger.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Flashlights and similar directional light items no longer make you glow forever under certain circumstances.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
