### PR TITLE
Adds unit test for items that can be equipped to suit storage slots that are missing sprites

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -132,8 +132,6 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/armour_penetration = 0
 	///Whether or not our object is easily hindered by the presence of armor
 	var/weak_against_armour = FALSE
-	///What objects the suit storage can store
-	var/list/allowed = null
 	///In deciseconds, how long an item takes to equip; counts only for normal clothing slots, not pockets etc.
 	var/equip_delay_self = 0
 	///In deciseconds, how long an item takes to put on another person

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -96,7 +96,6 @@
 /obj/item/changeling
 	name = "flesh"
 	slot_flags = ALL
-	allowed = list(/obj/item/changeling)
 	item_flags = DROPDEL
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -23,6 +23,8 @@
 	var/cooldown = 0
 
 	var/clothing_flags = NONE
+	///List of items that can be equipped in the suit storage slot while we're worn.
+	var/list/allowed
 
 	var/can_be_bloody = TRUE
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -176,6 +176,7 @@
 #include "stomach.dm"
 #include "strippable.dm"
 #include "subsystem_init.dm"
+#include "suit_storage_icons.dm"
 #include "surgeries.dm"
 #include "teleporters.dm"
 #include "tgui_create_message.dm"
@@ -183,7 +184,6 @@
 #include "traitor.dm"
 #include "unit_test.dm"
 #include "wizard_loadout.dm"
-#include "suit_storage_icons.dm"
 #ifdef REFERENCE_TRACKING_DEBUG //Don't try and parse this file if ref tracking isn't turned on. IE: don't parse ref tracking please mr linter
 #include "find_reference_sanity.dm"
 #endif

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -183,6 +183,7 @@
 #include "traitor.dm"
 #include "unit_test.dm"
 #include "wizard_loadout.dm"
+#include "suit_storage_icons.dm"
 #ifdef REFERENCE_TRACKING_DEBUG //Don't try and parse this file if ref tracking isn't turned on. IE: don't parse ref tracking please mr linter
 #include "find_reference_sanity.dm"
 #endif

--- a/code/modules/unit_tests/suit_storage_icons.dm
+++ b/code/modules/unit_tests/suit_storage_icons.dm
@@ -31,7 +31,7 @@
 
 		var/worn_icon = initial(item_path.worn_icon) //override icon file. where our sprite is contained if set. (ie modularity stuff)
 		var/worn_icon_state = initial(item_path.worn_icon_state) //overrides icon_state.
-		var/icon_state = !isnull(worn_icon_state) ? worn_icon_state : initial(item_path.icon_state) //icon_state. what sprite name we are looking for.
+		var/icon_state = worn_icon_state || initial(item_path.icon_state) //icon_state. what sprite name we are looking for.
 
 
 		if(isnull(icon_state))

--- a/code/modules/unit_tests/suit_storage_icons.dm
+++ b/code/modules/unit_tests/suit_storage_icons.dm
@@ -40,9 +40,9 @@
 
 		if(worn_icon) //easiest to check since we override everything.
 			if(!(icon_state in icon_states(worn_icon)))
-				log_test("CS:S - [item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\" in worn_icon override file, '[worn_icon]'")
+				log_test("\t[item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\" in worn_icon override file, '[worn_icon]'")
 			continue
 
 		if(!(icon_state in icon_states('icons/mob/clothing/belt_mirror.dmi')))
 			already_warned_icons += icon_state
-			log_test("CS:S - [item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\"")
+			log_test("\t[item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\"")

--- a/code/modules/unit_tests/suit_storage_icons.dm
+++ b/code/modules/unit_tests/suit_storage_icons.dm
@@ -24,6 +24,7 @@
 
 
 	var/list/already_warned_icons = list()
+	var/count = 1 //to be removed once the test goes live / into CI failure mode.
 	for(var/obj/item/item_path as anything in typecacheof(wearable_item_paths))
 		if(initial(item_path.item_flags) & ABSTRACT)
 			continue
@@ -40,9 +41,11 @@
 
 		if(worn_icon) //easiest to check since we override everything.
 			if(!(icon_state in icon_states(worn_icon)))
-				log_test("\t[item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\" in worn_icon override file, '[worn_icon]'")
+				log_test("\t[count] - [item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\" in worn_icon override file, '[worn_icon]'")
+				count++
 			continue
 
 		if(!(icon_state in icon_states('icons/mob/clothing/belt_mirror.dmi')))
 			already_warned_icons += icon_state
-			log_test("\t[item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\"")
+			log_test("\t[count] - [item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\"")
+			count++

--- a/code/modules/unit_tests/suit_storage_icons.dm
+++ b/code/modules/unit_tests/suit_storage_icons.dm
@@ -1,0 +1,48 @@
+/// Makes sure suit slot items aren't using CS:S fallbacks.
+/datum/unit_test/suit_storage_icons
+
+/datum/unit_test/suit_storage_icons/Run()
+	var/list/wearable_item_paths = list()
+
+	for(var/obj/item/item_path as anything in subtypesof(/obj/item))
+		var/cached_slot_flags = initial(item_path.slot_flags)
+		if(!(cached_slot_flags & ITEM_SLOT_SUITSTORE) || (initial(item_path.item_flags) & ABSTRACT))
+			continue
+		wearable_item_paths |= item_path
+
+	for(var/clothing_path in (subtypesof(/obj/item/clothing) - typesof(/obj/item/clothing/head/mob_holder) - typesof(/obj/item/clothing/suit/space/santa))) //mob_holder is a psuedo abstract item. santa suit is a VERY SNOWFLAKE admin spawn suit that can hold /every/ possible item.
+		var/obj/item/clothing/spawned_item = new clothing_path
+		for(var/path in spawned_item.allowed) //find all usable suit storage stuff.
+			wearable_item_paths |= path
+		qdel(spawned_item)
+
+	for(var/mod_path in subtypesof(/obj/item/mod/control))
+		var/obj/item/mod/control/control_mod = new
+		for(var/path in control_mod.chestplate.allowed)
+			wearable_item_paths |= path
+		qdel(control_mod)
+
+
+	var/list/already_warned_icons = list()
+	for(var/obj/item/item_path as anything in typecacheof(wearable_item_paths))
+		if(initial(item_path.item_flags) & ABSTRACT)
+			continue
+
+		var/worn_icon = initial(item_path.worn_icon) //override icon file. where our sprite is contained if set. (ie modularity stuff)
+		var/worn_icon_state = initial(item_path.worn_icon_state) //overrides icon_state.
+		var/icon_state = !isnull(worn_icon_state) ? worn_icon_state : initial(item_path.icon_state) //icon_state. what sprite name we are looking for.
+
+
+		if(isnull(icon_state))
+			continue //no sprite for the item.
+		if(icon_state in already_warned_icons)
+			continue
+
+		if(worn_icon) //easiest to check since we override everything.
+			if(!(icon_state in icon_states(worn_icon)))
+				log_test("CS:S - [item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\" in worn_icon override file, '[worn_icon]'")
+			continue
+
+		if(!(icon_state in icon_states('icons/mob/clothing/belt_mirror.dmi')))
+			already_warned_icons += icon_state
+			log_test("CS:S - [item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\"")

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -11,8 +11,8 @@ fi
 
 mkdir -p \
     $1/_maps \
-    $1/icons/mob/inhands \
 	$1/icons/mob/clothing \
+    $1/icons/mob/inhands \
     $1/icons/runtime \
     $1/sound/runtime \
     $1/strings \
@@ -26,8 +26,8 @@ fi
 
 cp tgstation.dmb tgstation.rsc $1/
 cp -r _maps/* $1/_maps/
-cp -r icons/mob/inhands/* $1/icons/mob/inhands/
 cp -r icons/mob/clothing/* $1/icons/mob/clothing/
+cp -r icons/mob/inhands/* $1/icons/mob/inhands/
 cp -r icons/runtime/* $1/icons/runtime/
 cp -r sound/runtime/* $1/sound/runtime/
 cp -r strings/* $1/strings/

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -12,6 +12,7 @@ fi
 mkdir -p \
     $1/_maps \
     $1/icons/mob/inhands \
+	$1/icons/mob/clothing \
     $1/icons/runtime \
     $1/sound/runtime \
     $1/strings \
@@ -26,6 +27,7 @@ fi
 cp tgstation.dmb tgstation.rsc $1/
 cp -r _maps/* $1/_maps/
 cp -r icons/mob/inhands/* $1/icons/mob/inhands/
+cp -r icons/mob/clothing/* $1/icons/mob/clothing/
 cp -r icons/runtime/* $1/icons/runtime/
 cp -r sound/runtime/* $1/sound/runtime/
 cp -r strings/* $1/strings/


### PR DESCRIPTION
## About The Pull Request

Adds a unit test find every item that can be equipped to a suit slot which is displaying a missing sprite / CS:S texture.

The test is presently fully functional. That said, the test is currently set to a warning / logging only mode and will not cause CI failure. 

There are currently 257 sprites found which need to be resolved. Once this number is whittled closer to zero, the test will be switched to live mode/CI failure.


## Why It's Good For The Game
Missing sprites are bad.

## Changelog

:cl: ShizCalev
code: Added a unit test to catch items that can be equipped to suit slots have missing textures.
/:cl:
