### PR TITLE
Reduces the vending machine crushing paralysis from ABSOLUTE to SEVERE

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -118,7 +118,7 @@
 	resilience = TRAUMA_RESILIENCE_ABSOLUTE
 
 /datum/brain_trauma/severe/paralysis/paraplegic/vending
-	resilience = TRAUMA_LIMIT_SURGERY
+	resilience = TRAUMA_RESILIENCE_SURGERY
 
 /datum/brain_trauma/severe/narcolepsy
 	name = "Narcolepsy"

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -117,6 +117,9 @@
 	paralysis_type = "legs"
 	resilience = TRAUMA_RESILIENCE_ABSOLUTE
 
+/datum/brain_trauma/severe/paralysis/paraplegic/vending
+	resilience = TRAUMA_LIMIT_SURGERY
+
 /datum/brain_trauma/severe/narcolepsy
 	name = "Narcolepsy"
 	desc = "Patient may involuntarily fall asleep during normal activities."

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -708,7 +708,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 					if(4) // paralyze this binch
 						// the new paraplegic gets like 4 lines of losing their legs so skip them
 						visible_message(span_danger("[C]'s spinal cord is obliterated with a sickening crunch!"), ignored_mobs = list(C))
-						C.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic)
+						C.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic/vending)
 					if(5) // limb squish!
 						for(var/i in C.bodyparts)
 							var/obj/item/bodypart/squish_part = i


### PR DESCRIPTION
## About The Pull Request

This adds a new sub-category to the paraplegic trauma called ``/datum/brain_trauma/severe/paralysis/paraplegic/vending``

This specifically reduces the paralysis trauma from ABSOLUTE to SEVERE

## Why It's Good For The Game

This is extremely punishing for something that can come from a vending machine. Despite it being a low chance, its punishing mechanics are way out of proportion to what it comes from.

Also, I know you can circumvent it with botany. This seems like an oversight, to be perfectly honest. You shouldn't need to rely on oversight to fix this. Permanent traumas should be confined to failed lobotomy and quirks (like pacifist)

## Changelog

:cl: Nuke
balance: Modern Medicine can now fix paralysis that comes from vending machines. 
/:cl:
