### PR TITLE
Fix AIs with AI Cores getting gibbed when the mech theyre controlling gets destroyed

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -289,12 +289,12 @@
 	spark_system?.start()
 	loc.assume_air(cabin_air)
 
-	var/mob/living/silicon/ai/unlucky_ais
+	var/mob/living/silicon/ai/unlucky_ai
 	for(var/mob/living/occupant as anything in occupants)
 		if(isAI(occupant))
 			var/mob/living/silicon/ai/AI = occupant
 			if(!AI.linked_core) // we probably shouldnt gib AIs with a core
-				unlucky_ais = occupant
+				unlucky_ai = occupant
 				AI.gib() //No wreck, no AI to recover
 			else
 				mob_exit(AI,silent = TRUE, forced = TRUE) // so we dont ghost the AI
@@ -303,7 +303,7 @@
 		occupant.SetSleeping(destruction_sleep_duration)
 
 	if(wreckage)
-		var/obj/structure/mecha_wreckage/WR = new wreckage(loc, unlucky_ais)
+		var/obj/structure/mecha_wreckage/WR = new wreckage(loc, unlucky_ai)
 		for(var/obj/item/mecha_parts/mecha_equipment/E in flat_equipment)
 			if(E.detachable && prob(30))
 				WR.crowbar_salvage += E

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -292,12 +292,12 @@
 	var/mob/living/silicon/ai/unlucky_ai
 	for(var/mob/living/occupant as anything in occupants)
 		if(isAI(occupant))
-			var/mob/living/silicon/ai/AI = occupant
-			if(!AI.linked_core) // we probably shouldnt gib AIs with a core
+			var/mob/living/silicon/ai/ai = occupant
+			if(!ai.linked_core) // we probably shouldnt gib AIs with a core
 				unlucky_ai = occupant
-				AI.gib() //No wreck, no AI to recover
+				ai.gib() //No wreck, no AI to recover
 			else
-				mob_exit(AI,silent = TRUE, forced = TRUE) // so we dont ghost the AI
+				mob_exit(ai,silent = TRUE, forced = TRUE) // so we dont ghost the AI
 			continue
 		mob_exit(occupant, FALSE, TRUE)
 		occupant.SetSleeping(destruction_sleep_duration)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -292,8 +292,12 @@
 	var/mob/living/silicon/ai/unlucky_ais
 	for(var/mob/living/occupant as anything in occupants)
 		if(isAI(occupant))
-			unlucky_ais = occupant
-			occupant.gib() //No wreck, no AI to recover
+			var/mob/living/silicon/ai/AI = occupant
+			if(!AI.linked_core) // we probably shouldnt gib AIs with a core
+				unlucky_ais = occupant
+				AI.gib() //No wreck, no AI to recover
+			else
+				mob_exit(AI,silent = TRUE, forced = TRUE) // so we dont ghost the AI
 			continue
 		mob_exit(occupant, FALSE, TRUE)
 		occupant.SetSleeping(destruction_sleep_duration)

--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -98,7 +98,7 @@
 				<b>Integrity:</b> [round((chassis.get_integrity()/chassis.max_integrity * 100), 0.01)]%<br>
 				<b>Cell Charge:</b> [isnull(cell_charge) ? "Not Found":"[chassis.cell.percent()]%"]<br>
 				<b>Airtank:</b> [chassis.internal_tank ? "[round(chassis.return_pressure(), 0.01)]" : "Not Equipped"] kPa<br>
-				<b>Pilot:</b> [chassis.return_drivers() || "None"]<br>
+				<b>Pilot:</b> [english_list(chassis.return_drivers(), nothing_text = "None")]<br>
 				<b>Location:</b> [get_area_name(chassis, TRUE) || "Unknown"]"}
 	if(istype(chassis, /obj/vehicle/sealed/mecha/working/ripley))
 		var/obj/vehicle/sealed/mecha/working/ripley/RM = chassis

--- a/code/modules/vehicles/mecha/mecha_mob_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_mob_interaction.dm
@@ -116,7 +116,8 @@
 		AI.eyeobj?.UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 		AI.eyeobj?.forceMove(newloc) //kick the eye out as well
 		if(forced)//This should only happen if there are multiple AIs in a round, and at least one is Malf.
-			AI.gib()  //If one Malf decides to steal a mech from another AI (even other Malfs!), they are destroyed, as they have nowhere to go when replaced.
+			if(!AI.linked_core) //if the victim AI has no core
+				AI.gib()  //If one Malf decides to steal a mech from another AI (even other Malfs!), they are destroyed, as they have nowhere to go when replaced.
 			AI = null
 			mecha_flags &= ~SILICON_PILOT
 			return


### PR DESCRIPTION
## About The Pull Request

Makes AIs with AI Cores not get gibbed when their mech gets destroyed or they get forcefully ejected which is a bug
Also, fixes a very very small bug which i didnt think was worth making a seperate PR for where the stats displayed when
clicking on an AI-controllable mech, it would show "Pilot: /list"
## Why It's Good For The Game
Fixes #68713
Fixes #70922
Im fairly sure AIs with AI cores getting gibbed in their core leaving a MMI behind is probably a bug introduced by
not updating the code when AI Tracking Beacons were added
Also bugs bad, and having a mech destroyed like 100 tiles away splode your core is nonsense
## Changelog


:cl:
fix: Fixes getting AIs with cores getting gibbed if their mech theyre controlling is destroyed
/:cl:
