### PR TITLE
UX Update To Saving Ordnance Log Recordings

### DIFF
--- a/code/modules/research/ordnance/doppler_array.dm
+++ b/code/modules/research/ordnance/doppler_array.dm
@@ -304,7 +304,7 @@
 				return
 			records -= record
 			return TRUE
-		if("print_record")
+		if("save_record")
 			var/datum/data/tachyon_record/record  = locate(params["ref"]) in records
 			if(!records || !(record in records))
 				return

--- a/code/modules/research/ordnance/tank_compressor.dm
+++ b/code/modules/research/ordnance/tank_compressor.dm
@@ -297,7 +297,7 @@
 				return
 			compressor_record -= record
 			return TRUE
-		if("print_record")
+		if("save_record")
 			var/datum/data/compressor_record/record  = locate(params["ref"]) in compressor_record
 			if(!compressor_record || !(record in compressor_record))
 				return

--- a/tgui/packages/tgui/interfaces/DopplerArray.js
+++ b/tgui/packages/tgui/interfaces/DopplerArray.js
@@ -69,13 +69,13 @@ const DopplerArrayContent = (props, context) => {
                     }
                   />
                   <Button
-                    icon="print"
-                    content="Print"
+                    icon="floppy-disk"
+                    content="Save"
                     disabled={!disk}
-                    tooltip="Print the record selected. Requires a data disk."
+                    tooltip="Save the record selected to an inserted data disk."
                     tooltipPosition="bottom"
                     onClick={() =>
-                      act('print_record', {
+                      act('save_record', {
                         'ref': activeRecord.ref,
                       })
                     }

--- a/tgui/packages/tgui/interfaces/TankCompressor.js
+++ b/tgui/packages/tgui/interfaces/TankCompressor.js
@@ -290,14 +290,14 @@ const TankCompressorRecords = (props, context) => {
                     }}
                   />,
                   <Button
-                    key="print"
-                    icon="print"
-                    content="Print"
+                    key="save"
+                    icon="floppy-disk"
+                    content="Save"
                     disabled={!disk}
-                    tooltip="Print the record selected. Requires a data disk."
+                    tooltip="Save the record selected to an inserted data disk."
                     tooltipPosition="bottom"
                     onClick={() => {
-                      act('print_record', {
+                      act('save_record', {
                         'ref': activeRecord.ref,
                       });
                     }}


### PR DESCRIPTION

## About The Pull Request

Hey there,

I was a bit lost earlier today when I was doing ordnance stuff, and it was because of THIS button:

![image](https://user-images.githubusercontent.com/34697715/199888797-dfa627cd-328e-43b2-98fa-8facecf8e93f.png)

Print to me implies that you're actually going to print out a paper copy of your results, not that you are going to save the recording data to the disk you inserted. So, let's just make it the standardized format.

I also updated the backend a bit to reflect this and make sure it's consistent.
## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/34697715/199888803-226ad3b8-6359-4486-8dc2-dfc1bf0157cb.png)

Lessens confusion to new people trying to get into Ordnance, because by God it fucked me up for a solid three minutes.
## Changelog
:cl:
qol: When saving Experiment Log Recording Data to a data disk on either the Tachyon Doppler or the Tank Compressor, Nanotrasen released a UI/UX update in order to have the button that saves the data onto your disk... say "Save".
/:cl:
