### PR TITLE
No More Infinite Wood

### DIFF
--- a/_maps/templates/holodeck_winterwonderland.dmm
+++ b/_maps/templates/holodeck_winterwonderland.dmm
@@ -10,22 +10,6 @@
 	},
 /turf/open/floor/holofloor/snow,
 /area/template_noop)
-"d" = (
-/obj/structure/flora/tree/pine/style_random,
-/turf/open/floor/holofloor/snow,
-/area/template_noop)
-"h" = (
-/obj/structure/flora/tree/pine/style_random{
-	pixel_y = -6
-	},
-/turf/open/floor/holofloor/snow,
-/area/template_noop)
-"l" = (
-/obj/structure/flora/tree/pine/style_random{
-	pixel_x = -21
-	},
-/turf/open/floor/holofloor/snow,
-/area/template_noop)
 "m" = (
 /obj/effect/holodeck_effect/mobspawner/penguin,
 /turf/open/floor/holofloor/snow,
@@ -42,7 +26,9 @@
 /turf/open/floor/holofloor/snow,
 /area/template_noop)
 "s" = (
-/obj/structure/flora/tree/pine/xmas,
+/obj/structure/flora/tree/pine/holodeck{
+	icon_state = "pine_c"
+	},
 /turf/open/floor/holofloor/snow,
 /area/template_noop)
 "u" = (
@@ -109,9 +95,7 @@
 /turf/open/floor/holofloor/snow,
 /area/template_noop)
 "R" = (
-/obj/structure/flora/tree/pine/style_random{
-	pixel_x = -10
-	},
+/obj/structure/flora/tree/pine/holodeck,
 /turf/open/floor/holofloor/snow,
 /area/template_noop)
 "S" = (
@@ -151,14 +135,14 @@ a
 "}
 (2,1,1) = {"
 Z
-h
+R
 Z
 Z
 Z
 Z
 Z
 Z
-l
+R
 Z
 "}
 (3,1,1) = {"
@@ -212,7 +196,7 @@ G
 (7,1,1) = {"
 Z
 Z
-d
+R
 O
 Z
 Z

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -491,6 +491,16 @@ GLOBAL_LIST_EMPTY(flora_uprooting_tools_typepaths)
 	desc = "A wonderous decorated Christmas tree. It has a seemly endless supply of presents!"
 	unlimited = TRUE
 
+/obj/structure/flora/tree/pine/holodeck
+	name = "holographic pine tree"
+	desc = "A coniferous pine tree, it looks very slightly digital."
+	product_types = list(/obj/effect/particle_effect/sparks = 1)
+	harvest_amount_low = 1
+	harvest_amount_high = 5
+	harvest_message_low = "The holographic tree bursts into a few sparks!"
+	harvest_message_med = "The holographic tree bursts into sparks!"
+	harvest_message_high = "The holographic tree bursts into a lot of sparks!"
+
 /obj/structure/festivus
 	name = "festivus pole"
 	desc = "During last year's Feats of Strength the Research Director was able to suplex this passing immobile rod into a planter."


### PR DESCRIPTION

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/70942
Replaces the trees in the holodeck with an identical subtype that when cut down produce sparks instead of wood.
## Why It's Good For The Game
Infinite wood is an exploit? Botany already gets a shitload of wood super easily but we may as well remove ways to bypass that.
## Changelog
:cl:
fix: The Holodeck can no longer produce wood infinitely
/:cl:
