### PR TITLE
Fixes a discrepancy in UpdatePath readme

### DIFF
--- a/tools/UpdatePaths/readme.md
+++ b/tools/UpdatePaths/readme.md
@@ -209,7 +209,7 @@ Alright, there's a few subsections here. This is how you are able to filter out 
 Alright, you saw something cool in a map that you wanted to expand upon codeside. So, you make the new path `/mob/living/basic/mouse/tom` with all sorts of nice behavior. However, you don't want to just replace all of the old `/mob/living/basic/mouse` paths with the new one, you want to only replace the ones that have a `name` variable of "Tom". You can do that by simply adding the following to your script:
 
 ```txt
-/mob/living/basic/mouse{name="Tom"} : /mob/living/basic/mouse/tom{name = @SKIP, @OLD}
+/mob/living/basic/mouse{name="Tom"} : /mob/living/basic/mouse/tom{@OLD;name=@SKIP}
 ```
 In this test example, you already set the name of the Mob to "Tom", so you don't need to worry about that, so you just insert `@SKIP` in order to skip adding that variable to the new path. However, maybe there's some other non-name variables that you do want to keep, so you add `@OLD` to the end of the new path. So, let's assume we have the following map file:
 

--- a/tools/UpdatePaths/readme.md
+++ b/tools/UpdatePaths/readme.md
@@ -211,7 +211,6 @@ Alright, you saw something cool in a map that you wanted to expand upon codeside
 ```txt
 /mob/living/basic/mouse{name="Tom"} : /mob/living/basic/mouse/tom{@OLD;name=@SKIP}
 ```
-In this test example, you already set the name of the Mob to "Tom", so you don't need to worry about that, so you just insert `@SKIP` in order to skip adding that variable to the new path. However, maybe there's some other non-name variables that you do want to keep, so you add `@OLD` to the end of the new path. So, let's assume we have the following map file:
 
 In this test example, you already set the name of the Mob to "Tom", so you don't need to worry about that, so first you'll insert `@OLD`, because you want to retain all the other variables, and then add `@SKIP` in order to skip adding that variable to the new path. Its important that '@OLD' goes before '@SKIP', otherwise the script won't see the variables to skip and will just keep all of them anyway. So, let's assume we have the following map file:
 

--- a/tools/UpdatePaths/readme.md
+++ b/tools/UpdatePaths/readme.md
@@ -213,6 +213,8 @@ Alright, you saw something cool in a map that you wanted to expand upon codeside
 ```
 In this test example, you already set the name of the Mob to "Tom", so you don't need to worry about that, so you just insert `@SKIP` in order to skip adding that variable to the new path. However, maybe there's some other non-name variables that you do want to keep, so you add `@OLD` to the end of the new path. So, let's assume we have the following map file:
 
+In this test example, you already set the name of the Mob to "Tom", so you don't need to worry about that, so first you'll insert `@OLD`, because you want to retain all the other variables, and then add `@SKIP` in order to skip adding that variable to the new path. Its important that '@OLD' goes before '@SKIP', otherwise the script won't see the variables to skip and will just keep all of them anyway. So, let's assume we have the following map file:
+
 ```dm
 "a" = (
 /mob/living/basic/mouse{


### PR DESCRIPTION
## About The Pull Request
The recent overhaul of UpdatePath's documentation contains a discrepancy. Currently, it mentions that the line `/mob/living/basic/mouse{name="Tom"} : /mob/living/basic/mouse/tom{name = @SKIP, @OLD}` will keep all the old variables except for 'name'. This format is slightly incorrect, and will actually cause the UpdatePaths script to error and not complete its task at all.

By cross-referencing some pre-existing scripts in the folder, as well as actual testing, the correct way to write this would be the following: `/mob/living/basic/mouse{name="Tom"} : /mob/living/basic/mouse/tom{@OLD;name=@SKIP}`

Note the use of a semi-colon instead of the comma, the removal of spaces, and the use of `@OLD` _before_ `@SKIP`. **Each of these cases are important and affect the outcome/success of the script!**