### PR TITLE
Fixes paper hats by giving them a worn_icon path

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -16,6 +16,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper"
 	inhand_icon_state = "paper"
+	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	worn_icon_state = "paper"
 	custom_fire_overlay = "paper_onfire_overlay"
 	throwforce = 0


### PR DESCRIPTION

## About The Pull Request

Wearing paper hats is tradition, or a chronic problem when you just auto-store it with the keybind. However, it appears that they lost their worn_icon with #70060. Easy mistake, easy fix. Sets worn_icon for `obj/item/paper` to the costume helmet .dmi file.

## Why It's Good For The Game

Fixes #70746.

## Changelog

:cl:
fix: Paper hats now display properly when worn.
/:cl: