### PR TITLE
Fixes incorrectly passed arguments to demoralise poster signal handler

### DIFF
--- a/code/modules/antagonists/traitor/objectives/demoralise_poster.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_poster.dm
@@ -57,7 +57,7 @@
  * Arguments
  * * victim - A mob who just got something stuck in their hand.
  */
-/datum/traitor_objective/demoralise/poster/proc/on_triggered_trap(mob/victim)
+/datum/traitor_objective/demoralise/poster/proc/on_triggered_trap(datum/source, mob/victim)
 	SIGNAL_HANDLER
 	on_mood_event(victim.mind)
 


### PR DESCRIPTION
## About The Pull Request

First argument is the source of the signal. This caused runtimes where it tried to check a poster's mind.

## Why It's Good For The Game

Less runtimes

## Changelog

:cl: Melbert
fix: Triggering a traitor poster trap progresses their objective. 
/:cl:
