### PR TITLE
 Fixes modsuit qdel loop (again)

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -132,7 +132,7 @@
 		part.siemens_coefficient = theme.siemens_coefficient
 	for(var/obj/item/part as anything in mod_parts)
 		RegisterSignal(part, COMSIG_ATOM_DESTRUCTION, .proc/on_part_destruction)
-		RegisterSignal(part, COMSIG_PARENT_QDELETING, .proc/on_part_deletion)
+		RegisterSignal(part, COMSIG_PARENT_PREQDELETED, .proc/on_part_deletion)
 	set_mod_skin(new_skin || theme.default_skin)
 	update_speed()
 	for(var/obj/item/mod/module/module as anything in initial_modules)
@@ -142,36 +142,32 @@
 	RegisterSignal(src, COMSIG_SPEED_POTION_APPLIED, .proc/on_potion)
 	movedelay = CONFIG_GET(number/movedelay/run_delay)
 
+/obj/item/mod/control/handle_atom_del(atom/deleting_atom)
+	if(deleting_atom in modules)
+		uninstall(deleting_atom, deleting = TRUE)
+	if(deleting_atom == helmet)
+		helmet = null
+	if(deleting_atom == chestplate)
+		chestplate = null
+	if(deleting_atom == gauntlets)
+		gauntlets = null
+	if(deleting_atom == boots)
+		boots = null
+	if(deleting_atom == core)
+		core = null
+	if(deleting_atom == wearer)
+		wearer = null
+	if(deleting_atom in mod_parts)
+		overslotting_parts -= deleting_atom
+		mod_parts -= deleting_atom
+	return ..()
+
 /obj/item/mod/control/Destroy()
 	if(active)
 		STOP_PROCESSING(SSobj, src)
-	for(var/obj/item/mod/module/module as anything in modules)
-		uninstall(module, deleting = TRUE)
-	for(var/obj/item/part as anything in mod_parts)
-		overslotting_parts -= part
-	var/atom/deleting_atom
-	if(!QDELETED(helmet))
-		deleting_atom = helmet
-		helmet = null
-		mod_parts -= deleting_atom
-		qdel(deleting_atom)
-	if(!QDELETED(chestplate))
-		deleting_atom = chestplate
-		chestplate = null
-		mod_parts -= deleting_atom
-		qdel(deleting_atom)
-	if(!QDELETED(gauntlets))
-		deleting_atom = gauntlets
-		gauntlets = null
-		mod_parts -= deleting_atom
-		qdel(deleting_atom)
-	if(!QDELETED(boots))
-		deleting_atom = boots
-		boots = null
-		mod_parts -= deleting_atom
-		qdel(deleting_atom)
-	if(core)
-		QDEL_NULL(core)
+	QDEL_LIST(modules)
+	QDEL_LIST(mod_parts)
+	QDEL_NULL(core)
 	QDEL_NULL(wires)
 	return ..()
 
@@ -694,7 +690,7 @@
 		return
 	atom_destruction(damage_flag)
 
-/obj/item/mod/control/proc/on_part_deletion(obj/item/part) //the part doesnt count as being qdeleted, so our destroying does an infinite loop, fix later
+/obj/item/mod/control/proc/on_part_deletion(obj/item/part)
 	SIGNAL_HANDLER
 
 	if(QDELETED(src))

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -80,8 +80,7 @@
 	var/obj/item/stock_parts/cell/cell
 
 /obj/item/mod/core/standard/Destroy()
-	if(cell)
-		QDEL_NULL(cell)
+	QDEL_NULL(cell)
 	return ..()
 
 /obj/item/mod/core/standard/install(obj/item/mod/control/mod_unit)

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -2,9 +2,9 @@
 	/// The skin we apply to the suit, defaults to the default_skin of the theme.
 	var/applied_skin
 	/// The MOD core we apply to the suit.
-	var/applied_core = /obj/item/mod/core/standard
+	var/obj/item/mod/core/applied_core = /obj/item/mod/core/standard
 	/// The cell we apply to the core. Only applies to standard core suits.
-	var/applied_cell = /obj/item/stock_parts/cell/high
+	var/obj/item/stock_parts/cell/applied_cell = /obj/item/stock_parts/cell/high
 
 /obj/item/mod/control/pre_equipped/Initialize(mapload, new_theme, new_skin, new_core)
 	new_skin = applied_skin


### PR DESCRIPTION
honestly hadn't noticed #70326 was failing unit test. fixed.

```
[2022-10-05 06:57:27.699] runtime error: /obj/item/clothing/head/mod destroy proc was called multiple times, likely due to a qdel loop in the Destroy logic
 - proc name: qdel (/proc/qdel)
 -   source file: garbage.dm,389
 -   usr: Bincee Bee (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the floor (171,47,1) (/turf/open/floor/iron)
 -   call stack:
 - qdel(the responsory MOD helmet (/obj/item/clothing/head/mod), 0)
 - the responsory MOD control uni... (/obj/item/mod/control/pre_equipped/responsory/clown): Destroy(0)
 - the responsory MOD control uni... (/obj/item/mod/control/pre_equipped/responsory/clown): Destroy(0)
 - the responsory MOD control uni... (/obj/item/mod/control/pre_equipped/responsory/clown): Destroy(0)
 - the responsory MOD control uni... (/obj/item/mod/control/pre_equipped/responsory/clown): Destroy(0)
 - qdel(the responsory MOD control uni... (/obj/item/mod/control/pre_equipped/responsory/clown), 0)
 - the responsory MOD control uni... (/obj/item/mod/control/pre_equipped/responsory/clown): on part deletion(the responsory MOD helmet (/obj/item/clothing/head/mod), 0)
 - the responsory MOD helmet (/obj/item/clothing/head/mod):  SendSignal("parent_qdeleting", /list (/list))
 - qdel(the responsory MOD helmet (/obj/item/clothing/head/mod), 0)
```