### PR TITLE
Adds a game option to toggle the MultiZ parallax effect for a player

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -161,8 +161,9 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	if(should_sight_scale(new_sight) == should_sight_scale(old_sight))
 		return
 
-	var/datum/plane_master_group/group = get_plane_group(PLANE_GROUP_MAIN)
-	group.transform_lower_turfs(src, current_plane_offset)
+	for(var/group_key as anything in master_groups)
+		var/datum/plane_master_group/group = master_groups[group_key]
+		group.transform_lower_turfs(src, current_plane_offset)
 
 /datum/hud/proc/should_use_scale()
 	return should_sight_scale(mymob.sight)
@@ -181,9 +182,10 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	current_plane_offset = new_offset
 
 	SEND_SIGNAL(src, COMSIG_HUD_OFFSET_CHANGED, old_offset, new_offset)
-	var/datum/plane_master_group/group = get_plane_group(PLANE_GROUP_MAIN)
-	if(group && should_use_scale())
-		group.transform_lower_turfs(src, new_offset)
+	if(should_use_scale())
+		for(var/group_key as anything in master_groups)
+			var/datum/plane_master_group/group = master_groups[group_key]
+			group.transform_lower_turfs(src, new_offset)
 
 /datum/hud/Destroy()
 	if(mymob.hud_used == src)

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -107,6 +107,11 @@
 	// Chosen because mothblocks liked it, didn't cause motion sickness while also giving a sense of height
 	var/scale_by = 0.965
 	if(!use_scale)
+		// This is a workaround for two things
+		// First of all, if a mob can see objects but not turfs, they will not be shown the holder objects we use for
+		// What I'd like to do is revert to images if this case throws, but image vis_contents is broken
+		// https://www.byond.com/forum/post/2821969
+		// If that's ever fixed, please just use that. thanks :)
 		scale_by = 1
 
 	var/list/offsets = list()

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -93,20 +93,20 @@
 // So they look nicer. if you can't it's all good, if you think you can sanely look at monster's work
 // It's hard, and potentially expensive. be careful
 /datum/plane_master_group/proc/transform_lower_turfs(datum/hud/source, new_offset, use_scale = TRUE)
+	// Check if this feature is disabled for the client, in which case don't use scale.
+	if(!our_hud?.mymob?.client?.prefs?.read_preference(/datum/preference/toggle/multiz_parallax))
+		use_scale = FALSE
+
 	// No offset? piss off
 	if(!SSmapping.max_plane_offset)
 		return
+
 	active_offset = new_offset
+
 	// Each time we go "down" a visual z level, we'll reduce the scale by this amount
 	// Chosen because mothblocks liked it, didn't cause motion sickness while also giving a sense of height
 	var/scale_by = 0.965
-	// If our mob can see through walls
 	if(!use_scale)
-		// This is a workaround for two things
-		// First of all, if a mob can see objects but not turfs, they will not be shown the holder objects we use for
-		// What I'd like to do is revert to images if this case throws, but image vis_contents is broken
-		// https://www.byond.com/forum/post/2821969
-		// If that's ever fixed, please just use that. thanks :)
 		scale_by = 1
 
 	var/list/offsets = list()
@@ -116,6 +116,7 @@
 		if(offset == 0)
 			offsets += null
 			continue
+
 		var/scale = scale_by ** (offset)
 		var/matrix/multiz_shrink = matrix()
 		multiz_shrink.Scale(scale)
@@ -128,11 +129,13 @@
 		var/atom/movable/screen/plane_master/plane = plane_masters[plane_key]
 		if(!plane.multiz_scaled || !plane.allows_offsetting)
 			continue
+
 		var/visual_offset = plane.offset - new_offset
 		if(plane.force_hidden || visual_offset < 0)
 			// We don't animate here because it should be invisble, but we do mark because it'll look nice
 			plane.transform = offsets[visual_offset + offset_offset]
 			continue
+
 		animate(plane, transform = offsets[visual_offset + offset_offset], 0.05 SECONDS, easing = LINEAR_EASING)
 
 /// Holds plane masters for popups, like camera windows

--- a/code/modules/client/preferences/multiz_parallax.dm
+++ b/code/modules/client/preferences/multiz_parallax.dm
@@ -1,0 +1,15 @@
+/// Whether or not to toggle ambient occlusion, the shadows around people
+/datum/preference/toggle/multiz_parallax
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "multiz_parallax"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/toggle/multiz_parallax/apply_to_client(client/client, value)
+	// Update the plane master group's Z transforms.
+
+	var/datum/hud/my_hud = client.mob?.hud_used
+	if(!my_hud)
+		return
+
+	var/datum/plane_master_group/group = my_hud.get_plane_group(PLANE_GROUP_MAIN)
+	group.transform_lower_turfs(my_hud, my_hud.current_plane_offset)

--- a/code/modules/client/preferences/multiz_parallax.dm
+++ b/code/modules/client/preferences/multiz_parallax.dm
@@ -11,5 +11,6 @@
 	if(!my_hud)
 		return
 
-	var/datum/plane_master_group/group = my_hud.get_plane_group(PLANE_GROUP_MAIN)
-	group.transform_lower_turfs(my_hud, my_hud.current_plane_offset)
+	for(var/group_key as anything in my_hud.master_groups)
+		var/datum/plane_master_group/group = my_hud.master_groups[group_key]
+		group.transform_lower_turfs(my_hud, my_hud.current_plane_offset)

--- a/code/modules/client/preferences/multiz_parallax.dm
+++ b/code/modules/client/preferences/multiz_parallax.dm
@@ -1,4 +1,4 @@
-/// Whether or not to toggle ambient occlusion, the shadows around people
+/// Whether or not to toggle multiz parallax, the parallax effect for lower z-levels.
 /datum/preference/toggle/multiz_parallax
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "multiz_parallax"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2726,6 +2726,7 @@
 #include "code\modules\client\preferences\item_outlines.dm"
 #include "code\modules\client\preferences\jobless_role.dm"
 #include "code\modules\client\preferences\mod_select.dm"
+#include "code\modules\client\preferences\multiz_parallax.dm"
 #include "code\modules\client\preferences\names.dm"
 #include "code\modules\client\preferences\ooc.dm"
 #include "code\modules\client\preferences\parallax.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/multiz_parallax.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/multiz_parallax.tsx
@@ -1,0 +1,8 @@
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const multiz_parallax: FeatureToggle = {
+  name: 'Enable multi-z parallax',
+  category: 'GAMEPLAY',
+  description: 'Enable multi-z parallax, for a 3D effect.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION

## About The Pull Request

Adds a game option, similar to Ambient Occlusion, to toggle MultiZ scaling, ie the MultiZ parallax effect, which I'm calling it in the option since that's more clear.

I mainly am curious if this is the cause of significant lag on icebox, or if it's just the use of a huge number of planes in general.

I don't experience any client lag locally (I'm guessing lemon doesn't either) so **I mainly intend this to be Test Merged** for people to find out if the the actual plane.transform being set is the cause.

Possibly closes #70735
## Why It's Good For The Game

Client performance
## Changelog
:cl:
add: Adds an option in Game Preferences -> Game Options to turn off MultiZ parallax.
/:cl:
