### PR TITLE
Raises minimum age to 18

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -408,7 +408,7 @@
 #define OFFSET_NECK "neck"
 
 //MINOR TWEAKS/MISC
-#define AGE_MIN 17 //youngest a character can be
+#define AGE_MIN 18 //youngest a character can be
 #define AGE_MAX 85 //oldest a character can be
 #define AGE_MINOR 20  //legal age of space drinking and smoking
 #define WIZARD_AGE_MIN 30 //youngest a wizard can be


### PR DESCRIPTION

## About The Pull Request

Minimum age for all mobs is now 18 instead of 17.

## Why It's Good For The Game

_Sigh._

OKAY.

HERE WE GO.

Let's start off simply with IC implications. I get it's a megacorporation, but even corporations know not to put _minors_ into roles of power or otherwise significant importance. Every single job in the game requires some form of education, training or otherwise specialisation that a 17-year old could not feasibly have. Nobody is hiring a 17-year old as a station captain, an engineer meant to FIX AND MAINTAIN the station, security, a doctor - the list goes on. No matter how corrupt NT is, they wouldn't hire goddamn children to do work on a sensitive research station. 

And, now, let's go with the actual reason this PR is being made.

Yes, I get the _potential_ for something interesting. Yes, I get that it's 'not weird until someone makes it weird', and that the admins will, hopefully, deal with anyone who does make it weird.

But let's be real here - why the hell are we letting something that has the potential to be that weird and cause issues for admin continue existing _for no real justifiable reason?_

Bombs can be used for PVP, for antagonising, for science. Traitor tools exist for traitoring. Almost every object, feature or function in-game that CAN break the rules still has a use outside of blatant grief. This? This is used exclusively to cause issues.

Genuinely - when's the last time you saw someone with character age 17 and went 'wow that's interesting' instead of 'this person is being weird about it'?

The only reason this feature exists is to make things weird. It's that simple. It's used exclusively by bad faith actors or worse, always causes headaches for the staff team when having to be dealt with, makes everyone uncomfortable when it IS used in that bad faith way and - look, it's WEIRD. We KNOW it's weird.

So, I am appealing to both the community and the maintainer team here. Sit, please, for a minute, and think about it for a second. What does /tg/ gain from having such an easily accessible drama source? What does /tg/ gain from having minors on-station? Isn't this an 18+ server? Yes, you can make the case that 'oh we're all adults here we can be responsible with this' but LET'S BE HONEST. WE CAN'T. You look at the average /tg/ player, do you think 'I can trust this man'? NO. Time and time again we've been proven wrong, not just about this, but with almost every feature in game. So much was nerfed or removed because players abused it, and this is probably the WORST of it all.

So, please, maintainers, people of /tg/, hear me out. Let's have the minimum age be 18. Just so no more of us have to deal with any more bullshit that happens because of its abuse. Let's make the jobs of staff easier, let's take a tool away from griefers, let's just BE DECENT PEOPLE. AND NOT PUT MINORS IN OUR FUNNY GAME.



## Changelog

:cl:
qol: Minimum age raised from 17 to 18.
/:cl:
