### PR TITLE
V8 Engine fixes

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -504,7 +504,7 @@
 /datum/mind/proc/has_crafting_recipe(mob/user, potential_recipe)
 	if(!learned_recipes)
 		return FALSE
-	if(!istype(potential_recipe, /datum/crafting_recipe))
+	if(!ispath(potential_recipe, /datum/crafting_recipe))
 		CRASH("Non-crafting recipe passed to has_crafting_recipe")
 	for(var/recipe in user.mind.learned_recipes)
 		if(recipe == potential_recipe)

--- a/code/game/objects/items/v8_engine.dm
+++ b/code/game/objects/items/v8_engine.dm
@@ -33,14 +33,13 @@
 	INVOKE_ASYNC(src, .proc/start_learning_recipe, user)
 
 /obj/item/v8_engine/proc/start_learning_recipe(mob/user)
-	var/edge = /datum/crafting_recipe/house_edge
 	if(!user.mind)
 		return
-	if(user.mind.has_crafting_recipe(user = user, potential_recipe = edge))
+	if(user.mind.has_crafting_recipe(user = user, potential_recipe = /datum/crafting_recipe/house_edge))
 		return
 	to_chat(user, span_notice("You peer at the label on the side, reading about some unique modifications that could be made to the engine..."))
 	if(do_after(user, 15 SECONDS, src))
-		user.mind.teach_crafting_recipe(edge)
+		user.mind.teach_crafting_recipe(/datum/crafting_recipe/house_edge)
 		to_chat(user, span_notice("You learned how to make the House Edge."))
 
 

--- a/code/game/objects/items/v8_engine.dm
+++ b/code/game/objects/items/v8_engine.dm
@@ -33,7 +33,7 @@
 	INVOKE_ASYNC(src, .proc/start_learning_recipe, user)
 
 /obj/item/v8_engine/proc/start_learning_recipe(mob/user)
-	var/datum/crafting_recipe/house_edge/edge
+	var/edge = /datum/crafting_recipe/house_edge
 	if(!user.mind)
 		return
 	if(user.mind.has_crafting_recipe(user = user, potential_recipe = edge))


### PR DESCRIPTION
## About The Pull Request

The V8 Engine item is currently broken in a couple of ways. Most importantly, it doesn't actually teach you the recipe for the House Edge like it's meant to - the recipe was inadvertently left null. Additionally, attempting to examine closely after "learning" the recipe causes an error that results in a progress bar that never actually fills.

I've corrected both of these errors, resulting in proper behavior.
## Why It's Good For The Game

If you've gone through all the effort to get your engine block, you'd probably be mad if you couldn't make your funny sword.
## Changelog
:cl:
fix: Made the V8 Engine teach you the House Edge recipe.
fix: Fixed an error related to the V8 Engine that caused an infinite progress bar.
/:cl:
