### PR TITLE
Added missing gardening supplies to Tramstation.

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -38291,6 +38291,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
+/obj/item/reagent_containers/cup/bottle/nutrient/ez,
+/obj/item/reagent_containers/cup/bottle/nutrient/rh,
+/obj/item/reagent_containers/cup/watering_can,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "nFA" = (


### PR DESCRIPTION

## About The Pull Request

Tramstation's garden, unlike the garden on every other station, does not have any watering cans or bottles of nutrient. I've added one watering can and one each of E-Z Nutrient and Robust Harvest to bring it in line with the other maps.

![image](https://user-images.githubusercontent.com/105025397/199639868-dc230218-6af0-4e50-b46e-7bb6277862ac.png)
## Why It's Good For The Game

Consistency is good, in terms of what items are supplied in what room. Also, without these items it's much more inconvenient to use Tramstation's public garden, which doesn't seem to be intended.
## Changelog
:cl:
fix: Added a missing watering can and two bottles of nutrient to the Tramstation public garden.
/:cl:
