### PR TITLE
Fixes Some Incredulously Fucked Up Recycler Behavior

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -159,9 +159,8 @@
 	if(!ismob(AM0))
 		qdel(AM0)
 	else // Lets not qdel a mob, yes?
-		for(var/i in AM0.contents)
-			var/atom/movable/content = i
-			content.moveToNullspace()
+		for(var/iterable in AM0.contents)
+			var/atom/movable/content = iterable
 			qdel(content)
 
 /obj/machinery/recycler/proc/recycle_item(obj/item/I)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -107,6 +107,7 @@
 #include "heretic_knowledge.dm"
 #include "heretic_rituals.dm"
 #include "holidays.dm"
+#include "human_through_recycler.dm"
 #include "hydroponics_extractor_storage.dm"
 #include "hydroponics_harvest.dm"
 #include "hydroponics_self_mutations.dm"

--- a/code/modules/unit_tests/human_through_recycler.dm
+++ b/code/modules/unit_tests/human_through_recycler.dm
@@ -15,7 +15,7 @@
 	// crush_living() on the recycler should have applied the crush_damage to the assistant.
 	var/damage_incurred = assistant.getBruteLoss()
 	TEST_ASSERT_EQUAL(damage_incurred, chewer.crush_damage, "Assistant did not take the expected amount of brute damage ([chewer.crush_damage]) from the emagged recycler! Took ([damage_incurred]) instead.")
-	TEST_ASSERT_EQUAL(chewer.bloody, TRUE, "The emagged recycler did not become bloody after crushing the assistant!")
+	TEST_ASSERT(chewer.bloody, "The emagged recycler did not become bloody after crushing the assistant!")
 
 	// Now, let's test to see if all of their clothing got properly deleted.
 	TEST_ASSERT_EQUAL(length(assistant.contents), 0, "Assistant still has items in its contents after being put through an emagged recycler!")

--- a/code/modules/unit_tests/human_through_recycler.dm
+++ b/code/modules/unit_tests/human_through_recycler.dm
@@ -3,7 +3,7 @@
 
 /datum/unit_test/human_through_recycler/Run()
 	var/mob/living/carbon/human/assistant = allocate(/mob/living/carbon/human, run_loc_floor_bottom_left) // we should be in the bottom_left by default, but let's be sooper dooper sure :)
-	var/obj/machinery/recycler/chewer = allocate(/obj/machinery/recycler/deathtrap, get_step(run_loc_floor_bottom_left, EAST)) //already existing subtype that has emagged set to TRUE, so it shall CHEW. Put it in the top right juuuust in case.
+	var/obj/machinery/recycler/chewer = allocate(/obj/machinery/recycler/deathtrap, get_step(run_loc_floor_bottom_left, EAST)) //already existing subtype that has emagged set to TRUE, so it shall CHEW. Put it directly right to the assistant to mimick a player entering the recycler.
 	assistant.equipOutfit(/datum/outfit/job/assistant/consistent) // consistent assistant juuuust in case
 	var/turf/open/stage = get_turf(chewer)
 	assistant.forceMove(stage) // put the assistant in the recycler, to ensure that the recycler still registers incoming input.

--- a/code/modules/unit_tests/human_through_recycler.dm
+++ b/code/modules/unit_tests/human_through_recycler.dm
@@ -1,0 +1,43 @@
+/// Puts a consistent assistant into an emagged recycler, and verifies that all intended behavior of an emagged recycler occurs (chewing up all the clothing, applying a level of melee damage, etc.)
+/datum/unit_test/human_through_recycler
+
+/datum/unit_test/human_through_recycler/Run()
+	var/mob/living/carbon/human/assistant = allocate(/mob/living/carbon/human, run_loc_floor_bottom_left) // we should be in the bottom_left by default, but let's be sooper dooper sure :)
+	var/obj/machinery/recycler/chewer = allocate(/obj/machinery/recycler/deathtrap, get_step(run_loc_floor_bottom_left, EAST)) //already existing subtype that has emagged set to TRUE, so it shall CHEW. Put it in the top right juuuust in case.
+	assistant.equipOutfit(/datum/outfit/job/assistant/consistent) // consistent assistant juuuust in case
+	var/turf/open/stage = get_turf(chewer)
+	assistant.forceMove(stage) // put the assistant in the recycler, to ensure that the recycler still registers incoming input.
+
+	// okay, let's first test the basics of how an emagged recycler should operate
+	TEST_ASSERT_NULL(QDELETED(assistant), "Assistant was deleted by the emagged recycler!") // The assistant should not be deleted by the recycler.
+	if(assistant.stat < UNCONSCIOUS)
+		TEST_FAIL("Assistant was not made unconscious by the emagged recycler!") // crush_living() on the recycler should have made the assistant unconscious or worse.
+	// crush_living() on the recycler should have applied the crush_damage to the assistant.
+	var/damage_incurred = assistant.getBruteLoss()
+	TEST_ASSERT_EQUAL(damage_incurred, chewer.crush_damage, "Assistant did not take the expected amount of brute damage ([chewer.crush_damage]) from the emagged recycler! Took ([damage_incurred]) instead.")
+	TEST_ASSERT_EQUAL(chewer.bloody, TRUE, "The emagged recycler did not become bloody after crushing the assistant!")
+
+	// Now, let's test to see if all of their clothing got properly deleted.
+	TEST_ASSERT_EQUAL(length(assistant.contents), 0, "Assistant still has items in its contents after being put through an emagged recycler!")
+	// Consistent Assistants will always have the following: ID, PDA, backpack, a uniform, a headset, and a pair of shoes. If any of these are still present, then the recycler did not properly delete the assistant's clothing.
+	// However, let's check for EVERYTHING just in case, because we don't want to miss anything.
+	// This is just what we expect to be deleted.
+	TEST_ASSERT_NULL(assistant.w_uniform, "Assistant still has a jumpsuit (undersuit) on after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.wear_id, "Assistant still has an ID on after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.shoes, "Assistant still has shoes on after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.belt, "Assistant still has an item in their belt slot after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.back, "Assistant still has an item in their back slot (backpack) after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.ears, "Assistant still has a headset on after being put through an emagged recycler!")
+
+	// This category is stuff that shouldn't exist in the first place, but let's test it anyways in case we decide consistent assistants should have more clothing in the future.
+	// Short point short, if any of the following error and none of these are present in the datum for this outfit, what the fuck?
+	TEST_ASSERT_NULL(assistant.wear_suit, "Assistant still has an oversuit on after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.gloves, "Assistant still has gloves on after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.head, "Assistant still has a head covering item on after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.wear_mask, "Assistant still has a mask on after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.l_store, "Assistant still has an item in their left pocket after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.r_store, "Assistant still has an item in their right pocket after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.s_store, "Assistant still has an item in their suit storage slot after being put through an emagged recycler!")
+	TEST_ASSERT_NULL(assistant.glasses, "Assistant still has glasses on after being put through an emagged recycler!")
+
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there!

Did you know that if you toss someone into a recycled emagger, that we delete _all_ of that mob's contents? You probably didn't because this shit is broken broken. Like, ow.

![image](https://user-images.githubusercontent.com/34697715/196551015-e988c44e-2f0d-4d56-91e6-ab38e23532e7.png)

Literally nothing suggested that! The uniform, pointing to nullspace, was still associated to the mob! After four hours of stepping through a debugger, I figured out that it was behavior introduced in #48711.

That's because we manually moved an item to nullspace, which caused a _slew_ of odd behavior in the Destroy chain for `obj/item` since it moves it to nullspace at a very specific point in time and makes all of it's assumptions on when you move the thing to nullspace. If it's in nullspace before you call qdel, you would shit out the ass with hanging references stuck on the mob (like `w_uniform` pointing to something in nullspace, like the image above).

I'm not sure if we were moving stuff to nullspace at the time of that linked PR (hence the confusion between the PR author and ninjanomnom's suggestion), but this shit has likely been broken since 2020.

All fixed now, though.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/196551273-c6cd0d18-b2a9-4185-8b1d-62e11aa31df0.png)

Fixes #57969.

We recycle and deleted literally all of the contents on the mob, yet absolutely nothing reflected that we did that. Even if you were to strip them, you'd strip nothing because it was qdeleted and in nullspace. Silly stuff, and now it's fixed.

Here's a snippet of the unit test running on current master:

![image](https://user-images.githubusercontent.com/34697715/196572088-64d79139-592b-4a62-bf56-2233816fbf21.png)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: When a human went through an emagged recycler, they would have literally everything on them chewed up in the recycler. However, they still appeared to have all of their stuff on them due to some faulty code. When you now punt that tider into the chewer-of-death, they should now appropriately reflect that all of their clothes have been deleted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
