### PR TITLE
Saves 2 seconds off init by inlining the bumpclick element

### DIFF
--- a/code/datums/elements/bump_click.dm
+++ b/code/datums/elements/bump_click.dm
@@ -17,7 +17,7 @@
 	///Click with any item?
 	var/allow_any = TRUE
 
-/datum/element/bump_click/Attach(datum/target, list/tool_behaviours, list/tool_items, allow_unarmed = FALSE, allow_combat = FALSE, allow_any = FALSE)
+/datum/element/bump_click/Attach(datum/target, list/tool_behaviours, list/tool_types, allow_unarmed = FALSE, allow_combat = FALSE, allow_any = FALSE)
 	. = ..()
 
 	if(!isatom(target) || isarea(target))

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -36,8 +36,17 @@
 	M.Translate(-4, -4)
 	transform = M
 	icon = smooth_icon
-	var/static/list/behaviors = list(TOOL_MINING)
-	AddElement(/datum/element/bump_click, tool_behaviours = behaviors, allow_unarmed = TRUE)
+
+/turf/closed/mineral/Bumped(atom/movable/bumped_atom)
+	. = ..()
+	if(!isliving(bumped_atom))
+		return
+
+	var/mob/living/bumping = bumped_atom
+	var/obj/item/held_item = bumping.get_active_held_item()
+	// !held_item exists to be nice to snow. the other bit is for pickaxes obviously
+	if(!held_item || held_item.tool_behaviour == TOOL_MINING)
+		INVOKE_ASYNC(bumping, /mob.proc/ClickOn, src)
 
 /turf/closed/mineral/proc/Spread_Vein()
 	var/spreadChance = initial(mineralType.spreadChance)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -37,6 +37,7 @@
 	transform = M
 	icon = smooth_icon
 
+// Inlined version of the bump click element. way faster this way, the element's nice but it's too much overhead
 /turf/closed/mineral/Bumped(atom/movable/bumped_atom)
 	. = ..()
 	if(!isliving(bumped_atom))


### PR DESCRIPTION

## About The Pull Request

It was also a tad yorked so I fixed that bit
bump_click did very little in this case, and while the modularity is nice, the hotness of minerals made this totally untenable
