### PR TITLE
Fixes secbot stun runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -324,14 +324,14 @@
 		current_target.set_stutter(10 SECONDS)
 		threat = current_target.assess_threat(judgement_criteria, weaponcheck = CALLBACK(src, .proc/check_for_weapons))
 
-	log_combat(src, target, "stunned")
+	log_combat(src, current_target, "stunned")
 	if(security_mode_flags & SECBOT_DECLARE_ARRESTS)
 		var/area/location = get_area(src)
 		speak("[security_mode_flags & SECBOT_HANDCUFF_TARGET ? "Arresting" : "Detaining"] level [threat] scumbag <b>[current_target]</b> in [location].", radio_channel)
 	current_target.visible_message(span_danger("[src] stuns [current_target]!"),\
 							span_userdanger("[src] stuns you!"))
 
-	target_lastloc = target.loc
+	target_lastloc = current_target.loc
 	mode = BOT_PREP_ARREST
 
 /mob/living/simple_animal/bot/secbot/handle_automated_action()


### PR DESCRIPTION
Wrong target.

:cl: ShizCalev
fix: Fixed a minor runtime keeping player controlled secbots from switching to arrest mode automatically after stunning someone. This also fixed the stun action being combat logged for an incorrect mob.
/:cl:

```
[23:14:49] Runtime in secbot.dm, line 334: Cannot read null.loc
proc name: stun attack (/mob/living/simple_animal/bot/secbot/proc/stun_attack)
usr: Indie-ana Jones/(Securitron)
usr.loc: (Hydroponics (131,112,2))
src: the Securitron (/mob/living/simple_animal/bot/secbot)
src.loc: the floor (131,112,2) (/turf/open/floor/iron)
call stack:
the Securitron (/mob/living/simple_animal/bot/secbot): stun attack(Manley Jyllian (/mob/living/carbon/human), 0)
the Securitron (/mob/living/simple_animal/bot/secbot): UnarmedAttack(Manley Jyllian (/mob/living/carbon/human), 1, /list (/list))
the Securitron (/mob/living/simple_animal/bot/secbot): ClickOn(Manley Jyllian (/mob/living/carbon/human), "icon-x=2;icon-y=17;left=1;butt...")
Manley Jyllian (/mob/living/carbon/human): Click(the floor (131,112,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=2;icon-y=17;left=1;butt...")
Indie-ana Jones (/client): Click(Manley Jyllian (/mob/living/carbon/human), the floor (131,112,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=2;icon-y=17;left=1;butt...")
Manley Jyllian (/mob/living/carbon/human): MouseDrop(Manley Jyllian (/mob/living/carbon/human), the floor (131,112,2) (/turf/open/floor/iron), the floor (131,112,2) (/turf/open/floor/iron), "mapwindow.map", "mapwindow.map", "icon-x=2;icon-y=17;left=1;butt...")
Manley Jyllian (/mob/living/carbon/human): MouseDrop(Manley Jyllian (/mob/living/carbon/human), the floor (131,112,2) (/turf/open/floor/iron), the floor (131,112,2) (/turf/open/floor/iron), "mapwindow.map", "mapwindow.map", "icon-x=2;icon-y=17;left=1;butt...")
Indie-ana Jones (/client): MouseDrop(Manley Jyllian (/mob/living/carbon/human), Manley Jyllian (/mob/living/carbon/human), the floor (131,112,2) (/turf/open/floor/iron), the floor (131,112,2) (/turf/open/floor/iron), "mapwindow.map", "mapwindow.map", "icon-x=2;icon-y=17;left=1;butt...")
```