### PR TITLE
Fixes ungenerated turf on Clockwork's ruin

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
@@ -34,7 +34,7 @@
 /area/icemoon/surface)
 "B" = (
 /turf/open/genturf,
-/area/lavaland/surface/outdoors)
+/area/lavaland/surface/outdoors/unexplored)
 "C" = (
 /obj/structure/fluff/clockwork/blind_eye,
 /turf/open/floor/bronze,


### PR DESCRIPTION
## About The Pull Request

The area used in the clockwork ruin didn't have cave generation on it, so I swapped it for the /unexplored subtype of it, which does.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/70672

## Changelog

:cl:
fix: Clockwork's ruin should no longer have ungenerated turfs.
/:cl:
