### PR TITLE
Fixes some monkey business with monkies trying to give items to mobs with no hands.

### DIFF
--- a/code/datums/ai/generic/generic_behaviors.dm
+++ b/code/datums/ai/generic/generic_behaviors.dm
@@ -137,6 +137,9 @@
 		return
 
 	var/mob/living/living_target = target
+
+	if(!try_to_give_item(controller, living_target, held_item))
+		return
 	controller.PauseAi(1.5 SECONDS)
 	living_target.visible_message(
 		span_info("[pawn] starts trying to give [held_item] to [living_target]!"),
@@ -144,16 +147,36 @@
 	)
 	if(!do_mob(pawn, living_target, 1 SECONDS))
 		return
-	if(QDELETED(held_item) || QDELETED(living_target))
-		finish_action(controller, FALSE)
-		return
-	var/pocket_choice = prob(50) ? ITEM_SLOT_RPOCKET : ITEM_SLOT_LPOCKET
-	if(prob(50))
-		living_target.put_in_hands(held_item)
-	else
-		living_target.equip_to_slot_if_possible(held_item, pocket_choice)
 
+	try_to_give_item(controller, living_target, held_item, actually_give = TRUE)
+
+/datum/ai_behavior/give/proc/try_to_give_item(datum/ai_controller/controller, mob/living/target, obj/item/held_item, actually_give)
+	if(QDELETED(held_item) || QDELETED(target))
+		finish_action(controller, FALSE)
+		return FALSE
+
+	var/has_left_pocket = target.can_equip(held_item, ITEM_SLOT_LPOCKET)
+	var/has_right_pocket = target.can_equip(held_item, ITEM_SLOT_RPOCKET)
+	var/has_valid_hand
+
+	for(var/hand_index in target.get_empty_held_indexes())
+		if(target.can_put_in_hand(held_item, hand_index))
+			has_valid_hand = TRUE
+			break
+
+	if(!has_left_pocket && !has_right_pocket && !has_valid_hand)
+		finish_action(controller, FALSE)
+		return FALSE
+
+	if(!actually_give)
+		return TRUE
+
+	if(!has_valid_hand || prob(50))
+		target.equip_to_slot_if_possible(held_item, (!has_left_pocket ? ITEM_SLOT_RPOCKET : (prob(50) ? ITEM_SLOT_LPOCKET : ITEM_SLOT_RPOCKET)))
+	else
+		target.put_in_hands(held_item)
 	finish_action(controller, TRUE)
+
 
 /datum/ai_behavior/consume
 	required_distance = 1
@@ -172,11 +195,9 @@
 	var/obj/item/target = target_ref.resolve()
 
 	if(!(target in living_pawn.held_items))
-		if(!living_pawn.put_in_hand_check(target))
+		if(!living_pawn.get_empty_held_indexes() || !living_pawn.put_in_hands(target))
 			finish_action(controller, FALSE, target, hunger_timer_key)
 			return
-
-		living_pawn.put_in_hands(target)
 
 	target.melee_attack_chain(living_pawn, living_pawn)
 

--- a/code/datums/ai/monkey/monkey_behaviors.dm
+++ b/code/datums/ai/monkey/monkey_behaviors.dm
@@ -53,7 +53,7 @@
 		return
 
 	// EVERYTHING ELSE
-	else if(living_pawn.get_empty_held_index_for_side(LEFT_HANDS) || living_pawn.get_empty_held_index_for_side(RIGHT_HANDS))
+	else if(living_pawn.get_empty_held_indexes())
 		living_pawn.put_in_hands(target)
 		finish_action(controller, TRUE)
 		return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -153,7 +153,7 @@
 	return !held_items[hand_index]
 
 /mob/proc/put_in_hand(obj/item/I, hand_index, forced = FALSE, ignore_anim = TRUE)
-	if(hand_index == null || (!forced && !can_put_in_hand(I, hand_index)))
+	if(hand_index == null || !held_items.len || (!forced && !can_put_in_hand(I, hand_index)))
 		return FALSE
 
 	if(isturf(I.loc) && !ignore_anim)


### PR DESCRIPTION
Interesting what happens when you leave the game idle in the background for a couple hours!

```
[2022-11-05 01:50:43.767] runtime error: list index out of bounds
 - proc name: put in hand (/mob/proc/put_in_hand)
 -   source file: inventory.dm,164
 -   usr: null
 -   src: Lizard (/mob/living/simple_animal/hostile/lizard)
 -   src.loc: the grass patch (210,82,1) (/turf/open/floor/grass)
 -   call stack:
 - Lizard (/mob/living/simple_animal/hostile/lizard): put in hand(the spade (/obj/item/shovel/spade), 1, 1, 1)
 - Lizard (/mob/living/simple_animal/hostile/lizard): put in active hand(the spade (/obj/item/shovel/spade), 1, 1)
 - Lizard (/mob/living/simple_animal/hostile/lizard): put in hands(the spade (/obj/item/shovel/spade), 0, 1, 1, 1)
 - Lizard (/mob/living/simple_animal/hostile/lizard): put in hands(the spade (/obj/item/shovel/spade), 0, 1, 1)
 - /datum/ai_behavior/give (/datum/ai_behavior/give): perform(0.8, /datum/ai_controller/monkey (/datum/ai_controller/monkey), "BB_monkey_current_give_target")
 - /datum/ai_controller/monkey (/datum/ai_controller/monkey): ProcessBehavior(0.8, /datum/ai_behavior/give (/datum/ai_behavior/give))
 - /datum/ai_controller/monkey (/datum/ai_controller/monkey): process(0.1)
 - 
```

https://github.com/tgstation/tgstation/blob/c15f622f7a8a3f64d20087a0a4799d223dcfcec9/code/modules/mob/inventory.dm#L164
held_items is only populated if the mob is able to hold things. In this case, lizards (and most simple / basic mobs) don't have hands, so it's just an empty list. Fixed that at the `/mob` level. 

Also made the giving logic a little more robust to handle mobs mobs not actually wearing anything as well.

:cl: ShizCalev
fix: Fixed a runtime when NPC monkeys attempt to put items in the hands of mobs with no hands (ie cyborgs, lizards, rats, ect.)
fix: Monkeys will no longer attempt to put items in your pockets if you have no pockets.
/:cl:
