### PR TITLE
Fixes hydroponics trays wasting water (take two)

### DIFF
--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -126,7 +126,7 @@
 
 ///returns TRUE if the source's reagents has only one entry
 /datum/component/plumbing/proc/is_pure_source()
-	return reagents.reagent_list.len == 1
+	return length(reagents.reagent_list) == 1
 
 ///this is where the reagent is actually transferred and is thus the finish point of our process()
 /datum/component/plumbing/proc/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net, disable_round_robin = FALSE)

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -124,14 +124,18 @@
 	else if(reagents.total_volume > 0) //take whatever
 		return TRUE
 
+///returns TRUE if the source's reagents has only one entry
+/datum/component/plumbing/proc/is_pure_source()
+	return reagents.reagent_list.len == 1
+
 ///this is where the reagent is actually transferred and is thus the finish point of our process()
-/datum/component/plumbing/proc/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net)
+/datum/component/plumbing/proc/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net, disable_round_robin = FALSE)
 	if(!reagents || !target || !target.reagents)
 		return FALSE
 	if(reagent)
 		reagents.trans_id_to(target.recipient_reagents_holder, reagent, amount)
 	else
-		reagents.trans_to(target.recipient_reagents_holder, amount, round_robin = TRUE, methods = methods)//we deal with alot of precise calculations so we round_robin=TRUE. Otherwise we get floating point errors, 1 != 1 and 2.5 + 2.5 = 6
+		reagents.trans_to(target.recipient_reagents_holder, amount, round_robin = !disable_round_robin, methods = methods)//we deal with alot of precise calculations so we round_robin=TRUE. Otherwise we get floating point errors, 1 != 1 and 2.5 + 2.5 = 6
 
 ///We create our luxurious piping overlays/underlays, to indicate where we do what. only called once if use_overlays = TRUE in Initialize()
 /datum/component/plumbing/proc/create_overlays(atom/movable/parent_movable, list/overlays)

--- a/code/datums/components/plumbing/filter.dm
+++ b/code/datums/components/plumbing/filter.dm
@@ -22,7 +22,7 @@
 			if(!can_give_in_direction(direction, reagent))
 				return FALSE
 
-/datum/component/plumbing/filter/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net)
+/datum/component/plumbing/filter/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net, disable_round_robin = FALSE)
 	if(!reagents || !target || !target.reagents)
 		return FALSE
 	var/direction

--- a/code/datums/components/plumbing/splitter.dm
+++ b/code/datums/components/plumbing/splitter.dm
@@ -29,7 +29,7 @@
 	return FALSE
 
 
-/datum/component/plumbing/splitter/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net)
+/datum/component/plumbing/splitter/transfer_to(datum/component/plumbing/target, amount, reagent, datum/ductnet/net, disable_round_robin = FALSE)
 	var/direction
 	for(var/A in ducts)
 		if(ducts[A] == net)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -17,6 +17,8 @@
 	var/nutridrain = 1
 	///The maximum nutrient reagent container size of the tray.
 	var/maxnutri = 20
+	///The target nutrient level for ducts (so you can still add stuff by hand)
+	var/maxductnutri = 15
 	///The amount of pests in the tray (max 10)
 	var/pestlevel = 0
 	///The amount of weeds in the tray (max 10)
@@ -208,76 +210,6 @@
 			return
 
 	return ..()
-
-/// Special demand connector that consumes as normal, but redirects water into the magical water space.
-/datum/component/plumbing/hydroponics
-	demand_connects = SOUTH
-	/// Alternate reagents container to buffer incoming water
-	var/datum/reagents/water_reagents
-	/// Actual parent reagents that has nutrients
-	var/datum/reagents/nutri_reagents
-
-/datum/component/plumbing/hydroponics/Initialize(start=TRUE, _ducting_layer, _turn_connects=TRUE, datum/reagents/custom_receiver)
-	. = ..()
-
-	if(!istype(parent, /obj/machinery/hydroponics/constructable))
-		return COMPONENT_INCOMPATIBLE
-
-	var/obj/machinery/hydroponics/constructable/hydro_parent = parent
-
-	water_reagents = new(hydro_parent.maxwater)
-	water_reagents.my_atom = hydro_parent
-
-	nutri_reagents = reagents
-
-/datum/component/plumbing/hydroponics/Destroy()
-	qdel(water_reagents)
-	nutri_reagents = null
-	return ..()
-
-/datum/component/plumbing/hydroponics/send_request(dir)
-	var/obj/machinery/hydroponics/constructable/hydro_parent = parent
-
-	var/initial_nutri_amount = nutri_reagents.total_volume
-	if(initial_nutri_amount < nutri_reagents.maximum_volume)
-		// Well boy howdy, we have no way to tell a supply to not mix the water with everything else,
-		// So we'll let it leak in, and move the water over.
-		set_recipient_reagents_holder(nutri_reagents)
-		reagents = nutri_reagents
-		process_request(
-			amount = MACHINE_REAGENT_TRANSFER,
-			reagent = null,
-			dir = dir
-		)
-
-		// Move the leaked water from nutrients to... water
-		var/leaking_water_amount = nutri_reagents.get_reagent_amount(/datum/reagent/water)
-		if(leaking_water_amount)
-			nutri_reagents.trans_id_to(water_reagents, /datum/reagent/water, leaking_water_amount)
-
-	// We should only take MACHINE_REAGENT_TRANSFER every tick; this is the remaining amount we can take
-	var/remaining_transfer_amount = max(MACHINE_REAGENT_TRANSFER - (nutri_reagents.total_volume - initial_nutri_amount), 0)
-
-	// How much extra water we should gather this tick to try to fill the water tray.
-	var/extra_water_to_gather = clamp(hydro_parent.maxwater - hydro_parent.waterlevel - water_reagents.total_volume, 0, remaining_transfer_amount)
-	if(extra_water_to_gather > 0)
-		set_recipient_reagents_holder(water_reagents)
-		reagents = water_reagents
-		process_request(
-			amount = extra_water_to_gather,
-			reagent = /datum/reagent/water,
-			dir = dir,
-		)
-
-	// Now transfer all remaining water in that buffer and clear it out.
-	var/final_water_amount = water_reagents.total_volume
-	if(final_water_amount)
-		hydro_parent.adjust_waterlevel(round(final_water_amount))
-		// Using a pipe doesn't afford you extra water storage and the baseline behavior for trays is that excess water goes into the shadow realm.
-		water_reagents.del_reagent(/datum/reagent/water)
-
-	// Plumbing pauses if reagents is full.. so let's cheat and make sure it ticks unless both trays are happy
-	reagents = hydro_parent.waterlevel < hydro_parent.maxwater ? water_reagents : nutri_reagents
 
 /obj/machinery/hydroponics/bullet_act(obj/projectile/Proj) //Works with the Somatoray to modify plant variables.
 	if(!myseed)

--- a/code/modules/hydroponics/hydroponics_plumbing.dm
+++ b/code/modules/hydroponics/hydroponics_plumbing.dm
@@ -33,19 +33,19 @@
 		return
 	var/obj/machinery/hydroponics/constructable/hydro_parent = parent
 	if(hydro_parent.reagents.total_volume < hydro_parent.maxductnutri || hydro_parent.waterlevel < hydro_parent.maxwater)
-		for(var/D in GLOB.cardinals)
-			if(D & demand_connects)
-				send_request(D)
+		for(var/dir in GLOB.cardinals)
+			if(dir & demand_connects)
+				send_request(dir)
 
 /// split_request_across(list/sources,amt,datum/ductnet/net): Request chems selectively from the given sources
 /// Returns: The amount transferred
 /datum/component/plumbing/hydroponics/proc/split_request_across(list/sources, amt, datum/ductnet/net)
-	var/suppliersLeft = sources.len
+	var/suppliers_left = sources.len
 	var/original_volume = reagents.total_volume
 	for(var/datum/component/plumbing/give as anything in sources)
-		var/currentRequest = (amt + original_volume - reagents.total_volume) / suppliersLeft
-		give.transfer_to( src, currentRequest, null, net, disable_round_robin = TRUE )
-		suppliersLeft--
+		var/current_request = (amt + original_volume - reagents.total_volume) / suppliers_left
+		give.transfer_to( src, current_request, null, net, disable_round_robin = TRUE )
+		suppliers_left--
 	return reagents.total_volume - original_volume
 
 /// send_request(dir): calculate needs for the tray, pass to process_request
@@ -69,14 +69,10 @@
 
 	for(var/datum/component/plumbing/supplier as anything in net.suppliers)
 		if(supplier.can_give(1, /datum/reagent/water, net))
-			water_suppliers.len = 1
-			if(supplier.is_pure_source())
-				water_suppliers += supplier
-			else
-				nutri_suppliers.len = 1
+			water_suppliers += supplier
+			if(!supplier.is_pure_source())
 				nutri_suppliers += supplier
 		else if(supplier.can_give(1,null,net))
-			nutri_suppliers.len = 1
 			nutri_suppliers += supplier
 
 	// Reserve some space if we could fill up entirely on water, but want and can get nutrients

--- a/code/modules/hydroponics/hydroponics_plumbing.dm
+++ b/code/modules/hydroponics/hydroponics_plumbing.dm
@@ -1,0 +1,98 @@
+/**
+ * Hydroponics plumbing component
+ *
+ * This will smartly separate water and misc chems in the pipes
+ * so that you never drain one while looking for the other.
+ *
+ * Will not fill hydro tray's nutrients above tray.maxductnutri
+ * so that you have room to add chems by hand (pest spray, mutagen, etc)
+ *
+ * Base code in datums/components/plumbing/_plumbing.dm
+ */
+/datum/component/plumbing/hydroponics
+	demand_connects = SOUTH
+
+/datum/component/plumbing/hydroponics/Initialize(start=TRUE, _ducting_layer, _turn_connects=TRUE, datum/reagents/custom_receiver)
+	. = ..()
+
+	if(!istype(parent, /obj/machinery/hydroponics/constructable))
+		return COMPONENT_INCOMPATIBLE
+
+	reagents = new(MACHINE_REAGENT_TRANSFER)
+	reagents.my_atom = parent
+	set_recipient_reagents_holder(reagents)// When we ask others to transfer to us, we mean the temporary buffer.
+
+/datum/component/plumbing/hydroponics/Destroy()
+	qdel(reagents)
+	return ..()
+
+// Add a check for the water level in determining whether or not to request fluids.
+/datum/component/plumbing/hydroponics/process()
+	if(!demand_connects || !reagents)
+		STOP_PROCESSING(SSplumbing, src)
+		return
+	var/obj/machinery/hydroponics/constructable/hydro_parent = parent
+	if(hydro_parent.reagents.total_volume < hydro_parent.maxductnutri || hydro_parent.waterlevel < hydro_parent.maxwater)
+		for(var/D in GLOB.cardinals)
+			if(D & demand_connects)
+				send_request(D)
+
+/// split_request_across(list/sources,amt,datum/ductnet/net): Request chems selectively from the given sources
+/// Returns: The amount transferred
+/datum/component/plumbing/hydroponics/proc/split_request_across(list/sources, amt, datum/ductnet/net)
+	var/suppliersLeft = sources.len
+	var/original_volume = reagents.total_volume
+	for(var/datum/component/plumbing/give as anything in sources)
+		var/currentRequest = (amt + original_volume - reagents.total_volume) / suppliersLeft
+		give.transfer_to( src, currentRequest, null, net, disable_round_robin = TRUE )
+		suppliersLeft--
+	return reagents.total_volume - original_volume
+
+/// send_request(dir): calculate needs for the tray, pass to process_request
+/datum/component/plumbing/hydroponics/send_request(dir)
+	var/obj/machinery/hydroponics/constructable/hydro_parent = parent
+	var/water_desired = clamp(hydro_parent.maxwater - hydro_parent.waterlevel, 0, MACHINE_REAGENT_TRANSFER)
+	var/nutri_desired = clamp(hydro_parent.maxductnutri - hydro_parent.reagents.total_volume, 0, MACHINE_REAGENT_TRANSFER)
+
+	process_request(water_desired, nutri_desired, dir)
+
+/// process_request(water_amt,nutri_amt,dir): pull water and/or nutrients from duct system
+/datum/component/plumbing/hydroponics/process_request(water_amt, nutri_amt, dir)
+	dir = num2text(dir)
+	if(!ducts.Find(dir))
+		return // Not connected
+
+	var/obj/machinery/hydroponics/constructable/hydro_parent = parent
+	var/datum/ductnet/net = ducts[dir]
+	var/list/water_suppliers = list()
+	var/list/nutri_suppliers = list()
+
+	for(var/datum/component/plumbing/supplier as anything in net.suppliers)
+		if(supplier.can_give(1, /datum/reagent/water, net))
+			water_suppliers.len = 1
+			if(supplier.is_pure_source())
+				water_suppliers += supplier
+			else
+				nutri_suppliers.len = 1
+				nutri_suppliers += supplier
+		else if(supplier.can_give(1,null,net))
+			nutri_suppliers.len = 1
+			nutri_suppliers += supplier
+
+	// Reserve some space if we could fill up entirely on water, but want and can get nutrients
+	var/total_request = MACHINE_REAGENT_TRANSFER
+	if(water_amt && nutri_amt && water_suppliers.len && nutri_suppliers.len)
+		if(nutri_suppliers.len)
+			water_amt = min(water_amt, MACHINE_REAGENT_TRANSFER * 0.75)
+
+	if(water_suppliers.len && water_amt)
+		total_request -= split_request_across( water_suppliers, water_amt, net ) // this may also get chems
+
+	if(nutri_suppliers.len && nutri_amt)
+		split_request_across( nutri_suppliers, min(nutri_amt, total_request), net ) // this may also get water
+
+	// finish by transferring to the tray itself
+	hydro_parent.adjust_waterlevel( reagents.get_reagent_amount(/datum/reagent/water) )
+	reagents.del_reagent( /datum/reagent/water )
+	reagents.trans_to( hydro_parent.reagents, reagents.total_volume )
+	reagents.clear_reagents()

--- a/code/modules/hydroponics/hydroponics_plumbing.dm
+++ b/code/modules/hydroponics/hydroponics_plumbing.dm
@@ -54,10 +54,10 @@
 	var/water_desired = clamp(hydro_parent.maxwater - hydro_parent.waterlevel, 0, MACHINE_REAGENT_TRANSFER)
 	var/nutri_desired = clamp(hydro_parent.maxductnutri - hydro_parent.reagents.total_volume, 0, MACHINE_REAGENT_TRANSFER)
 
-	process_request(water_desired, nutri_desired, dir)
+	process_hydro_request(water_desired, nutri_desired, dir)
 
-/// process_request(water_amt,nutri_amt,dir): pull water and/or nutrients from duct system
-/datum/component/plumbing/hydroponics/process_request(water_amt, nutri_amt, dir)
+/// process_hydro_request(water_amt,nutri_amt,dir): pull water and/or nutrients from duct system
+/datum/component/plumbing/hydroponics/proc/process_hydro_request(water_amt, nutri_amt, dir)
 	dir = num2text(dir)
 	if(!ducts.Find(dir))
 		return // Not connected

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3143,6 +3143,7 @@
 #include "code\modules\hydroponics\hydroitemdefines.dm"
 #include "code\modules\hydroponics\hydroponics.dm"
 #include "code\modules\hydroponics\hydroponics_chemreact.dm"
+#include "code\modules\hydroponics\hydroponics_plumbing.dm"
 #include "code\modules\hydroponics\plant_genes.dm"
 #include "code\modules\hydroponics\sample.dm"
 #include "code\modules\hydroponics\seed_extractor.dm"


### PR DESCRIPTION
## About The Pull Request

Cleaner implementation of my last attempt at this bugfix.  Moves hydroponics plumbing code into its own file instead of being stuck in the middle of the machine logic.  Still handles water and nutrients separately through the duct network, so you won't waste one when looking for the other.

When using the duct system to feed in nutrients, it will only feed up to 15/20 of the nutrient tray, so that you can use mutagen, pest spray, etc, on trays as necessary.  This is a var that can be set in code, but I didn't set up a way to change it in game.

![image](https://user-images.githubusercontent.com/84720/198153422-f538b45e-b763-4c3b-ba27-66f51455dab1.png)
A setup like this will Just Work(tm).  All hydro trays will be maintained at 100 water until the sources run out.  You can dump nutrient into the input gate and it will spread through the system.  With just these two ingredients plus an infinite supply of seeds you too can have Too Much Food(tm).

## Why It's Good For The Game

Fix.

## Changelog

:cl:
fix: Using ducts to connect a water tank to one or more hydroponics trays is no longer a monumental waste of resources.
fix: Hydroponics trays fed nutrients through a duct will leave room for you to add chemicals by hand.
/:cl:
