### PR TITLE
Fixes runtime with eye of god on destroy

### DIFF
--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -757,7 +757,9 @@
 	// Behead someone, their "glasses" drop on the floor
 	// and thus, the god eye should no longer be sticky
 	REMOVE_TRAIT(src, TRAIT_NODROP, EYE_OF_GOD_TRAIT)
-	scan_ability.Remove(user)
+	// And remove the scan ability, note that if we're being called from Destroy
+	// that this may already be nulled and removed
+	scan_ability?.Remove(user)
 
 /obj/item/clothing/glasses/godeye/proc/pain(mob/living/victim)
 	to_chat(victim, span_userdanger("You experience blinding pain, as [src] burrows into your skull."))


### PR DESCRIPTION
## About The Pull Request

When a mob is qdel'd, all of their items are qdel'd. When all of their items are qdel'd, `doUnEquip` is called, which calls `dropped`. This caused an error due to order of operations - `Destroy()` qdel_null'd the ability, then dropped tried to remove it, even though it no longer existed. 

So, all this needs is a sanity check before it tries to Remove. Qdel calls remove anyways. 

## Why It's Good For The Game

Less runtimes, even though this one is not noticable

## Changelog

:cl: Melbert
fix: Fixes a runtime from deleting a mob with an eye of god equipped
/:cl:

