### PR TITLE
De-runtimes dueling pistols

### DIFF
--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -171,8 +171,9 @@
 		if(!check_valid_duel(user, FALSE) && !other_gun.check_valid_duel(user, FALSE))
 			var/datum/duel/D = new(src, other_gun)
 			to_chat(user,span_notice("Pairing established. Pairing code: [D.pairing_code]"))
+			return
 
-	. = ..()
+	return ..()
 
 /obj/item/gun/energy/dueling/examine_more(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a check for a valid duel datum to dueling pistols in procs which touch the duel datum so it doesn't runtime if the gun is broken. Also refactors dueling pistol deletion to better clean up after itself by removing the duel datum and all references to it.

Fixes #70781 

## Why It's Good For The Game

Runtimes are bad, safe code that cleans up after itself and checks for nulls before they can cause runtimes is good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Dueling pistols have been refactored to be less prone to runtimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
