### PR TITLE
Fixes cult dagger grant runtime. 

### DIFF
--- a/code/datums/actions/items/cult_dagger.dm
+++ b/code/datums/actions/items/cult_dagger.dm
@@ -10,7 +10,6 @@
 
 /datum/action/item_action/cult_dagger/Grant(mob/grant_to)
 	if(!IS_CULTIST(grant_to))
-		Remove(owner)
 		return
 
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Owner is not guaranteed to be non-null, and `Remove(null)` is invalid.

This pretty much does nothing, anyways. It's an item action, so it's only ever granted when it's picked up, and only ever removed when it's dropped. 

## Why It's Good For The Game

Fixes a runtime.

## Changelog

:cl: Melbert
fix: Fixes a runtime from non-cultists picking up cult daggers 
/:cl:
