### PR TITLE
Fixes observer point_at queued verb runtime

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -693,7 +693,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!..())
 		return FALSE
 
-	usr.visible_message(span_deadsay("<b>[src]</b> points to [pointed_at]."))
+	visible_message(span_deadsay("<b>[src]</b> points to [pointed_at]."))
 
 /mob/dead/observer/verb/view_manifest()
 	set name = "View Crew Manifest"


### PR DESCRIPTION
No need for this to be from usr, src is fine. Verb queuing didn't like it.

```
[00:20:07] Runtime in observer.dm, line 696: Cannot execute null.visible message().
proc name: pointed (/mob/dead/observer/_pointed)
src: Fire-Burns-Dim (/mob/dead/observer)
src.loc: null
call stack:
Fire-Burns-Dim (/mob/dead/observer): pointed(Fire-Burns-Dim (/mob/living/carbon/human))
/datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
Verb Manager (/datum/controller/subsystem/verb_manager): run verb queue()
Verb Manager (/datum/controller/subsystem/verb_manager): fire(0)
Verb Manager (/datum/controller/subsystem/verb_manager): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```

:cl: ShizCalev
fix: Fixed a possible scenario which could result in ghosts not sending a chat message properly when pointing during high time dilation.
/:cl: