### PR TITLE
Ensures early assets init when expected during unit tests, 

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -55,7 +55,7 @@
 #endif // REFERENCE_DOING_IT_LIVE
 
 // If defined, we will NOT defer asset generation till later in the game, and will instead do it all at once, during initiialize
-#define DO_NOT_DEFER_ASSETS
+//#define DO_NOT_DEFER_ASSETS
 //#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 /// If this is uncommented, Autowiki will generate edits and shut down the server.
@@ -124,7 +124,7 @@
 #define FIND_REF_NO_CHECK_TICK
 #define GC_FAILURE_HARD_LOOKUP
 //Ensures all early assets can actually load early
-//#define DO_NOT_DEFER_ASSETS
+#define DO_NOT_DEFER_ASSETS
 #endif
 
 #ifdef TGS

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -54,6 +54,8 @@
 #define GC_FAILURE_HARD_LOOKUP
 #endif // REFERENCE_DOING_IT_LIVE
 
+// If defined, we will NOT defer asset generation till later in the game, and will instead do it all at once, during initiialize
+#define DO_NOT_DEFER_ASSETS
 //#define UNIT_TESTS //If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 /// If this is uncommented, Autowiki will generate edits and shut down the server.
@@ -121,6 +123,8 @@
 #define REFERENCE_TRACKING_DEBUG
 #define FIND_REF_NO_CHECK_TICK
 #define GC_FAILURE_HARD_LOOKUP
+//Ensures all early assets can actually load early
+//#define DO_NOT_DEFER_ASSETS
 #endif
 
 #ifdef TGS

--- a/code/controllers/subsystem/asset_loading.dm
+++ b/code/controllers/subsystem/asset_loading.dm
@@ -17,3 +17,12 @@ SUBSYSTEM_DEF(asset_loading)
 		if(MC_TICK_CHECK)
 			return
 		generate_queue.len--
+
+/datum/controller/subsystem/asset_loading/proc/queue_asset(datum/asset/queue)
+#ifdef DO_NOT_DEFER_ASSETS
+	stack_trace("We queued an instance of [queue.type] for lateloading despite not allowing it")
+#endif
+	generate_queue += queue
+
+/datum/controller/subsystem/asset_loading/proc/dequeue_asset(datum/asset/queue)
+	generate_queue -= queue

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -139,6 +139,13 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	/// Defaults to false so we can process this stuff nicely
 	var/load_immediately = FALSE
 
+#ifdef DO_NOT_DEFER_ASSETS
+/datum/asset/spritesheet/New()
+	// ALWAYS load now
+	load_immediately = TRUE
+	return ..()
+#endif
+
 /datum/asset/spritesheet/should_refresh()
 	if (..())
 		return TRUE
@@ -170,7 +177,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	if(load_immediately)
 		realize_spritesheets(yield = FALSE)
 	else
-		SSasset_loading.generate_queue += src
+		SSasset_loading.queue_asset(src)
 
 /datum/asset/spritesheet/proc/realize_spritesheets(yield)
 	if(fully_generated)
@@ -197,7 +204,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		write_to_cache()
 	fully_generated = TRUE
 	// If we were ever in there, remove ourselves
-	SSasset_loading.generate_queue -= src
+	SSasset_loading.dequeue_asset(src)
 
 /datum/asset/spritesheet/queued_generation()
 	realize_spritesheets(yield = TRUE)

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -144,6 +144,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	return TRUE
 #else
 	return load_immediately
+#endif
 
 
 /datum/asset/spritesheet/should_refresh()

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -139,12 +139,12 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	/// Defaults to false so we can process this stuff nicely
 	var/load_immediately = FALSE
 
+/datum/asset/spritesheet/proc/should_load_immediately()
 #ifdef DO_NOT_DEFER_ASSETS
-/datum/asset/spritesheet/New()
-	// ALWAYS load now
-	load_immediately = TRUE
-	return ..()
-#endif
+	return TRUE
+#else
+	return load_immediately
+
 
 /datum/asset/spritesheet/should_refresh()
 	if (..())
@@ -174,7 +174,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		load_immediately = TRUE
 
 	create_spritesheets()
-	if(load_immediately)
+	if(should_load_immediately())
 		realize_spritesheets(yield = FALSE)
 	else
 		SSasset_loading.queue_asset(src)
@@ -335,7 +335,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	CRASH("create_spritesheets() not implemented for [type]!")
 
 /datum/asset/spritesheet/proc/Insert(sprite_name, icon/I, icon_state="", dir=SOUTH, frame=1, moving=FALSE)
-	if(load_immediately)
+	if(should_load_immediately())
 		queuedInsert(sprite_name, I, icon_state, dir, frame, moving)
 	else
 		to_generate += list(args.Copy())


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

We can use this to catch errors in testing that'll pop up on live, without eating the 20 second init cost

## Why It's Good For The Game
moth got mad at me, needed immediate fixing
