### PR TITLE
Glass inconsistency fixes

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -356,7 +356,7 @@
 	remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 	for(var/atom/movable/cleanables as anything in src)
 		if(cleanables == src)
-			continue 
+			continue
 		if(!cleanables.wash(clean_types))
 			continue
 		vis_contents -= cleanables
@@ -446,7 +446,7 @@
 	damage_deflection = 11
 	state = RWINDOW_SECURE
 	glass_type = /obj/item/stack/sheet/rglass
-	rad_insulation = RAD_HEAVY_INSULATION
+	rad_insulation = RAD_LIGHT_INSULATION
 	receive_ricochet_chance_mod = 1.1
 
 //this is shitcode but all of construction is shitcode and needs a refactor, it works for now
@@ -567,7 +567,7 @@
 	max_integrity = 200
 	explosion_block = 1
 	glass_type = /obj/item/stack/sheet/plasmaglass
-	rad_insulation = RAD_NO_INSULATION
+	rad_insulation = RAD_MEDIUM_INSULATION
 
 /obj/structure/window/plasma/Initialize(mapload, direct)
 	. = ..()
@@ -605,6 +605,7 @@
 	damage_deflection = 21
 	explosion_block = 2
 	glass_type = /obj/item/stack/sheet/plasmarglass
+	rad_insulation = RAD_HEAVY_INSULATION
 
 /obj/structure/window/reinforced/plasma/block_superconductivity()
 	return TRUE
@@ -736,6 +737,7 @@
 	glass_type = /obj/item/stack/sheet/titaniumglass
 	glass_amount = 2
 	receive_ricochet_chance_mod = 1.2
+	rad_insulation = RAD_MEDIUM_INSULATION
 
 /obj/structure/window/reinforced/shuttle/spawnDebris(location)
 	. = list()
@@ -775,7 +777,7 @@
 	damage_deflection = 21 //The same as reinforced plasma windows.3
 	glass_type = /obj/item/stack/sheet/plastitaniumglass
 	glass_amount = 2
-	rad_insulation = RAD_HEAVY_INSULATION
+	rad_insulation = RAD_EXTREME_INSULATION
 
 /obj/structure/window/reinforced/plasma/plastitanium/spawnDebris(location)
 	. = list()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -652,7 +652,7 @@
 	icon = 'icons/obj/smooth_structures/plasma_window.dmi'
 	icon_state = "plasma_window-0"
 	base_icon_state = "plasma_window"
-	max_integrity = 300
+	max_integrity = 400
 	fulltile = TRUE
 	flags_1 = PREVENT_CLICK_UNDER_1
 	smoothing_flags = SMOOTH_BITMASK


### PR DESCRIPTION

## About The Pull Request
Some glass types strangely had no radiation blocking abilities like normal plasma glass, which doesn't make any sense, though reinforced glass was able to block almost all. This also fixes fulltile plasma glass to have twice as much integrity as the normal amount, like with all the other glass types.
## Why It's Good For The Game
Inconsistency fixes
## Changelog
:cl:
fix: Fixes radiation blocking properties of glass types.
/:cl:
