### PR TITLE
[s]Remove false positive heavy modified client admin alert.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -46,14 +46,6 @@
 	if(isnull(pixel_turf))
 		return
 	if(!can_see(A))
-		if(isturf(A)) //On unmodified clients clicking the static overlay clicks the turf underneath
-			return //So there's no point messaging admins
-		message_admins("[ADMIN_LOOKUPFLW(src)] might be running a modified client! (failed can_see on AI click of [A] (Turf Loc: [ADMIN_VERBOSEJMP(pixel_turf)]))")
-		var/message = "[key_name(src)] might be running a modified client! (failed can_see on AI click of [A] (Turf Loc: [AREACOORD(pixel_turf)]))"
-		log_admin(message)
-		if(REALTIMEOFDAY >= chnotify + 9000)
-			chnotify = REALTIMEOFDAY
-			send2tgs_adminless_only("NOCHEAT", message)
 		return
 
 	if(LAZYACCESS(modifiers, SHIFT_CLICK))


### PR DESCRIPTION
There are too many edge cases and this covers none of them. also i think there is a bug relating to some power of 2 code or maybe some plane/multi-z code or something because these messages are common and admins are ignoring them.

This is totally not a ploy to get the bug fixed or the fix merged or whatever.