### PR TITLE
Null-checks PR Body in removeGuideComments

### DIFF
--- a/tools/pull_request_hooks/removeGuideComments.js
+++ b/tools/pull_request_hooks/removeGuideComments.js
@@ -19,8 +19,9 @@ export async function removeGuideComments({ github, context }) {
   let newBody = context.payload.pull_request.body;
 
   // sometimes we make PRs without PR bodies and the whole thing will fail
-  if (!newBody)
-	return;
+  if (!newBody) {
+	return
+  }
 
   for (const comment of comments) {
     newBody = newBody.replace(

--- a/tools/pull_request_hooks/removeGuideComments.js
+++ b/tools/pull_request_hooks/removeGuideComments.js
@@ -19,7 +19,7 @@ export async function removeGuideComments({ github, context }) {
   let newBody = context.payload.pull_request.body;
 
   // sometimes we make PRs without PR bodies and the whole thing will fail
-  if (!newBody) {
+  if (newBody == "") {
     return;
   }
 

--- a/tools/pull_request_hooks/removeGuideComments.js
+++ b/tools/pull_request_hooks/removeGuideComments.js
@@ -20,7 +20,7 @@ export async function removeGuideComments({ github, context }) {
 
   // sometimes we make PRs without PR bodies and the whole thing will fail
   if (!newBody) {
-	console.log("PR body is empty, skipping");
+	console.log("PR body is empty, skipping...");
 	return;
   }
 

--- a/tools/pull_request_hooks/removeGuideComments.js
+++ b/tools/pull_request_hooks/removeGuideComments.js
@@ -20,7 +20,7 @@ export async function removeGuideComments({ github, context }) {
 
   // sometimes we make PRs without PR bodies and the whole thing will fail
   if (!newBody) {
-	return
+    return;
   }
 
   for (const comment of comments) {

--- a/tools/pull_request_hooks/removeGuideComments.js
+++ b/tools/pull_request_hooks/removeGuideComments.js
@@ -19,8 +19,9 @@ export async function removeGuideComments({ github, context }) {
   let newBody = context.payload.pull_request.body;
 
   // sometimes we make PRs without PR bodies and the whole thing will fail
-  if (newBody == "") {
-    return;
+  if (!newBody) {
+	console.log("PR body is empty, skipping");
+	return;
   }
 
   for (const comment of comments) {

--- a/tools/pull_request_hooks/removeGuideComments.js
+++ b/tools/pull_request_hooks/removeGuideComments.js
@@ -18,7 +18,6 @@ function escapeRegex(string) {
 export async function removeGuideComments({ github, context }) {
   let newBody = context.payload.pull_request.body;
 
-  // sometimes we make PRs without PR bodies and the whole thing will fail
   if (!newBody) {
 	console.log("PR body is empty, skipping...");
 	return;

--- a/tools/pull_request_hooks/removeGuideComments.js
+++ b/tools/pull_request_hooks/removeGuideComments.js
@@ -18,6 +18,10 @@ function escapeRegex(string) {
 export async function removeGuideComments({ github, context }) {
   let newBody = context.payload.pull_request.body;
 
+  // sometimes we make PRs without PR bodies and the whole thing will fail
+  if (!newBody)
+	return;
+
   for (const comment of comments) {
     newBody = newBody.replace(
       new RegExp(`^\\s*${escapeRegex(comment)}\\s*`, "gm"),


### PR DESCRIPTION

This is what #71041 was supposed to be.

## About The Pull Request
Hey there,

I was looking at #71028, and I noticed that this workflow failed because oranges left the PR body blank. I think that's silly, so let's just include an early return so the whole thing doesn't throw.

This is the error:

![image](https://user-images.githubusercontent.com/34697715/199852746-24b2ed53-442d-4c40-b81d-902236183328.png)
via: https://github.com/tgstation/tgstation/actions/runs/3382875608/jobs/5618241641

Here's an example PR where I fixed it (on my fork, just expand the "Remove guide comments" step): https://github.com/san7890/bruhstation/actions/runs/3389994395/jobs/5633658300

## Why It's Good For The Game

It hurts my heart to see checks red out in trivial situations like this.
## Changelog
Literally nothing here concerns players.

Ignore the commit history I was testing this PR the wrong way and was effectively gaslighting myself (we're good now though)
