### PR TITLE
Arcade machines dispense tickets instead of direct prizes

### DIFF
--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -561,7 +561,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 				obj_flags &= ~EMAGGED
 				xp_gained += 100
 			else
-				prizevend(user)
+				new /obj/item/stack/arcadeticket((get_turf(src)), 2)
+				to_chat(user, span_notice("[src] dispenses 2 tickets!"))
 				xp_gained += 50
 			SSblackbox.record_feedback("nested tally", "arcade_results", 1, list("win", (obj_flags & EMAGGED ? "emagged":"normal")))
 			user.won_game()
@@ -666,7 +667,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		user.mind?.adjust_experience(/datum/skill/gaming, 100)
 		user.won_game()
 		playsound(src, 'sound/arcade/win.ogg', 50, TRUE)
-		prizevend(user, rand(3,5))
+		new /obj/item/stack/arcadeticket((get_turf(src)), rand(6,10))
+		to_chat(user, span_notice("[src] dispenses a handful of tickets!"))
 		return
 	else if(!do_they_still_have_that_hand(user, chopchop))
 		to_chat(user, span_warning("The guillotine drops, but your hand seems to be gone already!"))

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -484,7 +484,8 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 		message_admins("[ADMIN_LOOKUPFLW(usr)] made it to Orion on an emagged machine and got an explosive toy ship.")
 		usr.log_message("made it to Orion on an emagged machine and got an explosive toy ship.", LOG_GAME)
 	else
-		prizevend(user)
+		new /obj/item/stack/arcadeticket((get_turf(src)), 2)
+		to_chat(user, span_notice("[src] dispenses 2 tickets!"))
 	obj_flags &= ~EMAGGED
 	name = initial(name)
 	desc = initial(desc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The games inside modular tablets/consoles don't give prizes directly, instead they give arcade tickets that you can use on a normal arcade machine to get a random prize.
This PR just makes the normal arcade machines work the same way, giving you tickets that you can swap for prizes at the machine itself.

The only difference this make balance wise is that it is easier to get tickets on one machine and spend in another, but that was a trick that already existed with tablets, just not well known.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Grinding your gamer skills is fun but I always disliked that I'm spawning a giant stack of random items on top of the machine.
Swapping the prizes for tickets cuts on that, as they are a stack item like metal sheets and bundle together into 1 entity, easy to carry around in a bag if you need to walk away to buy some PWR gamer and snacks.

This also open a few possibilities, you can make a fat stack of tickets and directly compare how much you won during a shift to other players.
And eventually if someone is interested, rework the prize rewards from what we have now from 2 tickets for a random item, to  something more interesting, like a choice to buy each prize for a different amount of tickets.
For now you can still use tickets as a pseudo economy and trade rare prizes to other gamers for some tickets.

> [common] Guillaume H. Prata says, "Selling unusual tacticool turtleneck for 20 ~~keys~~ tickets!"

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
balance: Arcade machines will dispense arcade tickets now instead of a direct prize. Slap them back into the machine to trade for the prizes or collect as many as you can to show of how much of a gamer you are!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
