### PR TITLE
makes wendigo ground slam not a global proc

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -145,7 +145,7 @@ Difficulty: Hard
 
 /// Slams the ground around the source throwing back enemies caught nearby, delay is for the radius increase
 /mob/living/simple_animal/hostile/megafauna/wendigo/proc/wendigo_slam(range, delay, throw_range)
-	var/turf/origin = get_turf(source)
+	var/turf/origin = get_turf(src)
 	if(!origin)
 		return
 	var/list/all_turfs = RANGE_TURFS(range, origin)
@@ -156,10 +156,10 @@ Difficulty: Hard
 				continue
 			new /obj/effect/temp_visual/small_smoke/halfsecond(stomp_turf)
 			for(var/mob/living/target in stomp_turf)
-				if(target == source || target.throwing)
+				if(target == src || target.throwing)
 					continue
-				to_chat(target, span_userdanger("[source]'s ground slam shockwave sends you flying!"))
-				var/turf/thrownat = get_ranged_target_turf_direct(source, target, throw_range, rand(-10, 10))
+				to_chat(target, span_userdanger("[src]'s ground slam shockwave sends you flying!"))
+				var/turf/thrownat = get_ranged_target_turf_direct(src, target, throw_range, rand(-10, 10))
 				target.throw_at(thrownat, 8, 2, null, TRUE, force = MOVE_FORCE_OVERPOWERING, gentle = TRUE)
 				target.apply_damage(20, BRUTE, wound_bonus=CANT_WOUND)
 				shake_camera(target, 2, 1)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -141,10 +141,10 @@ Difficulty: Hard
 	. = ..()
 	stored_move_dirs &= ~movement_dir
 	if(!stored_move_dirs)
-		INVOKE_ASYNC(GLOBAL_PROC, .proc/wendigo_slam, src, stomp_range, 1, 8)
+		INVOKE_ASYNC(src, .proc/wendigo_slam, src, stomp_range, 1, 8)
 
 /// Slams the ground around the source throwing back enemies caught nearby, delay is for the radius increase
-/proc/wendigo_slam(atom/source, range, delay, throw_range)
+/mob/living/simple_animal/hostile/megafauna/wendigo/proc/wendigo_slam(atom/source, range, delay, throw_range)
 	var/turf/orgin = get_turf(source)
 	if(!orgin)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -141,28 +141,28 @@ Difficulty: Hard
 	. = ..()
 	stored_move_dirs &= ~movement_dir
 	if(!stored_move_dirs)
-		INVOKE_ASYNC(src, .proc/wendigo_slam, src, stomp_range, 1, 8)
+		INVOKE_ASYNC(src, .proc/wendigo_slam, stomp_range, 1, 8)
 
 /// Slams the ground around the source throwing back enemies caught nearby, delay is for the radius increase
-/mob/living/simple_animal/hostile/megafauna/wendigo/proc/wendigo_slam(atom/source, range, delay, throw_range)
-	var/turf/orgin = get_turf(source)
-	if(!orgin)
+/mob/living/simple_animal/hostile/megafauna/wendigo/proc/wendigo_slam(range, delay, throw_range)
+	var/turf/origin = get_turf(source)
+	if(!origin)
 		return
-	var/list/all_turfs = RANGE_TURFS(range, orgin)
-	for(var/i = 0 to range)
-		playsound(orgin,'sound/effects/bamf.ogg', 600, TRUE, 10)
+	var/list/all_turfs = RANGE_TURFS(range, origin)
+	for(var/sound_range = 0 to range)
+		playsound(origin,'sound/effects/bamf.ogg', 600, TRUE, 10)
 		for(var/turf/stomp_turf in all_turfs)
-			if(get_dist(orgin, stomp_turf) > i)
+			if(get_dist(origin, stomp_turf) > sound_range)
 				continue
 			new /obj/effect/temp_visual/small_smoke/halfsecond(stomp_turf)
-			for(var/mob/living/L in stomp_turf)
-				if(L == source || L.throwing)
+			for(var/mob/living/target in stomp_turf)
+				if(target == source || target.throwing)
 					continue
-				to_chat(L, span_userdanger("[source]'s ground slam shockwave sends you flying!"))
-				var/turf/thrownat = get_ranged_target_turf_direct(source, L, throw_range, rand(-10, 10))
-				L.throw_at(thrownat, 8, 2, null, TRUE, force = MOVE_FORCE_OVERPOWERING, gentle = TRUE)
-				L.apply_damage(20, BRUTE, wound_bonus=CANT_WOUND)
-				shake_camera(L, 2, 1)
+				to_chat(target, span_userdanger("[source]'s ground slam shockwave sends you flying!"))
+				var/turf/thrownat = get_ranged_target_turf_direct(source, target, throw_range, rand(-10, 10))
+				target.throw_at(thrownat, 8, 2, null, TRUE, force = MOVE_FORCE_OVERPOWERING, gentle = TRUE)
+				target.apply_damage(20, BRUTE, wound_bonus=CANT_WOUND)
+				shake_camera(target, 2, 1)
 			all_turfs -= stomp_turf
 		sleep(delay)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes wendigo ground slam not a global proc and also unfucks it in its entirety

## Why It's Good For The Game

why was this a global proc
why was origin spelt as orgin
why are all the vars single letter
sleep(delay)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: wendigo ground slam no longer a global proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
