### PR TITLE
Fixes AnimatedNumber epsilon snapping for large numbers

### DIFF
--- a/tgui/packages/tgui/components/AnimatedNumber.tsx
+++ b/tgui/packages/tgui/components/AnimatedNumber.tsx
@@ -147,7 +147,7 @@ export class AnimatedNumber extends Component<AnimatedNumberProps> {
       this.stopTicking();
     }
 
-    if (Math.abs(value - this.currentValue) < EPSILON) {
+    if (Math.abs(value - this.currentValue) < Math.max(EPSILON, EPSILON * value)) {
       // We're about as close as we're going to get--snap to the value and
       // stop ticking.
       this.currentValue = value;

--- a/tgui/packages/tgui/components/AnimatedNumber.tsx
+++ b/tgui/packages/tgui/components/AnimatedNumber.tsx
@@ -147,7 +147,9 @@ export class AnimatedNumber extends Component<AnimatedNumberProps> {
       this.stopTicking();
     }
 
-    if (Math.abs(value - this.currentValue) < Math.max(EPSILON, EPSILON * value)) {
+    if (
+      Math.abs(value - this.currentValue) < Math.max(EPSILON, EPSILON * value)
+    ) {
       // We're about as close as we're going to get--snap to the value and
       // stop ticking.
       this.currentValue = value;


### PR DESCRIPTION

## About The Pull Request
The `AnimatedNumber` tgui component snaps to the end value based on an epsilon constant, but that doesn't work well for larger numbers leading to the snapping not working. This fixes that.
Let me know if I need to modify the copyright header or whatever.
## Why It's Good For The Game
It was annoying someone on goon so I'm PRing the fix here to port down to goon.
