### PR TITLE
Adds a special suicide to the Experi-Scanner

### DIFF
--- a/code/modules/experisci/handheld_scanner.dm
+++ b/code/modules/experisci/handheld_scanner.dm
@@ -23,7 +23,7 @@
 		allowed_experiments = list(/datum/experiment/scanning, /datum/experiment/physical),\
 		disallowed_traits = EXPERIMENT_TRAIT_DESTRUCTIVE)
 
-/obj/item/experi_scanner/suicide_act(mob/user)
+/obj/item/experi_scanner/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is giving in to the Great Toilet Beyond! It looks like [user.p_theyre()] trying to commit suicide!"))
 
 	forceMove(drop_location())

--- a/code/modules/experisci/handheld_scanner.dm
+++ b/code/modules/experisci/handheld_scanner.dm
@@ -46,7 +46,7 @@
 	var/obj/structure/toilet/greyscale/result_toilet = new (drop_location())
 
 	result_toilet.set_custom_materials(list(GET_MATERIAL_REF(/datum/material/meat/mob_meat, user) = MINERAL_MATERIAL_AMOUNT))
-	result_toilet.desc += "A horrendous mass of fused flesh resembling a standard-issue HT-451 model toilet. How it manages to function as one is beyond you. \
+	result_toilet.desc = "A horrendous mass of fused flesh resembling a standard-issue HT-451 model toilet. How it manages to function as one is beyond you. \
 	This one seems to be made out of the flesh of a devoted employee of the RnD department."
 	result_toilet.buildstacktype = /obj/effect/decal/remains/human //this also prevents the toilet from dropping meat sheets. if you want to cheese the meat exepriments, sacrifice more people
 

--- a/code/modules/experisci/handheld_scanner.dm
+++ b/code/modules/experisci/handheld_scanner.dm
@@ -22,3 +22,37 @@
 	AddComponent(/datum/component/experiment_handler, \
 		allowed_experiments = list(/datum/experiment/scanning, /datum/experiment/physical),\
 		disallowed_traits = EXPERIMENT_TRAIT_DESTRUCTIVE)
+
+/obj/item/experi_scanner/suicide_act(mob/user)
+	user.visible_message(span_suicide("[user] is giving in to the Great Toilet Beyond! It looks like [user.p_theyre()] trying to commit suicide!"))
+
+	forceMove(drop_location())
+	user.forceMove(src)
+	user.AddComponent(/datum/component/itembound, src) //basically a bread smite but with a bloody finale
+	icon_state = "experiscanner_closed"
+	add_atom_colour("#FF0000", ADMIN_COLOUR_PRIORITY)
+
+	playsound(src, 'sound/effects/pope_entry.ogg', 60, TRUE)
+	playsound(src, 'sound/machines/destructive_scanner/ScanDangerous.ogg', 40)
+	user.emote("scream")
+
+	addtimer(CALLBACK(src, .proc/make_meat_toilet, user), 5 SECONDS)
+	return MANUAL_SUICIDE
+
+/obj/item/experi_scanner/proc/make_meat_toilet(mob/living/carbon/user)
+	///The suicide victim's brain that will be placed inside the toilet's cistern
+	var/obj/item/organ/internal/brain/toilet_brain = user.getorganslot(ORGAN_SLOT_BRAIN)
+	///The toilet we're about to unleash unto this cursed plane of existence
+	var/obj/structure/toilet/greyscale/result_toilet = new (drop_location())
+
+	result_toilet.set_custom_materials(list(GET_MATERIAL_REF(/datum/material/meat/mob_meat, user) = MINERAL_MATERIAL_AMOUNT))
+	result_toilet.desc += "A horrendous mass of fused flesh resembling a standard-issue HT-451 model toilet. How it manages to function as one is beyond you. \
+	This one seems to be made out of the flesh of a devoted employee of the RnD department."
+	result_toilet.buildstacktype = /obj/effect/decal/remains/human //this also prevents the toilet from dropping meat sheets. if you want to cheese the meat exepriments, sacrifice more people
+
+	icon_state = "experiscanner"
+	remove_atom_colour(ADMIN_COLOUR_PRIORITY, "#FF0000")
+
+	user.gib(FALSE, TRUE, TRUE) //we delete everything but the brain, as it's going to be moved to the cistern
+	toilet_brain.forceMove(result_toilet)
+	result_toilet.w_items += toilet_brain.w_class


### PR DESCRIPTION
## About The Pull Request
Adds a `suicide_act` to the Experi-Scanner.

<details>
<summary>LiveLeak footage</summary>

https://user-images.githubusercontent.com/75863639/200129319-d112c8ea-e9f6-49a2-872b-8c2625f97e67.mp4

</details>

The victim's brain also gets placed into the resulting toilet's cistern.

<details>
<summary>Bodycam footage from the clean-up crew</summary>

https://user-images.githubusercontent.com/75863639/200129302-4b9b37fe-9c02-4712-8502-e4732b9258f5.mp4

</details>

The resulting toilet will not drop meat sheets when deconstructed, leaving only a pile of bones behind.

_might add some bone crunching sounds later_

## Why It's Good For The Game
More variety is nice. A use for the experiscanner-closed icon. An ultimate sacrifice for a single toilet that you can scan towards an experiment.

## Changelog
:cl:
add: Added a special suicide to the Experi-Scanner
/:cl:

