### PR TITLE
Save 0.28s of init time by removing an unnecessary timer in light/LateInitialize

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -101,7 +101,7 @@
 		if("bulb")
 			if(prob(5))
 				break_light_tube(TRUE)
-	addtimer(CALLBACK(src, .proc/update, FALSE), 0.1 SECONDS)
+	update(trigger = FALSE)
 
 /obj/machinery/light/Destroy()
 	var/area/local_area =get_room_area(src)


### PR DESCRIPTION
Replaces a timer with just calling the proc directly. This saves 0.28s of making timer events.

This timer exists as an artifact of being a `spawn (1)` since r4407. Local testing suggests it is completely unnecessary (lights work, lights break, new lights show)