### PR TITLE
Makes the Space Ninja modsuit module buttons pinned by default

### DIFF
--- a/code/modules/antagonists/space_ninja/space_ninja.dm
+++ b/code/modules/antagonists/space_ninja/space_ninja.dm
@@ -104,7 +104,6 @@
 	to_chat(owner.current, span_danger("I am an elite mercenary of the mighty Spider Clan!"))
 	to_chat(owner.current, span_warning("Surprise is my weapon. Shadows are my armor. Without them, I am nothing."))
 	to_chat(owner.current, span_notice("The station is located to your [dir2text(get_dir(owner.current, locate(world.maxx/2, world.maxy/2, owner.current.z)))]. A thrown ninja star will be a great way to get there."))
-	to_chat(owner.current, span_notice("<i>For easier ability access, you can pin your modules to your action bar in your suit's UI.</i>"))
 	owner.announce_objectives()
 
 /datum/antagonist/ninja/on_gain()

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -294,6 +294,9 @@
 
 /// Pins the module to the user's action buttons
 /obj/item/mod/module/proc/pin(mob/user)
+	if(module_type == MODULE_PASSIVE)
+		return
+
 	var/datum/action/item_action/mod/pinned_module/existing_action = pinned_to[REF(user)]
 	if(existing_action)
 		mod.remove_item_action(existing_action)

--- a/code/modules/ninja/outfit.dm
+++ b/code/modules/ninja/outfit.dm
@@ -26,6 +26,9 @@
 	if(!istype(weapon, recall.accepted_type))
 		return
 	recall.set_weapon(weapon)
+	for(var/obj/item/mod/module/module in mod.modules)
+		if(module.module_type)
+			module.pin(ninja)
 
 /datum/outfit/ninja_preview
 	name = "Space Ninja (Preview only)"

--- a/code/modules/ninja/outfit.dm
+++ b/code/modules/ninja/outfit.dm
@@ -26,9 +26,8 @@
 	if(!istype(weapon, recall.accepted_type))
 		return
 	recall.set_weapon(weapon)
-	for(var/obj/item/mod/module/module in mod.modules)
-		if(module.module_type)
-			module.pin(ninja)
+	for(var/obj/item/mod/module/module as anything in mod.modules)
+		module.pin(ninja)
 
 /datum/outfit/ninja_preview
 	name = "Space Ninja (Preview only)"


### PR DESCRIPTION

## About The Pull Request
Makes space ninjas spawn with their modsuit action buttons already pinned
## Why It's Good For The Game
The radial menu isn't really practical for abilities you're going to be using mid-combat, the throwing star dispenser is especially bad since it's basically impossible to use at the rate it comes off cooldown if you don't have it pinned.
People shouldn't need to know how to pin the modules or to go through the UI pinning each of them just for the antag to be playable.
## Changelog
:cl:
qol: Space Ninja now has their MODsuit module buttons pinned by default
/:cl:
