### PR TITLE
Adds Station's Date To NTos Window (check the time+date on your tablet!)

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -542,7 +542,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 
 		data["PC_programheaders"] = program_headers
 
-	data["PC_stationdateandtime"] = "[time2text(world.realtime, "MMM DD")], [GLOB.year_integer+540] [station_time_timestamp()]"
+	data["PC_stationdateandtime"] = "[time2text(world.realtime, "MMM/DD")]/[GLOB.year_integer+540] [station_time_timestamp()]"
 	data["PC_showexitprogram"] = !!active_program // Hides "Exit Program" button on mainscreen
 	return data
 

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -542,7 +542,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 
 		data["PC_programheaders"] = program_headers
 
-	data["PC_stationdateandtime"] = "[time2text(world.realtime, "MMM/DD")]/[GLOB.year_integer+540] [station_time_timestamp()]"
+	data["PC_stationtime"] = station_time_timestamp()
+	data["PC_stationdate"] = "[time2text(world.realtime, "DDD, Month DD")], [GLOB.year_integer+540]"
 	data["PC_showexitprogram"] = !!active_program // Hides "Exit Program" button on mainscreen
 	return data
 

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -542,7 +542,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 
 		data["PC_programheaders"] = program_headers
 
-	data["PC_stationtime"] = station_time_timestamp()
+	data["PC_stationdateandtime"] = "[time2text(world.realtime, "MMM DD")], [GLOB.year_integer+540] [station_time_timestamp()]"
 	data["PC_showexitprogram"] = !!active_program // Hides "Exit Program" button on mainscreen
 	return data
 

--- a/tgui/packages/tgui/layouts/NtosWindow.js
+++ b/tgui/packages/tgui/layouts/NtosWindow.js
@@ -18,7 +18,8 @@ export const NtosWindow = (props, context) => {
     PC_showbatteryicon,
     PC_batterypercent,
     PC_ntneticon,
-    PC_stationdateandtime,
+    PC_stationdate,
+    PC_stationtime,
     PC_programheaders = [],
     PC_showexitprogram,
   } = data;
@@ -28,7 +29,16 @@ export const NtosWindow = (props, context) => {
         <div className="NtosWindow__header NtosHeader">
           <div className="NtosHeader__left">
             <Box inline bold mr={2}>
-              {PC_stationdateandtime}
+              <Button
+                width="26px"
+                lineHeight="22px"
+                textAlign="left"
+                tooltip={PC_stationdate}
+                color="transparent"
+                icon="calendar"
+                tooltipPosition="bottom"
+              />
+              {PC_stationtime}
             </Box>
             <Box inline italic mr={2} opacity={0.33}>
               {PC_device_theme === 'ntos' && 'NtOS'}

--- a/tgui/packages/tgui/layouts/NtosWindow.js
+++ b/tgui/packages/tgui/layouts/NtosWindow.js
@@ -18,7 +18,7 @@ export const NtosWindow = (props, context) => {
     PC_showbatteryicon,
     PC_batterypercent,
     PC_ntneticon,
-    PC_stationtime,
+    PC_stationdateandtime,
     PC_programheaders = [],
     PC_showexitprogram,
   } = data;
@@ -28,7 +28,7 @@ export const NtosWindow = (props, context) => {
         <div className="NtosWindow__header NtosHeader">
           <div className="NtosHeader__left">
             <Box inline bold mr={2}>
-              {PC_stationtime}
+              {PC_stationdateandtime}
             </Box>
             <Box inline italic mr={2} opacity={0.33}>
               {PC_device_theme === 'ntos' && 'NtOS'}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

Since the transition from the old HTML PDAs to the modern TGUI Tablets, we've been missing that hole in our life... going "uuuuhhhh" and then checking our phones to figure out what month, day, or even year it is!  Much easier to glance at your phone than to tramp around the station in desperate search of a calendar. This PR just re-adds that bit of missing flavor by putting the date persistently.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/197379551-3d63c9cc-35bf-4504-8a74-fe7e4e78e9c6.png)

Although I've memorized that the date in SS13 is our current year plus 540 years, 99% of the station hasn't. It's also good flavor to remind them that canonically, they're going through the same dates we are, just another 540 days in the present. We already communicate the time, so why not pass through the date as well (much like modern OS's)?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Nanotrasen realized they forget to implement the date function into the new NTos tablets, so they doubled back and added those next to the time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
