### PR TITLE
Bluespace RPED only works within a user's view range

### DIFF
--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -31,7 +31,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 		if(!attacked_machinery.component_parts)
 			return ..()
 
-		if(works_from_distance)
+		if(check_range(attacked_machinery, user))
 			user.Beam(attacked_machinery, icon_state = "rped_upgrade", time = 5)
 		attacked_machinery.exchange_parts(user, src)
 		return TRUE
@@ -41,7 +41,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	if(!attacked_frame.components)
 		return ..()
 
-	if(works_from_distance)
+	if(check_range(attacked_frame, user))
 		user.Beam(attacked_frame, icon_state = "rped_upgrade", time = 5)
 	attacked_frame.attackby(src, user)
 	return TRUE
@@ -59,7 +59,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 		if(!attacked_machinery.component_parts)
 			return ..()
 
-		if(works_from_distance)
+		if(check_range(attacked_machinery, user))
 			user.Beam(attacked_machinery, icon_state = "rped_upgrade", time = 5)
 			attacked_machinery.exchange_parts(user, src)
 		return
@@ -69,9 +69,17 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	if(!attacked_frame.components)
 		return ..()
 
-	if(works_from_distance)
+	if(check_range(attacked_frame, user))
 		user.Beam(attacked_frame, icon_state = "rped_upgrade", time = 5)
 	attacked_frame.attackby(src, user)
+
+/obj/item/storage/part_replacer/proc/check_range(obj/attacked_object, mob/living/user)
+	if(!works_from_distance)
+		return FALSE
+
+	var/list/view_range = getviewsize(user.client.view)
+	if(IN_GIVEN_RANGE(user, attacked_object, view_range[2]))
+		return TRUE
 
 /obj/item/storage/part_replacer/proc/play_rped_sound()
 	//Plays the sound for RPED exhanging or installing parts.


### PR DESCRIPTION
## About The Pull Request

Limits the range of the Bluespace RPED to the user's view.
Its kind of a [downstream thing](https://github.com/Skyrat-SS13/Skyrat-tg/pull/17192), but what do you think?

## Why It's Good For The Game

In my view, upgrading the whole station from your chair in R&D discourages player interaction.
I know being let into a department for a simple goal isn't always offering the most thrilling of scenarios, but it is up to the players to put some spice behind it. The game is only as fun as you can make it together, offering a mechanic to avoid eachother does not help make it fun.

_([copy pasted from my later comment](https://github.com/tgstation/tgstation/pull/70828#issuecomment-1292855027):)_
It is unhealthy for gameplay and player interaction to give someone the ability to upgrade machinery to maximum efficiency without being present.
In my opinion, upgrading **everything** aboard station to the machinery's best components should be an effortful task, which it isn't if you can do it from behind something as simple as a security camera console.

## Changelog

:cl:
balance: Bluespace RPEDs can no longer teleport components across Z-level granted there's a camera connection.
/:cl:
