### PR TITLE
Save 0.13s (or more, it's hard to tell with Lavaland) by caching mineral spawn lists, and making effects not have integrity

### DIFF
--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -7,6 +7,7 @@
 	move_resist = INFINITY
 	obj_flags = NONE
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
+	uses_integrity = FALSE
 
 /obj/effect/attackby(obj/item/weapon, mob/user, params)
 	if(SEND_SIGNAL(weapon, COMSIG_ITEM_ATTACK_EFFECT, src, user, params) & COMPONENT_NO_AFTERATTACK)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -44,8 +44,8 @@
 	// The cost of the list() being in the type def is very large for something as common as minerals
 	src.smoothing_groups = smoothing_groups
 	src.canSmoothWith = canSmoothWith
-  
-  return ..()
+
+	return ..()
 
 // Inlined version of the bump click element. way faster this way, the element's nice but it's too much overhead
 /turf/closed/mineral/Bumped(atom/movable/bumped_atom)
@@ -218,9 +218,9 @@
 	if (prob(mineralChance))
 		var/list/spawn_chance_list = mineral_chances_by_type[type]
 		if (isnull(spawn_chance_list))
-			mineral_chances_by_type[type] = mineral_chances()
+			mineral_chances_by_type[type] = expand_weights(mineral_chances())
 			spawn_chance_list = mineral_chances_by_type[type]
-		var/path = pick_weight(spawn_chance_list)
+		var/path = pick(spawn_chance_list)
 		if(ispath(path, /turf))
 			var/stored_flags = 0
 			if(turf_flags & NO_RUINS)

--- a/code/game/turfs/open/planet.dm
+++ b/code/game/turfs/open/planet.dm
@@ -56,7 +56,16 @@
 	smooth_icon = 'icons/turf/floors/junglegrass.dmi'
 
 /turf/closed/mineral/random/jungle
-	mineralSpawnChanceList = list(/obj/item/stack/ore/uranium = 5, /obj/item/stack/ore/diamond = 1, /obj/item/stack/ore/gold = 10,
-		/obj/item/stack/ore/silver = 12, /obj/item/stack/ore/plasma = 20, /obj/item/stack/ore/iron = 40, /obj/item/stack/ore/titanium = 11,
-		/obj/item/stack/ore/bluespace_crystal = 1)
 	baseturfs = /turf/open/misc/dirt/dark
+
+/turf/closed/mineral/random/jungle/mineral_chances()
+	return list(
+		/obj/item/stack/ore/bluespace_crystal = 1,
+		/obj/item/stack/ore/diamond = 1,
+		/obj/item/stack/ore/gold = 10,
+		/obj/item/stack/ore/iron = 40,
+		/obj/item/stack/ore/plasma = 20,
+		/obj/item/stack/ore/silver = 12,
+		/obj/item/stack/ore/titanium = 11,
+		/obj/item/stack/ore/uranium = 5,
+	)


### PR DESCRIPTION
Decals calling `getArmor` was 50ms, gives them `uses_integrity = FALSE` to counter this. I don't think this should have any visible effects.

Makes mineral spawn chances a proc that caches its results rather than a brand new list initialized on every single mineral (80+ms). Also calls `check_holidays` only once instead of over 30,000 times (which was 43.76ms). Also caches `smoothing_groups` and `canSmoothWith`. Numbers aren't wholly inaccurate Lavaland do be random.