### PR TITLE
Adds a `silent_for_user` var to mute storage messages only for the user.

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -55,6 +55,8 @@
 
 	/// don't show any chat messages regarding inserting items
 	var/silent = FALSE
+	/// same as above but only for the user, useful to cut on chat spam without removing feedback for other players
+	var/silent_for_user = FALSE
 	/// play a rustling sound when interacting with the bag
 	var/rustle_sound = TRUE
 
@@ -457,7 +459,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(rustle_sound)
 		playsound(resolve_parent, SFX_RUSTLE, 50, TRUE, -5)
 
-	to_chat(user, span_notice("You put [thing] [insert_preposition]to [resolve_parent]."))
+	if(!silent_for_user)
+		to_chat(user, span_notice("You put [thing] [insert_preposition]to [resolve_parent]."))
 
 	for(var/mob/viewing in oviewers(user, null))
 		if(in_range(user, viewing))

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -115,6 +115,7 @@
 	atom_storage.allow_quick_empty = TRUE
 	atom_storage.allow_quick_gather = TRUE
 	atom_storage.set_holdable(list(/obj/item/stack/ore))
+	atom_storage.silent_for_user = TRUE
 
 /obj/item/storage/bag/ore/equipped(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
We have a `silent` var that makes storing/removing items from a backpack not send a message to anyone's chat.
This adds a midway point, silent messages only for the user to cut on spam/unnecessary messages while other players still keep them to prevent free stealth shenanigans.

For now the only storage item I have given this new variable is the ore bag for miners, as even with #70487 miners still have to deal with a lot of pointless messages getting in the way of radio chatter.
## Why It's Good For The Game
Less pointless spam.
You mined the ore, you stepped on it, you get a balloon alert explaining what happened.
There is no reason to also send the default storing/removing message to your chat.

it can also be easily ported to other backpack/boxes/bags, I personally would want it on basically any storage but that would hurt on new player's feedback, so it is a conversation for another PR.
## Changelog
:cl: Guillaume Prata
qol: Ore bags are "silent" for the wearer and won't send pointless chat messages about what has been stored/removed from it. Other players will still get a chat message, so miners can't get away with surprise plasma ore bombs.

/:cl:
