### PR TITLE
Fixes the berserker suit helmet sprite.

### DIFF
--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -641,6 +641,8 @@
 	name = "berserker helmet"
 	desc = "Peering into the eyes of the helmet is enough to seal damnation."
 	icon_state = "berserker"
+	icon = 'icons/obj/clothing/head/helmet.dmi'
+	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	armor = list(MELEE = 30, BULLET = 30, LASER = 10, ENERGY = 20, BOMB = 50, BIO = 0, FIRE = 100, ACID = 100)
 	actions_types = list(/datum/action/item_action/berserk_mode)
 	cold_protection = HEAD


### PR DESCRIPTION
## About The Pull Request

It appears that #70060 seems to have also broken the berserker suit helmet link. It was pointed out to me, and was an easy fix, so here we are.
![image](https://user-images.githubusercontent.com/41715314/198851055-a71b788d-dd6d-40c7-92a9-d13b99206639.png)

## Why It's Good For The Game

Fixes broken sprites, missing textures are the bane of my existence. 

## Changelog

:cl:
fix: Berserker Suit helmet now has the correct sprite.
/:cl:
