### PR TITLE
Fixes structure/industrial_lift/debug not working

### DIFF
--- a/code/modules/industrial_lift/industrial_lift.dm
+++ b/code/modules/industrial_lift/industrial_lift.dm
@@ -57,6 +57,8 @@ GLOBAL_LIST_EMPTY(lifts)
 	var/warns_on_down_movement = FALSE
 	/// if TRUE, we will gib anyone we land on top of. if FALSE, we will just apply damage with a serious wound penalty.
 	var/violent_landing = TRUE
+	/// damage multiplier if a mob is hit by the lift while it is moving horizontally
+	var/collision_lethality = 1
 	/// How long does it take for the elevator to move vertically?
 	var/elevator_vertical_speed = 2 SECONDS
 
@@ -332,8 +334,6 @@ GLOBAL_LIST_EMPTY(lifts)
 	else
 		///potentially finds a spot to throw the victim at for daring to be hit by a tram. is null if we havent found anything to throw
 		var/atom/throw_target
-		var/datum/lift_master/tram/our_lift = lift_master_datum
-		var/collision_lethality = our_lift.collision_lethality
 
 		for(var/turf/dest_turf as anything in entering_locs)
 			///handles any special interactions objects could have with the lift/tram, handled on the item itself
@@ -348,6 +348,13 @@ GLOBAL_LIST_EMPTY(lifts)
 						shake_camera(client_mob, 2, 3)
 
 				playsound(collided_wall, 'sound/effects/meteorimpact.ogg', 100, TRUE)
+
+			if(ismineralturf(dest_turf))
+				var/turf/closed/mineral/M = dest_turf
+				for(var/mob/client_mob in SSspatial_grid.orthogonal_range_search(M, SPATIAL_GRID_CONTENTS_TYPE_CLIENTS, 8))
+					if(get_dist(dest_turf, client_mob) <= 8)
+						shake_camera(client_mob, 2, 3)
+				M.gets_drilled(give_exp = FALSE)
 
 			for(var/obj/structure/victim_structure in dest_turf.contents)
 				if(QDELING(victim_structure))
@@ -713,8 +720,9 @@ GLOBAL_LIST_EMPTY(lifts)
 	lift_id = DEBUG_LIFT_ID
 	radial_travel = TRUE
 
-/obj/structure/industrial_lift/debug/open_lift_radial(mob/user)
-	if (!in_range(src, user))
+/obj/structure/industrial_lift/debug/open_lift_radial(mob/living/user)
+	var/starting_position = loc
+	if (!can_open_lift_radial(user,starting_position))
 		return
 //NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST
 	var/static/list/tool_list = list(
@@ -728,34 +736,38 @@ GLOBAL_LIST_EMPTY(lifts)
 		"NORTHWEST" = image(icon = 'icons/testing/turf_analysis.dmi', icon_state = "red_arrow", dir = WEST)
 		)
 
-	var/result = show_radial_menu(user, src, tool_list, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE, tooltips = FALSE)
-	if (!in_range(src, user))
+	var/result = show_radial_menu(user, src, tool_list, custom_check = CALLBACK(src, .proc/can_open_lift_radial, user, starting_position), require_near = TRUE, tooltips = FALSE)
+	if (!can_open_lift_radial(user,starting_position))
 		return  // nice try
+	if(!isnull(result) && result != "Cancel" && lift_master_datum.controls_locked)
+		// Only show this message if they actually wanted to move
+		balloon_alert(user, "elevator controls locked!")
+		return
 
 	switch(result)
 		if("NORTH")
-			lift_master_datum.move_lift_horizontally(NORTH, z)
+			lift_master_datum.move_lift_horizontally(NORTH)
 			open_lift_radial(user)
 		if("NORTHEAST")
-			lift_master_datum.move_lift_horizontally(NORTHEAST, z)
+			lift_master_datum.move_lift_horizontally(NORTHEAST)
 			open_lift_radial(user)
 		if("EAST")
-			lift_master_datum.move_lift_horizontally(EAST, z)
+			lift_master_datum.move_lift_horizontally(EAST)
 			open_lift_radial(user)
 		if("SOUTHEAST")
-			lift_master_datum.move_lift_horizontally(SOUTHEAST, z)
+			lift_master_datum.move_lift_horizontally(SOUTHEAST)
 			open_lift_radial(user)
 		if("SOUTH")
-			lift_master_datum.move_lift_horizontally(SOUTH, z)
+			lift_master_datum.move_lift_horizontally(SOUTH)
 			open_lift_radial(user)
 		if("SOUTHWEST")
-			lift_master_datum.move_lift_horizontally(SOUTHWEST, z)
+			lift_master_datum.move_lift_horizontally(SOUTHWEST)
 			open_lift_radial(user)
 		if("WEST")
-			lift_master_datum.move_lift_horizontally(WEST, z)
+			lift_master_datum.move_lift_horizontally(WEST)
 			open_lift_radial(user)
 		if("NORTHWEST")
-			lift_master_datum.move_lift_horizontally(NORTHWEST, z)
+			lift_master_datum.move_lift_horizontally(NORTHWEST)
 			open_lift_radial(user)
 		if("Cancel")
 			return

--- a/code/modules/industrial_lift/industrial_lift.dm
+++ b/code/modules/industrial_lift/industrial_lift.dm
@@ -344,17 +344,15 @@ GLOBAL_LIST_EMPTY(lifts)
 				do_sparks(2, FALSE, collided_wall)
 				collided_wall.dismantle_wall(devastated = TRUE)
 				for(var/mob/client_mob in SSspatial_grid.orthogonal_range_search(collided_wall, SPATIAL_GRID_CONTENTS_TYPE_CLIENTS, 8))
-					if(get_dist(dest_turf, client_mob) <= 8)
-						shake_camera(client_mob, 2, 3)
+					shake_camera(client_mob, duration = 2, strength = 3)
 
 				playsound(collided_wall, 'sound/effects/meteorimpact.ogg', 100, TRUE)
 
 			if(ismineralturf(dest_turf))
-				var/turf/closed/mineral/M = dest_turf
-				for(var/mob/client_mob in SSspatial_grid.orthogonal_range_search(M, SPATIAL_GRID_CONTENTS_TYPE_CLIENTS, 8))
-					if(get_dist(dest_turf, client_mob) <= 8)
-						shake_camera(client_mob, 2, 3)
-				M.gets_drilled(give_exp = FALSE)
+				var/turf/closed/mineral/dest_mineral_turf = dest_turf
+				for(var/mob/client_mob in SSspatial_grid.orthogonal_range_search(dest_mineral_turf, SPATIAL_GRID_CONTENTS_TYPE_CLIENTS, 8))
+					shake_camera(client_mob, duration = 2, strength = 3)
+				dest_mineral_turf.gets_drilled(give_exp = FALSE)
 
 			for(var/obj/structure/victim_structure in dest_turf.contents)
 				if(QDELING(victim_structure))

--- a/code/modules/industrial_lift/industrial_lift.dm
+++ b/code/modules/industrial_lift/industrial_lift.dm
@@ -738,7 +738,7 @@ GLOBAL_LIST_EMPTY(lifts)
 
 	var/result = show_radial_menu(user, src, tool_list, custom_check = CALLBACK(src, .proc/can_open_lift_radial, user, starting_position), require_near = TRUE, tooltips = FALSE)
 	if (!can_open_lift_radial(user,starting_position))
-		return  // nice try
+		return	// nice try
 	if(!isnull(result) && result != "Cancel" && lift_master_datum.controls_locked)
 		// Only show this message if they actually wanted to move
 		balloon_alert(user, "elevator controls locked!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the debug industrial lifts menu not opening when interacted with, and additionally to do so a bug 
had to also be fixed where collision_lethality was an undefined variable
Also allows it to destroy mineral walls
## Why It's Good For The Game

Nonfunctional code bad, admeme shenanigans funny
Also phasing through mineral walls and suffocating is probs a bug
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed debug industrial lifts not working
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
