### PR TITLE
Refactors how duplicate handling with traitor objectives work. Adds a 'can_generate_objective' function. Adds a limit to kidnapping objectives

### DIFF
--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -427,11 +427,10 @@
 				var/objective_typepath = tgui_input_list(usr, "Select objective", "Select objective", all_objectives)
 				if(!objective_typepath)
 					return
-				var/datum/traitor_objective/objective = uplink.uplink_handler.try_add_objective(objective_typepath)
+				var/datum/traitor_objective/objective = uplink.uplink_handler.try_add_objective(objective_typepath, force = TRUE)
 				if(objective)
 					message_admins("[key_name_admin(usr)] gave [current] a traitor objective ([objective_typepath]).")
 					log_admin("[key_name(usr)] gave [current] a traitor objective ([objective_typepath]).")
-					objective.forced = TRUE
 				else
 					to_chat(usr, span_warning("Failed to generate the objective!"))
 					message_admins("[key_name_admin(usr)] failed to give [current] a traitor objective ([objective_typepath]).")

--- a/code/modules/antagonists/traitor/objectives/assassination.dm
+++ b/code/modules/antagonists/traitor/objectives/assassination.dm
@@ -99,7 +99,7 @@
 		return //your target please
 	if(equipper.stat != DEAD)
 		return //kill them please
-	if(!(slot & (ITEM_SLOT_LPOCKET|ITEM_SLOT_RPOCKET)))	
+	if(!(slot & (ITEM_SLOT_LPOCKET|ITEM_SLOT_RPOCKET)))
 		return //in their pockets please
 	succeed_objective()
 
@@ -225,10 +225,6 @@
 /datum/traitor_objective/assassinate/ungenerate_objective()
 	UnregisterSignal(kill_target, COMSIG_LIVING_DEATH)
 	kill_target = null
-
-/datum/traitor_objective/assassinate/is_duplicate(datum/traitor_objective/assassinate/objective_to_compare)
-	. = ..()
-	return kill_target == objective_to_compare.kill_target
 
 ///proc for checking for special states that invalidate a target
 /datum/traitor_objective/assassinate/proc/special_target_filter(list/possible_targets)

--- a/code/modules/antagonists/traitor/objectives/bug_room.dm
+++ b/code/modules/antagonists/traitor/objectives/bug_room.dm
@@ -99,11 +99,6 @@
 /datum/traitor_objective/bug_room/ungenerate_objective()
 	bug = null
 
-/datum/traitor_objective/bug_room/is_duplicate(datum/traitor_objective/bug_room/objective_to_compare)
-	if(objective_to_compare.target_office == target_office)
-		return TRUE
-	return FALSE
-
 /obj/item/traitor_bug
 	name = "suspicious device"
 	desc = "It looks dangerous."

--- a/code/modules/antagonists/traitor/objectives/bug_room.dm
+++ b/code/modules/antagonists/traitor/objectives/bug_room.dm
@@ -17,6 +17,7 @@
 	progression_reward = list(2 MINUTES, 8 MINUTES)
 	telecrystal_reward = list(0, 1)
 
+	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
 
 	var/list/applicable_heads = list(

--- a/code/modules/antagonists/traitor/objectives/demoralise_crew.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_crew.dm
@@ -26,6 +26,11 @@
 	/// How many 'mood events' have happened so far?
 	var/demoralised_crew_events = 0
 
+/datum/traitor_objective/demoralise/can_generate_objective(datum/mind/generating_for, list/possible_duplicates)
+	if(length(possible_duplicates) > 0)
+		return FALSE
+	return TRUE
+
 /datum/traitor_objective/demoralise/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	demoralised_crew_required = (clamp(rand(MIN_CREW_DEMORALISED, length(get_crewmember_minds()) * MAX_CREW_RATIO), MIN_CREW_DEMORALISED, MAX_CREW_DEMORALISED))
 	replace_in_name("%VIEWS%", demoralised_crew_required)

--- a/code/modules/antagonists/traitor/objectives/demoralise_graffiti.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_graffiti.dm
@@ -6,6 +6,8 @@
 		five minutes following application, and it's slippery too! \
 		People seeing or slipping on your graffiti grants progress towards success."
 
+	progression_minimum = 0 MINUTES
+	duplicate_type = /datum/traitor_objective/demoralise/graffiti
 	/// Have we given out a spray can yet?
 	var/obtained_spray = FALSE
 	/// Graffiti 'rune' which we will be drawing

--- a/code/modules/antagonists/traitor/objectives/demoralise_poster.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_poster.dm
@@ -6,6 +6,8 @@
 		Try hiding some broken glass behind your poster before you hang it to give  \
 		do-gooders who try to take it down a hard time!"
 
+	progression_minimum = 0 MINUTES
+	duplicate_type = /datum/traitor_objective/demoralise/poster
 	/// Have we handed out a box of stuff yet?
 	var/granted_posters = FALSE
 	/// All of the posters the traitor gets, if this list is empty they've failed

--- a/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
@@ -109,7 +109,7 @@
 			continue
 		var/datum/quirk/item_quirk/family_heirloom/quirk = locate() in possible_target.current.quirks
 		if(!quirk || !quirk.heirloom.resolve())
-			return
+			continue
 		if(!(possible_target.assigned_role.type in target_jobs))
 			continue
 		possible_targets += possible_target

--- a/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
@@ -28,6 +28,7 @@
 
 /datum/traitor_objective/destroy_heirloom/common
 	/// 30 minutes in, syndicate won't care about common heirlooms anymore
+	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
 	target_jobs = list(
 		// Medical
@@ -56,6 +57,7 @@
 /// This is only for assistants, because the syndies are a lot less likely to give a shit about what an assistant does, so they're a lot less likely to appear
 /datum/traitor_objective/destroy_heirloom/less_common
 	/// 30 minutes in, syndicate won't care about common heirlooms anymore
+	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
 	target_jobs = list(
 		/datum/job/assistant
@@ -63,6 +65,7 @@
 
 /datum/traitor_objective/destroy_heirloom/uncommon
 	/// 45 minutes in, syndicate won't care about uncommon heirlooms anymore
+	progression_minimum = 0 MINUTES
 	progression_maximum = 45 MINUTES
 	target_jobs = list(
 		// Cargo

--- a/code/modules/antagonists/traitor/objectives/destroy_item.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_item.dm
@@ -70,11 +70,6 @@
 		signals = list(COMSIG_MOB_EQUIPPED_ITEM = .proc/on_item_pickup))
 	return TRUE
 
-/datum/traitor_objective/destroy_item/is_duplicate(datum/traitor_objective/destroy_item/objective_to_compare)
-	if(objective_to_compare.target_item.type == target_item.type)
-		return TRUE
-	return FALSE
-
 /datum/traitor_objective/destroy_item/generate_ui_buttons(mob/user)
 	var/list/buttons = list()
 	if(special_equipment)

--- a/code/modules/antagonists/traitor/objectives/destroy_machinery.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_machinery.dm
@@ -12,6 +12,7 @@
 	progression_reward = list(2 MINUTES, 8 MINUTES)
 	telecrystal_reward = list(0, 1)
 
+	progression_minimum = 0 MINUTES
 	progression_maximum = 10 MINUTES
 
 	/// The maximum amount of this type of objective a traitor can have.

--- a/code/modules/antagonists/traitor/objectives/destroy_machinery.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_machinery.dm
@@ -42,9 +42,12 @@
 		JOB_SCIENTIST = /obj/machinery/rnd/server,
 	)
 
-/datum/traitor_objective/destroy_machinery/generate_objective(datum/mind/generating_for, list/possible_duplicates)
+/datum/traitor_objective/destroy_machinery/can_generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	if(length(possible_duplicates) >= maximum_allowed && !allow_more_than_max)
 		return FALSE
+	return TRUE
+
+/datum/traitor_objective/destroy_machinery/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	for(var/datum/traitor_objective/destroy_machinery/objective as anything in possible_duplicates)
 		applicable_jobs -= objective.chosen_job
 	if(!length(applicable_jobs))
@@ -70,8 +73,3 @@
 	replace_in_name("%MACHINE%", possible_machines[1].name)
 	return TRUE
 
-
-/datum/traitor_objective/destroy_machinery/is_duplicate(datum/traitor_objective/destroy_machinery/objective_to_compare)
-	if(objective_to_compare.chosen_job == chosen_job)
-		return TRUE
-	return FALSE

--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -10,6 +10,8 @@
 	name = "Steal %TARGET%'s (%JOB TITLE%) eyes"
 	description = "%TARGET% messed with the wrong people. Steal their eyes to teach them a lesson. You will be provided an experimental eyesnatcher device to aid you in your mission."
 
+	progression_minimum = 10 MINUTES
+
 	progression_reward = list(4 MINUTES, 8 MINUTES)
 	telecrystal_reward = list(1, 2)
 

--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -162,7 +162,7 @@
 	if(!eyeballies || victim.is_eyes_covered())
 		return ..()
 
-	if((head && head.eyes != eyeballies) || eyeballies.zone != BODY_ZONE_HEAD)
+	if((head && head.eyes != eyeballies) || eyeballies.zone != BODY_ZONE_PRECISE_EYES)
 		to_chat(user, span_warning("You don't know how to apply [src] to the abomination that [victim] is!"))
 		return ..()
 

--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -28,6 +28,8 @@
 	/// Have we already spawned an eyesnatcher
 	var/spawned_eyesnatcher = FALSE
 
+	duplicate_type = /datum/traitor_objective/eyesnatching
+
 /datum/traitor_objective/eyesnatching/supported_configuration_changes()
 	. = ..()
 	. += NAMEOF(src, objective_period)
@@ -66,6 +68,9 @@
 		if(possible_target.has_antag_datum(/datum/antagonist/traitor))
 			continue
 
+		if(!possible_target.assigned_role)
+			continue
+
 		if(heads_of_staff)
 			if(!(possible_target.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
@@ -101,6 +106,7 @@
 	replace_in_name("%JOB TITLE%", victim_mind.assigned_role.title)
 	RegisterSignal(victim, COMSIG_CARBON_LOSE_ORGAN, .proc/check_eye_removal)
 	AddComponent(/datum/component/traitor_objective_register, victim, fail_signals = COMSIG_PARENT_QDELETING)
+	return TRUE
 
 /datum/traitor_objective/eyesnatching/proc/check_eye_removal(datum/source, obj/item/organ/internal/eyes/removed)
 	SIGNAL_HANDLER

--- a/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
@@ -10,8 +10,6 @@
 	var/datum/team/battlecruiser/team
 
 /datum/traitor_objective/final/battlecruiser/generate_objective(datum/mind/generating_for, list/possible_duplicates)
-	if(!can_take_final_objective())
-		return FALSE
 	// There's no empty space to load a battlecruiser in...
 	if(!SSmapping.empty_space)
 		return FALSE

--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -15,10 +15,12 @@
 	var/progression_points_in_objectives = 20 MINUTES
 
 /// Determines if this final objective can be taken. Should be put into every final objective's generate function.
-/datum/traitor_objective/final/proc/can_take_final_objective()
+/datum/traitor_objective/final/can_generate_objective(generating_for, list/possible_duplicates)
 	if(handler.get_completion_progression(/datum/traitor_objective) < progression_points_in_objectives)
 		return FALSE
 	if(SStraitor.get_taken_count(type) > 0) // Prevents multiple people from ever getting the same final objective.
+		return FALSE
+	if(length(possible_duplicates) > 0)
 		return FALSE
 	return TRUE
 
@@ -28,9 +30,6 @@
 	for(var/datum/traitor_objective/objective as anything in handler.potential_objectives)
 		objective.fail_objective()
 	user.playsound_local(get_turf(user), 'sound/traitor/final_objective.ogg', vol = 100, vary = FALSE, channel = CHANNEL_TRAITOR)
-
-/datum/traitor_objective/final/is_duplicate(datum/traitor_objective/objective_to_compare)
-	return TRUE
 
 /datum/traitor_objective/final/uplink_ui_data(mob/user)
 	. = ..()

--- a/code/modules/antagonists/traitor/objectives/final_objective/romerol.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/romerol.dm
@@ -11,13 +11,13 @@
 	var/sent_romerol = FALSE
 
 /datum/traitor_objective/final/romerol/generate_objective(datum/mind/generating_for, list/possible_duplicates)
-	if(!can_take_final_objective())
-		return
 	var/list/possible_areas = GLOB.the_station_areas.Copy()
 	for(var/area/possible_area as anything in possible_areas)
 		//remove areas too close to the destination, too obvious for our poor shmuck, or just unfair
 		if(istype(possible_area, /area/station/hallway) || istype(possible_area, /area/station/security))
 			possible_areas -= possible_area
+	if(length(possible_areas) == 0)
+		return FALSE
 	romerol_spawnarea_type = pick(possible_areas)
 	replace_in_name("%AREA%", initial(romerol_spawnarea_type.name))
 	return TRUE

--- a/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
@@ -15,13 +15,13 @@
 	carp_event.runEvent()
 
 /datum/traitor_objective/final/space_dragon/generate_objective(datum/mind/generating_for, list/possible_duplicates)
-	if(!can_take_final_objective())
-		return
 	var/list/possible_areas = GLOB.the_station_areas.Copy()
 	for(var/area/possible_area as anything in possible_areas)
 		//remove areas too close to the destination, too obvious for our poor shmuck, or just unfair
 		if(istype(possible_area, /area/station/hallway) || istype(possible_area, /area/station/security))
 			possible_areas -= possible_area
+	if(length(possible_areas) == 0)
+		return FALSE
 	dna_scanner_spawnarea_type = pick(possible_areas)
 	replace_in_name("%AREA%", initial(dna_scanner_spawnarea_type.name))
 	return TRUE

--- a/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
@@ -8,7 +8,7 @@
 	///checker on whether we have sent the crystal yet.
 	var/sent_crystal = FALSE
 
-/datum/traitor_objective/final/supermatter_cascade/can_take_final_objective()
+/datum/traitor_objective/final/supermatter_cascade/can_generate_objective(generating_for, list/generating_for)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -20,13 +20,13 @@
 	return FALSE
 
 /datum/traitor_objective/final/supermatter_cascade/generate_objective(datum/mind/generating_for, list/possible_duplicates)
-	if(!can_take_final_objective())
-		return
 	var/list/possible_areas = GLOB.the_station_areas.Copy()
 	for(var/area/possible_area as anything in possible_areas)
 		//remove areas too close to the destination, too obvious for our poor shmuck, or just unfair
 		if(istype(possible_area, /area/station/hallway) || istype(possible_area, /area/station/security))
 			possible_areas -= possible_area
+	if(length(possible_areas) == 0)
+		return FALSE
 	dest_crystal_area_pickup = pick(possible_areas)
 	replace_in_name("%AREA%", initial(dest_crystal_area_pickup.name))
 	return TRUE

--- a/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
+++ b/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
@@ -14,11 +14,14 @@
 
 	var/progression_objectives_minimum = 20 MINUTES
 
-/datum/traitor_objective/hack_comm_console/generate_objective(datum/mind/generating_for, list/possible_duplicates)
+/datum/traitor_objective/hack_comm_console/can_generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	if(SStraitor.get_taken_count(/datum/traitor_objective/hack_comm_console) > 0)
 		return FALSE
 	if(handler.get_completion_progression(/datum/traitor_objective) < progression_objectives_minimum)
 		return FALSE
+	return TRUE
+
+/datum/traitor_objective/hack_comm_console/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	AddComponent(/datum/component/traitor_objective_mind_tracker, generating_for, \
 		signals = list(COMSIG_HUMAN_EARLY_UNARMED_ATTACK = .proc/on_unarmed_attack))
 	RegisterSignal(SSdcs, COMSIG_GLOB_TRAITOR_OBJECTIVE_COMPLETED, .proc/on_global_obj_completed)

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -35,6 +35,7 @@
 	var/list/victim_belogings = list()
 
 /datum/traitor_objective/kidnapping/common
+	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
 	target_jobs = list(
 		// Medical
@@ -62,12 +63,14 @@
 	)
 
 /datum/traitor_objective/kidnapping/less_common
+	progression_minimum = 0 MINUTES
 	progression_maximum = 15 MINUTES
 	target_jobs = list(
 		/datum/job/assistant
 	)
 
 /datum/traitor_objective/kidnapping/uncommon //Hard to fish out victims
+	progression_minimum = 0 MINUTES
 	progression_maximum = 45 MINUTES
 	target_jobs = list(
 		// Medical

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -21,6 +21,11 @@
 	progression_reward = list(2 MINUTES, 4 MINUTES)
 	telecrystal_reward = list(1, 2)
 
+	/// The period of time until you can take another objective after taking 3 objectives.
+	var/objective_period = 15 MINUTES
+	/// The maximum number of objectives we can get within this period.
+	var/maximum_objectives_in_period = 3
+
 	/// The jobs that this objective is targetting.
 	var/list/target_jobs
 	/// The person we need to kidnap
@@ -33,6 +38,19 @@
 	var/alive_bonus = 0
 	/// All stripped victims belongings
 	var/list/victim_belogings = list()
+
+/datum/traitor_objective/kidnapping/supported_configuration_changes()
+	. = ..()
+	. += NAMEOF(src, objective_period)
+	. += NAMEOF(src, maximum_objectives_in_period)
+
+/datum/traitor_objective/kidnapping/New(datum/uplink_handler/handler)
+	. = ..()
+	AddComponent(/datum/component/traitor_objective_limit_per_time, \
+		/datum/traitor_objective/assassinate, \
+		time_period = objective_period, \
+		maximum_objectives = maximum_objectives_in_period \
+	)
 
 /datum/traitor_objective/kidnapping/common
 	progression_minimum = 0 MINUTES

--- a/code/modules/antagonists/traitor/objectives/kill_pet.dm
+++ b/code/modules/antagonists/traitor/objectives/kill_pet.dm
@@ -13,6 +13,7 @@
 	description = "The %DEPARTMENT HEAD% has particularly annoyed us by sending us spam emails and we want their %PET% dead to show them what happens when they cross us. "
 	telecrystal_reward = list(1, 2)
 
+	progression_minimum = 0 MINUTES
 	progression_reward = list(3 MINUTES, 6 MINUTES)
 
 	/// Possible heads mapped to their pet type. Can be a list of possible pets

--- a/code/modules/antagonists/traitor/objectives/kill_pet.dm
+++ b/code/modules/antagonists/traitor/objectives/kill_pet.dm
@@ -37,6 +37,8 @@
 	/// The actual pet that needs to be killed
 	var/mob/living/target_pet
 
+	duplicate_type = /datum/traitor_objective/kill_pet
+
 /datum/traitor_objective/kill_pet/medium_risk
 	progression_minimum = 10 MINUTES
 	progression_reward = list(5 MINUTES, 8 MINUTES)
@@ -91,8 +93,3 @@
 	if(target_pet)
 		UnregisterSignal(target_pet, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DEATH))
 	target_pet = null
-
-/datum/traitor_objective/kill_pet/is_duplicate(datum/traitor_objective/kill_pet/objective_to_compare)
-	if(objective_to_compare.target.type == target.type)
-		return TRUE
-	return FALSE

--- a/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
+++ b/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
@@ -26,13 +26,14 @@
 	/// Weakpoint where the bomb should be planted
 	var/area/weakpoint_area
 
-/datum/traitor_objective/locate_weakpoint/generate_objective(datum/mind/generating_for, list/possible_duplicates)
+/datum/traitor_objective/locate_weakpoint/can_generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	if(handler.get_completion_progression(/datum/traitor_objective) < progression_objectives_minimum)
 		return FALSE
-
 	if(SStraitor.get_taken_count(/datum/traitor_objective/locate_weakpoint) > 0)
 		return FALSE
+	return TRUE
 
+/datum/traitor_objective/locate_weakpoint/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	scan_areas = list()
 	/// List of high-security areas that we pick required ones from
 	var/list/allowed_areas = typecacheof(list(/area/station/command,
@@ -73,7 +74,7 @@
 	. = ..()
 
 	// We don't want multiple people being able to take weakpoint objectives if they get one available at the same time
-	for(var/datum/traitor_objective/locate_weakpoint/other_objective in SStraitor.all_objectives_by_type[/datum/traitor_objective/locate_weakpoint])
+	for(var/datum/traitor_objective/locate_weakpoint/other_objective as anything in SStraitor.all_objectives_by_type[/datum/traitor_objective/locate_weakpoint])
 		if(other_objective != src)
 			other_objective.fail_objective()
 

--- a/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
+++ b/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
@@ -10,6 +10,8 @@
 	name = "Perform the sleeper protocol on a crewmember"
 	description = "Use the button below to materialize a surgery disk in your hand, where you'll then be able to perform the sleeper protocol on a crewmember. If the disk gets destroyed, the objective will fail. This will only work on living and sentient crewmembers."
 
+	progression_minimum = 0 MINUTES
+
 	progression_reward = list(8 MINUTES, 15 MINUTES)
 	telecrystal_reward = 0
 

--- a/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
+++ b/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
@@ -48,22 +48,23 @@
 	if(istype(step, /datum/surgery_step/brainwash/sleeper_agent))
 		succeed_objective()
 
-/datum/traitor_objective/sleeper_protocol/generate_objective(datum/mind/generating_for, list/possible_duplicates)
+/datum/traitor_objective/sleeper_protocol/can_generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	var/datum/job/job = generating_for.assigned_role
 	if(!(job.title in limited_to) && !inverted_limitation)
 		return FALSE
 	if((job.title in limited_to) && inverted_limitation)
 		return FALSE
+	if(length(possible_duplicates) > 0)
+		return FALSE
+	return TRUE
+
+/datum/traitor_objective/sleeper_protocol/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	AddComponent(/datum/component/traitor_objective_mind_tracker, generating_for, \
 		signals = list(COMSIG_MOB_SURGERY_STEP_SUCCESS = .proc/on_surgery_success))
 	return TRUE
 
 /datum/traitor_objective/sleeper_protocol/ungenerate_objective()
 	disk = null
-
-/datum/traitor_objective/sleeper_protocol/is_duplicate()
-	return TRUE
-
 /obj/item/disk/surgery/sleeper_protocol
 	name = "Suspicious Surgery Disk"
 	desc = "The disk provides instructions on how to turn someone into a sleeper agent for the Syndicate."

--- a/code/modules/antagonists/traitor/objectives/steal.dm
+++ b/code/modules/antagonists/traitor/objectives/steal.dm
@@ -189,11 +189,6 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		UnregisterSignal(bug, list(COMSIG_TRAITOR_BUG_PLANTED_OBJECT, COMSIG_TRAITOR_BUG_PRE_PLANTED_OBJECT))
 	bug = null
 
-/datum/traitor_objective/steal_item/is_duplicate(datum/traitor_objective/steal_item/objective_to_compare)
-	if(objective_to_compare.target_item.type == target_item.type)
-		return TRUE
-	return FALSE
-
 /datum/traitor_objective/steal_item/generate_ui_buttons(mob/user)
 	var/list/buttons = list()
 	if(special_equipment)

--- a/code/modules/antagonists/traitor/traitor_objective.dm
+++ b/code/modules/antagonists/traitor/traitor_objective.dm
@@ -9,7 +9,7 @@
 	/// The uplink handler holder to give the progression and telecrystals to.
 	var/datum/uplink_handler/handler
 	/// The minimum required progression points for this objective
-	var/progression_minimum = 0 MINUTES
+	var/progression_minimum = null
 	/// The maximum progression before this objective cannot appear anymore
 	var/progression_maximum = INFINITY
 	/// The progression that is rewarded from completing this traitor objective. Can either be a list of list(min, max) or a direct value
@@ -44,6 +44,9 @@
 	var/original_progression = 0
 	/// Abstract type that won't be included as a possible objective
 	var/abstract_type = /datum/traitor_objective
+	/// The duplicate type that will be used to check for duplicates.
+	/// If undefined, this will either take from the abstract type or the type of the objective itself
+	var/duplicate_type = null
 
 /// Returns a list of variables that can be changed by config, allows for balance through configuration.
 /// It is not recommended to finetweak any values of objectives on your server.
@@ -132,6 +135,11 @@
 	handler = null
 	return ..()
 
+/// Called whenever the objective is about to be generated. Bypassed by forcefully adding objectives.
+/// Returning false or true will do the same as the generate_objective proc.
+/datum/traitor_objective/proc/can_generate_objective(datum/mind/generating_for, list/possible_duplicates)
+	return TRUE
+
 /// Called when the objective should be generated. Should return if the objective has been successfully generated.
 /// If false is returned, the objective will be removed as a potential objective for the traitor it is being generated for.
 /// This is only temporary, it will run the proc again when objectives are generated for the traitor again.
@@ -217,10 +225,6 @@
 /datum/traitor_objective/proc/completion_payout()
 	handler.progression_points += progression_reward
 	handler.telecrystals += telecrystal_reward
-
-/// Determines whether this objective is a duplicate. objective_to_compare is always of the type it is being called on.
-/datum/traitor_objective/proc/is_duplicate(datum/traitor_objective/objective_to_compare)
-	return TRUE
 
 /// Used for sending data to the uplink UI
 /datum/traitor_objective/proc/uplink_ui_data(mob/user)

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -116,7 +116,6 @@
 
 /datum/uplink_handler/proc/try_add_objective(datum/traitor_objective/objective_typepath, force = FALSE)
 	var/datum/traitor_objective/objective = new objective_typepath(src)
-	var/should_abort = SEND_SIGNAL(objective, COMSIG_TRAITOR_OBJECTIVE_PRE_GENERATE, owner, potential_duplicate_objectives[objective_typepath]) & COMPONENT_TRAITOR_OBJECTIVE_ABORT_GENERATION
 	var/duplicate_typepath = objective.duplicate_type
 	if(!duplicate_typepath)
 		if(objective.abstract_type != /datum/traitor_objective)
@@ -127,6 +126,8 @@
 	if(!force && !objective.can_generate_objective(owner, potential_duplicate_objectives[duplicate_typepath]))
 		qdel(objective)
 		return
+
+	var/should_abort = SEND_SIGNAL(objective, COMSIG_TRAITOR_OBJECTIVE_PRE_GENERATE, owner, potential_duplicate_objectives[duplicate_typepath]) & COMPONENT_TRAITOR_OBJECTIVE_ABORT_GENERATION
 	if(should_abort || !objective.generate_objective(owner, potential_duplicate_objectives[duplicate_typepath]))
 		qdel(objective)
 		return

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -114,16 +114,27 @@
 		potential_objectives_left--
 	on_update()
 
-/datum/uplink_handler/proc/try_add_objective(datum/traitor_objective/objective_typepath)
+/datum/uplink_handler/proc/try_add_objective(datum/traitor_objective/objective_typepath, force = FALSE)
 	var/datum/traitor_objective/objective = new objective_typepath(src)
 	var/should_abort = SEND_SIGNAL(objective, COMSIG_TRAITOR_OBJECTIVE_PRE_GENERATE, owner, potential_duplicate_objectives[objective_typepath]) & COMPONENT_TRAITOR_OBJECTIVE_ABORT_GENERATION
-	if(should_abort || !objective.generate_objective(owner, potential_duplicate_objectives[objective_typepath]))
+	var/duplicate_typepath = objective.duplicate_type
+	if(!duplicate_typepath)
+		if(objective.abstract_type != /datum/traitor_objective)
+			duplicate_typepath = objective.abstract_type
+		else
+			duplicate_typepath = objective_typepath
+
+	if(!force && !objective.can_generate_objective(owner, potential_duplicate_objectives[duplicate_typepath]))
+		qdel(objective)
+		return
+	if(should_abort || !objective.generate_objective(owner, potential_duplicate_objectives[duplicate_typepath]))
 		qdel(objective)
 		return
 	if(!handle_duplicate(objective))
 		qdel(objective)
 		return
-	log_traitor("[key_name(owner)] has received a potential objective: [objective.to_debug_string()]")
+	objective.forced = force
+	log_traitor("[key_name(owner)] has received a potential objective: [objective.to_debug_string()] | Forced: [force]")
 	objective.original_progression = objective.progression_reward
 	objective.update_progression_reward()
 	potential_objectives += objective
@@ -140,11 +151,6 @@
 		if(!potential_duplicate_objectives[current_type])
 			potential_duplicate_objectives[current_type] = list(potential_duplicate)
 		else
-			for(var/datum/traitor_objective/duplicate_checker as anything in potential_duplicate_objectives[current_type])
-				if(duplicate_checker.is_duplicate(potential_duplicate))
-					for(var/typepath in added_types)
-						potential_duplicate_objectives[typepath] -= potential_duplicate
-					return FALSE
 			potential_duplicate_objectives[current_type] += potential_duplicate
 
 		added_types += current_type

--- a/code/modules/unit_tests/objectives.dm
+++ b/code/modules/unit_tests/objectives.dm
@@ -16,7 +16,7 @@
 			TEST_FAIL("[objective_typepath] is not in a traitor category and isn't an abstract type! Place it into a [/datum/traitor_objective_category] or remove it from code.")
 		if(initial(objective_typepath.progression_minimum) == null)
 			TEST_FAIL("[objective_typepath] has not defined a minimum progression level and isn't an abstract type! Please define the progression minimum variable on the datum")
-		if(initial(objective_typepath.progression_reward) == 0 && initial(objective_typepath.telecrystal_reward) == 0)
+		if(!ispath(objective_typepath, /datum/traitor_objective/final) && initial(objective_typepath.progression_reward) == 0 && initial(objective_typepath.telecrystal_reward) == 0)
 			TEST_FAIL("[objective_typepath] has not set either a progression reward or a telecrystal reward! Please set either a telecrystal or progression reward for this objective.")
 
 /datum/unit_test/objectives_category/proc/recursive_check_list(base_type, list/to_check, list/to_add_to)

--- a/code/modules/unit_tests/objectives.dm
+++ b/code/modules/unit_tests/objectives.dm
@@ -14,6 +14,10 @@
 			continue
 		if(!(objective_typepath in objectives_that_exist))
 			TEST_FAIL("[objective_typepath] is not in a traitor category and isn't an abstract type! Place it into a [/datum/traitor_objective_category] or remove it from code.")
+		if(initial(objective_typepath.progression_minimum) == null)
+			TEST_FAIL("[objective_typepath] has not defined a minimum progression level and isn't an abstract type! Please define the progression minimum variable on the datum")
+		if(initial(objective_typepath.progression_reward) == 0 && initial(objective_typepath.telecrystal_reward) == 0)
+			TEST_FAIL("[objective_typepath] has not set either a progression reward or a telecrystal reward! Please set either a telecrystal or progression reward for this objective.")
 
 /datum/unit_test/objectives_category/proc/recursive_check_list(base_type, list/to_check, list/to_add_to)
 	for(var/value in to_check)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Duplicate handling is now handled only within the can_generate_objective and generate_objective functions.
Both of these functions are identical in implementation, but can_generate_objective is skipped if an objective is forcefully added. This allows for certain basic checks in generate_objective to be skipped where they don't matter to the target objective as a whole.

Also expands on the objectives unit test to do more sanity checking with objectives, such as making sure you can't get no rewards for completing an objective or forgetting to set the progression_minimum of an objective.

Closes #69019

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Better handling of duplicates. Force giving objectives will more commonly succeed now. Less chance of new contribs making common mistakes with objectives.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Refactored how duplicates are handled in traitor objective code. This will fix destroy heirloom and eyesnatching objectives from only ever being available once.
fix: Fixed destroy heirloom objectives never generating
fix: Fixed eyesnatching objectives never generating.
balance: Kidnapping objective can only be taken a maximum of 3 times within 15 minutes. This puts it in line with the assassinate and eyesnatching objectives.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
