### PR TITLE
renames TOXIN to BIOHAZARD in clothing protective tag

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -312,7 +312,7 @@
 		if(armor.bio || armor.bomb || armor.bullet || armor.energy || armor.laser || armor.melee)
 			readout += "\n<b>ARMOR (I-X)</b>"
 			if(armor.bio)
-				readout += "\nTOXIN [armor_to_protection_class(armor.bio)]"
+				readout += "\nBIOHAZARD [armor_to_protection_class(armor.bio)]"
 			if(armor.bomb)
 				readout += "\nEXPLOSIVE [armor_to_protection_class(armor.bomb)]"
 			if(armor.bullet)


### PR DESCRIPTION

## About The Pull Request
when you examine the protective values of an item, it will show you its bio armor as TOXIN, but thats not really the case, BIOHAZARD is more fit so we set it to that

## Why It's Good For The Game
wa

## Changelog
:cl:
spellcheck: renames TOXIN to BIOHAZARD in clothing protective tag
/:cl:
