### PR TITLE
Save .996s of init time by not initializing shards rods and coil in every single window, and a one line check in turf/Initialize

### DIFF
--- a/code/__HELPERS/bitflag_lists.dm
+++ b/code/__HELPERS/bitflag_lists.dm
@@ -14,12 +14,12 @@ GLOBAL_LIST_EMPTY(bitflag_lists)
 #define SET_BITFLAG_LIST(target) \
 	do { \
 		var/txt_signature = target.Join("-"); \
-		target = GLOB.bitflag_lists[txt_signature]; \
-		if(isnull(target)) { \
+		if(!GLOB.bitflag_lists[txt_signature]) { \
 			var/list/new_bitflag_list = list(); \
 			for(var/value in target) { \
 				new_bitflag_list["[round(value / 24)]"] |= (1 << (value % 24)); \
 			}; \
-			target = GLOB.bitflag_lists[txt_signature] = new_bitflag_list; \
+			GLOB.bitflag_lists[txt_signature] = new_bitflag_list; \
 		}; \
+		target = GLOB.bitflag_lists[txt_signature]; \
 	} while (FALSE)

--- a/code/__HELPERS/bitflag_lists.dm
+++ b/code/__HELPERS/bitflag_lists.dm
@@ -14,12 +14,12 @@ GLOBAL_LIST_EMPTY(bitflag_lists)
 #define SET_BITFLAG_LIST(target) \
 	do { \
 		var/txt_signature = target.Join("-"); \
-		if(!GLOB.bitflag_lists[txt_signature]) { \
+		target = GLOB.bitflag_lists[txt_signature]; \
+		if(isnull(target)) { \
 			var/list/new_bitflag_list = list(); \
 			for(var/value in target) { \
 				new_bitflag_list["[round(value / 24)]"] |= (1 << (value % 24)); \
 			}; \
-			GLOB.bitflag_lists[txt_signature] = new_bitflag_list; \
+			target = GLOB.bitflag_lists[txt_signature] = new_bitflag_list; \
 		}; \
-		target = GLOB.bitflag_lists[txt_signature]; \
 	} while (FALSE)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -335,7 +335,9 @@
 
 	orbiters = null // The component is attached to us normaly and will be deleted elsewhere
 
-	LAZYCLEARLIST(overlays)
+	if (length(overlays))
+		overlays.Cut()
+
 	LAZYNULL(managed_overlays)
 
 	QDEL_NULL(light)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -335,6 +335,7 @@
 
 	orbiters = null // The component is attached to us normaly and will be deleted elsewhere
 
+	// Checking length(overlays) before cutting has significant speed benefits
 	if (length(overlays))
 		overlays.Cut()
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -195,7 +195,9 @@
 
 
 	vis_locs = null //clears this atom out of all viscontents
-	vis_contents.Cut()
+
+	if (length(vis_contents))
+		vis_contents.Cut()
 
 /atom/movable/proc/update_emissive_block()
 	if(!blocks_emissive)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -196,6 +196,7 @@
 
 	vis_locs = null //clears this atom out of all viscontents
 
+	// Checking length(vis_contents) before cutting has significant speed benefits
 	if (length(vis_contents))
 		vis_contents.Cut()
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -22,7 +22,6 @@
 	var/shards = 2
 	var/rods = 2
 	var/cable = 1
-	var/list/debris = list()
 	var/associated_lift = null
 
 /obj/machinery/door/window/Initialize(mapload, set_dir, unres_sides)
@@ -34,12 +33,6 @@
 	if(LAZYLEN(req_access))
 		icon_state = "[icon_state]"
 		base_state = icon_state
-	for(var/i in 1 to shards)
-		debris += new /obj/item/shard(src)
-	if(rods)
-		debris += new /obj/item/stack/rods(src, rods)
-	if(cable)
-		debris += new /obj/item/stack/cable_coil(src, cable)
 
 	if(unres_sides)
 		//remove unres_sides from directions it can't be bumped from
@@ -66,7 +59,6 @@
 
 /obj/machinery/door/window/Destroy()
 	set_density(FALSE)
-	QDEL_LIST(debris)
 	if(atom_integrity == 0)
 		playsound(src, SFX_SHATTER, 70, TRUE)
 	electronics = null
@@ -251,11 +243,17 @@
 
 /obj/machinery/door/window/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1) && !disassembled)
-		for(var/obj/fragment in debris)
-			fragment.forceMove(get_turf(src))
-			transfer_fingerprints_to(fragment)
-			debris -= fragment
+		for(var/i in 1 to shards)
+			drop_debris(new /obj/item/shard(src))
+		if(rods)
+			drop_debris(new /obj/item/stack/rods(src, rods))
+		if(cable)
+			drop_debris(new /obj/item/stack/cable_coil(src, cable))
 	qdel(src)
+
+/obj/machinery/door/window/proc/drop_debris(obj/item/debris)
+	debris.forceMove(loc)
+	transfer_fingerprints_to(debris)
 
 /obj/machinery/door/window/narsie_act()
 	add_atom_colour("#7D1919", FIXED_COLOUR_PRIORITY)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -205,7 +205,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	requires_activation = FALSE
 	..()
 
-	vis_contents.Cut()
+	if (length(vis_contents))
+		vis_contents.Cut()
 
 /// WARNING WARNING
 /// Turfs DO NOT lose their signals when they get replaced, REMEMBER THIS

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -118,7 +118,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 			T.multiz_turf_new(src, UP)
 
 	// by default, vis_contents is inherited from the turf that was here before
-	vis_contents.Cut()
+	if (length(vis_contents))
+		vis_contents.Cut()
 
 	assemble_baseturfs()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -117,7 +117,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		if(T)
 			T.multiz_turf_new(src, UP)
 
-	// by default, vis_contents is inherited from the turf that was here before
+	// by default, vis_contents is inherited from the turf that was here before.
+	// Checking length(vis_contents) in a proc this hot has huge wins for performance.
 	if (length(vis_contents))
 		vis_contents.Cut()
 


### PR DESCRIPTION
/obj/machinery/door/window/Initialize lowers by 221.81ms.

/turf/Initialize lowers by 775ms.