### PR TITLE
Add security(in round, alive, dead) in check antagonists

### DIFF
--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -122,7 +122,8 @@
 	var/observers_connected = 0
 	var/living_players = 0
 	var/living_players_connected = 0
-	var/living_players_antagonist = 0
+	var/antagonists = 0
+	var/antagonists_dead = 0
 	var/brains = 0
 	var/other_players = 0
 	var/living_skipped = 0
@@ -143,12 +144,14 @@
 						living_skipped++
 						continue
 					living_players++
-					if(M.mind.special_role)
-						living_players_antagonist++
 					if(M.client)
 						living_players_connected++
-				
-				if(M.mind.assigned_role.departments_list.Find(/datum/job_department/security))
+
+				if(M.mind.special_role)
+					antagonists++
+					if(M.stat == DEAD)
+						antagonists_dead++
+				if(M.mind.assigned_role?.departments_list?.Find(/datum/job_department/security))
 					security++
 					if(M.stat == DEAD)
 						security_dead++
@@ -161,8 +164,9 @@
 			else
 				other_players++
 	dat += "<BR><b><font color='blue' size='3'>Players:|[connected_players - lobby_players] ingame|[connected_players] connected|[lobby_players] lobby|</font></b>"
-	dat += "<BR><b><font color='green'>Living Players:|[living_players_connected] active|[living_players - living_players_connected] disconnected|[living_players_antagonist] antagonists|</font></b>"
-	dat += "<BR><b><font color='#860e03'>Security Players:|[security] ingame||[security-security_dead] alive|[security_dead] dead|</font></b>"
+	dat += "<BR><b><font color='green'>Living Players:|[living_players_connected] active|[living_players - living_players_connected] disconnected|</font></b>"
+	dat += "<BR><b><font color='#e29300'>Antagonists Players:|[antagonists] ingame|[antagonists-antagonists_dead] alive|[antagonists_dead] dead|</font></b>"
+	dat += "<BR><b><font color='#860e03'>Security Players:|[security] ingame|[security-security_dead] alive|[security_dead] dead|</font></b>"
 	dat += "<BR><b><font color='#bf42f4'>SKIPPED \[On centcom Z-level\]: [living_skipped] living players|[drones] living drones|</font></b>"
 	dat += "<BR><b><font color='red'>Dead/Observing players:|[observers_connected] active|[observers - observers_connected] disconnected|[brains] brains|</font></b>"
 	if(other_players)

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -127,23 +127,31 @@
 	var/other_players = 0
 	var/living_skipped = 0
 	var/drones = 0
+	var/security = 0
+	var/security_dead = 0
 	for(var/mob/M in GLOB.mob_list)
 		if(M.ckey)
 			if(isnewplayer(M))
 				lobby_players++
 				continue
-			else if(M.stat != DEAD && M.mind && !isbrain(M))
-				if(isdrone(M))
-					drones++
-					continue
-				if(is_centcom_level(M.z))
-					living_skipped++
-					continue
-				living_players++
-				if(M.mind.special_role)
-					living_players_antagonist++
-				if(M.client)
-					living_players_connected++
+			else if(M.mind && !isbrain(M))
+				if(M.stat != DEAD)
+					if(isdrone(M))
+						drones++
+						continue
+					if(is_centcom_level(M.z))
+						living_skipped++
+						continue
+					living_players++
+					if(M.mind.special_role)
+						living_players_antagonist++
+					if(M.client)
+						living_players_connected++
+				
+				if(M.mind.assigned_role.departments_list.Find(/datum/job_department/security))
+					security++
+					if(M.stat == DEAD)
+						security_dead++
 			else if(M.stat == DEAD || isobserver(M))
 				observers++
 				if(M.client)
@@ -154,6 +162,7 @@
 				other_players++
 	dat += "<BR><b><font color='blue' size='3'>Players:|[connected_players - lobby_players] ingame|[connected_players] connected|[lobby_players] lobby|</font></b>"
 	dat += "<BR><b><font color='green'>Living Players:|[living_players_connected] active|[living_players - living_players_connected] disconnected|[living_players_antagonist] antagonists|</font></b>"
+	dat += "<BR><b><font color='#860e03'>Security Players:|[security] ingame||[security-security_dead] alive|[security_dead] dead|</font></b>"
 	dat += "<BR><b><font color='#bf42f4'>SKIPPED \[On centcom Z-level\]: [living_skipped] living players|[drones] living drones|</font></b>"
 	dat += "<BR><b><font color='red'>Dead/Observing players:|[observers_connected] active|[observers - observers_connected] disconnected|[brains] brains|</font></b>"
 	if(other_players)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
That PR just adds a line with info about security department. How much players join on security, how many of them are alive or dead.

## Why It's Good For The Game
Staff can analyze situation with antaghonist more faster(i hope).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Vishenka0704
admin: separate antagonists from living player, and add another field with security info
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
