### PR TITLE
Consciousness Transference potions tame creatures

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_simple.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_simple.dm
@@ -1,6 +1,8 @@
 // simple_animal signals
-/// called when a simplemob is given sentience from a potion (target = person who sentienced)
+/// called when a simplemob is given sentience from a sentience potion (target = person who sentienced)
 #define COMSIG_SIMPLEMOB_SENTIENCEPOTION "simplemob_sentiencepotion"
+/// called when a simplemob is given sentience from a consciousness transference potion (target = person who sentienced)
+#define COMSIG_SIMPLEMOB_TRANSFERPOTION "simplemob_transferpotion"
 
 // /mob/living/simple_animal/hostile signals
 ///before attackingtarget has happened, source is the attacker and target is the attacked

--- a/code/datums/components/tameable.dm
+++ b/code/datums/components/tameable.dm
@@ -27,6 +27,7 @@
 
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/try_tame)
 	RegisterSignal(parent, COMSIG_SIMPLEMOB_SENTIENCEPOTION, .proc/on_tame) //Instantly succeeds
+	RegisterSignal(parent, COMSIG_SIMPLEMOB_TRANSFERPOTION, .proc/on_tame) //Instantly succeeds
 
 /datum/component/tameable/proc/try_tame(datum/source, obj/item/food, mob/living/attacker, params)
 	SIGNAL_HANDLER

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -786,7 +786,7 @@
 	to_chat(user, span_notice("You drink the potion then place your hands on [switchy_mob]..."))
 
 	user.mind.transfer_to(switchy_mob)
-	SEND_SIGNAL(switchy_mob, COMSIG_SIMPLEMOB_SENTIENCEPOTION, user)
+	SEND_SIGNAL(switchy_mob, COMSIG_SIMPLEMOB_TRANSFERPOTION, user)
 	switchy_mob.faction = user.faction.Copy()
 	switchy_mob.copy_languages(user, LANGUAGE_MIND)
 	switchy_mob.update_atom_languages()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -786,6 +786,7 @@
 	to_chat(user, span_notice("You drink the potion then place your hands on [switchy_mob]..."))
 
 	user.mind.transfer_to(switchy_mob)
+	SEND_SIGNAL(switchy_mob, COMSIG_SIMPLEMOB_SENTIENCEPOTION, user)
 	switchy_mob.faction = user.faction.Copy()
 	switchy_mob.copy_languages(user, LANGUAGE_MIND)
 	switchy_mob.update_atom_languages()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Consciousness Transference potions now send the `COMSIG_SIMPLEMOB_TRANSFERPOTION` signal. This is also used so the potion will tame the mob you transfer to, such as a xenobio-spawned chaos magicarp.

Fixes #70777
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Oversights are bad, generally.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Vladoricious
fix: Consciousness Transference potions now tame the target creature, just like Sentience potions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
