### PR TITLE
Nitrous Oxide (chemical) Nerf

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1425,7 +1425,7 @@
 	M.adjust_drowsyness(2 * REM * delta_time)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.blood_volume = max(H.blood_volume - (10 * REM * delta_time), 0)
+		H.blood_volume = max(H.blood_volume - (5 * REM * delta_time), 0)
 	if(DT_PROB(10, delta_time))
 		M.losebreath += 2
 		M.adjust_confusion_up_to(2 SECONDS, 5 SECONDS)


### PR DESCRIPTION
## About The Pull Request

A simple nerf to the arguably meta N2O by halving the blood loss.
## Why It's Good For The Game

It encourages chemists to be somewhat more creative with their flavor of death by nerfing an arguably powerful poison that is simple to make. 
## Changelog
:cl:
balance: Halves the blood loss of N2O.
/:cl:
