### PR TITLE
Allows mobs caught in disposals to escape once they have stopped moving - Take two

### DIFF
--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -113,7 +113,7 @@
 	if(do_after(escapee, 20 SECONDS, get_turf(loc)))
 		for(var/mob/living/jailbird in contents)
 			jailbird.apply_damage(rand(5,15), damagetype = BRUTE)
-		loc.take_damage(loc.atom_integrity)
+		loc.take_damage(loc.max_integrity)
 
 //failsafe in the case the holder is somehow forcemoved somewhere that's not a disposal pipe. Otherwise the above loop breaks.
 /obj/structure/disposalholder/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -20,6 +20,8 @@
 	active = FALSE
 	last_pipe = null
 	current_pipe = null
+	for(var/atom/movable/thing in contents)
+		thing.forceMove(get_turf(src))
 	return ..()
 
 // initialize a holder from the contents of a disposal unit
@@ -32,6 +34,7 @@
 		if(M.client)
 			M.reset_perspective(src)
 		hasmob = TRUE
+		RegisterSignal(M, COMSIG_LIVING_RESIST, .proc/struggle, M)
 
 	//Checks 1 contents level deep. This means that players can be sent through disposals mail...
 	//...but it should require a second person to open the package. (i.e. person inside a wrapped locker)
@@ -90,6 +93,27 @@
 	current_pipe = null
 	last_pipe = null
 	active = FALSE
+	for(var/mob/living/piperider in contents)
+		to_chat(piperider, span_notice("Your movement has slowed to a stop. If you tried, you could probably <b>struggle</b> free."))
+
+
+/obj/structure/disposalholder/proc/struggle(mob/living/escapee)
+	if(escapee.loc != src)
+		UnregisterSignal(escapee, COMSIG_LIVING_RESIST)
+		return //Somehow they got out without telling us
+	if(!istype(loc, /obj/structure/disposalpipe))
+		return //Somehow we're not in a pipe, shits probably fucked
+	if(active)
+		to_chat(escapee, span_danger("You slide past [loc] and are unable to keep your grip!"))
+		return
+	if(src in escapee.do_afters)
+		return //already trying to escape
+	to_chat(escapee, span_warning("You push against the thin pipe walls..."))
+	playsound(loc, 'sound/machines/airlock_alien_prying.ogg',30,FALSE,3) //yeah I know but at least it sounds like metal being bent.
+	if(do_after(escapee, 20 SECONDS, get_turf(loc)))
+		for(var/mob/living/jailbird in contents)
+			jailbird.apply_damage(rand(5,15), damagetype = BRUTE)
+		loc.take_damage(loc.atom_integrity)
 
 //failsafe in the case the holder is somehow forcemoved somewhere that's not a disposal pipe. Otherwise the above loop breaks.
 /obj/structure/disposalholder/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -110,8 +110,9 @@
 		return //already trying to escape
 	to_chat(escapee, span_warning("You push against the thin pipe walls..."))
 	playsound(loc, 'sound/machines/airlock_alien_prying.ogg', vol = 30, vary = FALSE, extrarange = 3) //yeah I know but at least it sounds like metal being bent.
-	if(!do_after(escapee, 20 SECONDS, get_turf(loc)))
-		return
+
+	//if(!do_after(escapee, 20 SECONDS, get_turf(loc)))
+	//	return
 	for(var/mob/living/jailbird in contents)
 		jailbird.apply_damage(rand(5,15), damagetype = BRUTE)
 	transport_cylinder.spew_forth()

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -112,7 +112,8 @@
 	playsound(loc, 'sound/machines/airlock_alien_prying.ogg', vol = 30, vary = FALSE, extrarange = 3) //yeah I know but at least it sounds like metal being bent.
 	if(!do_after(escapee, 20 SECONDS, get_turf(loc)))
 		return
-	escapee.apply_damage(rand(5,15), damagetype = BRUTE)
+	for(var/mob/living/jailbird in contents)
+		jailbird.apply_damage(rand(5,15), damagetype = BRUTE)
 	transport_cylinder.spew_forth()
 	transport_cylinder.take_damage(transport_cylinder.max_integrity)
 

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -81,8 +81,10 @@
 	// find other holder in next loc, if inactive merge it with current
 	var/obj/structure/disposalholder/H2 = locate() in P
 	if(H2 && !H2.active)
-		H.merge(H2)
-
+		if(H2.hasmob) //If it's stopped and there's a mob, add to the pile
+			H2.merge(H)
+			return
+		H.merge(H2)//Otherwise, we push it along through.
 	H.forceMove(P)
 	return P
 

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -93,7 +93,7 @@
 		return
 	// find other holder in next loc, if inactive merge it with current
 	var/obj/structure/disposalholder/H2 = locate() in P
-	if(H2 && !H2.active && !H2.hasmob)
+	if(H2 && !H2.active)
 		if(H2.hasmob) //If it's stopped and there's a mob, add to the pile
 			H2.merge(H)
 			return

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -46,15 +46,28 @@
 		var/turf/turf_loc = loc
 		turf_loc.add_blueprints_preround(src)
 
-// pipe is deleted
-// ensure if holder is present, it is expelled
 /obj/structure/disposalpipe/Destroy()
-	var/obj/structure/disposalholder/H = locate() in src
-	if(H)
-		H.active = FALSE
-		expel(H, get_turf(src), 0)
-	stored = null //The qdel is handled in expel()
+	qdel(stored)
 	return ..()
+
+/obj/structure/disposalpipe/deconstruct()
+	spew_forth()
+	return ..()
+
+/**
+ * Expells the pipe's contents.
+ *
+ * This proc checks through src's contents for holder objects,
+ * and then tells each one to empty onto the tile. Called when
+ * the pipe is deconstructed or someone struggles out.
+ */
+/obj/structure/disposalpipe/proc/spew_forth()
+	for(var/obj/structure/disposalholder/holdplease in src)
+		if(!istype(holdplease))
+			continue
+		holdplease.active = FALSE
+		expel(holdplease, get_turf(src), 0)
+	stored = null //The qdel is handled in expel()
 
 /obj/structure/disposalpipe/handle_atom_del(atom/A)
 	if(A == stored && !QDELETED(src))
@@ -80,7 +93,7 @@
 		return
 	// find other holder in next loc, if inactive merge it with current
 	var/obj/structure/disposalholder/H2 = locate() in P
-	if(H2 && !H2.active)
+	if(H2 && !H2.active && !H2.hasmob)
 		if(H2.hasmob) //If it's stopped and there's a mob, add to the pile
 			H2.merge(H)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

This is a re-opening of #69960, after addressing all prior reviews (except one, see below).

## About The Pull Request
- A mob inside a disposalpipe holder object that has stopped can use the "resist" action (hotkey: B by default) to struggle out. This will take 20 seconds (on top of the time spent waiting for their holder to stop), and will play a sound. The pipe they are in will burst (taking the tile with it if applicable), and deal a random 5 to 15 brute damage to all mobs in the holder.
- When merging a moving holder with a stopped holder, pipes will now check if the stopped holder has a mob, and if so, will merge the moving holder into the stopped holder rather than the reverse. Thus, all new mobs will become stuck on a stopped mob.
- When deleted, holders will now drop their contents to the floor first. This is to prevent a very rare bug deleting all holder contents (including mobs) if the holder attempts to move through a pipe currently being destroyed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Disposal traps are fun, but there shouldn't be a scenario where a player is trapped indefinitely, with no ability to use tools or other items to escape, that can be made for free using round-start items. If you want to make a trap, the disposals pipes should be the delivery system, not the destination.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now resist out of disposals pipes once you have stopped, at the cost of some brute damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
