### PR TITLE
Balloonify the forensic scanner and cut on `to_chat` spam

### DIFF
--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -35,7 +35,7 @@
 		balloon_alert(user, "no logs!")
 		return
 	if(scanning)
-		balloon_alert(user, "scanner is busy!")
+		balloon_alert(user, "scanner busy!")
 		return
 	scanning = TRUE
 	balloon_alert(user, "printing report...")
@@ -201,7 +201,7 @@
 		balloon_alert(user, "no logs!")
 		return
 	if(scanning)
-		balloon_alert(user, "scanner is busy!")
+		balloon_alert(user, "scanner busy!")
 		return
 	balloon_alert(user, "deleting logs...")
 	if(do_after(user, 3 SECONDS, target = src))
@@ -219,7 +219,7 @@
 		balloon_alert(user, "no logs!")
 		return
 	if(scanning)
-		balloon_alert(user, "scanner is busy!")
+		balloon_alert(user, "scanner busy!")
 		return
 	to_chat(user, span_notice("<B>Scanner Report</B>"))
 	for(var/iterLog in log)

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -39,7 +39,7 @@
 		return
 	scanning = TRUE
 	balloon_alert(user, "printing report...")
-	addtimer(CALLBACK(src, .proc/PrintReport), 100)
+	addtimer(CALLBACK(src, .proc/PrintReport), 10 SECONDS)
 
 /obj/item/detective_scanner/proc/PrintReport()
 	// Create our paper

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -31,12 +31,15 @@
 		scanner.displayDetectiveScanResults(usr)
 
 /obj/item/detective_scanner/attack_self(mob/user)
-	if(log.len && !scanning)
-		scanning = TRUE
-		to_chat(user, span_notice("Printing report, please wait..."))
-		addtimer(CALLBACK(src, .proc/PrintReport), 100)
-	else
-		to_chat(user, span_notice("The scanner has no logs or is in use."))
+	if(!LAZYLEN(log))
+		balloon_alert(user, "no logs!")
+		return
+	if(scanning)
+		balloon_alert(user, "scanner is busy!")
+		return
+	scanning = TRUE
+	balloon_alert(user, "printing report...")
+	addtimer(CALLBACK(src, .proc/PrintReport), 100)
 
 /obj/item/detective_scanner/proc/PrintReport()
 	// Create our paper
@@ -54,9 +57,9 @@
 	report_paper.update_appearance()
 
 	if(ismob(loc))
-		var/mob/M = loc
-		M.put_in_hands(report_paper)
-		to_chat(M, span_notice("Report printed. Log cleared."))
+		var/mob/printer = loc
+		printer.put_in_hands(report_paper)
+		balloon_alert(printer, "logs cleared")
 
 	// Clear the logs
 	log = list()
@@ -80,7 +83,10 @@
 
 		scanning = TRUE
 
-		user.visible_message(span_notice("\The [user] points the [src.name] at \the [A] and performs a forensic scan."))
+		user.visible_message(
+			span_notice("\The [user] points the [src.name] at \the [A] and performs a forensic scan."),
+			ignored_mobs = user
+		)
 		to_chat(user, span_notice("You scan \the [A]. The scanner is now analysing the results..."))
 
 
@@ -178,8 +184,8 @@
 /obj/item/detective_scanner/proc/add_log(msg, broadcast = 1)
 	if(scanning)
 		if(broadcast && ismob(loc))
-			var/mob/M = loc
-			to_chat(M, msg)
+			var/mob/logger = loc
+			to_chat(logger, msg)
 		log += "&nbsp;&nbsp;[msg]"
 	else
 		CRASH("[src] [REF(src)] is adding a log when it was never put in scanning mode!")
@@ -192,13 +198,15 @@
 	if(!user.canUseTopic(src, be_close=TRUE))
 		return
 	if(!LAZYLEN(log))
-		to_chat(user, span_notice("Cannot clear logs, the scanner has no logs."))
+		balloon_alert(user, "no logs!")
 		return
 	if(scanning)
-		to_chat(user, span_notice("Cannot clear logs, the scanner is in use."))
+		balloon_alert(user, "scanner is busy!")
 		return
-	to_chat(user, span_notice("The scanner logs are cleared."))
-	log = list()
+	balloon_alert(user, "deleting logs...")
+	if(do_after(user, 3 SECONDS, target = src))
+		balloon_alert(user, "logs cleared")
+		log = list()
 
 /obj/item/detective_scanner/examine(mob/user)
 	. = ..()
@@ -208,10 +216,10 @@
 /obj/item/detective_scanner/proc/displayDetectiveScanResults(mob/living/user)
 	// No need for can-use checks since the action button should do proper checks
 	if(!LAZYLEN(log))
-		to_chat(user, span_notice("Cannot display logs, the scanner has no logs."))
+		balloon_alert(user, "no logs!")
 		return
 	if(scanning)
-		to_chat(user, span_notice("Cannot display logs, the scanner is in use."))
+		balloon_alert(user, "scanner is busy!")
 		return
 	to_chat(user, span_notice("<B>Scanner Report</B>"))
 	for(var/iterLog in log)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns all the minor `to_chat` messages that the forensic scanner made into balloon alerts.
Makes the `visible_message` be ignored by the scanner's user, as it was creating 2 messages on the chat box 4noresin.
Adds a 3 second `do_after` when you try to delete logs from your scanner to help avoid accidental deletion of logs.
Kills a pair of single letter variables while I was there.
And gave better clarity on an error message for the scanner saying it was either busy or had no logs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better UX for the forensic scanner.
Using it spammed your chat with too many pointless messages that work better as short balloon alerts.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
qol: The forensic scanner uses balloon alerts for most of it's simple feedback messages, enjoy having an easier time hearing the radio chatter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
