### PR TITLE
Save 0.1s in generate_station_area_list

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -425,12 +425,11 @@ Used by the AI doomsday and the self-destruct nuke.
 GLOBAL_LIST_EMPTY(the_station_areas)
 
 /datum/controller/subsystem/mapping/proc/generate_station_area_list()
-	for(var/area/station/A in world)
-		if (!A.contents.len || !(A.area_flags & UNIQUE_AREA))
+	for(var/area/station/station_area in world)
+		if (!(station_area.area_flags & UNIQUE_AREA))
 			continue
-		var/turf/picked = A.contents[1]
-		if (is_station_level(picked.z))
-			GLOB.the_station_areas += A.type
+		if (is_station_level(station_area.z))
+			GLOB.the_station_areas += station_area.type
 
 	if(!GLOB.the_station_areas.len)
 		log_world("ERROR: Station areas list failed to generate!")


### PR DESCRIPTION
`area.contents` loops over everything in the world to collect its list, every time.

We need to avoid it where possible. Lemon already working on a PR to cache it. In the distant future we will lint this.

This was a useless consumer of it. It cost 0.1s to index contents twice like this.