### PR TITLE
Removes the explosive holoparasite's teleportation punch ability

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -10,7 +10,7 @@
 	melee_damage_upper = 15
 	damage_coeff = list(BRUTE = 0.6, BURN = 0.6, TOX = 0.6, CLONE = 0.6, STAMINA = 0, OXY = 0.6)
 	range = 13
-	playstyle_string = "<span class='holoparasite'>As an <b>explosive</b> type, you have moderate close combat abilities, may explosively teleport targets on attack, and are capable of converting nearby items and objects into disguised bombs via alt click.</span>"
+	playstyle_string = "<span class='holoparasite'>As an <b>explosive</b> type, you have moderate close combat abilities and are capable of converting nearby items and objects into disguised bombs via alt click.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the Scientist, master of explosive death.</span>"
 	tech_fluff_string = "<span class='holoparasite'>Boot sequence complete. Explosive modules active. Holoparasite swarm online.</span>"
 	carp_fluff_string = "<span class='holoparasite'>CARP CARP CARP! Caught one! It's an explosive carp! Boom goes the fishy.</span>"
@@ -22,20 +22,6 @@
 	. = ..()
 	if(bomb_cooldown >= world.time)
 		. += "Bomb Cooldown Remaining: [DisplayTimeText(bomb_cooldown - world.time)]"
-
-/mob/living/simple_animal/hostile/guardian/bomb/AttackingTarget()
-	. = ..()
-	if(. && prob(40) && isliving(target))
-		var/mob/living/M = target
-		if(!M.anchored && M != summoner && !hasmatchingsummoner(M))
-			new /obj/effect/temp_visual/guardian/phase/out(get_turf(M))
-			do_teleport(M, M, 10, channel = TELEPORT_CHANNEL_BLUESPACE)
-			for(var/mob/living/L in range(1, M))
-				if(hasmatchingsummoner(L)) //if the summoner matches don't hurt them
-					continue
-				if(L != src && L != summoner)
-					L.apply_damage(15, BRUTE)
-			new /obj/effect/temp_visual/explosion(get_turf(M))
 
 /mob/living/simple_animal/hostile/guardian/bomb/AltClickOn(atom/movable/A)
 	if(!istype(A))


### PR DESCRIPTION
## About The Pull Request

Explosive holoparasites no longer have a 40% chance per punch to teleport living creatures they punch up to 10 tiles away in a random direction (with a 15 brute damage rider).

## Why It's Good For The Game

Currently, the optimal way to play an explosive holoparasite is to... never punch anyone. As a punch ghost.

This is because each of your punches have a 40% chance to teleport your target away, often to safety. They can teleport to an area you don't have access to, some unknown location outside of your line of sight, or even the middle of a primary hallway with several witnesses. It is very possible that punching even a critted victim or corpse will out your existence (as an explosive holoparasite) to the station, and possibly even your master's identity if paramedics/bystanders can reach whatever location the corpse teleported to before you can. Thus, the optimal play is to just... stand by as your master bashes the heads of your victims in with a fire extinguisher.

Punch ghosts should not be afraid to punch people because of a power that's supposed to help them.

![image](https://user-images.githubusercontent.com/42606352/196309653-1db93da5-553d-48cd-8274-2d4d0f3a816b.png)

_also what the fuck is this ability even based on killer queen never did anything like this in the source material they had so many secondary powers to choose from and you just made one up instead of picking one of them why_

## Changelog
:cl: ATHATH
del: Explosive holoparasites no longer have a 40% chance per punch to teleport their victims up to 10 tiles away. They can now join the other holoparasite types in partaking in the pastime of brutalizing the bleeding corpses of their victims without worrying about accidentally teleporting them into a primary hallway.
/:cl: