### PR TITLE
Makes stabilizing serum fit on explorer webbing

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -382,6 +382,7 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/flashlight,
 		/obj/item/gps,
+		/obj/item/hivelordstabilizer,
 		/obj/item/key/lasso,
 		/obj/item/knife,
 		/obj/item/lighter,


### PR DESCRIPTION
## About The Pull Request
This one-line change just makes stabilizing serum (the 400 point item for preventing a legion core's decay) fit on the explorer's webbing.

## Why It's Good For The Game
These are one-use items that solely exist to be injected into regenerative cores, and finding places for them kind of sucked if you were a hoarder/inventory juggling enthusiast.  Cores, however, fit on the webbing, so, might as well cut out the middleman and make them fit on the webbing, so that once you use it (to stabilize a core) you can just fill it back up (with your newly-stabilized/rejuvenated core).

## Changelog
:cl:
qol: Stabilizing serum (the item for stabilizing legion cores) now fit in explorer's webbings.
/:cl:
