### PR TITLE
Fixes cyborg projectile dampner runtime

### DIFF
--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -105,7 +105,7 @@
 	QDEL_NULL(dampening_field)
 	visible_message(span_warning("\The [src] shuts off!"))
 	for(var/projectile in tracked)
-		restore_projectile(projectile)
+		restore_projectile(projectile = projectile)
 	active = FALSE
 
 	var/mob/living/silicon/robot/owner = get_host()
@@ -160,13 +160,17 @@
 		host.cell.use(energy_recharge * delta_time * energy_recharge_cyborg_drain_coefficient)
 		energy += energy_recharge * delta_time
 
-/obj/item/borg/projectile_dampen/proc/dampen_projectile(obj/projectile/projectile)
+/obj/item/borg/projectile_dampen/proc/dampen_projectile(datum/source, obj/projectile/projectile)
+	SIGNAL_HANDLER
+
 	tracked[projectile] = projectile.damage
 	projectile.damage *= projectile_damage_coefficient
 	projectile.speed *= projectile_speed_coefficient
 	projectile.add_overlay(projectile_effect)
 
-/obj/item/borg/projectile_dampen/proc/restore_projectile(obj/projectile/projectile)
+/obj/item/borg/projectile_dampen/proc/restore_projectile(datum/source, obj/projectile/projectile)
+	SIGNAL_HANDLER
+
 	tracked -= projectile
 	projectile.damage *= (1 / projectile_damage_coefficient)
 	projectile.speed *= (1 / projectile_speed_coefficient)

--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -344,11 +344,15 @@
 	QDEL_NULL(dampening_field)
 
 /obj/item/mod/module/projectile_dampener/proc/dampen_projectile(datum/source, obj/projectile/projectile)
+	SIGNAL_HANDLER
+
 	projectile.damage *= damage_multiplier
 	projectile.speed *= speed_multiplier
 	projectile.add_overlay(projectile_effect)
 
 /obj/item/mod/module/projectile_dampener/proc/release_projectile(datum/source, obj/projectile/projectile)
+	SIGNAL_HANDLER
+
 	projectile.damage /= damage_multiplier
 	projectile.speed /= speed_multiplier
 	projectile.cut_overlay(projectile_effect)


### PR DESCRIPTION
## About The Pull Request

- Adds some missing `SIGNAL_HANDLERS` to projectile dampeners
- Fixes the cyborg projectile dampener having incorrect arguments 

## Why It's Good For The Game

Less runtimes, I think this actually caused the main functionally to fail

## Changelog

:cl: Melbert
fix: Fixes the cyborg projectile dampener doing nothing.
/:cl:
