### PR TITLE
Remove unnecessary doorjack visible messages

### DIFF
--- a/code/modules/pai/door_jack.dm
+++ b/code/modules/pai/door_jack.dm
@@ -88,7 +88,6 @@
  * Handles deleting the hacking cable and notifying the user.
  */
 /mob/living/silicon/pai/proc/retract_cable()
-	hacking_cable.visible_message(span_notice("The cable quickly retracts."))
 	balloon_alert(src, "cable retracted")
 	QDEL_NULL(hacking_cable)
 	return TRUE
@@ -112,8 +111,6 @@
 	// Now begin hacking
 	if(!do_after(src, 15 SECONDS, hacking_cable.machine, timed_action_flags = NONE,	progress = TRUE))
 		balloon_alert(src, "failed! retracting...")
-		hacking_cable.visible_message(
-			span_warning("The cable rapidly retracts back into its spool."), span_hear("You hear a click and the sound of wire spooling rapidly."))
 		untrack_pai()
 		untrack_thing(hacking_cable)
 		QDEL_NULL(hacking_cable)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes some doorjack messages that already have a balloon alert, including one that caused almost 10,000 runtimes in the past 7 days.

Visibility is unimportant to me since these are only relevant to the pAI.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Removed some doorjack chat messages that already have a balloon alert.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
