### PR TITLE
Remove ELEMENT_DETACH on everything that doesn't need it, rename to ELEMENT_DETACH_ON_HOST_DESTROY + a PSA (about 0.2s init time savings)

### DIFF
--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -9,8 +9,11 @@
 #define ELEMENT_INCOMPATIBLE 1
 
 // /datum/element flags
-/// Causes the detach proc to be called when the host object is being deleted
-#define ELEMENT_DETACH (1 << 0)
+/// Causes the detach proc to be called when the host object is being deleted.
+/// Should only be used if you need to perform cleanup not related to the host object.
+/// You do not need this if you are only unregistering signals, for instance.
+/// You would need it if you are doing something like removing the target from a processing list.
+#define ELEMENT_DETACH_ON_HOST_DESTROY (1 << 0)
 /**
  * Only elements created with the same arguments given after `id_arg_index` share an element instance
  * The arguments are the same when the text and number values are the same and all other values have the same ref

--- a/code/datums/elements/ELEMENT_TEMPLATE.md
+++ b/code/datums/elements/ELEMENT_TEMPLATE.md
@@ -5,7 +5,7 @@ See _element.dm for detailed explanations
 
 ```dm
 /datum/element/myelement
-	element_flags = ELEMENT_BESPOKE | ELEMENT_COMPLEX_DETACH | ELEMENT_DETACH | ELEMENT_NOTAREALFLAG    // code/__DEFINES/dcs/flags.dm
+	element_flags = ELEMENT_BESPOKE | ELEMENT_COMPLEX_DETACH | ELEMENT_DETACH_ON_HOST_DESTROY | ELEMENT_NOTAREALFLAG    // code/__DEFINES/dcs/flags.dm
 	//id_arg_index = 2                                                                                  // Use with ELEMENT_BESPOKE
 	var/list/myvar = list()
 

--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -22,7 +22,7 @@
 	if(type == /datum/element)
 		return ELEMENT_INCOMPATIBLE
 	SEND_SIGNAL(target, COMSIG_ELEMENT_ATTACH, src)
-	if(element_flags & ELEMENT_DETACH)
+	if(element_flags & ELEMENT_DETACH_ON_HOST_DESTROY)
 		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/OnTargetDelete, override = TRUE)
 
 /datum/element/proc/OnTargetDelete(datum/source, force)

--- a/code/datums/elements/art.dm
+++ b/code/datums/elements/art.dm
@@ -1,5 +1,5 @@
 /datum/element/art
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	var/impressiveness = 0
 

--- a/code/datums/elements/art.dm
+++ b/code/datums/elements/art.dm
@@ -1,5 +1,5 @@
 /datum/element/art
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 	var/impressiveness = 0
 

--- a/code/datums/elements/atmos_sensitive.dm
+++ b/code/datums/elements/atmos_sensitive.dm
@@ -3,7 +3,7 @@
 //And removes it as soon as the object is no longer interested
 //Don't put it on things that tend to clump into one spot, you will cause lag spikes.
 /datum/element/atmos_sensitive
-	element_flags = ELEMENT_DETACH
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 	var/static/list/pass_on = list(COMSIG_TURF_EXPOSE = /atom/proc/check_atmos_process)
 
 /datum/element/atmos_sensitive/Attach(datum/target, mapload)

--- a/code/datums/elements/bane.dm
+++ b/code/datums/elements/bane.dm
@@ -1,6 +1,6 @@
 /// Deals extra damage to mobs of a certain type or species.
 /datum/element/bane
-	element_flags = ELEMENT_DETACH|ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	/// can be a mob or a species.
 	var/target_type

--- a/code/datums/elements/basic_eating.dm
+++ b/code/datums/elements/basic_eating.dm
@@ -4,7 +4,7 @@
  * Small behavior for non-carbons to eat certain stuff they interact with
  */
 /datum/element/basic_eating
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	///Path of the reagent added
 	var/heal_amt

--- a/code/datums/elements/beauty.dm
+++ b/code/datums/elements/beauty.dm
@@ -4,7 +4,7 @@
  * Shabbier, dirtier ones lead to negative moodlets EXCLUSIVE to characters with the snob quirk.
  */
 /datum/element/beauty
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH_ON_HOST_DESTROY
 	id_arg_index = 2
 	var/beauty = 0
 	/**

--- a/code/datums/elements/bed_tucking.dm
+++ b/code/datums/elements/bed_tucking.dm
@@ -1,6 +1,6 @@
 /// Tucking element, for things that can be tucked into bed.
 /datum/element/bed_tuckable
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	/// our pixel_x offset - how much the item moves x when in bed (+x is closer to the pillow)
 	var/x_offset = 0

--- a/code/datums/elements/bump_click.dm
+++ b/code/datums/elements/bump_click.dm
@@ -4,7 +4,7 @@
  * Simulates a click on the attached atom when it's bumped, if the bumper and their active object meet certain criteria.
  */
 /datum/element/bump_click
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 	///Tool behaviours to check for on the bumper's active held item before clicking the attached atom with it.
 	var/list/tool_behaviours

--- a/code/datums/elements/bump_click.dm
+++ b/code/datums/elements/bump_click.dm
@@ -4,7 +4,7 @@
  * Simulates a click on the attached atom when it's bumped, if the bumper and their active object meet certain criteria.
  */
 /datum/element/bump_click
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	///Tool behaviours to check for on the bumper's active held item before clicking the attached atom with it.
 	var/list/tool_behaviours

--- a/code/datums/elements/chemical_transfer.dm
+++ b/code/datums/elements/chemical_transfer.dm
@@ -12,7 +12,7 @@
  * victim_message uses %ATTACKER for the same.
  */
 /datum/element/chemical_transfer
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	///chance for the chemical transfer to proc.
 	var/transfer_prob

--- a/code/datums/elements/chewable.dm
+++ b/code/datums/elements/chewable.dm
@@ -1,7 +1,7 @@
 /// Anything with this element will provide the reagents inside the
 /// item to the user when it is equipped.
 /datum/element/chewable
-	element_flags = ELEMENT_DETACH | ELEMENT_BESPOKE
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY | ELEMENT_BESPOKE
 	id_arg_index = 2
 
 	/// The amount to metabolize per second

--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -1,5 +1,5 @@
 /datum/element/climbable
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	///Time it takes to climb onto the object
 	var/climb_time = (2 SECONDS)

--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -1,5 +1,5 @@
 /datum/element/climbable
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 	///Time it takes to climb onto the object
 	var/climb_time = (2 SECONDS)

--- a/code/datums/elements/content_barfer.dm
+++ b/code/datums/elements/content_barfer.dm
@@ -4,7 +4,6 @@
  * Used for morphs and bileworms!
  */
 /datum/element/content_barfer
-	element_flags = ELEMENT_DETACH
 	id_arg_index = 2
 
 /datum/element/content_barfer/Attach(datum/target, tally_string)

--- a/code/datums/elements/crackable.dm
+++ b/code/datums/elements/crackable.dm
@@ -1,6 +1,6 @@
 /// Adds crack overlays to an object when integrity gets low
 /datum/element/crackable
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	var/list/icon/crack_icons
 	/// The level at which the object starts showing cracks, 1 being at full health and 0.5 being at half health

--- a/code/datums/elements/crusher_loot.dm
+++ b/code/datums/elements/crusher_loot.dm
@@ -4,7 +4,7 @@
  * Used for all the mobs droppin' crusher trophies
  */
 /datum/element/crusher_loot
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	/// Path of the trophy dropped
 	var/trophy_type

--- a/code/datums/elements/cult_eyes.dm
+++ b/code/datums/elements/cult_eyes.dm
@@ -4,7 +4,6 @@
  * Applies and removes the glowing cult eyes
  */
 /datum/element/cult_eyes
-	element_flags = ELEMENT_DETACH
 
 /datum/element/cult_eyes/Attach(datum/target, initial_delay = 20 SECONDS)
 	. = ..()

--- a/code/datums/elements/cult_halo.dm
+++ b/code/datums/elements/cult_halo.dm
@@ -4,7 +4,6 @@
  * Applies and removes the cult halo
  */
 /datum/element/cult_halo
-	element_flags = ELEMENT_DETACH
 
 /datum/element/cult_halo/Attach(datum/target, initial_delay = 20 SECONDS)
 	. = ..()

--- a/code/datums/elements/curse_announcement.dm
+++ b/code/datums/elements/curse_announcement.dm
@@ -6,7 +6,7 @@
  * Possible improvements for the future: add an option to allow the cursed affix to be a prefix. right now only coded for suffixes
  */
 /datum/element/curse_announcement
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	///message sent on announce
 	var/announcement_message

--- a/code/datums/elements/cursed.dm
+++ b/code/datums/elements/cursed.dm
@@ -4,7 +4,6 @@
  *Attaching this element to something will make it float, and get a special ai controller!
  */
 /datum/element/cursed
-	element_flags = ELEMENT_DETACH
 
 /datum/element/cursed/Attach(datum/target, slot)
 	. = ..()

--- a/code/datums/elements/decals/_decal.dm
+++ b/code/datums/elements/decals/_decal.dm
@@ -1,5 +1,5 @@
 /datum/element/decal
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH_ON_HOST_DESTROY
 	id_arg_index = 2
 	/// Whether this decal can be cleaned.
 	var/cleanable

--- a/code/datums/elements/delete_on_drop.dm
+++ b/code/datums/elements/delete_on_drop.dm
@@ -2,7 +2,6 @@
  * Attaches to an item, if that item is dropped on the floor delete it
  */
 /datum/element/delete_on_drop
-	element_flags = ELEMENT_DETACH
 	var/list/myvar = list()
 
 /datum/element/delete_on_drop/Attach(datum/target)

--- a/code/datums/elements/deliver_first.dm
+++ b/code/datums/elements/deliver_first.dm
@@ -9,7 +9,7 @@
 
 #define DENY_SOUND_COOLDOWN (2 SECONDS)
 /datum/element/deliver_first
-	element_flags = ELEMENT_DETACH | ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	///typepath of the area we will be allowed to be opened in
 	var/goal_area_type

--- a/code/datums/elements/diggable.dm
+++ b/code/datums/elements/diggable.dm
@@ -1,6 +1,6 @@
 /// Lets you make hitting a turf with a shovel pop something out, and scrape the turf
 /datum/element/diggable
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	/// Typepath of what we spawn on shovel
 	var/atom/to_spawn

--- a/code/datums/elements/diggable.dm
+++ b/code/datums/elements/diggable.dm
@@ -1,6 +1,6 @@
 /// Lets you make hitting a turf with a shovel pop something out, and scrape the turf
 /datum/element/diggable
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 	/// Typepath of what we spawn on shovel
 	var/atom/to_spawn

--- a/code/datums/elements/digitalcamo.dm
+++ b/code/datums/elements/digitalcamo.dm
@@ -1,5 +1,5 @@
 /datum/element/digitalcamo
-	element_flags = ELEMENT_DETACH
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 	var/list/attached_mobs = list()
 
 /datum/element/digitalcamo/New()

--- a/code/datums/elements/drag_pickup.dm
+++ b/code/datums/elements/drag_pickup.dm
@@ -4,7 +4,6 @@
  * Used for paper bins.
  */
 /datum/element/drag_pickup
-	element_flags = ELEMENT_DETACH
 
 /datum/element/drag_pickup/Attach(datum/target)
 	if(!ismovable(target))

--- a/code/datums/elements/earhealing.dm
+++ b/code/datums/elements/earhealing.dm
@@ -1,5 +1,5 @@
 /datum/element/earhealing
-	element_flags = ELEMENT_DETACH
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 	var/list/user_by_item = list()
 
 /datum/element/earhealing/Attach(datum/target)

--- a/code/datums/elements/easily_fragmented.dm
+++ b/code/datums/elements/easily_fragmented.dm
@@ -4,7 +4,7 @@
  */
 
 /datum/element/easily_fragmented
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 
 	var/break_chance

--- a/code/datums/elements/empprotection.dm
+++ b/code/datums/elements/empprotection.dm
@@ -1,5 +1,5 @@
 /datum/element/empprotection
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 	var/flags = NONE
 

--- a/code/datums/elements/empprotection.dm
+++ b/code/datums/elements/empprotection.dm
@@ -1,5 +1,5 @@
 /datum/element/empprotection
-	element_flags = ELEMENT_DETACH | ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	var/flags = NONE
 

--- a/code/datums/elements/eyestab.dm
+++ b/code/datums/elements/eyestab.dm
@@ -3,7 +3,7 @@
 
 /// An element that lets you stab people in the eyes when targeting them
 /datum/element/eyestab
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 
 	/// The amount of damage to do per eyestab

--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -2,7 +2,7 @@
 
 ///Footstep element. Plays footsteps at parents location when it is appropriate.
 /datum/element/footstep
-	element_flags = ELEMENT_DETACH|ELEMENT_BESPOKE
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY|ELEMENT_BESPOKE
 	id_arg_index = 2
 	///A list containing living mobs and the number of steps they have taken since the last time their footsteps were played.
 	var/list/steps_for_living = list()

--- a/code/datums/elements/frozen.dm
+++ b/code/datums/elements/frozen.dm
@@ -2,7 +2,6 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 
 ///simple element to handle frozen obj's
 /datum/element/frozen
-	element_flags = ELEMENT_DETACH
 
 /datum/element/frozen/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/haunted.dm
+++ b/code/datums/elements/haunted.dm
@@ -1,6 +1,5 @@
 ///Attaching this element to something will make it float, get a special ai controller, and gives it a spooky outline.
 /datum/element/haunted
-	element_flags = ELEMENT_DETACH
 
 /datum/element/haunted/Attach(datum/target, haunt_color = "#f8f8ff")
 	. = ..()

--- a/code/datums/elements/honkspam.dm
+++ b/code/datums/elements/honkspam.dm
@@ -1,6 +1,5 @@
 /// Attachable to items. Plays a bikehorn sound whenever attack_self is called (with a cooldown).
 /datum/element/honkspam
-	element_flags = ELEMENT_DETACH
 
 /datum/element/honkspam/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/item_fov.dm
+++ b/code/datums/elements/item_fov.dm
@@ -1,6 +1,6 @@
 /// An element to unconditonally add a FOV trait to the wearer, removing it when an item is unequipped
 /datum/element/item_fov
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	/// Angle of the FoV we will apply when someone wears the clothing this element is attached to.
 	var/fov_angle

--- a/code/datums/elements/kneecapping.dm
+++ b/code/datums/elements/kneecapping.dm
@@ -15,7 +15,6 @@
  * Passing all the checks will cancel the entire attack chain.
  */
 /datum/element/kneecapping
-	element_flags = ELEMENT_DETACH
 
 /datum/element/kneecapping/Attach(datum/target)
 	if(!isitem(target))

--- a/code/datums/elements/kneejerk.dm
+++ b/code/datums/elements/kneejerk.dm
@@ -1,6 +1,5 @@
 /// An element which enables certain items to tap people on their knees to measure brain health
 /datum/element/kneejerk
-	element_flags = ELEMENT_DETACH
 
 /datum/element/kneejerk/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/lazy_fishing_spot.dm
+++ b/code/datums/elements/lazy_fishing_spot.dm
@@ -1,6 +1,6 @@
 // Lazy fishing spot element so fisheable turfs do not have a component each since they're usually pretty common on their respective maps (lava/water/etc)
 /datum/element/lazy_fishing_spot
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 	var/configuration
 

--- a/code/datums/elements/lazy_fishing_spot.dm
+++ b/code/datums/elements/lazy_fishing_spot.dm
@@ -1,6 +1,6 @@
 // Lazy fishing spot element so fisheable turfs do not have a component each since they're usually pretty common on their respective maps (lava/water/etc)
 /datum/element/lazy_fishing_spot
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	var/configuration
 

--- a/code/datums/elements/lifesteal.dm
+++ b/code/datums/elements/lifesteal.dm
@@ -3,7 +3,7 @@
  * by a flat amount whenever a successful attack is performed against another living mob.
  */
 /datum/element/lifesteal
-	element_flags = ELEMENT_DETACH|ELEMENT_BESPOKE
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY|ELEMENT_BESPOKE
 	id_arg_index = 2
 	/// heals a constant amount every time a hit occurs
 	var/flat_heal

--- a/code/datums/elements/light_blocking.dm
+++ b/code/datums/elements/light_blocking.dm
@@ -2,7 +2,7 @@
  * Attached to movable atoms with opacity. Listens to them move and updates their old and new turf loc's opacity accordingly.
  */
 /datum/element/light_blocking
-	element_flags = ELEMENT_DETACH
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
 
 /datum/element/light_blocking/Attach(datum/target)

--- a/code/datums/elements/light_eaten.dm
+++ b/code/datums/elements/light_eaten.dm
@@ -2,7 +2,6 @@
  * Makes anything that it attaches to incapable of producing light
  */
 /datum/element/light_eaten
-	element_flags = ELEMENT_DETACH
 
 /datum/element/light_eaten/Attach(atom/target)
 	if(!isatom(target))

--- a/code/datums/elements/light_eaten.dm
+++ b/code/datums/elements/light_eaten.dm
@@ -2,6 +2,7 @@
  * Makes anything that it attaches to incapable of producing light
  */
 /datum/element/light_eaten
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 
 /datum/element/light_eaten/Attach(atom/target)
 	if(!isatom(target))

--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -4,7 +4,6 @@
  * The temporary equivalent is [/datum/component/light_eater]
  */
 /datum/element/light_eater
-	element_flags = ELEMENT_DETACH
 
 /datum/element/light_eater/Attach(datum/target)
 	if(isatom(target))

--- a/code/datums/elements/mob_killed_tally.dm
+++ b/code/datums/elements/mob_killed_tally.dm
@@ -4,7 +4,7 @@
  * Used for all the mining mobs!
  */
 /datum/element/mob_killed_tally
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	/// Which tally needs to be ticked up in the blackbox
 	var/tally_string

--- a/code/datums/elements/movement_turf_changer.dm
+++ b/code/datums/elements/movement_turf_changer.dm
@@ -4,7 +4,7 @@
  * Used for moonicorns!
  */
 /datum/element/movement_turf_changer
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	///Path of the turf added on top
 	var/turf_type

--- a/code/datums/elements/movetype_handler.dm
+++ b/code/datums/elements/movetype_handler.dm
@@ -5,7 +5,7 @@
  * before adding them to non-living movables.
  */
 /datum/element/movetype_handler
-	element_flags = ELEMENT_DETACH
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
 	var/list/attached_atoms = list()
 	var/list/paused_floating_anim_atoms = list()

--- a/code/datums/elements/nerfed_pulling.dm
+++ b/code/datums/elements/nerfed_pulling.dm
@@ -1,6 +1,6 @@
 /// This living will be slower when pulling/moving anything in the given typecache
 /datum/element/nerfed_pulling
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY
 	id_arg_index = 2
 
 	/// The typecache of things that shouldn't be easily movable

--- a/code/datums/elements/obj_regen.dm
+++ b/code/datums/elements/obj_regen.dm
@@ -1,7 +1,7 @@
 /** Object integrity regeneration element added by alien alloy.
  */
 /datum/element/obj_regen
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY
 	id_arg_index = 2
 	/// The rate of regeneration as a function of maximum integrity.
 	var/rate

--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -3,7 +3,6 @@
  * having to pixelhunt for portions not occupied by object or mob visuals.
  */
 /datum/element/openspace_item_click_handler
-	element_flags = ELEMENT_DETACH
 
 /datum/element/openspace_item_click_handler/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/pet_bonus.dm
+++ b/code/datums/elements/pet_bonus.dm
@@ -5,7 +5,7 @@
  * I may have been able to make this work for carbons, but it would have been interjecting on some help mode interactions anyways.
  */
 /datum/element/pet_bonus
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 
 	///optional cute message to send when you pet your pet!

--- a/code/datums/elements/point_of_interest.dm
+++ b/code/datums/elements/point_of_interest.dm
@@ -1,6 +1,6 @@
 /// Designates the atom as a "point of interest", meaning it can be directly orbited
 /datum/element/point_of_interest
-	element_flags = ELEMENT_DETACH
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
 /datum/element/point_of_interest/Attach(datum/target)
 	if (!isatom(target))

--- a/code/datums/elements/prevent_attacking_of_types.dm
+++ b/code/datums/elements/prevent_attacking_of_types.dm
@@ -1,7 +1,7 @@
 /// This hostile will not be able to attack a given typecache, and will receive
 /// a balloon alert when it tries to.
 /datum/element/prevent_attacking_of_types
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 
 	/// The typecache of things this hostile can't attack

--- a/code/datums/elements/radiation_protected_clothing.dm
+++ b/code/datums/elements/radiation_protected_clothing.dm
@@ -2,7 +2,6 @@
 /// Adds the TRAIT_RADIATION_PROTECTED_CLOTHING trait, as well as adding an
 /// extra bit to the examine descrpition.
 /datum/element/radiation_protected_clothing
-	element_flags = ELEMENT_DETACH
 
 /datum/element/radiation_protected_clothing/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/radioactive.dm
+++ b/code/datums/elements/radioactive.dm
@@ -3,7 +3,7 @@
 /// This atom will regularly pulse radiation.
 /// As this is only applied on uranium objects for now, this defaults to uranium constants.
 /datum/element/radioactive
-	element_flags = ELEMENT_DETACH
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
 	var/list/radioactive_objects = list()
 

--- a/code/datums/elements/ranged_attacks.dm
+++ b/code/datums/elements/ranged_attacks.dm
@@ -1,6 +1,6 @@
 ///This proc is used by basic mobs to give them a simple ranged attack! In theory this could be extended to
 /datum/element/ranged_attacks
-	element_flags = ELEMENT_DETACH | ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	var/casingtype = /obj/item/ammo_casing/glockroach
 	var/projectilesound = 'sound/weapons/gun/pistol/shot.ogg'

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -7,7 +7,7 @@
  * just having the variables, behavior, and procs be standardized is still a big improvement.
  */
 /datum/element/ridable
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH_ON_HOST_DESTROY
 	id_arg_index = 2
 
 	/// The specific riding component subtype we're loading our instructions from, don't leave this as default please!

--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -3,7 +3,7 @@
  * The overlay can be specified in new as the first paramter; if not set it defaults to rust_overlay's rust_default
  */
 /datum/element/rust
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 	/// The rust image itself, since the icon and icon state are only used as an argument
 	var/image/rust_overlay

--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -3,7 +3,7 @@
  * The overlay can be specified in new as the first paramter; if not set it defaults to rust_overlay's rust_default
  */
 /datum/element/rust
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	/// The rust image itself, since the icon and icon state are only used as an argument
 	var/image/rust_overlay

--- a/code/datums/elements/screentips/contextual_screentip_bare_hands.dm
+++ b/code/datums/elements/screentips/contextual_screentip_bare_hands.dm
@@ -2,7 +2,7 @@
 /// A "Type B" interaction.
 /// This stacks with other contextual screentip elements, though you may want to register the signal/flag manually at that point for performance.
 /datum/element/contextual_screentip_bare_hands
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 
 	/// If set, the text to show for LMB

--- a/code/datums/elements/screentips/contextual_screentip_bare_hands.dm
+++ b/code/datums/elements/screentips/contextual_screentip_bare_hands.dm
@@ -2,7 +2,7 @@
 /// A "Type B" interaction.
 /// This stacks with other contextual screentip elements, though you may want to register the signal/flag manually at that point for performance.
 /datum/element/contextual_screentip_bare_hands
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 
 	/// If set, the text to show for LMB

--- a/code/datums/elements/screentips/contextual_screentip_item_typechecks.dm
+++ b/code/datums/elements/screentips/contextual_screentip_item_typechecks.dm
@@ -2,7 +2,7 @@
 /// A "Type B" interaction.
 /// This stacks with other contextual screentip elements, though you may want to register the signal/flag manually at that point for performance.
 /datum/element/contextual_screentip_item_typechecks
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 
 	/// Map of item paths to contexts to usages

--- a/code/datums/elements/screentips/contextual_screentip_item_typechecks.dm
+++ b/code/datums/elements/screentips/contextual_screentip_item_typechecks.dm
@@ -2,7 +2,7 @@
 /// A "Type B" interaction.
 /// This stacks with other contextual screentip elements, though you may want to register the signal/flag manually at that point for performance.
 /datum/element/contextual_screentip_item_typechecks
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 
 	/// Map of item paths to contexts to usages

--- a/code/datums/elements/screentips/contextual_screentip_sharpness.dm
+++ b/code/datums/elements/screentips/contextual_screentip_sharpness.dm
@@ -2,7 +2,7 @@
 /// A "Type B" interaction.
 /// This stacks with other contextual screentip elements, though you may want to register the signal/flag manually at that point for performance.
 /datum/element/contextual_screentip_sharpness
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 
 	/// If set, the text to show for LMB

--- a/code/datums/elements/screentips/contextual_screentip_sharpness.dm
+++ b/code/datums/elements/screentips/contextual_screentip_sharpness.dm
@@ -2,7 +2,7 @@
 /// A "Type B" interaction.
 /// This stacks with other contextual screentip elements, though you may want to register the signal/flag manually at that point for performance.
 /datum/element/contextual_screentip_sharpness
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 
 	/// If set, the text to show for LMB

--- a/code/datums/elements/screentips/contextual_screentip_tools.dm
+++ b/code/datums/elements/screentips/contextual_screentip_tools.dm
@@ -2,7 +2,7 @@
 /// A "Type B" interaction.
 /// This stacks with other contextual screentip elements, though you may want to register the signal/flag manually at that point for performance.
 /datum/element/contextual_screentip_tools
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 
 	/// Map of tool behaviors to contexts to usages

--- a/code/datums/elements/screentips/contextual_screentip_tools.dm
+++ b/code/datums/elements/screentips/contextual_screentip_tools.dm
@@ -2,7 +2,7 @@
 /// A "Type B" interaction.
 /// This stacks with other contextual screentip elements, though you may want to register the signal/flag manually at that point for performance.
 /datum/element/contextual_screentip_tools
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 
 	/// Map of tool behaviors to contexts to usages

--- a/code/datums/elements/series.dm
+++ b/code/datums/elements/series.dm
@@ -5,7 +5,7 @@
  * used for mechas and rare collectable hats, should totally be used for way more ;)
  */
 /datum/element/series
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	id_arg_index = 2
 	var/list/subtype_list
 	var/series_name

--- a/code/datums/elements/series.dm
+++ b/code/datums/elements/series.dm
@@ -5,7 +5,7 @@
  * used for mechas and rare collectable hats, should totally be used for way more ;)
  */
 /datum/element/series
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	var/list/subtype_list
 	var/series_name

--- a/code/datums/elements/simple_flying.dm
+++ b/code/datums/elements/simple_flying.dm
@@ -5,7 +5,6 @@
  * Note: works for carbons and above, but please do something better. humans have wings got dangit!
  */
 /datum/element/simple_flying
-	element_flags = ELEMENT_DETACH
 
 /datum/element/simple_flying/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/skittish.dm
+++ b/code/datums/elements/skittish.dm
@@ -3,7 +3,6 @@
  */
 
 /datum/element/skittish
-	element_flags = ELEMENT_DETACH
 
 /datum/element/skittish/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/snail_crawl.dm
+++ b/code/datums/elements/snail_crawl.dm
@@ -1,5 +1,5 @@
 /datum/element/snailcrawl
-	element_flags = ELEMENT_DETACH
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
 /datum/element/snailcrawl/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -4,7 +4,6 @@
  * Non bespoke element (1 in existence) that makes objs provide a soft landing when you fall on them!
  */
 /datum/element/soft_landing
-	element_flags = ELEMENT_DETACH
 
 /datum/element/soft_landing/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/soft_landing.dm
+++ b/code/datums/elements/soft_landing.dm
@@ -4,6 +4,7 @@
  * Non bespoke element (1 in existence) that makes objs provide a soft landing when you fall on them!
  */
 /datum/element/soft_landing
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 
 /datum/element/soft_landing/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/spooky.dm
+++ b/code/datums/elements/spooky.dm
@@ -1,5 +1,5 @@
 /datum/element/spooky
-	element_flags = ELEMENT_DETACH|ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	var/too_spooky = TRUE //will it spawn a new instrument?
 

--- a/code/datums/elements/squish.dm
+++ b/code/datums/elements/squish.dm
@@ -9,7 +9,7 @@
  * Normal squishes apply vertically, as if the target is being squished from above, but you can set reverse to TRUE if you want to squish them from the sides, like if they pancake into a wall from the East or West
 */
 /datum/element/squish
-	element_flags = ELEMENT_DETACH
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
 /datum/element/squish/Attach(datum/target, duration=20 SECONDS, reverse=FALSE)
 	. = ..()

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -1,6 +1,6 @@
 /// An element for atoms that, when dragged and dropped onto a mob, opens a strip panel.
 /datum/element/strippable
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY
 	id_arg_index = 2
 
 	/// An assoc list of keys to /datum/strippable_item

--- a/code/datums/elements/tenacious.dm
+++ b/code/datums/elements/tenacious.dm
@@ -4,7 +4,6 @@
  * Used by sparring sect!
  */
 /datum/element/tenacious
-	element_flags = ELEMENT_DETACH
 
 /datum/element/tenacious/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/trait_loc.dm
+++ b/code/datums/elements/trait_loc.dm
@@ -4,7 +4,7 @@
  * Adds a trait to the movable's loc, and handles relocating the trait if the movable itself moves.
  */
 /datum/element/trait_loc
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH // handles if our movable is deleted
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH_ON_HOST_DESTROY // handles if our movable is deleted
 	id_arg_index = 2
 	/// What trait to apply to the movable's loc.
 	var/trait_to_give

--- a/code/datums/elements/turf_transparency.dm
+++ b/code/datums/elements/turf_transparency.dm
@@ -171,7 +171,7 @@ GLOBAL_LIST_EMPTY(pillars_by_z)
 		hold_this.display(orphan, src)
 
 /datum/element/turf_z_transparency
-	element_flags = ELEMENT_DETACH
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
 ///This proc sets up the signals to handle updating viscontents when turfs above/below update. Handle plane and layer here too so that they don't cover other obs/turfs in Dream Maker
 /datum/element/turf_z_transparency/Attach(datum/target, mapload)

--- a/code/datums/elements/venomous.dm
+++ b/code/datums/elements/venomous.dm
@@ -4,7 +4,7 @@
  * Used for spiders, frogs, and bees!
  */
 /datum/element/venomous
-	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 	///Path of the reagent added
 	var/poison_type

--- a/code/datums/elements/wall_engraver.dm
+++ b/code/datums/elements/wall_engraver.dm
@@ -1,6 +1,5 @@
 /// An element that lets you engrave walls when right click is used
 /datum/element/wall_engraver
-	element_flags = ELEMENT_DETACH
 
 /datum/element/wall_engraver/Attach(datum/target)
 	. = ..()

--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -6,7 +6,7 @@
  *
  */
 /datum/element/weapon_description
-	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	element_flags = ELEMENT_BESPOKE
 	id_arg_index = 2
 
 	// Additional proc to be run for specific object types


### PR DESCRIPTION
ELEMENT_DETACH is **not** a requirement to having `Detach` called. Detach is always called when the element itself is destroyed.

ELEMENT_DETACH is a flag that when set, makes sure Detach is called when the atom destroys. 

Sometimes you want this, for instance:

```dm
/datum/element/point_of_interest/Detach(datum/target)
	SSpoints_of_interest.on_poi_element_removed(target)
	return ..()
```

This Detach cleans up a reference that would have hung if target was destroyed without this being called.

However, most uses of Detach are cleaning up signals. Signals are automatically cleaned up when something is destroyed. You do not need ELEMENT_DETACH in this case, and it slows down init. This also includes somewhat more complex stuff, like removing overlays on the source object. It's getting deleted anyway, you don't care!

I have removed all uses of ELEMENT_DETACH that seemed superfluous. I have also renamed it to `ELEMENT_DETACH_ON_HOST_DESTROY` to make its purpose more clear, as me and a lot of other maintainers misunderstood what it did,

---

An update to this, ELEMENT_DETACH *is* needed for anything that can register to a turf, as turfs do not clear their signals on destroy.