### PR TITLE
Fix remove guide comments workflow on forks

### DIFF
--- a/.github/workflows/remove_guide_comments.yml
+++ b/.github/workflows/remove_guide_comments.yml
@@ -2,7 +2,7 @@
 # and reuse the pull request description, the clutter is not left behind
 name: Remove guide comments
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 jobs:
   remove_guide_comments:


### PR DESCRIPTION
pull_request only has access to your own fork. I figured it was only access to your own user, which would've let you edit your own pull requests.

pull_request_target runs from repo context. It is not possible to edit removeGuideComments.js to gain control of the repository, as checkout in pull_request_target uses repo master and not your fork. 