### PR TITLE
ORM welds to the floor

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -177,7 +177,7 @@
 /obj/machinery/mineral/ore_redemption/can_be_unfasten_wrench(mob/user, silent)
 	if(welded)
 		if(!silent)
-			to_chat(user, span_warning("[src] is welded to the floor!"))
+			balloon_alert(user, "it's welded!")
 		return FAILED_UNFASTEN
 
 	return ..()
@@ -192,29 +192,23 @@
 	if(welded)
 		if(!item.tool_start_check(user, amount=0))
 			return TRUE
-		user.visible_message(span_notice("[user.name] starts to cut the [name] free from the floor."), \
-			span_notice("You start to cut [src] free from the floor..."), \
-			span_hear("You hear welding."))
+		user.balloon_alert_to_viewers("unwelding...")
 		if(!item.use_tool(src, user, 20, 1, 50))
 			return FALSE
 		welded = FALSE
-		to_chat(user, span_notice("You cut [src] free from the floor."))
-		update_cable_icons_on_turf(get_turf(src))
+		balloon_alert(user, "unwelded")
 		return TRUE
 
 	if(!anchored)
-		to_chat(user, span_warning("[src] needs to be wrenched to the floor!"))
+	balloon_alert(user, "wrench it first!")
 		return TRUE
 	if(!item.tool_start_check(user, amount=0))
 		return TRUE
-	user.visible_message(span_notice("[user.name] starts to weld the [name] to the floor."), \
-		span_notice("You start to weld [src] to the floor..."), \
-		span_hear("You hear welding."))
+	user.balloon_alert_to_viewers("unwelding...")
 	if(!item.use_tool(src, user, 20, 1, 50))
 		return FALSE
 	welded = TRUE
-	to_chat(user, span_notice("You weld [src] to the floor."))
-	update_cable_icons_on_turf(get_turf(src))
+	balloon_alert(user, "welded")
 	return TRUE
 	
 /obj/machinery/mineral/ore_redemption/attackby(obj/item/W, mob/user, params)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -151,20 +151,6 @@
 		// gives 5 seconds for a load of ores to be sucked up by the ORM before it sends out request console notifications. This should be enough time for most deposits that people make
 		console_notify_timer = addtimer(CALLBACK(src, .proc/send_console_message), 5 SECONDS)
 
-/obj/machinery/mineral/ore_redemption/default_unfasten_wrench(mob/user, obj/item/I)
-	. = ..()
-	if(. != SUCCESSFUL_UNFASTEN)
-		return
-	if(anchored)
-		register_input_turf() // someone just wrenched us down, re-register the turf
-	else
-		unregister_input_turf() // someone just un-wrenched us, unregister the turf
-
-/obj/machinery/mineral/ore_redemption/wrench_act(mob/living/user, obj/item/tool)
-	. = ..()
-	default_unfasten_wrench(user, tool)
-	return TOOL_ACT_TOOLTYPE_SUCCESS
-
 /obj/machinery/mineral/ore_redemption/attackby(obj/item/W, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "ore_redemption-open", "ore_redemption", W))
 		return

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -177,7 +177,7 @@
 /obj/machinery/mineral/ore_redemption/can_be_unfasten_wrench(mob/user, silent)
 	if(welded)
 		if(!silent)
-			balloon_alert(user, "it's welded!")
+			to_chat(user, span_warning("[src] is welded to the floor!"))
 		return FAILED_UNFASTEN
 
 	return ..()
@@ -192,23 +192,29 @@
 	if(welded)
 		if(!item.tool_start_check(user, amount=0))
 			return TRUE
-		user.balloon_alert_to_viewers("unwelding...")
+		user.visible_message(span_notice("[user.name] starts to cut the [name] free from the floor."), \
+			span_notice("You start to cut [src] free from the floor..."), \
+			span_hear("You hear welding."))
 		if(!item.use_tool(src, user, 20, 1, 50))
 			return FALSE
 		welded = FALSE
-		balloon_alert(user, "unwelded")
+		to_chat(user, span_notice("You cut [src] free from the floor."))
+		update_cable_icons_on_turf(get_turf(src))
 		return TRUE
 
 	if(!anchored)
-	balloon_alert(user, "wrench it first!")
+		to_chat(user, span_warning("[src] needs to be wrenched to the floor!"))
 		return TRUE
 	if(!item.tool_start_check(user, amount=0))
 		return TRUE
-	user.balloon_alert_to_viewers("unwelding...")
+	user.visible_message(span_notice("[user.name] starts to weld the [name] to the floor."), \
+		span_notice("You start to weld [src] to the floor..."), \
+		span_hear("You hear welding."))
 	if(!item.use_tool(src, user, 20, 1, 50))
 		return FALSE
 	welded = TRUE
-	balloon_alert(user, "welded")
+	to_chat(user, span_notice("You weld [src] to the floor."))
+	update_cable_icons_on_turf(get_turf(src))
 	return TRUE
 	
 /obj/machinery/mineral/ore_redemption/attackby(obj/item/W, mob/user, params)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -193,7 +193,7 @@
 		if(!item.tool_start_check(user, amount=0))
 			return TRUE
 		user.balloon_alert_to_viewers("unwelding...")
-		if(!item.use_tool(src, user, 20, 1, 50))
+		if(!item.use_tool(src, user, 100, 1, 50))
 			return FALSE
 		welded = FALSE
 		balloon_alert(user, "unwelded")
@@ -205,7 +205,7 @@
 	if(!item.tool_start_check(user, amount=0))
 		return TRUE
 	user.balloon_alert_to_viewers("welding...")
-	if(!item.use_tool(src, user, 20, 1, 50))
+	if(!item.use_tool(src, user, 100, 1, 50))
 		return FALSE
 	welded = TRUE
 	balloon_alert(user, "welded")

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -177,7 +177,7 @@
 /obj/machinery/mineral/ore_redemption/can_be_unfasten_wrench(mob/user, silent)
 	if(welded)
 		if(!silent)
-			to_chat(user, span_warning("[src] is welded to the floor!"))
+			balloon_alert(user, "it's welded!")
 		return FAILED_UNFASTEN
 
 	return ..()
@@ -192,29 +192,23 @@
 	if(welded)
 		if(!item.tool_start_check(user, amount=0))
 			return TRUE
-		user.visible_message(span_notice("[user.name] starts to cut the [name] free from the floor."), \
-			span_notice("You start to cut [src] free from the floor..."), \
-			span_hear("You hear welding."))
+		user.balloon_alert_to_viewers("unwelding...")
 		if(!item.use_tool(src, user, 20, 1, 50))
 			return FALSE
 		welded = FALSE
-		to_chat(user, span_notice("You cut [src] free from the floor."))
-		update_cable_icons_on_turf(get_turf(src))
+		balloon_alert(user, "unwelded")
 		return TRUE
 
 	if(!anchored)
-		to_chat(user, span_warning("[src] needs to be wrenched to the floor!"))
+		balloon_alert(user, "wrench it first!")
 		return TRUE
 	if(!item.tool_start_check(user, amount=0))
 		return TRUE
-	user.visible_message(span_notice("[user.name] starts to weld the [name] to the floor."), \
-		span_notice("You start to weld [src] to the floor..."), \
-		span_hear("You hear welding."))
+	user.balloon_alert_to_viewers("welding...")
 	if(!item.use_tool(src, user, 20, 1, 50))
 		return FALSE
 	welded = TRUE
-	to_chat(user, span_notice("You weld [src] to the floor."))
-	update_cable_icons_on_turf(get_turf(src))
+	balloon_alert(user, "welded")
 	return TRUE
 	
 /obj/machinery/mineral/ore_redemption/attackby(obj/item/W, mob/user, params)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -193,7 +193,7 @@
 		if(!item.tool_start_check(user, amount=0))
 			return TRUE
 		user.balloon_alert_to_viewers("unwelding...")
-		if(!item.use_tool(src, user, 100, 1, 50))
+		if(!item.use_tool(src, user, 10 SECONDS, 1, 50))
 			return FALSE
 		welded = FALSE
 		balloon_alert(user, "unwelded")
@@ -205,7 +205,7 @@
 	if(!item.tool_start_check(user, amount=0))
 		return TRUE
 	user.balloon_alert_to_viewers("welding...")
-	if(!item.use_tool(src, user, 100, 1, 50))
+	if(!item.use_tool(src, user, 10 SECONDS, 1, 50))
 		return FALSE
 	welded = TRUE
 	balloon_alert(user, "welded")

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -193,7 +193,7 @@
 		if(!item.tool_start_check(user, amount=0))
 			return TRUE
 		user.balloon_alert_to_viewers("unwelding...")
-		if(!item.use_tool(src, user, 10 SECONDS, 1, 50))
+		if(!item.use_tool(src, user, 10 SECONDS, amount = 1, volume = 50))
 			return FALSE
 		welded = FALSE
 		balloon_alert(user, "unwelded")
@@ -205,7 +205,7 @@
 	if(!item.tool_start_check(user, amount=0))
 		return TRUE
 	user.balloon_alert_to_viewers("welding...")
-	if(!item.use_tool(src, user, 10 SECONDS, 1, 50))
+	if(!item.use_tool(src, user, 10 SECONDS, amount = 1, volume = 50))
 		return FALSE
 	welded = TRUE
 	balloon_alert(user, "welded")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is my second attempt at fixing an exploit where cargo can easily be broken into by unwrenching the ORM and dragging it out of the way. I essentially adapted the code from emitters to use the way that they must be unwelded from the floor before unwrenching. The ORM will still function as normal whether or not it secured but will now be both wrenched and welded to the floor at round start. This effectively makes it nearly as secure as a standard wall. Anyone attempting to exploit the ORM to break into cargo will have to unweld it first or else deconstruct it completely.

Additionally, I added examine text for securing the ORM that was missing before.

## Why It's Good For The Game

It will now take more than a just wrench for any bozo to break into the cargo bay.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: ORM can now be welded to the floor, and is welded round start
qol: ORM now has examine text for anchoring it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
