### PR TITLE
Fixes an edge case heretic sacrifice runtime

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -374,7 +374,8 @@
 	sac_target.adjust_stutter(40 SECONDS)
 
 	// They're already back on the station for some reason, don't bother teleporting
-	if(is_station_level(sac_target.z))
+	var/turf/below_target = get_turf(sac_target)
+	if(below_target && below_target.z != 0 && is_station_level(below_target.z))
 		return
 
 	// Teleport them to a random safe coordinate on the station z level.

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -375,6 +375,8 @@
 
 	// They're already back on the station for some reason, don't bother teleporting
 	var/turf/below_target = get_turf(sac_target)
+	// is_station_level runtimes when passed z = 0, so I'm being very explicit here about checking for nullspace until fixed
+	// otherwise, we really don't want this to runtime error, as it'll get people stuck in hell forever - not ideal!
 	if(below_target && below_target.z != 0 && is_station_level(below_target.z))
 		return
 


### PR DESCRIPTION
## About The Pull Request
```
[2022-10-21 20:06:42.612] runtime error: list index out of bounds
 - proc name: return target (/datum/heretic_knowledge/hunt_and_sacrifice/proc/return_target)
 -   source file: sacrifice_knowledge.dm,377
 -   usr: Lind Victus (/mob/living/carbon/human)
 -   src: Heartbeat of the Mansus (/datum/heretic_knowledge/hunt_and_sacrifice)
 -   usr.loc: the floor (182,124,3) (/turf/open/floor/iron/smooth)
 -   call stack:
 - Heartbeat of the Mansus (/datum/heretic_knowledge/hunt_and_sacrifice): return target(Jimmy Robertson (/mob/living/carbon/human))
 - /datum/callback (/datum/callback): Invoke()
 ```

Related to #69714 , if a runtime error occurred during this process it'd leave the person stranded, which is not ideal. So, a bit of runtime protection / sanity / nullspace checking should help

## Why It's Good For The Game

People don't get stuck in Heck

## Changelog

:cl: Melbert
fix: Fixes an edge case runtime with heretic sacrificing 
/:cl:
