### PR TITLE
Fixes regalrat runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -143,6 +143,8 @@
 			return
 	else
 		SEND_SIGNAL(target, COMSIG_RAT_INTERACT, src)
+		if(QDELETED(target))
+			return
 
 	if (DOING_INTERACTION(src, REGALRAT_INTERACTION)) // check again in case we started interacting
 		return


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed a minor runtime when regal rats attacked power cables.
/:cl:

`COMSIG_RAT_INTERACT` destroys power cables, ..() didn't anticipate null target values