### PR TITLE
fixes anomaly events not triggering when invoking the apocalypse rune

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -1013,51 +1013,51 @@ structure_check() searches for nearby cultist structures required for the invoca
 		switch(outcome)
 			if(1 to 10)
 				var/datum/round_event_control/disease_outbreak/covid_2562_event = locate() in SSevents.control
-				INVOKE_ASYNC(covid_2562_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(covid_2562_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 				var/datum/round_event_control/mice_migration/stuart_big_event = locate() in SSevents.control
-				INVOKE_ASYNC(stuart_big_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(stuart_big_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 
 			if(11 to 20)
 				var/datum/round_event_control/radiation_storm/my_skin_feels_funny_event = locate() in SSevents.control
-				INVOKE_ASYNC(my_skin_feels_funny_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(my_skin_feels_funny_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 
 			if(21 to 30)
 				var/datum/round_event_control/brand_intelligence/product_placement_gone_rogue_event = locate() in SSevents.control
-				INVOKE_ASYNC(product_placement_gone_rogue_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(product_placement_gone_rogue_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 
 			if(31 to 40)
 				var/datum/round_event_control/immovable_rod/huge_rod_event = locate() in SSevents.control //you've
-				INVOKE_ASYNC(huge_rod_event, /datum/round_event_control/.proc/runEvent) //got
-				INVOKE_ASYNC(huge_rod_event, /datum/round_event_control/.proc/runEvent) //a
-				INVOKE_ASYNC(huge_rod_event, /datum/round_event_control/.proc/runEvent) //huge...
+				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent)) //got
+				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent)) //a
+				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent)) //huge...
 
 			if(41 to 50)
 				var/datum/round_event_control/meteor_wave/dinosaur_purge_event = locate() in SSevents.control
-				INVOKE_ASYNC(dinosaur_purge_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(dinosaur_purge_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 
 			if(51 to 60)
 				var/datum/round_event_control/spider_infestation/creepy_crawly_event = locate() in SSevents.control
-				INVOKE_ASYNC(creepy_crawly_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(creepy_crawly_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 
 			if(61 to 70)
 				var/datum/round_event_control/anomaly/anomaly_flux/flux_event = locate() in SSevents.control
-				INVOKE_ASYNC(flux_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(flux_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 				var/datum/round_event_control/anomaly/anomaly_grav/grav_event = locate() in SSevents.control
-				INVOKE_ASYNC(grav_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(grav_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 				var/datum/round_event_control/anomaly/anomaly_pyro/pyro_event = locate() in SSevents.control
-				INVOKE_ASYNC(pyro_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(pyro_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 				var/datum/round_event_control/anomaly/anomaly_vortex/vortex_event = locate() in SSevents.control
-				INVOKE_ASYNC(vortex_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(vortex_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 
 			if(71 to 80)
 				var/datum/round_event_control/spacevine/ivy_event = locate() in SSevents.control
-				INVOKE_ASYNC(ivy_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(ivy_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 				var/datum/round_event_control/grey_tide/grey_tide_nation_wide = locate() in SSevents.control
-				INVOKE_ASYNC(grey_tide_nation_wide, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(grey_tide_nation_wide, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 
 			if(81 to 100)
 				var/datum/round_event_control/portal_storm_narsie/total_not_a_xen_storm_event = locate() in SSevents.control
-				INVOKE_ASYNC(total_not_a_xen_storm_event, /datum/round_event_control/.proc/runEvent)
+				INVOKE_ASYNC(total_not_a_xen_storm_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
 
 	qdel(src)
 

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -1012,44 +1012,53 @@ structure_check() searches for nearby cultist structures required for the invoca
 		var/outcome = rand(1,100)
 		switch(outcome)
 			if(1 to 10)
-				var/datum/round_event_control/disease_outbreak/D = new()
-				var/datum/round_event_control/mice_migration/M = new()
-				D.runEvent()
-				M.runEvent()
+				var/datum/round_event_control/disease_outbreak/covid_2562_event = locate() in SSevents.control
+				INVOKE_ASYNC(covid_2562_event, /datum/round_event_control/.proc/runEvent)
+				var/datum/round_event_control/mice_migration/stuart_big_event = locate() in SSevents.control
+				INVOKE_ASYNC(stuart_big_event, /datum/round_event_control/.proc/runEvent)
+
 			if(11 to 20)
-				var/datum/round_event_control/radiation_storm/RS = new()
-				RS.runEvent()
+				var/datum/round_event_control/radiation_storm/my_skin_feels_funny_event = locate() in SSevents.control
+				INVOKE_ASYNC(my_skin_feels_funny_event, /datum/round_event_control/.proc/runEvent)
+
 			if(21 to 30)
-				var/datum/round_event_control/brand_intelligence/BI = new()
-				BI.runEvent()
+				var/datum/round_event_control/brand_intelligence/product_placement_gone_rogue_event = locate() in SSevents.control
+				INVOKE_ASYNC(product_placement_gone_rogue_event, /datum/round_event_control/.proc/runEvent)
+
 			if(31 to 40)
-				var/datum/round_event_control/immovable_rod/R = new()
-				R.runEvent()
-				R.runEvent()
-				R.runEvent()
+				var/datum/round_event_control/immovable_rod/huge_rod_event = locate() in SSevents.control //you've
+				INVOKE_ASYNC(huge_rod_event, /datum/round_event_control/.proc/runEvent) //got
+				INVOKE_ASYNC(huge_rod_event, /datum/round_event_control/.proc/runEvent) //a
+				INVOKE_ASYNC(huge_rod_event, /datum/round_event_control/.proc/runEvent) //huge...
+
 			if(41 to 50)
-				var/datum/round_event_control/meteor_wave/MW = new()
-				MW.runEvent()
+				var/datum/round_event_control/meteor_wave/dinosaur_purge_event = locate() in SSevents.control
+				INVOKE_ASYNC(dinosaur_purge_event, /datum/round_event_control/.proc/runEvent)
+
 			if(51 to 60)
-				var/datum/round_event_control/spider_infestation/SI = new()
-				SI.runEvent()
+				var/datum/round_event_control/spider_infestation/creepy_crawly_event = locate() in SSevents.control
+				INVOKE_ASYNC(creepy_crawly_event, /datum/round_event_control/.proc/runEvent)
+
 			if(61 to 70)
-				var/datum/round_event_control/anomaly/anomaly_flux/AF
-				var/datum/round_event_control/anomaly/anomaly_grav/AG
-				var/datum/round_event_control/anomaly/anomaly_pyro/AP
-				var/datum/round_event_control/anomaly/anomaly_vortex/AV
-				AF.runEvent()
-				AG.runEvent()
-				AP.runEvent()
-				AV.runEvent()
+				var/datum/round_event_control/anomaly/anomaly_flux/flux_event = locate() in SSevents.control
+				INVOKE_ASYNC(flux_event, /datum/round_event_control/.proc/runEvent)
+				var/datum/round_event_control/anomaly/anomaly_grav/grav_event = locate() in SSevents.control
+				INVOKE_ASYNC(grav_event, /datum/round_event_control/.proc/runEvent)
+				var/datum/round_event_control/anomaly/anomaly_pyro/pyro_event = locate() in SSevents.control
+				INVOKE_ASYNC(pyro_event, /datum/round_event_control/.proc/runEvent)
+				var/datum/round_event_control/anomaly/anomaly_vortex/vortex_event = locate() in SSevents.control
+				INVOKE_ASYNC(vortex_event, /datum/round_event_control/.proc/runEvent)
+
 			if(71 to 80)
-				var/datum/round_event_control/spacevine/SV = new()
-				var/datum/round_event_control/grey_tide/GT = new()
-				SV.runEvent()
-				GT.runEvent()
+				var/datum/round_event_control/spacevine/ivy_event = locate() in SSevents.control
+				INVOKE_ASYNC(ivy_event, /datum/round_event_control/.proc/runEvent)
+				var/datum/round_event_control/grey_tide/grey_tide_nation_wide = locate() in SSevents.control
+				INVOKE_ASYNC(grey_tide_nation_wide, /datum/round_event_control/.proc/runEvent)
+
 			if(81 to 100)
-				var/datum/round_event_control/portal_storm_narsie/N = new()
-				N.runEvent()
+				var/datum/round_event_control/portal_storm_narsie/total_not_a_xen_storm_event = locate() in SSevents.control
+				INVOKE_ASYNC(total_not_a_xen_storm_event, /datum/round_event_control/.proc/runEvent)
+
 	qdel(src)
 
 /obj/effect/rune/apocalypse/proc/image_handler(list/images, duration)


### PR DESCRIPTION
`var/datum/round_event_control/anomaly/anomaly_flux/AF`
vars were never set to anything lol

:cl: ShizCalev
fix: Fixed anomalies not spawning when invoking the apocalypse rune
/:cl:
