### PR TITLE
[MDB IGNORE] Clothing var cleanup

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -7336,7 +7336,7 @@
 /obj/item/clothing/head/costume/cardborg,
 /obj/item/clothing/head/cone,
 /obj/item/clothing/head/costume/festive,
-/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/toggleable/riot,
 /obj/item/clothing/head/helmet/sec,
 /obj/item/clothing/head/costume/jester,
 /obj/item/clothing/head/chaplain/nun_hood,

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -3895,7 +3895,7 @@
 "AY" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/toggleable/riot,
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -50609,12 +50609,12 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot,
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_x = 3;
 	pixel_y = -3
 	},
@@ -75314,7 +75314,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/east,
 /obj/item/clothing/suit/costume/justice,
-/obj/item/clothing/head/helmet/justice/escape{
+/obj/item/clothing/head/helmet/toggleable/justice/escape{
 	name = "justice helmet"
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -43800,12 +43800,12 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot,
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_x = 3;
 	pixel_y = -3
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -901,12 +901,12 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot,
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_x = 3;
 	pixel_y = -3
 	},
@@ -81542,7 +81542,7 @@
 "xdl" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/black,
-/obj/item/clothing/head/helmet/justice/escape{
+/obj/item/clothing/head/helmet/toggleable/justice/escape{
 	name = "justice helmet"
 	},
 /turf/open/floor/iron/dark,
@@ -83716,7 +83716,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "xJK" = (
-/obj/item/clothing/head/helmet/justice/escape{
+/obj/item/clothing/head/helmet/toggleable/justice/escape{
 	name = "justice helmet"
 	},
 /obj/structure/sign/poster/official/the_owl{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -58128,14 +58128,14 @@
 "uwg" = (
 /obj/structure/rack,
 /obj/machinery/light/directional/west,
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_x = 3;
 	pixel_y = 2
 	},
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_y = 2
 	},
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_x = -3;
 	pixel_y = 2
 	},

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -46627,12 +46627,12 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
+/obj/item/clothing/head/helmet/toggleable/riot,
+/obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_x = 3;
 	pixel_y = -3
 	},

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -299,7 +299,7 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 		/obj/item/clothing/gloves/color/black = 1,
 		/obj/item/clothing/gloves/color/yellow = 1,
 		/obj/item/clothing/gloves/tackler/combat = 1,
-		/obj/item/clothing/head/helmet/justice = 1,
+		/obj/item/clothing/head/helmet/toggleable/justice = 1,
 		/obj/item/storage/belt/military/assault = 1,
 		/obj/item/storage/belt/security = 1,
 		) = 1,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -275,7 +275,7 @@
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/suit/armor/riot(src)
 	for(var/i in 1 to 3)
-		new /obj/item/clothing/head/helmet/riot(src)
+		new /obj/item/clothing/head/helmet/toggleable/riot(src)
 	for(var/i in 1 to 3)
 		new /obj/item/shield/riot(src)
 

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -142,7 +142,7 @@
 		Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 6 //justice comes at a price. An expensive, noisy price.
 	contraband = TRUE
-	contains = list(/obj/item/clothing/head/helmet/justice,
+	contains = list(/obj/item/clothing/head/helmet/toggleable/justice,
 					/obj/item/clothing/mask/gas/sechailer,
 				)
 	crate_name = "security clothing crate"
@@ -296,7 +296,7 @@
 	name = "Riot Helmets Crate"
 	desc = "Contains three riot helmets. Requires Armory access to open."
 	cost = CARGO_CRATE_VALUE * 4
-	contains = list(/obj/item/clothing/head/helmet/riot = 3)
+	contains = list(/obj/item/clothing/head/helmet/toggleable/riot = 3)
 	crate_name = "riot helmets crate"
 
 /datum/supply_pack/security/armory/riotshields
@@ -357,7 +357,7 @@
 	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/obj/item/storage/belt/holster/thermal = 2)
 	crate_name = "thermal pistol crate"
-	
+
 /datum/supply_pack/security/armory/wt550
 	name = "Recalled Weapon Pack"
 	desc = "Contains a set of old Nanotrasen brand autorifles recalled due to choking hazard."
@@ -368,7 +368,7 @@
 		/obj/item/ammo_box/magazine/wt550m9 = 2,
 	)
 	crate_name = "Recalled rifle crate"
-	
+
 /datum/supply_pack/security/armory/wt550ammo
 	name = "Recalled Ammo Pack"
 	desc = "Contains four 20-round magazine for the Recalled WT-550 Auto Rifle. \

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -16,11 +16,6 @@
 	var/visor_flags_cover = 0 //same as above, but for flags_cover
 	///What to toggle when toggled with weldingvisortoggle()
 	var/visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT | VISOR_VISIONFLAGS | VISOR_DARKNESSVIEW | VISOR_INVISVIEW
-	var/alt_desc = null
-	var/toggle_message = null
-	var/alt_toggle_message = null
-	var/toggle_cooldown = null
-	var/cooldown = 0
 
 	var/clothing_flags = NONE
 

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -6,7 +6,6 @@
 	righthand_file = 'icons/mob/inhands/clothing/hats_righthand.dmi'
 	body_parts_covered = HEAD
 	slot_flags = ITEM_SLOT_HEAD
-	var/can_toggle = null
 
 ///Special throw_impact for hats to frisbee hats at people to place them on their heads/attempt to de-hat them.
 /obj/item/clothing/head/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -105,9 +105,9 @@
 
 /obj/item/clothing/head/helmet/toggleable
 	dog_fashion = null
-	///to_chat() message when the visor is toggled down.
+	///chat message when the visor is toggled down.
 	var/toggle_message
-	///to_chat() message when the visor is toggled up.
+	///chat message when the visor is toggled up.
 	var/alt_toggle_message
 
 /obj/item/clothing/head/helmet/toggleable/attack_self(mob/user)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -105,7 +105,9 @@
 
 /obj/item/clothing/head/helmet/toggleable
 	dog_fashion = null
+	///Message when the visor is toggled down.
 	var/toggle_message
+	///Alternative message when the visor is toggled up.
 	var/alt_toggle_message
 
 /obj/item/clothing/head/helmet/toggleable/attack_self(mob/user)
@@ -144,12 +146,6 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 
-/obj/item/clothing/head/helmet/toggleable/justice/try_toggle()
-	if(!COOLDOWN_FINISHED(src, visor_toggle_cooldown))
-		return FALSE
-	COOLDOWN_START(src, visor_toggle_cooldown, 2 SECONDS)
-	return TRUE
-
 /obj/item/clothing/head/helmet/toggleable/justice
 	name = "helmet of justice"
 	desc = "WEEEEOOO. WEEEEEOOO. WEEEEOOOO."
@@ -158,9 +154,16 @@
 	toggle_message = "You turn off the lights on"
 	alt_toggle_message = "You turn on the lights on"
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
+	///Cooldown for toggling the visor.
 	COOLDOWN_DECLARE(visor_toggle_cooldown)
 	///Looping sound datum for the siren helmet
 	var/datum/looping_sound/siren/weewooloop
+
+/obj/item/clothing/head/helmet/toggleable/justice/try_toggle()
+	if(!COOLDOWN_FINISHED(src, visor_toggle_cooldown))
+		return FALSE
+	COOLDOWN_START(src, visor_toggle_cooldown, 2 SECONDS)
+	return TRUE
 
 /obj/item/clothing/head/helmet/toggleable/justice/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -104,6 +104,7 @@
 
 
 /obj/item/clothing/head/helmet/toggleable
+	dog_fashion = null
 	var/toggle_message
 	var/alt_toggle_message
 
@@ -142,7 +143,6 @@
 	visor_flags_inv = HIDEFACE|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
-	dog_fashion = null
 
 /obj/item/clothing/head/helmet/toggleable/justice/can_toggle()
 	if(!COOLDOWN_FINISHED(src, visor_toggle_cooldown))
@@ -158,7 +158,6 @@
 	toggle_message = "You turn off the lights on"
 	alt_toggle_message = "You turn on the lights on"
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	dog_fashion = null
 	COOLDOWN_DECLARE(visor_toggle_cooldown)
 	///Looping sound datum for the siren helmet
 	var/datum/looping_sound/siren/weewooloop
@@ -182,8 +181,6 @@
 	name = "alarm helmet"
 	desc = "WEEEEOOO. WEEEEEOOO. STOP THAT MONKEY. WEEEOOOO."
 	icon_state = "justice2"
-	toggle_message = "You turn off the light on"
-	alt_toggle_message = "You turn on the light on"
 
 /obj/item/clothing/head/helmet/swat
 	name = "\improper SWAT helmet"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -102,35 +102,17 @@
 	inhand_icon_state = "blueshift_helmet"
 	custom_premium_price = PAYCHECK_COMMAND
 
-/obj/item/clothing/head/helmet/riot
-	name = "riot helmet"
-	desc = "It's a helmet specifically designed to protect against close range attacks."
-	icon_state = "riot"
-	inhand_icon_state = "riot_helmet"
-	toggle_message = "You pull the visor down on"
-	alt_toggle_message = "You push the visor up on"
-	can_toggle = 1
-	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 80, ACID = 80, WOUND = 15)
-	flags_inv = HIDEEARS|HIDEFACE|HIDESNOUT
-	strip_delay = 80
-	actions_types = list(/datum/action/item_action/toggle)
-	visor_flags_inv = HIDEFACE|HIDESNOUT
-	toggle_cooldown = 0
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
-	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
-	dog_fashion = null
 
-/obj/item/clothing/head/helmet/attack_self(mob/user)
+/obj/item/clothing/head/helmet/toggleable
+	var/toggle_message
+	var/alt_toggle_message
+
+/obj/item/clothing/head/helmet/toggleable/attack_self(mob/user)
 	. = ..()
 	if(.)
 		return
-	if(!can_toggle)
+	if(user.incapacitated() || !can_toggle())
 		return
-
-	if(user.incapacitated() || world.time <= cooldown + toggle_cooldown)
-		return
-
-	cooldown = world.time
 	up = !up
 	flags_1 ^= visor_flags
 	flags_inv ^= visor_flags_inv
@@ -143,7 +125,32 @@
 		var/mob/living/carbon/carbon_user = user
 		carbon_user.head_update(src, forced = TRUE)
 
-/obj/item/clothing/head/helmet/justice
+/obj/item/clothing/head/helmet/toggleable/proc/can_toggle()
+	return TRUE
+
+/obj/item/clothing/head/helmet/toggleable/riot
+	name = "riot helmet"
+	desc = "It's a helmet specifically designed to protect against close range attacks."
+	icon_state = "riot"
+	inhand_icon_state = "riot_helmet"
+	toggle_message = "You pull the visor down on"
+	alt_toggle_message = "You push the visor up on"
+	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 80, ACID = 80, WOUND = 15)
+	flags_inv = HIDEEARS|HIDEFACE|HIDESNOUT
+	strip_delay = 80
+	actions_types = list(/datum/action/item_action/toggle)
+	visor_flags_inv = HIDEFACE|HIDESNOUT
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
+	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
+	dog_fashion = null
+
+/obj/item/clothing/head/helmet/toggleable/justice/can_toggle()
+	if(!COOLDOWN_FINISHED(src, visor_toggle_cooldown))
+		return FALSE
+	COOLDOWN_START(src, visor_toggle_cooldown, 2 SECONDS)
+	return TRUE
+
+/obj/item/clothing/head/helmet/toggleable/justice
 	name = "helmet of justice"
 	desc = "WEEEEOOO. WEEEEEOOO. WEEEEOOOO."
 	icon_state = "justice"
@@ -151,28 +158,27 @@
 	toggle_message = "You turn off the lights on"
 	alt_toggle_message = "You turn on the lights on"
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	can_toggle = 1
-	toggle_cooldown = 20
 	dog_fashion = null
+	COOLDOWN_DECLARE(visor_toggle_cooldown)
 	///Looping sound datum for the siren helmet
 	var/datum/looping_sound/siren/weewooloop
 
-/obj/item/clothing/head/helmet/justice/Initialize(mapload)
+/obj/item/clothing/head/helmet/toggleable/justice/Initialize(mapload)
 	. = ..()
 	weewooloop = new(src, FALSE, FALSE)
 
-/obj/item/clothing/head/helmet/justice/Destroy()
+/obj/item/clothing/head/helmet/toggleable/justice/Destroy()
 	QDEL_NULL(weewooloop)
 	return ..()
 
-/obj/item/clothing/head/helmet/justice/attack_self(mob/user)
+/obj/item/clothing/head/helmet/toggleable/justice/attack_self(mob/user)
 	. = ..()
 	if(up)
 		weewooloop.start()
 	else
 		weewooloop.stop()
 
-/obj/item/clothing/head/helmet/justice/escape
+/obj/item/clothing/head/helmet/toggleable/justice/escape
 	name = "alarm helmet"
 	desc = "WEEEEOOO. WEEEEEOOO. STOP THAT MONKEY. WEEEOOOO."
 	icon_state = "justice2"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -105,9 +105,9 @@
 
 /obj/item/clothing/head/helmet/toggleable
 	dog_fashion = null
-	///Message when the visor is toggled down.
+	///to_chat() message when the visor is toggled down.
 	var/toggle_message
-	///Alternative message when the visor is toggled up.
+	///to_chat() message when the visor is toggled up.
 	var/alt_toggle_message
 
 /obj/item/clothing/head/helmet/toggleable/attack_self(mob/user)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -112,7 +112,7 @@
 	. = ..()
 	if(.)
 		return
-	if(user.incapacitated() || !can_toggle())
+	if(user.incapacitated() || !try_toggle())
 		return
 	up = !up
 	flags_1 ^= visor_flags
@@ -126,7 +126,7 @@
 		var/mob/living/carbon/carbon_user = user
 		carbon_user.head_update(src, forced = TRUE)
 
-/obj/item/clothing/head/helmet/toggleable/proc/can_toggle()
+/obj/item/clothing/head/helmet/toggleable/proc/try_toggle()
 	return TRUE
 
 /obj/item/clothing/head/helmet/toggleable/riot
@@ -144,7 +144,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 
-/obj/item/clothing/head/helmet/toggleable/justice/can_toggle()
+/obj/item/clothing/head/helmet/toggleable/justice/try_toggle()
 	if(!COOLDOWN_FINISHED(src, visor_toggle_cooldown))
 		return FALSE
 	COOLDOWN_START(src, visor_toggle_cooldown, 2 SECONDS)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -128,6 +128,7 @@
 		var/mob/living/carbon/carbon_user = user
 		carbon_user.head_update(src, forced = TRUE)
 
+///Attempt to toggle the visor. Returns true if it does the thing.
 /obj/item/clothing/head/helmet/toggleable/proc/try_toggle()
 	return TRUE
 

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -2,8 +2,8 @@
 // **** Security gas mask ****
 
 // Cooldown times
-#define PHRASE_COOLDOWN 3 SECONDS
-#define OVERUSE_COOLDOWN 18 SECONDS
+#define PHRASE_COOLDOWN (3 SECONDS)
+#define OVERUSE_COOLDOWN (18 SECONDS)
 
 // Aggression levels
 #define AGGR_GOOD_COP 1

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -2,8 +2,8 @@
 // **** Security gas mask ****
 
 // Cooldown times
-#define PHRASE_COOLDOWN 30
-#define OVERUSE_COOLDOWN 180
+#define PHRASE_COOLDOWN 3 SECONDS
+#define OVERUSE_COOLDOWN 18 SECONDS
 
 // Aggression levels
 #define AGGR_GOOD_COP 1
@@ -57,6 +57,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	visor_flags_cover = MASKCOVERSMOUTH
 	tint = 0
 	has_fov = FALSE
+	COOLDOWN_DECLARE(hailer_cooldown)
 	var/aggressiveness = AGGR_BAD_COP
 	var/overuse_cooldown = FALSE
 	var/recent_uses = 0
@@ -129,7 +130,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	set category = "Object"
 	set name = "HALT"
 	set src in usr
-	if(!isliving(usr) || !can_use(usr) || cooldown)
+	if(!isliving(usr) || !can_use(usr) || !COOLDOWN_FINISHED(src, hailer_cooldown))
 		return
 	if(broken_hailer)
 		to_chat(usr, span_warning("\The [src]'s hailing system is broken."))
@@ -171,16 +172,12 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 		return rand(aggressiveness == AGGR_BROKEN ? BROKE_PHRASES : EMAG_PHRASE + 1, upper_limit)
 
 /obj/item/clothing/mask/gas/sechailer/proc/play_phrase(mob/user, datum/hailer_phrase/phrase)
-	. = FALSE
-	if (!cooldown)
-		usr.audible_message("[usr]'s Compli-o-Nator: <font color='red' size='4'><b>[initial(phrase.phrase_text)]</b></font>")
-		playsound(src, "sound/runtime/complionator/[initial(phrase.phrase_sound)].ogg", 100, FALSE, 4)
-		cooldown = TRUE
-		addtimer(CALLBACK(src, /obj/item/clothing/mask/gas/sechailer/proc/reset_cooldown), PHRASE_COOLDOWN)
-		. = TRUE
-
-/obj/item/clothing/mask/gas/sechailer/proc/reset_cooldown()
-	cooldown = FALSE
+	if(!COOLDOWN_FINISHED(src, hailer_cooldown))
+		return
+	COOLDOWN_START(src, hailer_cooldown, PHRASE_COOLDOWN)
+	user.audible_message("[user]'s Compli-o-Nator: <font color='red' size='4'><b>[initial(phrase.phrase_text)]</b></font>")
+	playsound(src, "sound/runtime/complionator/[initial(phrase.phrase_sound)].ogg", 100, FALSE, 4)
+	return TRUE
 
 /obj/item/clothing/mask/gas/sechailer/proc/reset_overuse_cooldown()
 	overuse_cooldown = FALSE
@@ -194,12 +191,14 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	custom_price = PAYCHECK_COMMAND * 1.5
 	w_class = WEIGHT_CLASS_SMALL
 	actions_types = list(/datum/action/item_action/halt)
+	COOLDOWN_DECLARE(whistle_cooldown)
 
 /obj/item/clothing/mask/whistle/ui_action_click(mob/user, action)
-	if(cooldown < world.time - 100)
-		usr.audible_message("<font color='red' size='5'><b>HALT!</b></font>")
-		playsound(src, 'sound/misc/whistle.ogg', 75, FALSE, 4)
-		cooldown = world.time
+	if(!COOLDOWN_FINISHED(src, whistle_cooldown))
+		return
+	COOLDOWN_START(src, whistle_cooldown, 10 SECONDS)
+	user.audible_message("<font color='red' size='5'><b>HALT!</b></font>")
+	playsound(src, 'sound/misc/whistle.ogg', 75, FALSE, 4)
 
 /datum/action/item_action/halt
 	name = "HALT!"

--- a/code/modules/mob/living/carbon/human/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey/monkey.dm
@@ -28,7 +28,7 @@
 
 /// Gives our funny monkey an Ape Escape hat reference
 /mob/living/carbon/human/species/monkey/angry/proc/give_ape_escape_helmet()
-	var/obj/item/clothing/head/helmet/justice/escape/helmet = new(src)
+	var/obj/item/clothing/head/helmet/toggleable/justice/escape/helmet = new(src)
 	equip_to_slot_or_del(helmet, ITEM_SLOT_HEAD)
 	helmet.attack_self(src) // todo encapsulate toggle
 

--- a/tools/UpdatePaths/Scripts/70773_toggleable_helmets_repath.txt
+++ b/tools/UpdatePaths/Scripts/70773_toggleable_helmets_repath.txt
@@ -1,4 +1,4 @@
 #comment This repaths the riothelmet and justice helmet to toggleable subtypes. see (https://github.com/tgstation/tgstation/pull/70773)
 
 /obj/item/clothing/head/helmet/riot : /obj/item/clothing/head/helmet/toggleable/riot{@OLD}
-/obj/item/clothing/head/helmet/justice : /obj/item/clothing/head/helmet/toggleable/justice{@OLD}
+/obj/item/clothing/head/helmet/justice/@SUBTYPES : /obj/item/clothing/head/helmet/toggleable/justice/@SUBTYPES {@OLD}

--- a/tools/UpdatePaths/Scripts/70773_toggleable_helmets_repath.txt
+++ b/tools/UpdatePaths/Scripts/70773_toggleable_helmets_repath.txt
@@ -1,0 +1,4 @@
+#comment This repaths the riothelmet and justice helmet to toggleable subtypes. see (https://github.com/tgstation/tgstation/pull/70773)
+
+/obj/item/clothing/head/helmet/riot : /obj/item/clothing/head/helmet/toggleable/riot
+/obj/item/clothing/head/helmet/justice : /obj/item/clothing/head/helmet/toggleable/justice

--- a/tools/UpdatePaths/Scripts/70773_toggleable_helmets_repath.txt
+++ b/tools/UpdatePaths/Scripts/70773_toggleable_helmets_repath.txt
@@ -1,4 +1,4 @@
 #comment This repaths the riothelmet and justice helmet to toggleable subtypes. see (https://github.com/tgstation/tgstation/pull/70773)
 
-/obj/item/clothing/head/helmet/riot : /obj/item/clothing/head/helmet/toggleable/riot
-/obj/item/clothing/head/helmet/justice : /obj/item/clothing/head/helmet/toggleable/justice
+/obj/item/clothing/head/helmet/riot : /obj/item/clothing/head/helmet/toggleable/riot{@OLD}
+/obj/item/clothing/head/helmet/justice : /obj/item/clothing/head/helmet/toggleable/justice{@OLD}


### PR DESCRIPTION
:cl: ShizCalev
code: Riot helmets and justice helmets are now in a /toggeable subtype.
/:cl:

Some cleanup. Probably fixes #70769