### PR TITLE
Adds the indestructible flag to implants

### DIFF
--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/implants.dmi'
 	icon_state = "generic" //Shows up as the action button icon
 	item_flags = DROPDEL
+	resistance_flags = INDESTRUCTIBLE
 	// This gives the user an action button that allows them to activate the implant.
 	// If the implant needs no action button, then null this out.
 	// Or, if you want to add a unique action button, then replace this.

--- a/code/game/objects/items/implants/implantuplink.dm
+++ b/code/game/objects/items/implants/implantuplink.dm
@@ -5,6 +5,7 @@
 	icon_state = "radio"
 	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
+	resistance_flags = INDESTRUCTIBLE
 	var/starting_tc = 0
 	/// The uplink flags of the implant uplink inside, only checked during initialisation so modifying it after initialisation will do nothing
 	var/uplink_flag = UPLINK_TRAITORS

--- a/code/game/objects/items/implants/implantuplink.dm
+++ b/code/game/objects/items/implants/implantuplink.dm
@@ -5,7 +5,6 @@
 	icon_state = "radio"
 	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
-	resistance_flags = INDESTRUCTIBLE
 	var/starting_tc = 0
 	/// The uplink flags of the implant uplink inside, only checked during initialisation so modifying it after initialisation will do nothing
 	var/uplink_flag = UPLINK_TRAITORS


### PR DESCRIPTION
## About The Pull Request

Grants all Implants the resistance_flag INDESTRUCTIBLE to make them immune to damage from outside explosions.

## Why It's Good For The Game

When you take an uplink implant you trade 4tc for the utility and security of the implant. Due to how explosions work, enough light-grade explosions nearby will somehow destroy your uplink from within and potentially neuter you as a traitor. Depending on how you've chosen to play the antagonist, this can be easily self inflicted [such as by wearing a bomb suit and using explosive lances], and it's pretty unintuitive compared to getting your PDA or any other equipment destroyed. You'd think the implant being surrounded by meat would protect it. 

Also there's a couple other cases where enough tickle-grade explosions might delete an important implant, and this all happens without any kind of warning or message, as well as being completely outside of player expectations.

This PR changes nothing about removing implants via surgery, gibbing, or similar events, since the implant gets deleted upon removal by any expected method. I'm pretty sure nobody is using explosions on purpose to specifically try and destroy someone's implants.

## Changelog
:cl:
balance: Implants can no longer be destroyed by enough external explosions. Bomb Suit Knights can wield their explosive lances with pride!
/:cl:
