### PR TITLE
Makes jobconfig.toml respect values of 0 and Fixes the Generate Job Configuration verb when there's a job that wasn't in the jobconfig.toml already

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -729,10 +729,17 @@ SUBSYSTEM_DEF(job)
 		var/job_name = occupation.title
 		var/job_key = occupation.config_tag
 
-		var/default_positions = job_config[job_key][TOTAL_POSITIONS]
-		var/starting_positions = job_config[job_key][SPAWN_POSITIONS]
-		var/playtime_requirements = job_config[job_key][PLAYTIME_REQUIREMENTS]
-		var/required_account_age = job_config[job_key][REQUIRED_ACCOUNT_AGE]
+		// We start by initializing them to these values, to allow for using this verb when adding new jobs, so it doesn't runtime.
+		var/default_positions = occupation.total_positions
+		var/starting_positions = occupation.spawn_positions
+		var/playtime_requirements = occupation.exp_requirements
+		var/required_account_age = occupation.minimal_player_age
+
+		if(job_config[job_key])
+			default_positions = job_config[job_key][TOTAL_POSITIONS]
+			starting_positions = job_config[job_key][SPAWN_POSITIONS]
+			playtime_requirements = job_config[job_key][PLAYTIME_REQUIREMENTS]
+			required_account_age = job_config[job_key][REQUIRED_ACCOUNT_AGE]
 
 		// When we regenerate, we want to make sure commented stuff stays commented, but we also want to migrate information that remains uncommented. So, let's make sure we keep that pattern.
 		if(job_config["[job_key]"]) // Let's see if any data for this job exists.

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -729,17 +729,10 @@ SUBSYSTEM_DEF(job)
 		var/job_name = occupation.title
 		var/job_key = occupation.config_tag
 
-		// We start by initializing them to these values, to allow for using this verb when adding new jobs, so it doesn't runtime.
-		var/default_positions = occupation.total_positions
-		var/starting_positions = occupation.spawn_positions
-		var/playtime_requirements = occupation.exp_requirements
-		var/required_account_age = occupation.minimal_player_age
-
-		if(job_config[job_key])
-			default_positions = job_config[job_key][TOTAL_POSITIONS]
-			starting_positions = job_config[job_key][SPAWN_POSITIONS]
-			playtime_requirements = job_config[job_key][PLAYTIME_REQUIREMENTS]
-			required_account_age = job_config[job_key][REQUIRED_ACCOUNT_AGE]
+		var/default_positions = job_config[job_key][TOTAL_POSITIONS]
+		var/starting_positions = job_config[job_key][SPAWN_POSITIONS]
+		var/playtime_requirements = job_config[job_key][PLAYTIME_REQUIREMENTS]
+		var/required_account_age = job_config[job_key][REQUIRED_ACCOUNT_AGE]
 
 		// When we regenerate, we want to make sure commented stuff stays commented, but we also want to migrate information that remains uncommented. So, let's make sure we keep that pattern.
 		if(job_config["[job_key]"]) // Let's see if any data for this job exists.

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -629,13 +629,13 @@ SUBSYSTEM_DEF(job)
 			var/playtime_requirements = job_config[job_key][PLAYTIME_REQUIREMENTS]
 			var/required_account_age = job_config[job_key][REQUIRED_ACCOUNT_AGE]
 
-			if(default_positions)
+			if(default_positions || default_positions == 0) // We need to account for jobs that were intentionally turned off via config too.
 				occupation.total_positions = default_positions
-			if(starting_positions)
+			if(starting_positions || starting_positions == 0)
 				occupation.spawn_positions = starting_positions
-			if(playtime_requirements)
+			if(playtime_requirements || playtime_requirements == 0)
 				occupation.exp_requirements = playtime_requirements
-			if(required_account_age)
+			if(required_account_age || required_account_age == 0)
 				occupation.minimal_player_age = required_account_age
 
 		return

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -729,13 +729,13 @@ SUBSYSTEM_DEF(job)
 		var/job_name = occupation.title
 		var/job_key = occupation.config_tag
 
-		var/default_positions = job_config[job_key][TOTAL_POSITIONS]
-		var/starting_positions = job_config[job_key][SPAWN_POSITIONS]
-		var/playtime_requirements = job_config[job_key][PLAYTIME_REQUIREMENTS]
-		var/required_account_age = job_config[job_key][REQUIRED_ACCOUNT_AGE]
-
 		// When we regenerate, we want to make sure commented stuff stays commented, but we also want to migrate information that remains uncommented. So, let's make sure we keep that pattern.
 		if(job_config["[job_key]"]) // Let's see if any data for this job exists.
+			var/default_positions = job_config[job_key][TOTAL_POSITIONS]
+			var/starting_positions = job_config[job_key][SPAWN_POSITIONS]
+			var/playtime_requirements = job_config[job_key][PLAYTIME_REQUIREMENTS]
+			var/required_account_age = job_config[job_key][REQUIRED_ACCOUNT_AGE]
+
 			if(file_data["[job_key]"]) // Sanity, let's just make sure we don't overwrite anything or add any dupe keys. We also unit test for this, but eh, you never know sometimes.
 				stack_trace("We were about to over-write a job key that already exists in file_data while generating a new jobconfig.toml! This should not happen! Verify you do not have any duplicate job keys in your codebase!")
 				continue


### PR DESCRIPTION
## About The Pull Request
Basically it was in the documentation of #70199 that this verb was meant for when a new job is added, or for downstreams that have more jobs than /tg/ does. So I tried to use it, and it runtimed because it didn't have one of our own jobs in the jobconfig.toml file already, thus completely defeating the point of the verb.

So I just scooted the variable declarations into the proper null-checked if block, and now it works just fine!

Also, I noticed that a job we had disabled via config wasn't getting properly disabled, turns out values of 0 in the config weren't being respected, and were getting reset to the codebase default. This behavior is now fixed, and shouldn't be an issue anymore, hopefully.

## Why It's Good For The Game
Makes a useful verb, actually work for its intended usecase :)

## Changelog

:cl: GoldenAlpharex
config: The Generate Job Configuration verb now works as expected when there's at least one job in-game that doesn't exist in the new jobconfig.toml file already.
fix: Any value that is set to 0 in jobconfig.toml will no longer default to the codebase's default, and will actually be considered as 0.
/:cl: