### PR TITLE
Fixes & Improves ntnrc client & ntnet conversations

### DIFF
--- a/code/__DEFINES/modular_computer.dm
+++ b/code/__DEFINES/modular_computer.dm
@@ -6,7 +6,7 @@
 #define MC_CELL "CELL"
 
 //NTNet stuff, for modular computers
-									// NTNet module-configuration values. Do not change these. If you need to add another use larger number (5..6..7 etc)
+// NTNet module-configuration values. Do not change these. If you need to add another use larger number (5..6..7 etc)
 #define NTNET_SOFTWAREDOWNLOAD 1 // Downloads of software from NTNet
 #define NTNET_PEERTOPEER 2 // P2P transfers of files between devices
 #define NTNET_COMMUNICATION 3 // Communication (messaging)

--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -1,35 +1,46 @@
 #define MAX_CHANNELS 1000
 
 /datum/ntnet_conversation
-	var/id = null
+	///The title of the conversation, seen in the UI.
 	var/title = "Untitled Conversation"
-	var/datum/computer_file/program/chatclient/operator // "Administrator" of this channel. Creator starts as channel's operator,
-	var/list/messages = list()
-	///chat clients who are active or minimized
-	var/list/active_clients = list()
-	///chat clients who have exited out of the program.
-	var/list/offline_clients = list()
-	///clients muted by operator
-	var/list/muted_clients = list()
-	//if a channel is strong, it cannot be renamed or deleted.
+	//If a channel is strong, it cannot be renamed or deleted.
 	var/strong = FALSE
+	///The password to join a channel, set by an Administrator.
 	var/password
-	var/static/ntnrc_uid = 0
 
-/datum/ntnet_conversation/New()
-	id = ntnrc_uid + 1
+	///A static UID to ensure no conversations are the same.
+	var/static/ntnrc_uid = 0
+	///ID using the UID.
+	var/id
+
+	///List of all messages sent in the conversation.
+	var/list/messages = list()
+
+	///The "Administrator" of the channel, the creator starts as channel's operator by default.
+	var/datum/computer_file/program/chatclient/channel_operator
+	///Chat clients who are active or minimized.
+	var/list/datum/computer_file/program/chatclient/active_clients = list()
+	///Chat clients who have exited out of the program.
+	var/list/datum/computer_file/program/chatclient/offline_clients = list()
+	///Chat clients currently muted by the operator, rendering them unable to ping other people.
+	var/list/datum/computer_file/program/chatclient/muted_clients = list()
+
+/datum/ntnet_conversation/New(title, strong = FALSE)
+	src.title = title
+	src.strong = strong
+
+	id = ntnrc_uid++
 	if(id > MAX_CHANNELS)
 		qdel(src)
 		return
-	ntnrc_uid = id
 	if(SSnetworks.station_network)
 		SSnetworks.station_network.chat_channels.Add(src)
-	..()
+	return ..()
 
 /datum/ntnet_conversation/Destroy()
 	if(SSnetworks.station_network)
 		SSnetworks.station_network.chat_channels.Remove(src)
-	for(var/datum/computer_file/program/chatclient/chatterbox in (active_clients | offline_clients | muted_clients))
+	for(var/datum/computer_file/program/chatclient/chatterbox as anything in (active_clients | offline_clients))
 		purge_client(chatterbox)
 	return ..()
 
@@ -54,15 +65,13 @@
 	active_clients.Add(new_user)
 	if(!silent)
 		add_status_message("[new_user.username] has joined the channel.")
-	// No operator, so we assume the channel was empty. Assign this user as operator.
-	if(!operator)
-		changeop(new_user)
+	// No operator, so we assume the channel was empty. Assign this user as operator, without the message, since you're the creator.
+	if(!channel_operator)
+		changeop(new_user, silent = TRUE)
 
 //Clear all of our references to a client, used for client deletion
 /datum/ntnet_conversation/proc/purge_client(datum/computer_file/program/chatclient/forget)
 	remove_client(forget)
-	muted_clients -= forget
-	offline_clients -= forget
 	forget.conversations -= src
 
 /datum/ntnet_conversation/proc/remove_client(datum/computer_file/program/chatclient/leaving)
@@ -71,10 +80,12 @@
 	if(leaving in active_clients)
 		active_clients.Remove(leaving)
 		add_status_message("[leaving.username] has left the channel.")
+	muted_clients -= leaving
+	offline_clients -= leaving
 
 	// Channel operator left, pick new operator
-	if(leaving == operator)
-		operator = null
+	if(leaving == channel_operator)
+		channel_operator = null
 		if(active_clients.len)
 			var/datum/computer_file/program/chatclient/newop = pick(active_clients)
 			changeop(newop)
@@ -86,7 +97,7 @@
 	offline_clients.Add(offline)
 
 /datum/ntnet_conversation/proc/mute_user(datum/computer_file/program/chatclient/op, datum/computer_file/program/chatclient/muted)
-	if(!op.netadmin_mode && operator != op) //sanity even if the person shouldn't be able to see the mute button
+	if(!op.netadmin_mode && (channel_operator != op)) //sanity even if the person shouldn't be able to see the mute button
 		return
 	if(muted in muted_clients)
 		muted_clients.Remove(muted)
@@ -101,15 +112,16 @@
 	add_status_message("[pinger.username] pinged [pinged.username].")
 	pinged.computer.alert_call(pinged, "You have been pinged in [title] by [pinger.username]!", 'sound/machines/ping.ogg')
 
-/datum/ntnet_conversation/proc/changeop(datum/computer_file/program/chatclient/newop)
-	if(istype(newop))
-		operator = newop
+/datum/ntnet_conversation/proc/changeop(datum/computer_file/program/chatclient/newop, silent = FALSE)
+	if(!istype(newop))
+		CRASH("[src] is attempting to add [newop] as the operator, but it isn't a chat client.")
+	channel_operator = newop
+	if(!silent)
 		add_status_message("Channel operator status transferred to [newop.username].")
 
 /datum/ntnet_conversation/proc/change_title(newtitle, datum/computer_file/program/chatclient/renamer)
-	if(operator != renamer || strong)
-		return FALSE // Not Authorised or channel cannot be editted
-
+	if((channel_operator != renamer) || strong) // Not Authorised or channel cannot be editted
+		return FALSE
 	add_status_message("[renamer.username] has changed channel title from [title] to [newtitle]")
 	title = newtitle
 

--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -29,7 +29,8 @@
 	src.title = title
 	src.strong = strong
 
-	id = ntnrc_uid++
+	id = ntnrc_uid
+	ntnrc_uid++
 	if(id > MAX_CHANNELS)
 		qdel(src)
 		return

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -110,35 +110,6 @@
 	chatprogram.program_state = PROGRAM_STATE_ACTIVE
 	cpu.active_program = chatprogram
 
-//ONE PER MAP PLEASE, IT MAKES A CARGOBUS FOR EACH ONE OF THESE
-/obj/machinery/modular_computer/console/preset/cargochat/cargo
-	console_department = "Cargo"
-	name = "department chatroom console"
-	desc = "A stationary computer. This one comes preloaded with a chatroom for incoming cargo requests. You may moderate it from this computer."
-
-/obj/machinery/modular_computer/console/preset/cargochat/cargo/Initialize(mapload)
-	. = ..()
-	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")
-	//setting up chat
-	chatprogram.username = "cargo_requests_operator"
-	var/datum/ntnet_conversation/cargochat = new
-	cargochat.operator = chatprogram //adding operator before joining the chat prevents an unnecessary message about switching op from showing
-	cargochat.add_client(chatprogram)
-	cargochat.title = "#cargobus"
-	cargochat.strong = TRUE
-	chatprogram.active_channel = cargochat.id
-
-/obj/machinery/modular_computer/console/preset/cargochat/cargo/LateInitialize()
-	. = ..()
-	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")
-	var/datum/ntnet_conversation/cargochat = SSnetworks.station_network.get_chat_channel_by_id(chatprogram.active_channel)
-	for(var/obj/machinery/modular_computer/console/preset/cargochat/cargochat_console in GLOB.machines)
-		if(cargochat_console == src)
-			continue
-		var/datum/computer_file/program/chatclient/other_chatprograms = cargochat_console.cpu.find_file_by_name("ntnrc_client")
-		other_chatprograms.active_channel = chatprogram.active_channel
-		cargochat.add_client(chatprogram, silent = TRUE)
-
 /obj/machinery/modular_computer/console/preset/cargochat/service
 	console_department = "Service"
 
@@ -153,3 +124,23 @@
 
 /obj/machinery/modular_computer/console/preset/cargochat/medical
 	console_department = "Medical"
+
+
+//ONE PER MAP PLEASE, IT MAKES A CARGOBUS FOR EACH ONE OF THESE
+/obj/machinery/modular_computer/console/preset/cargochat/cargo
+	console_department = "Cargo"
+	name = "department chatroom console"
+	desc = "A stationary computer. This one comes preloaded with a chatroom for incoming cargo requests. You may moderate it from this computer."
+
+/obj/machinery/modular_computer/console/preset/cargochat/cargo/LateInitialize()
+	. = ..()
+	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")
+	chatprogram.username = "cargo_requests_operator"
+
+	var/datum/ntnet_conversation/cargochat = chatprogram.create_new_channel("#cargobus", strong = TRUE)
+	for(var/obj/machinery/modular_computer/console/preset/cargochat/cargochat_console in GLOB.machines)
+		if(cargochat_console == src)
+			continue
+		var/datum/computer_file/program/chatclient/other_chatprograms = cargochat_console.cpu.find_file_by_name("ntnrc_client")
+		other_chatprograms.active_channel = chatprogram.active_channel
+		cargochat.add_client(other_chatprograms, silent = TRUE)

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -16,13 +16,16 @@
 	tgui_id = "NtosNetChat"
 	program_icon = "comment-alt"
 	alert_able = TRUE
-	var/last_message // Used to generate the toolbar icon
+
+	///The user's screen name.
 	var/username
+	///The last message you sent in a channel, used to tell if someone has sent a new message yet.
+	var/last_message
+	///The channel currently active in.
 	var/active_channel
-	var/list/channel_history = list()
-	var/operator_mode = FALSE // Channel operator mode
-	var/netadmin_mode = FALSE // Administrator mode (invisible to other users + bypasses passwords)
-	//A list of all the converstations we're a part of
+	///If the tablet is in Admin mode, you bypass Passwords and aren't announced when entering a channel.
+	var/netadmin_mode = FALSE
+	///All NTnet conversations the application is apart of.
 	var/list/datum/ntnet_conversation/conversations = list()
 
 /datum/computer_file/program/chatclient/New()
@@ -34,6 +37,13 @@
 	conversations.Cut()
 	return ..()
 
+/datum/computer_file/program/chatclient/proc/create_new_channel(channel_title, strong = FALSE)
+	var/datum/ntnet_conversation/new_converstaion = new /datum/ntnet_conversation(channel_title, strong)
+	new_converstaion.add_client(src)
+	new_converstaion.title = channel_title
+	active_channel = new_converstaion.id
+	return new_converstaion
+
 /datum/computer_file/program/chatclient/ui_act(action, params)
 	. = ..()
 	if(.)
@@ -41,8 +51,9 @@
 
 	var/datum/ntnet_conversation/channel = SSnetworks.station_network.get_chat_channel_by_id(active_channel)
 	var/authed = FALSE
-	if(channel && ((channel.operator == src) || netadmin_mode))
+	if(channel && ((channel.channel_operator == src) || netadmin_mode))
 		authed = TRUE
+
 	switch(action)
 		if("PRG_speak")
 			if(!channel || isnull(active_channel))
@@ -57,7 +68,7 @@
 
 			channel.add_message(message, username)
 			var/mob/living/user = usr
-			user.log_talk(message, LOG_CHAT, tag="as [username] to channel [channel.title]")
+			user.log_talk(message, LOG_CHAT, tag = "as [username] to channel [channel.title]")
 			return TRUE
 		if("PRG_joinchannel")
 			var/new_target = text2num(params["id"])
@@ -82,24 +93,19 @@
 			var/channel_title = reject_bad_chattext(params["new_channel_name"], CHANNELNAME_SIZE)
 			if(!channel_title)
 				return
-			var/datum/ntnet_conversation/C = new /datum/ntnet_conversation()
-			C.add_client(src)
-			C.operator = src
-			C.title = channel_title
-			active_channel = C.id
+			create_new_channel(channel_title)
 			return TRUE
 		if("PRG_toggleadmin")
 			if(netadmin_mode)
 				netadmin_mode = FALSE
 				channel?.add_client(src)
-				return TRUE
+				return UI_UPDATE
 			var/mob/living/user = usr
 			if(can_run(user, TRUE, ACCESS_NETWORK))
-				for(var/C in SSnetworks.station_network.chat_channels)
-					var/datum/ntnet_conversation/chan = C
-					chan.remove_client(src)
+				for(var/datum/ntnet_conversation/channels as anything in SSnetworks.station_network.chat_channels)
+					channels.remove_client(src)
 				netadmin_mode = TRUE
-				return TRUE
+				return UI_UPDATE
 		if("PRG_changename")
 			var/newname = reject_bad_chattext(params["new_name"], USERNAME_SIZE)
 			newname = replacetext(newname, " ", "_")
@@ -109,7 +115,7 @@
 				if(src in anychannel.active_clients)
 					anychannel.add_status_message("[username] is now known as [newname].")
 			username = newname
-			return TRUE
+			return UI_UPDATE
 		if("PRG_savelog")
 			if(!channel)
 				return
@@ -147,11 +153,9 @@
 		if("PRG_setpassword")
 			if(!authed)
 				return
-
 			var/new_password = sanitize(params["new_password"])
 			if(!authed)
 				return
-
 			channel.password = new_password
 			return TRUE
 		if("PRG_mute_user")
@@ -179,7 +183,7 @@
 			last_message = null
 		return TRUE
 	if(channel?.messages?.len)
-		ui_header = last_message == channel.messages[length(channel.messages)] ? "ntnrc_idle.gif" : "ntnrc_new.gif"
+		ui_header = (last_message == channel.messages[length(channel.messages)] ? "ntnrc_idle.gif" : "ntnrc_new.gif")
 	else
 		ui_header = "ntnrc_idle.gif"
 
@@ -196,42 +200,38 @@
 	for(var/datum/ntnet_conversation/channel as anything in SSnetworks.station_network.chat_channels)
 		channel.go_offline(src)
 	active_channel = null
-	..()
+	return ..()
 
 /datum/computer_file/program/chatclient/ui_static_data(mob/user)
 	var/list/data = list()
 	data["can_admin"] = can_run(user, FALSE, ACCESS_NETWORK)
-	return data
-
-/datum/computer_file/program/chatclient/ui_data(mob/user)
-	if(!SSnetworks.station_network || !SSnetworks.station_network.chat_channels)
-		return list()
-
-	var/list/data = list()
-
-	data = get_header_data()
-
-	var/list/all_channels = list()
-	for(var/C in SSnetworks.station_network.chat_channels)
-		var/datum/ntnet_conversation/conv = C
-		if(conv?.title)
-			all_channels.Add(list(list(
-				"chan" = conv.title,
-				"id" = conv.id
-			)))
-	data["all_channels"] = all_channels
-
-	data["active_channel"] = active_channel
 	data["selfref"] = REF(src) //used to verify who is you, as usernames can be copied.
 	data["username"] = username
 	data["adminmode"] = netadmin_mode
+	return data
+
+/datum/computer_file/program/chatclient/ui_data(mob/user)
+	var/list/data = get_header_data()
+	if(!SSnetworks.station_network || !SSnetworks.station_network.chat_channels)
+		return data
+
+	var/list/all_channels = list()
+	for(var/datum/ntnet_conversation/conversations as anything in SSnetworks.station_network.chat_channels)
+		if(conversations.title)
+			all_channels.Add(list(list(
+				"chan" = conversations.title,
+				"id" = conversations.id,
+			)))
+	data["all_channels"] = all_channels
+	data["active_channel"] = active_channel
+
 	var/datum/ntnet_conversation/channel = SSnetworks.station_network.get_chat_channel_by_id(active_channel)
+	var/authed = FALSE
+	data["clients"] = list()
+	data["messages"] = list()
 	if(channel)
 		data["title"] = channel.title
-		var/authed = FALSE
-		if(!channel.password)
-			authed = TRUE
-		if(netadmin_mode)
+		if(!channel.password || netadmin_mode)
 			authed = TRUE
 		var/list/clients = list()
 		for(var/datum/computer_file/program/chatclient/channel_client as anything in channel.active_clients + channel.offline_clients)
@@ -241,10 +241,9 @@
 				"name" = channel_client.username,
 				"status" = channel_client.program_state,
 				"muted" = (channel_client in channel.muted_clients),
-				"operator" = channel.operator == channel_client,
-				"ref" = REF(channel_client)
+				"operator" = (channel.channel_operator == channel_client),
+				"ref" = REF(channel_client),
 			)))
-		data["authed"] = authed
 		//no fishing for ui data allowed
 		if(authed)
 			data["strong"] = channel.strong
@@ -252,18 +251,12 @@
 			var/list/messages = list()
 			for(var/message in channel.messages)
 				messages.Add(list(list(
-					"msg" = message
+					"msg" = message,
 				)))
 			data["messages"] = messages
-			data["is_operator"] = (channel.operator == src) || netadmin_mode
-		else
-			data["clients"] = list()
-			data["messages"] = list()
-	else
-		data["clients"] = list()
-		data["authed"] = FALSE
-		data["messages"] = list()
+			data["is_operator"] = (channel.channel_operator == src) || netadmin_mode
 
+	data["authed"] = authed
 	return data
 
 #undef USERNAME_SIZE


### PR DESCRIPTION
## About The Pull Request

* Actually adds all departments to the #cargobus channel, instead of adding cargo 6 times over.
* Moves creating new channels to its own proc, so it isn't copy pasted from ui_act to the cargobus console
* Adds autodoc comments to all the vars on ntnrc client AND ntnet conversations
* renames 'operator' var to 'channel_operator', both so it sounds clearer and because vscode kept seeing it as some built-in byond thing.
* Makes better use of 'as anything' when chechking chat channels
* Removes checking for muted clients when clearing all ntnet conversation clients, because they're already in active or offline anyways. They aren't exclusive.
* Creating a channel now by default doesn't broadcast the creator being 'made an operator'.
* Removing a client from ntnet conversations now also removes them from muted and offline clients, it is no longer only done on purge.
* Moves some generally static info (like names) to ui_static_data, but ui_act will call UI_UPDATE if they DO change their name.

Closes https://github.com/tgstation/tgstation/issues/70832

## Why It's Good For The Game

#cargobus works again, and the code is a lot nicer now.
Less copy paste overall, so less chance of more things breaking in the future.

This was also the cause for the runtime people would see, so this fixes that too. There's no issue reports on it from what I see so there's nothing to link here.

## Changelog

:cl:
fix: The #cargobus channel now has all the department consoles again.
/:cl: