### PR TITLE
Fixes runtime with the infective component on gibs

### DIFF
--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -117,6 +117,10 @@
 /datum/component/infective/proc/try_infect_streak(datum/source, list/directions, list/output_diseases)
 	SIGNAL_HANDLER
 
+	// This blood is not infectable / does not have a diseases list
+	if(!islist(output_diseases))
+		return
+
 	output_diseases |= diseases
 
 /datum/component/infective/proc/try_infect(mob/living/L, target_zone)

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -116,6 +116,10 @@
 	. = ..()
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, .proc/on_pipe_eject)
 
+/obj/effect/decal/cleanable/blood/gibs/Destroy()
+	streak_diseases = null
+	return ..()
+
 /obj/effect/decal/cleanable/blood/gibs/replace_decal(obj/effect/decal/cleanable/C)
 	return FALSE //Never fail to place us
 
@@ -145,9 +149,9 @@
 	streak(dirs)
 
 /obj/effect/decal/cleanable/blood/gibs/proc/streak(list/directions, mapload=FALSE)
+	LAZYINITLIST(streak_diseases)
 	SEND_SIGNAL(src, COMSIG_GIBS_STREAK, directions, streak_diseases)
 	var/direction = pick(directions)
-	streak_diseases = list()
 	var/delay = 2
 	var/range = pick(0, 200; 1, 150; 2, 50; 3, 17; 50) //the 3% chance of 50 steps is intentional and played for laughs.
 	if(!step_to(src, get_step(src, direction), 0))

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -117,7 +117,7 @@
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, .proc/on_pipe_eject)
 
 /obj/effect/decal/cleanable/blood/gibs/Destroy()
-	streak_diseases = null
+	LAZYNULL(streak_diseases)
 	return ..()
 
 /obj/effect/decal/cleanable/blood/gibs/replace_decal(obj/effect/decal/cleanable/C)


### PR DESCRIPTION
## About The Pull Request

Infective attempts to add its diseases to a gib's list of streaking diseases when it triggers. But for some reason the list was never instantiated until after the signal sent, so this runtime. 

However, it goes a little deeper beyond that, as `COMSIG_GIBS_STREAK` is sent from a second place which does _not_ supply a list at all. Meaning it can be null, even if in this place it did not intend to be null.

Honestly this is emblematic of a larger issue with the fact that the gib streaking is kinda old and needs a face lift, I got like 95% of the way through doing it and wanted to toss it out. Maybe I'll return to it.

## Why It's Good For The Game

Infective component actually spreads diseases to gibs

## Changelog

:cl: Melbert
fix: Streaks of blood from gibs will now all be infective with diseases, instead of only the parent gib
/:cl:

