### PR TITLE
Fixes attack equip element passing incorrect args

### DIFF
--- a/code/datums/elements/attack_equip.dm
+++ b/code/datums/elements/attack_equip.dm
@@ -27,7 +27,7 @@
 	if(!attire.compare_zone_to_item_slot(targeted_zone))
 		return
 
-	if(attire.mob_can_equip(target, user,  attire.slot_flags, disable_warning = TRUE, bypass_equip_delay_self = TRUE))
+	if(attire.mob_can_equip(target, attire.slot_flags, disable_warning = TRUE, bypass_equip_delay_self = TRUE))
 		INVOKE_ASYNC(src, .proc/equip, attire, sharp_dresser, user)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 

--- a/code/datums/elements/attack_equip.dm
+++ b/code/datums/elements/attack_equip.dm
@@ -44,9 +44,6 @@
 	if(!do_mob(user, sharp_dresser, equip_time))
 		return
 
-	if(QDELETED(src) || QDELETED(sharp_dresser))
-		return
-
 	if(!user.Adjacent(sharp_dresser)) // Due to teleporting shenanigans
 		user.put_in_hands(attire)
 		return


### PR DESCRIPTION
## About The Pull Request

The second arg of `mob_can_equip` is the slot, not the user. Causes a runtime / failure. 

Also removed some qdel checks, cause this is an element and those would never fail. 

## Why It's Good For The Game

Things work

## Changelog

:cl: Melbert
fix: Fixes being unable to attack people with clothing to quickly equip it without the strip menu
/:cl:
