### PR TITLE
Adds a crash to camera logic if we attempt to add a qdeleting camera

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -123,8 +123,6 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
  * If you want to update the chunks around an object, without adding/removing a camera, use choice 2.
  */
 /datum/cameranet/proc/majorChunkChange(atom/c, choice)
-	if(!c)
-		return
 	if(QDELETED(c) && choice == 1)
 		CRASH("Tried to add a qdeleting camera to the net")
 

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -125,6 +125,8 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 /datum/cameranet/proc/majorChunkChange(atom/c, choice)
 	if(!c)
 		return
+	if(QDELETED(c) && choice == 1)
+		CRASH("Tried to add a qdeleting camera to the net")
 
 	var/turf/T = get_turf(c)
 	if(T)


### PR DESCRIPTION
It's causing harddels and runtimes and I want to know why