### PR TITLE
Accurately report the dead in check-antagonists

### DIFF
--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -130,42 +130,42 @@
 	var/drones = 0
 	var/security = 0
 	var/security_dead = 0
-	for(var/mob/M in GLOB.mob_list)
-		if(M.ckey)
-			if(isnewplayer(M))
+	for(var/mob/checked_mob in GLOB.mob_list)
+		if(checked_mob.ckey)
+			if(isnewplayer(checked_mob))
 				lobby_players++
 				continue
-			else if(M.mind && !isbrain(M) && !isobserver(M))
-				if(M.stat != DEAD)
-					if(isdrone(M))
+			else if(checked_mob.mind && !isbrain(checked_mob) && !isobserver(checked_mob))
+				if(checked_mob.stat != DEAD)
+					if(isdrone(checked_mob))
 						drones++
 						continue
-					if(is_centcom_level(M.z))
+					if(is_centcom_level(checked_mob.z))
 						living_skipped++
 						continue
 					living_players++
-					if(M.client)
+					if(checked_mob.client)
 						living_players_connected++
-				else if (M.ckey)
+				else if (checked_mob.ckey)
 					// This finds all dead mobs that still have a ckey inside them
 					// Ie, they have died, but have not ghosted
 					observers++
-					if (M.client)
+					if (checked_mob.client)
 						observers_connected++
 
-				if(M.mind.special_role)
+				if(checked_mob.mind.special_role)
 					antagonists++
-					if(M.stat == DEAD)
+					if(checked_mob.stat == DEAD)
 						antagonists_dead++
-				if(M.mind.assigned_role?.departments_list?.Find(/datum/job_department/security))
+				if(checked_mob.mind.assigned_role?.departments_list?.Find(/datum/job_department/security))
 					security++
-					if(M.stat == DEAD)
+					if(checked_mob.stat == DEAD)
 						security_dead++
-			else if(M.stat == DEAD || isobserver(M))
+			else if(checked_mob.stat == DEAD || isobserver(checked_mob))
 				observers++
-				if(M.client)
+				if(checked_mob.client)
 					observers_connected++
-			else if(isbrain(M))
+			else if(isbrain(checked_mob))
 				brains++
 			else
 				other_players++

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -135,7 +135,7 @@
 			if(isnewplayer(M))
 				lobby_players++
 				continue
-			else if(M.mind && !isbrain(M))
+			else if(M.mind && !isbrain(M) && !isobserver(M))
 				if(M.stat != DEAD)
 					if(isdrone(M))
 						drones++
@@ -146,6 +146,12 @@
 					living_players++
 					if(M.client)
 						living_players_connected++
+				else if (M.ckey)
+					// This finds all dead mobs that still have a ckey inside them
+					// Ie, they have died, but have not ghosted
+					observers++
+					if (M.client)
+						observers_connected++
 
 				if(M.mind.special_role)
 					antagonists++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So a small thing with this code is that the alive and dead code are dependent on eachother. And what counts as a player (having a mind and not being a brain) means that you aren't dead/an observer.  Two things happened with this.

- Only Lobby observers don't have a mind. This means if you were dead, and you were had ghosted, you counted as a player, and not an observer/dead. The first check adjusts for this.
- Secondly, if you /were/ dead but remained in your body, you still have a mind and were counted as a player. Therefore, a small check to see if you were /also dead/(and still controlling the body) was added.

Please let me know of any thoughts you have.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #70795 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Foxtrot (Funce)
fix: The amount of dead in the admin verb 'Check-antagonists' should now accurately report dead people (still in body) as well as ghosts that have died.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
