### PR TITLE
Fixes exploit allowing banned away lathe items from working on autolathe

### DIFF
--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -3,7 +3,10 @@
 ///////////////Bluespace/////////////////
 /////////////////////////////////////////
 
-/datum/design/beacon
+/datum/design/bluespace
+	autolathe_exportable = FALSE
+
+/datum/design/bluespace/beacon
 	name = "Tracking Beacon"
 	desc = "A bluespace tracking beacon."
 	id = "beacon"
@@ -15,7 +18,7 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SECURITY
 
-/datum/design/bag_holding
+/datum/design/bluespace/bag_holding
 	name = "Inert Bag of Holding"
 	desc = "A block of metal ready to be transformed into a bag of holding with a bluespace anomaly core."
 	id = "bag_holding"
@@ -28,7 +31,7 @@
 	dangerous_construction = TRUE
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/bluespace_crystal
+/datum/design/bluespace/bluespace_crystal
 	name = "Artificial Bluespace Crystal"
 	desc = "A small blue crystal with mystical properties."
 	id = "bluespace_crystal"
@@ -39,8 +42,9 @@
 		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
+		autolathe_exportable = TRUE
 
-/datum/design/telesci_gps
+/datum/design/bluespace/telesci_gps
 	name = "GPS Device"
 	desc = "Little thingie that can track its position at all times."
 	id = "telesci_gps"
@@ -51,9 +55,8 @@
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_BLUESPACE
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
-	autolathe_exportable = FALSE
 
-/datum/design/desynchronizer
+/datum/design/bluespace/desynchronizer
 	name = "Desynchronizer"
 	desc = "A device that can desynchronize the user from spacetime."
 	id = "desynchronizer"
@@ -65,7 +68,7 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/miningsatchel_holding
+/datum/design/bluespace/miningsatchel_holding
 	name = "Mining Satchel of Holding"
 	desc = "A mining satchel that can hold an infinite amount of ores."
 	id = "minerbag_holding"
@@ -76,8 +79,9 @@
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MINING
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_CARGO
+		autolathe_exportable = TRUE
 
-/datum/design/swapper
+/datum/design/bluespace/swapper
 	name = "Quantum Spin Inverter"
 	desc = "An experimental device that is able to swap the locations of two entities by switching their particles' spin values. Must be linked to another device to function."
 	id = "swapper"

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -31,7 +31,7 @@
 	dangerous_construction = TRUE
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/bluespace/bluespace_crystal
+/datum/design/bluespace_crystal //it's not /bluespace/ because less copypaste and it's away friendly
 	name = "Artificial Bluespace Crystal"
 	desc = "A small blue crystal with mystical properties."
 	id = "bluespace_crystal"
@@ -42,7 +42,6 @@
 		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
-		autolathe_exportable = TRUE
 
 /datum/design/bluespace/telesci_gps
 	name = "GPS Device"
@@ -68,7 +67,7 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/bluespace/miningsatchel_holding
+/datum/design/miningsatchel_holding
 	name = "Mining Satchel of Holding"
 	desc = "A mining satchel that can hold an infinite amount of ores."
 	id = "minerbag_holding"
@@ -79,7 +78,6 @@
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MINING
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_CARGO
-		autolathe_exportable = TRUE
 
 /datum/design/bluespace/swapper
 	name = "Quantum Spin Inverter"

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -6,6 +6,12 @@
 	build_type = IMPRINTER | AWAY_IMPRINTER
 	materials = list(/datum/material/glass = 1000)
 
+/datum/design/board/bluespace
+	name = "BLUESPACE RESTRICTED NULL ENTRY Board"
+	desc = "Nanotrasen intellectual property so blackboxed it doesn't do anything"
+	build_type = IMPRINTER
+	autolathe_exportable = FALSE
+
 /datum/design/board/arcade_battle
 	name = "Battle Arcade Machine Board"
 	desc = "Allows for the construction of circuit boards used to build a new arcade machine."
@@ -118,11 +124,10 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SECURITY //Honestly should have a bridge techfab for this sometime.
 
-/datum/design/board/crewconsole
+/datum/design/board/bluespace/crewconsole
 	name = "Crew Monitoring Computer Board"
 	desc = "Allows for the construction of circuit boards used to build a Crew monitoring computer."
 	id = "crewconsole"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/computer/crew
 	category = list(
 		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_MEDICAL
@@ -241,22 +246,20 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/cargo
+/datum/design/board/bluespace/cargo
 	name = "Supply Console Board"
 	desc = "Allows for the construction of circuit boards used to build a Supply Console."
 	id = "cargo"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/computer/cargo
 	category = list(
 		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_CARGO
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/board/cargorequest
+/datum/design/board/bluespace/cargorequest
 	name = "Supply Request Console Board"
 	desc = "Allows for the construction of circuit boards used to build a Supply Request Console."
 	id = "cargorequest"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/computer/cargo/request
 	category = list(
 		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_CARGO
@@ -353,33 +356,30 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/board/exoscanner_console
+/datum/design/board/bluespace/exoscanner_console
 	name = "Scanner Array Control Console Board"
 	desc = "Allows for the construction of circuit boards used to build a new scanner array control console."
 	id = "exoscanner_console"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/computer/exoscanner_console
 	category = list(
 		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_RESEARCH
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/exodrone_console
+/datum/design/board/bluespace/exodrone_console
 	name = "Exploration Drone Control Console Board"
 	desc = "Allows for the construction of circuit boards used to build a new exploration drone control console."
 	id = "exodrone_console"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/computer/exodrone_console
 	category = list(
 		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_RESEARCH
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/accounting_console
+/datum/design/board/bluespace/accounting_console
 	name = "Account Lookup Console Board"
 	desc = "Allows for the construction of circuit boards used to assess the wealth of crewmates on station."
 	id = "account_console"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/computer/accounting
 	category = list(
 		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_SECURITY

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -101,75 +101,72 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/teleport_station
+/datum/design/board/bluespace
+	build_type = IMPRINTER
+	autolathe_exportable = FALSE
+
+/datum/design/board/bluespace/teleport_station
 	name = "Teleportation Station Board"
 	desc = "The circuit board for a teleportation station."
 	id = "tele_station"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/teleporter_station
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_TELEPORT
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/teleport_hub
+/datum/design/board/bluespace/teleport_hub
 	name = "Teleportation Hub Board"
 	desc = "The circuit board for a teleportation hub."
 	id = "tele_hub"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/teleporter_hub
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_TELEPORT
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/quantumpad
+/datum/design/board/bluespace/quantumpad
 	name = "Quantum Pad Board"
 	desc = "The circuit board for a quantum telepad."
 	id = "quantumpad"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/quantumpad
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_TELEPORT
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/botpad
+/datum/design/board/bluespace/botpad
 	name = "Machine Design (Bot launchpad)"
 	desc = "The circuit board for a bot launchpad."
 	id = "botpad"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/botpad
 	category = list(RND_CATEGORY_MACHINE)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/launchpad
+/datum/design/board/bluespace/launchpad
 	name = "Bluespace Launchpad Board"
 	desc = "The circuit board for a bluespace Launchpad."
 	id = "launchpad"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/launchpad
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_TELEPORT
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/launchpad_console
+/datum/design/board/bluespace/launchpad_console
 	name = "Bluespace Launchpad Console Board"
 	desc = "The circuit board for a bluespace launchpad Console."
 	id = "launchpad_console"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/computer/launchpad_console
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_TELEPORT
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/teleconsole
+/datum/design/board/bluespace/teleconsole
 	name = "Teleporter Console Board"
 	desc = "Allows for the construction of circuit boards used to build a teleporter control console."
 	id = "teleconsole"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/computer/teleporter
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_TELEPORT

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -101,10 +101,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/bluespace
-	build_type = IMPRINTER
-	autolathe_exportable = FALSE
-
 /datum/design/board/bluespace/teleport_station
 	name = "Teleportation Station Board"
 	desc = "The circuit board for a teleportation station."
@@ -304,11 +300,10 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/board/protolathe
+/datum/design/board/bluespace/protolathe
 	name = "Protolathe Board"
 	desc = "The circuit board for a protolathe."
 	id = "protolathe"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/protolathe
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_FAB
@@ -326,11 +321,10 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/circuit_imprinter
+/datum/design/board/bluespace/circuit_imprinter
 	name = "Circuit Imprinter Board"
 	desc = "The circuit board for a circuit imprinter."
 	id = "circuit_imprinter"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/circuit_imprinter
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_FAB
@@ -639,11 +633,10 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/ntnet_relay
+/datum/design/board/bluespace/ntnet_relay
 	name = "NTNet Relay Board"
 	desc = "The circuit board for a wireless network relay."
 	id = "ntnet_relay"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/ntnet_relay
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_TELECOMMS
@@ -780,11 +773,10 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/board/spaceship_navigation_beacon
+/datum/design/board/bluespace/spaceship_navigation_beacon
 	name = "Bluespace Navigation Gigabeacon Board"
 	desc = "The circuit board for a Bluespace Navigation Gigabeacon."
 	id = "spaceship_navigation_beacon"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/spaceship_navigation_beacon
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_TELEPORT

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -141,6 +141,7 @@
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	autolathe_exportable = FALSE
 
 /datum/design/defibrillator
 	name = "Defibrillator"


### PR DESCRIPTION
## About The Pull Request

I made a previous PR about this but wasn't really broad enough in the scope before.
Ghost roles with access to research machines (eg. golems, charlie) could bypass the restriction removing most items from the away lathe by just exporting the designs to the autolathe. This fixes that, and cleans up a little bit of copypaste in the process. Certain items like BS crystals and miner bags are still available to print.

## Why It's Good For The Game

Fixes an exploit
Prevents another easy way to for golems, etc to get on station

## Changelog

:cl:
fix: Away roles with lathes (eg golems) can't build teleporters, etc using the autolathe anymore.
/:cl: