### PR TITLE
Adds Hydroponics door to Airlock Painter

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -26,14 +26,15 @@
 		"Security" = /obj/machinery/door/airlock/security,
 		"Command" = /obj/machinery/door/airlock/command,
 		"Medical" = /obj/machinery/door/airlock/medical,
+		"Virology" = /obj/machinery/door/airlock/virology,
 		"Research" = /obj/machinery/door/airlock/research,
+		"Hydroponics" = /obj/machinery/door/airlock/hydroponics,
 		"Freezer" = /obj/machinery/door/airlock/freezer,
 		"Science" = /obj/machinery/door/airlock/science,
 		"Mining" = /obj/machinery/door/airlock/mining,
 		"Maintenance" = /obj/machinery/door/airlock/maintenance,
 		"External" = /obj/machinery/door/airlock/external,
 		"External Maintenance"= /obj/machinery/door/airlock/maintenance/external,
-		"Virology" = /obj/machinery/door/airlock/virology,
 		"Standard" = /obj/machinery/door/airlock
 	)
 


### PR DESCRIPTION
## About The Pull Request

a friend of mine noticed that the hydroponics door was missing from the airlock painter. so i added it, because it was the only door in that group that wasnt.

## Why It's Good For The Game

A door was missing from the Airlock Painter! It's good to keep things in order.

## Changelog

:cl:
fix: Added Missing Hydroponics door to Airlock Painter
/:cl: