### PR TITLE
Fixes random bedsheets not getting their dir applied to the bedsheet they spawn

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -284,7 +284,8 @@ LINEN BINS
 				spawn_list += sheet
 		LAZYSET(bedsheet_list, spawn_type, spawn_list)
 	var/chosen_type = pick(bedsheet_list[spawn_type])
-	new chosen_type(loc)
+	var/obj/item/bedsheet = new chosen_type(loc)
+	bedsheet.dir = dir
 	return INITIALIZE_HINT_QDEL
 
 /obj/item/bedsheet/random/double


### PR DESCRIPTION
## About The Pull Request
Someone just forgot to copy over that line from the proc for the dorms bedsheets. Mappers rejoice!

## Why It's Good For The Game
It looks silly when the game spawns in a bed with the pillow towards the east side, but that no matter what that random bedsheet will always be oriented to the west.

## Changelog

:cl: GoldenAlpharex
fix: Random bedsheet spawners will now give their orientation to their spawned bedsheet, for beds that aren't orientated in the regular direction. Mappers rejoice!
/:cl: