### PR TITLE
Speed up autoname/LateInitialize from 0.27s to 400us (on Meta)

### DIFF
--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -56,17 +56,15 @@
 
 /obj/machinery/camera/autoname/LateInitialize()
 	. = ..()
-	number = 1
-	var/area/A = get_area(src)
-	if(A)
-		for(var/obj/machinery/camera/autoname/C in GLOB.machines)
-			if(C == src)
-				continue
-			var/area/CA = get_area(C)
-			if(CA.type == A.type)
-				if(C.number)
-					number = max(number, C.number+1)
-		c_tag = "[format_text(A.name)] #[number]"
+
+	var/static/list/autonames_in_areas = list()
+
+	var/area/camera_area = get_area(src)
+
+	number = autonames_in_areas[camera_area] + 1
+	autonames_in_areas[camera_area] = number
+
+	c_tag = "[format_text(camera_area.name)] #[number]"
 
 
 // UPGRADE PROCS


### PR DESCRIPTION
Each call was taking 3ms each, 56 times for Meta. Actual results are slightly better because I'm testing with only the map, and no ruins.