### PR TITLE
Fixes organ `on_death` being called for alive mobs

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -334,7 +334,10 @@
 		if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || reagents.has_reagent(/datum/reagent/cryostylane)) // No organ decay if the body contains formaldehyde.
 			return
 		for(var/obj/item/organ/internal/organ as anything in internal_organs)
-			organ.on_death(delta_time, times_fired) //Needed so organs decay while inside the body.
+			// We need to re-check the stat every organ, as one of our others may have revived us
+			if(stat == DEAD)
+				// On-death is where organ decay is handled
+				organ.on_death(delta_time, times_fired)
 		return
 
 	// NOTE: internal_organs_slot is sorted by GLOB.organ_process_order on insertion

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -334,10 +334,11 @@
 		if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || reagents.has_reagent(/datum/reagent/cryostylane)) // No organ decay if the body contains formaldehyde.
 			return
 		for(var/obj/item/organ/internal/organ as anything in internal_organs)
+			// On-death is where organ decay is handled
+			organ.on_death(delta_time, times_fired)
 			// We need to re-check the stat every organ, as one of our others may have revived us
-			if(stat == DEAD)
-				// On-death is where organ decay is handled
-				organ.on_death(delta_time, times_fired)
+			if(stat != DEAD)
+				break
 		return
 
 	// NOTE: internal_organs_slot is sorted by GLOB.organ_process_order on insertion


### PR DESCRIPTION
## About The Pull Request

```
[2022-10-18 00:51:02.192] runtime error: on_death() called for the liver (/obj/item/organ/internal/liver) with not-dead owner (Gyrg-mylin)
 - proc name: on death (/obj/item/organ/internal/liver/on_death)
 -   source file: liver.dm,193
 -   usr: null
 -   src: the liver (/obj/item/organ/internal/liver)
 ```

`on_death` was being called for mobs which were not dead. 

This happened exclusively to Nightmares because their heart has the potential to revive them (change their stat from dead) while this loop was running, meaning it was calling `on_death` for the rest of the organs even though they weren't dead anymore

So, we just need to stat check between `on_death` calls.

## Why It's Good For The Game

Less runtimes

## Changelog

:cl: Melbert
fix: Fixes Nightmare heart revival causing their other organs to not realize they're no longer dead on the same tick. 
/:cl:
