### PR TITLE
makes mining point cards reusable

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -255,28 +255,45 @@
 	w_class = WEIGHT_CLASS_TINY
 
 /**********************Mining Point Card**********************/
-
+#define TO_USER_ID "To ID"
+#define TO_POINT_CARD "To Card"
 /obj/item/card/mining_point_card
-	name = "mining points card"
-	desc = "A small card preloaded with mining points. Swipe your ID card over it to transfer the points, then discard."
+	name = "mining point transfer card"
+	desc = "A small, reusable card for transferring mining points. Swipe your ID card over it to start the process."
 	icon_state = "data_1"
 	var/points = 500
 
 /obj/item/card/mining_point_card/attackby(obj/item/I, mob/user, params)
 	if(isidcard(I))
-		if(points)
-			var/obj/item/card/id/C = I
-			C.mining_points += points
-			to_chat(user, span_info("You transfer [points] points to [C]."))
-			points = 0
-		else
-			to_chat(user, span_alert("There's no points left on [src]."))
+		var/obj/item/card/id/swiped = I
+		balloon_alert(user, "starting transfer")
+		var/point_movement = (tgui_alert(user, "To ID (from card) or to card (from ID)?", "Mining Points Transfer", list(TO_USER_ID, TO_POINT_CARD)))
+		if(!point_movement)
+			return
+		var/amount = tgui_input_number(user, "How much do you want to transfer?\nID Balance: [swiped.mining_points], Card Balance: [points]", "Transfer Points", min_value = 0, round_value = 1)
+		if(!amount)
+			return
+		switch(point_movement)
+			if(TO_USER_ID)
+				if(amount > points)
+					amount = points
+				swiped.mining_points += amount
+				points -= amount
+				to_chat(user, span_notice("You transfer [amount] mining points from [src] to [swiped]."))
+			if(TO_POINT_CARD)
+				if(amount > swiped.mining_points)
+					amount = swiped.mining_points
+				swiped.mining_points -= amount
+				points += amount
+				to_chat(user, span_notice("You transfer [amount] mining points from [swiped] to [src]."))
 	..()
 
 /obj/item/card/mining_point_card/examine(mob/user)
 	. = ..()
-	. += span_alert("There's [points] point\s on the card.")
+	. += span_notice("There's [points] point\s on the card.")
 
+#undef TO_POINT_CARD
+#undef TO_USER_ID
 /obj/item/storage/backpack/duffelbag/mining_conscript
 	name = "mining conscription kit"
 	desc = "A kit containing everything a crewmember needs to support a shaft miner in the field."

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -267,7 +267,7 @@
 	if(isidcard(I))
 		var/obj/item/card/id/swiped = I
 		balloon_alert(user, "starting transfer")
-		var/point_movement = (tgui_alert(user, "To ID (from card) or to card (from ID)?", "Mining Points Transfer", list(TO_USER_ID, TO_POINT_CARD)))
+		var/point_movement = tgui_alert(user, "To ID (from card) or to card (from ID)?", "Mining Points Transfer", list(TO_USER_ID, TO_POINT_CARD))
 		if(!point_movement)
 			return
 		var/amount = tgui_input_number(user, "How much do you want to transfer? ID Balance: [swiped.mining_points], Card Balance: [points]", "Transfer Points", min_value = 0, round_value = 1)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -270,7 +270,7 @@
 		var/point_movement = (tgui_alert(user, "To ID (from card) or to card (from ID)?", "Mining Points Transfer", list(TO_USER_ID, TO_POINT_CARD)))
 		if(!point_movement)
 			return
-		var/amount = tgui_input_number(user, "How much do you want to transfer?\nID Balance: [swiped.mining_points], Card Balance: [points]", "Transfer Points", min_value = 0, round_value = 1)
+		var/amount = tgui_input_number(user, "How much do you want to transfer? ID Balance: [swiped.mining_points], Card Balance: [points]", "Transfer Points", min_value = 0, round_value = 1)
 		if(!amount)
 			return
 		switch(point_movement)


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/31829017/199078509-678b7139-f99a-4f10-b716-33ccb8faef7b.png)
![image](https://user-images.githubusercontent.com/31829017/199137091-9555afde-5d1b-4b3e-a3a0-ec21a7acf7f3.png)
![image](https://user-images.githubusercontent.com/31829017/199078524-d71831dd-b164-40f3-92d0-8446c0976e3c.png)
Mining point cards are now reusable sources of point storage and transfer, because printing a billion cards to transfer points was pretty dumb and I disagree with it fundamentally.

## Why It's Good For The Game
No longer will shaft mining spessmen have to print twenty point cards to line their friend's pockets with vendor gear of their choice, or whatever.

also because I firmly believe nobody actually liked printing that many point cards I mean goddamn what a hassle -

## Changelog
:cl:
qol: Mining point cards are now reusable, allowing user-set transfers of mining points to and from the point card itself.
/:cl: