### PR TITLE
reverts the omnitool getting eyestab element when becoming a screwdriver

### DIFF
--- a/code/game/objects/items/debug_items.dm
+++ b/code/game/objects/items/debug_items.dm
@@ -117,11 +117,6 @@
 		if("Wire Brush")
 			tool_behaviour = TOOL_RUSTSCRAPER
 
-	if(tool_behaviour == TOOL_SCREWDRIVER)
-		AddElement(/datum/element/eyestab)
-	else
-		RemoveElement(/datum/element/eyestab)
-
 /obj/item/debug/omnitool/item_spawner/attack_self(mob/user)
 	if(!user || !user.client)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
reverts #69918

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
as the creator of the omnitool i disagree that everything that can acts as a screwdriver should be eye stabbing. its a debug tool for quickly switching between all the tools, not an object to stick random behavior on. it doesnt have fuel management of a welder, weather checking of the analyzer, and hell, knives, scalpels and drills all eyestab too but the behavior isnt added when its set to those mode