### PR TITLE
Fixes nutition reagents healing robotic limbs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -62,7 +62,7 @@
 
 /datum/reagent/consumable/nutriment/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	if(DT_PROB(30, delta_time))
-		M.heal_bodypart_damage(brute = brute_heal, burn = burn_heal)
+		M.heal_bodypart_damage(brute = brute_heal, burn = burn_heal, updating_health = FALSE, required_status = BODYTYPE_ORGANIC)
 		. = TRUE
 	..()
 


### PR DESCRIPTION
## About The Pull Request

Fixes #70699

Healing from nutrition only affects organic limbs - cybernetic organs will not be repaired by Peptides or eating a burger. 

## Why It's Good For The Game

Fixes an oversight(?) which allowed for reagents to heal things which traditionally cannot be healed by chemical means.

## Changelog

:cl: Melbert
fix: Nutriments and Peptides will no longer heal robotic limbs. 
/:cl:

