### PR TITLE
close span on examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -357,7 +357,7 @@
 			msg += "[span_notice("<i>[t_He] [t_has] significantly disfiguring scarring, you can look again to take a closer look...</i>")]\n"
 		if(12 to INFINITY)
 			msg += "[span_notice("<b><i>[t_He] [t_is] just absolutely fucked up, you can look again to take a closer look...</i></b>")]\n"
-
+	msg += "</span>"
 
 	if (length(msg))
 		. += span_warning("[msg.Join("")]")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -357,7 +357,7 @@
 			msg += "[span_notice("<i>[t_He] [t_has] significantly disfiguring scarring, you can look again to take a closer look...</i>")]\n"
 		if(12 to INFINITY)
 			msg += "[span_notice("<b><i>[t_He] [t_is] just absolutely fucked up, you can look again to take a closer look...</i></b>")]\n"
-	msg += "</span>"
+	msg += "</span>" // closes info class
 
 	if (length(msg))
 		. += span_warning("[msg.Join("")]")


### PR DESCRIPTION
## About The Pull Request
adds a close span to msg on line 360. tested locally on dullahan and non dullahan both appear well
<details><summary>with wounds+not dullahan+leg missing</summary>
<img src="https://user-images.githubusercontent.com/85910816/198895505-2fceafcf-4bbc-4ebd-9e89-8cc38a74b8ab.png">
</details>
<details><summary>dullahan</summary>
<img src="https://user-images.githubusercontent.com/85910816/198895515-7d2b0d47-c309-40e8-aa6d-f215a80e3555.png">
</details>
Fixes: #70899

## Why It's Good For The Game

Formatting error fix

## Changelog

:cl:
spellcheck: Formatting error fix with examining headless bodies.
/:cl:
