### PR TITLE
Fix an error message in `ReadLayerGroup()`

### DIFF
--- a/code/datums/greyscale/_greyscale_config.dm
+++ b/code/datums/greyscale/_greyscale_config.dm
@@ -176,7 +176,7 @@
 	if(!islist(data[1]))
 		var/layer_type = SSgreyscale.layer_types[data["type"]]
 		if(!layer_type)
-			CRASH("An unknown layer type was specified in the json of greyscale configuration [DebugName()]: [data["layer_type"]]")
+			CRASH("An unknown layer type was specified in the json of greyscale configuration [DebugName()]: [data["type"]]")
 		return new layer_type(icon_file, data.Copy()) // We don't want anything in there touching our version of the data
 	var/list/output = list()
 	for(var/list/group as anything in data)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I found that this error message references `data["layer_type"]`, which is always null as no such property appears in any json. I changed it to `data["type"]` which is likely what was intended in the first place.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This changes the error message to appear like this:

`An unknown layer type was specified in the json of greyscale configuration Default Canister (icons/obj/atmospherics/canisters.dmi|code/datums/greyscale/json_configs/canister_default.json): reference`

instead of like this:

`An unknown layer type was specified in the json of greyscale configuration Default Canister (icons/obj/atmospherics/canisters.dmi|code/datums/greyscale/json_configs/canister_default.json): `

which makes debugging potential issues easier.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
