### PR TITLE
Fixes incorrect mine examine span

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -26,7 +26,7 @@
 /obj/effect/mine/examine(mob/user)
 	. = ..()
 	if(!armed)
-		. += "\t<span class='information'>It appears to be inactive...</span>"
+		. += span_info("\tIt appears to be inactive...")
 
 /// The effect of the mine
 /obj/effect/mine/proc/mineEffect(mob/victim)


### PR DESCRIPTION
:cl: ShizCalev
spellcheck: Corrected formatting on the examine message for unarmed mines
/:cl:
