### PR TITLE
Frequency locks Confessional intercoms, but an emag can bypass it

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -121,3 +121,10 @@
 
 ///give this to can_receive to specify that there is no restriction on what z level this signal is sent to
 #define RADIO_NO_Z_LEVEL_RESTRICTION 0
+
+/// Radio frequency is unlocked and can be ajusted by anyone
+#define RADIO_FREQENCY_UNLOCKED 0
+/// Radio frequency is locked, unchangeable by players
+#define RADIO_FREQENCY_LOCKED 1
+/// Radio frequency is locked and unchangeable, but can be unlocked by an emag
+#define RADIO_FREQENCY_EMAGGABLE_LOCK 2

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -36,6 +36,15 @@
 	else
 		. += span_notice("It's <i>unscrewed</i> from the wall, and can be <b>detached</b>.")
 
+	if(anonymize)
+		. += span_notice("Speaking through this intercom will anonymize your voice.")
+
+	if(freqlock == RADIO_FREQENCY_UNLOCKED)
+		if(obj_flags & EMAGGED)
+			. += span_warning("Its frequency lock has been shorted...")
+	else
+		. += span_notice("It has a frequency lock set to [frequency].")
+
 /obj/item/radio/intercom/screwdriver_act(mob/living/user, obj/item/tool)
 	if(unscrewed)
 		user.visible_message(span_notice("[user] starts tightening [src]'s screws..."), span_notice("You start screwing in [src]..."))
@@ -109,6 +118,29 @@
 	. = ..()
 	AreaPowerCheck() // Make sure the area/local APC is powered first before we actually turn back on.
 
+/obj/item/radio/intercom/emag_act(mob/user, obj/item/card/emag/emag_card)
+	if(obj_flags & EMAGGED)
+		return
+
+	switch(freqlock)
+		// Emagging an intercom with an emaggable lock will remove the lock
+		if(RADIO_FREQENCY_EMAGGABLE_LOCK)
+			balloon_alert(user, "frequency lock cleared")
+			playsound(src, SFX_SPARKS, 75, TRUE, SILENCED_SOUND_EXTRARANGE)
+			freqlock = RADIO_FREQENCY_UNLOCKED
+			obj_flags |= EMAGGED
+
+		// A fully locked one will do nothing, as locked is intended to be used for stuff that should never be changed
+		if(RADIO_FREQENCY_LOCKED)
+			balloon_alert(user, "can't override frequency lock!")
+			playsound(src, 'sound/machines/buzz-two.ogg', 50, FALSE, SILENCED_SOUND_EXTRARANGE)
+
+		// Emagging an unlocked one will do nothing, for now
+		else
+			return
+
+	return ..()
+
 /obj/item/radio/intercom/update_icon_state()
 	icon_state = on ? initial(icon_state) : "intercom-p"
 	return ..()
@@ -145,8 +177,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 
 /obj/item/radio/intercom/chapel
 	name = "Confessional intercom"
+	desc = "Talk through this... to confess your many sins. Conceals your voice, to keep them secret."
 	anonymize = TRUE
-	freqlock = TRUE
+	freqlock = RADIO_FREQENCY_EMAGGABLE_LOCK
 
 /obj/item/radio/intercom/chapel/Initialize(mapload, ndir, building)
 	. = ..()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -146,6 +146,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 /obj/item/radio/intercom/chapel
 	name = "Confessional intercom"
 	anonymize = TRUE
+	freqlock = TRUE
 
 /obj/item/radio/intercom/chapel/Initialize(mapload, ndir, building)
 	. = ..()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -43,7 +43,7 @@
 		if(obj_flags & EMAGGED)
 			. += span_warning("Its frequency lock has been shorted...")
 	else
-		. += span_notice("It has a frequency lock set to [frequency].")
+		. += span_notice("It has a frequency lock set to [frequency/10].")
 
 /obj/item/radio/intercom/screwdriver_act(mob/living/user, obj/item/tool)
 	if(unscrewed)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -54,7 +54,7 @@
 	/// If true, subspace_transmission can be toggled at will.
 	var/subspace_switchable = FALSE
 	/// Frequency lock to stop the user from untuning specialist radios.
-	var/freqlock = FALSE
+	var/freqlock = RADIO_FREQENCY_UNLOCKED
 	/// If true, broadcasts will be large and BOLD.
 	var/use_command = FALSE
 	/// If true, use_command can be toggled at will.
@@ -372,7 +372,7 @@
 	data["frequency"] = frequency
 	data["minFrequency"] = freerange ? MIN_FREE_FREQ : MIN_FREQ
 	data["maxFrequency"] = freerange ? MAX_FREE_FREQ : MAX_FREQ
-	data["freqlock"] = freqlock
+	data["freqlock"] = freqlock != RADIO_FREQENCY_UNLOCKED
 	data["channels"] = list()
 	for(var/channel in channels)
 		data["channels"][channel] = channels[channel] & FREQ_LISTENING
@@ -390,7 +390,7 @@
 		return
 	switch(action)
 		if("frequency")
-			if(freqlock)
+			if(freqlock != RADIO_FREQENCY_UNLOCKED)
 				return
 			var/tune = params["tune"]
 			var/adjust = text2num(params["adjust"])

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -30,7 +30,7 @@
 		return
 	var/obj/item/radio/radio = nukie.ears
 	radio.set_frequency(FREQ_SYNDICATE)
-	radio.freqlock = TRUE
+	radio.freqlock = RADIO_FREQENCY_LOCKED
 	if(command_radio)
 		radio.command = TRUE
 		radio.use_command = TRUE

--- a/code/modules/capture_the_flag/ctf_classes.dm
+++ b/code/modules/capture_the_flag/ctf_classes.dm
@@ -54,7 +54,7 @@
 	if(has_radio)
 		var/obj/item/radio/headset = human_to_equip.ears
 		headset.set_frequency(team_radio_freq)
-		headset.freqlock = TRUE
+		headset.freqlock = RADIO_FREQENCY_LOCKED
 		headset.independent = TRUE
 	human_to_equip.dna.species.stunmod = 0
 

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -23,7 +23,7 @@
 
 	var/obj/item/radio/headset/R = H.ears
 	R.set_frequency(FREQ_CENTCOM)
-	R.freqlock = TRUE
+	R.freqlock = RADIO_FREQENCY_LOCKED
 	if(additional_radio)
 		R.keyslot2 = new additional_radio()
 		R.recalculateChannels()
@@ -460,7 +460,7 @@
 
 	var/obj/item/radio/R = H.ears
 	R.set_frequency(FREQ_CENTCOM)
-	R.freqlock = TRUE
+	R.freqlock = RADIO_FREQENCY_LOCKED
 	var/obj/item/card/id/W = H.wear_id
 	W.registered_name = H.real_name
 	W.update_label()

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -26,7 +26,7 @@
 
 	var/obj/item/radio/headset/R = H.ears
 	R.set_frequency(FREQ_CENTCOM)
-	R.freqlock = TRUE
+	R.freqlock = RADIO_FREQENCY_LOCKED
 	..()
 
 /datum/outfit/space
@@ -131,7 +131,7 @@
 	var/obj/item/radio/outfit_radio = equipped.ears
 	if(outfit_radio)
 		outfit_radio.set_frequency(FREQ_SYNDICATE)
-		outfit_radio.freqlock = TRUE
+		outfit_radio.freqlock = RADIO_FREQENCY_LOCKED
 
 	var/obj/item/card/id/outfit_id = equipped.wear_id
 	if(outfit_id)


### PR DESCRIPTION
## About The Pull Request

Confessional intercoms are locked to the confessional frequency, 148.1

## Why It's Good For The Game

Confessional intercoms anonymize your voice regardless of which channel it's on, which gives people an easy way to become unknown on the common channel where typically specialized equipment is required to accomplish that. (Such as a voice changer.)

## Changelog

:cl: Melbert
balance: The chapel's confessional intercom is locked to its initial frequency, but an emag could bypass it.
/:cl:
