### PR TITLE
Fixes runtime with wendigo slam

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -169,7 +169,7 @@ Difficulty: Hard
 /// Larger but slower ground stomp
 /mob/living/simple_animal/hostile/megafauna/wendigo/proc/heavy_stomp()
 	can_move = FALSE
-	wendigo_slam(src, 5, 3 - WENDIGO_ENRAGED, 8)
+	wendigo_slam(5, 3 - WENDIGO_ENRAGED, 8)
 	update_cooldowns(list(COOLDOWN_UPDATE_SET_MELEE = 0 SECONDS, COOLDOWN_UPDATE_SET_RANGED = 0 SECONDS))
 	can_move = TRUE
 


### PR DESCRIPTION
## About The Pull Request

#70668 didn't update all the places where wendigo slam is called. Causes runtimes

```
[22:05:06] Runtime in wendigo.dm, line 151: type mismatch: 202 - the wendigo (/mob/living/simple_animal/hostile/megafauna/wendigo)
```

## Why It's Good For The Game

Slam works when it should

## Changelog

:cl: Melbert
fix: Fixes a runtime with Wendigo's slam
/:cl:

