### PR TITLE
Carrying a null rod no longer disables the ability to use the traitor chef's meat hook

### DIFF
--- a/code/modules/projectiles/guns/special/meat_hook.dm
+++ b/code/modules/projectiles/guns/special/meat_hook.dm
@@ -14,6 +14,7 @@
 	item_flags = NEEDS_PERMIT | NOBLUDGEON
 	sharpness = SHARP_POINTY
 	force = 18
+	antimagic_flags = NONE
 
 /obj/item/gun/magic/hook/shoot_with_empty_chamber(mob/living/user)
 	to_chat(user, span_warning("[src] isn't ready to fire yet!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Because it seems to have been originally made as a miner-loot item with loose references to sweaty nerd games like DOTA2, or possibly due to its mechanics, the meat hook has always been a magic item. This means it inherits antimagic flags that don't really make sense. This PR changes its antimagic flags to none.

## Why It's Good For The Game

The meat hook does not read as magical in any way. It doesn't describe itself as magical in its tooltips, uplink description, name, etc. This might seem like an edge-case interaction, but it's entirely possible for a traitor chef to end up carrying a null rod when doing a destroy null rod objective, or just stealing it because they wanted a weapon. If that happens and then they try to use their 11tc traitor item, right now the meat hook will just refuse to work while you're carrying a null rod with no feedback as to why.

If this is intended behaviour then it should really be called 'mystic meat hook' or something. But that seems like a sillier way to resolve this.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Carrying a null rod no longer disables the ability to use the traitor chef's meat hook
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
