### PR TITLE
Assembly bombs will now simply heat the gases in the tank, and make the tank process. Also makes assembly bombs bulky.

### DIFF
--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -174,11 +174,11 @@
 	bomb.bombtank = src //Same for tank
 	master = bomb
 
-	forceMove(bomb)
 	bomb.update_appearance()
 
 	user.put_in_hands(bomb) //Equips the bomb if possible, or puts it on the floor.
 	to_chat(user, span_notice("You attach [assembly] to [src]."))
+	forceMove(bomb)
 	return
 
 /obj/item/tank/proc/ignite(ignition_heat_capacity) //This happens when a bomb is told to explode


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes assembly bomb functionality. The assembly bomb will release a spark into the tank, delivering 7.5kJ (for reference, plasma filled to 2.533MPa in a 70L tank has a thermal energy over 4MJ) of thermal energy per litre of the tank, and having a heat capacity of 7.5J (or 2.5kJ if condenser) per litre of the tank. The tank will then process as normal, with the extra energy transferred to it which can lead to an explosion.

A room temperature oxygen tank with oxygen filled to 2.533MPa can create a 0, 0, 1 explosion. An oxygen tank filled to 2.533MPa at 2.7 Kelvin can create a 1, 2, 5 explosion. It is possible to create a maxcap if it is filled with antinoblium, if it has a tritium/hydrogen and oxygen gas mixture, or a tritium and nitrogen gas mixture with a condenser assembly.

Assembly bombs are bulky when created with a tank larger than 6L. Assembly bombs will always ignite and heat (or cool) the gas regardless of whether it is welded or not. The gas will escape before it can explode if it isn't welded though.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The assembly bomb was filled with a forest of stacked if checks that did hardcoded explosions based on random temperatures and strengths. The only way a person could find the best mixture (673.16 Kelvin plasma at max pressure) was to codedive, or have a codediver tell them the mixture, which isn't very interesting. Changing the functionality to instead heat the gas in the tank, and let the tank process allows people to use their knowledge of toxins/atmospherics to design their bomb and allow them to share an explanation on their mixture outside of "because the if check says so".

This change does make it possible to create a maxcap, so I decided to make the assembly bombs bulky so people can't carry a concealed maxcap in their bag.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Assembly bombs will heat the gas tank with 7.5kJ of thermal energy per litre of tank with a heat capacity of 7.5J (or 2.5kJ if a condenser is used) per litre of the tank, and let the tank process.
balance: Assembly bombs no longer do hardcoded explosions based on random conditions.
balance: Assembly bombs are bulky if created with a tank larger than 6L.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
