### PR TITLE
Fixes grammar in statue code

### DIFF
--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -389,7 +389,7 @@ Moving interrupts
 
 /obj/structure/carving_block
 	name = "block"
-	desc = "ready for sculpting."
+	desc = "Ready for sculpting."
 	icon = 'icons/obj/art/statue.dmi'
 	icon_state = "block"
 	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS | MATERIAL_ADD_PREFIX
@@ -460,7 +460,7 @@ Moving interrupts
 		new_statue.set_custom_materials(custom_materials)
 		var/mutable_appearance/ma = current_target
 		new_statue.name = "statue of [ma.name]"
-		new_statue.desc = "statue depicting [ma.name]"
+		new_statue.desc = "A carved statue depicting [ma.name]."
 		qdel(src)
 
 /obj/structure/carving_block/proc/set_completion(value)


### PR DESCRIPTION
## About The Pull Request
Essentially just puts a full stop and some capital letters on some old code so that it reads a tiny bit nicer. Also makes the Statue description make sense.

## Why It's Good For The Game
Grammar is good, and consistency in the way we write descriptions is good too!

## Changelog
:cl:
spellcheck: Statue descriptions now have full stops and capital letters. 
/:cl:

