### PR TITLE
Fixes the ice block status effect not clearing the ice block overlay upon being replaced

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -363,6 +363,11 @@ Difficulty: Extremely Hard
 	SIGNAL_HANDLER
 	return COMPONENT_MOVABLE_BLOCK_PRE_MOVE
 
+/datum/status_effect/ice_block_talisman/be_replaced()
+	owner.cut_overlay(cube)
+	UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
+	return ..()
+
 /datum/status_effect/ice_block_talisman/on_remove()
 	if(!owner.stat)
 		to_chat(owner, span_notice("The cube melts!"))


### PR DESCRIPTION
## About The Pull Request
It basically wasn't removing the overlay when it was getting replaced, because its `on_remove()` wasn't getting called, and it hadn't overridden its `be_replaced()` to remove the overlay too, so now it does remove the overlay as well!

I would've sworn this bug would have been reported as an issue by now, but as far as I'm aware, it hasn't, as I couldn't find it.

## Why It's Good For The Game
No more funny infinite ice block when you get hit by the freezing breath of at least two ice whelps at once.

## Changelog

:cl: GoldenAlpharex
fix: Being hit by the freezing breath of two (or more) ice whelps will no longer leave you looking like an ice cube for the rest of the round.
/:cl: