### PR TITLE
You cannot plant c4 on observers

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -85,6 +85,8 @@
 /obj/item/grenade/c4/afterattack(atom/movable/bomb_target, mob/user, flag)
 	. = ..()
 	aim_dir = get_dir(user, bomb_target)
+	if(isobserver(bomb_target))
+		return
 	if(!flag)
 		return
 	if(bomb_target != user && HAS_TRAIT(user, TRAIT_PACIFISM) && isliving(bomb_target))

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -85,7 +85,7 @@
 /obj/item/grenade/c4/afterattack(atom/movable/bomb_target, mob/user, flag)
 	. = ..()
 	aim_dir = get_dir(user, bomb_target)
-	if(isobserver(bomb_target))
+	if(isdead(bomb_target))
 		return
 	if(!flag)
 		return


### PR DESCRIPTION
## About The Pull Request

Very clever use of the ghost sword (or wizards, badmins, etc) allowed you to target visible ghosted players with c4.
The player who found this bug dared me to fix it. You're welcome.

## Why It's Good For The Game

Letting living players use the capricious ghosts to teleport explosives to literally anywhere in the world, while a hilarious idea, is also not a good idea.

## Changelog

:cl:
fix: Plastic explosives can no longer be planted on observer players when made visible.
/:cl: