### PR TITLE
One use portals will only become used up when they successfully teleport

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -183,5 +183,5 @@
 
 /obj/effect/portal/permanent/one_way/one_use/teleport(atom/movable/M, force = FALSE)
 	. = ..()
-	if (. == TRUE && !isdead(M))
+	if (. && !isdead(M))
 		qdel(src)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -183,4 +183,5 @@
 
 /obj/effect/portal/permanent/one_way/one_use/teleport(atom/movable/M, force = FALSE)
 	. = ..()
-	qdel(src)
+	if (. == TRUE && !isdead(M))
+		qdel(src)


### PR DESCRIPTION
## About The Pull Request
Makes one use portals self-qdel only when they confirm that whatever tries using them has teleported.

## Why It's Good For The Game

One use portals were very frustrating to use, as they delete themselves when a ghost clicks them, or anything that can't even be teleported bumps into them.

...not that I've seen anyone use them except me
## Changelog
:cl:
fix: permanent one-use portals will no longer get used up when clicked by a ghost
/:cl:
