### PR TITLE
Fixes some ling sting jankiness

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -273,14 +273,22 @@
 	else
 		adjust_chemicals((chem_recharge_rate - chem_recharge_slowdown) * delta_time)
 
-/*
+/**
  * Signal proc for [COMSIG_MOB_MIDDLECLICKON] and [COMSIG_MOB_ALTCLICKON].
  * Allows the changeling to sting people with a click.
  */
 /datum/antagonist/changeling/proc/on_click_sting(mob/living/ling, atom/clicked)
 	SIGNAL_HANDLER
 
-	if(!chosen_sting || clicked == ling || !istype(ling) || ling.stat != CONSCIOUS)
+	// nothing to handle
+	if(!chosen_sting)
+		return
+	if(!isliving(ling) || clicked == ling || ling.stat != CONSCIOUS)
+		return
+	// sort-of hack done here: we use in_given_range here because it's quicker.
+	// actual ling stings do pathfinding to determine whether the target's "in range".
+	// however, this is "close enough" preliminary checks to not block click
+	if(!isliving(clicked) || !IN_GIVEN_RANGE(ling, clicked, sting_range))
 		return
 
 	INVOKE_ASYNC(chosen_sting, /datum/action/changeling/sting.proc/try_to_sting, ling, clicked)

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -46,7 +46,7 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
  *The deduction of the cost of this power.
  *Returns TRUE on a successful activation.
  */
-/datum/action/changeling/proc/try_to_sting(mob/user, mob/target)
+/datum/action/changeling/proc/try_to_sting(mob/living/user, mob/living/target)
 	if(!can_sting(user, target))
 		return FALSE
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
@@ -57,15 +57,15 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 		return TRUE
 	return FALSE
 
-/datum/action/changeling/proc/sting_action(mob/user, mob/target)
+/datum/action/changeling/proc/sting_action(mob/living/user, mob/living/target)
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
 	return FALSE
 
-/datum/action/changeling/proc/sting_feedback(mob/user, mob/target)
+/datum/action/changeling/proc/sting_feedback(mob/living/user, mob/living/target)
 	return FALSE
 
 // Fairly important to remember to return 1 on success >.< // Return TRUE not 1 >.<
-/datum/action/changeling/proc/can_sting(mob/living/user, mob/target)
+/datum/action/changeling/proc/can_sting(mob/living/user, mob/living/target)
 	if(!can_be_used_by(user))
 		return FALSE
 	var/datum/antagonist/changeling/c = user.mind.has_antag_datum(/datum/antagonist/changeling)
@@ -86,7 +86,7 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 		return FALSE
 	return TRUE
 
-/datum/action/changeling/proc/can_be_used_by(mob/user)
+/datum/action/changeling/proc/can_be_used_by(mob/living/user)
 	if(QDELETED(user))
 		return FALSE
 	if(!ishuman(user))


### PR DESCRIPTION
## About The Pull Request

Fixes #62010 , (Likely) Fixes #70301 (Unable to reproduce the exact issue, but I believe it's related to this) 

Ling stinging won't block clicks unless it's something you can actually sting. Non-living mobs and distant atoms will no longer block clicks.

## Why It's Good For The Game

Having a sting active shouldn't stop a few important hotkeys

## Changelog

:cl: Melbert
fix: Having a Changeling sting active will no longer block alt-clicking to open bags and middle mouse to swap hands in most circumstances
/:cl:
