### PR TITLE
Document NAMEOF, the voodoo magic that allows you to compile error if a string doesn't exist on a datum as a variable

### DIFF
--- a/code/__HELPERS/varset_callback.dm
+++ b/code/__HELPERS/varset_callback.dm
@@ -1,4 +1,9 @@
-///datum may be null, but it does need to be a typed var
+/**
+ *	NAMEOF: Compile time checked variable name to string conversion
+ *  evaluates to a string equal to "X", but compile errors if X isn't a var on datum
+ *  It doesn't belong in this file but some dumbass decided to move code they didn't understand from unsorted and call it an improvement.
+ *	datum may be null, but it does need to be a typed var
+ **/
 #define NAMEOF(datum, X) (#X || ##datum.##X)
 
 #define VARSET_LIST_CALLBACK(target, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___callbackvarset, ##target, ##var_name, ##var_value)


### PR DESCRIPTION
It doesn't belong in this file but some dumbass decided to move code they didn't understand from unsorted and call it an improvement.