### PR TITLE
The Shuttle Loan event can now roll multiple times per round

### DIFF
--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -16,14 +16,14 @@
 	description = "If cargo accepts the offer, fills the shuttle with loot and/or enemies."
 	///The types of loan offers that the crew can recieve.
 	var/list/shuttle_loan_offers = list(
-	ANTIDOTE_NEEDED,
-	DEPARTMENT_RESUPPLY,
-	HIJACK_SYNDIE,
-	ITS_HIP_TO,
-	MY_GOD_JC,
-	PIZZA_DELIVERY,
-	RUSKY_PARTY,
-	SPIDER_GIFT,
+		ANTIDOTE_NEEDED,
+		DEPARTMENT_RESUPPLY,
+		HIJACK_SYNDIE,
+		ITS_HIP_TO,
+		MY_GOD_JC,
+		PIZZA_DELIVERY,
+		RUSKY_PARTY,
+		SPIDER_GIFT,
 	)
 	///The types of loan events already run (and to be excluded if the event triggers).
 	var/list/run_events = list()

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -43,14 +43,19 @@
 	var/loan_type //for logging
 
 /datum/round_event/shuttle_loan/setup()
-	for(var/datum/round_event_control/shuttle_loan/loan_event_control in SSevents.control) //We can't just call round_event.control, because it hasn't been set to the round_event_control yet
-		var/list/event_list = loan_event_control.shuttle_loan_events
-		var/list/run_events = loan_event_control.run_events
+	for(var/datum/round_event_control/shuttle_loan/loan_event_control in SSevents.control) //We can't call control, because it hasn't been set yet
+		var/list/loan_list = list()
+		loan_list += loan_event_control.shuttle_loan_events
+		var/list/run_events = loan_event_control.run_events //Ask the round_event_control which loans have already been offered
 
-		for(var/event in run_events) //Exclude already run events
-			event_list.Remove(event)
+		for(var/event in run_events) //Remove the already offered loans from the candidate list
+			loan_list.Remove(event)
 
-		dispatch_type = pick(event_list)
+		if(!length(loan_list)) //If we somehow run out of loans, they all become available again
+			loan_list = loan_event_control.shuttle_loan_events
+			run_events.Cut()
+
+		dispatch_type = pick(loan_list) //Pick a loan to offer, and add it to the blacklist
 		loan_event_control.run_events += dispatch_type
 
 /datum/round_event/shuttle_loan/announce(fake)

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -16,6 +16,13 @@
 	category = EVENT_CATEGORY_BUREAUCRATIC
 	description = "If cargo accepts the offer, fills the shuttle with loot and/or enemies."
 
+/datum/round_event_control/shuttle_loan/can_spawn_event(players_amt)
+	. = ..()
+
+	for(var/datum/round_event/running_event in SSevents.running)
+		if(istype(running_event, /datum/round_event/shuttle_loan)) //Make sure two of these don't happen at once.
+			return FALSE
+
 /datum/round_event/shuttle_loan
 	announce_when = 1
 	end_when = 500

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -7,6 +7,7 @@
 #define ITS_HIP_TO 7
 #define MY_GOD_JC 8
 
+GLOBAL_LIST_INIT(shuttle_loan_events, list(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY, ITS_HIP_TO, MY_GOD_JC))
 
 /datum/round_event_control/shuttle_loan
 	name = "Shuttle Loan"
@@ -27,8 +28,12 @@
 	if(!check_rights(R_FUN))
 		return ADMIN_CANCEL_EVENT
 
-	for(var/datum/round_event/running_event in SSevents.running)
-		running_event.kill() //Replace the old event with the new one!
+	if(!length(GLOB.shuttle_loan_events))
+		message_admins("The station has already recieved all possible loans!") //Change this to a list of options later
+		return ADMIN_CANCEL_EVENT
+
+	for(var/datum/round_event/shuttle_loan/loan_event in SSevents.running)
+		loan_event.kill() //Replace the old event with the new one!
 
 /datum/round_event/shuttle_loan
 	announce_when = 1
@@ -40,7 +45,7 @@
 	var/loan_type //for logging
 
 /datum/round_event/shuttle_loan/setup()
-	dispatch_type = pick(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY, ITS_HIP_TO, MY_GOD_JC)
+	dispatch_type = pick_n_take(GLOB.shuttle_loan_events)
 
 /datum/round_event/shuttle_loan/announce(fake)
 	SSshuttle.shuttle_loan = src

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -11,7 +11,7 @@
 /datum/round_event_control/shuttle_loan
 	name = "Shuttle Loan"
 	typepath = /datum/round_event/shuttle_loan
-	max_occurrences = 1
+	max_occurrences = 3
 	earliest_start = 7 MINUTES
 	category = EVENT_CATEGORY_BUREAUCRATIC
 	description = "If cargo accepts the offer, fills the shuttle with loot and/or enemies."

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -15,7 +15,7 @@
 	category = EVENT_CATEGORY_BUREAUCRATIC
 	description = "If cargo accepts the offer, fills the shuttle with loot and/or enemies."
 	///The types of loan offers that the crew can recieve.
-	var/list/shuttle_loan_offers= list(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY, ITS_HIP_TO, MY_GOD_JC)
+	var/list/shuttle_loan_offers = list(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY, ITS_HIP_TO, MY_GOD_JC)
 	///The types of loan events already run (and to be excluded if the event triggers).
 	var/list/run_events = list()
 

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -57,8 +57,7 @@
 		loan_list += loan_event_control.shuttle_loan_offers
 		var/list/run_events = loan_event_control.run_events //Ask the round_event_control which loans have already been offered
 
-		for(var/event in run_events) //Remove the already offered loans from the candidate list
-			loan_list.Remove(event)
+		loan_list -= run_events //Remove the already offered loans from the candidate list
 
 		if(!length(loan_list)) //If we somehow run out of loans, they all become available again
 			loan_list += loan_event_control.shuttle_loan_offers

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -23,6 +23,13 @@
 		if(istype(running_event, /datum/round_event/shuttle_loan)) //Make sure two of these don't happen at once.
 			return FALSE
 
+/datum/round_event_control/shuttle_loan/admin_setup()
+	if(!check_rights(R_FUN))
+		return ADMIN_CANCEL_EVENT
+
+	for(var/datum/round_event/running_event in SSevents.running)
+		running_event.kill() //Replace the old event with the new one!
+
 /datum/round_event/shuttle_loan
 	announce_when = 1
 	end_when = 500

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -14,9 +14,9 @@
 	earliest_start = 7 MINUTES
 	category = EVENT_CATEGORY_BUREAUCRATIC
 	description = "If cargo accepts the offer, fills the shuttle with loot and/or enemies."
-	///The types of loan events that the crew can recieve.
-	var/list/shuttle_loan_events = list(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY, ITS_HIP_TO, MY_GOD_JC)
-	///The types of loan events already run (and to be excluded if the event naturally triggers).
+	///The types of loan offers that the crew can recieve.
+	var/list/shuttle_loan_offers= list(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY, ITS_HIP_TO, MY_GOD_JC)
+	///The types of loan events already run (and to be excluded if the event triggers).
 	var/list/run_events = list()
 
 /datum/round_event_control/shuttle_loan/can_spawn_event(players_amt)
@@ -31,7 +31,7 @@
 		return ADMIN_CANCEL_EVENT
 
 	for(var/datum/round_event/shuttle_loan/loan_event in SSevents.running)
-		loan_event.kill() //Replace the old event with the new one!
+		loan_event.kill() //Force out the old event for a new one to take its place
 
 /datum/round_event/shuttle_loan
 	announce_when = 1
@@ -45,14 +45,14 @@
 /datum/round_event/shuttle_loan/setup()
 	for(var/datum/round_event_control/shuttle_loan/loan_event_control in SSevents.control) //We can't call control, because it hasn't been set yet
 		var/list/loan_list = list()
-		loan_list += loan_event_control.shuttle_loan_events
+		loan_list += loan_event_control.shuttle_loan_offers
 		var/list/run_events = loan_event_control.run_events //Ask the round_event_control which loans have already been offered
 
 		for(var/event in run_events) //Remove the already offered loans from the candidate list
 			loan_list.Remove(event)
 
 		if(!length(loan_list)) //If we somehow run out of loans, they all become available again
-			loan_list = loan_event_control.shuttle_loan_events
+			loan_list += loan_event_control.shuttle_loan_offers
 			run_events.Cut()
 
 		dispatch_type = pick(loan_list) //Pick a loan to offer, and add it to the blacklist

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -15,7 +15,16 @@
 	category = EVENT_CATEGORY_BUREAUCRATIC
 	description = "If cargo accepts the offer, fills the shuttle with loot and/or enemies."
 	///The types of loan offers that the crew can recieve.
-	var/list/shuttle_loan_offers = list(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY, ITS_HIP_TO, MY_GOD_JC)
+	var/list/shuttle_loan_offers = list(
+	ANTIDOTE_NEEDED,
+	DEPARTMENT_RESUPPLY,
+	HIJACK_SYNDIE,
+	ITS_HIP_TO,
+	MY_GOD_JC,
+	PIZZA_DELIVERY,
+	RUSKY_PARTY,
+	SPIDER_GIFT,
+	)
 	///The types of loan events already run (and to be excluded if the event triggers).
 	var/list/run_events = list()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Shuttle Loan event can now roll multiple times (up to 3) per round. When a loan is offered, the event cannot roll again until the current offer is accepted. If an admin forces the event, the current loan offer will be replaced by the new one. A specific type of loan offer will not appear more than once per round under normal circumstances.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I think the Shuttle Loan event is really neat. It's presents Cargo with the option to take on risk and reap the rewards, with some opportunities for things to go very very wrong. There are twice as many loan offers as there were when this event was introduced nine years ago, with more potentially on the way (wink wink nudge nudge). I don't think it should be constrained to just one per round any longer.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Shuttle Loan event no longer only rolls once per round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
