### PR TITLE
Cardborg Suit only undisguises when actually taking it off

### DIFF
--- a/code/modules/clothing/head/costume.dm
+++ b/code/modules/clothing/head/costume.dm
@@ -122,9 +122,9 @@
 		var/obj/item/clothing/suit/costume/cardborg/CB = H.wear_suit
 		CB.disguise(user, src)
 
-/obj/item/clothing/head/costume/cardborg/dropped(mob/living/user, slot)
+/obj/item/clothing/head/costume/cardborg/dropped(mob/living/carbon/human/user)
 	..()
-	if(ishuman(user) && (slot & ITEM_SLOT_HEAD))
+	if(!istype(user?.head, /obj/item/clothing/head/costume/cardborg))  // is it really unequipped?
 		user.remove_alt_appearance("standard_borg_disguise")
 
 /obj/item/clothing/head/costume/bronze

--- a/code/modules/clothing/head/costume.dm
+++ b/code/modules/clothing/head/costume.dm
@@ -114,15 +114,18 @@
 
 /obj/item/clothing/head/costume/cardborg/equipped(mob/living/user, slot)
 	..()
-	if(ishuman(user) && (slot & ITEM_SLOT_HEAD))
-		var/mob/living/carbon/human/H = user
-		if(istype(H.wear_suit, /obj/item/clothing/suit/costume/cardborg))
-			var/obj/item/clothing/suit/costume/cardborg/CB = H.wear_suit
-			CB.disguise(user, src)
+	if(!ishuman(user) || !(slot & ITEM_SLOT_HEAD))
+		return
 
-/obj/item/clothing/head/costume/cardborg/dropped(mob/living/user)
+	var/mob/living/carbon/human/H = user
+	if(istype(H.wear_suit, /obj/item/clothing/suit/costume/cardborg))
+		var/obj/item/clothing/suit/costume/cardborg/CB = H.wear_suit
+		CB.disguise(user, src)
+
+/obj/item/clothing/head/costume/cardborg/dropped(mob/living/user, slot)
 	..()
-	user.remove_alt_appearance("standard_borg_disguise")
+	if(ishuman(user) && (slot & ITEM_SLOT_HEAD))
+		user.remove_alt_appearance("standard_borg_disguise")
 
 /obj/item/clothing/head/costume/bronze
 	name = "bronze hat"

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -171,9 +171,9 @@
 	if(slot & ITEM_SLOT_OCLOTHING)
 		disguise(user)
 
-/obj/item/clothing/suit/costume/cardborg/dropped(mob/living/user, slot)
+/obj/item/clothing/suit/costume/cardborg/dropped(mob/living/carbon/human/user)
 	..()
-	if(slot & ITEM_SLOT_OCLOTHING)
+	if(!istype(user?.wear_suit, /obj/item/clothing/suit/costume/cardborg))  // is it still equipped?
 		user.remove_alt_appearance("standard_borg_disguise")
 
 /obj/item/clothing/suit/costume/cardborg/proc/disguise(mob/living/carbon/human/H, obj/item/clothing/head/costume/cardborg/borghead)

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -171,9 +171,10 @@
 	if(slot & ITEM_SLOT_OCLOTHING)
 		disguise(user)
 
-/obj/item/clothing/suit/costume/cardborg/dropped(mob/living/user)
+/obj/item/clothing/suit/costume/cardborg/dropped(mob/living/user, slot)
 	..()
-	user.remove_alt_appearance("standard_borg_disguise")
+	if(slot & ITEM_SLOT_OCLOTHING)
+		user.remove_alt_appearance("standard_borg_disguise")
 
 /obj/item/clothing/suit/costume/cardborg/proc/disguise(mob/living/carbon/human/H, obj/item/clothing/head/costume/cardborg/borghead)
 	if(istype(H))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixed the cardborg suit disguise, so it only undisguises when you remove a piece from your head/outer suit
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
closes #35748 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: cardborg suit keeps disguise when dropping a second suit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
