### PR TITLE
[NO GBP] Fix zombie tongue to only apply to infectious species

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -25,7 +25,6 @@
 		TRAIT_TOXIMMUNE,
 	)
 	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
-	mutanttongue = /obj/item/organ/internal/tongue/zombie
 	var/static/list/spooks = list('sound/hallucinations/growl1.ogg','sound/hallucinations/growl2.ogg','sound/hallucinations/growl3.ogg','sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/wail.ogg')
 	disliked_food = NONE
 	liked_food = GROSS | MEAT | RAW | GORE
@@ -83,6 +82,7 @@
 	speedmod = 1.6
 	mutanteyes = /obj/item/organ/internal/eyes/night_vision/zombie
 	mutantbrain = /obj/item/organ/internal/brain/zombie
+	mutanttongue = /obj/item/organ/internal/tongue/zombie
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 	/// The rate the zombies regenerate at
 	var/heal_rate = 0.5
@@ -145,7 +145,6 @@
 	id = SPECIES_ZOMBIE_KROKODIL
 	examine_limb_id = SPECIES_HUMAN
 	sexes = 0
-	mutanttongue = /obj/item/organ/internal/tongue/zombie
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 
 	bodypart_overrides = list(


### PR DESCRIPTION

## About The Pull Request
Fixes #70976

Zombie tongue speech modifier should only be applying to the infectious zombies species.

## Why It's Good For The Game
Halloween zombies can now communicate normally.

## Changelog
:cl:
fix: Fix zombie tongue to only apply to infectious species
/:cl:
