### PR TITLE
Fix admin 2fa not syncing authorized admins to the player table in the db.

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -139,7 +139,7 @@ GLOBAL_PROTECT(href_token)
 
 		return
 	else if (blocked_by_2fa)
-		sync_lastadminrank(client.ckey, client.key)
+		sync_lastadminrank(client.ckey, client.key, src)
 
 	blocked_by_2fa = FALSE
 

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -139,6 +139,7 @@ GLOBAL_PROTECT(href_token)
 
 		return
 	else if (blocked_by_2fa)
+		//previously blocked by 2fa but has now verified, sync the lastadminrank column on the player table.
 		sync_lastadminrank(client.ckey, client.key, src)
 
 	blocked_by_2fa = FALSE


### PR DESCRIPTION
if you don't supply an admin datum to this proc, it syncs over 'player'.

## Changelog

:cl:
admin: Forum 2fa (verify admin) now properly updates your record in the database without needing a reconnect to trigger a dbsync.
/:cl:

