### PR TITLE
Fixes some inconsistencies with computers

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -686,6 +686,9 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	return TRUE
 
 /obj/item/modular_computer/proc/UpdateDisplay()
+	if(!saved_identification && !saved_job)
+		name = initial(name)
+		return
 	name = "[saved_identification] ([saved_job])"
 
 /obj/item/modular_computer/attackby(obj/item/attacking_item, mob/user, params)

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -10,25 +10,20 @@
 	hardware_flag = 0
 	max_bays = 4
 
-	var/obj/machinery/modular_computer/machinery_computer = null
+	///The modular computer MACHINE that hosts us.
+	var/obj/machinery/modular_computer/machinery_computer
 
-/obj/item/modular_computer/processor/Destroy()
-	if(machinery_computer && (machinery_computer.cpu == src))
-		machinery_computer.cpu = null
-		machinery_computer.UnregisterSignal(src, COMSIG_ATOM_UPDATED_ICON)
-	machinery_computer = null
-	return ..()
+/obj/item/modular_computer/processor/UpdateDisplay()
+	. = ..()
+	//update the name with us
+	machinery_computer.name = name
 
-/obj/item/modular_computer/processor/New(comp)
-	..()
-	STOP_PROCESSING(SSobj, src) // Processed by its machine
+/obj/item/modular_computer/processor/Initialize(mapload)
+	if(!istype(loc, /obj/machinery/modular_computer))
+		CRASH("A non '/obj/machinery/modular_computer' had a [src] initialized in it!")
 
-	if(!comp || !istype(comp, /obj/machinery/modular_computer))
-		CRASH("Inapropriate type passed to obj/item/modular_computer/processor/New()! Aborting.")
 	// Obtain reference to machinery computer
-	all_components = list()
-	idle_threads = list()
-	machinery_computer = comp
+	machinery_computer = loc
 	machinery_computer.cpu = src
 	hardware_flag = machinery_computer.hardware_flag
 	max_hardware_size = machinery_computer.max_hardware_size
@@ -40,13 +35,14 @@
 	base_active_power_usage = machinery_computer.base_active_power_usage
 	base_idle_power_usage = machinery_computer.base_idle_power_usage
 	machinery_computer.RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, /obj/machinery/modular_computer/proc/relay_icon_update) //when we update_icon, also update the computer
+	return ..()
+
+/obj/item/modular_computer/processor/Destroy(force)
+	if(machinery_computer && (machinery_computer.cpu == src))
+		machinery_computer.cpu = null
+		machinery_computer.UnregisterSignal(src, COMSIG_ATOM_UPDATED_ICON)
+	machinery_computer = null
+	return ..()
 
 /obj/item/modular_computer/processor/relay_qdel()
 	qdel(machinery_computer)
-
-/obj/item/modular_computer/processor/shutdown_computer()
-	if(!machinery_computer)
-		return
-	..()
-	machinery_computer.update_appearance()
-	return

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -113,13 +113,6 @@
 		return cpu.interact(user)
 	return ..()
 
-// Process currently calls handle_power(), may be expanded in future if more things are added.
-/obj/machinery/modular_computer/process(delta_time)
-	if(cpu)
-		// Keep names in sync.
-		cpu.name = name
-		cpu.process(delta_time)
-
 // Modular computers can have battery in them, we handle power in previous proc, so prevent this from messing it up for us.
 /obj/machinery/modular_computer/power_change()
 	if(cpu?.use_power()) // If it still has a power source, PC wouldn't go offline.


### PR DESCRIPTION
## About The Pull Request

* Modular computers now have their initial name if they don't have an idenfitication and job, which previously meant they would have the name ()
* Removes MACHINE modular computer's process, because all it did was update the name, then call computer's process. Now it just does what every computer does, BUT UpdateDisplay on ITEM modular computers will now update the machine's name.
* Additionally, I moved the modular computer processor's New to an Initialize, and removed the shutdown_computer code, because we already register update_icon signal to update the computer's appearance, why do we need to do it twice?

## Why It's Good For The Game

Computers without a job/ID will no longer be called " ()"
Machine modular computers no longer stop processing processors to instead process themselves which just calls processor's process.

Basically it's helpful because the less things on the processor thing, the easier it would be to remove it in the future, if we so want.

## Changelog

:cl:
fix: Computers without a saved job/ID are no longer called " ()"
/:cl:
