### PR TITLE
Give auto_changelog a GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -21,3 +21,4 @@ jobs:
         script: |
           const { processAutoChangelog } = await import('${{ github.workspace }}/tools/pull_request_hooks/autoChangelog.js')
           await processAutoChangelog({ github, context })
+        github-token: ${{ secrets.COMFY_ORANGE_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Forgot this is needed because of required status checks. Same fix as with compile changelogs