### PR TITLE
AIs and Cyborgs have NTnrc, AIs lose PDA and aren't admins anymore.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -98,7 +98,6 @@
 		modularInterface.saved_job = "Cyborg"
 	return ..()
 
-
 /**
  * Sets the tablet theme and icon
  *

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -97,13 +97,6 @@
 		modularInterface.saved_job = "Cyborg"
 	return ..()
 
-/mob/living/silicon/robot/model/syndicate/create_modularInterface()
-	if(!modularInterface)
-		modularInterface = new /obj/item/modular_computer/tablet/integrated/syndicate(src)
-		modularInterface.saved_job = "Cyborg"
-	return ..()
-
-
 /mob/living/silicon/med_hud_set_health()
 	return //we use a different hud
 

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -257,7 +257,7 @@
 		silicon_owner = null
 		stack_trace("[type] initialized outside of a silicon, deleting.")
 		return INITIALIZE_HINT_QDEL
-	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")
+	var/datum/computer_file/program/chatclient/chatprogram = find_file_by_name("ntnrc_client")
 	chatprogram.username = "Silicon_[rand(100, 999)]"
 
 /obj/item/modular_computer/tablet/integrated/install_default_programs()

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -257,6 +257,8 @@
 		silicon_owner = null
 		stack_trace("[type] initialized outside of a silicon, deleting.")
 		return INITIALIZE_HINT_QDEL
+	var/datum/computer_file/program/chatclient/chatprogram = cpu.find_file_by_name("ntnrc_client")
+	chatprogram.username = "Silicon_[rand(100, 999)]"
 
 /obj/item/modular_computer/tablet/integrated/install_default_programs()
 	for(var/programs in starting_programs)

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -231,7 +231,7 @@
 	has_variants = FALSE
 	inserted_item = null
 	starting_programs = list(
-		/datum/computer_file/program/messenger,
+		/datum/computer_file/program/chatclient,
 	)
 
 	///Ref to the RoboTact app. Important enough to borgs to deserve a ref.
@@ -246,6 +246,7 @@
 		/datum/computer_file/program/computerconfig,
 		/datum/computer_file/program/filemanager,
 		/datum/computer_file/program/robotact,
+		/datum/computer_file/program/chatclient,
 	)
 
 /obj/item/modular_computer/tablet/integrated/Initialize(mapload)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -102,8 +102,8 @@
  *transfer, if TRUE and access_to_check is null, will tell this proc to use the program's transfer_access in place of access_to_check
  *access can contain a list of access numbers to check against. If access is not empty, it will be used istead of checking any inserted ID.
 */
-/datum/computer_file/program/proc/can_run(mob/user, loud = FALSE, access_to_check, transfer = FALSE, list/access)
-	if(issilicon(user))
+/datum/computer_file/program/proc/can_run(mob/user, loud = FALSE, access_to_check, transfer = FALSE, list/access, silicon_allowed = TRUE)
+	if(silicon_allowed && issilicon(user))
 		return TRUE
 
 	if(isAdminGhostAI(user))
@@ -163,16 +163,16 @@
  **/
 /datum/computer_file/program/proc/on_start(mob/living/user)
 	SHOULD_CALL_PARENT(TRUE)
-	if(can_run(user, 1))
-		if(requires_ntnet)
-			var/obj/item/card/id/ID
-			var/obj/item/computer_hardware/card_slot/card_holder = computer.all_components[MC_CARD]
-			if(card_holder)
-				ID = card_holder.GetID()
-			generate_network_log("Connection opened -- Program ID: [filename] User:[ID?"[ID.registered_name]":"None"]")
-		program_state = PROGRAM_STATE_ACTIVE
-		return TRUE
-	return FALSE
+	if(!can_run(user, TRUE))
+		return FALSE
+	if(requires_ntnet)
+		var/obj/item/card/id/ID
+		var/obj/item/computer_hardware/card_slot/card_holder = computer.all_components[MC_CARD]
+		if(card_holder)
+			ID = card_holder.GetID()
+		generate_network_log("Connection opened -- Program ID: [filename] User:[ID?"[ID.registered_name]":"None"]")
+	program_state = PROGRAM_STATE_ACTIVE
+	return TRUE
 
 /**
  *

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -162,7 +162,7 @@
 			"installed" = !!computer.find_file_by_name(programs.filename),
 			"compatible" = check_compatibility(programs),
 			"size" = programs.size,
-			"access" = emagged && programs.available_on_syndinet ? TRUE : programs.can_run(user,transfer = 1, access = access),
+			"access" = emagged && programs.available_on_syndinet ? TRUE : programs.can_run(user, transfer = TRUE, access = access),
 			"verifiedsource" = programs.available_on_ntnet,
 		))
 

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -94,7 +94,7 @@
 				channel?.add_client(src)
 				return TRUE
 			var/mob/living/user = usr
-			if(can_run(user, TRUE, ACCESS_NETWORK))
+			if(can_run(user, TRUE, ACCESS_NETWORK, silicon_allowed = FALSE))
 				for(var/C in SSnetworks.station_network.chat_channels)
 					var/datum/ntnet_conversation/chan = C
 					chan.remove_client(src)
@@ -200,7 +200,7 @@
 
 /datum/computer_file/program/chatclient/ui_static_data(mob/user)
 	var/list/data = list()
-	data["can_admin"] = can_run(user, FALSE, ACCESS_NETWORK)
+	data["can_admin"] = can_run(user, FALSE, ACCESS_NETWORK, silicon_allowed = FALSE)
 	return data
 
 /datum/computer_file/program/chatclient/ui_data(mob/user)


### PR DESCRIPTION
## About The Pull Request

* AIs no longer have direct PDA messaging, but both AIs and Cyborgs now have the NTnrc application in their integrated tablets. They also have a default name of Silicon_[random numbers], similar to humans' "DefaultUser[random numbers]"
* AIs are also no longer 'Admins', and follow the same rules as everyone else using the application.

I'm open to discussion on AI's PDA removal, I wrote this down at 5 in the morning so I likely forgot some things and probably am wrong on some others. I would like to see them get NTnrc applications though.

## Why It's Good For The Game

1. The NTnrc client is pretty much unused, and I thought allowing Silicons to use it would be a nice way to encourage its use, though if AIs have both, I don't see an AI who uses NTnrc over PDA, nor do I think it's a good idea for them to have both at once, as then it splits their attention to two separate applications to check.
2. PDA messages are seen by the CE, while NTnrc messages are seen by the RD. I think that, since the RD is the head of Silicon, they should be the ones that are able to see their messages. Basically, I want to move the jurisdiction of Silicon messaging from the CE to the RD, while also giving Cyborgs the ability to use it for the first time.
3. I thought PDA'ing the AI was a lame way to contact them, unless the CE goes out of their way to check logs, there's no way for anyone to know what you've law 2'd the AI to do, until it's way too late. This now at least makes their actions more visible to people. Now people need to use alternative methods to get the AI to do what they need quickly, and usually it is in a way that is more visible to those around them, or can backfire.
4. Cyborgs don't have any way to contact people, and I don't like the idea of them getting a PDA, so I thought this was a nice alternative, with the AI being there as a benefit.

For the removal of AI as an admin, since Admin mode is generally used to snoop in rooms that are password locked, I would like to see the people who can use it, restricted. Outside of the AI, only the RD and Captain can use Admin mode, which I think is fair.

## Changelog

:cl:
balance: AIs are no longer NTnrc Admins.
balance: AIs no longer have the PDA app
balance: AIs and Cyborgs now have the NTnrc application by default.
/:cl: