### PR TITLE
Funny merge skew from banana

### DIFF
--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -28,22 +28,9 @@
 	juice_results = list(/datum/reagent/consumable/banana = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/bananahonk
 
-///Override for checkliked callback
 /obj/item/food/grown/banana/MakeEdible()
-	AddComponent(
-		/datum/component/edible,\
-		initial_reagents = food_reagents,\
-		food_flags = food_flags,\
-		foodtypes = foodtypes,\
-		volume = max_volume,\
-		eat_time = eat_time,\
-		tastes = tastes,\
-		eatverbs = eatverbs,\
-		bite_consumption = bite_consumption,\
-		microwaved_type = microwaved_type,\
-		junkiness = junkiness,\
-		check_liked = CALLBACK(src, .proc/check_liked),\
-	)
+	. = ..()
+	AddComponent(/datum/component/edible, check_liked = CALLBACK(src, .proc/check_liked))
 
 /obj/item/food/grown/banana/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
When a food feature PR and a food refactor come together, and get merged without re-running checks, something very funny happens. 

A merge skew. 

Edible component uses inherent component so this is fine.