### PR TITLE
fixes nulls in microwave ingredients list

### DIFF
--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -205,23 +205,32 @@
 		update_appearance()
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
+/obj/machinery/microwave/crowbar_act(mob/living/user, obj/item/tool)
+	if(operating)
+		return
+	if(!default_deconstruction_crowbar(tool))
+		return
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
+/obj/machinery/microwave/screwdriver_act(mob/living/user, obj/item/tool)
+	if(operating)
+		return
+	if(dirty >= 100)
+		return
+	if(default_deconstruction_screwdriver(user, icon_state, icon_state, tool))
+		update_appearance()
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
 /obj/machinery/microwave/attackby(obj/item/O, mob/living/user, params)
 	if(operating)
 		return
-	if(default_deconstruction_crowbar(O))
-		return
-
-	if(dirty < 100)
-		if(default_deconstruction_screwdriver(user, icon_state, icon_state, O))
-			update_appearance()
-			return
 
 	if(panel_open && is_wire_tool(O))
 		wires.interact(user)
 		return TRUE
 
 	if(broken > 0)
-		if(broken == 2 && O.tool_behaviour == TOOL_WIRECUTTER) // If it's broken and they're using a screwdriver
+		if(broken == 2 && O.tool_behaviour == TOOL_WIRECUTTER) // If it's broken and they're using a TOOL_WIRECUTTER
 			user.visible_message(span_notice("[user] starts to fix part of \the [src]."), span_notice("You start to fix part of \the [src]..."))
 			if(O.use_tool(src, user, 20))
 				user.visible_message(span_notice("[user] fixes part of \the [src]."), span_notice("You fix part of \the [src]."))
@@ -293,7 +302,7 @@
 		update_appearance()
 		return
 
-	..()
+	return ..()
 
 /obj/machinery/microwave/attack_hand_secondary(mob/user, list/modifiers)
 	if(user.canUseTopic(src, !issilicon(usr)))

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -41,12 +41,25 @@
 
 	update_appearance(UPDATE_ICON)
 
-/obj/machinery/microwave/Destroy()
+/obj/machinery/microwave/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	ingredients += arrived
+	return ..()
+
+/obj/machinery/microwave/Exited(atom/movable/gone, direction)
+	if(gone in ingredients)
+		ingredients -= gone
+	return ..()
+
+
+/obj/machinery/microwave/on_deconstruction()
 	eject()
-	if(wires)
-		QDEL_NULL(wires)
+	return ..()
+
+/obj/machinery/microwave/Destroy()
+	QDEL_LIST(ingredients)
+	QDEL_NULL(wires)
 	QDEL_NULL(soundloop)
-	. = ..()
+	return ..()
 
 /obj/machinery/microwave/set_anchored(anchorvalue)
 	. = ..()
@@ -264,7 +277,6 @@
 				return TRUE
 			if(T.atom_storage.attempt_remove(S, src))
 				loaded++
-				ingredients += S
 		if(loaded)
 			to_chat(user, span_notice("You insert [loaded] items into \the [src]."))
 		return
@@ -277,7 +289,6 @@
 			to_chat(user, span_warning("\The [O] is stuck to your hand!"))
 			return FALSE
 
-		ingredients += O
 		user.visible_message(span_notice("[user] adds \a [O] to \the [src]."), span_notice("You add [O] to \the [src]."))
 		update_appearance()
 		return
@@ -322,10 +333,9 @@
 			examine(user)
 
 /obj/machinery/microwave/proc/eject()
-	for(var/i in ingredients)
-		var/atom/movable/AM = i
-		AM.forceMove(drop_location())
-	ingredients.Cut()
+	var/atom/drop_loc = drop_location()
+	for(var/atom/movable/movable_ingredient as anything in ingredients)
+		movable_ingredient.forceMove(drop_loc)
 	open()
 	playsound(loc, 'sound/machines/click.ogg', 15, TRUE, -3)
 
@@ -381,7 +391,7 @@
 
 /obj/machinery/microwave/proc/muck()
 	wzhzhzh()
-	playsound(src.loc, 'sound/effects/splat.ogg', 50, TRUE)
+	playsound(loc, 'sound/effects/splat.ogg', 50, TRUE)
 	dirty_anim_playing = TRUE
 	update_appearance()
 	loop(MICROWAVE_MUCK, 4)
@@ -390,7 +400,8 @@
 	if((machine_stat & BROKEN) && type == MICROWAVE_PRE)
 		pre_fail()
 		return
-	if(!time)
+
+	if(!time || !length(ingredients))
 		switch(type)
 			if(MICROWAVE_NORMAL)
 				loop_finish()
@@ -428,10 +439,6 @@
 		dump_inventory_contents()
 
 	after_finish_loop()
-
-/obj/machinery/microwave/dump_inventory_contents()
-	. = ..()
-	ingredients.Cut()
 
 /obj/machinery/microwave/proc/pre_fail()
 	broken = 2


### PR DESCRIPTION
Didn't have any handle_atom_del logic to handle stuff inside of it getting deleted.

```
 - 
[2022-10-21 01:32:22.541] runtime error: Cannot read null.icon
 - proc name: update overlays (/obj/machinery/microwave/update_overlays)
 -   source file: microwave.dm,140
 -   usr: Graham Steele (/mob/living/carbon/human)
 -   src: the microwave oven (/obj/machinery/microwave)
 -   usr.loc: the floor (163,100,3) (/turf/open/floor/iron)
 -   src.loc: the floor (163,99,3) (/turf/open/floor/iron)
 -   call stack:
 - the microwave oven (/obj/machinery/microwave): update overlays(16777215)
 - the microwave oven (/obj/machinery/microwave): update icon(16777215)
 - the microwave oven (/obj/machinery/microwave): update appearance(16777215)
 - the microwave oven (/obj/machinery/microwave): attackby(the Donk-pocket (/obj/item/food/donkpocket), Graham Steele (/mob/living/carbon/human), "icon-x=18;icon-y=14;left=1;but...")
 - the Donk-pocket (/obj/item/food/donkpocket): melee attack chain(Graham Steele (/mob/living/carbon/human), the microwave oven (/obj/machinery/microwave), "icon-x=18;icon-y=14;left=1;but...")
 - Graham Steele (/mob/living/carbon/human): ClickOn(the microwave oven (/obj/machinery/microwave), "icon-x=18;icon-y=14;left=1;but...")
 - the microwave oven (/obj/machinery/microwave): Click(the floor (163,99,3) (/turf/open/floor/iron), "mapwindow.map", "icon-x=18;icon-y=14;left=1;but...")
 - AnotherAdvent (/client): Click(the microwave oven (/obj/machinery/microwave), the floor (163,99,3) (/turf/open/floor/iron), "mapwindow.map", "icon-x=18;icon-y=14;left=1;but...")
```

```
[2022-10-21 01:33:04.118] runtime error: Cannot execute null.forceMove().
 - proc name: eject (/obj/machinery/microwave/proc/eject)
 -   source file: microwave.dm,343
 -   usr: Jonathan Applejack (/mob/living/carbon/human)
 -   src: the microwave oven (/obj/machinery/microwave)
 -   usr.loc: the floor (162,99,3) (/turf/open/floor/iron)
 -   src.loc: the floor (163,99,3) (/turf/open/floor/iron)
 -   call stack:
 - the microwave oven (/obj/machinery/microwave): eject()
 - the microwave oven (/obj/machinery/microwave): Destroy(0)
 - qdel(the microwave oven (/obj/machinery/microwave), 0)
 - the microwave oven (/obj/machinery/microwave): deconstruct(1)
 - the microwave oven (/obj/machinery/microwave): deconstruct(1)
 - the microwave oven (/obj/machinery/microwave): default deconstruction crowbar(the pocket crowbar (/obj/item/crowbar), 0, 0)
 - the microwave oven (/obj/machinery/microwave): attackby(the pocket crowbar (/obj/item/crowbar), Jonathan Applejack (/mob/living/carbon/human), "icon-x=21;icon-y=10;left=1;but...")
 - the pocket crowbar (/obj/item/crowbar): melee attack chain(Jonathan Applejack (/mob/living/carbon/human), the microwave oven (/obj/machinery/microwave), "icon-x=21;icon-y=10;left=1;but...")
 - Jonathan Applejack (/mob/living/carbon/human): ClickOn(the microwave oven (/obj/machinery/microwave), "icon-x=21;icon-y=10;left=1;but...")
 - the microwave oven (/obj/machinery/microwave): Click(the floor (163,99,3) (/turf/open/floor/iron), "mapwindow.map", "icon-x=21;icon-y=10;left=1;but...")
 - Mike32oz (/client): Click(the microwave oven (/obj/machinery/microwave), the floor (163,99,3) (/turf/open/floor/iron), "mapwindow.map", "icon-x=21;icon-y=10;left=1;but...")
```

:cl: ShizCalev
fix: Microwaves are now less likely to break if things inside of it are deleted.
/:cl:
