### PR TITLE
Add EXPORT_STATS_TO_FILE_LATER to stat_tracking macros

### DIFF
--- a/code/__DEFINES/stat_tracking.dm
+++ b/code/__DEFINES/stat_tracking.dm
@@ -37,3 +37,16 @@
 	usage = TICK_USAGE;
 
 #define SET_COST_LINE(...) SET_COST("[__LINE__]")
+
+#define EXPORT_STATS_TO_FILE_LATER(filename, costs, counts) \
+	do { \
+		var/static/last_export = 0; \
+		if (world.time - last_export > 1.1 SECONDS) { \
+			last_export = world.time; \
+			/* spawn() is used here because this is often used to track init times, where timers act oddly. */ \
+			/* I was making timers and even after init times were complete, the timers didn't run :shrug: */ \
+			spawn (1 SECONDS) { \
+				stat_tracking_export_to_file_later(filename, costs, counts); \
+			} \
+		} \
+	} while (FALSE);

--- a/code/__HELPERS/stat_tracking.dm
+++ b/code/__HELPERS/stat_tracking.dm
@@ -11,3 +11,17 @@
 		user << browse("<ol><li>[lines.Join("</li><li>")]</li></ol>", "window=[url_encode("stats:[REF(stats)]")]")
 
 	. = lines.Join("\n")
+
+/proc/stat_tracking_export_to_file_later(filename, costs, counts)
+	if (IsAdminAdvancedProcCall())
+		return
+
+	var/list/output = list()
+
+	for (var/key in costs)
+		output[key] = list(
+			"cost" = costs[key],
+			"count" = counts[key],
+		)
+
+	rustg_file_write(json_encode(output), "[GLOB.log_directory]/[filename]")


### PR DESCRIPTION
Adds a macro to the stat_tracking macros that lets you export counts/costs into a JSON file, which is significantly easier to parse with stuff like jq.

It is delayed because these macros are used to profile potentially extremely hot functions, where we cannot afford to do I/O every time. It is sent every second rather than waiting until all are done because it can also be used to profile functions that are potentially called constantly, forever.

Usual concerns about unused code being added do not apply as this entire file is for profiling macros that are only ever used at time of profiling, and are never ever merged to master.