### PR TITLE
The reagent dartgun's uplink description no longer lies to the player

### DIFF
--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -214,7 +214,7 @@
 
 /datum/uplink_item/role_restricted/chemical_gun
 	name = "Reagent Dartgun"
-	desc = "A heavily modified syringe gun which is capable of synthesizing its own chemical darts using input reagents. Can hold 100u of reagents."
+	desc = "A heavily modified syringe gun which is capable of synthesizing its own chemical darts using input reagents. Can hold 90u of reagents."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/gun/chem
 	cost = 12


### PR DESCRIPTION
## About The Pull Request

Updates the uplink description of the reagent dartgun to reflect it's post-change reagent capacity (90u).

## Why It's Good For The Game

This is definitely an oversight.

Lying to the player is bad.

## Changelog
:cl: ATHATH
spellcheck: Updated the reagent dartgun's uplink description to reflect its current reagent capacity (90u).
/:cl: