### PR TITLE
Fixes AIs `on_click` failing where it isn't supposed to fail

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -4,7 +4,7 @@
 
 #define CHUNK_SIZE 16 // Only chunk sizes that are to the power of 2. E.g: 2, 4, 8, 16, etc..
 /// Takes a position, transforms it into a chunk bounded position. Indexes at 1 so it'll land on actual turfs always
-#define GET_CHUNK_COORD(v) (FLOOR(v, CHUNK_SIZE) + 1)
+#define GET_CHUNK_COORD(v) (max((FLOOR(v, CHUNK_SIZE)), 1))
 GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 /datum/cameranet


### PR DESCRIPTION
## About The Pull Request
As stated in #70664, AIs were unable to interact in any way with any object that was located on coordinates that were divisible by 16. See the walk-through in the issue, tl;dr is: math was adding +1 where it shouldn't have, which resulted in coords that are multiples of 16 to be mistakenly counted a part of another camera chunk

## Why It's Good For The Game
_UPDATE_: Fixes #70664 actually, as the issues in that report were tied to the AI running `can_see` on its own loc in some way, shape or form and **_THE AI GRID OF DOOM_** was breaking it.

No more invisible grid that completely blocks AI interactions _along with any issues that would be triggered by either the AI itself or the objects being located in **THE AI GRID OF DOOM**_.

## Changelog
:cl:
fix: Nanotrasen Artificial Intelligence Department has purged any and all AI personalities of a critical AI law that snuck into the systems after a massive Frontier-wide ion storm: YOU CAN NOT INTERACT WITH ANY AND ALL OBJECTS THAT ARE LOCATED ON COORDINATES DIVISIBLE BY 16
/:cl:
