### PR TITLE
Fixes the messenger app not being responsive when certain buttons are clicked

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -201,11 +201,8 @@
 	var/list/data = ..()
 
 	data["owner"] = computer.saved_identification
-	data["ringer_status"] = ringer_status
-	data["sending_and_receiving"] = sending_and_receiving
 	data["sortByJob"] = sort_by_job
 	data["isSilicon"] = issilicon(user)
-	data["viewing_messages"] = viewing_messages
 
 	return data
 
@@ -214,6 +211,9 @@
 
 	data["messages"] = messages
 	data["messengers"] = ScrubMessengerList()
+	data["ringer_status"] = ringer_status
+	data["sending_and_receiving"] = sending_and_receiving
+	data["viewing_messages"] = viewing_messages
 	data["photo"] = photo_path
 	data["canSpam"] = spam_mode
 

--- a/tgui/packages/tgui/interfaces/NtosMessenger.js
+++ b/tgui/packages/tgui/interfaces/NtosMessenger.js
@@ -57,7 +57,7 @@ const ContactsScreen = (props, context) => {
           <Section fill textAlign="center">
             <Box bold>
               <Icon name="address-card" mr={1} />
-              SpaceMessenger V6.4.7
+              SpaceMessenger V6.4.8
             </Box>
             <Box italic opacity={0.3}>
               Bringing you spy-proof communications since 2467.


### PR DESCRIPTION
## About The Pull Request
The buttons to toggle the ringer, to toggle the sending/receiving and the button to see message history all stopped being responsive, because the information they were changing when pressed was wrongly kept in `ui_static_data()` rather than `ui_data()`. Now, they're back in `ui_data()`, and behave as expected once again.

## Why It's Good For The Game
A non-responsive TGUI interface is probably the saddest thing to see.

## Changelog

:cl: GoldenAlpharex
fix: SpaceMessenger was now updated to 6.4.8, bringing you more responsiveness than ever (so long as ever is shorter than seven days ago)!
/:cl: