### PR TITLE
Makes it so Dullahans don't speak in robot span

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -42,6 +42,7 @@
 			my_head = new /obj/item/dullahan_relay(head, human)
 			human.put_in_hands(head)
 			head.show_organs_on_examine = FALSE
+			head.speech_span = null // so we don't look roboty when talking through it
 
 			// We want to give the head some boring old eyes just so it doesn't look too jank on the head sprite.
 			head.eyes = new /obj/item/organ/internal/eyes(head)


### PR DESCRIPTION
## About The Pull Request

Dullahan heads speak without a span, instead of the robot span from "an object is speaking".

## Why It's Good For The Game

I think the robot span is kinda un-natural, when it's just supposed to be an extension of a mob.

## Changelog

:cl: Melbert
qol: Dullahans, when speaking, use normal spans instead of robot span
/:cl:
