### PR TITLE
Make Del the World tests process the filter queue

### DIFF
--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -138,6 +138,27 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 	//Now that we've qdel'd everything, let's sleep until the gc has processed all the shit we care about
 	var/time_needed = SSgarbage.collection_timeout[GC_QUEUE_CHECK]
 	var/start_time = world.time
+	// spin until the first item in the filter queue is older than start_time
+	var/filter_queue_finished = FALSE
+	var/list/filter_queue = SSgarbage.queues[GC_QUEUE_FILTER]
+	while(!filter_queue_finished)
+		if(!length(filter_queue))
+			filter_queue_finished = TRUE
+			break
+		var/list/oldest_item = filter_queue[1]
+		//Pull out the time we deld at
+		var/qdel_time = oldest_item[1]
+		if(qdel_time > start_time) // Everything we care about has graduated to the check queue now!
+			filter_queue_finished = TRUE
+			break
+		if(world.time > start_time + GC_FILTER_QUEUE + 2 MINUTES) // This is much faster than the check queue.
+			TEST_FAIL("Something has gone horribly wrong, the filter queue has been processing for well over 2 minutes. What the hell did you do??")
+			break
+		// We want to fire every time.
+		SSgarbage.next_fire = 1
+		sleep(SSgarbage.wait + GC_FILTER_QUEUE)
+	// We need to check the check queue now.
+	start_time = world.time
 	var/garbage_queue_processed = FALSE
 
 	sleep(time_needed)


### PR DESCRIPTION
## About The Pull Request
Makes Del the World ensure that all objects have left the filter queue before checking the check queue, and update start_time to be more accurate.

## Why It's Good For The Game
The filter queue was added two months after DtW and kind of throws a wrench in the whole thing. Usually the filter queue is pretty fast, but sometimes it can get bogged down with large numbers of items and can theoretically take a variable amount of time, meaning some items might not be in the check queue at all by the time we're running through it, leading to a premature end to the test.

More problematic, the first `start_time` value is checked against the check queue, but set while items are still in the filter queue! Every time something graduates to a new queue, its `qdeld_at` time is reset to the current `world.time`. This means we might get a lot of false negatives because things have a later time than we expect. If we ensure that the filter queue is done when we set (or re-set) `start_time`, then we know that we have a reasonable upper-bound on the `qdeld_at` time for all the items we care about.