### PR TITLE
Meta Wall Change

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3549,7 +3549,7 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bla" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/wood,
 /area/station/service/library)
 "blb" = (
@@ -4501,6 +4501,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"bBA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "bBI" = (
 /obj/structure/window{
 	dir = 4
@@ -63298,10 +63308,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "wki" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/central)
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/turf/open/floor/wood,
+/area/station/service/library)
 "wkv" = (
 /obj/structure/railing{
 	dir = 8
@@ -88052,7 +88061,7 @@ cyk
 qzS
 rIa
 ahD
-mjr
+wki
 jIY
 mjr
 tbK
@@ -90890,7 +90899,7 @@ sVY
 sVY
 sVY
 sVY
-wki
+sVY
 xxk
 ahr
 bMY
@@ -91147,7 +91156,7 @@ vLi
 usA
 jWg
 tKu
-usA
+bBA
 txz
 wYe
 bMY


### PR DESCRIPTION
## About The Pull Request
Look at this. Two walls connected diagonally with nothing else. This is NOT up to standard.
![image](https://user-images.githubusercontent.com/73589390/199264417-f521ce60-4883-4c72-a3d1-d33557bac85e.png)
I adjust the wall, newscaster, and area to be in perfect unison, removing the blatant crime that is diagonal walls.
![image](https://user-images.githubusercontent.com/73589390/199264759-8963b34b-f1d1-4c58-a4a5-5f73f72c5199.png)
But the poor vending machine! I cannot remove it, it is put next to it's brother in the library, and the beacon spawner is moved to compensate.
![image](https://user-images.githubusercontent.com/73589390/199265137-94aa8601-12bc-4709-998e-634288742a90.png)
All is right on Metastation once again.
## Why It's Good For The Game
I can guarantee that two walls connected only via diagonals is not up to map standard. This removes the eyesore and makes sure the vending unit is still nearby for anyone in need of a treat.
## Changelog
:cl:
fix: A design fault near the library has been removed, there is now a snack vendor within the library that was once in the hall.
/:cl:
