### PR TITLE
Makes the beer nuke use scrubber overflow

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
@@ -57,21 +57,7 @@
 	foam.start()
 	disarm_nuke()
 
-/obj/machinery/nuclearbomb/beer/proc/stationwide_foam()
-	priority_announce("The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.", "Atmospherics alert")
-
-	for (var/obj/machinery/atmospherics/components/unary/vent_scrubber/vent in GLOB.machines)
-		var/turf/vent_turf = get_turf(vent)
-		if (!vent_turf || !is_station_level(vent_turf.z) || vent.welded)
-			continue
-
-		var/datum/reagents/beer = new /datum/reagents(1000)
-		beer.my_atom = vent
-		beer.add_reagent(/datum/reagent/consumable/ethanol/beer, 100)
-		beer.create_foam(/datum/effect_system/fluid_spread/foam, DIAMOND_AREA(10))
-
-		CHECK_TICK
-
 /obj/machinery/nuclearbomb/beer/really_actually_explode(detonation_status)
 	disarm_nuke()
-	stationwide_foam()
+	var/datum/round_event_control/event = locate(/datum/round_event_control/scrubber_overflow/beer) in SSevents.control
+	event.runEvent()

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -14,6 +14,12 @@
 	var/danger_chance = 1
 	/// Amount of reagents ejected from each scrubber
 	var/reagents_amount = 50
+	/// Probability of an individual scrubber overflowing
+	var/overflow_probability = 50
+	/// Whether or not to force all scrubbers to eject the same reagent
+	var/force_specific_reagent = FALSE
+	/// If forcing all scrubbers to eject the same reagent, what reagent to use
+	var/forced_reagent
 	/// A list of scrubbers that will have reagents ejected from them
 	var/list/scrubbers = list()
 	/// The list of chems that scrubbers can produce
@@ -67,7 +73,7 @@
 			continue
 		if(temp_vent.welded)
 			continue
-		if(!prob(50))
+		if(!prob(overflow_probability))
 			continue
 		scrubbers += temp_vent
 
@@ -98,7 +104,9 @@
 
 		var/datum/reagents/dispensed_reagent = new /datum/reagents(reagents_amount)
 		dispensed_reagent.my_atom = vent
-		if (prob(danger_chance))
+		if (force_specific_reagent)
+			dispensed_reagent.add_reagent(forced_reagent, reagents_amount)
+		else if (prob(danger_chance))
 			dispensed_reagent.add_reagent(get_random_reagent_id(), reagents_amount)
 			new /mob/living/basic/cockroach(get_turf(vent))
 			new /mob/living/basic/cockroach(get_turf(vent))
@@ -134,3 +142,17 @@
 /datum/round_event/scrubber_overflow/catastrophic
 	danger_chance = 30
 	reagents_amount = 150
+
+/datum/round_event_control/scrubber_overflow/beer // Used when the beer nuke "detonates"
+	name = "Scrubber Overflow: Beer"
+	typepath = /datum/round_event/scrubber_overflow/beer
+	weight = 0
+	max_occurrences = 0
+	description = "The scrubbers release a tide of boozy froth."
+
+/datum/round_event/scrubber_overflow/beer
+	overflow_probability = 100
+	force_specific_reagent = TRUE
+	forced_reagent = /datum/reagent/consumable/ethanol/beer
+	reagents_amount = 100
+

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -16,9 +16,7 @@
 	var/reagents_amount = 50
 	/// Probability of an individual scrubber overflowing
 	var/overflow_probability = 50
-	/// Whether or not to force all scrubbers to eject the same reagent
-	var/force_specific_reagent = FALSE
-	/// If forcing all scrubbers to eject the same reagent, what reagent to use
+	/// Specific reagent to force all scrubbers to use, null for random reagent choice
 	var/forced_reagent
 	/// A list of scrubbers that will have reagents ejected from them
 	var/list/scrubbers = list()
@@ -104,7 +102,7 @@
 
 		var/datum/reagents/dispensed_reagent = new /datum/reagents(reagents_amount)
 		dispensed_reagent.my_atom = vent
-		if (force_specific_reagent)
+		if (forced_reagent)
 			dispensed_reagent.add_reagent(forced_reagent, reagents_amount)
 		else if (prob(danger_chance))
 			dispensed_reagent.add_reagent(get_random_reagent_id(), reagents_amount)
@@ -152,7 +150,6 @@
 
 /datum/round_event/scrubber_overflow/beer
 	overflow_probability = 100
-	force_specific_reagent = TRUE
 	forced_reagent = /datum/reagent/consumable/ethanol/beer
 	reagents_amount = 100
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Refactors the beer nuke's detonation to use a scrubber overflow subtype instead of its own snowflake code. Adds some new functionality to scrubber overflows to support changing the per-scrubber probability of being involved, and forcing a specific reagent.

## Why It's Good For The Game

Removes largely duplicated code in favour of extending existing functionality.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: The beer nuke detonation is now a special type of scrubber overflow event.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
