### PR TITLE
Head pikes now drop their mounted heads upon destruction

### DIFF
--- a/code/game/objects/structures/headpike.dm
+++ b/code/game/objects/structures/headpike.dm
@@ -24,9 +24,7 @@
 	pixel_x = rand(-8, 8)
 
 /obj/structure/headpike/Destroy()
-	if(victim)
-		victim.forceMove(drop_location())
-		victim = null
+	QDEL_NULL(victim)
 	QDEL_NULL(spear)
 	return ..()
 
@@ -65,11 +63,11 @@
 	return ..()
 
 /obj/structure/headpike/deconstruct(disassembled)
-	if(!disassembled)
-		return ..()
-	if(victim)
+	if(victim) //Make sure the head always comes off
 		victim.forceMove(drop_location())
 		victim = null
+	if(!disassembled)
+		return ..()
 	if(spear)
 		spear.forceMove(drop_location())
 		spear = null

--- a/code/game/objects/structures/headpike.dm
+++ b/code/game/objects/structures/headpike.dm
@@ -24,7 +24,9 @@
 	pixel_x = rand(-8, 8)
 
 /obj/structure/headpike/Destroy()
-	QDEL_NULL(victim)
+	if(victim)
+		victim.forceMove(drop_location())
+		victim = null
 	QDEL_NULL(spear)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Head pikes would call QDEL_NULL on their mounted head upon being bashed down with something. This meant that taking down a headpike the wrong way could delete a person's head and brain. The deconstruct proc has been slightly reordered to ensure that the head always drops.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a way of accidentally/intentionally deleting a person's severed head.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: headpikes now drop their mounted head on destruction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
