### PR TITLE
Fixes caravan ambush ruin's id

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -138,7 +138,7 @@
 	description = "Just somewhere quiet, where I can focus on my work with no interruptions."
 
 /datum/map_template/ruin/space/caravanambush
-	id = "space/caravanambush"
+	id = "caravanambush"
 	suffix = "caravanambush.dmm"
 	name = "Syndicate Ambush"
 	description = "A caravan route used by passing cargo freights has been ambushed by a salvage team manned by the syndicate. \


### PR DESCRIPTION

## About The Pull Request

During initialization, when the Caravan Ambush space ruin loaded, there have been error message during initialization, such as
`create_network_simple: SPACE/CARAVANAMBUSH.DOORS.AIRLOCKS IS INVALID, replacing with LIMBO`. This was caused by the `/` present in the space ruin's ID, which the network validation regex did not accept. I removed `space/` from the beginning, both to make it compliant with the regex, and also because there is no other kind of caravan ambushes to differentiate it from. 

## Why It's Good For The Game

Less error messages during initialization.

## Changelog

Nothing player facing