### PR TITLE
Fixes Raw Turf in Tramstation + Patches Lint for Raw Turf

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -34403,7 +34403,6 @@
 "mmI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/turf,
 /area/station/security/checkpoint/engineering)
 "mmL" = (
 /obj/machinery/door/morgue{

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -192,7 +192,7 @@ if grep -P '^/area/.+[\{]' _maps/**/*.dmm;	then
     echo -e "${RED}ERROR: Variable editted /area path use detected in a map, please replace with a proper area path.${NC}"
     st=1
 fi;
-if grep -P '\W\/turf\s*[,\){]' _maps/**/*.dmm; then
+if grep -P '\/turf\s*[,\){]' _maps/**/*.dmm; then
 	echo
     echo -e "${RED}ERROR: Base /turf path use detected in maps, please replace a with proper turf path.${NC}"
     st=1

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -194,7 +194,7 @@ if grep -P '^/area/.+[\{]' _maps/**/*.dmm;	then
 fi;
 if grep -P '\/turf\s*[,\){]' _maps/**/*.dmm; then
 	echo
-    echo -e "${RED}ERROR: Base /turf path use detected in maps, please replace a with proper turf path.${NC}"
+    echo -e "${RED}ERROR: Base /turf path use detected in maps, please replace it with a proper turf path.${NC}"
     st=1
 fi;
 if grep -Pzo '"\w+" = \(\n[^)]*?/turf/[/\w]*?,\n[^)]*?/turf/[/\w]*?,\n[^)]*?/area/.+?\)' _maps/**/*.dmm; then


### PR DESCRIPTION
## About The Pull Request

Hey there,

So basically in #70765, a raw `/turf` was introduced into tramstation.dmm AND it was also a duplicate stacked turf in the same key. I only found this because I was running UpdatePaths yesterday.

This is because the grep for raw `/turf` is flakey with the `\W` identifier. I don't know if this grep ever worked, but it certainly didn't fail (work correctly) when we needed it.

Old Grep Regex:

![image](https://user-images.githubusercontent.com/34697715/199373826-94b13e0b-ee2f-46b4-b95f-3ddca2daf740.png)

New Grep Regex:

![image](https://user-images.githubusercontent.com/34697715/199373836-bda243ac-b5b5-440a-bcde-11a7304c1bd2.png)

Regex working in Grep:

![image](https://user-images.githubusercontent.com/34697715/199379899-e88bad22-69b4-4aed-b30c-2c1ea7a3f8cd.png)

I think it's that selection of whitespace that doesn't let it throw properly? Just very odd overall.
## Why It's Good For The Game

AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA BAD RAW /TURF!!!! BAD MULTIPLE-TURFS-PER-KEY!!!!!! CI WAS NOT OUR FRIEND!!! THIS PR SHOULDN'T HAVE PASSED CHECK_GREP.SH BUT IT DID ABLOOOO HOOOO

## Changelog

Nothing that players should care about.