### PR TITLE
Fixes an invalid engine path in the Tramstation modular maintenance files

### DIFF
--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowertunnel_leftup_attachment_a_1.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowertunnel_leftup_attachment_a_1.dmm
@@ -5,7 +5,7 @@
 "c" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/structure/shuttle/engine/propulsion{
+/obj/machinery/power/shuttle_engine/propulsion{
 	desc = "A standard reliable bluespace engine used by many forms of shuttles. This one has the bluespace core removed.";
 	name = "inactive propulsion engine"
 	},
@@ -15,7 +15,7 @@
 "d" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/structure/shuttle/engine/propulsion{
+/obj/machinery/power/shuttle_engine/propulsion{
 	desc = "A standard reliable bluespace engine used by many forms of shuttles. This one has the bluespace core removed.";
 	name = "inactive propulsion engine"
 	},
@@ -30,7 +30,7 @@
 /area/station/maintenance/port/central)
 "q" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/shuttle/engine/propulsion{
+/obj/machinery/power/shuttle_engine/propulsion{
 	desc = "A standard reliable bluespace engine used by many forms of shuttles. This one has the bluespace core removed.";
 	name = "inactive propulsion engine"
 	},
@@ -57,7 +57,7 @@
 /area/station/maintenance/port/central)
 "H" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/shuttle/engine/propulsion{
+/obj/machinery/power/shuttle_engine/propulsion{
 	desc = "A standard reliable bluespace engine used by many forms of shuttles. This one has the bluespace core removed.";
 	name = "inactive propulsion engine"
 	},


### PR DESCRIPTION
## About The Pull Request
I'm not entirely sure why this hasn't been an issue for you guys in CI yet, but it's been flagged on our CI downstream for a few days. Had to look it up a little longer because the stack trace wasn't very talkative, though.

Basically, someone didn't update their PR properly when the shuttle engine refactor kicked in, and there was now invalid typepaths on the map, which would get converted to `null`s, which the map loader obviously didn't like.

## Why It's Good For The Game
Less runtimes, more intended behavior. Also fixes our CI downstream, which is nice.

## Changelog

:cl: GoldenAlpharex
fix: The inactive propulsion engines left around in Tramstation's maintenance by drunk engineers will now properly spawn again, rather than disappearing in thin air after a recent change to shuttle engines.
/:cl: