### PR TITLE
Fix github not announcing new prs

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -772,6 +772,7 @@ function checkchangelog($payload) {
 				break;
 		}
 	}
+	return $tags;
 }
 
 function game_server_send($addr, $port, $str) {


### PR DESCRIPTION
```
[2022-10-27T04:37:47+00:00] Error on line 215: array_merge(): Argument #1 is not an array
[2022-10-27T04:58:55+00:00] Error on line 215: array_merge(): Argument #1 is not an array
[2022-10-27T08:42:49+00:00] Error on line 215: array_merge(): Argument #1 is not an array
[2022-10-27T08:48:18+00:00] Error on line 215: array_merge(): Argument #1 is not an array
[2022-10-27T09:47:46+00:00] Error on line 215: array_merge(): Argument #1 is not an array
[2022-10-27T16:08:52+00:00] Error on line 215: array_merge(): Argument #1 is not an array
[2022-10-27T17:14:28+00:00] Error on line 215: array_merge(): Argument #1 is not an array
```