### PR TITLE
Removes the infinite pocket a-heal from the Wand Belt to shake up the Wizard meta

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -634,7 +634,6 @@
 
 /obj/item/storage/belt/wands/full/PopulateContents()
 	new /obj/item/gun/magic/wand/death(src)
-	new /obj/item/gun/magic/wand/resurrection(src)
 	new /obj/item/gun/magic/wand/polymorph(src)
 	new /obj/item/gun/magic/wand/teleport(src)
 	new /obj/item/gun/magic/wand/door(src)


### PR DESCRIPTION
## About The Pull Request

Removes the infinite pocket a-heal from the Wand Belt to shake up the Wizard meta

## Why It's Good For The Game

Infinite pocket a-heal is boring and this made the wand belt the most purchased wizard item as per maintainer statements on the matter.

## Changelog
:cl:
del: Removes the infinite pocket a-heal from the Wand Belt to shake up the Wizard meta
/:cl:
