### PR TITLE
Fixes leftover uses of hallucination var

### DIFF
--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -56,8 +56,6 @@
 	VAR_PROTECTED/lying_angle = 0
 	/// Value of lying lying_angle before last change. TODO: Remove the need for this.
 	var/lying_prev = 0
-	///Directly affects how long a mob will hallucinate for
-	var/hallucination = 0
 	///Used by the resist verb, likely used to prevent players from bypassing next_move by logging in/out.
 	var/last_special = 0
 	var/timeofdeath = 0

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1239,5 +1239,5 @@
 	health_required = 10
 
 /datum/reagent/toxin/viperspider/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.hallucination += 5 * REM * delta_time
+	M.adjust_hallucinations(10 SECONDS * REM * delta_time)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Left cause of merge skew when the hallucination refactor went through

`var/hallucination` does nothing and is a dead var now, 

## Why It's Good For The Game

Things actually hallucinate when expected!

10 seconds per life tick (uncapped) is a little insane btw but balance moment

## Changelog

:cl: Melbert
fix: Viper spider venom actually causes hallucinations
/:cl:
