### PR TITLE
fixes _queue_verb() runtiming from /client/Click() thousands of times

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -82,7 +82,7 @@ VERB_MANAGER_SUBSYSTEM_DEF(input)
 			stack_trace("non /datum/callback/verb_callback instance inside SSinput's verb_queue!")
 			continue
 
-		average_click_delay = MC_AVG_FAST_UP_SLOW_DOWN(average_click_delay, (REALTIMEOFDAY - queued_click.creation_time) SECONDS)
+		average_click_delay = MC_AVG_FAST_UP_SLOW_DOWN(average_click_delay, TICKS2DS((DS2TICKS(world.time) - queued_click.creation_time)) SECONDS)
 		queued_click.InvokeAsync()
 
 		current_clicks++

--- a/code/controllers/subsystem/verb_manager.dm
+++ b/code/controllers/subsystem/verb_manager.dm
@@ -65,8 +65,8 @@ SUBSYSTEM_DEF(verb_manager)
 
 		stack_trace("_queue_verb() returned false because it was given a deleted callback! [destroyed_string]")
 		return FALSE
-	if(!istext(incoming_callback.object) && QDELETED(incoming_callback.object)) //just in case the object is GLOBAL_PROC
 
+	if(!istext(incoming_callback.object) && QDELETED(incoming_callback.object)) //just in case the object is GLOBAL_PROC
 		var/destroyed_string
 		if(!incoming_callback.object)
 			destroyed_string = "callback.object is null."

--- a/code/controllers/subsystem/verb_manager.dm
+++ b/code/controllers/subsystem/verb_manager.dm
@@ -56,9 +56,24 @@ SUBSYSTEM_DEF(verb_manager)
  * returns TRUE if the queuing was successful, FALSE otherwise.
  */
 /proc/_queue_verb(datum/callback/verb_callback/incoming_callback, tick_check, datum/controller/subsystem/verb_manager/subsystem_to_use = SSverb_manager, ...)
-	if(QDELETED(incoming_callback) \
-	|| QDELETED(incoming_callback.object))
-		stack_trace("_queue_verb() returned false because it was given an invalid callback!")
+	if(QDELETED(incoming_callback))
+		var/destroyed_string
+		if(!incoming_callback)
+			destroyed_string = "callback is null."
+		else
+			destroyed_string = "callback was deleted [DS2TICKS(world.time - incoming_callback.gc_destroyed)] ticks ago. callback was created [DS2TICKS(world.time) - incoming_callback.creation_time] ticks ago."
+
+		stack_trace("_queue_verb() returned false because it was given a deleted callback! [destroyed_string]")
+		return FALSE
+	if(!istext(incoming_callback.object) && QDELETED(incoming_callback.object)) //just in case the object is GLOBAL_PROC
+
+		var/destroyed_string
+		if(!incoming_callback.object)
+			destroyed_string = "callback.object is null."
+		else
+			destroyed_string = "callback.object was deleted [DS2TICKS(world.time - incoming_callback.object.gc_destroyed)] ticks ago. callback was created [DS2TICKS(world.time) - incoming_callback.creation_time] ticks ago."
+
+		stack_trace("_queue_verb() returned false because it was given a callback acting on a qdeleted object! [destroyed_string]")
 		return FALSE
 
 	//we want unit tests to be able to directly call verbs that attempt to queue, and since unit tests should test internal behavior, we want the queue

--- a/code/datums/verb_callbacks.dm
+++ b/code/datums/verb_callbacks.dm
@@ -1,8 +1,8 @@
 ///like normal callbacks but they also record their creation time for measurement purposes
 /datum/callback/verb_callback
-	///the REALTIMEOFDAY this callback datum was created in. used for testing latency
+	///the tick this callback datum was created in. used for testing latency
 	var/creation_time = 0
 
 /datum/callback/verb_callback/New(thingtocall, proctocall, ...)
-	creation_time = REALTIMEOFDAY
+	creation_time = DS2TICKS(world.time)
 	. = ..()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -954,7 +954,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	//check if the server is overloaded and if it is then queue up the click for next tick
 	//yes having it call a wrapping proc on the subsystem is fucking stupid glad we agree unfortunately byond insists its reasonable
-	if(TRY_QUEUE_VERB(VERB_CALLBACK(object, /atom/proc/_Click, location, control, params), VERB_HIGH_PRIORITY_QUEUE_THRESHOLD, SSinput, control))
+	if(!QDELETED(object) && TRY_QUEUE_VERB(VERB_CALLBACK(object, /atom/proc/_Click, location, control, params), VERB_HIGH_PRIORITY_QUEUE_THRESHOLD, SSinput, control))
 		return
 
 	if (hotkeys)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://runtimes.moth.fans/runtime/_queue_verb()%20returned%20false%20because%20it%20was%20given%20an%20invalid%20callback!%20(code%2Fcontrollers%2Fsubsystem%2Fverb_manager.dm%3A61)_______%2Fproc%2F_stack_trace
it seems to almost always be from /client/Click() and since the callback itself isnt deleted it must mean that Click() is being called when the client doesnt know when something is deleted and passes that on to _queue_verb(). which screams because the object of the callback is deleted. now it only queues the verb if the object isnt deleted, and _queue_verb() separates the cases where the callback is deleted and when the object is deleted, and puts more info into the stack trace

Fixes #70602
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
this runtimes every round except for campbell rounds maybe
![Screenshot_2226](https://user-images.githubusercontent.com/15794172/196834389-cf53c0ff-1861-4668-be5d-3f1d86557874.png)
![Screenshot_2227](https://user-images.githubusercontent.com/15794172/196834392-ac7b2a13-6ec1-4f9f-8d34-8ab7c54119a4.png)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
