### PR TITLE
Add missing Ian festivities to Icebox and Kilo

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -46752,6 +46752,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
+"ool" = (
+/obj/effect/mapping_helpers/iannewyear,
+/turf/open/floor/carpet,
+/area/station/command/heads_quarters/hop)
 "ooo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/processor/slime,
@@ -236182,7 +236186,7 @@ xvZ
 iYb
 mlY
 cqQ
-cqQ
+ool
 jRC
 shc
 sFy

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -75328,6 +75328,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
+/obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "vvE" = (


### PR DESCRIPTION
## About The Pull Request

An Ian birthday map helper was missing on Kilo, and the new year map helper was missing on Icebox. This PR fixes these.

## Why It's Good For The Game

Ian is no longer sad about not getting his cake on Kilo, and he can once again celebrate new year on Icebox

## Changelog

:cl:
fix: Ian once again celebrates his birthday on Kilo, and new year on Icebox
/:cl: