### PR TITLE
Adds a Desert Eagle to the traitor uplink.

### DIFF
--- a/code/modules/uplink/uplink_items/ammunition.dm
+++ b/code/modules/uplink/uplink_items/ammunition.dm
@@ -62,7 +62,7 @@
 /datum/uplink_item/ammo/deagle
 	name = ".50 AE Magazine"
 	desc = "An additional 7-round .50 AE magazine, compatible with the Desert Eagle pistol. \
-			Just in case you need to turn your enemies OFF."
+	Just in case you need to turn your enemies OFF."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m50
 	cost = 4

--- a/code/modules/uplink/uplink_items/ammunition.dm
+++ b/code/modules/uplink/uplink_items/ammunition.dm
@@ -59,6 +59,16 @@
 	cost = 2
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
+/datum/uplink_item/ammo/deagle
+	name = ".50 AE Magazine"
+	desc = "An additional 7-round .50 AE magazine, compatible with the Desert Eagle pistol. \
+			Just in case you need to turn your enemies OFF."
+	progression_minimum = 30 MINUTES
+	item = /obj/item/ammo_box/magazine/m50
+	cost = 4
+	purchasable_from = ~UPLINK_CLOWN_OPS
+	illegal_tech = FALSE
+
 /datum/uplink_item/ammo/revolver
 	name = ".357 Speed Loader"
 	desc = "A speed loader that contains seven additional .357 Magnum rounds; usable with the Syndicate revolver. \

--- a/code/modules/uplink/uplink_items/ammunition.dm
+++ b/code/modules/uplink/uplink_items/ammunition.dm
@@ -35,7 +35,7 @@
 /datum/uplink_item/ammo/pistolap
 	name = "9mm Armour Piercing Magazine"
 	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
-	These rounds are less effective at injuring the target but penetrate protective gear."
+		These rounds are less effective at injuring the target but penetrate protective gear."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m9mm/ap
 	cost = 2
@@ -44,7 +44,7 @@
 /datum/uplink_item/ammo/pistolhp
 	name = "9mm Hollow Point Magazine"
 	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
-	These rounds are more damaging but ineffective against armour."
+		These rounds are more damaging but ineffective against armour."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m9mm/hp
 	cost = 3
@@ -53,7 +53,7 @@
 /datum/uplink_item/ammo/pistolfire
 	name = "9mm Incendiary Magazine"
 	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
-	Loaded with incendiary rounds which inflict little damage, but ignite the target."
+		Loaded with incendiary rounds which inflict little damage, but ignite the target."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m9mm/fire
 	cost = 2
@@ -62,7 +62,7 @@
 /datum/uplink_item/ammo/deagle
 	name = ".50 AE Magazine"
 	desc = "An additional 7-round .50 AE magazine, compatible with the Desert Eagle pistol. \
-	Just in case you need to turn your enemies OFF."
+		Just in case you need to turn your enemies OFF."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m50
 	cost = 4
@@ -72,7 +72,7 @@
 /datum/uplink_item/ammo/revolver
 	name = ".357 Speed Loader"
 	desc = "A speed loader that contains seven additional .357 Magnum rounds; usable with the Syndicate revolver. \
-	For when you really need a lot of things dead."
+		For when you really need a lot of things dead."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/a357
 	cost = 4

--- a/code/modules/uplink/uplink_items/ammunition.dm
+++ b/code/modules/uplink/uplink_items/ammunition.dm
@@ -35,7 +35,7 @@
 /datum/uplink_item/ammo/pistolap
 	name = "9mm Armour Piercing Magazine"
 	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
-			These rounds are less effective at injuring the target but penetrate protective gear."
+	These rounds are less effective at injuring the target but penetrate protective gear."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m9mm/ap
 	cost = 2
@@ -44,7 +44,7 @@
 /datum/uplink_item/ammo/pistolhp
 	name = "9mm Hollow Point Magazine"
 	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
-			These rounds are more damaging but ineffective against armour."
+	These rounds are more damaging but ineffective against armour."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m9mm/hp
 	cost = 3
@@ -53,7 +53,7 @@
 /datum/uplink_item/ammo/pistolfire
 	name = "9mm Incendiary Magazine"
 	desc = "An additional 8-round 9mm magazine, compatible with the Makarov pistol. \
-			Loaded with incendiary rounds which inflict little damage, but ignite the target."
+	Loaded with incendiary rounds which inflict little damage, but ignite the target."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m9mm/fire
 	cost = 2
@@ -72,7 +72,7 @@
 /datum/uplink_item/ammo/revolver
 	name = ".357 Speed Loader"
 	desc = "A speed loader that contains seven additional .357 Magnum rounds; usable with the Syndicate revolver. \
-			For when you really need a lot of things dead."
+	For when you really need a lot of things dead."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/a357
 	cost = 4

--- a/code/modules/uplink/uplink_items/ammunition.dm
+++ b/code/modules/uplink/uplink_items/ammunition.dm
@@ -66,7 +66,7 @@
 	progression_minimum = 30 MINUTES
 	item = /obj/item/ammo_box/magazine/m50
 	cost = 4
-	purchasable_from = ~UPLINK_CLOWN_OPS
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	illegal_tech = FALSE
 
 /datum/uplink_item/ammo/revolver

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -100,7 +100,7 @@
 	progression_minimum = 30 MINUTES
 	cost = 13
 	surplus = 50
-	purchasable_from = ~UPLINK_CLOWN_OPS
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/dangerous/revolver
 	name = "Syndicate Revolver"

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -93,6 +93,15 @@
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	restricted = TRUE
 
+/datum/uplink_item/dangerous/deagle
+	name = "Desert Eagle"
+	desc = "The tried-and-true, bulky behemoth of a pistol. Fires .50 AE rounds and contains 8 shots."
+	item = /obj/item/gun/ballistic/automatic/pistol/deagle
+	progression_minimum = 30 MINUTES
+	cost = 13
+	surplus = 50
+	purchasable_from = ~UPLINK_CLOWN_OPS
+
 /datum/uplink_item/dangerous/revolver
 	name = "Syndicate Revolver"
 	desc = "A brutally simple Syndicate revolver that fires .357 Magnum rounds and has 7 chambers."


### PR DESCRIPTION

## About The Pull Request

Adds a Deagle (and its corresponding magazine) to the traitor uplink.
## Why It's Good For The Game

Mostly cosmetic difference to the .357, I figured more variety in firearms would be nice. Gives you the choice between being a traitor with a revolver to an internal affairs agent with a Deagle--etc etc.
## Changelog
:cl: dessysalta and dopamiin
add: Added deagle and .50 AE magazine to traitor uplink.
/:cl:
