### PR TITLE
Autodocs dreams and bedsheets, triples the number of dream strings

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -519,11 +519,11 @@ LINEN BINS
 	anchored = TRUE
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
-	///The number of bedsheets in the bin
+	/// The number of bedsheets in the bin
 	var/amount = 10
-	///A list of actual sheets within the bin
+	/// A list of actual sheets within the bin
 	var/list/sheets = list()
-	///The object hiddin within the bedsheet bin
+	/// The object hiddin within the bedsheet bin
 	var/obj/item/hidden = null
 
 /obj/structure/bedsheetbin/empty

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -26,8 +26,11 @@ LINEN BINS
 	dying_key = DYE_REGISTRY_BEDSHEET
 
 	dog_fashion = /datum/dog_fashion/head/ghost
+	/// Custom nouns to act as the subject of dreams
 	var/list/dream_messages = list("white")
+	/// The number of cloth sheets to be dropped by this bedsheet when cut
 	var/stack_amount = 3
+	/// Denotes if the bedsheet is a single, double, or other kind of bedsheet
 	var/bedsheet_type = BEDSHEET_SINGLE
 
 /obj/item/bedsheet/Initialize(mapload)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -519,8 +519,11 @@ LINEN BINS
 	anchored = TRUE
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
+	///The number of bedsheets in the bin
 	var/amount = 10
+	///A list of actual sheets within the bin
 	var/list/sheets = list()
+	///The object hiddin within the bedsheet bin
 	var/obj/item/hidden = null
 
 /obj/structure/bedsheetbin/empty

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -13,11 +13,10 @@
  * Generates a dream sequence to be displayed to the sleeper
  *
  *
- * Generates the "dream" to display to the sleeper. A dream consists of a subject, a verb, and an object, displayed in sequence to the sleeper.
+ * Generates the "dream" to display to the sleeper. A dream consists of a subject, a verb, and (most of the time) an object, displayed in sequence to the sleeper.
  * Dreams are generated as a list of strings stored inside dream_fragments, which is passed to and displayed in dream_sequence().
  * Bedsheets on the sleeper will provide a custom subject for the dream, pulled from the dream_messages on each bedsheet.
- * When nouns are selected for the subject/object, they may have blanks for adjectives, which are filled in immediately afterwards.
- *
+ * When nouns are selected for the subject/object, they usually have sections for adjectives, which are either replaced or removed.
  */
 
 /mob/living/carbon/proc/dream()
@@ -73,6 +72,16 @@
 
 	dreaming = TRUE
 	dream_sequence(dream_fragments)
+
+/**
+ * Displays the passed list of dream fragments to a sleeping carbon
+ *
+ * Displays the first string of the passed dream fragments, then either ends the dream sequence
+ * or performs a callback on itself depending on if there are any remaining dream fragments to display
+ *
+ * Arguments:
+ * * dream_fragments - A list of strings, in the order they will be displayed.
+ */
 
 /mob/living/carbon/proc/dream_sequence(list/dream_fragments)
 	if(stat != UNCONSCIOUS || HAS_TRAIT(src, TRAIT_CRITICAL_CONDITION))

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -1,16 +1,24 @@
 /**
  * Begins the dreaming process on a sleeping carbon
  *
- * Longer detailed paragraph about the proc
- * including any relevant detail
- * Arguments:
- * * arg1 - Relevance of this argument
- * * arg2 - Relevance of this argument
+ * Checks a 10% chance and whether or not the carbon this is called on is already dreaming. If
+ * the prob() passes and there are no dream images queued, the carbon begins generating a new dream in dream()
  */
 
 /mob/living/carbon/proc/handle_dreams()
 	if(prob(10) && !dreaming)
 		dream()
+
+/**
+ * Generates a dream sequence to be displayed to the sleeper
+ *
+ *
+ * Generates the "dream" to display to the sleeper. A dream consists of a subject, a verb, and an object, displayed in sequence to the sleeper.
+ * Dreams are generated as a list of strings stored inside dream_fragments, which is passed to and displayed in dream_sequence().
+ * Bedsheets on the sleeper will provide a custom subject for the dream, pulled from the dream_messages on each bedsheet.
+ * When nouns are selected for the subject/object, they may have blanks for adjectives, which are filled in immediately afterwards.
+ *
+ */
 
 /mob/living/carbon/proc/dream()
 	set waitfor = FALSE

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -1,3 +1,13 @@
+/**
+ * Begins the dreaming process on a sleeping carbon
+ *
+ * Longer detailed paragraph about the proc
+ * including any relevant detail
+ * Arguments:
+ * * arg1 - Relevance of this argument
+ * * arg2 - Relevance of this argument
+ */
+
 /mob/living/carbon/proc/handle_dreams()
 	if(prob(10) && !dreaming)
 		dream()

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -1,8 +1,8 @@
 /**
- * Begins the dreaming process on a sleeping carbon
+ * Begins the dreaming process on a sleeping carbon.
  *
  * Checks a 10% chance and whether or not the carbon this is called on is already dreaming. If
- * the prob() passes and there are no dream images queued, the carbon begins generating a new dream in dream()
+ * the prob() passes and there are no dream images left to display, a new dream is constructed.
  */
 
 /mob/living/carbon/proc/handle_dreams()
@@ -10,13 +10,11 @@
 		dream()
 
 /**
- * Generates a dream sequence to be displayed to the sleeper
- *
+ * Generates a dream sequence to be displayed to the sleeper.
  *
  * Generates the "dream" to display to the sleeper. A dream consists of a subject, a verb, and (most of the time) an object, displayed in sequence to the sleeper.
  * Dreams are generated as a list of strings stored inside dream_fragments, which is passed to and displayed in dream_sequence().
  * Bedsheets on the sleeper will provide a custom subject for the dream, pulled from the dream_messages on each bedsheet.
- * When nouns are selected for the subject/object, they usually have sections for adjectives, which are either replaced or removed.
  */
 
 /mob/living/carbon/proc/dream()
@@ -36,7 +34,7 @@
 	else
 		fragment += pick(GLOB.dream_strings)
 
-	if(prob(50))
+	if(prob(50)) //Replace the adjective space with an adjective, or just get rid of it
 		fragment = replacetext(fragment, "%ADJECTIVE%", pick(GLOB.adjectives))
 	else
 		fragment = replacetext(fragment, "%ADJECTIVE% ", "")
@@ -74,10 +72,10 @@
 	dream_sequence(dream_fragments)
 
 /**
- * Displays the passed list of dream fragments to a sleeping carbon
+ * Displays the passed list of dream fragments to a sleeping carbon.
  *
  * Displays the first string of the passed dream fragments, then either ends the dream sequence
- * or performs a callback on itself depending on if there are any remaining dream fragments to display
+ * or performs a callback on itself depending on if there are any remaining dream fragments to display.
  *
  * Arguments:
  * * dream_fragments - A list of strings, in the order they will be displayed.

--- a/strings/dreamstrings.txt
+++ b/strings/dreamstrings.txt
@@ -1,38 +1,57 @@
 %A% %ADJECTIVE% admiral
+%A% %ADJECTIVE% army
 %A% %ADJECTIVE% airlock
 %A% %ADJECTIVE% alien
 %A% %ADJECTIVE% ally
+%A% %ADJECTIVE% angel
 %A% %ADJECTIVE% armblade
 %A% %ADJECTIVE% bear
 %A% %ADJECTIVE% bee
 %A% %ADJECTIVE% blob
 %A% %ADJECTIVE% bottle
+%A% %ADJECTIVE% chemist
 %A% %ADJECTIVE% corgi
 %A% %ADJECTIVE% crewmember
 %A% %ADJECTIVE% crowd
+%A% %ADJECTIVE% cyborg
+%A% %ADJECTIVE% demon
 %A% %ADJECTIVE% disguise
 %A% %ADJECTIVE% doctor
+%A% %ADJECTIVE% drone
+%A% %ADJECTIVE% ending
 %A% %ADJECTIVE% enemy
 %A% %ADJECTIVE% engineer
+%A% %ADJECTIVE% ethereal
 %A% %ADJECTIVE% explosion
 %A% %ADJECTIVE% familiar face
+%A% %ADJECTIVE% felinid
 %A% %ADJECTIVE% foe
+%A% %ADJECTIVE% friend
+%A% %ADJECTIVE% ghost
 %A% %ADJECTIVE% gun
 %A% %ADJECTIVE% geneticist
 %A% %ADJECTIVE% hat
+%A% %ADJECTIVE% heretic
 %A% %ADJECTIVE% hideout
 %A% %ADJECTIVE% ID card
 %A% %ADJECTIVE% imposter
 %A% %ADJECTIVE% inspector
 %A% %ADJECTIVE% laboratory
+%A% %ADJECTIVE% lizard
 %A% %ADJECTIVE% loved one
+%A% %ADJECTIVE% meat grinder
 %A% %ADJECTIVE% memory
 %A% %ADJECTIVE% meteor
 %A% %ADJECTIVE% miner
 %A% %ADJECTIVE% monkey
 %A% %ADJECTIVE% monster
+%A% %ADJECTIVE% moth
+%A% %ADJECTIVE% nightmare
+%A% %ADJECTIVE% ninja
 %A% %ADJECTIVE% ocean
+%A% %ADJECTIVE% pill
 %A% %ADJECTIVE% planet
+%A% %ADJECTIVE% plasmaman
 %A% %ADJECTIVE% pool
 %A% %ADJECTIVE% scientist
 %A% %ADJECTIVE% security officer
@@ -40,23 +59,34 @@
 %A% %ADJECTIVE% shuttle
 %A% %ADJECTIVE% singularity
 %A% %ADJECTIVE% slime
+%A% %ADJECTIVE% task
 %A% %ADJECTIVE% toolbox
 %A% %ADJECTIVE% traitor
+%A% %ADJECTIVE% universe
+%A% %ADJECTIVE% vent
 %A% %ADJECTIVE% virologist
 %A% %ADJECTIVE% virus
+%A% %ADJECTIVE% voice in your head
+%A% %ADJECTIVE% wheelchair
 %ADJECTIVE% blinking lights
 %ADJECTIVE% blood
+%ADJECTIVE% credits
 %ADJECTIVE% darkness
 %ADJECTIVE% death
+%ADJECTIVE% evidence
+%ADJECTIVE% evil
 %ADJECTIVE% flames
+%ADJECTIVE% handcuffs
 %ADJECTIVE% horror
 %ADJECTIVE% light
+%ADJECTIVE% operatives
 %ADJECTIVE% plasma
 %ADJECTIVE% power
 %ADJECTIVE% riches
 %ADJECTIVE% waves
 %ADJECTIVE% wind
 Ian
+mutiny
 Nanotrasen
 Poly
 some %ADJECTIVE% cultists
@@ -68,6 +98,9 @@ the %ADJECTIVE% bartender
 the %ADJECTIVE% bridge
 the %ADJECTIVE% brig
 the %ADJECTIVE% captain
+the %ADJECTIVE% clown
+the %ADJECTIVE% depths
+the %ADJECTIVE% gods
 the %ADJECTIVE% Icemoon wastes
 the %ADJECTIVE% maintenance tunnels
 the %ADJECTIVE% recycler
@@ -75,6 +108,7 @@ the %ADJECTIVE% sun
 the %ADJECTIVE% Supermatter
 the %ADJECTIVE% void of space
 the bar
+the bottom of a chasm
 the engine
 the emergency shuttle
 the library
@@ -82,5 +116,7 @@ the medical bay
 the station
 the sun
 the Syndicate
+the tram
 the Wizard Federation
+time itself
 water

--- a/strings/dreamstrings.txt
+++ b/strings/dreamstrings.txt
@@ -1,41 +1,83 @@
+%A% %ADJECTIVE% admiral
+%A% %ADJECTIVE% airlock
 %A% %ADJECTIVE% alien
 %A% %ADJECTIVE% ally
+%A% %ADJECTIVE% armblade
+%A% %ADJECTIVE% bear
+%A% %ADJECTIVE% bee
+%A% %ADJECTIVE% blob
 %A% %ADJECTIVE% bottle
+%A% %ADJECTIVE% corgi
 %A% %ADJECTIVE% crewmember
+%A% %ADJECTIVE% crowd
+%A% %ADJECTIVE% disguise
 %A% %ADJECTIVE% doctor
+%A% %ADJECTIVE% enemy
 %A% %ADJECTIVE% engineer
+%A% %ADJECTIVE% explosion
 %A% %ADJECTIVE% familiar face
+%A% %ADJECTIVE% foe
 %A% %ADJECTIVE% gun
+%A% %ADJECTIVE% geneticist
 %A% %ADJECTIVE% hat
+%A% %ADJECTIVE% hideout
 %A% %ADJECTIVE% ID card
+%A% %ADJECTIVE% imposter
+%A% %ADJECTIVE% inspector
 %A% %ADJECTIVE% laboratory
 %A% %ADJECTIVE% loved one
+%A% %ADJECTIVE% memory
+%A% %ADJECTIVE% meteor
 %A% %ADJECTIVE% miner
 %A% %ADJECTIVE% monkey
 %A% %ADJECTIVE% monster
+%A% %ADJECTIVE% ocean
 %A% %ADJECTIVE% planet
+%A% %ADJECTIVE% pool
 %A% %ADJECTIVE% scientist
 %A% %ADJECTIVE% security officer
+%A% %ADJECTIVE% shrine
 %A% %ADJECTIVE% shuttle
+%A% %ADJECTIVE% singularity
 %A% %ADJECTIVE% slime
 %A% %ADJECTIVE% toolbox
 %A% %ADJECTIVE% traitor
+%A% %ADJECTIVE% virologist
+%A% %ADJECTIVE% virus
 %ADJECTIVE% blinking lights
 %ADJECTIVE% blood
 %ADJECTIVE% darkness
 %ADJECTIVE% death
 %ADJECTIVE% flames
+%ADJECTIVE% horror
 %ADJECTIVE% light
 %ADJECTIVE% plasma
 %ADJECTIVE% power
 %ADJECTIVE% riches
+%ADJECTIVE% waves
 %ADJECTIVE% wind
+Ian
 Nanotrasen
+Poly
+some %ADJECTIVE% cultists
+some %ADJECTIVE% lovers
 some %ADJECTIVE% melons
+some %ADJECTIVE% strangers
+some %ADJECTIVE% Xenomorphs
+the %ADJECTIVE% bartender
 the %ADJECTIVE% bridge
 the %ADJECTIVE% brig
 the %ADJECTIVE% captain
+the %ADJECTIVE% Icemoon wastes
+the %ADJECTIVE% maintenance tunnels
+the %ADJECTIVE% recycler
+the %ADJECTIVE% sun
+the %ADJECTIVE% Supermatter
+the %ADJECTIVE% void of space
+the bar
 the engine
+the emergency shuttle
+the library
 the medical bay
 the station
 the sun

--- a/strings/dreamstrings.txt
+++ b/strings/dreamstrings.txt
@@ -53,6 +53,7 @@
 %A% %ADJECTIVE% planet
 %A% %ADJECTIVE% plasmaman
 %A% %ADJECTIVE% pool
+%A% %ADJECTIVE% rat
 %A% %ADJECTIVE% scientist
 %A% %ADJECTIVE% security officer
 %A% %ADJECTIVE% shrine
@@ -80,15 +81,18 @@
 %ADJECTIVE% horror
 %ADJECTIVE% light
 %ADJECTIVE% operatives
+%ADJECTIVE% paperwork
 %ADJECTIVE% plasma
 %ADJECTIVE% power
 %ADJECTIVE% riches
 %ADJECTIVE% waves
 %ADJECTIVE% wind
+cigarettes
 Ian
 mutiny
 Nanotrasen
 Poly
+Runtime
 some %ADJECTIVE% cultists
 some %ADJECTIVE% lovers
 some %ADJECTIVE% melons
@@ -109,6 +113,9 @@ the %ADJECTIVE% Supermatter
 the %ADJECTIVE% void of space
 the bar
 the bottom of a chasm
+the chapel
+the curator's back room
+the departure lounge
 the engine
 the emergency shuttle
 the library


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Autodocs dreaming.dm and bedsheet_bin.dm.

Also adds a bunch of new subjects for your dreams to choose from. This list was way more sparse than I expected, so I felt obligated to add to it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Easier to read code. Gives players have more stuff to dream about.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Autodocs dreaming.dm and bedsheet_bin.dm.
code: Dreams now have an expanded list of subjects to choose from.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
