### PR TITLE
Fire breath properly updates when lacking power chromosome.

### DIFF
--- a/code/datums/mutations/fire_breath.dm
+++ b/code/datums/mutations/fire_breath.dm
@@ -18,6 +18,8 @@
 		return
 
 	if(GET_MUTATION_POWER(src) <= 1) // we only care about power from here on
+		to_modify.cone_levels = initial(to_modify.cone_levels) //resets to default if no power chromosome
+		to_modify.self_throw_range = initial(to_modify.self_throw_range)
 		return
 
 	to_modify.cone_levels += 2  // Cone fwooshes further, and...


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically, if you put a power chromosome in your fire breath and then lose the mutation and got a new fire breath mutation (without a power chromosome) you would still retain the benefits of the power chromosome and could stack it with energetic.


This pr fixes that by reverting to initial values when lacking power chromosome.
## Why It's Good For The Game

Because if it isnt merged i`m going to abuse this.

## Changelog



:cl:
fix: Firebreath can no longer benefit from both power and energetic chromosomes at the same time
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
