### PR TITLE
Fixes minor fleshmend runtime from clearing scars

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -161,7 +161,7 @@
 	if(!iscarbon(owner))
 		return
 	var/mob/living/carbon/C = owner
-	QDEL_LIST(C.all_scars)
+	QDEL_LAZYLIST(C.all_scars)
 
 /atom/movable/screen/alert/status_effect/fleshmend
 	name = "Fleshmend"


### PR DESCRIPTION
## About The Pull Request

- `all_scars` is a lazylist, so this would runtime on occasion. 
   - (scars call `LAZYREMOVE` on delete, so the list would null before `QDEL_LIST` finishes and cause a `null.Cut()` runtime)

## Why It's Good For The Game

Minor runtime.

## Changelog

:cl: Melbert
fix: Fixes a minor runtime with Fleshmend clearing scars. 
/:cl:

