### PR TITLE
Fixes being unable to old a paper up to AI cameras if you are "unknown"

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -401,7 +401,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 				log_paper("[key_name(user)] held [last_shown_paper] up to [src], requesting [key_name(ai)] read it.")
 
 				if(user.name == "Unknown")
-					to_chat(ai, "[span_name(user)] holds <a href='?_src_=usr;show_paper_note=[REF(last_shown_paper)];'>\a [item_name]</a> up to one of your cameras ...")
+					to_chat(ai, "[span_name("[user]")] holds <a href='?_src_=usr;show_paper_note=[REF(last_shown_paper)];'>\a [item_name]</a> up to one of your cameras ...")
 				else
 					to_chat(ai, "<b><a href='?src=[REF(ai)];track=[html_encode(user.name)]'>[user]</a></b> holds <a href='?_src_=usr;show_paper_note=[REF(last_shown_paper)];'>\a [item_name]</a> up to one of your cameras ...")
 				continue

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -401,7 +401,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 				log_paper("[key_name(user)] held [last_shown_paper] up to [src], requesting [key_name(ai)] read it.")
 
 				if(user.name == "Unknown")
-					to_chat(ai, "[span_name("[user]")] holds <a href='?_src_=usr;show_paper_note=[REF(last_shown_paper)];'>\a [item_name]</a> up to one of your cameras ...")
+					to_chat(ai, "[span_name(user.name)] holds <a href='?_src_=usr;show_paper_note=[REF(last_shown_paper)];'>\a [item_name]</a> up to one of your cameras ...")
 				else
 					to_chat(ai, "<b><a href='?src=[REF(ai)];track=[html_encode(user.name)]'>[user]</a></b> holds <a href='?_src_=usr;show_paper_note=[REF(last_shown_paper)];'>\a [item_name]</a> up to one of your cameras ...")
 				continue


### PR DESCRIPTION
## About The Pull Request

```
[2022-10-17 04:51:07.849] runtime error: type mismatch: "<span class=\'name\'>" + Unknown (/mob/living/carbon/human)
 - proc name: attackby (/obj/machinery/camera/attackby)
 -   source file: camera.dm,404
 -   usr: Unknown (/mob/living/carbon/human)
 -   src: the security camera (/obj/machinery/camera/directional/south)
 ```

`span_name(ref to mob)` tries to do a string concat between a string and a ref to a mob, instead of a string to a string. 

This fixes that by just passing the mob's name, as the next line does. 

## Why It's Good For The Game

One less runtime that breaks a feature

## Changelog

:cl: Melbert
fix: Fixes pressing a paper up to a camera while you are "Unknown".
/:cl:

