### PR TITLE
lowers megafauna chance, forces a bdm spawn on lavaland

### DIFF
--- a/code/datums/mapgen/Cavegens/IcemoonCaves.dm
+++ b/code/datums/mapgen/Cavegens/IcemoonCaves.dm
@@ -23,9 +23,9 @@
 
 /datum/map_generator/cave_generator/icemoon/deep
 	weighted_closed_turf_types = list(/turf/closed/mineral/random/snow/underground = 1)
-	weighted_mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/ice_demon = 50, /obj/structure/spawner/ice_moon/demonic_portal = 3, \
-						  /mob/living/simple_animal/hostile/asteroid/ice_whelp = 30, /obj/structure/spawner/ice_moon/demonic_portal/ice_whelp = 3, \
-						  /mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow = 50, /obj/structure/spawner/ice_moon/demonic_portal/snowlegion = 3, \
-						  SPAWN_MEGAFAUNA = 2)
+	weighted_mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/ice_demon = 100, /obj/structure/spawner/ice_moon/demonic_portal = 6, \
+						  /mob/living/simple_animal/hostile/asteroid/ice_whelp = 60, /obj/structure/spawner/ice_moon/demonic_portal/ice_whelp = 6, \
+						  /mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow = 100, /obj/structure/spawner/ice_moon/demonic_portal/snowlegion = 6, \
+						  SPAWN_MEGAFAUNA = 1)
 	weighted_megafauna_spawn_list = list(/mob/living/simple_animal/hostile/megafauna/colossus = 1)
 	weighted_flora_spawn_list = list(/obj/structure/flora/rock/icy/style_random = 6, /obj/structure/flora/rock/pile/icy/style_random = 6, /obj/structure/flora/ash/chilly = 1)

--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -10,7 +10,7 @@
 		/obj/structure/spawner/lavaland = 2,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/random = 30,
 		/obj/structure/spawner/lavaland/legion = 3,
-		SPAWN_MEGAFAUNA = 4,
+		SPAWN_MEGAFAUNA = 2,
 		/mob/living/simple_animal/hostile/asteroid/goldgrub = 10,
 		/mob/living/simple_animal/hostile/asteroid/lobstrosity/lava = 20,
 		/mob/living/simple_animal/hostile/asteroid/brimdemon = 20,

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -150,6 +150,15 @@
 	name = "Blood-Drunk Miner (Hunter)"
 	suffix = "lavaland_surface_blooddrunk3.dmm"
 
+/datum/map_template/ruin/lavaland/blood_drunk_miner/random
+	name = "Blood-Drunk Miner (Random)"
+	suffix = null
+	always_place = TRUE
+
+/datum/map_template/ruin/lavaland/blood_drunk_miner/random/New()
+	suffix = pick("lavaland_surface_blooddrunk1.dmm", "lavaland_surface_blooddrunk2.dmm", "lavaland_surface_blooddrunk3.dmm")
+	return ..()
+
 /datum/map_template/ruin/lavaland/ufo_crash
 	name = "UFO Crash"
 	id = "ufo-crash"


### PR DESCRIPTION
## About The Pull Request
quarters the chance of megafauna spawns on icebox (this only applies to the colossi)
halves the chance of megafauna spawns on lavaland
forces a bdm spawn on lavaland
closes #69677

## Why It's Good For The Game
26 colossi is not fun
![image](https://user-images.githubusercontent.com/23585223/199024381-166e05dd-fe62-4f50-b03f-d7c9754c3576.png)

fighting megafauna is fun and ruin rng screwing you out of one is not fun

## Changelog
:cl:
balance: less megafauna should spawn on icebox and lavaland
qol: blood drunk miner ruin on lavaland will spawn every round
/:cl:
