### PR TITLE
Makes tanks drop if ejected when not adjacent

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -178,7 +178,10 @@
 	if(!user)
 		return FALSE
 	if(holding)
-		user.put_in_hands(holding)
+		if(Adjacent(user))
+			user.put_in_hands(holding)
+		else
+			holding.forceMove(get_turf(src))
 		UnregisterSignal(holding, COMSIG_PARENT_QDELETING)
 		holding = null
 	if(new_tank)


### PR DESCRIPTION

## About The Pull Request
Makes atmos machines drop their tanks on their tile when eject is pressed if the user isn't adjacent to it.
## Why It's Good For The Game
Fixes #70950 
## Changelog
:cl:
fix: AIs no longer teleport gas tanks to them when ejecting tanks from atmos machinery
/:cl:
