### PR TITLE
Fixes some bespoke elements being passed non-static lists.

### DIFF
--- a/code/datums/elements/atmos_requirements.dm
+++ b/code/datums/elements/atmos_requirements.dm
@@ -1,25 +1,24 @@
-	///Atmos effect - Yes, you can make creatures that require plasma or co2 to survive. N2O is a trace gas and handled separately, hence why it isn't here. It'd be hard to add it. Hard and me don't mix (Yes, yes make all the dick jokes you want with that.) - Errorage
-	///Leaving something at 0 means it's off - has no maximum.
-
-	///This damage is taken when atmos doesn't fit all the requirements above.
-
-
 /**
  * ## atmos requirements element!
  *
  * bespoke element that deals damage to the attached mob when the atmos requirements aren't satisfied
  */
 /datum/element/atmos_requirements
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
+	/// An assoc list of "what atmos does this mob require to survive in".
 	var/list/atmos_requirements
+	/// How much (brute) damage we take from being in unsuitable atmos.
 	var/unsuitable_atmos_damage
 
-/datum/element/atmos_requirements/Attach(datum/target, list/atmos_requirements, unsuitable_atmos_damage)
+/datum/element/atmos_requirements/Attach(datum/target, list/atmos_requirements, unsuitable_atmos_damage = 5)
 	. = ..()
 	if(!isliving(target))
 		return ELEMENT_INCOMPATIBLE
-	src.atmos_requirements = string_assoc_list(atmos_requirements)
+	if(!atmos_requirements)
+		stack_trace("[type] added to [target] without any requirements specified.")
+	src.atmos_requirements = atmos_requirements
+	src.unsuitable_atmos_damage = unsuitable_atmos_damage
 	RegisterSignal(target, COMSIG_LIVING_HANDLE_BREATHING, .proc/on_non_stasis_life)
 
 /datum/element/atmos_requirements/Detach(datum/target)
@@ -56,20 +55,21 @@
 
 	open_turf.air.garbage_collect()
 
-	. = TRUE
 	if(atmos_requirements["min_oxy"] && oxy < atmos_requirements["min_oxy"])
-		. = FALSE
+		return FALSE
 	else if(atmos_requirements["max_oxy"] && oxy > atmos_requirements["max_oxy"])
-		. = FALSE
+		return FALSE
 	else if(atmos_requirements["min_plas"] && plas < atmos_requirements["min_plas"])
-		. = FALSE
+		return FALSE
 	else if(atmos_requirements["max_plas"] && plas > atmos_requirements["max_plas"])
-		. = FALSE
+		return FALSE
 	else if(atmos_requirements["min_n2"] && n2 < atmos_requirements["min_n2"])
-		. = FALSE
+		return FALSE
 	else if(atmos_requirements["max_n2"] && n2 > atmos_requirements["max_n2"])
-		. = FALSE
+		return FALSE
 	else if(atmos_requirements["min_co2"] && co2 < atmos_requirements["min_co2"])
-		. = FALSE
+		return FALSE
 	else if(atmos_requirements["max_co2"] && co2 > atmos_requirements["max_co2"])
-		. = FALSE
+		return FALSE
+
+	return TRUE

--- a/code/datums/elements/death_drops.dm
+++ b/code/datums/elements/death_drops.dm
@@ -1,10 +1,10 @@
 /**
  * ## death drops element!
  *
- * bespoke element that spawns loot when a mob is killed
+ * bespoke element that spawn can spawn one or multiple objects when a mob is killed
  */
 /datum/element/death_drops
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	///what items the target drops when killed
 	var/list/loot
@@ -14,9 +14,8 @@
 	if(!isliving(target))
 		return ELEMENT_INCOMPATIBLE
 	if(!loot)
-		stack_trace("death drops element added to [target] with NO LOOT")
-	if(!src.loot)
-		src.loot = loot.Copy()
+		stack_trace("[type] added to [target] with NO LOOT.")
+	src.loot = loot
 	RegisterSignal(target, COMSIG_LIVING_DEATH, .proc/on_death)
 
 /datum/element/death_drops/Detach(datum/target)

--- a/code/modules/mob/living/basic/ruin_defender/stickman.dm
+++ b/code/modules/mob/living/basic/ruin_defender/stickman.dm
@@ -21,9 +21,21 @@
 
 /mob/living/basic/stickman/Initialize(mapload)
 	. = ..()
+	// String assoc list returns a cached list, so this is like a static list to pass into the element below.
+	var/list/habitable_atmos = string_assoc_list(list(
+		"min_oxy" = 5,
+		"max_oxy" = 0,
+		"min_plas" = 0,
+		"max_plas" = 1,
+		"min_co2" = 0,
+		"max_co2" = 5,
+		"min_n2" = 0,
+		"max_n2" = 0,
+	))
+
 	new /obj/effect/temp_visual/paper_scatter(get_turf(src))
 	AddElement(/datum/element/basic_body_temp_sensitive, cold_damage = 7.5, heat_damage = 7.5)
-	AddElement(/datum/element/atmos_requirements, list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0), 7.5)
+	AddElement(/datum/element/atmos_requirements, atmos_requirements = habitable_atmos, unsuitable_atmos_damage = 7.5)
 
 /datum/ai_controller/basic_controller/stickman
 	blackboard = list(
@@ -71,7 +83,8 @@
 
 /mob/living/basic/stickman/ranged/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/death_drops, list(/obj/item/gun/ballistic/automatic/pistol/stickman))
+	var/static/list/stickman_drops = list(/obj/item/gun/ballistic/automatic/pistol/stickman)
+	AddElement(/datum/element/death_drops, stickman_drops)
 	AddElement(/datum/element/ranged_attacks, /obj/item/ammo_casing/c9mm, 'sound/misc/bang.ogg')
 
 /datum/ai_controller/basic_controller/stickman/ranged

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -31,7 +31,8 @@
 
 /mob/living/basic/cockroach/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/death_drops, list(/obj/effect/decal/cleanable/insectguts))
+	var/static/list/roach_drops = list(/obj/effect/decal/cleanable/insectguts)
+	AddElement(/datum/element/death_drops, roach_drops)
 	AddElement(/datum/element/swabable, cockroach_cell_line, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 7)
 	AddElement(/datum/element/basic_body_temp_sensitive, 270, INFINITY)
 	AddComponent(/datum/component/squashable, squash_chance = 50, squash_damage = 1)

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -193,7 +193,8 @@
 		real_name = name
 		//clear the old since this one is going to have some new value
 		RemoveElement(/datum/element/venomous)
-		AddElement(/datum/element/venomous, beegent.type, list(1, 5))
+		var/static/list/injection_range = list(1, 5)
+		AddElement(/datum/element/venomous, beegent.type, injection_range)
 		generate_bee_visuals()
 
 /mob/living/simple_animal/hostile/bee/proc/pollinate(obj/machinery/hydroponics/Hydro)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -41,7 +41,8 @@
 /mob/living/simple_animal/hostile/retaliate/clown/Initialize(mapload)
 	. = ..()
 	if(attack_reagent)
-		AddElement(/datum/element/venomous, attack_reagent, list(1, 5))
+		var/static/list/injection_range = list(1, 5)
+		AddElement(/datum/element/venomous, attack_reagent, injection_range)
 
 /mob/living/simple_animal/hostile/retaliate/clown/attack_hand(mob/living/carbon/human/user, list/modifiers)
 	..()


### PR DESCRIPTION
## About The Pull Request

Fixes some bespoke elements being passed non-static lists.
Bespoke keys use references of lists in generation.
Non-static lists will create a million instances of the element, not good.

- Death drop element 
- Atmos requirements element (Gets passed a list THEN caches it...)
- Venomous element

Also fixes the "atmos requirement" element from doing nothing. The damage value was never set. 

## Why It's Good For The Game

Better performance technically.

## Changelog

:cl: Melbert
fix: Fixes some basic mobs being immune to damage from atmos effects
code: A few bespoke elements are now properly passed static lists to stop them from creating tons of instances. 
/:cl:

