### PR TITLE
Remove guide comments action

### DIFF
--- a/.github/workflows/remove_guide_comments.yml
+++ b/.github/workflows/remove_guide_comments.yml
@@ -1,0 +1,18 @@
+# Removes guide comments from PRs when opened, so that when we merge them
+# and reuse the pull request description, the clutter is not left behind
+name: Remove guide comments
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  remove_guide_comments:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Remove guide comments
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { removeGuideComments } = await import('${{ github.workspace }}/tools/pull_request_hooks/removeGuideComments.js')
+          await removeGuideComments({ github, context })

--- a/tools/pull_request_hooks/package.json
+++ b/tools/pull_request_hooks/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "module"
+}

--- a/tools/pull_request_hooks/removeGuideComments.js
+++ b/tools/pull_request_hooks/removeGuideComments.js
@@ -1,0 +1,34 @@
+import fs from "fs";
+
+const REGEX_COMMENT = /<!--.+?-->/g;
+
+// Make sure we only remove default comments
+const comments = [];
+
+for (const match of fs
+	.readFileSync(".github/PULL_REQUEST_TEMPLATE.md", { encoding: "utf8" })
+	.matchAll(REGEX_COMMENT)) {
+	comments.push(match[0]);
+}
+
+function escapeRegex(string) {
+	return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&");
+}
+
+export async function removeGuideComments({ github, context }) {
+	let newBody = context.payload.pull_request.body;
+
+	for (const comment of comments) {
+		newBody = newBody.replace(
+			new RegExp(`^\\s*${escapeRegex(comment)}\\s*`)
+		);
+	}
+
+	if (newBody !== context.payload.pull_request.body) {
+		await github.pulls.update({
+			...context.repo,
+			pull_number: context.payload.pull_request.number,
+			body: newBody,
+		});
+	}
+}


### PR DESCRIPTION
Removes all default comments after a PR is opened  (and only when it is opened).

![image](https://user-images.githubusercontent.com/35135081/197364895-00a2758d-7b12-492b-8b1d-772b3aded394.png)


Means that I can turn on this option without keeping all the cruft:

![image](https://user-images.githubusercontent.com/35135081/197364904-20a15f15-8f0f-41f6-87b5-7b9e50dd4558.png)
