### PR TITLE
Shuttle Catastrophe event now has a warning to prevent it from being forced when it REALLY shouldn't.

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -19,6 +19,11 @@
 		return FALSE //don't remove all players when its already on station or going to centcom
 	return TRUE
 
+/datum/round_event_control/shuttle_catastrophe/admin_setup(mob/admin)
+	. = ..()
+
+	if(EMERGENCY_AT_LEAST_DOCKED || istype(SSshuttle.emergency, /obj/docking_port/mobile/emergency/shuttle_build))
+		if(tgui_alert(usr, "WARNING: This will unload the currently docked emergency shuttle and anything on it. Proceed anyways?", "How about a REAL catastrophe?", list("Yes", "No")) == "Yes")
 
 /datum/round_event/shuttle_catastrophe
 	var/datum/map_template/shuttle/new_shuttle

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -23,7 +23,7 @@
 	. = ..()
 
 	if(EMERGENCY_AT_LEAST_DOCKED || istype(SSshuttle.emergency, /obj/docking_port/mobile/emergency/shuttle_build))
-		if(tgui_alert(usr, "WARNING: This will unload the currently docked emergency shuttle and anything on it. Proceed anyways?", "How about a REAL catastrophe?", list("Yes", "No")) == "Yes")
+		if(tgui_alert(usr, "WARNING: This will unload the currently docked emergency shuttle, and ERASE ANYTHING within it. Proceed anyways?", "How about a REAL catastrophe?", list("Yes", "No")) == "Yes")
 			message_admins("[admin.ckey] has forced a shuttle catastrophe while a shuttle was already docked.") //Just in case
 		else
 			return ADMIN_CANCEL_EVENT

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -24,6 +24,9 @@
 
 	if(EMERGENCY_AT_LEAST_DOCKED || istype(SSshuttle.emergency, /obj/docking_port/mobile/emergency/shuttle_build))
 		if(tgui_alert(usr, "WARNING: This will unload the currently docked emergency shuttle and anything on it. Proceed anyways?", "How about a REAL catastrophe?", list("Yes", "No")) == "Yes")
+			message_admins("[admin.ckey] has forced a shuttle catastrophe while a shuttle was already docked.") //Just in case
+		else
+			return ADMIN_CANCEL_EVENT
 
 /datum/round_event/shuttle_catastrophe
 	var/datum/map_template/shuttle/new_shuttle


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For a button that, if misused, could delete players or their hard work en-masse, this thing really should have a warning on it.

I figured that instead of blocking it entirely, there should at least be the option to force it knowing the risks. Maybe if the shuttle gets REALLY messed up and needs replacing. I dunno.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Gives admins a moment to consider all of the complaints they're about to recieve before they do something stupid.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Forcing the shuttle catastrophe event while an emergency shuttle is docked comes with a warning now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
