### PR TITLE
Restricted access to MetaStation's medical maint doors.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1818,6 +1818,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "aIC" = (
@@ -50577,6 +50578,7 @@
 	name = "Surgery C Maintenance"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "rTL" = (


### PR DESCRIPTION

## About The Pull Request

Two of MetaStation's medical maint doors were missing access helpers, allowing literally anybody to open them - even without an ID at all. This made it easy for anyone who could get into maint at all to break into Medical - both its main hallway, and the auxiliary surgery room. This appears to be an oversight, so I've copied the Medical access helpers from the other maint doors in the area onto these airlocks as well.

![image](https://user-images.githubusercontent.com/105025397/199633945-3f0d2c6a-323a-49fb-ba8c-d1c6ac08cf54.png)
## Why It's Good For The Game

It doesn't make much sense for part of Medbay, just on this one map, to be freely accessible. Breaking and entering should take _some_ amount of effort - especially when it allows easily stealing surgical tools and the like. The fact that other maint doors in the area have the proper helpers makes me assume this was an oversight to begin with.
## Changelog
:cl:
fix: Put the proper access helpers on two maintenance airlocks in MetaStation medical.
/:cl:
