### PR TITLE
Changes water turf exposure atmospherics heat stuff to be thermal heat exchange based, and doesn't care if there's a hotspot or not. Sets default chemical temperature to 293.15 Kelvin.

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -56,7 +56,7 @@
 #define ALLERGIC_REMOVAL_SKIP "Allergy"
 
 /// the default temperature at which chemicals are added to reagent holders at
-#define DEFAULT_REAGENT_TEMPERATURE 300
+#define DEFAULT_REAGENT_TEMPERATURE T20C
 
 //Used in holder.dm/equlibrium.dm to set values and volume limits
 ///stops floating point errors causing issues with checking reagent amounts

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -27,7 +27,6 @@
 	var/sprite_name = "fire_extinguisher"
 	var/power = 5 //Maximum distance launched water will travel
 	var/precision = FALSE //By default, turfs picked from a spray are random, set to 1 to make it always have at least one water effect per row
-	var/cooling_power = 2 //Sets the cooling_temperature of the water reagent datum inside of the extinguisher when it is refilled
 	/// Icon state when inside a tank holder
 	var/tank_holder_icon_state = "holder_extinguisher"
 
@@ -62,7 +61,6 @@
 	max_water = 30
 	sprite_name = "coolant"
 	dog_fashion = null
-	cooling_power = 1.5
 	power = 3
 
 /obj/item/extinguisher/crafted/attack_self(mob/user)
@@ -143,8 +141,6 @@
 		if(transferred > 0)
 			to_chat(user, span_notice("\The [src] has been refilled by [transferred] units."))
 			playsound(src.loc, 'sound/effects/refill.ogg', 50, TRUE, -6)
-			for(var/datum/reagent/water/R in reagents.reagent_list)
-				R.cooling_temperature = cooling_power
 		else
 			to_chat(user, span_warning("\The [W] is empty!"))
 

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -245,7 +245,6 @@
 	power = 8
 	force = 10
 	precision = 1
-	cooling_power = 5
 	w_class = WEIGHT_CLASS_HUGE
 	item_flags = ABSTRACT  // don't put in storage
 	chem = null //holds no chems of its own, it takes from the tank.

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -103,7 +103,7 @@
 	/// The atom this holder is attached to
 	var/atom/my_atom = null
 	/// Current temp of the holder volume
-	var/chem_temp = 150
+	var/chem_temp = DEFAULT_REAGENT_TEMPERATURE
 	///pH of the whole system
 	var/ph = CHEMICAL_NORMAL_PH
 	/// unused

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -189,7 +189,7 @@
 		exposed_slime.apply_water()
 
 	// Heat exchange with the air.
-	var/datum/gas_mixture/air = exposed_turf.air
+	var/datum/gas_mixture/air = exposed_turf.return_air()
 	if(!istype(air, /datum/gas_mixture/immutable))
 		var/temperature_delta = holder.chem_temp - air.temperature
 		var/air_heat_capacity = air.heat_capacity()

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -169,7 +169,7 @@
 		if (extinguisher.reagents.total_volume < 1)
 			to_chat(user, span_warning("\The [extinguisher] is empty!"))
 			return
-		var/cooling = (0 - reagents.chem_temp) * extinguisher.cooling_power * 2
+		var/cooling = -4 * reagents.chem_temp
 		reagents.expose_temperature(cooling)
 		to_chat(user, span_notice("You cool the [name] with the [attacking_item]!"))
 		playsound(loc, 'sound/effects/extinguish.ogg', 75, TRUE, -3)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -121,7 +121,7 @@
 		if (extinguisher.reagents.total_volume < 1)
 			to_chat(user, span_warning("\The [extinguisher] is empty!"))
 			return
-		var/cooling = (0 - reagents.chem_temp) * extinguisher.cooling_power * 2
+		var/cooling = -4 * reagents.chem_temp
 		reagents.expose_temperature(cooling)
 		to_chat(user, span_notice("You cool the [name] with the [I]!"))
 		playsound(loc, 'sound/effects/extinguish.ogg', 75, TRUE, -3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Water turf exposure will check if the turf's gas mixture is immutable, then exchange heat with the water if it isn't. It will delete hotspots still. The water uses a specific heat of 4kJ instead of its specific heat, because fire extinguishers only expose 1 unit to the turfs. This will make fire extinguishers help cool (or heat) the air even if there is no fire. Using fire extinguishers will still be effective for small and relatively cold fires, but a single spaceman with a fire extinguisher won't be able to outpace a hot and large fire, and would require cooperation with people with multiple fire extinguishers or advanced atmos tech to handle it.

Also removes weird cooling power multiplier stuff. Water should act the same regardless of what holder it came out of.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Room temperature water cooling a fire down to 2.7 Kelvin is the most stupid thing I have ever seen in this entire game. This will end spaceman slipping to ice they created when they try to fight a fire with water. People will not have to care whether there is a hotspot or not either, allowing people to cool plasma deficient air that is heating and igniting nearby plasma rich air, allowing such situations to be easier solved.

It doesn't make sense that a property of water is based on what fire extinguisher it came from.

It makes sense that chemicals by default when created are room temperature, instead of slightly above room temperature.

It would be better if I generalised this to any chemical exchanging heat with the air, but I had to exaggerate water heat capacity and I don't think I would want to do that with every chemical, so I'll leave that for another time.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Room temperature water no longer cools fires to 2.7 Kelvin.
balance: Changes water turf exposure atmospherics thermal interaction to be thermal heat exchange based.
balance: Chemical default temperature is now room temperature, 293.15 Kelvin, instead of 300 Kelvin.
balance: Water no longer cares about what fire extinguisher it came from.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
