### PR TITLE
Surgery computers tell which tool to use.

### DIFF
--- a/code/modules/surgery/advanced/bioware/cortex_folding.dm
+++ b/code/modules/surgery/advanced/bioware/cortex_folding.dm
@@ -20,7 +20,7 @@
 	return ..()
 
 /datum/surgery_step/fold_cortex
-	name = "fold cortex"
+	name = "fold cortex (hand)"
 	accept_hand = TRUE
 	time = 125
 

--- a/code/modules/surgery/advanced/bioware/cortex_imprint.dm
+++ b/code/modules/surgery/advanced/bioware/cortex_imprint.dm
@@ -20,7 +20,7 @@
 	return ..()
 
 /datum/surgery_step/imprint_cortex
-	name = "imprint cortex"
+	name = "imprint cortex (hand)"
 	accept_hand = TRUE
 	time = 125
 

--- a/code/modules/surgery/advanced/bioware/ligament_hook.dm
+++ b/code/modules/surgery/advanced/bioware/ligament_hook.dm
@@ -14,7 +14,7 @@
 	bioware_target = BIOWARE_LIGAMENTS
 
 /datum/surgery_step/reshape_ligaments
-	name = "reshape ligaments"
+	name = "reshape ligaments (hand)"
 	accept_hand = TRUE
 	time = 125
 

--- a/code/modules/surgery/advanced/bioware/ligament_reinforcement.dm
+++ b/code/modules/surgery/advanced/bioware/ligament_reinforcement.dm
@@ -14,7 +14,7 @@
 	bioware_target = BIOWARE_LIGAMENTS
 
 /datum/surgery_step/reinforce_ligaments
-	name = "reinforce ligaments"
+	name = "reinforce ligaments (hand)"
 	accept_hand = TRUE
 	time = 125
 

--- a/code/modules/surgery/advanced/bioware/muscled_veins.dm
+++ b/code/modules/surgery/advanced/bioware/muscled_veins.dm
@@ -13,7 +13,7 @@
 	bioware_target = BIOWARE_CIRCULATION
 
 /datum/surgery_step/muscled_veins
-	name = "shape vein muscles"
+	name = "shape vein muscles (hand)"
 	accept_hand = TRUE
 	time = 125
 

--- a/code/modules/surgery/advanced/bioware/nerve_grounding.dm
+++ b/code/modules/surgery/advanced/bioware/nerve_grounding.dm
@@ -13,7 +13,7 @@
 	bioware_target = BIOWARE_NERVES
 
 /datum/surgery_step/ground_nerves
-	name = "ground nerves"
+	name = "ground nerves (hand)"
 	accept_hand = TRUE
 	time = 155
 

--- a/code/modules/surgery/advanced/bioware/nerve_splicing.dm
+++ b/code/modules/surgery/advanced/bioware/nerve_splicing.dm
@@ -13,7 +13,7 @@
 	bioware_target = BIOWARE_NERVES
 
 /datum/surgery_step/splice_nerves
-	name = "splice nerves"
+	name = "splice nerves (hand)"
 	accept_hand = TRUE
 	time = 155
 

--- a/code/modules/surgery/advanced/bioware/vein_threading.dm
+++ b/code/modules/surgery/advanced/bioware/vein_threading.dm
@@ -13,7 +13,7 @@
 	bioware_target = BIOWARE_CIRCULATION
 
 /datum/surgery_step/thread_veins
-	name = "thread veins"
+	name = "thread veins (hand)"
 	accept_hand = TRUE
 	time = 125
 

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -26,7 +26,7 @@
 	return TRUE
 
 /datum/surgery_step/brainwash
-	name = "brainwash"
+	name = "brainwash (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 85,
 		TOOL_WIRECUTTER = 50,

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -22,7 +22,7 @@
 	return TRUE
 
 /datum/surgery_step/lobotomize
-	name = "perform lobotomy"
+	name = "perform lobotomy (scalpel)"
 	implements = list(
 		TOOL_SCALPEL = 85,
 		/obj/item/melee/energy/sword = 55,

--- a/code/modules/surgery/advanced/necrotic_revival.dm
+++ b/code/modules/surgery/advanced/necrotic_revival.dm
@@ -18,7 +18,7 @@
 		return FALSE
 
 /datum/surgery_step/bionecrosis
-	name = "start bionecrosis"
+	name = "start bionecrosis (syringe)"
 	implements = list(
 		/obj/item/reagent_containers/syringe = 100,
 		/obj/item/pen = 30)

--- a/code/modules/surgery/advanced/pacification.dm
+++ b/code/modules/surgery/advanced/pacification.dm
@@ -20,7 +20,7 @@
 		return FALSE
 
 /datum/surgery_step/pacify
-	name = "rewire brain"
+	name = "rewire brain (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 100,
 		TOOL_SCREWDRIVER = 35,

--- a/code/modules/surgery/advanced/viral_bonding.dm
+++ b/code/modules/surgery/advanced/viral_bonding.dm
@@ -20,7 +20,7 @@
 	return TRUE
 
 /datum/surgery_step/viral_bond
-	name = "viral bond"
+	name = "viral bond (cautery)"
 	implements = list(
 		TOOL_CAUTERY = 100,
 		TOOL_WELDER = 50,

--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -18,7 +18,7 @@
 	return ..() && wings?.burnt
 
 /datum/surgery_step/wing_reconstruction
-	name = "start wing reconstruction"
+	name = "start wing reconstruction (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 85,
 		TOOL_SCREWDRIVER = 35,

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -14,7 +14,7 @@
 
 
 /datum/surgery_step/sever_limb
-	name = "sever limb"
+	name = "sever limb (shears/scalpel/saw)"
 	implements = list(
 		/obj/item/shears = 300,
 		TOOL_SCALPEL = 100,

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -14,7 +14,7 @@
 
 
 /datum/surgery_step/sever_limb
-	name = "sever limb (shears/scalpel/saw)"
+	name = "sever limb (circular saw)"
 	implements = list(
 		/obj/item/shears = 300,
 		TOOL_SCALPEL = 100,

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -47,7 +47,7 @@
 	return FALSE
 
 /datum/surgery_step/filter_blood
-	name = "Filter blood"
+	name = "Filter blood (blood filter)"
 	implements = list(/obj/item/blood_filter = 95)
 	repeatable = TRUE
 	time = 2.5 SECONDS

--- a/code/modules/surgery/bone_mending.dm
+++ b/code/modules/surgery/bone_mending.dm
@@ -89,7 +89,7 @@
 
 ///// Reset Compound Fracture (Crticial)
 /datum/surgery_step/reset_compound_fracture
-	name = "reset bone"
+	name = "reset bone (bonesetter)"
 	implements = list(
 		/obj/item/bonesetter = 100,
 		/obj/item/stack/sticky_tape/surgical = 60,

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -13,7 +13,7 @@
 	requires_bodypart_type = 0
 
 /datum/surgery_step/fix_brain
-	name = "fix brain"
+	name = "fix brain (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 85,
 		TOOL_SCREWDRIVER = 35,

--- a/code/modules/surgery/burn_dressing.dm
+++ b/code/modules/surgery/burn_dressing.dm
@@ -24,7 +24,7 @@
 
 ///// Debride
 /datum/surgery_step/debride
-	name = "excise infection"
+	name = "excise infection (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 100,
 		TOOL_SCALPEL = 85,
@@ -108,7 +108,7 @@
 
 ///// Dressing burns
 /datum/surgery_step/dress
-	name = "bandage burns"
+	name = "bandage burns (gauze/tape)"
 	implements = list(
 		/obj/item/stack/medical/gauze = 100,
 		/obj/item/stack/sticky_tape/surgical = 100)

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -16,7 +16,7 @@
 
 //extract brain
 /datum/surgery_step/extract_core
-	name = "extract core"
+	name = "extract core (hemostat/crowbar)"
 	implements = list(
 		TOOL_HEMOSTAT = 100,
 		TOOL_CROWBAR = 100)

--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -21,7 +21,7 @@
 
 //an incision but with greater bleed, and a 90% base success chance
 /datum/surgery_step/incise_heart
-	name = "incise heart"
+	name = "incise heart (scalpel)"
 	implements = list(
 		TOOL_SCALPEL = 90,
 		/obj/item/melee/energy/sword = 45,
@@ -63,7 +63,7 @@
 
 //grafts a coronary bypass onto the individual's heart, success chance is 90% base again
 /datum/surgery_step/coronary_bypass
-	name = "graft coronary bypass"
+	name = "graft coronary bypass (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 90,
 		TOOL_WIRECUTTER = 35,

--- a/code/modules/surgery/dissection.dm
+++ b/code/modules/surgery/dissection.dm
@@ -30,7 +30,7 @@
 	return TRUE
 
 /datum/surgery_step/dissection
-	name = "dissect"
+	name = "dissect (scalpel)"
 	time = 16 SECONDS
 	implements = list(
 		TOOL_SCALPEL = 100,

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -13,7 +13,7 @@
 
 //fix eyes
 /datum/surgery_step/fix_eyes
-	name = "fix eyes"
+	name = "fix eyes (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 100,
 		TOOL_SCREWDRIVER = 45,

--- a/code/modules/surgery/gastrectomy.dm
+++ b/code/modules/surgery/gastrectomy.dm
@@ -24,7 +24,7 @@
 ////Gastrectomy, because we truly needed a way to repair stomachs.
 //95% chance of success to be consistent with most organ-repairing surgeries.
 /datum/surgery_step/gastrectomy
-	name = "remove lower duodenum"
+	name = "remove lower duodenum (scalpel)"
 	implements = list(
 		TOOL_SCALPEL = 95,
 		/obj/item/melee/energy/sword = 65,

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -33,7 +33,7 @@
 			/datum/surgery_step/close)
 
 /datum/surgery_step/heal
-	name = "repair body"
+	name = "repair body (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 100,
 		TOOL_SCREWDRIVER = 65,
@@ -167,7 +167,7 @@
 	return progress_text
 
 /datum/surgery_step/heal/brute/basic
-	name = "tend bruises"
+	name = "tend bruises (hemostat)"
 	brutehealing = 5
 	brute_multiplier = 0.07
 
@@ -232,7 +232,7 @@
 	return progress_text
 
 /datum/surgery_step/heal/burn/basic
-	name = "tend burn wounds"
+	name = "tend burn wounds (hemostat)"
 	burnhealing = 5
 	burn_multiplier = 0.07
 
@@ -303,7 +303,7 @@
 	return progress_text
 
 /datum/surgery_step/heal/combo
-	name = "tend physical wounds"
+	name = "tend physical wounds (hemostat)"
 	brutehealing = 3
 	burnhealing = 3
 	brute_multiplier = 0.07

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -23,7 +23,7 @@
 ////hepatectomy, removes damaged parts of the liver so that the liver may regenerate properly
 //95% chance of success, not 100 because organs are delicate
 /datum/surgery_step/hepatectomy
-	name = "remove damaged liver section"
+	name = "remove damaged liver section (scalpel)"
 	implements = list(
 		TOOL_SCALPEL = 95,
 		/obj/item/melee/energy/sword = 65,

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -12,7 +12,7 @@
 
 //extract implant
 /datum/surgery_step/extract_implant
-	name = "extract implant"
+	name = "extract implant (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 100,
 		TOOL_CROWBAR = 65,

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -16,7 +16,7 @@
 
 //cut fat
 /datum/surgery_step/cut_fat
-	name = "cut excess fat"
+	name = "cut excess fat (circular saw)"
 	implements = list(
 		TOOL_SAW = 100,
 		/obj/item/hatchet = 35,
@@ -39,7 +39,7 @@
 
 //remove fat
 /datum/surgery_step/remove_fat
-	name = "remove loose fat"
+	name = "remove loose fat (retractor)"
 	implements = list(
 		TOOL_RETRACTOR = 100,
 		TOOL_SCREWDRIVER = 45,

--- a/code/modules/surgery/lobectomy.dm
+++ b/code/modules/surgery/lobectomy.dm
@@ -20,7 +20,7 @@
 
 //lobectomy, removes the most damaged lung lobe with a 95% base success chance
 /datum/surgery_step/lobectomy
-	name = "excise damaged lung node"
+	name = "excise damaged lung node (scalpel)"
 	implements = list(
 		TOOL_SCALPEL = 95,
 		/obj/item/melee/energy/sword = 65,

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -1,6 +1,6 @@
 //open shell
 /datum/surgery_step/mechanic_open
-	name = "unscrew shell"
+	name = "unscrew shell (screwdriver)"
 	implements = list(
 		TOOL_SCREWDRIVER = 100,
 		TOOL_SCALPEL = 75, // med borgs could try to unscrew shell with scalpel
@@ -26,7 +26,7 @@
 
 //close shell
 /datum/surgery_step/mechanic_close
-	name = "screw shell"
+	name = "screw shell (screwdriver)"
 	implements = list(
 		TOOL_SCREWDRIVER = 100,
 		TOOL_SCALPEL = 75,
@@ -52,7 +52,7 @@
 
 //prepare electronics
 /datum/surgery_step/prepare_electronics
-	name = "prepare electronics"
+	name = "prepare electronics (multitool)"
 	implements = list(
 		TOOL_MULTITOOL = 100,
 		TOOL_HEMOSTAT = 10) // try to reboot internal controllers via short circuit with some conductor
@@ -68,7 +68,7 @@
 
 //unwrench
 /datum/surgery_step/mechanic_unwrench
-	name = "unwrench bolts"
+	name = "unwrench bolts (wrench)"
 	implements = list(
 		TOOL_WRENCH = 100,
 		TOOL_RETRACTOR = 10)
@@ -89,7 +89,7 @@
 
 //wrench
 /datum/surgery_step/mechanic_wrench
-	name = "wrench bolts"
+	name = "wrench bolts (wrench)"
 	implements = list(
 		TOOL_WRENCH = 100,
 		TOOL_RETRACTOR = 10)
@@ -110,7 +110,7 @@
 
 //open hatch
 /datum/surgery_step/open_hatch
-	name = "open the hatch"
+	name = "open the hatch (hand)"
 	accept_hand = TRUE
 	time = 10
 	preop_sound = 'sound/items/ratchet.ogg'

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -201,7 +201,7 @@
 ///Surgery step for internal organs, like hearts and brains
 /datum/surgery_step/manipulate_organs/internal
 	time = 6.4 SECONDS
-	name = "manipulate organs"
+	name = "manipulate organs (hemostat/organ)"
 
 ///only operate on internal organs
 /datum/surgery_step/manipulate_organs/internal/can_use_organ(mob/user, obj/item/organ/organ)
@@ -210,7 +210,7 @@
 ///Surgery step for external organs/features, like tails, frills, wings etc
 /datum/surgery_step/manipulate_organs/external
 	time = 3.2 SECONDS
-	name = "manipulate features"
+	name = "manipulate features (hemostat/feature)"
 
 ///Only operate on external organs
 /datum/surgery_step/manipulate_organs/external/can_use_organ(mob/user, obj/item/organ/organ)

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -1,7 +1,7 @@
 
 //make incision
 /datum/surgery_step/incise
-	name = "make incision"
+	name = "make incision (scalpel)"
 	implements = list(
 		TOOL_SCALPEL = 100,
 		/obj/item/melee/energy/sword = 75,
@@ -44,7 +44,7 @@
 
 //clamp bleeders
 /datum/surgery_step/clamp_bleeders
-	name = "clamp bleeders"
+	name = "clamp bleeders (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 100,
 		TOOL_WIRECUTTER = 60,
@@ -71,7 +71,7 @@
 
 //retract skin
 /datum/surgery_step/retract_skin
-	name = "retract skin"
+	name = "retract skin (retractor)"
 	implements = list(
 		TOOL_RETRACTOR = 100,
 		TOOL_SCREWDRIVER = 45,
@@ -89,7 +89,7 @@
 
 //close incision
 /datum/surgery_step/close
-	name = "mend incision"
+	name = "mend incision (cautery)"
 	implements = list(
 		TOOL_CAUTERY = 100,
 		/obj/item/gun/energy/laser = 90,
@@ -125,7 +125,7 @@
 
 //saw bone
 /datum/surgery_step/saw
-	name = "saw bone"
+	name = "saw bone (circular saw)"
 	implements = list(
 		TOOL_SAW = 100,
 		/obj/item/melee/arm_blade = 75,
@@ -141,7 +141,7 @@
 		/obj/item/hatchet = 'sound/surgery/scalpel1.ogg',
 		/obj/item/knife/butcher = 'sound/surgery/scalpel1.ogg',
 		/obj/item = 'sound/surgery/scalpel1.ogg',
-	) 
+	)
 	success_sound = 'sound/surgery/organ2.ogg'
 
 /datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -165,7 +165,7 @@
 
 //drill bone
 /datum/surgery_step/drill
-	name = "drill bone"
+	name = "drill bone (surgical drill)"
 	implements = list(
 		TOOL_DRILL = 100,
 		/obj/item/screwdriver/power = 80,

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -9,7 +9,7 @@
 
 //reshape_face
 /datum/surgery_step/reshape_face
-	name = "reshape face"
+	name = "reshape face (scalpel)"
 	implements = list(
 		TOOL_SCALPEL = 100,
 		/obj/item/knife = 50,

--- a/code/modules/surgery/repair_puncture.dm
+++ b/code/modules/surgery/repair_puncture.dm
@@ -31,7 +31,7 @@
 
 ///// realign the blood vessels so we can reweld them
 /datum/surgery_step/repair_innards
-	name = "realign blood vessels"
+	name = "realign blood vessels (hemostat)"
 	implements = list(
 		TOOL_HEMOSTAT = 100,
 		TOOL_SCALPEL = 85,
@@ -77,7 +77,7 @@
 
 ///// Sealing the vessels back together
 /datum/surgery_step/seal_veins
-	name = "weld veins" // if your doctor says they're going to weld your blood vessels back together, you're either A) on SS13, or B) in grave mortal peril
+	name = "weld veins (cautery)" // if your doctor says they're going to weld your blood vessels back together, you're either A) on SS13, or B) in grave mortal peril
 	implements = list(
 		TOOL_CAUTERY = 100,
 		/obj/item/gun/energy/laser = 90,

--- a/code/modules/surgery/revival.dm
+++ b/code/modules/surgery/revival.dm
@@ -29,7 +29,7 @@
 	return TRUE
 
 /datum/surgery_step/revive
-	name = "shock brain"
+	name = "shock brain (defibrillator)"
 	implements = list(
 		/obj/item/shockpaddles = 100,
 		/obj/item/melee/touch_attack/shock = 100,

--- a/code/modules/surgery/stomachpump.dm
+++ b/code/modules/surgery/stomachpump.dm
@@ -24,7 +24,7 @@
 
 //Working the stomach by hand in such a way that you induce vomiting.
 /datum/surgery_step/stomach_pump
-	name = "Pump Stomach"
+	name = "pump stomach (hand)"
 	accept_hand = TRUE
 	repeatable = TRUE
 	time = 20


### PR DESCRIPTION

## About The Pull Request

![image](https://user-images.githubusercontent.com/105025397/199194075-d1a3b42a-5c2e-4a02-84d1-84b4be2b601b.png)

All surgery step names, displayed in the surgical computer, will now show which tool to use for that step in parentheses. In cases where multiple tools have a 100% success chance, all are listed; if no tool has a 100% chance then the "correct" one is shown.

Surgery computers will never display "alternate" tools for surgeries (those with a lower success chance), but this shouldn't be a problem. Surgical computers are _usually_ in places with surgical tools at hand, and NanoTrasen wouldn't want to encourage doing brain surgery with a screwdriver. Y'know, probably.
## Why It's Good For The Game

Firstly, this change is particularly helpful to new players. If you have little experience with surgery, it's not always clear which tool you're meant to use for which step. This is especially true for some of the odder surgeries - if you didn't already know, it's not clear at all that "brainwash" means "use a hemostat". While there are certainly guides on the wiki, it's nice to have as much information provided in-game as possible.

Secondly, this change brings consistency. A _small_ number of surgical steps (healing broken bones, namely) already do this! I see no reason why this shouldn't be extended to the remaining surgical steps, especially because it's not particularly obtrusive to the surgery computer interface.
## Changelog
:cl:
qol: Made surgical computers tell you what tool to use for the current surgical step.
/:cl:
