### PR TITLE
fixes runtime when building things with proxy sensors that get deleted in the process

### DIFF
--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -20,8 +20,8 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/item/assembly/prox_sensor/Destroy()
-	QDEL_NULL(proximity_monitor)
 	STOP_PROCESSING(SSobj, src)
+	QDEL_NULL(proximity_monitor)
 	. = ..()
 
 /obj/item/assembly/prox_sensor/examine(mob/user)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -20,6 +20,7 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/item/assembly/prox_sensor/Destroy()
+	QDEL_NULL(proximity_monitor)
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
@@ -44,7 +45,7 @@
 	// assembly holder's attached object
 	// assembly holder itself
 	// us
-	proximity_monitor.set_host(connected?.holder || holder?.master || holder || src, src)
+	proximity_monitor?.set_host(connected?.holder || holder?.master || holder || src, src)
 
 /obj/item/assembly/prox_sensor/on_attach()
 	. = ..()

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -22,7 +22,7 @@
 /obj/item/assembly/prox_sensor/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(proximity_monitor)
-	. = ..()
+	return ..()
 
 /obj/item/assembly/prox_sensor/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
proximity_monitor.set_host() was being called after being deleted (qdel -> movetonullspace -> dropped())

```
[2022-10-25 05:13:39.397] runtime error: Attempted to add a new component of type [/datum/component/connect_containers] to a qdeleting parent of type [/datum/proximity_monitor]!
 - proc name:  AddComponent (/datum/proc/_AddComponent)
 -   source file: _component.dm,403
 -   usr: Gratian Hunter (/mob/living/carbon/human)
 -   src: /datum/proximity_monitor (/datum/proximity_monitor)
 -   usr.loc: the floor (126,198,2) (/turf/open/floor/iron)
 -   call stack:
 - /datum/proximity_monitor (/datum/proximity_monitor):  AddComponent(/list (/list))
 - /datum/proximity_monitor (/datum/proximity_monitor): set host(the proximity sensor (/obj/item/assembly/prox_sensor), the proximity sensor (/obj/item/assembly/prox_sensor))
 - the proximity sensor (/obj/item/assembly/prox_sensor): dropped(Gratian Hunter (/mob/living/carbon/human), 1)
 - Gratian Hunter (/mob/living/carbon/human): doUnEquip(the proximity sensor (/obj/item/assembly/prox_sensor), 1, null, 1, 1, 1)
 - Gratian Hunter (/mob/living/carbon/human): doUnEquip(the proximity sensor (/obj/item/assembly/prox_sensor), 1, null, 1, 1, 1)
 - Gratian Hunter (/mob/living/carbon/human): doUnEquip(the proximity sensor (/obj/item/assembly/prox_sensor), 1, null, 1, 1, 1)
 - Gratian Hunter (/mob/living/carbon/human): temporarilyRemoveItemFromInventory(the proximity sensor (/obj/item/assembly/prox_sensor), 1, 1)
 - the proximity sensor (/obj/item/assembly/prox_sensor): Destroy(0)
 - the proximity sensor (/obj/item/assembly/prox_sensor): Destroy(0)
 - the proximity sensor (/obj/item/assembly/prox_sensor): Destroy(0)
 - qdel(the proximity sensor (/obj/item/assembly/prox_sensor), 0)
 - the wooden bucket (/obj/item/reagent_containers/cup/bucket/wooden): attackby(the proximity sensor (/obj/item/assembly/prox_sensor), Gratian Hunter (/mob/living/carbon/human), "icon-x=17;icon-y=14;left=1;but...")
 - the proximity sensor (/obj/item/assembly/prox_sensor): melee attack chain(Gratian Hunter (/mob/living/carbon/human), the wooden bucket (/obj/item/reagent_containers/cup/bucket/wooden), "icon-x=17;icon-y=14;left=1;but...")
 - Gratian Hunter (/mob/living/carbon/human): ClickOn(the wooden bucket (/obj/item/reagent_containers/cup/bucket/wooden), "icon-x=17;icon-y=14;left=1;but...")
 - the wooden bucket (/obj/item/reagent_containers/cup/bucket/wooden): Click(the floor (126,197,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=17;icon-y=14;left=1;but...")
 - ShizCalev (/client): Click(the wooden bucket (/obj/item/reagent_containers/cup/bucket/wooden), the floor (126,197,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=17;icon-y=14;left=1;but...")
 - 
[2022-10-25 05:13:42.164] runtime error: Attempted to add a new component of type [/datum/component/connect_range] to a qdeleting parent of type [/datum/proximity_monitor]!
 - proc name:  AddComponent (/datum/proc/_AddComponent)
 -   source file: _component.dm,403
 -   usr: Gratian Hunter (/mob/living/carbon/human)
 -   src: /datum/proximity_monitor (/datum/proximity_monitor)
 -   usr.loc: the floor (126,198,2) (/turf/open/floor/iron)
 -   call stack:
 - /datum/proximity_monitor (/datum/proximity_monitor):  AddComponent(/list (/list))
 - /datum/proximity_monitor (/datum/proximity_monitor): set range(0, 1)
 - /datum/proximity_monitor (/datum/proximity_monitor): set host(the proximity sensor (/obj/item/assembly/prox_sensor), the proximity sensor (/obj/item/assembly/prox_sensor))
 - the proximity sensor (/obj/item/assembly/prox_sensor): dropped(Gratian Hunter (/mob/living/carbon/human), 1)
 - Gratian Hunter (/mob/living/carbon/human): doUnEquip(the proximity sensor (/obj/item/assembly/prox_sensor), 1, null, 1, 1, 1)
 - Gratian Hunter (/mob/living/carbon/human): doUnEquip(the proximity sensor (/obj/item/assembly/prox_sensor), 1, null, 1, 1, 1)
 - Gratian Hunter (/mob/living/carbon/human): doUnEquip(the proximity sensor (/obj/item/assembly/prox_sensor), 1, null, 1, 1, 1)
 - Gratian Hunter (/mob/living/carbon/human): temporarilyRemoveItemFromInventory(the proximity sensor (/obj/item/assembly/prox_sensor), 1, 1)
 - the proximity sensor (/obj/item/assembly/prox_sensor): Destroy(0)
 - the proximity sensor (/obj/item/assembly/prox_sensor): Destroy(0)
 - the proximity sensor (/obj/item/assembly/prox_sensor): Destroy(0)
 - qdel(the proximity sensor (/obj/item/assembly/prox_sensor), 0)
 - the wooden bucket (/obj/item/reagent_containers/cup/bucket/wooden): attackby(the proximity sensor (/obj/item/assembly/prox_sensor), Gratian Hunter (/mob/living/carbon/human), "icon-x=17;icon-y=14;left=1;but...")
 - the proximity sensor (/obj/item/assembly/prox_sensor): melee attack chain(Gratian Hunter (/mob/living/carbon/human), the wooden bucket (/obj/item/reagent_containers/cup/bucket/wooden), "icon-x=17;icon-y=14;left=1;but...")
 - Gratian Hunter (/mob/living/carbon/human): ClickOn(the wooden bucket (/obj/item/reagent_containers/cup/bucket/wooden), "icon-x=17;icon-y=14;left=1;but...")
 - the wooden bucket (/obj/item/reagent_containers/cup/bucket/wooden): Click(the floor (126,197,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=17;icon-y=14;left=1;but...")
 - ShizCalev (/client): Click(the wooden bucket (/obj/item/reagent_containers/cup/bucket/wooden), the floor (126,197,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=17;icon-y=14;left=1;but...")
 - 
[2022-10-25 05:18:44.595] ## TESTING: GC: -- [0x210534b2] | /datum/proximity_monitor was unable to be GC'd --
[2022-10-25 05:18:44.600] ## TESTING: GC: -- [0x2009168] | /obj/item/assembly/prox_sensor was unable to be GC'd --
```