### PR TITLE
Fixes Type Mismatch Causing Infinite Irrevocable Welding

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -120,9 +120,9 @@
 /obj/item/weldingtool/use_tool(atom/target, mob/living/user, delay, amount, volume, datum/callback/extra_checks)
 	var/mutable_appearance/sparks = mutable_appearance('icons/effects/welding_effect.dmi', "welding_sparks", GASFIRE_LAYER, src, ABOVE_LIGHTING_PLANE)
 	target.add_overlay(sparks)
-	target.update_overlays_on_z += sparks
+	LAZYADD(update_overlays_on_z, sparks)
 	. = ..()
-	target.update_overlays_on_z -= sparks
+	LAZYREMOVE(update_overlays_on_z, sparks)
 	target.cut_overlay(sparks)
 
 /obj/item/weldingtool/attack(mob/living/carbon/human/attacked_humanoid, mob/living/user)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -178,9 +178,9 @@
 	if(amount)
 		var/mutable_appearance/sparks = mutable_appearance('icons/effects/welding_effect.dmi', "welding_sparks", GASFIRE_LAYER, src, ABOVE_LIGHTING_PLANE)
 		target.add_overlay(sparks)
-		target.update_overlays_on_z += sparks
+		LAZYADD(update_overlays_on_z, sparks)
 		. = ..()
-		target.update_overlays_on_z -= sparks
+		LAZYREMOVE(update_overlays_on_z, sparks)
 		target.cut_overlay(sparks)
 	else
 		. = ..(amount=1)


### PR DESCRIPTION
(and plasma cutters too, because that seemed to be broken as well).

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Behavior introduced in #70235 caused this shit to break, causing infinite welding that you could never undo, with an overlay that could never be removed. This was due to a type_mismatch runtime that plagued servers for a bit, I just stole the pattern from Lemon and used LAZYADD/LAZYREMOVE and that seemed to have fixed the issue.

The weird thing is that it was merged on Manuel for 11 rounds before it was full-merged. Did no-one weld anything on manuel for those shifts?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #70651, which I inappropriately thought was associated to Willard's test merge. Sorry Willard.

![image](https://user-images.githubusercontent.com/34697715/196845311-e1afe83b-e7bc-422f-9969-80b7334285ce.png)

This is not good. It broke welding for any borgs, any walls, any mechs, literally anything that used a welding tool would be trapped in an extremely fucked state due to this runtiming out. Blargh.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can now properly weld and use plasma cutters without the target of your actions being irrevocably FUCKED.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
