### PR TITLE
Fixes tablet pens

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -37,6 +37,11 @@
 		/obj/item/clothing/mask/cigarette,
 	)
 
+/obj/item/modular_computer/tablet/Initialize(mapload)
+	. = ..()
+	if(inserted_item)
+		inserted_item = new inserted_item(src)
+
 /obj/item/modular_computer/tablet/update_icon_state()
 	if(has_variants && !bypass_state)
 		if(!finish_color)
@@ -378,6 +383,3 @@
 	if(loaded_cartridge)
 		var/obj/item/computer_hardware/hard_drive/portable/disk = new loaded_cartridge(src)
 		install_component(disk)
-
-	if(inserted_item)
-		inserted_item = new inserted_item(src)


### PR DESCRIPTION
## About The Pull Request

Tablets and PDAs have pens which can be removed, but only PDAs would actually make their default pen on Iniitalize, meaning tablets were sorta just broken. This fixes that by moving the pen's creation on Tablet's initialize instead, since PDA is a subtype of it.

## Why It's Good For The Game

Closes the other half of https://github.com/tgstation/tgstation/issues/70692 
Fixes tablets, the thing even more unused than laptops.

## Changelog

:cl:
fix: Tablets (not PDAs) now have pens properly.
/:cl:
