### PR TITLE
Lower laser armor from miners explorer suit, goliath cloak and ash drake armor

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -133,7 +133,7 @@
 		/obj/item/t_scanner/adv_mining_scanner,
 		/obj/item/tank/internals,
 		)
-	armor = list(MELEE = 65, BULLET = 15, LASER = 20, ENERGY = 40, BOMB = 70, BIO = 60, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 65, BULLET = 15, LASER = 20, ENERGY = 20, BOMB = 70, BIO = 60, FIRE = 100, ACID = 100)
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/drake
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -149,7 +149,7 @@
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "dragon"
 	desc = "The skull of a dragon."
-	armor = list(MELEE = 65, BULLET = 15, LASER = 20, ENERGY = 40, BOMB = 70, BIO = 60, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 65, BULLET = 15, LASER = 20, ENERGY = 20, BOMB = 70, BIO = 60, FIRE = 100, ACID = 100)
 	clothing_flags = SNUG_FIT
 	cold_protection = HEAD
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -12,7 +12,7 @@
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	hoodtype = /obj/item/clothing/head/hooded/explorer
-	armor = list(MELEE = 30, BULLET = 10, LASER = 10, ENERGY = 20, BOMB = 50, BIO = 0, FIRE = 50, ACID = 50)
+	armor = list(MELEE = 30, BULLET = 10, LASER = 0, ENERGY = 20, BOMB = 50, BIO = 0, FIRE = 50, ACID = 50)
 	allowed = list(
 		/obj/item/flashlight,
 		/obj/item/gun/energy/recharge/kinetic_accelerator,
@@ -37,7 +37,7 @@
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
-	armor = list(MELEE = 30, BULLET = 10, LASER = 10, ENERGY = 20, BOMB = 50, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
+	armor = list(MELEE = 30, BULLET = 10, LASER = 0, ENERGY = 20, BOMB = 50, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
 	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/suit/hooded/explorer/Initialize(mapload)
@@ -58,7 +58,7 @@
 	visor_flags_inv = HIDEFACIALHAIR
 	visor_flags_cover = MASKCOVERSMOUTH
 	actions_types = list(/datum/action/item_action/adjust)
-	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 0, BIO = 50, FIRE = 20, ACID = 40, WOUND = 5)
+	armor = list(MELEE = 10, BULLET = 5, LASER = 0, ENERGY = 5, BOMB = 0, BIO = 50, FIRE = 20, ACID = 40, WOUND = 5)
 	resistance_flags = FIRE_PROOF
 	has_fov = FALSE
 
@@ -104,7 +104,7 @@
 		/obj/item/spear,
 		/obj/item/tank/internals,
 		)
-	armor = list(MELEE = 35, BULLET = 10, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 0, FIRE = 60, ACID = 60) //a fair alternative to bone armor, requiring alternative materials and gaining a suit slot
+	armor = list(MELEE = 35, BULLET = 10, LASER = 10, ENERGY = 5, BOMB = 25, BIO = 0, FIRE = 60, ACID = 60) //a fair alternative to bone armor, requiring alternative materials and gaining a suit slot
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/goliath
 	body_parts_covered = CHEST|GROIN|ARMS
 
@@ -114,7 +114,7 @@
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "golhood"
 	desc = "A protective & concealing hood."
-	armor = list(MELEE = 35, BULLET = 10, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 0, FIRE = 60, ACID = 60)
+	armor = list(MELEE = 35, BULLET = 10, LASER = 10, ENERGY = 5, BOMB = 25, BIO = 0, FIRE = 60, ACID = 60)
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
 	transparent_protection = HIDEMASK
@@ -133,7 +133,7 @@
 		/obj/item/t_scanner/adv_mining_scanner,
 		/obj/item/tank/internals,
 		)
-	armor = list(MELEE = 65, BULLET = 15, LASER = 40, ENERGY = 40, BOMB = 70, BIO = 60, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 65, BULLET = 15, LASER = 20, ENERGY = 40, BOMB = 70, BIO = 60, FIRE = 100, ACID = 100)
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/drake
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -149,7 +149,7 @@
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "dragon"
 	desc = "The skull of a dragon."
-	armor = list(MELEE = 65, BULLET = 15, LASER = 40, ENERGY = 40, BOMB = 70, BIO = 60, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 65, BULLET = 15, LASER = 20, ENERGY = 40, BOMB = 70, BIO = 60, FIRE = 100, ACID = 100)
 	clothing_flags = SNUG_FIT
 	cold_protection = HEAD
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT


### PR DESCRIPTION

## About The Pull Request

Removes the laser armor from miners explorer suit and lowers laser and energy armor from the goliath cloak and ash drake armor and their headpieces.

There is no reason for miners to get at roundstart laser resistence in their explorer suit. Keeps the energy values as basilisk attacks deal energy but there isn't a single lavaland mob that attacks with laser.

Lowers laser armor from the goliath cloak  as its extremly fast and effortless to get and its a flat out improved armor vest. There is no source of laser damage on lavaland, all this armor does is empower antags and tiders. Easily craftable armor should not be replacing conspicuous and expensive tc items.

Also lowers the ash drake armor laser from 40 to 20, for the same reason as above. On a additional note it was a better armor than both the swat mk. I and swat mk. II armors and without slowdown 1. And lowers the energy armor as 40 energy is enough to increase the disabler shots needed to stun you from 3 to 5, with the new values it takes 4. Note that it also outperformed the syndicate modsuit with the armor booster module on, the elite modsuit without the armor booster module on and was almost in pair with the elite modsuit with the armor booster module on and in line with the wizard modsuit except for the melee armor which is higher on the drake armor
## Why It's Good For The Game

It brings lavaland armor more in line with lavaland mob fighting. Specially with the drake armor no longer being better than the heaviest and slowest armor available onstation agaisn't laser.

It also makes traitor more conspicuous tc armor options valuable again as they are no longer out performed by 'stealth' armor pieces which do not trigger immediate response.
## Changelog
:cl:
Lowered lavaland available armor values agaisn't laser and energy projectiles.
/:cl:
