### PR TITLE
Mindshield implanting removes "hypnotized victim" antag.

### DIFF
--- a/code/modules/antagonists/hypnotized/hypnotized.dm
+++ b/code/modules/antagonists/hypnotized/hypnotized.dm
@@ -17,3 +17,7 @@
 /datum/antagonist/hypnotized/Destroy()
 	QDEL_NULL(trauma)
 	return ..()
+
+/datum/antagonist/hypnotized/on_mindshield(mob/implanter)
+	owner.remove_antag_datum(/datum/antagonist/hypnotized)
+	return COMPONENT_MINDSHIELD_DECONVERTED


### PR DESCRIPTION

## About The Pull Request

I was suggested to send this change upstream, so here it is.

Currently, the mindshield implant _protects_ against hypnosis and brainwashing, and implanting someone who's already brainwashed removes that antag status from them. For some reason, this is not the case with hypnosis, which can only be removed via brain surgery. This PR makes mindshield also remove hypnosis from hypnotized victims, bringing them (ideally) back to the side of the crew.
## Why It's Good For The Game

It makes logical sense to me that if mindshielding _protects_ you from hypnosis, it should also remove it. This is, as stated above, in line with the behavior for brainwashing, which is very similar.

This can also provide a fun, but risky, method for Security to deal with the situation nonlethally if someone manages to make an army of hypnotic thralls - if they manage to successfully implant one of the victims with the mindshield, they'll be rescued from their hypnosis. This is also not a _hard_ counter to hypnosis - it's faster than surgery, but requires an expensive and limited resource and still requires the target to hold still long enough to be implanted.
## Changelog
:cl:
balance: Mindshield implanting removes the "hypnotized victim" antag.
/:cl:
