### PR TITLE
Renames a duplicate proc arg

### DIFF
--- a/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
@@ -8,7 +8,7 @@
 	///checker on whether we have sent the crystal yet.
 	var/sent_crystal = FALSE
 
-/datum/traitor_objective/final/supermatter_cascade/can_generate_objective(generating_for, list/generating_for)
+/datum/traitor_objective/final/supermatter_cascade/can_generate_objective(generating_for, list/possible_duplicates)
 	. = ..()
 	if(!.)
 		return FALSE


### PR DESCRIPTION
BYOND silently errors with duplicate proc arg names: https://www.byond.com/forum/post/2737322

I don't think this actually affects the behavior in this case but leaving it as a footgun is probably a bad idea.