### PR TITLE
Adds more pepper spray refillers to Ice Box

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -22152,7 +22152,6 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "fnA" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3844,6 +3844,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/tile/red/full,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
 "bjn" = (
@@ -8696,6 +8697,7 @@
 	pixel_y = -5
 	},
 /obj/structure/rack,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "cBL" = (
@@ -24565,6 +24567,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Equipment Room"
 	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
 /turf/open/floor/glass/reinforced,
 /area/station/security/lockers)
 "hwW" = (
@@ -49464,6 +49467,7 @@
 /obj/item/clothing/gloves/color/orange,
 /obj/item/restraints/handcuffs,
 /obj/item/reagent_containers/spray/pepper,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
 "pgL" = (


### PR DESCRIPTION
## About The Pull Request
Adds several new pepper spray refillers to Ice Box:
The medbay checkpoint
![image](https://user-images.githubusercontent.com/1313921/199897162-09a94738-d272-4e23-bc7d-20171703e1d2.png)

The Security Locker Room and Security Office
![image](https://user-images.githubusercontent.com/1313921/199898320-5019523c-17b5-4d83-9c56-123d1fe311b0.png)

The Security Transfer Centre
![image](https://user-images.githubusercontent.com/1313921/199897312-a512a1a0-7553-42de-ad65-5b528c5a5a55.png)

I also removed a doubled-up refiller on DeltaStation outside the HOS office. No screenshot here, sorry.
## Why It's Good For The Game
Sec officers should be encouraged to use their other nonlethal means and not just the winbaton, having only 2 refillers accessible to all sec (customs and escape) kinda sucks. At the very least every sec checkpoint should have one and the locker room. A couple more scattered around is nice too.

Fixes #71050
## Changelog
:cl: VexingRaven
add: Added several new pepper spray refillers around the Security wing of Ice Box Station
fix: Fixed missing pepper spray refiller in the Medbay Checkpoint on Ice Box Station
fix: Fixed a doubled-up pepper spray refiller in the Security Office on Delta Station
/:cl:
