### PR TITLE
Morgue access fixes

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -79676,6 +79676,7 @@
 "twq" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -44171,6 +44171,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mCk" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -23271,6 +23271,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ixP" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7561,7 +7561,6 @@
 /obj/modular_map_root/tramstation{
 	key = "maintenance_uppermedsci"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/medical)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7558,11 +7558,11 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/modular_map_root/tramstation{
 	key = "maintenance_uppermedsci"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/medical)
 "cIQ" = (
@@ -27022,7 +27022,6 @@
 	name = "Morgue External Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "jKL" = (
@@ -27969,6 +27968,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "kbS" = (


### PR DESCRIPTION
## About The Pull Request

On Tramstation, there were a few issues with the morgue.

- The maintenance leading to the external morgue door required you to have both maintenance, and kitchen access, so the only person who could go there, was the cook, if they somehow got maintenance access.
- The morgue door itself was set to kitchen and morgue access, meaning the only person who could enter it that way, was the cook.

This PR fixes these issues: The maintenance door now checks for morgue access, and the external morgue door only checks for morgue access. The cook already had morgue access. Now roboticists, chaplains, detectives and medical security officers and their ilk can once again approach this place.

Conversely, the internal doors of morgues all checked only for morgue access on all maps except for Icebox, where it is not directly linked to medbay. This meant that everyone with morgue access could easily enter the medbay lobby areas. This has been fixed, the internal morgue doors now check for medbay access and morgue access.

Arguably, this is funny, so if it turns out that it is intentional, I will remove this bit from the PR.

## Why It's Good For The Game

Its good for jobs who might have to deposit or withdraws dead bodies to be able to again reach them.
Conversely, its good for morgue access to not act like the "Medical backdoor" access.

## Changelog

:cl:
fix: On tramstation, jobs that have morgue access should be able to access it
fix: In general, morgue access does not let you sneak into medbay
/:cl:

