### PR TITLE
Adds REAGENT_CAN_BE_SYNTHESIZED to determination, universal indicator, and organic slurry

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2460,6 +2460,7 @@
 	taste_description = "insides"
 	taste_mult = 4
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	var/yuck_cycle = 0 //! The `current_cycle` when puking starts.
 
 /datum/reagent/yuck/on_mob_add(mob/living/L)
@@ -2607,6 +2608,7 @@
 	reagent_state = LIQUID
 	color = "#D2FFFA"
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM // 5u (WOUND_DETERMINATION_CRITICAL) will last for ~34 seconds
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	self_consuming = TRUE
 	/// Whether we've had at least WOUND_DETERMINATION_SEVERE (2.5u) of determination at any given time. No damage slowdown immunity or indication we're having a second wind if it's just a single moderate wound
 	var/significant = FALSE
@@ -2675,6 +2677,7 @@
 	description = "A solution that can be used to create pH paper booklets, or sprayed on things to colour them by their pH."
 	taste_description = "a strong chemical taste"
 	color = "#1f8016"
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 //Colours things by their pH
 /datum/reagent/universal_indicator/expose_atom(atom/exposed_atom, reac_volume)
@@ -2708,6 +2711,7 @@
 		"MY GOD THEY'RE INSIDE ME!!",
 		"GET THEM OUT!!"
 		)
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/ants/on_mob_life(mob/living/carbon/victim, delta_time)
 	victim.adjustBruteLoss(max(0.1, round((ant_damage * 0.025),0.1))) //Scales with time. Roughly 32 brute with 100u.

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2711,7 +2711,6 @@
 		"MY GOD THEY'RE INSIDE ME!!",
 		"GET THEM OUT!!"
 		)
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/ants/on_mob_life(mob/living/carbon/victim, delta_time)
 	victim.adjustBruteLoss(max(0.1, round((ant_damage * 0.025),0.1))) //Scales with time. Roughly 32 brute with 100u.


### PR DESCRIPTION
## About The Pull Request

The determination, universal indicator, and organic slurry reagents now have the REAGENT_CAN_BE_SYNTHESIZED flag, like most other reagents in the game. This allows those reagents to be harvested from corpses (if the corpse had them in their system when they died), to appear in randomized chemical plant traits, and to be replicated by Odysseuses (Odyssi?).

## Why It's Good For The Game

To my understanding, every reagent in the game is supposed to have the REAGENT_CAN_BE_SYNTHESIZED flag unless there's a good reason to specifically exclude them from being harvested or replicated.

![image](https://user-images.githubusercontent.com/42606352/198740606-ec0f267e-a431-49f4-aa9c-5a0fec5c5911.png)

Determination is a chemical that's generated when you receive a wound. Its effects are incredibly minor and mostly wound-related (you can see them here: https://github.com/tgstation/tgstation/blob/master/code/modules/reagents/chemistry/reagents/other_reagents.dm#L2604). Pretty much the only reason to go through the lengthy process of harvesting determination (which involves torturing someone until they generate it, then killing them, grinding them up, and extracting the chem from their meat) is for the coolness factor, and I think that should be respected. There are also no balance concerns with making determination available to players, it's entirely outclassed by roundstart chems, let alone chems that require a similar amount of effort to obtain (such as bath salts).

Universal indicator is a chemical that changes color based on the pH of the chems you mix it with. I think its inability to be synthesized is genuinely just an oversight. 

Organic slurry (aka yuck) is a chemical that's generated by dipping a dead rat in welding fuel. It's that easy. It really shouldn't be so complex that an Odysseus can't synthesize it.

## Changelog
:cl: ATHATH
qol: The determination, universal indicator, and organic slurry reagents now have the REAGENT_CAN_BE_SYNTHESIZED flag, like most other reagents in the game. This allows those reagents to be harvested from corpses (if the corpse had them in their system when they died), to appear in randomized chemical plant traits, and to be replicated by Odysseuses (Odyssi?).
/:cl: