### PR TITLE
Fixes runtime from voting action `Remove()`

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -49,12 +49,7 @@ SUBSYSTEM_DEF(vote)
 	current_vote?.reset()
 	current_vote = null
 
-	for(var/datum/action/vote/voting_action as anything in generated_actions)
-		if(QDELETED(voting_action))
-			continue
-		voting_action.Remove(voting_action.owner)
-
-	generated_actions.Cut()
+	QDEL_LIST(generated_actions)
 
 	SStgui.update_uis(src)
 


### PR DESCRIPTION
## About The Pull Request

- Voting reset went through all actions and tried to remove it from their owners. Unfortunately, if a user actually opened the voting action, they would be removed from their owner and be ownerless. This cause it to be a `Remove(null)` call, which shouldn't be allowed - we expect `remove_from` to be non-null. So, I fixed it by replacing the loop-remove-all with just a `QDEL_LIST`. These accomplish pretty much the same thing - just one has in-built handling for null owners and the other does not. (The actions should've been qdeleted anyways - otherwise they were just hanging, ownerless actions.)

## Why It's Good For The Game

Less runtimes, especially one as spammy as this. Might be my bad. 

## Changelog

:cl: Melbert
fix: Fixes a runtime with voting actions.
/:cl:

