### PR TITLE
Placed a GeneDrobe in MetaStation genetics.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -28069,12 +28069,11 @@
 /turf/open/space,
 /area/space/nearstation)
 "jZP" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/purple{
 	dir = 5
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "jZR" = (
@@ -36804,6 +36803,7 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "neG" = (


### PR DESCRIPTION

## About The Pull Request

MetaStation is the only map that was missing a GeneDrobe in its Genetics lab. I've placed one there.

![image](https://user-images.githubusercontent.com/105025397/199632408-332ebfe2-32ab-4b2f-950a-47a3b6389e57.png)
_(Left: old; Right: new)_

The air alarm was moved to make space as well. A potted plant had to be removed, as an unfortunate - but necessary - casualty of fashion.
## Why It's Good For The Game

Consistency. Geneticists should be able to access their own wardrobe on every map, and the lack of one was presumably an oversight.
## Changelog
:cl:
fix: Added a missing GeneDrobe to MetaStation.
/:cl:
