### PR TITLE
Fixes some grammar in sleeper protocol code

### DIFF
--- a/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
+++ b/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
@@ -66,7 +66,7 @@
 
 /obj/item/disk/surgery/sleeper_protocol
 	name = "Suspicious Surgery Disk"
-	desc = "The disk provides instructions on how to turn someone into a sleeper agent for the Syndicate"
+	desc = "The disk provides instructions on how to turn someone into a sleeper agent for the Syndicate."
 	surgeries = list(/datum/surgery/advanced/brainwashing_sleeper)
 
 /datum/surgery/advanced/brainwashing_sleeper
@@ -94,12 +94,12 @@
 /datum/surgery_step/brainwash/sleeper_agent
 	time = 25 SECONDS
 	var/static/list/possible_objectives = list(
-		"You love the Syndicate",
-		"Do not trust Nanotrasen",
-		"The Captain is a lizardperson",
-		"Nanotrasen isn't real",
-		"They put things in the food to make you forget",
-		"You are the only real person on the station"
+		"You love the Syndicate.",
+		"Do not trust Nanotrasen.",
+		"The Captain is a lizardperson.",
+		"Nanotrasen isn't real.",
+		"They put something in the food to make you forget.",
+		"You are the only real person on the station."
 	)
 
 /datum/surgery_step/brainwash/sleeper_agent/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
## About The Pull Request
Switches "things" for "something" and puts punctuation at the end of all the objectives for the sleeper protocol. Also adds a full stop to the description of the disk.

## Why It's Good For The Game
More grammar fixes, it's just nice to have consistent grammar when possible! This also makes these objectives fit with other existing objectives that end in full stops.

## Changelog
:cl:
spellcheck: Sleeper protocol grammar is better now. Wahoo!
/:cl:
