### PR TITLE
Removes misplaced unrestricted access from Lavaland Shuttle Airlocks  

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -232,10 +232,6 @@
 	},
 /area/mine/lounge)
 "bL" = (
-/obj/machinery/door/airlock/external{
-	name = "Lavaland Shuttle Airlock";
-	space_dir = 8
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -244,6 +240,9 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Lavaland Shuttle Airlock"
 	},
 /turf/open/floor/iron/textured_large,
 /area/mine/lounge)
@@ -1965,15 +1964,14 @@
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
 "lM" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Mining Shuttle Airlock";
-	space_dir = 8
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
+/obj/machinery/door/airlock/external/glass{
+	name = "Mining Shuttle Airlock"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production)
 "lN" = (
@@ -2232,8 +2230,8 @@
 /obj/docking_port/stationary{
 	dwidth = 2;
 	height = 5;
-	shuttle_id = "laborcamp_away";
 	name = "labor camp";
+	shuttle_id = "laborcamp_away";
 	width = 9
 	},
 /obj/effect/turf_decal/sand/plating/volcanic,
@@ -4064,12 +4062,11 @@
 /turf/open/floor/iron,
 /area/mine/cafeteria)
 "xN" = (
-/obj/machinery/door/airlock/external{
-	name = "Lavaland Shuttle Airlock";
-	space_dir = 8
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Lavaland Shuttle Airlock"
 	},
 /turf/open/floor/iron/textured_large,
 /area/mine/lounge)
@@ -4111,8 +4108,8 @@
 	dir = 2;
 	dwidth = 11;
 	height = 22;
-	shuttle_id = "whiteship_lavaland";
 	name = "lavaland wastes";
+	shuttle_id = "whiteship_lavaland";
 	width = 35
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -4945,8 +4942,8 @@
 	dir = 2;
 	dwidth = 3;
 	height = 10;
-	shuttle_id = "mining_away";
 	name = "lavaland mine";
+	shuttle_id = "mining_away";
 	width = 7
 	},
 /obj/effect/turf_decal/sand/plating/volcanic,
@@ -5164,8 +5161,8 @@
 	dir = 4;
 	dwidth = 3;
 	height = 7;
-	shuttle_id = "lavaland_common_away";
 	name = "Mining base public dock";
+	shuttle_id = "lavaland_common_away";
 	width = 7
 	},
 /obj/effect/turf_decal/sand/plating/volcanic,
@@ -7097,10 +7094,6 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp/quarters)
 "RW" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Mining Shuttle Airlock";
-	space_dir = 8
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
@@ -7109,6 +7102,9 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
 	dir = 1
+	},
+/obj/machinery/door/airlock/external/glass{
+	name = "Mining Shuttle Airlock"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/production)


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/75863639/199025549-9611879f-ebb4-4cc5-abdd-38aba1a0fd6a.png)

Removes unrestricted access from the sides facing the wall over here.

Also removes unrestricted access from the Public Shuttle Airlocks because they are AA already like come on.

## Why It's Good For The Game
less jank, makes fikou happy

## Changelog

:cl:
fix: removed misplaced unrestricted access from Lavaland Shuttle Airlocks  
/:cl:

