### PR TITLE
Change `drop_all_held_items` to work with cyborgs

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -360,15 +360,14 @@
 
 	owner.drop_all_held_items()
 
-	chainsaw = new(get_turf(owner))
-	ADD_TRAIT(chainsaw, TRAIT_NODROP, CHAINSAW_FRENZY_TRAIT)
-	owner.put_in_hands(chainsaw, forced = TRUE)
-	chainsaw.attack_self(owner)
-
-	owner.log_message("entered a blood frenzy", LOG_ATTACK)
 	if(iscarbon(owner))
+		chainsaw = new(get_turf(owner))
+		ADD_TRAIT(chainsaw, TRAIT_NODROP, CHAINSAW_FRENZY_TRAIT)
+		owner.put_in_hands(chainsaw, forced = TRUE)
+		chainsaw.attack_self(owner)
 		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 25)
 
+	owner.log_message("entered a blood frenzy", LOG_ATTACK)
 	to_chat(owner, span_warning("KILL, KILL, KILL! YOU HAVE NO ALLIES ANYMORE, KILL THEM ALL!"))
 
 	var/datum/client_colour/colour = owner.add_client_colour(/datum/client_colour/bloodlust)
@@ -379,7 +378,8 @@
 	. = ..()
 	to_chat(owner, span_notice("Your bloodlust seeps back into the bog of your subconscious and you regain self control."))
 	owner.log_message("exited a blood frenzy", LOG_ATTACK)
-	QDEL_NULL(chainsaw)
+	if(chainsaw)
+		QDEL_NULL(chainsaw)
 
 /datum/status_effect/speed_boost
 	id = "speed_boost"

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -378,8 +378,7 @@
 	. = ..()
 	to_chat(owner, span_notice("Your bloodlust seeps back into the bog of your subconscious and you regain self control."))
 	owner.log_message("exited a blood frenzy", LOG_ATTACK)
-	if(chainsaw)
-		QDEL_NULL(chainsaw)
+	QDEL_NULL(chainsaw)
 
 /datum/status_effect/speed_boost
 	id = "speed_boost"

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -366,7 +366,9 @@
 	chainsaw.attack_self(owner)
 
 	owner.log_message("entered a blood frenzy", LOG_ATTACK)
-	owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 25)
+	if(iscarbon(owner))
+		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 25)
+
 	to_chat(owner, span_warning("KILL, KILL, KILL! YOU HAVE NO ALLIES ANYMORE, KILL THEM ALL!"))
 
 	var/datum/client_colour/colour = owner.add_client_colour(/datum/client_colour/bloodlust)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -27,7 +27,7 @@
 		builtInCamera.toggle_cam(src,0)
 	toggle_headlamp(TRUE) //So borg lights are disabled when killed.
 
-	uneq_all() // particularly to ensure sight modes are cleared
+	drop_all_held_items() // particularly to ensure sight modes are cleared
 
 	update_icons()
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -265,9 +265,7 @@
 	if(module_active)
 		unequip_module_from_slot(module_active, get_selected_module())
 
-/**
- * Unequips all held items.
- */
+// Technically none of the items are dropped, only unequipped
 /mob/living/silicon/robot/drop_all_held_items()
 	for(var/cyborg_slot in 1 to length(held_items))
 		if(!held_items[cyborg_slot])

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -269,7 +269,7 @@
  * Unequips all held items.
  */
 /mob/living/silicon/robot/drop_all_held_items()
-	for(var/cyborg_slot in 1 to 3)
+	for(var/cyborg_slot in 1 to length(held_items))
 		if(!held_items[cyborg_slot])
 			continue
 		unequip_module_from_slot(held_items[cyborg_slot], cyborg_slot)

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -268,7 +268,7 @@
 /**
  * Unequips all held items.
  */
-/mob/living/silicon/robot/proc/uneq_all()
+/mob/living/silicon/robot/drop_all_held_items()
 	for(var/cyborg_slot in 1 to 3)
 		if(!held_items[cyborg_slot])
 			continue

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -19,11 +19,11 @@
 /mob/living/silicon/robot/proc/use_power(delta_time, times_fired)
 	if(cell?.charge)
 		if(cell.charge <= 100)
-			uneq_all()
+			drop_all_held_items()
 		var/amt = clamp(lamp_enabled * lamp_intensity * delta_time, 0.5 * delta_time, cell.charge) //Lamp will use a max of 5 charge, depending on brightness of lamp. If lamp is off, borg systems consume 1 point of charge, or the rest of the cell if it's lower than that.
 		cell.use(amt) //Usage table: 0.5/second if off/lowest setting, 4 = 2/second, 6 = 4/second, 8 = 6/second, 10 = 8/second
 	else
-		uneq_all()
+		drop_all_held_items()
 		low_power_mode = TRUE
 		toggle_headlamp(TRUE)
 	diag_hud_set_borgcell()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -708,7 +708,7 @@
 
 /mob/living/silicon/robot/proc/ResetModel()
 	SEND_SIGNAL(src, COMSIG_BORG_SAFE_DECONSTRUCT)
-	uneq_all()
+	drop_all_held_items()
 	shown_robot_modules = FALSE
 
 	for(var/obj/item/storage/bag in model.contents) // drop all of the items that may be stored by the cyborg

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -124,7 +124,7 @@
 		return
 	var/list/held_modules = cyborg.held_items.Copy()
 	var/active_module = cyborg.module_active
-	cyborg.uneq_all()
+	cyborg.drop_all_held_items()
 	modules = list()
 	for(var/obj/item/module in basic_modules)
 		add_module(module, FALSE, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #70675

This renames `uneq_all` to be `drop_all_held_items` for cyborgs.  This should make it easier for the code to be maintained since there won't be separate procs that do (nearly) the same thing for both silicons and living mobs.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

One less bug and better code maintenance. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix cyborgs dropping items when sent to the arena shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
