### PR TITLE
Fixes microwaves shitting out their upgraded parts after cooking stuff

### DIFF
--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -57,10 +57,6 @@
 
 	update_appearance(UPDATE_ICON)
 
-/obj/machinery/microwave/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
-	ingredients += arrived
-	return ..()
-
 /obj/machinery/microwave/Exited(atom/movable/gone, direction)
 	if(gone in ingredients)
 		ingredients -= gone
@@ -264,7 +260,7 @@
 				update_appearance()
 				return FALSE //to use some fuel
 		else
-			to_chat(user, span_warning("It's broken!"))
+			balloon_alert(user, "it's broken!")
 			return TRUE
 		return
 
@@ -293,7 +289,7 @@
 		return TRUE
 
 	if(dirty >= MAX_MICROWAVE_DIRTINESS) // The microwave is all dirty so can't be used!
-		to_chat(user, span_warning("\The [src] is dirty!"))
+		balloon_alert(user, "it's too dirty!")
 		return TRUE
 
 	if(istype(O, /obj/item/storage/bag/tray))
@@ -303,22 +299,24 @@
 			if(!IS_EDIBLE(S))
 				continue
 			if(ingredients.len >= max_n_of_items)
-				to_chat(user, span_warning("\The [src] is full, you can't put anything in!"))
+				balloon_alert(user, "it's full!")
 				return TRUE
 			if(T.atom_storage.attempt_remove(S, src))
 				loaded++
+				ingredients += S
 		if(loaded)
 			to_chat(user, span_notice("You insert [loaded] items into \the [src]."))
 		return
 
 	if(O.w_class <= WEIGHT_CLASS_NORMAL && !istype(O, /obj/item/storage) && !user.combat_mode)
 		if(ingredients.len >= max_n_of_items)
-			to_chat(user, span_warning("\The [src] is full, you can't put anything in!"))
+			balloon_alert(user, "it's full!")
 			return TRUE
 		if(!user.transferItemToLoc(O, src))
-			to_chat(user, span_warning("\The [O] is stuck to your hand!"))
+			balloon_alert(user, "it's stuck to your hand!")
 			return FALSE
 
+		ingredients += O
 		user.visible_message(span_notice("[user] adds \a [O] to \the [src]."), span_notice("You add [O] to \the [src]."))
 		update_appearance()
 		return
@@ -327,6 +325,9 @@
 
 /obj/machinery/microwave/attack_hand_secondary(mob/user, list/modifiers)
 	if(user.canUseTopic(src, !issilicon(usr)))
+		if(!length(ingredients))
+			balloon_alert(user, "it's empty!")
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 		cook()
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
@@ -342,7 +343,7 @@
 		if(isAI(user))
 			examine(user)
 		else
-			to_chat(user, span_warning("\The [src] is empty."))
+			balloon_alert(user, "it's empty!")
 		return
 
 	var/choice = show_radial_menu(user, src, isAI(user) ? ai_radial_options : radial_options, require_near = !issilicon(user))


### PR DESCRIPTION
Fixes #71063

Fixed microwave component parts being added to the ingredients list.
Also converted some stuff over to balloon messages
:cl:
fix: Microwaves no longer shit out their upgraded parts when cooking stuff.
/:cl:
