### PR TITLE
Makes drones and lightgeists be able to understand galactic common

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -262,9 +262,9 @@ Key procs
 							/datum/language/narsie = list(LANGUAGE_ATOM))
 
 /datum/language_holder/drone
-	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+								/datum/language/drone = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
-	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/drone/syndicate
 	blocked_languages = list()
@@ -276,9 +276,9 @@ Key procs
 							/datum/language/slime = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lightbringer
-	understood_languages = list(/datum/language/slime = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/slime = list(LANGUAGE_ATOM),
+								/datum/language/common = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/slime = list(LANGUAGE_ATOM))
-	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lizard
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -276,8 +276,8 @@ Key procs
 							/datum/language/slime = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lightbringer
-	understood_languages = list(/datum/language/slime = list(LANGUAGE_ATOM),
-								/datum/language/common = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+								/datum/language/slime = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/slime = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lizard


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes drones and lightgeist be able to understand (but not speak!) galactic common
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Drones fucking suck, but not even getting to listen to people chat while you repair the station is the ultimate misery. Your participation in the story of a round is limited, yes, but I believe you should at least be able to follow the story as it unfolds. So, at least you would be able to understand the crew talking about engineers being useless while you do all the hard work. Pretty cool!

And lightgeists are just cute, rare, non-hostile mobs, why were they not able to understand common in the first place?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: drones can now understand galactic common. Not that they are going to respond to you.
balance: lightgeists can now understand galactic common. They still only speak slime though!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
