### PR TITLE
Atomized fix: Qdeleted / null mobs being told to stop moving by their ai controller

### DIFF
--- a/code/datums/ai/movement/_ai_movement.dm
+++ b/code/datums/ai/movement/_ai_movement.dm
@@ -15,7 +15,11 @@
 /datum/ai_movement/proc/stop_moving_towards(datum/ai_controller/controller)
 	controller.pathing_attempts = 0
 	moving_controllers -= controller
-	SSmove_manager.stop_looping(controller.pawn, SSai_movement)
+	// Qdeleted check is for when our controller's pawn was unassigned
+	// or qdeleted before (or as) we told them to stop moving.
+	// Jet let them handle the stopping of the moveloop instesad.
+	if(!QDELETED(controller.pawn))
+		SSmove_manager.stop_looping(controller.pawn, SSai_movement)
 
 /datum/ai_movement/proc/increment_pathing_failures(datum/ai_controller/controller)
 	controller.pathing_attempts++


### PR DESCRIPTION
## About The Pull Request

Fixes #70836

- If a mob is qdeleted / nulled from their controller as they are undergoing / finishing a behavior, they will runtime, as a null mob is attempted to stop a move loop. Fixes that by inputting a qdel check. 

## Why It's Good For The Game

Fixes a unit test failure

## Changelog

:cl: Melbert
fix: Fixes a runtime from ai controllers finishing a movement of a qdeleted / null mob. 
/:cl: