### PR TITLE
Fixes Sneaksuit not hiding sec huds

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -256,7 +256,7 @@ Security HUDs! Basic mode shows only the job.
 	var/icon/I = icon(icon, icon_state, dir)
 	holder.pixel_y = I.Height() - world.icon_size
 	var/sechud_icon_state = wear_id?.get_sechud_job_icon_state()
-	if(!sechud_icon_state)
+	if(!sechud_icon_state || HAS_TRAIT(src, TRAIT_UNKNOWN))
 		sechud_icon_state = "hudno_id"
 	holder.icon_state = sechud_icon_state
 	sec_hud_set_security_status()

--- a/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/code/modules/mob/living/carbon/human/init_signals.dm
@@ -1,0 +1,11 @@
+/mob/living/carbon/human/register_init_signals()
+	. = ..()
+
+	RegisterSignal(src, list(SIGNAL_ADDTRAIT(TRAIT_UNKNOWN), SIGNAL_REMOVETRAIT(TRAIT_UNKNOWN)), .proc/on_unknown_trait)
+
+/// Gaining or losing [TRAIT_UNKNOWN] updates our name and our sechud
+/mob/living/carbon/human/proc/on_unknown_trait(datum/source)
+	SIGNAL_HANDLER
+
+	name = get_visible_name()
+	sec_hud_set_ID()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3592,6 +3592,7 @@
 #include "code\modules\mob\living\carbon\human\human_say.dm"
 #include "code\modules\mob\living\carbon\human\human_stripping.dm"
 #include "code\modules\mob\living\carbon\human\human_update_icons.dm"
+#include "code\modules\mob\living\carbon\human\init_signals.dm"
 #include "code\modules\mob\living\carbon\human\inventory.dm"
 #include "code\modules\mob\living\carbon\human\life.dm"
 #include "code\modules\mob\living\carbon\human\login.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #70519

- When gaining or losing the "unknown" trait, update sechuds and name. 
- When updating sechuds, if we have the "unknown" trait always use the missing ID icon.

## Why It's Good For The Game

Makes it more sneaky to be unknown.

## Changelog

:cl: Melbert
fix:  Sechuds cannot pierce the sneak suit to see the wearer's ID trim. 
/:cl:

