### PR TITLE
Fixes exosuit internal damage diagnostic HUD blip not appearing

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -429,6 +429,7 @@ Diagnostic HUDs!
 	if(internal_damage)
 		holder.icon_state = "hudwarn"
 		set_hud_image_active(DIAG_STAT_HUD)
+		return
 	holder.icon_state = null
 	set_hud_image_inactive(DIAG_STAT_HUD)
 


### PR DESCRIPTION
## About The Pull Request
Introduces a `return` that was probably supposed to be there back in #65189

## Why It's Good For The Game
Fixes previously broken HUD item that was a good clue whether the mecha has sustained a crippling malfunction or not.

## Changelog

:cl:
fix: fixed mecha internal damage diagnostic HUD blip not appearing
/:cl:

