### PR TITLE
Fix assemblies not pick-upable after detaching from chemical grenade

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -82,6 +82,7 @@
 	if(S && istype(S))
 		assemblies -= color
 		S.connected = null
+		S.holder = null
 		S.forceMove(holder.drop_location())
 		var/obj/item/grenade/chem_grenade/G = holder
 		G.landminemode = null


### PR DESCRIPTION
Assemblies (signallers, mousetraps, timers, etc.) can be picked up again after detaching from chemical grenade
Fixes #70955

## Changelog
:cl:
fix: Assemblies can be picked up again after detaching from chemical grenade
/:cl:
