### PR TITLE
Fixed an infinitely-printing log message about pipenets.

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -444,9 +444,9 @@ SUBSYSTEM_DEF(air)
 				var/static/pipenetwarnings = 10
 				if(pipenetwarnings > 0)
 					log_mapping("build_pipeline(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)].")
-				if(pipenetwarnings == 0)
-					log_mapping("build_pipeline(): further messages about pipenets will be suppressed")
-				pipenetwarnings--
+					pipenetwarnings--
+					if(pipenetwarnings == 0)
+						log_mapping("build_pipeline(): further messages about pipenets will be suppressed")
 
 			net.members += item
 			border += item

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -444,9 +444,9 @@ SUBSYSTEM_DEF(air)
 				var/static/pipenetwarnings = 10
 				if(pipenetwarnings > 0)
 					log_mapping("build_pipeline(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)].")
-					pipenetwarnings--
 				if(pipenetwarnings == 0)
 					log_mapping("build_pipeline(): further messages about pipenets will be suppressed")
+				pipenetwarnings--
 
 			net.members += item
 			border += item

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -92,9 +92,9 @@
 					var/static/pipenetwarnings = 10
 					if(pipenetwarnings > 0)
 						log_mapping("build_pipeline(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)].")
-					if(pipenetwarnings == 0)
-						log_mapping("build_pipeline(): further messages about pipenets will be suppressed")
-					pipenetwarnings--
+						pipenetwarnings--
+						if(pipenetwarnings == 0)
+							log_mapping("build_pipeline(): further messages about pipenets will be suppressed")
 
 				members += item
 				possible_expansions += item


### PR DESCRIPTION

## About The Pull Request

A slight logging error resulted in a specific warning about pipenets never being suppressed, instead continually printing the message that states that further messages will be suppressed. This was caused by the limit on pipenet warnings being decremented in the wrong place. This oversight has been corrected.
## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/105025397/199134575-ce47f47c-6796-4478-8478-19087308bfd8.png)

This is really annoying to scroll through.
## Changelog
:cl:
fix: Properly suppressed a message about suppressing messages.
/:cl:
