### PR TITLE
Catches invalid external organ sprite datums

### DIFF
--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -159,6 +159,8 @@
 /obj/item/organ/external/proc/set_sprite(sprite_name)
 	stored_feature_id = sprite_name
 	sprite_datum = get_sprite_datum(sprite_name)
+	if(!sprite_datum && sprite_name)
+		CRASH("External organ attempted to load with an invalid sprite datum. Sprite key: [sprite_name].")
 	cache_key = jointext(generate_icon_cache(), "_")
 
 ///Generate a unique key based on our sprites. So that if we've aleady drawn these sprites, they can be found in the cache and wont have to be drawn again (blessing and curse)


### PR DESCRIPTION
I don't really feel this is a fix, since I intentionally didn't add it because I didnt think this would ever come up.

@Kapu1178 asked me to make this

This just warns coders when they fuck something up while developing external organs