### PR TITLE
Document NAMEOF and put it in a proper file

### DIFF
--- a/code/__HELPERS/nameof.dm
+++ b/code/__HELPERS/nameof.dm
@@ -1,0 +1,7 @@
+/**
+ *	NAMEOF: Compile time checked variable name to string conversion
+ *  evaluates to a string equal to "X", but compile errors if X isn't a var on datum
+ *  It doesn't belong in this file but some dumbass decided to move code they didn't understand from unsorted and call it an improvement.
+ *	datum may be null, but it does need to be a typed var
+ **/
+#define NAMEOF(datum, X) (#X || ##datum.##X)

--- a/code/__HELPERS/nameof.dm
+++ b/code/__HELPERS/nameof.dm
@@ -1,7 +1,6 @@
 /**
- *	NAMEOF: Compile time checked variable name to string conversion
- *  evaluates to a string equal to "X", but compile errors if X isn't a var on datum
- *  It doesn't belong in this file but some dumbass decided to move code they didn't understand from unsorted and call it an improvement.
- *	datum may be null, but it does need to be a typed var
+ * NAMEOF: Compile time checked variable name to string conversion
+ * evaluates to a string equal to "X", but compile errors if X isn't a var on datum.
+ * datum may be null, but it does need to be a typed var.
  **/
 #define NAMEOF(datum, X) (#X || ##datum.##X)

--- a/code/__HELPERS/varset_callback.dm
+++ b/code/__HELPERS/varset_callback.dm
@@ -1,6 +1,3 @@
-///datum may be null, but it does need to be a typed var
-#define NAMEOF(datum, X) (#X || ##datum.##X)
-
 #define VARSET_LIST_CALLBACK(target, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___callbackvarset, ##target, ##var_name, ##var_value)
 //dupe code because dm can't handle 3 level deep macros
 #define VARSET_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___callbackvarset, ##datum, NAMEOF(##datum, ##var), ##var_value)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -334,6 +334,7 @@
 #include "code\__HELPERS\memory_helpers.dm"
 #include "code\__HELPERS\mobs.dm"
 #include "code\__HELPERS\mouse_control.dm"
+#include "code\__HELPERS\nameof.dm"
 #include "code\__HELPERS\names.dm"
 #include "code\__HELPERS\path.dm"
 #include "code\__HELPERS\piping_colors_lists.dm"


### PR DESCRIPTION
Takes the documentation of #70625 and moves it to its own file, rather than the inaccurate varset callback.