### PR TITLE
flicker() no longer overrides lights being turned off

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -444,12 +444,15 @@
 	flickering = TRUE
 	if(on && status == LIGHT_OK)
 		for(var/i in 1 to amount)
-			if(status != LIGHT_OK)
+			if(status != LIGHT_OK || !has_power())
 				break
 			on = !on
 			update(FALSE)
 			sleep(rand(5, 15))
-		on = (status == LIGHT_OK)
+		if(has_power())
+			on = (status == LIGHT_OK)
+		else
+			on = FALSE
 		update(FALSE)
 		. = TRUE //did we actually flicker?
 	flickering = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If a light has flicker() running and the light is turned off/disabled, it would ignore the light being turned off and continue flickering. This could lead to lights remaining on despite the area not having power, or having the lighting disabled in the APC.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a bug found while testing for a different PR.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Flickering lights will now stop flickering and turn off properly when depowered or disabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
