### PR TITLE
Fix training toolboxes not setting vis_flags correctly

### DIFF
--- a/code/game/objects/structures/training_machine.dm
+++ b/code/game/objects/structures/training_machine.dm
@@ -145,7 +145,7 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(attached_item, COMSIG_PARENT_QDELETING)
 	vis_contents -= attached_item
-	attached_item &= ~(VIS_INHERIT_ID | VIS_INHERIT_PLANE)
+	attached_item.vis_flags &= ~(VIS_INHERIT_ID | VIS_INHERIT_PLANE)
 	attached_item = null
 	handle_density()
 


### PR DESCRIPTION
Not tested don't really know what this does know it was causing runtimes

:cl:
fix: Fixed problems relating to detaching items from training toolboxes.
/:cl: