### PR TITLE
Assigns quirks to humans that are transformed from a ghost.

### DIFF
--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -50,14 +50,16 @@
 		client?.prefs.safe_transfer_prefs_to(new_human)
 		new_human.dna.update_dna_identity()
 		new_human.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
-	
+		if(client)
+			SSquirks.AssignQuirks(new_human, client)
+
 	//Ghosts have copys of their minds, but if an admin put somebody else in their og body, the mind will have a new mind.key
 	//	and transfer_to will transfer the wrong person since it uses mind.key
 	if(mind && isliving(desired_mob) && (!isobserver(src) || mind.current == src || QDELETED(mind.current)))
-		if (ckey(mind.key) != ckey) 
+		if (ckey(mind.key) != ckey)
 			//we could actually prevent the bug from happening here, but then nobody would know to look for the stack trace we are about to print.
 			stack_trace("DEBUG: The bug where mob transfers or transforms sometimes kick unrelated people out of mobs has happened again. mob [src]([type])\ref[src] owned by [ckey] is being changed into a [new_type] but has a mind owned by [ckey(mind.key)].")
-		
+
 		mind.transfer_to(desired_mob, 1) // second argument to force key move to new mob
 	else
 		desired_mob.key = key


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When an admin transforms a ghost into a human, either with the "Make Human" button or with ctrl-shift-click, the spawned mob will now have quirks assigned for the player's currently-selected character. Note that this only applies to transformation from a ghost, not from any other sort of mob.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Quirks can sometimes be character-defining. If a character is spawned from a ghost, they should probably maintain their quirks without them having to be added manually.

As an admin of a downstream server, I've found it irritating to have to manually assign quirks when I have to respawn someone this way for any reason. This makes that job much easier, and should not impact anything else.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Humans spawned from a ghost by an admin have their quirks assigned
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
