### PR TITLE
Refactors radios to not use the prison_radio var

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -294,7 +294,7 @@
  *
  * To have your LateIntialize proc be called, your atoms [Initalization][/atom/proc/Initialize]
  *  proc must return the hint
- * [INITIALIZE_HINT_LATELOAD] otherwise you will never be called.
+ * [INITIALIZE_HINT_LATELOAD] otherwise it will never be called.
  *
  * useful for doing things like finding other machines on GLOB.machines because you can guarantee
  * that all atoms will actually exist in the "WORLD" at this time and that all their Intialization

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -14,7 +14,11 @@
 /obj/item/radio/intercom/prison
 	name = "prison intercom"
 	desc = "A station intercom. It looks like it has been modified to not broadcast."
-	prison_radio = TRUE
+
+/obj/item/radio/intercom/prison/Initialize(mapload, ndir, building)
+	. = ..()
+	if(wires)
+		wires.cut(WIRES_TX)
 
 /obj/item/radio/intercom/Initialize(mapload, ndir, building)
 	. = ..()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -18,7 +18,7 @@
 /obj/item/radio/intercom/prison/Initialize(mapload, ndir, building)
 	. = ..()
 	if(wires)
-		wires.cut(WIRES_TX)
+		wires.cut(WIRE_TX)
 
 /obj/item/radio/intercom/Initialize(mapload, ndir, building)
 	. = ..()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -17,8 +17,7 @@
 
 /obj/item/radio/intercom/prison/Initialize(mapload, ndir, building)
 	. = ..()
-	if(wires)
-		wires.cut(WIRE_TX)
+	wires?.cut(WIRE_TX)
 
 /obj/item/radio/intercom/Initialize(mapload, ndir, building)
 	. = ..()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -43,8 +43,6 @@
 	/// Tracks the number of EMPs currently stacked.
 	var/emped = 0
 
-	/// If true, the transmit wire starts cut.
-	var/prison_radio = FALSE
 	/// Whether wires are accessible. Toggleable by screwdrivering.
 	var/unscrewed = FALSE
 	/// If true, the radio has access to the full spectrum.

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -78,8 +78,6 @@
 
 /obj/item/radio/Initialize(mapload)
 	wires = new /datum/wires/radio(src)
-	if(prison_radio)
-		wires.cut(WIRE_TX) // OH GOD WHY
 	secure_radio_connections = list()
 	. = ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes prison_radio, moves the wirecut code to the initialize of the prisonradio
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
its really silly and pointless to have an entire variable dedicated to something that is only referenced *3 times* in the entire codebase 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: removed prison_radio var
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
