### PR TITLE
Tear juice makes you cry on touch instead of ingestion

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -481,7 +481,7 @@
 		return
 
 	var/mob/living/carbon/victim = exposed_mob
-	if(methods & (INGEST | VAPOR))
+	if(methods & (TOUCH|VAPOR))
 		var/tear_proof = victim.is_eyes_covered()
 		if (!tear_proof)
 			to_chat(exposed_mob, span_warning("Your eyes sting!"))

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -481,7 +481,7 @@
 		return
 
 	var/mob/living/carbon/victim = exposed_mob
-	if(methods & (TOUCH|VAPOR))
+	if(methods & (TOUCH | VAPOR))
 		var/tear_proof = victim.is_eyes_covered()
 		if (!tear_proof)
 			to_chat(exposed_mob, span_warning("Your eyes sting!"))


### PR DESCRIPTION
## About The Pull Request

Changes the requirements for crying from being exposed to tear juice from ingestion to touch.

## Why It's Good For The Game

Spam crying whenever you eat food with onions in is funny-ish but doesn't really make sense.
What *doubly* doesn't make sense is that wearing glasses while eating food with onions in stops you from crying.
Now, you can eat onions all you like. Cutting them will still make you cry, though.

## Changelog
:cl:
fix: Eating food with onions in will no longer make you cry.
/:cl: