### PR TITLE
Adds fire alarms to the Metastation chapel

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -33233,6 +33233,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
+"lTA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel/funeral)
 "lTB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60945,6 +60951,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"vtD" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/station/service/chapel)
 "vtF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -90963,7 +90975,7 @@ vQg
 gzm
 vQg
 iez
-hto
+lTA
 gYU
 gYU
 gYU
@@ -93273,7 +93285,7 @@ tSw
 oBN
 iZi
 kVN
-qri
+vtD
 mKv
 qri
 iIq


### PR DESCRIPTION
## About The Pull Request

Did you know the chapel on Metastation has absolutely no fire alarms? Neither did I, until I went there to try and clear an alarm and found a conspicuous lack of alarms. Well, now there are. I added 1 alarm each to the chapel and funeral room, right next to their main door for easy access.
## Why It's Good For The Game
No more unclearable fire alarms. Also I guess we can let the poor plebs without crowbars have a slightly better chance of getting out of the chapel if the fire doors are closed.
## Changelog
:cl: VexingRaven
fix: Adding missing fire alarms to the Chapel and Funeral Room on Metastation
/:cl:
